### PR TITLE
feat(desktop): add authenticated remote port forwarding

### DIFF
--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -369,6 +369,7 @@ const migrateSavedEnvironmentRecords = Effect.fn(
   return {
     schemaVersion: 1,
     targets,
+    routes: targets,
     profiles,
     credentials,
     remoteDpopTokens: [],

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -95,6 +95,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(PortForwardIpc.listPortForwards);
   yield* ipc.handle(PortForwardIpc.stopPortForward);
   yield* ipc.handle(PortForwardIpc.stopEnvironmentPortForwards);
+  yield* ipc.handle(PortForwardIpc.resetEnvironmentPortForwardConnections);
   yield* ipc.handle(PortForwardIpc.resolvePortForwardAuthorization);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -45,11 +45,13 @@ import {
   showContextMenu,
 } from "./methods/window.ts";
 import * as PreviewIpc from "./methods/preview.ts";
+import * as PortForwardIpc from "./methods/portForward.ts";
 import { getWslState, setWslBackendEnabled, setWslDistro, setWslOnly } from "./methods/wsl.ts";
 
 export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers")(function* () {
   const ipc = yield* DesktopIpc.DesktopIpc;
   yield* PreviewIpc.installPreviewEventForwarding();
+  yield* PortForwardIpc.installPortForwardEventForwarding();
 
   yield* ipc.handleSync(getAppBranding);
   yield* ipc.handleSync(getSystemLocale);
@@ -89,6 +91,11 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
   yield* ipc.handle(probeRemoteEditors);
+  yield* ipc.handle(PortForwardIpc.createPortForward);
+  yield* ipc.handle(PortForwardIpc.listPortForwards);
+  yield* ipc.handle(PortForwardIpc.stopPortForward);
+  yield* ipc.handle(PortForwardIpc.stopEnvironmentPortForwards);
+  yield* ipc.handle(PortForwardIpc.resolvePortForwardAuthorization);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);
   yield* ipc.handle(downloadUpdate);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -47,6 +47,8 @@ export const PORT_FORWARD_CREATE_CHANNEL = "desktop:port-forward-create";
 export const PORT_FORWARD_LIST_CHANNEL = "desktop:port-forward-list";
 export const PORT_FORWARD_STOP_CHANNEL = "desktop:port-forward-stop";
 export const PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL = "desktop:port-forward-stop-environment";
+export const PORT_FORWARD_RESET_ENVIRONMENT_CONNECTIONS_CHANNEL =
+  "desktop:port-forward-reset-environment-connections";
 export const PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL =
   "desktop:port-forward-resolve-authorization";
 export const PORT_FORWARD_STATE_CHANNEL = "desktop:port-forward-state";

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -43,6 +43,15 @@ export const SET_WSL_BACKEND_ENABLED_CHANNEL = "desktop:set-wsl-backend-enabled"
 export const SET_WSL_DISTRO_CHANNEL = "desktop:set-wsl-distro";
 export const SET_WSL_ONLY_CHANNEL = "desktop:set-wsl-only";
 export const SSH_PASSWORD_PROMPT_CANCELLED_RESULT = "ssh-password-prompt-cancelled";
+export const PORT_FORWARD_CREATE_CHANNEL = "desktop:port-forward-create";
+export const PORT_FORWARD_LIST_CHANNEL = "desktop:port-forward-list";
+export const PORT_FORWARD_STOP_CHANNEL = "desktop:port-forward-stop";
+export const PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL = "desktop:port-forward-stop-environment";
+export const PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL =
+  "desktop:port-forward-resolve-authorization";
+export const PORT_FORWARD_STATE_CHANNEL = "desktop:port-forward-state";
+export const PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL =
+  "desktop:port-forward-authorization-request";
 export const PREVIEW_CREATE_TAB_CHANNEL = "desktop:preview-create-tab";
 export const PREVIEW_CLOSE_TAB_CHANNEL = "desktop:preview-close-tab";
 export const PREVIEW_REGISTER_WEBVIEW_CHANNEL = "desktop:preview-register-webview";

--- a/apps/desktop/src/ipc/methods/portForward.test.ts
+++ b/apps/desktop/src/ipc/methods/portForward.test.ts
@@ -1,0 +1,42 @@
+import {
+  DesktopPortForwardId,
+  EnvironmentId,
+  type DesktopPortForwardAuthorizationRequest,
+} from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import { vi } from "vite-plus/test";
+
+import * as ElectronWindow from "../../electron/ElectronWindow.ts";
+import * as IpcChannels from "../channels.ts";
+import { sendPortForwardAuthorizationRequest } from "./portForward.ts";
+
+it.effect("sends port-forward authorization only to the main renderer", () => {
+  const send = vi.fn();
+  const sendAll = vi.fn(() => Effect.void);
+  const mainWindow = { webContents: { send } } as unknown as Electron.BrowserWindow;
+  const electronWindow = ElectronWindow.ElectronWindow.of({
+    currentMainOrFirst: Effect.succeed(Option.some(mainWindow)),
+    sendAll,
+  } as unknown as ElectronWindow.ElectronWindow["Service"]);
+  const request: DesktopPortForwardAuthorizationRequest = {
+    requestId: "request-1",
+    forwardId: DesktopPortForwardId.make("forward-1"),
+    environmentId: EnvironmentId.make("environment-1"),
+    remoteHost: "127.0.0.1",
+    remotePort: 5174,
+  };
+
+  return sendPortForwardAuthorizationRequest(electronWindow, request).pipe(
+    Effect.andThen(
+      Effect.sync(() => {
+        expect(send).toHaveBeenCalledWith(
+          IpcChannels.PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL,
+          request,
+        );
+        expect(sendAll).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+});

--- a/apps/desktop/src/ipc/methods/portForward.ts
+++ b/apps/desktop/src/ipc/methods/portForward.ts
@@ -1,17 +1,35 @@
 import {
   DesktopPortForwardAuthorizationResolution,
+  type DesktopPortForwardAuthorizationRequest,
   DesktopPortForwardCreateInput,
   DesktopPortForwardSnapshot,
   DesktopPortForwardStopEnvironmentInput,
   DesktopPortForwardStopInput,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import * as DesktopPortForwardManager from "../../portForward/DesktopPortForwardManager.ts";
 import * as IpcChannels from "../channels.ts";
 import * as DesktopIpc from "../DesktopIpc.ts";
+
+export const sendPortForwardAuthorizationRequest = Effect.fn(
+  "desktop.ipc.portForward.sendAuthorizationRequest",
+)(function* (
+  electronWindow: ElectronWindow.ElectronWindow["Service"],
+  request: DesktopPortForwardAuthorizationRequest,
+) {
+  const target = yield* electronWindow.currentMainOrFirst;
+  yield* Option.match(target, {
+    onNone: () => Effect.void,
+    onSome: (window) =>
+      Effect.sync(() => {
+        window.webContents.send(IpcChannels.PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL, request);
+      }),
+  });
+});
 
 export const installPortForwardEventForwarding = Effect.fn(
   "desktop.ipc.portForward.installEventForwarding",
@@ -22,7 +40,7 @@ export const installPortForwardEventForwarding = Effect.fn(
     electronWindow.sendAll(IpcChannels.PORT_FORWARD_STATE_CHANNEL, snapshots),
   );
   yield* manager.subscribeAuthorizationRequests((request) =>
-    electronWindow.sendAll(IpcChannels.PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL, request),
+    sendPortForwardAuthorizationRequest(electronWindow, request),
   );
 });
 

--- a/apps/desktop/src/ipc/methods/portForward.ts
+++ b/apps/desktop/src/ipc/methods/portForward.ts
@@ -1,0 +1,80 @@
+import {
+  DesktopPortForwardAuthorizationResolution,
+  DesktopPortForwardCreateInput,
+  DesktopPortForwardSnapshot,
+  DesktopPortForwardStopEnvironmentInput,
+  DesktopPortForwardStopInput,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import * as ElectronWindow from "../../electron/ElectronWindow.ts";
+import * as DesktopPortForwardManager from "../../portForward/DesktopPortForwardManager.ts";
+import * as IpcChannels from "../channels.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+
+export const installPortForwardEventForwarding = Effect.fn(
+  "desktop.ipc.portForward.installEventForwarding",
+)(function* () {
+  const electronWindow = yield* ElectronWindow.ElectronWindow;
+  const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+  yield* manager.subscribeStateChanges((snapshots) =>
+    electronWindow.sendAll(IpcChannels.PORT_FORWARD_STATE_CHANNEL, snapshots),
+  );
+  yield* manager.subscribeAuthorizationRequests((request) =>
+    electronWindow.sendAll(IpcChannels.PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL, request),
+  );
+});
+
+export const createPortForward = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PORT_FORWARD_CREATE_CHANNEL,
+  payload: DesktopPortForwardCreateInput,
+  result: DesktopPortForwardSnapshot,
+  handler: Effect.fn("desktop.ipc.portForward.create")(function* (input) {
+    const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+    return yield* manager.create(input);
+  }),
+});
+
+export const listPortForwards = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PORT_FORWARD_LIST_CHANNEL,
+  payload: Schema.Void,
+  result: Schema.Array(DesktopPortForwardSnapshot),
+  handler: Effect.fn("desktop.ipc.portForward.list")(function* () {
+    const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+    return yield* manager.list;
+  }),
+});
+
+export const stopPortForward = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PORT_FORWARD_STOP_CHANNEL,
+  payload: DesktopPortForwardStopInput,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.portForward.stop")(function* ({ id }) {
+    const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+    yield* manager.stop(id);
+  }),
+});
+
+export const stopEnvironmentPortForwards = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL,
+  payload: DesktopPortForwardStopEnvironmentInput,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.portForward.stopEnvironment")(function* ({ environmentId }) {
+    const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+    yield* manager.stopEnvironment(environmentId);
+  }),
+});
+
+export const resolvePortForwardAuthorization = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL,
+  payload: DesktopPortForwardAuthorizationResolution,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.portForward.resolveAuthorization")(function* ({
+    requestId,
+    socketUrl,
+  }) {
+    const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+    yield* manager.resolveAuthorization(requestId, socketUrl);
+  }),
+});

--- a/apps/desktop/src/ipc/methods/portForward.ts
+++ b/apps/desktop/src/ipc/methods/portForward.ts
@@ -84,6 +84,18 @@ export const stopEnvironmentPortForwards = DesktopIpc.makeIpcMethod({
   }),
 });
 
+export const resetEnvironmentPortForwardConnections = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PORT_FORWARD_RESET_ENVIRONMENT_CONNECTIONS_CHANNEL,
+  payload: DesktopPortForwardStopEnvironmentInput,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.portForward.resetEnvironmentConnections")(function* ({
+    environmentId,
+  }) {
+    const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+    yield* manager.resetEnvironmentConnections(environmentId);
+  }),
+});
+
 export const resolvePortForwardAuthorization = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL,
   payload: DesktopPortForwardAuthorizationResolution,

--- a/apps/desktop/src/ipc/methods/portForward.ts
+++ b/apps/desktop/src/ipc/methods/portForward.ts
@@ -73,8 +73,9 @@ export const resolvePortForwardAuthorization = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.portForward.resolveAuthorization")(function* ({
     requestId,
     socketUrl,
+    error,
   }) {
     const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
-    yield* manager.resolveAuthorization(requestId, socketUrl);
+    yield* manager.resolveAuthorization(requestId, socketUrl, error);
   }),
 });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -63,6 +63,7 @@ import * as DesktopWindow from "./window/DesktopWindow.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
 import * as DesktopWslServerTree from "./wsl/DesktopWslServerTree.ts";
+import * as DesktopPortForwardManager from "./portForward/DesktopPortForwardManager.ts";
 
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {
@@ -188,6 +189,7 @@ const desktopApplicationLayer = Layer.mergeAll(
   DesktopLinuxUrlHandler.layer,
   DesktopShellEnvironment.layer,
   desktopSshLayer,
+  DesktopPortForwardManager.layer,
 ).pipe(
   Layer.provideMerge(DesktopUpdates.layer),
   Layer.provideMerge(desktopWslBackendLayer),

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -106,6 +106,16 @@ it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
     );
   });
 
+  it("identifies the local port for listener failures", () => {
+    const error = new DesktopPortForwardManager.DesktopPortForwardError({
+      operation: "listen",
+      localPort: 4321,
+      cause: new Error("address in use"),
+    });
+
+    expect(error.message).toContain("local port 4321");
+  });
+
   it.effect("flushes credit-blocked local data before sending write end", () =>
     Effect.gen(function* () {
       const socket = makeConnectionSocket();

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -1,10 +1,19 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { EnvironmentId, type DesktopPortForwardAuthorizationRequest } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  TCP_PORT_FORWARD_FRAME_ACK,
+  TCP_PORT_FORWARD_FRAME_DATA,
+  TCP_PORT_FORWARD_FRAME_WRITE_END,
+  TCP_PORT_FORWARD_INITIAL_CREDIT,
+  type DesktopPortForwardAuthorizationRequest,
+} from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as NodeNet from "node:net";
 import * as Queue from "effect/Queue";
+import { EventEmitter } from "node:events";
 
 import * as DesktopPortForwardManager from "./DesktopPortForwardManager.ts";
 
@@ -35,11 +44,60 @@ const awaitSocketClose = (socket: NodeNet.Socket) =>
         socket.once("close", () => resume(Effect.void));
       });
 
+const makeAckFrame = (bytes: number) => {
+  const frame = new Uint8Array(5);
+  frame[0] = TCP_PORT_FORWARD_FRAME_ACK;
+  new DataView(frame.buffer).setUint32(1, bytes, false);
+  return frame;
+};
+
+const makeConnectionSocket = () => {
+  const emitter = new EventEmitter();
+  const socket = Object.assign(emitter, {
+    destroy: () => socket,
+    end: () => socket,
+    pause: () => socket,
+    resume: () => socket,
+    setTimeout: () => socket,
+    write: (_payload: Uint8Array, callback: (error?: Error | null) => void) => {
+      callback();
+      return true;
+    },
+  });
+  return socket as unknown as NodeNet.Socket;
+};
+
+const makeConnectionWebSocket = () => {
+  const listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+  const sent: Array<Uint8Array> = [];
+  const webSocket = {
+    readyState: WebSocket.OPEN,
+    send: (data: ArrayBuffer) => sent.push(new Uint8Array(data)),
+    close: () => undefined,
+    addEventListener: (type: string, listener: (event: MessageEvent) => void) => {
+      const current = listeners.get(type) ?? new Set();
+      current.add(listener);
+      listeners.set(type, current);
+    },
+    removeEventListener: (type: string, listener: (event: MessageEvent) => void) => {
+      listeners.get(type)?.delete(listener);
+    },
+  };
+  return {
+    webSocket: webSocket as unknown as WebSocket,
+    sent,
+    receive: (frame: Uint8Array) => {
+      for (const listener of listeners.get("message") ?? []) {
+        listener({ data: frame.slice().buffer } as MessageEvent);
+      }
+    },
+  };
+};
+
 it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
   it("preserves renderer authorization failures for the forward status", () => {
     const error = new DesktopPortForwardManager.DesktopPortForwardError({
       operation: "authorize",
-      cause: "Remote environment returned 404.",
       detail: "Remote environment returned 404",
     });
 
@@ -47,6 +105,31 @@ it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
       "Desktop port forward authorize failed: Remote environment returned 404.",
     );
   });
+
+  it.effect("flushes credit-blocked local data before sending write end", () =>
+    Effect.gen(function* () {
+      const socket = makeConnectionSocket();
+      const webSocket = makeConnectionWebSocket();
+      const connection = yield* DesktopPortForwardManager.runConnection(
+        socket,
+        webSocket.webSocket,
+      ).pipe(Effect.forkChild({ startImmediately: true }));
+
+      socket.emit("data", Buffer.alloc(TCP_PORT_FORWARD_INITIAL_CREDIT + 1));
+      socket.emit("end");
+      expect(webSocket.sent.some((frame) => frame[0] === TCP_PORT_FORWARD_FRAME_WRITE_END)).toBe(
+        false,
+      );
+
+      webSocket.receive(makeAckFrame(TCP_PORT_FORWARD_INITIAL_CREDIT));
+      const dataBytes = webSocket.sent
+        .filter((frame) => frame[0] === TCP_PORT_FORWARD_FRAME_DATA)
+        .reduce((total, frame) => total + frame.byteLength - 1, 0);
+      expect(dataBytes).toBe(TCP_PORT_FORWARD_INITIAL_CREDIT + 1);
+      expect(webSocket.sent.at(-1)?.[0]).toBe(TCP_PORT_FORWARD_FRAME_WRITE_END);
+      yield* Fiber.interrupt(connection);
+    }),
+  );
 
   it.effect("atomically allocates and stops a desktop loopback listener", () =>
     Effect.gen(function* () {

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -6,6 +6,18 @@ import * as Effect from "effect/Effect";
 import * as DesktopPortForwardManager from "./DesktopPortForwardManager.ts";
 
 it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
+  it("preserves renderer authorization failures for the forward status", () => {
+    const error = new DesktopPortForwardManager.DesktopPortForwardError({
+      operation: "authorize",
+      cause: "Remote environment returned 404.",
+      detail: "Remote environment returned 404",
+    });
+
+    expect(error.message).toBe(
+      "Desktop port forward authorize failed: Remote environment returned 404.",
+    );
+  });
+
   it.effect("atomically allocates and stops a desktop loopback listener", () =>
     Effect.gen(function* () {
       const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -4,6 +4,7 @@ import { expect, it } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as NodeNet from "node:net";
+import * as Queue from "effect/Queue";
 
 import * as DesktopPortForwardManager from "./DesktopPortForwardManager.ts";
 
@@ -26,6 +27,13 @@ const connectLocal = (port: number) =>
       socket.destroy();
     });
   });
+
+const awaitSocketClose = (socket: NodeNet.Socket) =>
+  socket.destroyed
+    ? Effect.void
+    : Effect.callback<void>((resume) => {
+        socket.once("close", () => resume(Effect.void));
+      });
 
 it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
   it("preserves renderer authorization failures for the forward status", () => {
@@ -160,6 +168,51 @@ it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
         expect(settled?.connectingConnections).toBe(0);
         expect(settled?.activeConnections).toBe(0);
         expect(settled?.lastError).toContain("validate-ticket-url");
+      }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+    ),
+  );
+
+  it.effect("keeps the listener but retires connecting sockets when the route changes", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+        const environmentId = EnvironmentId.make("environment-a");
+        const authorizations = yield* Queue.unbounded<DesktopPortForwardAuthorizationRequest>();
+        yield* manager.subscribeAuthorizationRequests((request) =>
+          Queue.offer(authorizations, request).pipe(Effect.asVoid),
+        );
+        const created = yield* manager.create({
+          environmentId,
+          remoteHost: "127.0.0.1",
+          remotePort: 3000,
+        });
+
+        const firstSocket = yield* connectLocal(created.localPort);
+        const firstAuthorization = yield* Queue.take(authorizations);
+        expect((yield* manager.list)[0]?.connectingConnections).toBe(1);
+
+        yield* manager.resetEnvironmentConnections(environmentId);
+        yield* awaitSocketClose(firstSocket);
+        yield* manager.resolveAuthorization(
+          firstAuthorization.requestId,
+          "ws://127.0.0.1:1/ws/tcp-forward?ticket=stale",
+        );
+
+        const [reset] = yield* manager.list;
+        expect(reset).toMatchObject({
+          id: created.id,
+          localPort: created.localPort,
+          status: "running",
+          connectingConnections: 0,
+          activeConnections: 0,
+          lastError: null,
+        });
+
+        const secondSocket = yield* connectLocal(created.localPort);
+        const secondAuthorization = yield* Queue.take(authorizations);
+        expect(secondAuthorization.requestId).not.toBe(firstAuthorization.requestId);
+        yield* manager.resetEnvironmentConnections(environmentId);
+        yield* awaitSocketClose(secondSocket);
       }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
     ),
   );

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -7,7 +7,7 @@ import {
   TCP_PORT_FORWARD_INITIAL_CREDIT,
   type DesktopPortForwardAuthorizationRequest,
 } from "@t3tools/contracts";
-import { expect, it } from "@effect/vitest";
+import { expect, it, vi } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -54,7 +54,7 @@ const makeAckFrame = (bytes: number) => {
 const makeConnectionSocket = () => {
   const emitter = new EventEmitter();
   const socket = Object.assign(emitter, {
-    destroy: () => socket,
+    destroy: vi.fn(() => socket),
     end: () => socket,
     pause: () => socket,
     resume: () => socket,
@@ -67,11 +67,11 @@ const makeConnectionSocket = () => {
   return socket as unknown as NodeNet.Socket;
 };
 
-const makeConnectionWebSocket = () => {
+const makeConnectionWebSocket = (readyState: number = WebSocket.OPEN) => {
   const listeners = new Map<string, Set<(event: MessageEvent) => void>>();
   const sent: Array<Uint8Array> = [];
   const webSocket = {
-    readyState: WebSocket.OPEN,
+    readyState,
     send: (data: ArrayBuffer) => sent.push(new Uint8Array(data)),
     close: () => undefined,
     addEventListener: (type: string, listener: (event: MessageEvent) => void) => {
@@ -128,6 +128,17 @@ it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
       expect(dataBytes).toBe(TCP_PORT_FORWARD_INITIAL_CREDIT + 1);
       expect(webSocket.sent.at(-1)?.[0]).toBe(TCP_PORT_FORWARD_FRAME_WRITE_END);
       yield* Fiber.interrupt(connection);
+    }),
+  );
+
+  it.effect("closes a local socket when the bridge closed during handoff", () =>
+    Effect.gen(function* () {
+      const socket = makeConnectionSocket();
+      const webSocket = makeConnectionWebSocket(WebSocket.CLOSED);
+
+      yield* DesktopPortForwardManager.runConnection(socket, webSocket.webSocket);
+
+      expect(socket.destroy).toHaveBeenCalled();
     }),
   );
 

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -1,0 +1,89 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { EnvironmentId } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import * as DesktopPortForwardManager from "./DesktopPortForwardManager.ts";
+
+it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
+  it.effect("atomically allocates and stops a desktop loopback listener", () =>
+    Effect.gen(function* () {
+      const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+      const created = yield* manager.create({
+        environmentId: EnvironmentId.make("environment-a"),
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+
+      expect(created.localHost).toBe("127.0.0.1");
+      expect(created.localPort).toBeGreaterThan(0);
+      expect(yield* manager.list).toEqual([created]);
+
+      yield* manager.stop(created.id);
+      expect(yield* manager.list).toEqual([]);
+    }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+  );
+
+  it.effect("stops only forwards owned by the removed environment", () =>
+    Effect.gen(function* () {
+      const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+      const firstEnvironment = EnvironmentId.make("environment-a");
+      const secondEnvironment = EnvironmentId.make("environment-b");
+      yield* manager.create({
+        environmentId: firstEnvironment,
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+      const retained = yield* manager.create({
+        environmentId: secondEnvironment,
+        remoteHost: "127.0.0.1",
+        remotePort: 3001,
+      });
+
+      yield* manager.stopEnvironment(firstEnvironment);
+      expect(yield* manager.list).toEqual([retained]);
+    }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+  );
+
+  it.effect("reports an explicit local-port conflict without replacing the owner", () =>
+    Effect.gen(function* () {
+      const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+      const environmentId = EnvironmentId.make("environment-a");
+      const owner = yield* manager.create({
+        environmentId,
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+
+      const conflict = yield* Effect.flip(
+        manager.create({
+          environmentId,
+          remoteHost: "127.0.0.1",
+          remotePort: 3001,
+          localPort: owner.localPort,
+        }),
+      );
+      expect(conflict._tag).toBe("DesktopPortForwardError");
+      expect(yield* manager.list).toEqual([owner]);
+    }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+  );
+
+  it.effect("chooses another local port when two environments prefer the same port", () =>
+    Effect.gen(function* () {
+      const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+      const first = yield* manager.create({
+        environmentId: EnvironmentId.make("environment-a"),
+        remoteHost: "127.0.0.1",
+        remotePort: 42000,
+      });
+      const second = yield* manager.create({
+        environmentId: EnvironmentId.make("environment-b"),
+        remoteHost: "127.0.0.1",
+        remotePort: first.localPort,
+      });
+
+      expect(second.localPort).not.toBe(first.localPort);
+      expect(yield* manager.list).toHaveLength(2);
+    }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+  );
+});

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.test.ts
@@ -1,9 +1,31 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, type DesktopPortForwardAuthorizationRequest } from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as NodeNet from "node:net";
 
 import * as DesktopPortForwardManager from "./DesktopPortForwardManager.ts";
+
+const connectLocal = (port: number) =>
+  Effect.callback<NodeNet.Socket, Error>((resume) => {
+    const socket = NodeNet.createConnection({ host: "127.0.0.1", port });
+    const onConnect = () => {
+      socket.off("error", onError);
+      resume(Effect.succeed(socket));
+    };
+    const onError = (cause: Error) => {
+      socket.off("connect", onConnect);
+      resume(Effect.fail(cause));
+    };
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+    return Effect.sync(() => {
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+      socket.destroy();
+    });
+  });
 
 it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
   it("preserves renderer authorization failures for the forward status", () => {
@@ -97,5 +119,48 @@ it.layer(NodeServices.layer)("DesktopPortForwardManager", (it) => {
       expect(second.localPort).not.toBe(first.localPort);
       expect(yield* manager.list).toHaveLength(2);
     }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+  );
+
+  it.effect("does not report a local socket as active before its bridge connects", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const manager = yield* DesktopPortForwardManager.DesktopPortForwardManager;
+        const authorization = yield* Deferred.make<DesktopPortForwardAuthorizationRequest>();
+        const failed = yield* Deferred.make<void>();
+
+        yield* manager.subscribeAuthorizationRequests((request) =>
+          Deferred.succeed(authorization, request).pipe(Effect.asVoid),
+        );
+        yield* manager.subscribeStateChanges((snapshots) => {
+          const snapshot = snapshots[0];
+          return snapshot !== undefined &&
+            snapshot.connectingConnections === 0 &&
+            snapshot.lastError !== null
+            ? Deferred.succeed(failed, undefined).pipe(Effect.asVoid)
+            : Effect.void;
+        });
+
+        const created = yield* manager.create({
+          environmentId: EnvironmentId.make("environment-a"),
+          remoteHost: "127.0.0.1",
+          remotePort: 3000,
+        });
+        const socket = yield* connectLocal(created.localPort);
+        yield* Effect.addFinalizer(() => Effect.sync(() => socket.destroy()));
+
+        const request = yield* Deferred.await(authorization);
+        const [connecting] = yield* manager.list;
+        expect(connecting?.connectingConnections).toBe(1);
+        expect(connecting?.activeConnections).toBe(0);
+
+        yield* manager.resolveAuthorization(request.requestId, "not a valid WebSocket URL");
+        yield* Deferred.await(failed);
+
+        const [settled] = yield* manager.list;
+        expect(settled?.connectingConnections).toBe(0);
+        expect(settled?.activeConnections).toBe(0);
+        expect(settled?.lastError).toContain("validate-ticket-url");
+      }).pipe(Effect.provide(DesktopPortForwardManager.layer)),
+    ),
   );
 });

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -431,8 +431,9 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  const handleConnection = (forward: ManagedForward, socket: NodeNet.Socket) =>
-    Effect.gen(function* () {
+  const handleConnection = (forward: ManagedForward, socket: NodeNet.Socket) => {
+    let connectionState: "connecting" | "connected" = "connecting";
+    return Effect.gen(function* () {
       const accepted = yield* Ref.modify(forwards, (current) => {
         const activeTotal = [...current.values()].reduce(
           (total, entry) => total + entry.sockets.size,
@@ -454,12 +455,18 @@ export const make = Effect.gen(function* () {
       }
       yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
         ...snapshot,
-        activeConnections: snapshot.activeConnections + 1,
+        connectingConnections: snapshot.connectingConnections + 1,
         lastError: null,
       }));
       const socketUrl = yield* authorize(forward);
       const webSocket = yield* openWebSocket(socketUrl);
       forward.webSockets.add(webSocket);
+      yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
+        ...snapshot,
+        connectingConnections: Math.max(0, snapshot.connectingConnections - 1),
+        activeConnections: snapshot.activeConnections + 1,
+      }));
+      connectionState = "connected";
       yield* runConnection(socket, webSocket);
       forward.webSockets.delete(webSocket);
     }).pipe(
@@ -475,11 +482,16 @@ export const make = Effect.gen(function* () {
           socket.destroy();
           yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
             ...snapshot,
-            activeConnections: Math.max(0, snapshot.activeConnections - 1),
+            ...(connectionState === "connected"
+              ? { activeConnections: Math.max(0, snapshot.activeConnections - 1) }
+              : {
+                  connectingConnections: Math.max(0, snapshot.connectingConnections - 1),
+                }),
           }));
         }),
       ),
     );
+  };
 
   const create: DesktopPortForwardManager["Service"]["create"] = Effect.fn(
     "DesktopPortForwardManager.create",
@@ -506,6 +518,7 @@ export const make = Effect.gen(function* () {
       remoteHost: input.remoteHost,
       remotePort: input.remotePort,
       status: "running",
+      connectingConnections: 0,
       activeConnections: 0,
       lastError: null,
     };

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -1,0 +1,601 @@
+import {
+  DesktopPortForwardId,
+  type DesktopPortForwardAuthorizationRequest,
+  type DesktopPortForwardCreateInput,
+  type DesktopPortForwardSnapshot,
+  TCP_PORT_FORWARD_FRAME_ACK,
+  TCP_PORT_FORWARD_FRAME_CLOSE,
+  TCP_PORT_FORWARD_FRAME_DATA,
+  TCP_PORT_FORWARD_FRAME_ERROR,
+  TCP_PORT_FORWARD_FRAME_WRITE_END,
+  TCP_PORT_FORWARD_INITIAL_CREDIT,
+  TCP_PORT_FORWARD_MAX_DATA_SIZE,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as NodeNet from "node:net";
+
+const AUTHORIZATION_TIMEOUT = Duration.seconds(15);
+const MAX_CONNECTIONS_PER_FORWARD = 32;
+const MAX_CONNECTIONS_TOTAL = 128;
+const IDLE_TIMEOUT_MS = 5 * 60 * 1_000;
+const NEARBY_PORT_SEARCH_DISTANCE = 20;
+
+type StateListener = (snapshots: ReadonlyArray<DesktopPortForwardSnapshot>) => Effect.Effect<void>;
+type AuthorizationListener = (
+  request: DesktopPortForwardAuthorizationRequest,
+) => Effect.Effect<void>;
+
+interface ManagedForward {
+  snapshot: DesktopPortForwardSnapshot;
+  readonly server: NodeNet.Server;
+  readonly sockets: Set<NodeNet.Socket>;
+  readonly webSockets: Set<WebSocket>;
+}
+
+export class DesktopPortForwardError extends Schema.TaggedErrorClass<DesktopPortForwardError>()(
+  "DesktopPortForwardError",
+  { operation: Schema.String, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `Desktop port forward ${this.operation} failed.`;
+  }
+}
+
+const controlFrame = (kind: number) => Uint8Array.of(kind);
+
+const dataFrame = (data: Uint8Array) => {
+  const frame = new Uint8Array(data.byteLength + 1);
+  frame[0] = TCP_PORT_FORWARD_FRAME_DATA;
+  frame.set(data, 1);
+  return frame;
+};
+
+const ackFrame = (bytes: number) => {
+  const frame = new Uint8Array(5);
+  frame[0] = TCP_PORT_FORWARD_FRAME_ACK;
+  new DataView(frame.buffer).setUint32(1, bytes, false);
+  return frame;
+};
+
+const listen = (server: NodeNet.Server, port: number) =>
+  Effect.callback<number, DesktopPortForwardError>((resume) => {
+    const onError = (cause: Error) => {
+      server.off("listening", onListening);
+      resume(Effect.fail(new DesktopPortForwardError({ operation: "listen", cause })));
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        resume(
+          Effect.fail(
+            new DesktopPortForwardError({
+              operation: "resolve-listener-address",
+              cause: address,
+            }),
+          ),
+        );
+        return;
+      }
+      resume(Effect.succeed(address.port));
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: "127.0.0.1", port, exclusive: true });
+    return Effect.sync(() => {
+      server.off("error", onError);
+      server.off("listening", onListening);
+      server.close();
+    });
+  });
+
+const automaticLocalPortCandidates = (preferredPort: number): ReadonlyArray<number> => {
+  const candidates = [preferredPort];
+  for (let distance = 1; distance <= NEARBY_PORT_SEARCH_DISTANCE; distance += 1) {
+    const higher = preferredPort + distance;
+    const lower = preferredPort - distance;
+    if (higher <= 65_535) candidates.push(higher);
+    if (lower >= 1) candidates.push(lower);
+  }
+  return candidates;
+};
+
+const listenAutomatically = Effect.fn("DesktopPortForwardManager.listenAutomatically")(function* (
+  server: NodeNet.Server,
+  preferredPort: number,
+) {
+  for (const candidate of automaticLocalPortCandidates(preferredPort)) {
+    const attempt = yield* Effect.result(listen(server, candidate));
+    if (Result.isSuccess(attempt)) return attempt.success;
+
+    const cause = attempt.failure.cause;
+    const code =
+      typeof cause === "object" &&
+      cause !== null &&
+      "code" in cause &&
+      typeof cause.code === "string"
+        ? cause.code
+        : null;
+    if (code === "EACCES") break;
+    if (code !== "EADDRINUSE") return yield* attempt.failure;
+  }
+  return yield* listen(server, 0);
+});
+
+const openWebSocket = (socketUrl: string) =>
+  Effect.callback<WebSocket, DesktopPortForwardError>((resume) => {
+    let url: URL;
+    try {
+      url = new URL(socketUrl);
+    } catch (cause) {
+      resume(Effect.fail(new DesktopPortForwardError({ operation: "validate-ticket-url", cause })));
+      return;
+    }
+    if (
+      (url.protocol !== "ws:" && url.protocol !== "wss:") ||
+      url.pathname !== "/ws/tcp-forward" ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      resume(
+        Effect.fail(
+          new DesktopPortForwardError({
+            operation: "validate-ticket-url",
+            cause: "The renderer supplied an invalid bridge URL.",
+          }),
+        ),
+      );
+      return;
+    }
+    const webSocket = new WebSocket(url);
+    webSocket.binaryType = "arraybuffer";
+    const onOpen = () => {
+      webSocket.removeEventListener("error", onError);
+      resume(Effect.succeed(webSocket));
+    };
+    const onError = (cause: Event) => {
+      webSocket.removeEventListener("open", onOpen);
+      webSocket.close();
+      resume(Effect.fail(new DesktopPortForwardError({ operation: "connect-bridge", cause })));
+    };
+    webSocket.addEventListener("open", onOpen, { once: true });
+    webSocket.addEventListener("error", onError, { once: true });
+    return Effect.sync(() => {
+      webSocket.removeEventListener("open", onOpen);
+      webSocket.removeEventListener("error", onError);
+      webSocket.close();
+    });
+  });
+
+const runConnection = (socket: NodeNet.Socket, webSocket: WebSocket): Effect.Effect<void, never> =>
+  Effect.callback<void>((resume) => {
+    let credit = TCP_PORT_FORWARD_INITIAL_CREDIT;
+    let outstanding = 0;
+    let pending: Uint8Array = new Uint8Array(0);
+    let socketEnded = false;
+    let closed = false;
+
+    const send = (frame: Uint8Array) => {
+      if (webSocket.readyState === WebSocket.OPEN) {
+        webSocket.send(frame.slice().buffer as ArrayBuffer);
+      }
+    };
+    const finish = () => {
+      if (closed) return;
+      closed = true;
+      socket.destroy();
+      if (
+        webSocket.readyState === WebSocket.OPEN ||
+        webSocket.readyState === WebSocket.CONNECTING
+      ) {
+        webSocket.close();
+      }
+      resume(Effect.void);
+    };
+    const protocolFailure = () => {
+      send(controlFrame(TCP_PORT_FORWARD_FRAME_ERROR));
+      finish();
+    };
+    const flushSocketData = () => {
+      while (credit > 0 && pending.byteLength > 0) {
+        const size = Math.min(credit, TCP_PORT_FORWARD_MAX_DATA_SIZE, pending.byteLength);
+        const chunk = pending.subarray(0, size);
+        pending = pending.subarray(size);
+        credit -= size;
+        outstanding += size;
+        send(dataFrame(chunk));
+      }
+      if (pending.byteLength === 0 && credit > 0) socket.resume();
+      else socket.pause();
+    };
+    const onSocketData = (chunk: Buffer) => {
+      if (pending.byteLength === 0) {
+        pending = chunk;
+      } else {
+        const combined = new Uint8Array(pending.byteLength + chunk.byteLength);
+        combined.set(pending);
+        combined.set(chunk, pending.byteLength);
+        pending = combined;
+      }
+      flushSocketData();
+    };
+    const onSocketEnd = () => send(controlFrame(TCP_PORT_FORWARD_FRAME_WRITE_END));
+    const onSocketError = () => finish();
+    const onSocketClose = () => {
+      send(controlFrame(TCP_PORT_FORWARD_FRAME_CLOSE));
+      finish();
+    };
+    const onWebSocketClose = () => finish();
+    const onWebSocketError = () => finish();
+    const onWebSocketMessage = (event: MessageEvent) => {
+      if (!(event.data instanceof ArrayBuffer)) {
+        protocolFailure();
+        return;
+      }
+      const frame = new Uint8Array(event.data);
+      switch (frame[0]) {
+        case TCP_PORT_FORWARD_FRAME_DATA: {
+          const payload = frame.subarray(1);
+          if (
+            payload.byteLength === 0 ||
+            payload.byteLength > TCP_PORT_FORWARD_MAX_DATA_SIZE ||
+            socketEnded
+          ) {
+            protocolFailure();
+            return;
+          }
+          socket.write(payload, (error) => {
+            if (error) finish();
+            else send(ackFrame(payload.byteLength));
+          });
+          return;
+        }
+        case TCP_PORT_FORWARD_FRAME_ACK: {
+          if (frame.byteLength !== 5) {
+            protocolFailure();
+            return;
+          }
+          const bytes = new DataView(frame.buffer, frame.byteOffset, frame.byteLength).getUint32(
+            1,
+            false,
+          );
+          if (bytes === 0 || bytes > outstanding) {
+            protocolFailure();
+            return;
+          }
+          outstanding -= bytes;
+          credit += bytes;
+          flushSocketData();
+          return;
+        }
+        case TCP_PORT_FORWARD_FRAME_WRITE_END:
+          if (frame.byteLength !== 1 || socketEnded) {
+            protocolFailure();
+            return;
+          }
+          socketEnded = true;
+          socket.end();
+          return;
+        case TCP_PORT_FORWARD_FRAME_CLOSE:
+          if (frame.byteLength !== 1) {
+            protocolFailure();
+            return;
+          }
+          finish();
+          return;
+        case TCP_PORT_FORWARD_FRAME_ERROR:
+          if (frame.byteLength > 513) {
+            protocolFailure();
+            return;
+          }
+          finish();
+          return;
+        default:
+          protocolFailure();
+      }
+    };
+
+    socket.on("data", onSocketData);
+    socket.once("end", onSocketEnd);
+    socket.once("error", onSocketError);
+    socket.once("close", onSocketClose);
+    webSocket.addEventListener("message", onWebSocketMessage);
+    webSocket.addEventListener("close", onWebSocketClose, { once: true });
+    webSocket.addEventListener("error", onWebSocketError, { once: true });
+    socket.setTimeout(IDLE_TIMEOUT_MS, finish);
+
+    return Effect.sync(() => {
+      socket.off("data", onSocketData);
+      socket.off("end", onSocketEnd);
+      socket.off("error", onSocketError);
+      socket.off("close", onSocketClose);
+      webSocket.removeEventListener("message", onWebSocketMessage);
+      webSocket.removeEventListener("close", onWebSocketClose);
+      webSocket.removeEventListener("error", onWebSocketError);
+      socket.destroy();
+      webSocket.close();
+    });
+  });
+
+export class DesktopPortForwardManager extends Context.Service<
+  DesktopPortForwardManager,
+  {
+    readonly create: (
+      input: DesktopPortForwardCreateInput,
+    ) => Effect.Effect<DesktopPortForwardSnapshot, DesktopPortForwardError>;
+    readonly list: Effect.Effect<ReadonlyArray<DesktopPortForwardSnapshot>>;
+    readonly stop: (id: DesktopPortForwardId) => Effect.Effect<void>;
+    readonly stopEnvironment: (
+      environmentId: DesktopPortForwardSnapshot["environmentId"],
+    ) => Effect.Effect<void>;
+    readonly resolveAuthorization: (
+      requestId: string,
+      socketUrl: string | null,
+    ) => Effect.Effect<void>;
+    readonly subscribeStateChanges: (
+      listener: StateListener,
+    ) => Effect.Effect<void, never, Scope.Scope>;
+    readonly subscribeAuthorizationRequests: (
+      listener: AuthorizationListener,
+    ) => Effect.Effect<void, never, Scope.Scope>;
+  }
+>()("@t3tools/desktop/portForward/DesktopPortForwardManager") {}
+
+export const make = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const context = yield* Effect.context<never>();
+  const runFork = Effect.runForkWith(context);
+  const forwards = yield* Ref.make(new Map<DesktopPortForwardId, ManagedForward>());
+  const pendingAuthorizations = yield* Ref.make(
+    new Map<string, Deferred.Deferred<string, DesktopPortForwardError>>(),
+  );
+  const stateListeners = yield* Ref.make(new Set<StateListener>());
+  const authorizationListeners = yield* Ref.make(new Set<AuthorizationListener>());
+
+  const snapshots = Ref.get(forwards).pipe(
+    Effect.map((current) =>
+      [...current.values()]
+        .map((forward) => forward.snapshot)
+        .toSorted((a, b) => a.localPort - b.localPort),
+    ),
+  );
+  const publishState = Effect.flatMap(snapshots, (next) =>
+    Ref.get(stateListeners).pipe(
+      Effect.flatMap((listeners) => Effect.forEach(listeners, (listener) => listener(next))),
+      Effect.asVoid,
+    ),
+  );
+  const updateSnapshot = (
+    id: DesktopPortForwardId,
+    update: (snapshot: DesktopPortForwardSnapshot) => DesktopPortForwardSnapshot,
+  ) =>
+    Ref.update(forwards, (current) => {
+      const forward = current.get(id);
+      if (forward === undefined) return current;
+      forward.snapshot = update(forward.snapshot);
+      return new Map(current);
+    }).pipe(Effect.andThen(publishState));
+
+  const authorize = Effect.fn("DesktopPortForwardManager.authorize")(function* (
+    forward: ManagedForward,
+  ) {
+    const requestId = yield* crypto.randomUUIDv4.pipe(
+      Effect.mapError((cause) => new DesktopPortForwardError({ operation: "authorize", cause })),
+    );
+    const deferred = yield* Deferred.make<string, DesktopPortForwardError>();
+    yield* Ref.update(pendingAuthorizations, (current) =>
+      new Map(current).set(requestId, deferred),
+    );
+    const listeners = yield* Ref.get(authorizationListeners);
+    const request: DesktopPortForwardAuthorizationRequest = {
+      requestId,
+      forwardId: forward.snapshot.id,
+      environmentId: forward.snapshot.environmentId,
+      remoteHost: forward.snapshot.remoteHost,
+      remotePort: forward.snapshot.remotePort,
+    };
+    yield* Effect.forEach(listeners, (listener) => listener(request), { discard: true });
+    return yield* Deferred.await(deferred).pipe(
+      Effect.timeoutOption(AUTHORIZATION_TIMEOUT),
+      Effect.flatMap(
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new DesktopPortForwardError({
+                operation: "authorize",
+                cause: "Timed out waiting for renderer authorization.",
+              }),
+            ),
+          onSome: Effect.succeed,
+        }),
+      ),
+      Effect.ensuring(
+        Ref.update(pendingAuthorizations, (current) => {
+          const next = new Map(current);
+          next.delete(requestId);
+          return next;
+        }),
+      ),
+    );
+  });
+
+  const handleConnection = (forward: ManagedForward, socket: NodeNet.Socket) =>
+    Effect.gen(function* () {
+      const accepted = yield* Ref.modify(forwards, (current) => {
+        const activeTotal = [...current.values()].reduce(
+          (total, entry) => total + entry.sockets.size,
+          0,
+        );
+        if (
+          !current.has(forward.snapshot.id) ||
+          forward.sockets.size >= MAX_CONNECTIONS_PER_FORWARD ||
+          activeTotal >= MAX_CONNECTIONS_TOTAL
+        ) {
+          return [false, current] as const;
+        }
+        forward.sockets.add(socket);
+        return [true, new Map(current)] as const;
+      });
+      if (!accepted) {
+        socket.destroy();
+        return;
+      }
+      yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
+        ...snapshot,
+        activeConnections: snapshot.activeConnections + 1,
+        lastError: null,
+      }));
+      const socketUrl = yield* authorize(forward);
+      const webSocket = yield* openWebSocket(socketUrl);
+      forward.webSockets.add(webSocket);
+      yield* runConnection(socket, webSocket);
+      forward.webSockets.delete(webSocket);
+    }).pipe(
+      Effect.catch((error) =>
+        updateSnapshot(forward.snapshot.id, (snapshot) => ({
+          ...snapshot,
+          lastError: error.message,
+        })),
+      ),
+      Effect.ensuring(
+        Effect.gen(function* () {
+          forward.sockets.delete(socket);
+          socket.destroy();
+          yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
+            ...snapshot,
+            activeConnections: Math.max(0, snapshot.activeConnections - 1),
+          }));
+        }),
+      ),
+    );
+
+  const create: DesktopPortForwardManager["Service"]["create"] = Effect.fn(
+    "DesktopPortForwardManager.create",
+  )(function* (input) {
+    const id = DesktopPortForwardId.make(
+      yield* crypto.randomUUIDv4.pipe(
+        Effect.mapError((cause) => new DesktopPortForwardError({ operation: "create", cause })),
+      ),
+    );
+    let managed: ManagedForward | undefined;
+    const server = NodeNet.createServer({ allowHalfOpen: true }, (socket) => {
+      if (managed !== undefined) runFork(handleConnection(managed, socket));
+      else socket.destroy();
+    });
+    const localPort =
+      input.localPort === undefined
+        ? yield* listenAutomatically(server, input.remotePort)
+        : yield* listen(server, input.localPort);
+    const snapshot: DesktopPortForwardSnapshot = {
+      id,
+      environmentId: input.environmentId,
+      localHost: "127.0.0.1",
+      localPort,
+      remoteHost: input.remoteHost,
+      remotePort: input.remotePort,
+      status: "running",
+      activeConnections: 0,
+      lastError: null,
+    };
+    managed = { snapshot, server, sockets: new Set(), webSockets: new Set() };
+    yield* Ref.update(forwards, (current) => new Map(current).set(id, managed!));
+    yield* publishState;
+    return snapshot;
+  });
+
+  const stopManaged = (managed: ManagedForward) =>
+    Effect.sync(() => {
+      managed.server.close();
+      for (const socket of managed.sockets) socket.destroy();
+      for (const webSocket of managed.webSockets) webSocket.close();
+    });
+
+  const stop: DesktopPortForwardManager["Service"]["stop"] = (id) =>
+    Ref.modify(forwards, (current) => {
+      const next = new Map(current);
+      const managed = next.get(id);
+      next.delete(id);
+      return [Option.fromUndefinedOr(managed), next] as const;
+    }).pipe(
+      Effect.flatMap(Option.match({ onNone: () => Effect.void, onSome: stopManaged })),
+      Effect.andThen(publishState),
+    );
+
+  const stopEnvironment: DesktopPortForwardManager["Service"]["stopEnvironment"] = (
+    environmentId,
+  ) =>
+    Effect.gen(function* () {
+      const current = yield* Ref.get(forwards);
+      yield* Effect.forEach(
+        current.values(),
+        (managed) =>
+          managed.snapshot.environmentId === environmentId
+            ? stop(managed.snapshot.id)
+            : Effect.void,
+        { discard: true },
+      );
+    });
+
+  const resolveAuthorization: DesktopPortForwardManager["Service"]["resolveAuthorization"] = (
+    requestId,
+    socketUrl,
+  ) =>
+    Effect.gen(function* () {
+      const current = yield* Ref.get(pendingAuthorizations);
+      const deferred = current.get(requestId);
+      if (deferred === undefined) return;
+      if (socketUrl === null) {
+        yield* Deferred.fail(
+          deferred,
+          new DesktopPortForwardError({
+            operation: "authorize",
+            cause: "The environment could not authorize this connection.",
+          }),
+        );
+      } else {
+        yield* Deferred.succeed(deferred, socketUrl);
+      }
+    });
+
+  const subscribe = <A>(
+    ref: Ref.Ref<Set<(value: A) => Effect.Effect<void>>>,
+    listener: (value: A) => Effect.Effect<void>,
+  ) =>
+    Effect.acquireRelease(
+      Ref.update(ref, (current) => new Set(current).add(listener)),
+      () =>
+        Ref.update(ref, (current) => {
+          const next = new Set(current);
+          next.delete(listener);
+          return next;
+        }),
+    );
+
+  yield* Effect.addFinalizer(() =>
+    Ref.get(forwards).pipe(
+      Effect.flatMap((current) => Effect.forEach(current.values(), stopManaged, { discard: true })),
+    ),
+  );
+
+  return DesktopPortForwardManager.of({
+    create,
+    list: snapshots,
+    stop,
+    stopEnvironment,
+    resolveAuthorization,
+    subscribeStateChanges: (listener) => subscribe(stateListeners, listener),
+    subscribeAuthorizationRequests: (listener) => subscribe(authorizationListeners, listener),
+  });
+});
+
+export const layer = Layer.effect(DesktopPortForwardManager, make);

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -37,9 +37,16 @@ type AuthorizationListener = (
 
 interface ManagedForward {
   snapshot: DesktopPortForwardSnapshot;
+  generation: number;
   readonly server: NodeNet.Server;
   readonly sockets: Set<NodeNet.Socket>;
   readonly webSockets: Set<WebSocket>;
+}
+
+interface PendingAuthorization {
+  readonly forwardId: DesktopPortForwardId;
+  readonly generation: number;
+  readonly deferred: Deferred.Deferred<string, DesktopPortForwardError>;
 }
 
 export class DesktopPortForwardError extends Schema.TaggedErrorClass<DesktopPortForwardError>()(
@@ -339,6 +346,9 @@ export class DesktopPortForwardManager extends Context.Service<
     readonly stopEnvironment: (
       environmentId: DesktopPortForwardSnapshot["environmentId"],
     ) => Effect.Effect<void>;
+    readonly resetEnvironmentConnections: (
+      environmentId: DesktopPortForwardSnapshot["environmentId"],
+    ) => Effect.Effect<void>;
     readonly resolveAuthorization: (
       requestId: string,
       socketUrl: string | null,
@@ -358,9 +368,7 @@ export const make = Effect.gen(function* () {
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
   const forwards = yield* Ref.make(new Map<DesktopPortForwardId, ManagedForward>());
-  const pendingAuthorizations = yield* Ref.make(
-    new Map<string, Deferred.Deferred<string, DesktopPortForwardError>>(),
-  );
+  const pendingAuthorizations = yield* Ref.make(new Map<string, PendingAuthorization>());
   const stateListeners = yield* Ref.make(new Set<StateListener>());
   const authorizationListeners = yield* Ref.make(new Set<AuthorizationListener>());
 
@@ -380,23 +388,34 @@ export const make = Effect.gen(function* () {
   const updateSnapshot = (
     id: DesktopPortForwardId,
     update: (snapshot: DesktopPortForwardSnapshot) => DesktopPortForwardSnapshot,
+    generation?: number,
   ) =>
     Ref.update(forwards, (current) => {
       const forward = current.get(id);
-      if (forward === undefined) return current;
+      if (
+        forward === undefined ||
+        (generation !== undefined && forward.generation !== generation)
+      ) {
+        return current;
+      }
       forward.snapshot = update(forward.snapshot);
       return new Map(current);
     }).pipe(Effect.andThen(publishState));
 
   const authorize = Effect.fn("DesktopPortForwardManager.authorize")(function* (
     forward: ManagedForward,
+    generation: number,
   ) {
     const requestId = yield* crypto.randomUUIDv4.pipe(
       Effect.mapError((cause) => new DesktopPortForwardError({ operation: "authorize", cause })),
     );
     const deferred = yield* Deferred.make<string, DesktopPortForwardError>();
     yield* Ref.update(pendingAuthorizations, (current) =>
-      new Map(current).set(requestId, deferred),
+      new Map(current).set(requestId, {
+        forwardId: forward.snapshot.id,
+        generation,
+        deferred,
+      }),
     );
     const listeners = yield* Ref.get(authorizationListeners);
     const request: DesktopPortForwardAuthorizationRequest = {
@@ -433,6 +452,7 @@ export const make = Effect.gen(function* () {
 
   const handleConnection = (forward: ManagedForward, socket: NodeNet.Socket) => {
     let connectionState: "connecting" | "connected" = "connecting";
+    const generation = forward.generation;
     return Effect.gen(function* () {
       const accepted = yield* Ref.modify(forwards, (current) => {
         const activeTotal = [...current.values()].reduce(
@@ -453,41 +473,62 @@ export const make = Effect.gen(function* () {
         socket.destroy();
         return;
       }
-      yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
-        ...snapshot,
-        connectingConnections: snapshot.connectingConnections + 1,
-        lastError: null,
-      }));
-      const socketUrl = yield* authorize(forward);
+      yield* updateSnapshot(
+        forward.snapshot.id,
+        (snapshot) => ({
+          ...snapshot,
+          connectingConnections: snapshot.connectingConnections + 1,
+          lastError: null,
+        }),
+        generation,
+      );
+      const socketUrl = yield* authorize(forward, generation);
+      if (forward.generation !== generation || !forward.sockets.has(socket)) return;
       const webSocket = yield* openWebSocket(socketUrl);
+      if (forward.generation !== generation || !forward.sockets.has(socket)) {
+        webSocket.close();
+        return;
+      }
       forward.webSockets.add(webSocket);
-      yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
-        ...snapshot,
-        connectingConnections: Math.max(0, snapshot.connectingConnections - 1),
-        activeConnections: snapshot.activeConnections + 1,
-      }));
+      yield* updateSnapshot(
+        forward.snapshot.id,
+        (snapshot) => ({
+          ...snapshot,
+          connectingConnections: Math.max(0, snapshot.connectingConnections - 1),
+          activeConnections: snapshot.activeConnections + 1,
+        }),
+        generation,
+      );
       connectionState = "connected";
       yield* runConnection(socket, webSocket);
       forward.webSockets.delete(webSocket);
     }).pipe(
       Effect.catch((error) =>
-        updateSnapshot(forward.snapshot.id, (snapshot) => ({
-          ...snapshot,
-          lastError: error.message,
-        })),
+        updateSnapshot(
+          forward.snapshot.id,
+          (snapshot) => ({
+            ...snapshot,
+            lastError: error.message,
+          }),
+          generation,
+        ),
       ),
       Effect.ensuring(
         Effect.gen(function* () {
           forward.sockets.delete(socket);
           socket.destroy();
-          yield* updateSnapshot(forward.snapshot.id, (snapshot) => ({
-            ...snapshot,
-            ...(connectionState === "connected"
-              ? { activeConnections: Math.max(0, snapshot.activeConnections - 1) }
-              : {
-                  connectingConnections: Math.max(0, snapshot.connectingConnections - 1),
-                }),
-          }));
+          yield* updateSnapshot(
+            forward.snapshot.id,
+            (snapshot) => ({
+              ...snapshot,
+              ...(connectionState === "connected"
+                ? { activeConnections: Math.max(0, snapshot.activeConnections - 1) }
+                : {
+                    connectingConnections: Math.max(0, snapshot.connectingConnections - 1),
+                  }),
+            }),
+            generation,
+          );
         }),
       ),
     );
@@ -522,7 +563,7 @@ export const make = Effect.gen(function* () {
       activeConnections: 0,
       lastError: null,
     };
-    managed = { snapshot, server, sockets: new Set(), webSockets: new Set() };
+    managed = { snapshot, generation: 0, server, sockets: new Set(), webSockets: new Set() };
     yield* Ref.update(forwards, (current) => new Map(current).set(id, managed!));
     yield* publishState;
     return snapshot;
@@ -530,9 +571,12 @@ export const make = Effect.gen(function* () {
 
   const stopManaged = (managed: ManagedForward) =>
     Effect.sync(() => {
+      managed.generation += 1;
       managed.server.close();
       for (const socket of managed.sockets) socket.destroy();
       for (const webSocket of managed.webSockets) webSocket.close();
+      managed.sockets.clear();
+      managed.webSockets.clear();
     });
 
   const stop: DesktopPortForwardManager["Service"]["stop"] = (id) =>
@@ -561,6 +605,76 @@ export const make = Effect.gen(function* () {
       );
     });
 
+  const resetEnvironmentConnections: DesktopPortForwardManager["Service"]["resetEnvironmentConnections"] =
+    (environmentId) =>
+      Effect.gen(function* () {
+        const retired = yield* Ref.modify(forwards, (current) => {
+          const resources: Array<{
+            readonly id: DesktopPortForwardId;
+            readonly generation: number;
+            readonly sockets: ReadonlyArray<NodeNet.Socket>;
+            readonly webSockets: ReadonlyArray<WebSocket>;
+          }> = [];
+          let changed = false;
+          for (const managed of current.values()) {
+            if (managed.snapshot.environmentId !== environmentId) continue;
+            changed = true;
+            resources.push({
+              id: managed.snapshot.id,
+              generation: managed.generation,
+              sockets: [...managed.sockets],
+              webSockets: [...managed.webSockets],
+            });
+            managed.generation += 1;
+            managed.sockets.clear();
+            managed.webSockets.clear();
+            managed.snapshot = {
+              ...managed.snapshot,
+              connectingConnections: 0,
+              activeConnections: 0,
+              lastError: null,
+            };
+          }
+          return [resources, changed ? new Map(current) : current] as const;
+        });
+        if (retired.length === 0) return;
+
+        const retiredGenerations = new Map(
+          retired.map((entry) => [entry.id, entry.generation] as const),
+        );
+        const interrupted = yield* Ref.modify(pendingAuthorizations, (current) => {
+          const next = new Map(current);
+          const pending: Array<PendingAuthorization> = [];
+          for (const [requestId, authorization] of next) {
+            if (retiredGenerations.get(authorization.forwardId) !== authorization.generation) {
+              continue;
+            }
+            pending.push(authorization);
+            next.delete(requestId);
+          }
+          return [pending, next] as const;
+        });
+        yield* Effect.forEach(
+          interrupted,
+          (authorization) =>
+            Deferred.fail(
+              authorization.deferred,
+              new DesktopPortForwardError({
+                operation: "route-transition",
+                cause: "The selected environment connection method changed.",
+              }),
+            ),
+          { discard: true },
+        );
+        yield* Effect.sync(() => {
+          for (const entry of retired) {
+            for (const socket of entry.sockets) socket.destroy();
+            for (const webSocket of entry.webSockets) webSocket.close();
+          }
+        });
+        yield* publishState;
+      });
+
   const resolveAuthorization: DesktopPortForwardManager["Service"]["resolveAuthorization"] = (
     requestId,
     socketUrl,
@@ -568,11 +682,11 @@ export const make = Effect.gen(function* () {
   ) =>
     Effect.gen(function* () {
       const current = yield* Ref.get(pendingAuthorizations);
-      const deferred = current.get(requestId);
-      if (deferred === undefined) return;
+      const authorization = current.get(requestId);
+      if (authorization === undefined) return;
       if (socketUrl === null) {
         yield* Deferred.fail(
-          deferred,
+          authorization.deferred,
           new DesktopPortForwardError({
             operation: "authorize",
             cause: error ?? "The environment could not authorize this connection.",
@@ -580,7 +694,7 @@ export const make = Effect.gen(function* () {
           }),
         );
       } else {
-        yield* Deferred.succeed(deferred, socketUrl);
+        yield* Deferred.succeed(authorization.deferred, socketUrl);
       }
     });
 
@@ -609,6 +723,7 @@ export const make = Effect.gen(function* () {
     list: snapshots,
     stop,
     stopEnvironment,
+    resetEnvironmentConnections,
     resolveAuthorization,
     subscribeStateChanges: (listener) => subscribe(stateListeners, listener),
     subscribeAuthorizationRequests: (listener) => subscribe(authorizationListeners, listener),

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -22,6 +22,7 @@ import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as NodeNet from "node:net";
 
 const AUTHORIZATION_TIMEOUT = Duration.seconds(45);
@@ -407,6 +408,7 @@ export const make = Effect.gen(function* () {
   const pendingAuthorizations = yield* Ref.make(new Map<string, PendingAuthorization>());
   const stateListeners = yield* Ref.make(new Set<StateListener>());
   const authorizationListeners = yield* Ref.make(new Set<AuthorizationListener>());
+  const statePublicationMutex = yield* Semaphore.make(1);
 
   const snapshots = Ref.get(forwards).pipe(
     Effect.map((current) =>
@@ -415,10 +417,12 @@ export const make = Effect.gen(function* () {
         .toSorted((a, b) => a.localPort - b.localPort),
     ),
   );
-  const publishState = Effect.flatMap(snapshots, (next) =>
-    Ref.get(stateListeners).pipe(
-      Effect.flatMap((listeners) => Effect.forEach(listeners, (listener) => listener(next))),
-      Effect.asVoid,
+  const publishState = statePublicationMutex.withPermit(
+    Effect.flatMap(snapshots, (next) =>
+      Ref.get(stateListeners).pipe(
+        Effect.flatMap((listeners) => Effect.forEach(listeners, (listener) => listener(next))),
+        Effect.asVoid,
+      ),
     ),
   );
   const updateSnapshot = (

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -63,13 +63,15 @@ export class DesktopPortForwardError extends Schema.TaggedErrorClass<DesktopPort
       "stop",
       "validate-ticket-url",
     ]),
+    localPort: Schema.optionalKey(Schema.Number),
     cause: Schema.optionalKey(Schema.Defect()),
     detail: Schema.optionalKey(Schema.String),
   },
 ) {
   override get message(): string {
+    const target = this.localPort === undefined ? "" : ` on local port ${this.localPort}`;
     const suffix = this.detail === undefined ? "" : `: ${this.detail}`;
-    return `Desktop port forward ${this.operation} failed${suffix}.`;
+    return `Desktop port forward ${this.operation} failed${target}${suffix}.`;
   }
 }
 
@@ -93,7 +95,9 @@ const listen = (server: NodeNet.Server, port: number) =>
   Effect.callback<number, DesktopPortForwardError>((resume) => {
     const onError = (cause: Error) => {
       server.off("listening", onListening);
-      resume(Effect.fail(new DesktopPortForwardError({ operation: "listen", cause })));
+      resume(
+        Effect.fail(new DesktopPortForwardError({ operation: "listen", localPort: port, cause })),
+      );
     };
     const onListening = () => {
       server.off("error", onError);
@@ -103,6 +107,7 @@ const listen = (server: NodeNet.Server, port: number) =>
           Effect.fail(
             new DesktopPortForwardError({
               operation: "resolve-listener-address",
+              localPort: port,
               detail: "The listener returned an unusable address.",
             }),
           ),

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -51,7 +51,20 @@ interface PendingAuthorization {
 
 export class DesktopPortForwardError extends Schema.TaggedErrorClass<DesktopPortForwardError>()(
   "DesktopPortForwardError",
-  { operation: Schema.String, cause: Schema.Defect(), detail: Schema.optionalKey(Schema.String) },
+  {
+    operation: Schema.Literals([
+      "authorize",
+      "connect-bridge",
+      "create",
+      "listen",
+      "resolve-listener-address",
+      "route-transition",
+      "stop",
+      "validate-ticket-url",
+    ]),
+    cause: Schema.optionalKey(Schema.Defect()),
+    detail: Schema.optionalKey(Schema.String),
+  },
 ) {
   override get message(): string {
     const suffix = this.detail === undefined ? "" : `: ${this.detail}`;
@@ -89,7 +102,7 @@ const listen = (server: NodeNet.Server, port: number) =>
           Effect.fail(
             new DesktopPortForwardError({
               operation: "resolve-listener-address",
-              cause: address,
+              detail: "The listener returned an unusable address.",
             }),
           ),
         );
@@ -159,7 +172,7 @@ const openWebSocket = (socketUrl: string) =>
         Effect.fail(
           new DesktopPortForwardError({
             operation: "validate-ticket-url",
-            cause: "The renderer supplied an invalid bridge URL.",
+            detail: "The renderer supplied an invalid bridge URL.",
           }),
         ),
       );
@@ -185,12 +198,18 @@ const openWebSocket = (socketUrl: string) =>
     });
   });
 
-const runConnection = (socket: NodeNet.Socket, webSocket: WebSocket): Effect.Effect<void, never> =>
+export const runConnection = (
+  socket: NodeNet.Socket,
+  webSocket: WebSocket,
+): Effect.Effect<void, never> =>
   Effect.callback<void>((resume) => {
     let credit = TCP_PORT_FORWARD_INITIAL_CREDIT;
     let outstanding = 0;
+    let receiveCredit = TCP_PORT_FORWARD_INITIAL_CREDIT;
     let pending: Uint8Array = new Uint8Array(0);
-    let socketEnded = false;
+    let socketReadEnded = false;
+    let socketReadEndSent = false;
+    let socketWriteEnded = false;
     let closed = false;
 
     const send = (frame: Uint8Array) => {
@@ -223,8 +242,17 @@ const runConnection = (socket: NodeNet.Socket, webSocket: WebSocket): Effect.Eff
         outstanding += size;
         send(dataFrame(chunk));
       }
-      if (pending.byteLength === 0 && credit > 0) socket.resume();
-      else socket.pause();
+      if (pending.byteLength === 0) {
+        if (socketReadEnded && !socketReadEndSent) {
+          socketReadEndSent = true;
+          send(controlFrame(TCP_PORT_FORWARD_FRAME_WRITE_END));
+        }
+        if (!socketReadEnded && credit > 0) {
+          socket.resume();
+          return;
+        }
+      }
+      socket.pause();
     };
     const onSocketData = (chunk: Buffer) => {
       if (pending.byteLength === 0) {
@@ -237,7 +265,10 @@ const runConnection = (socket: NodeNet.Socket, webSocket: WebSocket): Effect.Eff
       }
       flushSocketData();
     };
-    const onSocketEnd = () => send(controlFrame(TCP_PORT_FORWARD_FRAME_WRITE_END));
+    const onSocketEnd = () => {
+      socketReadEnded = true;
+      flushSocketData();
+    };
     const onSocketError = () => finish();
     const onSocketClose = () => {
       send(controlFrame(TCP_PORT_FORWARD_FRAME_CLOSE));
@@ -257,14 +288,19 @@ const runConnection = (socket: NodeNet.Socket, webSocket: WebSocket): Effect.Eff
           if (
             payload.byteLength === 0 ||
             payload.byteLength > TCP_PORT_FORWARD_MAX_DATA_SIZE ||
-            socketEnded
+            socketWriteEnded ||
+            payload.byteLength > receiveCredit
           ) {
             protocolFailure();
             return;
           }
+          receiveCredit -= payload.byteLength;
           socket.write(payload, (error) => {
             if (error) finish();
-            else send(ackFrame(payload.byteLength));
+            else {
+              receiveCredit += payload.byteLength;
+              send(ackFrame(payload.byteLength));
+            }
           });
           return;
         }
@@ -287,11 +323,11 @@ const runConnection = (socket: NodeNet.Socket, webSocket: WebSocket): Effect.Eff
           return;
         }
         case TCP_PORT_FORWARD_FRAME_WRITE_END:
-          if (frame.byteLength !== 1 || socketEnded) {
+          if (frame.byteLength !== 1 || socketWriteEnded) {
             protocolFailure();
             return;
           }
-          socketEnded = true;
+          socketWriteEnded = true;
           socket.end();
           return;
         case TCP_PORT_FORWARD_FRAME_CLOSE:
@@ -434,7 +470,7 @@ export const make = Effect.gen(function* () {
             Effect.fail(
               new DesktopPortForwardError({
                 operation: "authorize",
-                cause: "Timed out waiting for renderer authorization.",
+                detail: "Timed out waiting for renderer authorization.",
               }),
             ),
           onSome: Effect.succeed,
@@ -603,7 +639,7 @@ export const make = Effect.gen(function* () {
           authorization.deferred,
           new DesktopPortForwardError({
             operation: "stop",
-            cause: "The desktop port forward stopped.",
+            detail: "The desktop port forward stopped.",
           }),
         ),
       { discard: true },
@@ -692,7 +728,7 @@ export const make = Effect.gen(function* () {
               authorization.deferred,
               new DesktopPortForwardError({
                 operation: "route-transition",
-                cause: "The selected environment connection method changed.",
+                detail: "The selected environment connection method changed.",
               }),
             ),
           { discard: true },
@@ -720,8 +756,7 @@ export const make = Effect.gen(function* () {
           authorization.deferred,
           new DesktopPortForwardError({
             operation: "authorize",
-            cause: error ?? "The environment could not authorize this connection.",
-            ...(error === undefined ? {} : { detail: error }),
+            detail: error ?? "The environment could not authorize this connection.",
           }),
         );
       } else {

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -44,10 +44,11 @@ interface ManagedForward {
 
 export class DesktopPortForwardError extends Schema.TaggedErrorClass<DesktopPortForwardError>()(
   "DesktopPortForwardError",
-  { operation: Schema.String, cause: Schema.Defect() },
+  { operation: Schema.String, cause: Schema.Defect(), detail: Schema.optionalKey(Schema.String) },
 ) {
   override get message(): string {
-    return `Desktop port forward ${this.operation} failed.`;
+    const suffix = this.detail === undefined ? "" : `: ${this.detail}`;
+    return `Desktop port forward ${this.operation} failed${suffix}.`;
   }
 }
 
@@ -341,6 +342,7 @@ export class DesktopPortForwardManager extends Context.Service<
     readonly resolveAuthorization: (
       requestId: string,
       socketUrl: string | null,
+      error?: string,
     ) => Effect.Effect<void>;
     readonly subscribeStateChanges: (
       listener: StateListener,
@@ -549,6 +551,7 @@ export const make = Effect.gen(function* () {
   const resolveAuthorization: DesktopPortForwardManager["Service"]["resolveAuthorization"] = (
     requestId,
     socketUrl,
+    error,
   ) =>
     Effect.gen(function* () {
       const current = yield* Ref.get(pendingAuthorizations);
@@ -559,7 +562,8 @@ export const make = Effect.gen(function* () {
           deferred,
           new DesktopPortForwardError({
             operation: "authorize",
-            cause: "The environment could not authorize this connection.",
+            cause: error ?? "The environment could not authorize this connection.",
+            ...(error === undefined ? {} : { detail: error }),
           }),
         );
       } else {

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -569,8 +569,11 @@ export const make = Effect.gen(function* () {
     return snapshot;
   });
 
-  const stopManaged = (managed: ManagedForward) =>
-    Effect.sync(() => {
+  const stopManaged = Effect.fn("DesktopPortForwardManager.stopManaged")(function* (
+    managed: ManagedForward,
+  ) {
+    const generation = managed.generation;
+    yield* Effect.sync(() => {
       managed.generation += 1;
       managed.server.close();
       for (const socket of managed.sockets) socket.destroy();
@@ -578,6 +581,34 @@ export const make = Effect.gen(function* () {
       managed.sockets.clear();
       managed.webSockets.clear();
     });
+    const interrupted = yield* Ref.modify(pendingAuthorizations, (current) => {
+      const next = new Map(current);
+      const pending: Array<PendingAuthorization> = [];
+      for (const [requestId, authorization] of next) {
+        if (
+          authorization.forwardId !== managed.snapshot.id ||
+          authorization.generation !== generation
+        ) {
+          continue;
+        }
+        pending.push(authorization);
+        next.delete(requestId);
+      }
+      return [pending, next] as const;
+    });
+    yield* Effect.forEach(
+      interrupted,
+      (authorization) =>
+        Deferred.fail(
+          authorization.deferred,
+          new DesktopPortForwardError({
+            operation: "stop",
+            cause: "The desktop port forward stopped.",
+          }),
+        ),
+      { discard: true },
+    );
+  });
 
   const stop: DesktopPortForwardManager["Service"]["stop"] = (id) =>
     Ref.modify(forwards, (current) => {

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -181,7 +181,6 @@ const openWebSocket = (socketUrl: string) =>
     const webSocket = new WebSocket(url);
     webSocket.binaryType = "arraybuffer";
     const onOpen = () => {
-      webSocket.removeEventListener("error", onError);
       resume(Effect.succeed(webSocket));
     };
     const onError = (cause: Event) => {
@@ -357,6 +356,7 @@ export const runConnection = (
     webSocket.addEventListener("close", onWebSocketClose, { once: true });
     webSocket.addEventListener("error", onWebSocketError, { once: true });
     socket.setTimeout(IDLE_TIMEOUT_MS, finish);
+    if (webSocket.readyState !== WebSocket.OPEN) finish();
 
     return Effect.sync(() => {
       socket.off("data", onSocketData);
@@ -496,7 +496,8 @@ export const make = Effect.gen(function* () {
           0,
         );
         if (
-          !current.has(forward.snapshot.id) ||
+          current.get(forward.snapshot.id) !== forward ||
+          forward.generation !== generation ||
           forward.sockets.size >= MAX_CONNECTIONS_PER_FORWARD ||
           activeTotal >= MAX_CONNECTIONS_TOTAL
         ) {

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -457,7 +457,6 @@ export const make = Effect.gen(function* () {
         deferred,
       }),
     );
-    const listeners = yield* Ref.get(authorizationListeners);
     const request: DesktopPortForwardAuthorizationRequest = {
       requestId,
       forwardId: forward.snapshot.id,
@@ -465,21 +464,25 @@ export const make = Effect.gen(function* () {
       remoteHost: forward.snapshot.remoteHost,
       remotePort: forward.snapshot.remotePort,
     };
-    yield* Effect.forEach(listeners, (listener) => listener(request), { discard: true });
-    return yield* Deferred.await(deferred).pipe(
-      Effect.timeoutOption(AUTHORIZATION_TIMEOUT),
-      Effect.flatMap(
-        Option.match({
-          onNone: () =>
-            Effect.fail(
-              new DesktopPortForwardError({
-                operation: "authorize",
-                detail: "Timed out waiting for renderer authorization.",
-              }),
-            ),
-          onSome: Effect.succeed,
-        }),
-      ),
+    return yield* Effect.gen(function* () {
+      const listeners = yield* Ref.get(authorizationListeners);
+      yield* Effect.forEach(listeners, (listener) => listener(request), { discard: true });
+      return yield* Deferred.await(deferred).pipe(
+        Effect.timeoutOption(AUTHORIZATION_TIMEOUT),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new DesktopPortForwardError({
+                  operation: "authorize",
+                  detail: "Timed out waiting for renderer authorization.",
+                }),
+              ),
+            onSome: Effect.succeed,
+          }),
+        ),
+      );
+    }).pipe(
       Effect.ensuring(
         Ref.update(pendingAuthorizations, (current) => {
           const next = new Map(current);

--- a/apps/desktop/src/portForward/DesktopPortForwardManager.ts
+++ b/apps/desktop/src/portForward/DesktopPortForwardManager.ts
@@ -24,7 +24,7 @@ import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as NodeNet from "node:net";
 
-const AUTHORIZATION_TIMEOUT = Duration.seconds(15);
+const AUTHORIZATION_TIMEOUT = Duration.seconds(45);
 const MAX_CONNECTIONS_PER_FORWARD = 32;
 const MAX_CONNECTIONS_TOTAL = 128;
 const IDLE_TIMEOUT_MS = 5 * 60 * 1_000;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -112,6 +112,39 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
   probeRemoteEditors: () => ipcRenderer.invoke(IpcChannels.PROBE_REMOTE_EDITORS_CHANNEL, undefined),
+  portForward: {
+    create: (input) => ipcRenderer.invoke(IpcChannels.PORT_FORWARD_CREATE_CHANNEL, input),
+    list: () => ipcRenderer.invoke(IpcChannels.PORT_FORWARD_LIST_CHANNEL),
+    stop: (id) => ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_CHANNEL, { id }),
+    stopEnvironment: (environmentId) =>
+      ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL, { environmentId }),
+    resolveAuthorization: (requestId, socketUrl) =>
+      ipcRenderer.invoke(IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL, {
+        requestId,
+        socketUrl,
+      }),
+    onStateChange: (listener) => {
+      const wrappedListener = (_event: Electron.IpcRendererEvent, snapshots: unknown) => {
+        if (!Array.isArray(snapshots)) return;
+        listener(snapshots as Parameters<typeof listener>[0]);
+      };
+      ipcRenderer.on(IpcChannels.PORT_FORWARD_STATE_CHANNEL, wrappedListener);
+      return () =>
+        ipcRenderer.removeListener(IpcChannels.PORT_FORWARD_STATE_CHANNEL, wrappedListener);
+    },
+    onAuthorizationRequest: (listener) => {
+      const wrappedListener = (_event: Electron.IpcRendererEvent, request: unknown) => {
+        if (typeof request !== "object" || request === null) return;
+        listener(request as Parameters<typeof listener>[0]);
+      };
+      ipcRenderer.on(IpcChannels.PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL, wrappedListener);
+      return () =>
+        ipcRenderer.removeListener(
+          IpcChannels.PORT_FORWARD_AUTHORIZATION_REQUEST_CHANNEL,
+          wrappedListener,
+        );
+    },
+  },
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -118,12 +118,14 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     stop: (id) => ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_CHANNEL, { id }),
     stopEnvironment: (environmentId) =>
       ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL, { environmentId }),
-    resolveAuthorization: (requestId, socketUrl, error) =>
-      ipcRenderer.invoke(IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL, {
+    resolveAuthorization: (requestId, socketUrl, error) => {
+      const normalizedError = error?.trim();
+      return ipcRenderer.invoke(IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL, {
         requestId,
         socketUrl,
-        ...(error === undefined ? {} : { error }),
-      }),
+        ...(normalizedError ? { error: normalizedError } : {}),
+      });
+    },
     onStateChange: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, snapshots: unknown) => {
         if (!Array.isArray(snapshots)) return;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -118,6 +118,10 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     stop: (id) => ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_CHANNEL, { id }),
     stopEnvironment: (environmentId) =>
       ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL, { environmentId }),
+    resetEnvironmentConnections: (environmentId) =>
+      ipcRenderer.invoke(IpcChannels.PORT_FORWARD_RESET_ENVIRONMENT_CONNECTIONS_CHANNEL, {
+        environmentId,
+      }),
     resolveAuthorization: (requestId, socketUrl, error) => {
       const normalizedError = error?.trim();
       return ipcRenderer.invoke(IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL, {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -118,10 +118,11 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     stop: (id) => ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_CHANNEL, { id }),
     stopEnvironment: (environmentId) =>
       ipcRenderer.invoke(IpcChannels.PORT_FORWARD_STOP_ENVIRONMENT_CHANNEL, { environmentId }),
-    resolveAuthorization: (requestId, socketUrl) =>
+    resolveAuthorization: (requestId, socketUrl, error) =>
       ipcRenderer.invoke(IpcChannels.PORT_FORWARD_RESOLVE_AUTHORIZATION_CHANNEL, {
         requestId,
         socketUrl,
+        ...(error === undefined ? {} : { error }),
       }),
     onStateChange: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, snapshots: unknown) => {

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -3,6 +3,7 @@ import {
   ConnectionRegistrationStore,
   ConnectionTargetStore,
   registerConnectionInCatalog,
+  removeConnectionRouteFromCatalog,
   removeConnectionFromCatalog,
   removeCatalogValue,
   replaceCatalogValue,
@@ -27,6 +28,7 @@ function targetPersistenceError(
     | "list-routes"
     | "register-connection"
     | "select-connection-route"
+    | "remove-connection-route"
     | "remove-connection",
   error: ConnectionTransientError,
 ) {
@@ -60,6 +62,12 @@ export const connectionStorageLayer = Layer.effectContext(
           .update((document) => selectConnectionRouteInCatalog(document, target))
           .pipe(
             Effect.mapError((error) => targetPersistenceError("select-connection-route", error)),
+          ),
+      removeRoute: (target, fallback) =>
+        catalog
+          .update((document) => removeConnectionRouteFromCatalog(document, target, fallback))
+          .pipe(
+            Effect.mapError((error) => targetPersistenceError("remove-connection-route", error)),
           ),
       remove: (target) =>
         catalog

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -6,6 +6,8 @@ import {
   removeConnectionFromCatalog,
   removeCatalogValue,
   replaceCatalogValue,
+  selectConnectionRouteInCatalog,
+  connectionRoutes,
 } from "@t3tools/client-runtime/platform";
 import { TokenStore } from "@t3tools/client-runtime/authorization";
 import {
@@ -20,7 +22,12 @@ import * as Option from "effect/Option";
 import * as CatalogStore from "./catalog-store";
 
 function targetPersistenceError(
-  operation: "list-targets" | "register-connection" | "remove-connection",
+  operation:
+    | "list-targets"
+    | "list-routes"
+    | "register-connection"
+    | "select-connection-route"
+    | "remove-connection",
   error: ConnectionTransientError,
 ) {
   return new ConnectionPersistenceError({
@@ -38,12 +45,22 @@ export const connectionStorageLayer = Layer.effectContext(
         Effect.map((document) => document.targets),
         Effect.mapError((error) => targetPersistenceError("list-targets", error)),
       ),
+      listRoutes: catalog.read.pipe(
+        Effect.map(connectionRoutes),
+        Effect.mapError((error) => targetPersistenceError("list-routes", error)),
+      ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
+      select: (target) =>
+        catalog
+          .update((document) => selectConnectionRouteInCatalog(document, target))
+          .pipe(
+            Effect.mapError((error) => targetPersistenceError("select-connection-route", error)),
+          ),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))

--- a/apps/server/src/auth/SessionStore.ts
+++ b/apps/server/src/auth/SessionStore.ts
@@ -17,6 +17,7 @@ import * as Layer from "effect/Layer";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as Option from "effect/Option";
 
@@ -389,6 +390,11 @@ export class SessionStore extends Context.Service<
       SessionCredentialInternalError
     >;
     readonly streamChanges: Stream.Stream<SessionCredentialChange>;
+    readonly subscribeChanges: Effect.Effect<
+      PubSub.Subscription<SessionCredentialChange>,
+      never,
+      Scope.Scope
+    >;
     readonly revoke: (
       sessionId: AuthSessionId,
     ) => Effect.Effect<boolean, SessionCredentialInternalError>;
@@ -938,6 +944,7 @@ export const make = Effect.gen(function* () {
     get streamChanges() {
       return Stream.fromPubSub(changesPubSub);
     },
+    subscribeChanges: PubSub.subscribe(changesPubSub),
     revoke,
     revokeAllExcept,
     markConnected,

--- a/apps/server/src/auth/http.ts
+++ b/apps/server/src/auth/http.ts
@@ -36,6 +36,7 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 
 import * as EnvironmentAuth from "./EnvironmentAuth.ts";
 import * as SessionStore from "./SessionStore.ts";
+import * as TcpForwardTicketStore from "../portForward/TcpForwardTicketStore.ts";
 import { traceAuthenticatedRelayRequest, traceRelayRequest } from "../cloud/traceRelayRequest.ts";
 import { deriveAuthClientMetadata } from "./utils.ts";
 import { verifyRequestDpopProof } from "./dpop.ts";
@@ -203,6 +204,7 @@ export const authHttpApiLayer = HttpApiBuilder.group(
   Effect.fnUntraced(function* (handlers) {
     const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
     const sessions = yield* SessionStore.SessionStore;
+    const tcpForwardTickets = yield* TcpForwardTicketStore.TcpForwardTicketStore;
 
     return handlers
       .handle(
@@ -328,6 +330,24 @@ export const authHttpApiLayer = HttpApiBuilder.group(
           },
           Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
             failEnvironmentInternal("websocket_ticket_issuance_failed", error),
+          ),
+        ),
+      )
+      .handle(
+        "tcpPortForwardTicket",
+        Effect.fn("environment.auth.tcpPortForwardTicket")(
+          function* (args) {
+            yield* annotateEnvironmentRequest(args.endpoint.name);
+            const session = yield* requireEnvironmentScope(AuthTerminalOperateScope);
+            yield* appendCredentialResponseHeaders;
+            return yield* tcpForwardTickets.issue({
+              sessionId: session.sessionId,
+              remoteHost: args.payload.remoteHost,
+              remotePort: args.payload.remotePort,
+            });
+          },
+          Effect.catchTag("TcpForwardTicketIssueError", (error) =>
+            failEnvironmentInternal("tcp_forward_ticket_issuance_failed", error),
           ),
         ),
       )

--- a/apps/server/src/auth/http.ts
+++ b/apps/server/src/auth/http.ts
@@ -346,9 +346,10 @@ export const authHttpApiLayer = HttpApiBuilder.group(
               remotePort: args.payload.remotePort,
             });
           },
-          Effect.catchTag("TcpForwardTicketIssueError", (error) =>
-            failEnvironmentInternal("tcp_forward_ticket_issuance_failed", error),
-          ),
+          Effect.catchTags({
+            TcpForwardTicketIssueError: (error) =>
+              failEnvironmentInternal("tcp_forward_ticket_issuance_failed", error),
+          }),
         ),
       )
       .handle(

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -152,6 +152,7 @@ export const make = Effect.gen(function* () {
       threadPinning: true,
       threadPinReorder: true,
       threadTitleRegeneration: true,
+      tcpPortForwarding: true,
       ...(serverSelfUpdate === null ? {} : { serverSelfUpdate }),
       ...(serverSelfUpdate === "boot-service" ? { serverSelfUpdateProgress: true } : {}),
     },

--- a/apps/server/src/portForward/TcpForwardBridge.test.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.test.ts
@@ -117,9 +117,15 @@ it("fails after both loopback addresses are unavailable", async () => {
     return createSocket("error");
   });
 
-  await expect(
-    Effect.runPromise(makeConnectTarget(createConnection)("127.0.0.1", 5173)),
-  ).rejects.toMatchObject({ host: "127.0.0.1", port: 5173 });
+  const failure = await Effect.runPromise(
+    Effect.flip(makeConnectTarget(createConnection)("127.0.0.1", 5173)),
+  );
+  expect(failure).toMatchObject({ host: "127.0.0.1", port: 5173 });
+  expect(failure.cause).toBeInstanceOf(AggregateError);
+  expect((failure.cause as AggregateError).errors).toMatchObject([
+    { host: "127.0.0.1", port: 5173 },
+    { host: "::1", port: 5173 },
+  ]);
   expect(attemptedHosts).toEqual(["127.0.0.1", "::1"]);
 });
 

--- a/apps/server/src/portForward/TcpForwardBridge.test.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.test.ts
@@ -101,6 +101,15 @@ it("keeps IPv4 loopback as the first target when it is available", async () => {
   target.destroy();
 });
 
+it("keeps an error handler installed while handing off a connected target", async () => {
+  const target = await Effect.runPromise(
+    makeConnectTarget(() => createSocket("connect"))("127.0.0.1", 5173),
+  );
+
+  expect(() => target.emit("error", new Error("reset during handoff"))).not.toThrow();
+  expect(target.destroyed).toBe(true);
+});
+
 it("fails after both loopback addresses are unavailable", async () => {
   const attemptedHosts: Array<string> = [];
   const createConnection = vi.fn(({ host }: { host: string; port: number }) => {

--- a/apps/server/src/portForward/TcpForwardBridge.test.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.test.ts
@@ -23,6 +23,12 @@ it("connects to IPv6 loopback when the IPv4 loopback target is unavailable", asy
   const target = await Effect.runPromise(makeConnectTarget(createConnection)("127.0.0.1", 5173));
 
   expect(attemptedHosts).toEqual(["127.0.0.1", "::1"]);
+  expect(createConnection).toHaveBeenCalledWith({
+    host: "127.0.0.1",
+    port: 5173,
+    allowHalfOpen: true,
+  });
+  expect(createConnection).toHaveBeenCalledWith({ host: "::1", port: 5173, allowHalfOpen: true });
   target.destroy();
 });
 

--- a/apps/server/src/portForward/TcpForwardBridge.test.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.test.ts
@@ -1,8 +1,30 @@
+import {
+  AuthSessionId,
+  TCP_PORT_FORWARD_FRAME_ACK,
+  TCP_PORT_FORWARD_FRAME_DATA,
+  TCP_PORT_FORWARD_FRAME_WRITE_END,
+  TCP_PORT_FORWARD_INITIAL_CREDIT,
+  TCP_PORT_FORWARD_MAX_DATA_SIZE,
+} from "@t3tools/contracts";
 import { expect, it, vi } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as NodeNet from "node:net";
+import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import * as Socket from "effect/unstable/socket/Socket";
+import { EventEmitter } from "node:events";
 
-import { makeConnectTarget } from "./TcpForwardBridge.ts";
+import * as SessionStore from "../auth/SessionStore.ts";
+import {
+  makeConnectTarget,
+  makeTargetResource,
+  runBridge,
+  subscribeAndVerifySession,
+} from "./TcpForwardBridge.ts";
 
 const createSocket = (result: "connect" | "error") => {
   const socket = new NodeNet.Socket();
@@ -11,6 +33,40 @@ const createSocket = (result: "connect" | "error") => {
     else socket.emit("error", new Error("connection refused"));
   });
   return socket;
+};
+
+const makeAckFrame = (bytes: number) => {
+  const frame = new Uint8Array(5);
+  frame[0] = TCP_PORT_FORWARD_FRAME_ACK;
+  new DataView(frame.buffer).setUint32(1, bytes, false);
+  return frame;
+};
+
+const makeDataFrame = (bytes: number) => {
+  const frame = new Uint8Array(bytes + 1);
+  frame[0] = TCP_PORT_FORWARD_FRAME_DATA;
+  return frame;
+};
+
+const makeBridgeTarget = () => {
+  const emitter = new EventEmitter();
+  let destroyed = false;
+  const writeCallbacks: Array<(error?: Error | null) => void> = [];
+  const target = Object.assign(emitter, {
+    end: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    setTimeout: vi.fn(),
+    write: vi.fn((_payload: Uint8Array, callback: (error?: Error | null) => void) => {
+      writeCallbacks.push(callback);
+      return false;
+    }),
+    destroy: vi.fn(() => {
+      destroyed = true;
+    }),
+  });
+  Object.defineProperty(target, "destroyed", { get: () => destroyed });
+  return { target: target as unknown as NodeNet.Socket, writeCallbacks };
 };
 
 it("connects to IPv6 loopback when the IPv4 loopback target is unavailable", async () => {
@@ -54,7 +110,7 @@ it("fails after both loopback addresses are unavailable", async () => {
 
   await expect(
     Effect.runPromise(makeConnectTarget(createConnection)("127.0.0.1", 5173)),
-  ).rejects.toBeDefined();
+  ).rejects.toMatchObject({ host: "127.0.0.1", port: 5173 });
   expect(attemptedHosts).toEqual(["127.0.0.1", "::1"]);
 });
 
@@ -70,3 +126,128 @@ it("does not expand non-loopback targets to IPv6 loopback", async () => {
   ).rejects.toBeDefined();
   expect(attemptedHosts).toEqual(["192.0.2.1"]);
 });
+
+it.effect("subscribes to revocations before re-verifying the consumed session", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const changes = yield* PubSub.unbounded<SessionStore.SessionCredentialChange>();
+      const session = {
+        sessionId: AuthSessionId.make("session-a"),
+        token: "websocket-token",
+        scopes: ["terminal:operate"],
+      } as unknown as SessionStore.VerifiedSession;
+      const sessions = {
+        subscribeChanges: PubSub.subscribe(changes),
+        verifyWebSocketToken: () =>
+          PubSub.publish(changes, {
+            type: "clientRemoved" as const,
+            sessionId: session.sessionId,
+          }).pipe(Effect.as(session)),
+      };
+
+      const watcher = yield* subscribeAndVerifySession(sessions, session);
+      const observed = yield* PubSub.take(watcher.changes);
+
+      expect(observed).toEqual({
+        type: "clientRemoved",
+        sessionId: session.sessionId,
+      });
+    }),
+  ),
+);
+
+it.effect("destroys an acquired target when a later upgrade step fails", () =>
+  Effect.gen(function* () {
+    const { target } = makeBridgeTarget();
+    const acquireTarget = makeTargetResource(() => Effect.succeed(target));
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        yield* acquireTarget("127.0.0.1", 5173);
+        return yield* Effect.fail("upgrade failed");
+      }),
+    ).pipe(Effect.flip);
+
+    expect(target.destroyed).toBe(true);
+  }),
+);
+
+it.effect("flushes credit-blocked target data before sending write end", () =>
+  Effect.gen(function* () {
+    const handlerReady = yield* Deferred.make<void>();
+    const initialWindowSent = yield* Deferred.make<void>();
+    const writeEndSent = yield* Deferred.make<void>();
+    const sentDataBytes = yield* Ref.make(0);
+    let receiveFrame: ((frame: Uint8Array) => void) | undefined;
+    const webSocket = {
+      writer: Effect.succeed((frame: Uint8Array | Socket.CloseEvent) =>
+        frame instanceof Uint8Array
+          ? Effect.gen(function* () {
+              if (frame[0] === TCP_PORT_FORWARD_FRAME_DATA) {
+                const total = yield* Ref.updateAndGet(
+                  sentDataBytes,
+                  (current) => current + frame.byteLength - 1,
+                );
+                if (total === TCP_PORT_FORWARD_INITIAL_CREDIT) {
+                  yield* Deferred.succeed(initialWindowSent, undefined);
+                }
+              } else if (frame[0] === TCP_PORT_FORWARD_FRAME_WRITE_END) {
+                yield* Deferred.succeed(writeEndSent, undefined);
+              }
+            })
+          : Effect.void,
+      ),
+      run: (handler: (frame: Uint8Array) => void) => {
+        receiveFrame = handler;
+        return Deferred.succeed(handlerReady, undefined).pipe(Effect.andThen(Effect.never));
+      },
+    } as unknown as Socket.Socket;
+    const { target } = makeBridgeTarget();
+    const bridge = yield* runBridge(webSocket, target).pipe(
+      Effect.forkChild({ startImmediately: true }),
+    );
+    yield* Deferred.await(handlerReady);
+
+    target.emit("data", Buffer.alloc(TCP_PORT_FORWARD_INITIAL_CREDIT + 1));
+    target.emit("end");
+    yield* Deferred.await(initialWindowSent);
+    expect(Option.isNone(yield* Deferred.poll(writeEndSent))).toBe(true);
+
+    receiveFrame?.(makeAckFrame(TCP_PORT_FORWARD_INITIAL_CREDIT));
+    yield* Deferred.await(writeEndSent);
+    expect(yield* Ref.get(sentDataBytes)).toBe(TCP_PORT_FORWARD_INITIAL_CREDIT + 1);
+    yield* Fiber.interrupt(bridge);
+  }),
+);
+
+it.effect("rejects data beyond the advertised receive-credit window", () =>
+  Effect.gen(function* () {
+    const handlerReady = yield* Deferred.make<void>();
+    let receiveFrame: ((frame: Uint8Array) => void) | undefined;
+    const webSocket = {
+      writer: Effect.succeed(() => Effect.void),
+      run: (handler: (frame: Uint8Array) => void) => {
+        receiveFrame = handler;
+        return Deferred.succeed(handlerReady, undefined).pipe(Effect.andThen(Effect.never));
+      },
+    } as unknown as Socket.Socket;
+    const { target } = makeBridgeTarget();
+    const bridge = yield* runBridge(webSocket, target).pipe(
+      Effect.forkChild({ startImmediately: true }),
+    );
+    yield* Deferred.await(handlerReady);
+
+    let remaining = TCP_PORT_FORWARD_INITIAL_CREDIT;
+    while (remaining > 0) {
+      const size = Math.min(remaining, TCP_PORT_FORWARD_MAX_DATA_SIZE);
+      receiveFrame?.(makeDataFrame(size));
+      remaining -= size;
+    }
+    expect(target.write).toHaveBeenCalled();
+    expect(target.destroyed).toBe(false);
+
+    receiveFrame?.(makeDataFrame(1));
+    expect(target.destroyed).toBe(true);
+    yield* Fiber.interrupt(bridge);
+  }),
+);

--- a/apps/server/src/portForward/TcpForwardBridge.test.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.test.ts
@@ -1,0 +1,66 @@
+import { expect, it, vi } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as NodeNet from "node:net";
+
+import { makeConnectTarget } from "./TcpForwardBridge.ts";
+
+const createSocket = (result: "connect" | "error") => {
+  const socket = new NodeNet.Socket();
+  queueMicrotask(() => {
+    if (result === "connect") socket.emit("connect");
+    else socket.emit("error", new Error("connection refused"));
+  });
+  return socket;
+};
+
+it("connects to IPv6 loopback when the IPv4 loopback target is unavailable", async () => {
+  const attemptedHosts: Array<string> = [];
+  const createConnection = vi.fn(({ host }: { host: string; port: number }) => {
+    attemptedHosts.push(host);
+    return createSocket(host === "::1" ? "connect" : "error");
+  });
+
+  const target = await Effect.runPromise(makeConnectTarget(createConnection)("127.0.0.1", 5173));
+
+  expect(attemptedHosts).toEqual(["127.0.0.1", "::1"]);
+  target.destroy();
+});
+
+it("keeps IPv4 loopback as the first target when it is available", async () => {
+  const attemptedHosts: Array<string> = [];
+  const createConnection = vi.fn(({ host }: { host: string; port: number }) => {
+    attemptedHosts.push(host);
+    return createSocket("connect");
+  });
+
+  const target = await Effect.runPromise(makeConnectTarget(createConnection)("127.0.0.1", 5173));
+
+  expect(attemptedHosts).toEqual(["127.0.0.1"]);
+  target.destroy();
+});
+
+it("fails after both loopback addresses are unavailable", async () => {
+  const attemptedHosts: Array<string> = [];
+  const createConnection = vi.fn(({ host }: { host: string; port: number }) => {
+    attemptedHosts.push(host);
+    return createSocket("error");
+  });
+
+  await expect(
+    Effect.runPromise(makeConnectTarget(createConnection)("127.0.0.1", 5173)),
+  ).rejects.toBeDefined();
+  expect(attemptedHosts).toEqual(["127.0.0.1", "::1"]);
+});
+
+it("does not expand non-loopback targets to IPv6 loopback", async () => {
+  const attemptedHosts: Array<string> = [];
+  const createConnection = vi.fn(({ host }: { host: string; port: number }) => {
+    attemptedHosts.push(host);
+    return createSocket("error");
+  });
+
+  await expect(
+    Effect.runPromise(makeConnectTarget(createConnection)("192.0.2.1", 5173)),
+  ).rejects.toBeDefined();
+  expect(attemptedHosts).toEqual(["192.0.2.1"]);
+});

--- a/apps/server/src/portForward/TcpForwardBridge.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.ts
@@ -61,9 +61,15 @@ const errorFrame = (message: string) => {
   return frame;
 };
 
-const connectTarget = (host: string, port: number) =>
+type CreateTargetConnection = (options: { host: string; port: number }) => NodeNet.Socket;
+
+const connectTargetAddress = (
+  createConnection: CreateTargetConnection,
+  host: string,
+  port: number,
+) =>
   Effect.callback<NodeNet.Socket, TcpForwardTargetConnectError>((resume) => {
-    const target = NodeNet.createConnection({ host, port });
+    const target = createConnection({ host, port });
     const onConnect = () => {
       target.off("error", onError);
       resume(Effect.succeed(target));
@@ -81,6 +87,28 @@ const connectTarget = (host: string, port: number) =>
       target.destroy();
     });
   });
+
+export const makeConnectTarget = (createConnection: CreateTargetConnection) =>
+  Effect.fn("TcpForwardBridge.connectTarget")(function* (host: string, port: number) {
+    return yield* connectTargetAddress(createConnection, host, port).pipe(
+      Effect.catchTag("TcpForwardTargetConnectError", (ipv4Error) => {
+        if (host !== "127.0.0.1") return Effect.fail(ipv4Error);
+        return connectTargetAddress(createConnection, "::1", port).pipe(
+          Effect.mapError(
+            (ipv6Error) =>
+              new TcpForwardTargetConnectError({
+                cause: new AggregateError(
+                  [ipv4Error.cause, ipv6Error.cause],
+                  `Could not connect to loopback target on port ${port}`,
+                ),
+              }),
+          ),
+        );
+      }),
+    );
+  });
+
+const connectTarget = makeConnectTarget((options) => NodeNet.createConnection(options));
 
 const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
   webSocket: Socket.Socket,

--- a/apps/server/src/portForward/TcpForwardBridge.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.ts
@@ -61,7 +61,11 @@ const errorFrame = (message: string) => {
   return frame;
 };
 
-type CreateTargetConnection = (options: { host: string; port: number }) => NodeNet.Socket;
+type CreateTargetConnection = (options: {
+  host: string;
+  port: number;
+  allowHalfOpen: true;
+}) => NodeNet.Socket;
 
 const connectTargetAddress = (
   createConnection: CreateTargetConnection,
@@ -69,7 +73,7 @@ const connectTargetAddress = (
   port: number,
 ) =>
   Effect.callback<NodeNet.Socket, TcpForwardTargetConnectError>((resume) => {
-    const target = createConnection({ host, port });
+    const target = createConnection({ host, port, allowHalfOpen: true });
     const onConnect = () => {
       target.off("error", onError);
       resume(Effect.succeed(target));

--- a/apps/server/src/portForward/TcpForwardBridge.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.ts
@@ -80,14 +80,17 @@ const connectTargetAddress = (
 ) =>
   Effect.callback<NodeNet.Socket, TcpForwardTargetConnectError>((resume) => {
     const target = createConnection({ host, port, allowHalfOpen: true });
+    let connected = false;
     const onConnect = () => {
-      target.off("error", onError);
+      connected = true;
       resume(Effect.succeed(target));
     };
     const onError = (cause: Error) => {
       target.off("connect", onConnect);
       target.destroy();
-      resume(Effect.fail(new TcpForwardTargetConnectError({ host, port, cause })));
+      if (!connected) {
+        resume(Effect.fail(new TcpForwardTargetConnectError({ host, port, cause })));
+      }
     };
     target.once("connect", onConnect);
     target.once("error", onError);
@@ -225,6 +228,7 @@ export const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
   target.once("error", onError);
   target.once("close", onClose);
   target.setTimeout(IDLE_TIMEOUT_MS, () => target.destroy());
+  if (target.destroyed) close();
 
   const protocolFailure = (reason: string) => {
     writeWebSocket(errorFrame(reason));

--- a/apps/server/src/portForward/TcpForwardBridge.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.ts
@@ -1,4 +1,5 @@
 import {
+  AuthTerminalOperateScope,
   TCP_PORT_FORWARD_FRAME_ACK,
   TCP_PORT_FORWARD_FRAME_CLOSE,
   TCP_PORT_FORWARD_FRAME_DATA,
@@ -13,6 +14,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
@@ -34,8 +36,12 @@ const IDLE_TIMEOUT_MS = 5 * 60 * 1_000;
 
 export class TcpForwardTargetConnectError extends Schema.TaggedErrorClass<TcpForwardTargetConnectError>()(
   "TcpForwardTargetConnectError",
-  { cause: Schema.Defect() },
-) {}
+  { host: Schema.String, port: Schema.Number, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `Could not connect to TCP forward target ${this.host}:${this.port}.`;
+  }
+}
 
 const controlFrame = (kind: number) => Uint8Array.of(kind);
 
@@ -81,7 +87,7 @@ const connectTargetAddress = (
     const onError = (cause: Error) => {
       target.off("connect", onConnect);
       target.destroy();
-      resume(Effect.fail(new TcpForwardTargetConnectError({ cause })));
+      resume(Effect.fail(new TcpForwardTargetConnectError({ host, port, cause })));
     };
     target.once("connect", onConnect);
     target.once("error", onError);
@@ -95,26 +101,55 @@ const connectTargetAddress = (
 export const makeConnectTarget = (createConnection: CreateTargetConnection) =>
   Effect.fn("TcpForwardBridge.connectTarget")(function* (host: string, port: number) {
     return yield* connectTargetAddress(createConnection, host, port).pipe(
-      Effect.catchTag("TcpForwardTargetConnectError", (ipv4Error) => {
-        if (host !== "127.0.0.1") return Effect.fail(ipv4Error);
-        return connectTargetAddress(createConnection, "::1", port).pipe(
-          Effect.mapError(
-            (ipv6Error) =>
-              new TcpForwardTargetConnectError({
-                cause: new AggregateError(
-                  [ipv4Error.cause, ipv6Error.cause],
-                  `Could not connect to loopback target on port ${port}`,
-                ),
-              }),
-          ),
-        );
+      Effect.catchTags({
+        TcpForwardTargetConnectError: (ipv4Error) => {
+          if (host !== "127.0.0.1") return Effect.fail(ipv4Error);
+          return connectTargetAddress(createConnection, "::1", port).pipe(
+            Effect.mapError(
+              (ipv6Error) =>
+                new TcpForwardTargetConnectError({
+                  host,
+                  port,
+                  cause: new AggregateError(
+                    [ipv4Error.cause, ipv6Error.cause],
+                    `Could not connect to loopback target on port ${port}`,
+                  ),
+                }),
+            ),
+          );
+        },
       }),
     );
   });
 
 const connectTarget = makeConnectTarget((options) => NodeNet.createConnection(options));
 
-const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
+export const makeTargetResource = <E, R>(
+  connect: (host: string, port: number) => Effect.Effect<NodeNet.Socket, E, R>,
+) =>
+  Effect.fn("TcpForwardBridge.acquireTarget")(function* (host: string, port: number) {
+    return yield* Effect.acquireRelease(connect(host, port), (socket) =>
+      Effect.sync(() => socket.destroy()),
+    );
+  });
+
+const acquireTarget = makeTargetResource(connectTarget);
+
+export const subscribeAndVerifySession = Effect.fn("TcpForwardBridge.subscribeAndVerifySession")(
+  function* (
+    sessions: Pick<
+      SessionStore.SessionStore["Service"],
+      "subscribeChanges" | "verifyWebSocketToken"
+    >,
+    session: SessionStore.VerifiedSession,
+  ) {
+    const changes = yield* sessions.subscribeChanges;
+    const refreshedSession = yield* sessions.verifyWebSocketToken(session.token);
+    return { changes, session: refreshedSession };
+  },
+);
+
+export const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
   webSocket: Socket.Socket,
   target: NodeNet.Socket,
 ) {
@@ -124,8 +159,11 @@ const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
   const closed = yield* Deferred.make<void>();
   let credit = TCP_PORT_FORWARD_INITIAL_CREDIT;
   let outstanding = 0;
+  let receiveCredit = TCP_PORT_FORWARD_INITIAL_CREDIT;
   let pending: Uint8Array = new Uint8Array(0);
-  let targetEnded = false;
+  let targetReadEnded = false;
+  let targetReadEndSent = false;
+  let targetWriteEnded = false;
   let closedOnce = false;
 
   const writeWebSocket = (frame: Uint8Array | Socket.CloseEvent) => {
@@ -145,11 +183,17 @@ const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
       outstanding += size;
       writeWebSocket(dataFrame(chunk));
     }
-    if (pending.byteLength === 0 && credit > 0) {
-      target.resume();
-    } else {
-      target.pause();
+    if (pending.byteLength === 0) {
+      if (targetReadEnded && !targetReadEndSent) {
+        targetReadEndSent = true;
+        writeWebSocket(controlFrame(TCP_PORT_FORWARD_FRAME_WRITE_END));
+      }
+      if (!targetReadEnded && credit > 0) {
+        target.resume();
+        return;
+      }
     }
+    target.pause();
   };
   const onData = (chunk: Buffer) => {
     if (pending.byteLength === 0) {
@@ -163,7 +207,8 @@ const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
     flushTargetData();
   };
   const onEnd = () => {
-    writeWebSocket(controlFrame(TCP_PORT_FORWARD_FRAME_WRITE_END));
+    targetReadEnded = true;
+    flushTargetData();
   };
   const onError = (cause: Error) => {
     writeWebSocket(errorFrame(cause.message));
@@ -196,13 +241,21 @@ const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
           protocolFailure("invalid data frame");
           return;
         }
-        if (targetEnded || target.destroyed) {
+        if (targetWriteEnded || target.destroyed) {
           protocolFailure("data received after write end");
           return;
         }
+        if (payload.byteLength > receiveCredit) {
+          protocolFailure("data exceeds receive credit");
+          return;
+        }
+        receiveCredit -= payload.byteLength;
         target.write(payload, (error) => {
           if (error) onError(error);
-          else writeWebSocket(ackFrame(payload.byteLength));
+          else {
+            receiveCredit += payload.byteLength;
+            writeWebSocket(ackFrame(payload.byteLength));
+          }
         });
         return;
       }
@@ -225,11 +278,11 @@ const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
         return;
       }
       case TCP_PORT_FORWARD_FRAME_WRITE_END:
-        if (frame.byteLength !== 1 || targetEnded) {
+        if (frame.byteLength !== 1 || targetWriteEnded) {
           protocolFailure("invalid write-end frame");
           return;
         }
-        targetEnded = true;
+        targetWriteEnded = true;
         target.end();
         return;
       case TCP_PORT_FORWARD_FRAME_CLOSE:
@@ -279,51 +332,61 @@ export const tcpPortForwardWebSocketRouteLayer = Layer.unwrap(
         if (ticket === null || ticket.trim() === "") {
           return yield* failEnvironmentAuthInvalid("missing_credential");
         }
-        const authorization = yield* tickets
-          .consume(ticket)
-          .pipe(
-            Effect.catchTag("TcpForwardTicketInvalidError", () =>
-              failEnvironmentAuthInvalid("invalid_credential"),
-            ),
-          );
-        return yield* capacity.withPermit(
-          Effect.gen(function* () {
-            const target = yield* connectTarget(authorization.remoteHost, authorization.remotePort);
-            const webSocket = yield* request.upgrade;
-            const revoked = sessions.streamChanges.pipe(
-              Stream.filter(
-                (change) =>
-                  change.type === "clientRemoved" &&
-                  change.sessionId === authorization.session.sessionId,
-              ),
-              Stream.runHead,
-              Effect.asVoid,
-            );
-            const expiresAt = authorization.session.expiresAt;
-            const expired =
-              expiresAt === undefined
-                ? Effect.never
-                : DateTime.now.pipe(
-                    Effect.flatMap((now) =>
-                      Effect.sleep(
-                        Duration.millis(
-                          Math.max(0, expiresAt.epochMilliseconds - now.epochMilliseconds),
-                        ),
-                      ),
-                    ),
-                  );
-            yield* Effect.raceFirst(
-              runBridge(webSocket, target),
-              Effect.raceFirst(revoked, expired),
-            );
-            return HttpServerResponse.empty();
+        const authorization = yield* tickets.consume(ticket).pipe(
+          Effect.catchTags({
+            TcpForwardTicketInvalidError: () => failEnvironmentAuthInvalid("invalid_credential"),
           }),
         );
+        return yield* capacity.withPermit(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const sessionWatcher = yield* subscribeAndVerifySession(
+                sessions,
+                authorization.session,
+              ).pipe(Effect.catch(() => failEnvironmentAuthInvalid("invalid_credential")));
+              const refreshedSession = sessionWatcher.session;
+              if (!refreshedSession.scopes.includes(AuthTerminalOperateScope)) {
+                return yield* failEnvironmentAuthInvalid("invalid_credential");
+              }
+              const target = yield* acquireTarget(
+                authorization.remoteHost,
+                authorization.remotePort,
+              );
+              const webSocket = yield* request.upgrade;
+              const revoked = Stream.fromEffectRepeat(PubSub.take(sessionWatcher.changes)).pipe(
+                Stream.filter(
+                  (change) =>
+                    change.type === "clientRemoved" &&
+                    change.sessionId === refreshedSession.sessionId,
+                ),
+                Stream.runHead,
+                Effect.asVoid,
+              );
+              const expiresAt = refreshedSession.expiresAt;
+              const expired =
+                expiresAt === undefined
+                  ? Effect.never
+                  : DateTime.now.pipe(
+                      Effect.flatMap((now) =>
+                        Effect.sleep(
+                          Duration.millis(
+                            Math.max(0, expiresAt.epochMilliseconds - now.epochMilliseconds),
+                          ),
+                        ),
+                      ),
+                    );
+              yield* Effect.raceFirst(
+                runBridge(webSocket, target),
+                Effect.raceFirst(revoked, expired),
+              );
+              return HttpServerResponse.empty();
+            }),
+          ),
+        );
       }).pipe(
-        Effect.catchTag("TcpForwardTargetConnectError", () =>
-          Effect.succeed(HttpServerResponse.text("TCP target unavailable", { status: 502 })),
-        ),
         Effect.catchTags({
+          TcpForwardTargetConnectError: () =>
+            Effect.succeed(HttpServerResponse.text("TCP target unavailable", { status: 502 })),
           EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
         }),
       ),

--- a/apps/server/src/portForward/TcpForwardBridge.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.ts
@@ -114,7 +114,7 @@ export const makeConnectTarget = (createConnection: CreateTargetConnection) =>
                   host,
                   port,
                   cause: new AggregateError(
-                    [ipv4Error.cause, ipv6Error.cause],
+                    [ipv4Error, ipv6Error],
                     `Could not connect to loopback target on port ${port}`,
                   ),
                 }),

--- a/apps/server/src/portForward/TcpForwardBridge.ts
+++ b/apps/server/src/portForward/TcpForwardBridge.ts
@@ -1,0 +1,300 @@
+import {
+  TCP_PORT_FORWARD_FRAME_ACK,
+  TCP_PORT_FORWARD_FRAME_CLOSE,
+  TCP_PORT_FORWARD_FRAME_DATA,
+  TCP_PORT_FORWARD_FRAME_ERROR,
+  TCP_PORT_FORWARD_FRAME_WRITE_END,
+  TCP_PORT_FORWARD_INITIAL_CREDIT,
+  TCP_PORT_FORWARD_MAX_DATA_SIZE,
+} from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import {
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerRespondable,
+  HttpServerResponse,
+} from "effect/unstable/http";
+import * as Socket from "effect/unstable/socket/Socket";
+import * as NodeNet from "node:net";
+
+import { failEnvironmentAuthInvalid } from "../auth/http.ts";
+import * as SessionStore from "../auth/SessionStore.ts";
+import * as TcpForwardTicketStore from "./TcpForwardTicketStore.ts";
+
+const MAX_CONCURRENT_FORWARD_CONNECTIONS = 128;
+const IDLE_TIMEOUT_MS = 5 * 60 * 1_000;
+
+export class TcpForwardTargetConnectError extends Schema.TaggedErrorClass<TcpForwardTargetConnectError>()(
+  "TcpForwardTargetConnectError",
+  { cause: Schema.Defect() },
+) {}
+
+const controlFrame = (kind: number) => Uint8Array.of(kind);
+
+const dataFrame = (data: Uint8Array) => {
+  const frame = new Uint8Array(data.byteLength + 1);
+  frame[0] = TCP_PORT_FORWARD_FRAME_DATA;
+  frame.set(data, 1);
+  return frame;
+};
+
+const ackFrame = (bytes: number) => {
+  const frame = new Uint8Array(5);
+  frame[0] = TCP_PORT_FORWARD_FRAME_ACK;
+  new DataView(frame.buffer).setUint32(1, bytes, false);
+  return frame;
+};
+
+const errorFrame = (message: string) => {
+  const encoded = new TextEncoder().encode(message).slice(0, 512);
+  const frame = new Uint8Array(encoded.byteLength + 1);
+  frame[0] = TCP_PORT_FORWARD_FRAME_ERROR;
+  frame.set(encoded, 1);
+  return frame;
+};
+
+const connectTarget = (host: string, port: number) =>
+  Effect.callback<NodeNet.Socket, TcpForwardTargetConnectError>((resume) => {
+    const target = NodeNet.createConnection({ host, port });
+    const onConnect = () => {
+      target.off("error", onError);
+      resume(Effect.succeed(target));
+    };
+    const onError = (cause: Error) => {
+      target.off("connect", onConnect);
+      target.destroy();
+      resume(Effect.fail(new TcpForwardTargetConnectError({ cause })));
+    };
+    target.once("connect", onConnect);
+    target.once("error", onError);
+    return Effect.sync(() => {
+      target.off("connect", onConnect);
+      target.off("error", onError);
+      target.destroy();
+    });
+  });
+
+const runBridge = Effect.fn("TcpForwardBridge.run")(function* (
+  webSocket: Socket.Socket,
+  target: NodeNet.Socket,
+) {
+  const writer = yield* webSocket.writer;
+  const context = yield* Effect.context<never>();
+  const runFork = Effect.runForkWith(context);
+  const closed = yield* Deferred.make<void>();
+  let credit = TCP_PORT_FORWARD_INITIAL_CREDIT;
+  let outstanding = 0;
+  let pending: Uint8Array = new Uint8Array(0);
+  let targetEnded = false;
+  let closedOnce = false;
+
+  const writeWebSocket = (frame: Uint8Array | Socket.CloseEvent) => {
+    runFork(writer(frame).pipe(Effect.catch(() => Effect.void)));
+  };
+  const close = () => {
+    if (closedOnce) return;
+    closedOnce = true;
+    runFork(Deferred.succeed(closed, undefined));
+  };
+  const flushTargetData = () => {
+    while (credit > 0 && pending.byteLength > 0) {
+      const size = Math.min(credit, TCP_PORT_FORWARD_MAX_DATA_SIZE, pending.byteLength);
+      const chunk = pending.subarray(0, size);
+      pending = pending.subarray(size);
+      credit -= size;
+      outstanding += size;
+      writeWebSocket(dataFrame(chunk));
+    }
+    if (pending.byteLength === 0 && credit > 0) {
+      target.resume();
+    } else {
+      target.pause();
+    }
+  };
+  const onData = (chunk: Buffer) => {
+    if (pending.byteLength === 0) {
+      pending = chunk;
+    } else {
+      const combined = new Uint8Array(pending.byteLength + chunk.byteLength);
+      combined.set(pending);
+      combined.set(chunk, pending.byteLength);
+      pending = combined;
+    }
+    flushTargetData();
+  };
+  const onEnd = () => {
+    writeWebSocket(controlFrame(TCP_PORT_FORWARD_FRAME_WRITE_END));
+  };
+  const onError = (cause: Error) => {
+    writeWebSocket(errorFrame(cause.message));
+    target.destroy();
+  };
+  const onClose = () => {
+    writeWebSocket(controlFrame(TCP_PORT_FORWARD_FRAME_CLOSE));
+    writeWebSocket(new Socket.CloseEvent(1000));
+    close();
+  };
+
+  target.on("data", onData);
+  target.once("end", onEnd);
+  target.once("error", onError);
+  target.once("close", onClose);
+  target.setTimeout(IDLE_TIMEOUT_MS, () => target.destroy());
+
+  const protocolFailure = (reason: string) => {
+    writeWebSocket(errorFrame(reason));
+    writeWebSocket(new Socket.CloseEvent(1002, "invalid tcp forward frame"));
+    target.destroy();
+  };
+
+  const readWebSocket = webSocket.run((frame) => {
+    const kind = frame[0];
+    switch (kind) {
+      case TCP_PORT_FORWARD_FRAME_DATA: {
+        const payload = frame.subarray(1);
+        if (payload.byteLength === 0 || payload.byteLength > TCP_PORT_FORWARD_MAX_DATA_SIZE) {
+          protocolFailure("invalid data frame");
+          return;
+        }
+        if (targetEnded || target.destroyed) {
+          protocolFailure("data received after write end");
+          return;
+        }
+        target.write(payload, (error) => {
+          if (error) onError(error);
+          else writeWebSocket(ackFrame(payload.byteLength));
+        });
+        return;
+      }
+      case TCP_PORT_FORWARD_FRAME_ACK: {
+        if (frame.byteLength !== 5) {
+          protocolFailure("invalid acknowledgement frame");
+          return;
+        }
+        const bytes = new DataView(frame.buffer, frame.byteOffset, frame.byteLength).getUint32(
+          1,
+          false,
+        );
+        if (bytes === 0 || bytes > outstanding) {
+          protocolFailure("invalid acknowledgement credit");
+          return;
+        }
+        outstanding -= bytes;
+        credit += bytes;
+        flushTargetData();
+        return;
+      }
+      case TCP_PORT_FORWARD_FRAME_WRITE_END:
+        if (frame.byteLength !== 1 || targetEnded) {
+          protocolFailure("invalid write-end frame");
+          return;
+        }
+        targetEnded = true;
+        target.end();
+        return;
+      case TCP_PORT_FORWARD_FRAME_CLOSE:
+        if (frame.byteLength !== 1) {
+          protocolFailure("invalid close frame");
+          return;
+        }
+        target.destroy();
+        return;
+      case TCP_PORT_FORWARD_FRAME_ERROR:
+        if (frame.byteLength > 513) {
+          protocolFailure("invalid error frame");
+          return;
+        }
+        target.destroy();
+        return;
+      default:
+        protocolFailure("unknown frame type");
+    }
+  });
+
+  yield* Effect.raceFirst(readWebSocket, Deferred.await(closed)).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        target.off("data", onData);
+        target.off("end", onEnd);
+        target.off("error", onError);
+        target.off("close", onClose);
+        target.destroy();
+      }),
+    ),
+  );
+});
+
+export const tcpPortForwardWebSocketRouteLayer = Layer.unwrap(
+  Effect.gen(function* () {
+    const tickets = yield* TcpForwardTicketStore.TcpForwardTicketStore;
+    const sessions = yield* SessionStore.SessionStore;
+    const capacity = yield* Semaphore.make(MAX_CONCURRENT_FORWARD_CONNECTIONS);
+    return HttpRouter.add(
+      "GET",
+      "/ws/tcp-forward",
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const url = HttpServerRequest.toURL(request);
+        const ticket = Option.isSome(url) ? url.value.searchParams.get("ticket") : null;
+        if (ticket === null || ticket.trim() === "") {
+          return yield* failEnvironmentAuthInvalid("missing_credential");
+        }
+        const authorization = yield* tickets
+          .consume(ticket)
+          .pipe(
+            Effect.catchTag("TcpForwardTicketInvalidError", () =>
+              failEnvironmentAuthInvalid("invalid_credential"),
+            ),
+          );
+        return yield* capacity.withPermit(
+          Effect.gen(function* () {
+            const target = yield* connectTarget(authorization.remoteHost, authorization.remotePort);
+            const webSocket = yield* request.upgrade;
+            const revoked = sessions.streamChanges.pipe(
+              Stream.filter(
+                (change) =>
+                  change.type === "clientRemoved" &&
+                  change.sessionId === authorization.session.sessionId,
+              ),
+              Stream.runHead,
+              Effect.asVoid,
+            );
+            const expiresAt = authorization.session.expiresAt;
+            const expired =
+              expiresAt === undefined
+                ? Effect.never
+                : DateTime.now.pipe(
+                    Effect.flatMap((now) =>
+                      Effect.sleep(
+                        Duration.millis(
+                          Math.max(0, expiresAt.epochMilliseconds - now.epochMilliseconds),
+                        ),
+                      ),
+                    ),
+                  );
+            yield* Effect.raceFirst(
+              runBridge(webSocket, target),
+              Effect.raceFirst(revoked, expired),
+            );
+            return HttpServerResponse.empty();
+          }),
+        );
+      }).pipe(
+        Effect.catchTag("TcpForwardTargetConnectError", () =>
+          Effect.succeed(HttpServerResponse.text("TCP target unavailable", { status: 502 })),
+        ),
+        Effect.catchTags({
+          EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
+        }),
+      ),
+    );
+  }),
+);

--- a/apps/server/src/portForward/TcpForwardTicketStore.test.ts
+++ b/apps/server/src/portForward/TcpForwardTicketStore.test.ts
@@ -21,6 +21,17 @@ const sessionStoreLayer = SessionStore.layer.pipe(
 const testLayer = TcpForwardTicketStore.layer.pipe(Layer.provideMerge(sessionStoreLayer));
 
 it.layer(NodeServices.layer)("TcpForwardTicketStore", (it) => {
+  it("describes the failed issuance stage and session", () => {
+    const error = new TcpForwardTicketStore.TcpForwardTicketIssueError({
+      stage: "generate-ticket",
+      sessionId: AuthSessionId.make("session-a"),
+      cause: new Error("random source unavailable"),
+    });
+
+    expect(error.message).toContain("generate-ticket");
+    expect(error.message).toContain("session-a");
+  });
+
   it.effect("binds a ticket to its destination and consumes it only once", () =>
     Effect.gen(function* () {
       const sessions = yield* SessionStore.SessionStore;

--- a/apps/server/src/portForward/TcpForwardTicketStore.test.ts
+++ b/apps/server/src/portForward/TcpForwardTicketStore.test.ts
@@ -1,0 +1,106 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { AuthSessionId } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as TestClock from "effect/testing/TestClock";
+
+import * as ServerConfig from "../config.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import * as SessionStore from "../auth/SessionStore.ts";
+import * as TcpForwardTicketStore from "./TcpForwardTicketStore.ts";
+
+const sessionStoreLayer = SessionStore.layer.pipe(
+  Layer.provide(SqlitePersistenceMemory),
+  Layer.provide(ServerSecretStore.layer),
+  Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-tcp-forward-ticket-test-" })),
+);
+
+const testLayer = TcpForwardTicketStore.layer.pipe(Layer.provideMerge(sessionStoreLayer));
+
+it.layer(NodeServices.layer)("TcpForwardTicketStore", (it) => {
+  it.effect("binds a ticket to its destination and consumes it only once", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const store = yield* TcpForwardTicketStore.TcpForwardTicketStore;
+      const session = yield* sessions.issue({
+        subject: "desktop",
+        scopes: ["terminal:operate"],
+      });
+      const issued = yield* store.issue({
+        sessionId: session.sessionId,
+        remoteHost: "127.0.0.1",
+        remotePort: 4321,
+      });
+
+      const consumed = yield* store.consume(issued.ticket);
+      expect(consumed.remoteHost).toBe("127.0.0.1");
+      expect(consumed.remotePort).toBe(4321);
+      expect(consumed.session.sessionId).toBe(session.sessionId);
+
+      const replay = yield* Effect.flip(store.consume(issued.ticket));
+      expect(replay._tag).toBe("TcpForwardTicketInvalidError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects expired tickets", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const store = yield* TcpForwardTicketStore.TcpForwardTicketStore;
+      const session = yield* sessions.issue({
+        subject: "desktop",
+        scopes: ["terminal:operate"],
+      });
+      const issued = yield* store.issue({
+        sessionId: session.sessionId,
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+      yield* TestClock.adjust(Duration.seconds(31));
+
+      const expired = yield* Effect.flip(store.consume(issued.ticket));
+      expect(expired._tag).toBe("TcpForwardTicketInvalidError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects sessions without terminal access", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const store = yield* TcpForwardTicketStore.TcpForwardTicketStore;
+      const session = yield* sessions.issue({
+        subject: "read-only",
+        scopes: ["orchestration:read"],
+      });
+      const issued = yield* store.issue({
+        sessionId: AuthSessionId.make(session.sessionId),
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+
+      const rejected = yield* Effect.flip(store.consume(issued.ticket));
+      expect(rejected._tag).toBe("TcpForwardTicketInvalidError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects a ticket after its parent session is revoked", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const store = yield* TcpForwardTicketStore.TcpForwardTicketStore;
+      const session = yield* sessions.issue({
+        subject: "desktop",
+        scopes: ["terminal:operate"],
+      });
+      const issued = yield* store.issue({
+        sessionId: session.sessionId,
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+      yield* sessions.revoke(session.sessionId);
+
+      const revoked = yield* Effect.flip(store.consume(issued.ticket));
+      expect(revoked._tag).toBe("TcpForwardTicketInvalidError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+});

--- a/apps/server/src/portForward/TcpForwardTicketStore.test.ts
+++ b/apps/server/src/portForward/TcpForwardTicketStore.test.ts
@@ -42,6 +42,7 @@ it.layer(NodeServices.layer)("TcpForwardTicketStore", (it) => {
 
       const replay = yield* Effect.flip(store.consume(issued.ticket));
       expect(replay._tag).toBe("TcpForwardTicketInvalidError");
+      expect(replay.reason).toBe("unknown");
     }).pipe(Effect.provide(testLayer)),
   );
 
@@ -62,6 +63,7 @@ it.layer(NodeServices.layer)("TcpForwardTicketStore", (it) => {
 
       const expired = yield* Effect.flip(store.consume(issued.ticket));
       expect(expired._tag).toBe("TcpForwardTicketInvalidError");
+      expect(expired.reason).toBe("expired");
     }).pipe(Effect.provide(testLayer)),
   );
 
@@ -81,6 +83,7 @@ it.layer(NodeServices.layer)("TcpForwardTicketStore", (it) => {
 
       const rejected = yield* Effect.flip(store.consume(issued.ticket));
       expect(rejected._tag).toBe("TcpForwardTicketInvalidError");
+      expect(rejected.reason).toBe("scope-missing");
     }).pipe(Effect.provide(testLayer)),
   );
 
@@ -101,6 +104,8 @@ it.layer(NodeServices.layer)("TcpForwardTicketStore", (it) => {
 
       const revoked = yield* Effect.flip(store.consume(issued.ticket));
       expect(revoked._tag).toBe("TcpForwardTicketInvalidError");
+      expect(revoked.reason).toBe("token-rejected");
+      expect(revoked.cause).toBeDefined();
     }).pipe(Effect.provide(testLayer)),
   );
 });

--- a/apps/server/src/portForward/TcpForwardTicketStore.ts
+++ b/apps/server/src/portForward/TcpForwardTicketStore.ts
@@ -27,8 +27,15 @@ export class TcpForwardTicketIssueError extends Schema.TaggedErrorClass<TcpForwa
 
 export class TcpForwardTicketInvalidError extends Schema.TaggedErrorClass<TcpForwardTicketInvalidError>()(
   "TcpForwardTicketInvalidError",
-  {},
-) {}
+  {
+    reason: Schema.Literals(["unknown", "expired", "token-rejected", "scope-missing"]),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `TCP forward ticket rejected: ${this.reason}.`;
+  }
+}
 
 export class TcpForwardTicketStore extends Context.Service<
   TcpForwardTicketStore,
@@ -95,17 +102,21 @@ export const make = Effect.gen(function* () {
       return [Option.fromUndefinedOr(found), next] as const;
     });
     if (Option.isNone(record)) {
-      return yield* new TcpForwardTicketInvalidError({});
+      return yield* new TcpForwardTicketInvalidError({ reason: "unknown" });
     }
     const now = yield* DateTime.now;
     if (record.value.expiresAtEpochMs <= now.epochMilliseconds) {
-      return yield* new TcpForwardTicketInvalidError({});
+      return yield* new TcpForwardTicketInvalidError({ reason: "expired" });
     }
     const session = yield* sessions
       .verifyWebSocketToken(record.value.webSocketToken)
-      .pipe(Effect.mapError(() => new TcpForwardTicketInvalidError({})));
+      .pipe(
+        Effect.mapError(
+          (cause) => new TcpForwardTicketInvalidError({ reason: "token-rejected", cause }),
+        ),
+      );
     if (!session.scopes.includes(AuthTerminalOperateScope)) {
-      return yield* new TcpForwardTicketInvalidError({});
+      return yield* new TcpForwardTicketInvalidError({ reason: "scope-missing" });
     }
     return {
       session,

--- a/apps/server/src/portForward/TcpForwardTicketStore.ts
+++ b/apps/server/src/portForward/TcpForwardTicketStore.ts
@@ -1,4 +1,8 @@
-import { AuthTerminalOperateScope, type TcpPortForwardHost } from "@t3tools/contracts";
+import {
+  AuthSessionId,
+  AuthTerminalOperateScope,
+  type TcpPortForwardHost,
+} from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
@@ -22,8 +26,16 @@ interface TicketRecord {
 
 export class TcpForwardTicketIssueError extends Schema.TaggedErrorClass<TcpForwardTicketIssueError>()(
   "TcpForwardTicketIssueError",
-  { cause: Schema.Defect() },
-) {}
+  {
+    stage: Schema.Literals(["generate-ticket", "issue-session-token"]),
+    sessionId: AuthSessionId,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `TCP forward ticket issuance failed during ${this.stage} for session ${this.sessionId}.`;
+  }
+}
 
 export class TcpForwardTicketInvalidError extends Schema.TaggedErrorClass<TcpForwardTicketInvalidError>()(
   "TcpForwardTicketInvalidError",
@@ -67,11 +79,25 @@ export const make = Effect.gen(function* () {
   const issue: TcpForwardTicketStore["Service"]["issue"] = Effect.fn("TcpForwardTicketStore.issue")(
     function* (input) {
       const ticket = yield* crypto.randomUUIDv4.pipe(
-        Effect.mapError((cause) => new TcpForwardTicketIssueError({ cause })),
+        Effect.mapError(
+          (cause) =>
+            new TcpForwardTicketIssueError({
+              stage: "generate-ticket",
+              sessionId: input.sessionId,
+              cause,
+            }),
+        ),
       );
-      const issued = yield* sessions
-        .issueWebSocketToken(input.sessionId, { ttl: TICKET_TTL })
-        .pipe(Effect.mapError((cause) => new TcpForwardTicketIssueError({ cause })));
+      const issued = yield* sessions.issueWebSocketToken(input.sessionId, { ttl: TICKET_TTL }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TcpForwardTicketIssueError({
+              stage: "issue-session-token",
+              sessionId: input.sessionId,
+              cause,
+            }),
+        ),
+      );
       yield* Ref.update(records, (current) => {
         const next = new Map(
           [...current].filter(

--- a/apps/server/src/portForward/TcpForwardTicketStore.ts
+++ b/apps/server/src/portForward/TcpForwardTicketStore.ts
@@ -1,0 +1,120 @@
+import { AuthTerminalOperateScope, type TcpPortForwardHost } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+
+import * as SessionStore from "../auth/SessionStore.ts";
+
+const TICKET_TTL = Duration.seconds(30);
+
+interface TicketRecord {
+  readonly webSocketToken: string;
+  readonly remoteHost: TcpPortForwardHost;
+  readonly remotePort: number;
+  readonly expiresAtEpochMs: number;
+}
+
+export class TcpForwardTicketIssueError extends Schema.TaggedErrorClass<TcpForwardTicketIssueError>()(
+  "TcpForwardTicketIssueError",
+  { cause: Schema.Defect() },
+) {}
+
+export class TcpForwardTicketInvalidError extends Schema.TaggedErrorClass<TcpForwardTicketInvalidError>()(
+  "TcpForwardTicketInvalidError",
+  {},
+) {}
+
+export class TcpForwardTicketStore extends Context.Service<
+  TcpForwardTicketStore,
+  {
+    readonly issue: (input: {
+      readonly sessionId: SessionStore.VerifiedSession["sessionId"];
+      readonly remoteHost: TcpPortForwardHost;
+      readonly remotePort: number;
+    }) => Effect.Effect<
+      { readonly ticket: string; readonly expiresAt: DateTime.Utc },
+      TcpForwardTicketIssueError
+    >;
+    readonly consume: (ticket: string) => Effect.Effect<
+      {
+        readonly session: SessionStore.VerifiedSession;
+        readonly remoteHost: TcpPortForwardHost;
+        readonly remotePort: number;
+      },
+      TcpForwardTicketInvalidError
+    >;
+  }
+>()("t3/portForward/TcpForwardTicketStore") {}
+
+export const make = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const sessions = yield* SessionStore.SessionStore;
+  const records = yield* Ref.make(new Map<string, TicketRecord>());
+
+  const issue: TcpForwardTicketStore["Service"]["issue"] = Effect.fn("TcpForwardTicketStore.issue")(
+    function* (input) {
+      const ticket = yield* crypto.randomUUIDv4.pipe(
+        Effect.mapError((cause) => new TcpForwardTicketIssueError({ cause })),
+      );
+      const issued = yield* sessions
+        .issueWebSocketToken(input.sessionId, { ttl: TICKET_TTL })
+        .pipe(Effect.mapError((cause) => new TcpForwardTicketIssueError({ cause })));
+      yield* Ref.update(records, (current) => {
+        const next = new Map(
+          [...current].filter(
+            ([, record]) =>
+              record.expiresAtEpochMs >
+              issued.expiresAt.epochMilliseconds - Duration.toMillis(TICKET_TTL),
+          ),
+        );
+        next.set(ticket, {
+          webSocketToken: issued.token,
+          remoteHost: input.remoteHost,
+          remotePort: input.remotePort,
+          expiresAtEpochMs: issued.expiresAt.epochMilliseconds,
+        });
+        return next;
+      });
+      return { ticket, expiresAt: DateTime.toUtc(issued.expiresAt) };
+    },
+  );
+
+  const consume: TcpForwardTicketStore["Service"]["consume"] = Effect.fn(
+    "TcpForwardTicketStore.consume",
+  )(function* (ticket) {
+    const record = yield* Ref.modify(records, (current) => {
+      const next = new Map(current);
+      const found = next.get(ticket);
+      next.delete(ticket);
+      return [Option.fromUndefinedOr(found), next] as const;
+    });
+    if (Option.isNone(record)) {
+      return yield* new TcpForwardTicketInvalidError({});
+    }
+    const now = yield* DateTime.now;
+    if (record.value.expiresAtEpochMs <= now.epochMilliseconds) {
+      return yield* new TcpForwardTicketInvalidError({});
+    }
+    const session = yield* sessions
+      .verifyWebSocketToken(record.value.webSocketToken)
+      .pipe(Effect.mapError(() => new TcpForwardTicketInvalidError({})));
+    if (!session.scopes.includes(AuthTerminalOperateScope)) {
+      return yield* new TcpForwardTicketInvalidError({});
+    }
+    return {
+      session,
+      remoteHost: record.value.remoteHost,
+      remotePort: record.value.remotePort,
+    };
+  });
+
+  return TcpForwardTicketStore.of({ issue, consume });
+});
+
+export const layer = Layer.effect(TcpForwardTicketStore, make);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -21,6 +21,8 @@ import {
 import { guardHttpResponseWriteErrors } from "./httpResponseErrorGuard.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
+import { tcpPortForwardWebSocketRouteLayer } from "./portForward/TcpForwardBridge.ts";
+import * as TcpForwardTicketStore from "./portForward/TcpForwardTicketStore.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { pullRequestHttpApiLayer } from "./pullRequest/http.ts";
 import * as PullRequestProviderRegistry from "./pullRequest/PullRequestProviderRegistry.ts";
@@ -458,12 +460,14 @@ export const makeRoutesLayer = Layer.mergeAll(
     assetRouteLayer,
     staticAndDevRouteLayer,
     websocketRpcRouteLayer,
+    tcpPortForwardWebSocketRouteLayer,
   ),
   McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer)),
 ).pipe(
   // Both transports consume the same service instance, so caches single-flight across clients
   // and mutations observed on WebSocket invalidate patches subsequently read over HTTP.
   Layer.provide(PullRequestServiceLive),
+  Layer.provideMerge(TcpForwardTicketStore.layer),
   Layer.provide(PreviewAutomationBroker.layer),
   Layer.provide(ServerSelfUpdate.layer),
   Layer.provide(commandReadinessLayer),

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -45,6 +45,7 @@ import {
   WorkspaceBreadcrumbSeparator,
 } from "../WorkspaceBreadcrumb";
 import { cn } from "~/lib/utils";
+import { DesktopPortForwardControl } from "../desktop/DesktopPortForwardControl";
 
 interface ChatHeaderProps {
   activeThreadEnvironmentId: EnvironmentId;
@@ -408,6 +409,10 @@ export const ChatHeader = memo(function ChatHeader({
             {...(draftId ? { draftId } : {})}
           />
         )}
+        <DesktopPortForwardControl
+          key={activeThreadEnvironmentId}
+          preferredEnvironmentId={activeThreadEnvironmentId}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import { useEffect } from "react";
 
 import { runtime } from "../../lib/runtime";
-import { readPreparedConnection } from "../../state/session";
+import { readCurrentPreparedConnection } from "../../state/session";
 
 export function DesktopPortForwardAuthorizationBridge() {
   useEffect(() => {
@@ -12,29 +12,39 @@ export function DesktopPortForwardAuthorizationBridge() {
     if (bridge === undefined) return;
 
     return bridge.onAuthorizationRequest((request) => {
-      const prepared = readPreparedConnection(request.environmentId);
-      if (prepared === null) {
-        void bridge.resolveAuthorization(request.requestId, null);
-        return;
-      }
-
-      void runtime
-        .runPromise(
-          Effect.gen(function* () {
-            const signer = yield* Effect.serviceOption(ManagedRelay.ManagedRelayDpopSigner);
-            return yield* resolveTcpPortForwardSocketUrl({
-              prepared,
-              signer,
-              remoteHost: request.remoteHost,
-              remotePort: request.remotePort,
-            });
-          }),
-        )
-        .then(
-          (socketUrl) => bridge.resolveAuthorization(request.requestId, socketUrl),
-          () => bridge.resolveAuthorization(request.requestId, null),
-        )
-        .catch(() => undefined);
+      void readCurrentPreparedConnection(request.environmentId)
+        .then((prepared) => {
+          if (prepared === null) {
+            // Authorization requests are broadcast to every desktop window.
+            // Only the renderer that owns a live connection should answer.
+            return;
+          }
+          return runtime.runPromise(
+            Effect.gen(function* () {
+              const signer = yield* Effect.serviceOption(ManagedRelay.ManagedRelayDpopSigner);
+              return yield* resolveTcpPortForwardSocketUrl({
+                prepared,
+                signer,
+                remoteHost: request.remoteHost,
+                remotePort: request.remotePort,
+              });
+            }),
+          );
+        })
+        .then((socketUrl) => {
+          if (socketUrl !== undefined) {
+            return bridge.resolveAuthorization(request.requestId, socketUrl);
+          }
+        })
+        .catch((cause) =>
+          bridge
+            .resolveAuthorization(
+              request.requestId,
+              null,
+              cause instanceof Error ? cause.message : String(cause),
+            )
+            .catch(() => undefined),
+        );
     });
   }, []);
 

--- a/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
@@ -1,0 +1,42 @@
+import { resolveTcpPortForwardSocketUrl } from "@t3tools/client-runtime/authorization";
+import { ManagedRelay } from "@t3tools/client-runtime/relay";
+import * as Effect from "effect/Effect";
+import { useEffect } from "react";
+
+import { runtime } from "../../lib/runtime";
+import { readPreparedConnection } from "../../state/session";
+
+export function DesktopPortForwardAuthorizationBridge() {
+  useEffect(() => {
+    const bridge = window.desktopBridge?.portForward;
+    if (bridge === undefined) return;
+
+    return bridge.onAuthorizationRequest((request) => {
+      const prepared = readPreparedConnection(request.environmentId);
+      if (prepared === null) {
+        void bridge.resolveAuthorization(request.requestId, null);
+        return;
+      }
+
+      void runtime
+        .runPromise(
+          Effect.gen(function* () {
+            const signer = yield* Effect.serviceOption(ManagedRelay.ManagedRelayDpopSigner);
+            return yield* resolveTcpPortForwardSocketUrl({
+              prepared,
+              signer,
+              remoteHost: request.remoteHost,
+              remotePort: request.remotePort,
+            });
+          }),
+        )
+        .then(
+          (socketUrl) => bridge.resolveAuthorization(request.requestId, socketUrl),
+          () => bridge.resolveAuthorization(request.requestId, null),
+        )
+        .catch(() => undefined);
+    });
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
@@ -6,9 +6,13 @@ import * as Exit from "effect/Exit";
 import { useEffect } from "react";
 
 import { runtime } from "../../lib/runtime";
-import { readCurrentPreparedConnection } from "../../state/session";
+import {
+  readCurrentPreparedConnection,
+  refreshCurrentPreparedConnection,
+} from "../../state/session";
 import {
   isMissingPortForwardEnvironment,
+  isRejectedPortForwardAuthorization,
   portForwardAuthorizationErrorMessage,
 } from "./desktopPortForwardAuthorization";
 
@@ -18,24 +22,35 @@ export function DesktopPortForwardAuthorizationBridge() {
     if (bridge === undefined) return;
 
     return bridge.onAuthorizationRequest((request) => {
+      const authorize = (
+        prepared: NonNullable<Awaited<ReturnType<typeof readCurrentPreparedConnection>>>,
+      ) =>
+        runtime.runPromiseExit(
+          Effect.gen(function* () {
+            const signer = yield* Effect.serviceOption(ManagedRelay.ManagedRelayDpopSigner);
+            return yield* resolveTcpPortForwardSocketUrl({
+              prepared,
+              signer,
+              remoteHost: request.remoteHost,
+              remotePort: request.remotePort,
+            });
+          }),
+        );
+
       void readCurrentPreparedConnection(request.environmentId)
-        .then((prepared) => {
+        .then(async (prepared) => {
           if (prepared === null) {
             // Authorization requests are broadcast to every desktop window.
             // Only the renderer that owns a live connection should answer.
             return;
           }
-          return runtime.runPromiseExit(
-            Effect.gen(function* () {
-              const signer = yield* Effect.serviceOption(ManagedRelay.ManagedRelayDpopSigner);
-              return yield* resolveTcpPortForwardSocketUrl({
-                prepared,
-                signer,
-                remoteHost: request.remoteHost,
-                remotePort: request.remotePort,
-              });
-            }),
-          );
+          const first = await authorize(prepared);
+          if (Exit.isSuccess(first)) return first;
+          const failure = first.cause.reasons.find(Cause.isFailReason)?.error;
+          if (!isRejectedPortForwardAuthorization(failure)) return first;
+
+          const refreshed = await refreshCurrentPreparedConnection(request.environmentId);
+          return refreshed === null ? first : authorize(refreshed);
         })
         .then((result) => {
           if (result === undefined) return;

--- a/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardAuthorizationBridge.tsx
@@ -1,10 +1,16 @@
 import { resolveTcpPortForwardSocketUrl } from "@t3tools/client-runtime/authorization";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import { useEffect } from "react";
 
 import { runtime } from "../../lib/runtime";
 import { readCurrentPreparedConnection } from "../../state/session";
+import {
+  isMissingPortForwardEnvironment,
+  portForwardAuthorizationErrorMessage,
+} from "./desktopPortForwardAuthorization";
 
 export function DesktopPortForwardAuthorizationBridge() {
   useEffect(() => {
@@ -19,7 +25,7 @@ export function DesktopPortForwardAuthorizationBridge() {
             // Only the renderer that owns a live connection should answer.
             return;
           }
-          return runtime.runPromise(
+          return runtime.runPromiseExit(
             Effect.gen(function* () {
               const signer = yield* Effect.serviceOption(ManagedRelay.ManagedRelayDpopSigner);
               return yield* resolveTcpPortForwardSocketUrl({
@@ -31,20 +37,30 @@ export function DesktopPortForwardAuthorizationBridge() {
             }),
           );
         })
-        .then((socketUrl) => {
-          if (socketUrl !== undefined) {
-            return bridge.resolveAuthorization(request.requestId, socketUrl);
+        .then((result) => {
+          if (result === undefined) return;
+          if (Exit.isSuccess(result)) {
+            return bridge.resolveAuthorization(request.requestId, result.value);
           }
+          return bridge.resolveAuthorization(
+            request.requestId,
+            null,
+            portForwardAuthorizationErrorMessage(Cause.squash(result.cause)),
+          );
         })
-        .catch((cause) =>
-          bridge
+        .catch((cause) => {
+          // Authorization requests used to be broadcast to every desktop
+          // renderer. Old windows that do not own this environment must stay
+          // silent so they cannot race the connected renderer's response.
+          if (isMissingPortForwardEnvironment(cause)) return;
+          return bridge
             .resolveAuthorization(
               request.requestId,
               null,
-              cause instanceof Error ? cause.message : String(cause),
+              portForwardAuthorizationErrorMessage(cause),
             )
-            .catch(() => undefined),
-        );
+            .catch(() => undefined);
+        });
     });
   }, []);
 

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.test.ts
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.test.ts
@@ -1,0 +1,48 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolvePortForwardEnvironmentId } from "./DesktopPortForwardControl";
+
+const development = "development" as EnvironmentId;
+const emaildev = "emaildev" as EnvironmentId;
+
+describe("resolvePortForwardEnvironmentId", () => {
+  it("follows the active thread when its environment changes", () => {
+    expect(
+      resolvePortForwardEnvironmentId({
+        connectedEnvironmentIds: [development, emaildev],
+        preferredEnvironmentId: emaildev,
+        selection: {
+          contextEnvironmentId: development,
+          environmentId: development,
+        },
+      }),
+    ).toBe(emaildev);
+  });
+
+  it("preserves an explicit selection within the current thread", () => {
+    expect(
+      resolvePortForwardEnvironmentId({
+        connectedEnvironmentIds: [development, emaildev],
+        preferredEnvironmentId: emaildev,
+        selection: {
+          contextEnvironmentId: emaildev,
+          environmentId: development,
+        },
+      }),
+    ).toBe(development);
+  });
+
+  it("falls back when the preferred environment is disconnected", () => {
+    expect(
+      resolvePortForwardEnvironmentId({
+        connectedEnvironmentIds: [development],
+        preferredEnvironmentId: emaildev,
+        selection: {
+          contextEnvironmentId: emaildev,
+          environmentId: emaildev,
+        },
+      }),
+    ).toBe(development);
+  });
+});

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -103,6 +103,7 @@ export function DesktopPortForwardControl({
                       : "Port forwarding"
                   }
                   className="relative shrink-0 [--control-icon-color:var(--foreground)]"
+                  data-toolbar-control=""
                   size="icon-xs"
                   variant="outline"
                 />

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -140,8 +140,8 @@ export function DesktopPortForwardControl({
           </p>
         ) : null}
         <div className="space-y-3">
-          <label className="text-xs text-muted-foreground">
-            <span className="mb-1.5 block">Environment</span>
+          <label className="block">
+            <span className="mb-1.5 block text-xs font-medium text-foreground">Environment</span>
             <Select
               value={selectedEnvironmentId ?? ""}
               onValueChange={(value) => {
@@ -174,11 +174,16 @@ export function DesktopPortForwardControl({
             </Select>
           </label>
           <div className="grid grid-cols-2 gap-3">
-            <label className="text-xs text-muted-foreground">
-              <span className="mb-1.5 block">Remote port</span>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-medium text-foreground">Remote port</span>
               <Input
                 aria-label="Remote port"
                 aria-invalid={parsedRemotePort === null}
+                aria-describedby={
+                  parsedRemotePort === null
+                    ? "desktop-port-forward-control-remote-port-error"
+                    : undefined
+                }
                 type="number"
                 min={1}
                 max={65_535}
@@ -188,16 +193,24 @@ export function DesktopPortForwardControl({
                 onChange={(event) => setRemotePort(event.target.value)}
               />
               {parsedRemotePort === null ? (
-                <span className="mt-1 block text-[11px] text-destructive">
+                <span
+                  id="desktop-port-forward-control-remote-port-error"
+                  className="mt-1 block text-[11px] text-destructive"
+                >
                   Enter a port from 1 to 65535.
                 </span>
               ) : null}
             </label>
-            <label className="text-xs text-muted-foreground">
-              <span className="mb-1.5 block">Local port</span>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-medium text-foreground">Local port</span>
               <Input
                 aria-label="Local port"
                 aria-invalid={localPort.trim() !== "" && parsedLocalPort === null}
+                aria-describedby={
+                  localPort.trim() !== "" && parsedLocalPort === null
+                    ? "desktop-port-forward-control-local-port-error"
+                    : undefined
+                }
                 type="number"
                 min={1}
                 max={65_535}
@@ -208,7 +221,10 @@ export function DesktopPortForwardControl({
                 onChange={(event) => setLocalPort(event.target.value)}
               />
               {localPort.trim() !== "" && parsedLocalPort === null ? (
-                <span className="mt-1 block text-[11px] text-destructive">
+                <span
+                  id="desktop-port-forward-control-local-port-error"
+                  className="mt-1 block text-[11px] text-destructive"
+                >
                   Enter a port from 1 to 65535.
                 </span>
               ) : null}

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -210,8 +210,8 @@ export function DesktopPortForwardControl({
                     {forward.localHost}:{forward.localPort}
                   </p>
                   <p className="truncate text-muted-foreground tabular-nums">
-                    {environmentLabels.get(forward.environmentId) ?? "Unknown environment"} · →
-                    {forward.remoteHost}:{forward.remotePort} ·{" "}
+                    {environmentLabels.get(forward.environmentId) ?? "Unknown environment"} ·{" "}
+                    <span aria-hidden="true">→</span> {forward.remoteHost}:{forward.remotePort} ·{" "}
                     {portForwardConnectionSummary(forward)}
                   </p>
                   {forward.lastError === null ? null : (

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -177,20 +177,40 @@ export function DesktopPortForwardControl({
               <span className="mb-1.5 block">Remote port</span>
               <Input
                 aria-label="Remote port"
+                aria-invalid={parsedRemotePort === null}
+                type="number"
+                min={1}
+                max={65_535}
+                step={1}
                 inputMode="numeric"
                 value={remotePort}
                 onChange={(event) => setRemotePort(event.target.value)}
               />
+              {parsedRemotePort === null ? (
+                <span className="mt-1 block text-[11px] text-destructive">
+                  Enter a port from 1 to 65535.
+                </span>
+              ) : null}
             </label>
             <label className="text-xs text-muted-foreground">
               <span className="mb-1.5 block">Local port</span>
               <Input
                 aria-label="Local port"
+                aria-invalid={localPort.trim() !== "" && parsedLocalPort === null}
+                type="number"
+                min={1}
+                max={65_535}
+                step={1}
                 inputMode="numeric"
                 placeholder="Same as remote"
                 value={localPort}
                 onChange={(event) => setLocalPort(event.target.value)}
               />
+              {localPort.trim() !== "" && parsedLocalPort === null ? (
+                <span className="mt-1 block text-[11px] text-destructive">
+                  Enter a port from 1 to 65535.
+                </span>
+              ) : null}
             </label>
           </div>
           <Button className="w-full" size="sm" disabled={!canCreate} onClick={() => void create()}>

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -1,24 +1,14 @@
-import type {
-  DesktopPortForwardId,
-  DesktopPortForwardSnapshot,
-  EnvironmentId,
-} from "@t3tools/contracts";
+import type { EnvironmentId } from "@t3tools/contracts";
 import { CableIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 
-import { useEnvironments } from "../../state/environments";
-import { useServerConfigs } from "../../state/entities";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { portForwardConnectionSummary } from "./desktopPortForwardPresentation";
-
-function parsePort(value: string): number | null {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : null;
-}
+import { parseDesktopPortForwardPort, useDesktopPortForwards } from "./useDesktopPortForwards";
 
 interface EnvironmentSelection {
   readonly contextEnvironmentId: EnvironmentId;
@@ -48,39 +38,24 @@ export function DesktopPortForwardControl({
 }: {
   preferredEnvironmentId: EnvironmentId;
 }) {
-  const bridge = window.desktopBridge?.portForward;
-  const { environments } = useEnvironments();
-  const serverConfigs = useServerConfigs();
-  const connectedEnvironments = useMemo(
-    () => environments.filter((environment) => environment.connection.phase === "connected"),
-    [environments],
-  );
-  const forwardableEnvironments = useMemo(
-    () =>
-      connectedEnvironments.filter(
-        (environment) =>
-          serverConfigs.get(environment.environmentId)?.environment.capabilities
-            .tcpPortForwarding === true,
-      ),
-    [connectedEnvironments, serverConfigs],
-  );
-  const environmentLabels = useMemo(
-    () =>
-      new Map(
-        environments.map((environment) => [environment.environmentId, environment.label] as const),
-      ),
-    [environments],
-  );
+  const {
+    available,
+    connectedEnvironments,
+    create: createForward,
+    creating,
+    environmentLabels,
+    error,
+    forwardableEnvironments,
+    forwards,
+    stop,
+    stoppingId,
+  } = useDesktopPortForwards();
   const [environmentSelection, setEnvironmentSelection] = useState<EnvironmentSelection>(() => ({
     contextEnvironmentId: preferredEnvironmentId,
     environmentId: preferredEnvironmentId,
   }));
   const [remotePort, setRemotePort] = useState("3000");
   const [localPort, setLocalPort] = useState("");
-  const [forwards, setForwards] = useState<ReadonlyArray<DesktopPortForwardSnapshot>>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [stoppingId, setStoppingId] = useState<DesktopPortForwardId | null>(null);
 
   const selectedEnvironmentId = resolvePortForwardEnvironmentId({
     connectedEnvironmentIds: forwardableEnvironments.map(
@@ -90,28 +65,11 @@ export function DesktopPortForwardControl({
     selection: environmentSelection,
   });
 
-  useEffect(() => {
-    if (bridge === undefined) return;
-    let disposed = false;
-    void bridge.list().then(
-      (next) => {
-        if (!disposed) setForwards(next);
-      },
-      () => undefined,
-    );
-    const unsubscribe = bridge.onStateChange((next) => {
-      setForwards(next);
-    });
-    return () => {
-      disposed = true;
-      unsubscribe();
-    };
-  }, [bridge]);
+  if (!available) return null;
 
-  if (bridge === undefined) return null;
-
-  const parsedRemotePort = parsePort(remotePort);
-  const parsedLocalPort = localPort.trim() === "" ? undefined : parsePort(localPort);
+  const parsedRemotePort = parseDesktopPortForwardPort(remotePort);
+  const parsedLocalPort =
+    localPort.trim() === "" ? undefined : parseDesktopPortForwardPort(localPort);
   const canCreate =
     selectedEnvironmentId !== null &&
     parsedRemotePort !== null &&
@@ -120,36 +78,14 @@ export function DesktopPortForwardControl({
 
   const create = async () => {
     if (!canCreate || selectedEnvironmentId === null || parsedRemotePort === null) return;
-    setCreating(true);
-    setError(null);
-    try {
-      const created = await bridge.create({
-        environmentId: selectedEnvironmentId,
-        remoteHost: "127.0.0.1",
-        remotePort: parsedRemotePort,
-        ...(parsedLocalPort === undefined ? {} : { localPort: parsedLocalPort }),
-      });
-      setForwards((current) =>
-        current.some((forward) => forward.id === created.id) ? current : [...current, created],
-      );
+    const created = await createForward({
+      environmentId: selectedEnvironmentId,
+      remoteHost: "127.0.0.1",
+      remotePort: parsedRemotePort,
+      ...(parsedLocalPort === undefined ? {} : { localPort: parsedLocalPort }),
+    });
+    if (created) {
       setLocalPort("");
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const stop = async (id: DesktopPortForwardId) => {
-    setStoppingId(id);
-    setError(null);
-    try {
-      await bridge.stop(id);
-      setForwards((current) => current.filter((forward) => forward.id !== id));
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setStoppingId(null);
     }
   };
 
@@ -161,14 +97,18 @@ export function DesktopPortForwardControl({
             <PopoverTrigger
               render={
                 <Button
-                  aria-label="Port forwarding"
+                  aria-label={
+                    forwards.length > 0
+                      ? `Port forwarding, ${forwards.length} active`
+                      : "Port forwarding"
+                  }
                   className="relative shrink-0 [--control-icon-color:var(--foreground)]"
                   size="icon-xs"
                   variant="outline"
                 />
               }
             >
-              <CableIcon aria-hidden className="size-3.5 text-foreground" />
+              <CableIcon aria-hidden className="size-3.5" />
               {forwards.length > 0 ? (
                 <span
                   aria-hidden
@@ -219,7 +159,7 @@ export function DesktopPortForwardControl({
                     : (environmentLabels.get(selectedEnvironmentId) ?? selectedEnvironmentId)}
                 </SelectValue>
               </SelectTrigger>
-              <SelectPopup alignItemWithTrigger={false} positionerClassName="z-70">
+              <SelectPopup alignItemWithTrigger={false}>
                 {forwardableEnvironments.map((environment) => (
                   <SelectItem
                     hideIndicator
@@ -266,10 +206,13 @@ export function DesktopPortForwardControl({
                 className="flex items-center justify-between gap-3 rounded-md bg-muted/40 px-2 py-1.5"
               >
                 <div className="min-w-0 text-xs">
-                  <p className="truncate font-medium tabular-nums">127.0.0.1:{forward.localPort}</p>
+                  <p className="truncate font-medium tabular-nums">
+                    {forward.localHost}:{forward.localPort}
+                  </p>
                   <p className="truncate text-muted-foreground tabular-nums">
                     {environmentLabels.get(forward.environmentId) ?? "Unknown environment"} · →
-                    127.0.0.1:{forward.remotePort} · {portForwardConnectionSummary(forward)}
+                    {forward.remoteHost}:{forward.remotePort} ·{" "}
+                    {portForwardConnectionSummary(forward)}
                   </p>
                   {forward.lastError === null ? null : (
                     <p className="truncate text-destructive">{forward.lastError}</p>

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -7,6 +7,7 @@ import { CableIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { useEnvironments } from "../../state/environments";
+import { useServerConfigs } from "../../state/entities";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
@@ -48,9 +49,19 @@ export function DesktopPortForwardControl({
 }) {
   const bridge = window.desktopBridge?.portForward;
   const { environments } = useEnvironments();
+  const serverConfigs = useServerConfigs();
   const connectedEnvironments = useMemo(
     () => environments.filter((environment) => environment.connection.phase === "connected"),
     [environments],
+  );
+  const forwardableEnvironments = useMemo(
+    () =>
+      connectedEnvironments.filter(
+        (environment) =>
+          serverConfigs.get(environment.environmentId)?.environment.capabilities
+            .tcpPortForwarding === true,
+      ),
+    [connectedEnvironments, serverConfigs],
   );
   const environmentLabels = useMemo(
     () =>
@@ -71,7 +82,9 @@ export function DesktopPortForwardControl({
   const [stoppingId, setStoppingId] = useState<DesktopPortForwardId | null>(null);
 
   const selectedEnvironmentId = resolvePortForwardEnvironmentId({
-    connectedEnvironmentIds: connectedEnvironments.map((environment) => environment.environmentId),
+    connectedEnvironmentIds: forwardableEnvironments.map(
+      (environment) => environment.environmentId,
+    ),
     preferredEnvironmentId,
     selection: environmentSelection,
   });
@@ -179,6 +192,10 @@ export function DesktopPortForwardControl({
           <p className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
             Connect an environment before starting a port forward.
           </p>
+        ) : forwardableEnvironments.length === 0 ? (
+          <p className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+            Update the connected T3 server before starting a port forward.
+          </p>
         ) : null}
         <div className="space-y-3">
           <label className="text-xs text-muted-foreground">
@@ -202,7 +219,7 @@ export function DesktopPortForwardControl({
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup alignItemWithTrigger={false} positionerClassName="z-70">
-                {connectedEnvironments.map((environment) => (
+                {forwardableEnvironments.map((environment) => (
                   <SelectItem
                     hideIndicator
                     key={environment.environmentId}
@@ -254,6 +271,9 @@ export function DesktopPortForwardControl({
                     127.0.0.1:{forward.remotePort}
                     {forward.activeConnections > 0 ? ` · ${forward.activeConnections} active` : ""}
                   </p>
+                  {forward.lastError === null ? null : (
+                    <p className="truncate text-destructive">{forward.lastError}</p>
+                  )}
                 </div>
                 <Button
                   size="xs"

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -13,6 +13,7 @@ import { Input } from "../ui/input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { portForwardConnectionSummary } from "./desktopPortForwardPresentation";
 
 function parsePort(value: string): number | null {
   const parsed = Number(value);
@@ -268,8 +269,7 @@ export function DesktopPortForwardControl({
                   <p className="truncate font-medium tabular-nums">127.0.0.1:{forward.localPort}</p>
                   <p className="truncate text-muted-foreground tabular-nums">
                     {environmentLabels.get(forward.environmentId) ?? "Unknown environment"} · →
-                    127.0.0.1:{forward.remotePort}
-                    {forward.activeConnections > 0 ? ` · ${forward.activeConnections} active` : ""}
+                    127.0.0.1:{forward.remotePort} · {portForwardConnectionSummary(forward)}
                   </p>
                   {forward.lastError === null ? null : (
                     <p className="truncate text-destructive">{forward.lastError}</p>

--- a/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
+++ b/apps/web/src/components/desktop/DesktopPortForwardControl.tsx
@@ -1,0 +1,273 @@
+import type {
+  DesktopPortForwardId,
+  DesktopPortForwardSnapshot,
+  EnvironmentId,
+} from "@t3tools/contracts";
+import { CableIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { useEnvironments } from "../../state/environments";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+function parsePort(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : null;
+}
+
+interface EnvironmentSelection {
+  readonly contextEnvironmentId: EnvironmentId;
+  readonly environmentId: EnvironmentId;
+}
+
+export function resolvePortForwardEnvironmentId(input: {
+  readonly connectedEnvironmentIds: ReadonlyArray<EnvironmentId>;
+  readonly preferredEnvironmentId: EnvironmentId;
+  readonly selection: EnvironmentSelection;
+}): EnvironmentId | null {
+  const { connectedEnvironmentIds, preferredEnvironmentId, selection } = input;
+  if (
+    selection.contextEnvironmentId === preferredEnvironmentId &&
+    connectedEnvironmentIds.includes(selection.environmentId)
+  ) {
+    return selection.environmentId;
+  }
+  if (connectedEnvironmentIds.includes(preferredEnvironmentId)) {
+    return preferredEnvironmentId;
+  }
+  return connectedEnvironmentIds[0] ?? null;
+}
+
+export function DesktopPortForwardControl({
+  preferredEnvironmentId,
+}: {
+  preferredEnvironmentId: EnvironmentId;
+}) {
+  const bridge = window.desktopBridge?.portForward;
+  const { environments } = useEnvironments();
+  const connectedEnvironments = useMemo(
+    () => environments.filter((environment) => environment.connection.phase === "connected"),
+    [environments],
+  );
+  const environmentLabels = useMemo(
+    () =>
+      new Map(
+        environments.map((environment) => [environment.environmentId, environment.label] as const),
+      ),
+    [environments],
+  );
+  const [environmentSelection, setEnvironmentSelection] = useState<EnvironmentSelection>(() => ({
+    contextEnvironmentId: preferredEnvironmentId,
+    environmentId: preferredEnvironmentId,
+  }));
+  const [remotePort, setRemotePort] = useState("3000");
+  const [localPort, setLocalPort] = useState("");
+  const [forwards, setForwards] = useState<ReadonlyArray<DesktopPortForwardSnapshot>>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [stoppingId, setStoppingId] = useState<DesktopPortForwardId | null>(null);
+
+  const selectedEnvironmentId = resolvePortForwardEnvironmentId({
+    connectedEnvironmentIds: connectedEnvironments.map((environment) => environment.environmentId),
+    preferredEnvironmentId,
+    selection: environmentSelection,
+  });
+
+  useEffect(() => {
+    if (bridge === undefined) return;
+    let disposed = false;
+    void bridge.list().then(
+      (next) => {
+        if (!disposed) setForwards(next);
+      },
+      () => undefined,
+    );
+    const unsubscribe = bridge.onStateChange((next) => {
+      setForwards(next);
+    });
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [bridge]);
+
+  if (bridge === undefined) return null;
+
+  const parsedRemotePort = parsePort(remotePort);
+  const parsedLocalPort = localPort.trim() === "" ? undefined : parsePort(localPort);
+  const canCreate =
+    selectedEnvironmentId !== null &&
+    parsedRemotePort !== null &&
+    parsedLocalPort !== null &&
+    !creating;
+
+  const create = async () => {
+    if (!canCreate || selectedEnvironmentId === null || parsedRemotePort === null) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await bridge.create({
+        environmentId: selectedEnvironmentId,
+        remoteHost: "127.0.0.1",
+        remotePort: parsedRemotePort,
+        ...(parsedLocalPort === undefined ? {} : { localPort: parsedLocalPort }),
+      });
+      setForwards((current) =>
+        current.some((forward) => forward.id === created.id) ? current : [...current, created],
+      );
+      setLocalPort("");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const stop = async (id: DesktopPortForwardId) => {
+    setStoppingId(id);
+    setError(null);
+    try {
+      await bridge.stop(id);
+      setForwards((current) => current.filter((forward) => forward.id !== id));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setStoppingId(null);
+    }
+  };
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <PopoverTrigger
+              render={
+                <Button
+                  aria-label="Port forwarding"
+                  className="relative shrink-0 [--control-icon-color:var(--foreground)]"
+                  size="icon-xs"
+                  variant="outline"
+                />
+              }
+            >
+              <CableIcon aria-hidden className="size-3.5 text-foreground" />
+              {forwards.length > 0 ? (
+                <span
+                  aria-hidden
+                  className="absolute -top-1.5 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
+                >
+                  {forwards.length}
+                </span>
+              ) : null}
+            </PopoverTrigger>
+          }
+        />
+        <TooltipPopup side="bottom">Port forwarding</TooltipPopup>
+      </Tooltip>
+      <PopoverPopup align="end" className="w-88" sideOffset={8} viewportClassName="space-y-4">
+        <div className="space-y-1.5">
+          <p className="text-sm font-semibold">Port forwarding</p>
+          <p className="text-xs text-muted-foreground">
+            Forward remote loopback ports to this computer.
+          </p>
+        </div>
+        {connectedEnvironments.length === 0 ? (
+          <p className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+            Connect an environment before starting a port forward.
+          </p>
+        ) : null}
+        <div className="space-y-3">
+          <label className="text-xs text-muted-foreground">
+            <span className="mb-1.5 block">Environment</span>
+            <Select
+              value={selectedEnvironmentId ?? ""}
+              onValueChange={(value) => {
+                if (typeof value === "string" && value !== "") {
+                  setEnvironmentSelection({
+                    contextEnvironmentId: preferredEnvironmentId,
+                    environmentId: value as EnvironmentId,
+                  });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full" aria-label="Forward environment">
+                <SelectValue>
+                  {selectedEnvironmentId === null
+                    ? "Select an environment"
+                    : (environmentLabels.get(selectedEnvironmentId) ?? selectedEnvironmentId)}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup alignItemWithTrigger={false} positionerClassName="z-70">
+                {connectedEnvironments.map((environment) => (
+                  <SelectItem
+                    hideIndicator
+                    key={environment.environmentId}
+                    value={environment.environmentId}
+                  >
+                    {environment.label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-xs text-muted-foreground">
+              <span className="mb-1.5 block">Remote port</span>
+              <Input
+                aria-label="Remote port"
+                inputMode="numeric"
+                value={remotePort}
+                onChange={(event) => setRemotePort(event.target.value)}
+              />
+            </label>
+            <label className="text-xs text-muted-foreground">
+              <span className="mb-1.5 block">Local port</span>
+              <Input
+                aria-label="Local port"
+                inputMode="numeric"
+                placeholder="Same as remote"
+                value={localPort}
+                onChange={(event) => setLocalPort(event.target.value)}
+              />
+            </label>
+          </div>
+          <Button className="w-full" size="sm" disabled={!canCreate} onClick={() => void create()}>
+            {creating ? "Starting…" : "Start forward"}
+          </Button>
+        </div>
+        {error === null ? null : <p className="text-xs text-destructive">{error}</p>}
+        {forwards.length > 0 ? (
+          <div className="space-y-1 border-t border-border/60 pt-3">
+            {forwards.map((forward) => (
+              <div
+                key={forward.id}
+                className="flex items-center justify-between gap-3 rounded-md bg-muted/40 px-2 py-1.5"
+              >
+                <div className="min-w-0 text-xs">
+                  <p className="truncate font-medium tabular-nums">127.0.0.1:{forward.localPort}</p>
+                  <p className="truncate text-muted-foreground tabular-nums">
+                    {environmentLabels.get(forward.environmentId) ?? "Unknown environment"} · →
+                    127.0.0.1:{forward.remotePort}
+                    {forward.activeConnections > 0 ? ` · ${forward.activeConnections} active` : ""}
+                  </p>
+                </div>
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  disabled={stoppingId === forward.id}
+                  onClick={() => void stop(forward.id)}
+                >
+                  Stop
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.test.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isMissingPortForwardEnvironment,
+  portForwardAuthorizationErrorMessage,
+} from "./desktopPortForwardAuthorization";
+
+describe("desktop port-forward authorization", () => {
+  it("never sends an empty IPC error", () => {
+    expect(portForwardAuthorizationErrorMessage(new Error(""))).toBe(
+      "The environment could not authorize this connection.",
+    );
+    expect(portForwardAuthorizationErrorMessage("   ")).toBe(
+      "The environment could not authorize this connection.",
+    );
+  });
+
+  it("preserves a typed authorization failure message", () => {
+    expect(
+      portForwardAuthorizationErrorMessage({
+        _tag: "RemoteEnvironmentAuthUndeclaredStatusError",
+        message: "Remote environment returned status 404.",
+      }),
+    ).toBe("Remote environment returned status 404.");
+  });
+
+  it("identifies renderers that do not own the requested environment", () => {
+    expect(isMissingPortForwardEnvironment({ _tag: "EnvironmentNotRegisteredError" })).toBe(true);
+    expect(isMissingPortForwardEnvironment({ _tag: "RemoteEnvironmentAuthFetchError" })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.test.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   isMissingPortForwardEnvironment,
+  isRejectedPortForwardAuthorization,
   portForwardAuthorizationErrorMessage,
 } from "./desktopPortForwardAuthorization";
 
@@ -24,10 +25,24 @@ describe("desktop port-forward authorization", () => {
     ).toBe("Remote environment returned status 404.");
   });
 
+  it("explains structured environment authorization failures", () => {
+    expect(portForwardAuthorizationErrorMessage({ _tag: "EnvironmentAuthInvalidError" })).toBe(
+      "The environment authorization expired or was rejected after reconnecting.",
+    );
+    expect(portForwardAuthorizationErrorMessage({ _tag: "EnvironmentScopeRequiredError" })).toBe(
+      "Port forwarding requires terminal access on this environment.",
+    );
+  });
+
   it("identifies renderers that do not own the requested environment", () => {
     expect(isMissingPortForwardEnvironment({ _tag: "EnvironmentNotRegisteredError" })).toBe(true);
     expect(isMissingPortForwardEnvironment({ _tag: "RemoteEnvironmentAuthFetchError" })).toBe(
       false,
     );
+  });
+
+  it("identifies a rejected environment credential for one reconnect attempt", () => {
+    expect(isRejectedPortForwardAuthorization({ _tag: "EnvironmentAuthInvalidError" })).toBe(true);
+    expect(isRejectedPortForwardAuthorization({ _tag: "EnvironmentInternalError" })).toBe(false);
   });
 });

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.test.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.test.ts
@@ -1,3 +1,9 @@
+import { EnvironmentNotRegisteredError } from "@t3tools/client-runtime/connection";
+import {
+  EnvironmentAuthInvalidError,
+  EnvironmentId,
+  EnvironmentScopeRequiredError,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -26,23 +32,47 @@ describe("desktop port-forward authorization", () => {
   });
 
   it("explains structured environment authorization failures", () => {
-    expect(portForwardAuthorizationErrorMessage({ _tag: "EnvironmentAuthInvalidError" })).toBe(
-      "The environment authorization expired or was rejected after reconnecting.",
-    );
-    expect(portForwardAuthorizationErrorMessage({ _tag: "EnvironmentScopeRequiredError" })).toBe(
-      "Port forwarding requires terminal access on this environment.",
-    );
+    expect(
+      portForwardAuthorizationErrorMessage(
+        new EnvironmentAuthInvalidError({
+          code: "auth_invalid",
+          reason: "invalid_credential",
+          traceId: "trace-a",
+        }),
+      ),
+    ).toBe("The environment authorization expired or was rejected after reconnecting.");
+    expect(
+      portForwardAuthorizationErrorMessage(
+        new EnvironmentScopeRequiredError({
+          code: "insufficient_scope",
+          requiredScope: "terminal:operate",
+          traceId: "trace-b",
+        }),
+      ),
+    ).toBe("Port forwarding requires terminal access on this environment.");
   });
 
   it("identifies renderers that do not own the requested environment", () => {
-    expect(isMissingPortForwardEnvironment({ _tag: "EnvironmentNotRegisteredError" })).toBe(true);
+    expect(
+      isMissingPortForwardEnvironment(
+        new EnvironmentNotRegisteredError({ environmentId: EnvironmentId.make("missing") }),
+      ),
+    ).toBe(true);
     expect(isMissingPortForwardEnvironment({ _tag: "RemoteEnvironmentAuthFetchError" })).toBe(
       false,
     );
   });
 
   it("identifies a rejected environment credential for one reconnect attempt", () => {
-    expect(isRejectedPortForwardAuthorization({ _tag: "EnvironmentAuthInvalidError" })).toBe(true);
+    expect(
+      isRejectedPortForwardAuthorization(
+        new EnvironmentAuthInvalidError({
+          code: "auth_invalid",
+          reason: "invalid_credential",
+          traceId: "trace-c",
+        }),
+      ),
+    ).toBe(true);
     expect(isRejectedPortForwardAuthorization({ _tag: "EnvironmentInternalError" })).toBe(false);
   });
 });

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
@@ -7,6 +7,15 @@ export function isMissingPortForwardEnvironment(cause: unknown): boolean {
   );
 }
 
+export function isRejectedPortForwardAuthorization(cause: unknown): boolean {
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    "_tag" in cause &&
+    cause._tag === "EnvironmentAuthInvalidError"
+  );
+}
+
 export function portForwardAuthorizationErrorMessage(cause: unknown): string {
   if (cause instanceof Error && cause.message.trim().length > 0) {
     return cause.message.trim();
@@ -20,6 +29,17 @@ export function portForwardAuthorizationErrorMessage(cause: unknown): string {
     cause.message.trim().length > 0
   ) {
     return cause.message.trim();
+  }
+
+  if (typeof cause === "object" && cause !== null && "_tag" in cause) {
+    switch (cause._tag) {
+      case "EnvironmentAuthInvalidError":
+        return "The environment authorization expired or was rejected after reconnecting.";
+      case "EnvironmentScopeRequiredError":
+        return "Port forwarding requires terminal access on this environment.";
+      case "EnvironmentInternalError":
+        return "The environment could not issue a port-forward connection ticket.";
+    }
   }
 
   if (typeof cause === "string" && cause.trim().length > 0) {

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
@@ -1,0 +1,30 @@
+export function isMissingPortForwardEnvironment(cause: unknown): boolean {
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    "_tag" in cause &&
+    cause._tag === "EnvironmentNotRegisteredError"
+  );
+}
+
+export function portForwardAuthorizationErrorMessage(cause: unknown): string {
+  if (cause instanceof Error && cause.message.trim().length > 0) {
+    return cause.message.trim();
+  }
+
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string" &&
+    cause.message.trim().length > 0
+  ) {
+    return cause.message.trim();
+  }
+
+  if (typeof cause === "string" && cause.trim().length > 0) {
+    return cause.trim();
+  }
+
+  return "The environment could not authorize this connection.";
+}

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
@@ -6,21 +6,13 @@ import {
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
-const isEnvironmentNotRegisteredError = Schema.is(EnvironmentNotRegisteredError);
-const isEnvironmentAuthInvalidError = Schema.is(EnvironmentAuthInvalidError);
+export const isMissingPortForwardEnvironment = Schema.is(EnvironmentNotRegisteredError);
+export const isRejectedPortForwardAuthorization = Schema.is(EnvironmentAuthInvalidError);
 const isEnvironmentScopeRequiredError = Schema.is(EnvironmentScopeRequiredError);
 const isEnvironmentInternalError = Schema.is(EnvironmentInternalError);
 
-export function isMissingPortForwardEnvironment(cause: unknown): boolean {
-  return isEnvironmentNotRegisteredError(cause);
-}
-
-export function isRejectedPortForwardAuthorization(cause: unknown): boolean {
-  return isEnvironmentAuthInvalidError(cause);
-}
-
 export function portForwardAuthorizationErrorMessage(cause: unknown): string {
-  if (isEnvironmentAuthInvalidError(cause)) {
+  if (isRejectedPortForwardAuthorization(cause)) {
     return "The environment authorization expired or was rejected after reconnecting.";
   }
   if (isEnvironmentScopeRequiredError(cause)) {

--- a/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardAuthorization.ts
@@ -1,22 +1,35 @@
+import { EnvironmentNotRegisteredError } from "@t3tools/client-runtime/connection";
+import {
+  EnvironmentAuthInvalidError,
+  EnvironmentInternalError,
+  EnvironmentScopeRequiredError,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+const isEnvironmentNotRegisteredError = Schema.is(EnvironmentNotRegisteredError);
+const isEnvironmentAuthInvalidError = Schema.is(EnvironmentAuthInvalidError);
+const isEnvironmentScopeRequiredError = Schema.is(EnvironmentScopeRequiredError);
+const isEnvironmentInternalError = Schema.is(EnvironmentInternalError);
+
 export function isMissingPortForwardEnvironment(cause: unknown): boolean {
-  return (
-    typeof cause === "object" &&
-    cause !== null &&
-    "_tag" in cause &&
-    cause._tag === "EnvironmentNotRegisteredError"
-  );
+  return isEnvironmentNotRegisteredError(cause);
 }
 
 export function isRejectedPortForwardAuthorization(cause: unknown): boolean {
-  return (
-    typeof cause === "object" &&
-    cause !== null &&
-    "_tag" in cause &&
-    cause._tag === "EnvironmentAuthInvalidError"
-  );
+  return isEnvironmentAuthInvalidError(cause);
 }
 
 export function portForwardAuthorizationErrorMessage(cause: unknown): string {
+  if (isEnvironmentAuthInvalidError(cause)) {
+    return "The environment authorization expired or was rejected after reconnecting.";
+  }
+  if (isEnvironmentScopeRequiredError(cause)) {
+    return "Port forwarding requires terminal access on this environment.";
+  }
+  if (isEnvironmentInternalError(cause)) {
+    return "The environment could not issue a port-forward connection ticket.";
+  }
+
   if (cause instanceof Error && cause.message.trim().length > 0) {
     return cause.message.trim();
   }
@@ -29,17 +42,6 @@ export function portForwardAuthorizationErrorMessage(cause: unknown): string {
     cause.message.trim().length > 0
   ) {
     return cause.message.trim();
-  }
-
-  if (typeof cause === "object" && cause !== null && "_tag" in cause) {
-    switch (cause._tag) {
-      case "EnvironmentAuthInvalidError":
-        return "The environment authorization expired or was rejected after reconnecting.";
-      case "EnvironmentScopeRequiredError":
-        return "Port forwarding requires terminal access on this environment.";
-      case "EnvironmentInternalError":
-        return "The environment could not issue a port-forward connection ticket.";
-    }
   }
 
   if (typeof cause === "string" && cause.trim().length > 0) {

--- a/apps/web/src/components/desktop/desktopPortForwardPresentation.test.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardPresentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { portForwardConnectionSummary } from "./desktopPortForwardPresentation";
+
+describe("desktop port-forward presentation", () => {
+  it("distinguishes an idle listener from a pending connection", () => {
+    expect(
+      portForwardConnectionSummary({
+        activeConnections: 0,
+        connectingConnections: 0,
+        lastError: null,
+      }),
+    ).toBe("Listening");
+    expect(
+      portForwardConnectionSummary({
+        activeConnections: 0,
+        connectingConnections: 1,
+        lastError: null,
+      }),
+    ).toBe("1 connecting");
+  });
+
+  it("only calls an established bridge connected", () => {
+    expect(
+      portForwardConnectionSummary({
+        activeConnections: 2,
+        connectingConnections: 1,
+        lastError: null,
+      }),
+    ).toBe("2 connected · 1 connecting");
+  });
+
+  it("surfaces a failed connection after its socket closes", () => {
+    expect(
+      portForwardConnectionSummary({
+        activeConnections: 0,
+        connectingConnections: 0,
+        lastError: "Authorization failed.",
+      }),
+    ).toBe("Connection failed");
+  });
+});

--- a/apps/web/src/components/desktop/desktopPortForwardPresentation.ts
+++ b/apps/web/src/components/desktop/desktopPortForwardPresentation.ts
@@ -1,0 +1,22 @@
+import type { DesktopPortForwardSnapshot } from "@t3tools/contracts";
+
+type PortForwardConnectionState = Pick<
+  DesktopPortForwardSnapshot,
+  "activeConnections" | "connectingConnections" | "lastError"
+>;
+
+function countLabel(count: number, label: string): string {
+  return `${count} ${label}`;
+}
+
+export function portForwardConnectionSummary(forward: PortForwardConnectionState): string {
+  const parts = [
+    ...(forward.activeConnections > 0 ? [countLabel(forward.activeConnections, "connected")] : []),
+    ...(forward.connectingConnections > 0
+      ? [countLabel(forward.connectingConnections, "connecting")]
+      : []),
+  ];
+
+  if (parts.length > 0) return parts.join(" · ");
+  return forward.lastError === null ? "Listening" : "Connection failed";
+}

--- a/apps/web/src/components/desktop/useDesktopPortForwards.ts
+++ b/apps/web/src/components/desktop/useDesktopPortForwards.ts
@@ -1,0 +1,111 @@
+import type {
+  DesktopPortForwardCreateInput,
+  DesktopPortForwardId,
+  DesktopPortForwardSnapshot,
+} from "@t3tools/contracts";
+import { useEffect, useMemo, useState } from "react";
+
+import { useEnvironments } from "../../state/environments";
+import { useServerConfigs } from "../../state/entities";
+
+export function parseDesktopPortForwardPort(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : null;
+}
+
+export function useDesktopPortForwards() {
+  const bridge = window.desktopBridge?.portForward;
+  const { environments } = useEnvironments();
+  const serverConfigs = useServerConfigs();
+  const [forwards, setForwards] = useState<ReadonlyArray<DesktopPortForwardSnapshot>>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [stoppingId, setStoppingId] = useState<DesktopPortForwardId | null>(null);
+  const connectedEnvironments = useMemo(
+    () => environments.filter((environment) => environment.connection.phase === "connected"),
+    [environments],
+  );
+  const forwardableEnvironments = useMemo(
+    () =>
+      connectedEnvironments.filter(
+        (environment) =>
+          serverConfigs.get(environment.environmentId)?.environment.capabilities
+            .tcpPortForwarding === true,
+      ),
+    [connectedEnvironments, serverConfigs],
+  );
+  const environmentLabels = useMemo(
+    () =>
+      new Map(
+        environments.map((environment) => [environment.environmentId, environment.label] as const),
+      ),
+    [environments],
+  );
+
+  useEffect(() => {
+    if (bridge === undefined) return;
+    let disposed = false;
+    let stateChangeReceived = false;
+    const unsubscribe = bridge.onStateChange((next) => {
+      stateChangeReceived = true;
+      setForwards(next);
+    });
+    void bridge.list().then(
+      (next) => {
+        if (!disposed && !stateChangeReceived) setForwards(next);
+      },
+      (cause) => {
+        if (!disposed) setError(cause instanceof Error ? cause.message : String(cause));
+      },
+    );
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [bridge]);
+
+  const create = async (input: DesktopPortForwardCreateInput): Promise<boolean> => {
+    if (bridge === undefined || creating) return false;
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await bridge.create(input);
+      setForwards((current) =>
+        current.some((forward) => forward.id === created.id) ? current : [...current, created],
+      );
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const stop = async (id: DesktopPortForwardId): Promise<void> => {
+    if (bridge === undefined) return;
+    setStoppingId(id);
+    setError(null);
+    try {
+      await bridge.stop(id);
+      setForwards((current) => current.filter((forward) => forward.id !== id));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setStoppingId(null);
+    }
+  };
+
+  return {
+    available: bridge !== undefined,
+    connectedEnvironments,
+    create,
+    creating,
+    environmentLabels,
+    error,
+    forwardableEnvironments,
+    forwards,
+    stop,
+    stoppingId,
+  };
+}

--- a/apps/web/src/components/desktop/useDesktopPortForwards.ts
+++ b/apps/web/src/components/desktop/useDesktopPortForwards.ts
@@ -55,7 +55,9 @@ export function useDesktopPortForwards() {
         if (!disposed && !stateChangeReceived) setForwards(next);
       },
       (cause) => {
-        if (!disposed) setError(cause instanceof Error ? cause.message : String(cause));
+        if (!disposed && !stateChangeReceived) {
+          setError(cause instanceof Error ? cause.message : String(cause));
+        }
       },
     );
     return () => {

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -90,6 +90,7 @@ import { Button } from "../ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { AnimatedHeight } from "../AnimatedHeight";
 import { Textarea } from "../ui/textarea";
+import { DesktopPortForwardsSettings } from "./DesktopPortForwardsSettings";
 import { getPairingTokenFromUrl, setPairingTokenOnUrl } from "../../pairingUrl";
 import { readHostedPairingRequest } from "../../hostedPairing";
 import {
@@ -3475,6 +3476,8 @@ export function ConnectionsSettings() {
           <CloudLinkRow canManageRelay={canManageRelay} />
         </SettingsSection>
       )}
+
+      <DesktopPortForwardsSettings />
 
       <SettingsSection
         {...searchableSetting("remote-environments")}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1356,7 +1356,7 @@ type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   routes: ReadonlyArray<ConnectionCatalogEntry>;
   removingEnvironmentId: EnvironmentId | null;
-  switchingRouteEnvironmentId: EnvironmentId | null;
+  switchingRouteEnvironmentIds: ReadonlySet<EnvironmentId>;
   onConnect: (environmentId: EnvironmentId) => void;
   onRemove: (environmentId: EnvironmentId) => void;
   onSelectRoute: (environmentId: EnvironmentId, routeId: string) => void;
@@ -1381,7 +1381,7 @@ function SavedBackendListRow({
   environment,
   routes,
   removingEnvironmentId,
-  switchingRouteEnvironmentId,
+  switchingRouteEnvironmentIds,
   onConnect,
   onRemove,
   onSelectRoute,
@@ -1517,11 +1517,12 @@ function SavedBackendListRow({
                 className="w-full min-w-0 sm:w-48"
                 aria-label={`Connection method for ${environment.label}`}
                 disabled={
-                  switchingRouteEnvironmentId !== null || removingEnvironmentId === environmentId
+                  switchingRouteEnvironmentIds.has(environmentId) ||
+                  removingEnvironmentId === environmentId
                 }
               >
                 <SelectValue>
-                  {switchingRouteEnvironmentId === environmentId
+                  {switchingRouteEnvironmentIds.has(environmentId)
                     ? "Switching…"
                     : connectionRouteLabel(environment.entry)}
                 </SelectValue>
@@ -1869,8 +1870,9 @@ export function ConnectionsSettings() {
     return keys;
   }, [savedEnvironments]);
   const [sshConnectionError, setSshConnectionError] = useState<string | null>(null);
-  const [switchingRouteEnvironmentId, setSwitchingRouteEnvironmentId] =
-    useState<EnvironmentId | null>(null);
+  const [switchingRouteEnvironmentIds, setSwitchingRouteEnvironmentIds] = useState<
+    ReadonlySet<EnvironmentId>
+  >(new Set());
   const [connectingSshHostAlias, setConnectingSshHostAlias] = useState<string | null>(null);
 
   const [desktopServerExposureMutationError, setDesktopServerExposureMutationError] = useState<
@@ -2334,10 +2336,14 @@ export function ConnectionsSettings() {
 
   const handleSelectSavedBackendRoute = useCallback(
     async (environmentId: EnvironmentId, routeId: string) => {
-      setSwitchingRouteEnvironmentId(environmentId);
+      setSwitchingRouteEnvironmentIds((current) => new Set(current).add(environmentId));
       setSavedBackendError(null);
       const result = await selectEnvironmentRoute({ environmentId, routeId });
-      setSwitchingRouteEnvironmentId(null);
+      setSwitchingRouteEnvironmentIds((current) => {
+        const next = new Set(current);
+        next.delete(environmentId);
+        return next;
+      });
       if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
         const error = squashAtomCommandFailure(result);
         const message =
@@ -3540,7 +3546,7 @@ export function ConnectionsSettings() {
             environment={environment}
             routes={desktopBridge ? (environmentRoutes.get(environment.environmentId) ?? []) : []}
             removingEnvironmentId={removingSavedEnvironmentId}
-            switchingRouteEnvironmentId={switchingRouteEnvironmentId}
+            switchingRouteEnvironmentIds={switchingRouteEnvironmentIds}
             onConnect={handleConnectSavedBackend}
             onRemove={handleRemoveSavedBackend}
             onSelectRoute={handleSelectSavedBackendRoute}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1520,7 +1520,11 @@ function SavedBackendListRow({
                   switchingRouteEnvironmentId !== null || removingEnvironmentId === environmentId
                 }
               >
-                <SelectValue>{connectionRouteLabel(environment.entry)}</SelectValue>
+                <SelectValue>
+                  {switchingRouteEnvironmentId === environmentId
+                    ? "Switching…"
+                    : connectionRouteLabel(environment.entry)}
+                </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
                 {routes.map((route) => (

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -33,7 +33,6 @@ import {
   connectionRouteId,
   connectionStatusText,
 } from "@t3tools/client-runtime/connection";
-import type { Discovery } from "@t3tools/client-runtime/relay";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -1356,7 +1355,6 @@ function NetworkAccessDescription({
 type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   routes: ReadonlyArray<ConnectionCatalogEntry>;
-  relayEnvironment: Discovery.RelayDiscoveredEnvironment | null;
   removingEnvironmentId: EnvironmentId | null;
   switchingRouteEnvironmentId: EnvironmentId | null;
   onConnect: (environmentId: EnvironmentId) => void;
@@ -1382,7 +1380,6 @@ function connectionRouteLabel(entry: ConnectionCatalogEntry): string {
 function SavedBackendListRow({
   environment,
   routes,
-  relayEnvironment,
   removingEnvironmentId,
   switchingRouteEnvironmentId,
   onConnect,
@@ -3539,9 +3536,6 @@ export function ConnectionsSettings() {
             key={environment.environmentId}
             environment={environment}
             routes={desktopBridge ? (environmentRoutes.get(environment.environmentId) ?? []) : []}
-            relayEnvironment={
-              relayEnvironmentDiscoveryState.environments.get(environment.environmentId) ?? null
-            }
             removingEnvironmentId={removingSavedEnvironmentId}
             switchingRouteEnvironmentId={switchingRouteEnvironmentId}
             onConnect={handleConnectSavedBackend}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -28,7 +28,12 @@ import {
   type DesktopWslState,
   type EnvironmentId,
 } from "@t3tools/contracts";
-import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import {
+  type ConnectionCatalogEntry,
+  connectionRouteId,
+  connectionStatusText,
+} from "@t3tools/client-runtime/connection";
+import type { Discovery } from "@t3tools/client-runtime/relay";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -1350,16 +1355,39 @@ function NetworkAccessDescription({
 
 type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
+  routes: ReadonlyArray<ConnectionCatalogEntry>;
+  relayEnvironment: Discovery.RelayDiscoveredEnvironment | null;
   removingEnvironmentId: EnvironmentId | null;
+  switchingRouteEnvironmentId: EnvironmentId | null;
   onConnect: (environmentId: EnvironmentId) => void;
   onRemove: (environmentId: EnvironmentId) => void;
+  onSelectRoute: (environmentId: EnvironmentId, routeId: string) => void;
 };
+
+function connectionRouteLabel(entry: ConnectionCatalogEntry): string {
+  switch (entry.target._tag) {
+    case "RelayConnectionTarget":
+      return "T3 Connect";
+    case "SshConnectionTarget":
+      return Option.isSome(entry.profile) && entry.profile.value._tag === "SshConnectionProfile"
+        ? `SSH ${formatDesktopSshTarget(entry.profile.value.target)}`
+        : "SSH";
+    case "BearerConnectionTarget":
+      return "Direct";
+    case "PrimaryConnectionTarget":
+      return "Local";
+  }
+}
 
 function SavedBackendListRow({
   environment,
+  routes,
+  relayEnvironment,
   removingEnvironmentId,
+  switchingRouteEnvironmentId,
   onConnect,
   onRemove,
+  onSelectRoute,
 }: SavedBackendListRowProps) {
   const environmentId = environment.environmentId;
   const connectionState = environment.connection.phase;
@@ -1478,6 +1506,39 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
+          {routes.length > 1 ? (
+            <Select
+              value={connectionRouteId(environment.entry.target)}
+              onValueChange={(value) => {
+                if (typeof value === "string") {
+                  onSelectRoute(environmentId, value);
+                }
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-full sm:w-48"
+                aria-label={`Connection method for ${environment.label}`}
+                disabled={
+                  switchingRouteEnvironmentId === environmentId ||
+                  removingEnvironmentId === environmentId
+                }
+              >
+                <SelectValue>{connectionRouteLabel(environment.entry)}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {routes.map((route) => (
+                  <SelectItem
+                    hideIndicator
+                    key={connectionRouteId(route.target)}
+                    value={connectionRouteId(route.target)}
+                  >
+                    {connectionRouteLabel(route)}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          ) : null}
           {versionMismatch &&
           (serverUpdateState.status === "idle" || serverUpdateState.status === "failed") ? (
             <ServerUpdateAction
@@ -1753,6 +1814,10 @@ export function ConnectionsSettings() {
   });
   const removeEnvironment = useAtomCommand(environmentCatalog.remove, { reportFailure: false });
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
+  const selectEnvironmentRoute = useAtomCommand(environmentCatalog.selectRoute, {
+    reportFailure: false,
+  });
+  const environmentRoutes = useAtomValue(environmentCatalog.routesValueAtom);
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
   const primarySessionState = usePrimarySessionState();
   const currentSessionScopes = desktopBridge
@@ -1804,6 +1869,8 @@ export function ConnectionsSettings() {
     return keys;
   }, [savedEnvironments]);
   const [sshConnectionError, setSshConnectionError] = useState<string | null>(null);
+  const [switchingRouteEnvironmentId, setSwitchingRouteEnvironmentId] =
+    useState<EnvironmentId | null>(null);
   const [connectingSshHostAlias, setConnectingSshHostAlias] = useState<string | null>(null);
 
   const [desktopServerExposureMutationError, setDesktopServerExposureMutationError] = useState<
@@ -2263,6 +2330,29 @@ export function ConnectionsSettings() {
       }
     },
     [retryEnvironment],
+  );
+
+  const handleSelectSavedBackendRoute = useCallback(
+    async (environmentId: EnvironmentId, routeId: string) => {
+      setSwitchingRouteEnvironmentId(environmentId);
+      setSavedBackendError(null);
+      const result = await selectEnvironmentRoute({ environmentId, routeId });
+      setSwitchingRouteEnvironmentId(null);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        const message =
+          error instanceof Error ? error.message : "Failed to switch connection method.";
+        setSavedBackendError(message);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not switch connection method",
+            description: message,
+          }),
+        );
+      }
+    },
+    [selectEnvironmentRoute],
   );
 
   const handleRemoveSavedBackend = useCallback(
@@ -3448,9 +3538,15 @@ export function ConnectionsSettings() {
           <SavedBackendListRow
             key={environment.environmentId}
             environment={environment}
+            routes={desktopBridge ? (environmentRoutes.get(environment.environmentId) ?? []) : []}
+            relayEnvironment={
+              relayEnvironmentDiscoveryState.environments.get(environment.environmentId) ?? null
+            }
             removingEnvironmentId={removingSavedEnvironmentId}
+            switchingRouteEnvironmentId={switchingRouteEnvironmentId}
             onConnect={handleConnectSavedBackend}
             onRemove={handleRemoveSavedBackend}
+            onSelectRoute={handleSelectSavedBackendRoute}
           />
         ))}
         <CloudRemoteEnvironmentRows

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1517,8 +1517,7 @@ function SavedBackendListRow({
                 className="w-full min-w-0 sm:w-48"
                 aria-label={`Connection method for ${environment.label}`}
                 disabled={
-                  switchingRouteEnvironmentId === environmentId ||
-                  removingEnvironmentId === environmentId
+                  switchingRouteEnvironmentId !== null || removingEnvironmentId === environmentId
                 }
               >
                 <SelectValue>{connectionRouteLabel(environment.entry)}</SelectValue>

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1513,7 +1513,7 @@ function SavedBackendListRow({
               }}
             >
               <SelectTrigger
-                size="sm"
+                size="xs"
                 className="w-full sm:w-48"
                 aria-label={`Connection method for ${environment.label}`}
                 disabled={

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1514,7 +1514,7 @@ function SavedBackendListRow({
             >
               <SelectTrigger
                 size="xs"
-                className="w-full sm:w-48"
+                className="w-full min-w-0 sm:w-48"
                 aria-label={`Connection method for ${environment.label}`}
                 disabled={
                   switchingRouteEnvironmentId === environmentId ||

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -74,88 +74,112 @@ export function DesktopPortForwardsSettings() {
         description="Expose a remote loopback port on this computer. Leaving the local port blank tries the same port first, then nearby free ports. Forwards last until you stop them or quit T3 Code."
         status={error === null ? null : <span className="text-destructive">{error}</span>}
       >
-        <div className="grid gap-2 pb-2 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_auto] sm:items-end">
-          <label className="space-y-1 text-xs text-muted-foreground">
-            <span className="block">Environment</span>
-            <Select
-              value={environmentId ?? ""}
-              onValueChange={(value) => {
-                if (typeof value === "string" && value !== "") {
-                  setEnvironmentId(value as EnvironmentId);
+        <div className="space-y-1 pb-2">
+          <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_auto] sm:items-end">
+            <label className="space-y-1 text-xs text-muted-foreground">
+              <span className="block">Environment</span>
+              <Select
+                value={environmentId ?? ""}
+                onValueChange={(value) => {
+                  if (typeof value === "string" && value !== "") {
+                    setEnvironmentId(value as EnvironmentId);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  className="w-full"
+                  aria-label="Forward environment"
+                  aria-describedby={
+                    connectedEnvironments.length === 0 || forwardableEnvironments.length === 0
+                      ? "desktop-port-forward-environment-hint"
+                      : undefined
+                  }
+                >
+                  <SelectValue>
+                    {environmentId === null
+                      ? "Select"
+                      : (environmentLabels.get(environmentId) ?? environmentId)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup alignItemWithTrigger={false}>
+                  {forwardableEnvironments.map((environment) => (
+                    <SelectItem
+                      hideIndicator
+                      key={environment.environmentId}
+                      value={environment.environmentId}
+                    >
+                      {environment.label}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
+            </label>
+            <label className="space-y-1 text-xs text-muted-foreground">
+              <span className="block">Remote port</span>
+              <Input
+                type="number"
+                min={1}
+                max={65_535}
+                step={1}
+                inputMode="numeric"
+                value={remotePort}
+                onChange={(event) => setRemotePort(event.target.value)}
+                aria-label="Remote port"
+                aria-invalid={parsedRemotePort === null}
+                aria-describedby={
+                  parsedRemotePort === null ? "desktop-port-forward-remote-port-error" : undefined
                 }
-              }}
+              />
+            </label>
+            <label className="space-y-1 text-xs text-muted-foreground">
+              <span className="block">Local port</span>
+              <Input
+                type="number"
+                min={1}
+                max={65_535}
+                step={1}
+                inputMode="numeric"
+                value={localPort}
+                placeholder="Same as remote"
+                onChange={(event) => setLocalPort(event.target.value)}
+                aria-label="Local port"
+                aria-invalid={localPort.trim() !== "" && parsedLocalPort === null}
+                aria-describedby={
+                  localPort.trim() !== "" && parsedLocalPort === null
+                    ? "desktop-port-forward-local-port-error"
+                    : undefined
+                }
+              />
+            </label>
+            <Button size="sm" disabled={!canCreate} onClick={() => void create()}>
+              {creating ? "Starting…" : "Start"}
+            </Button>
+          </div>
+          {connectedEnvironments.length === 0 ? (
+            <p
+              id="desktop-port-forward-environment-hint"
+              className="text-[11px] text-muted-foreground"
             >
-              <SelectTrigger className="w-full" aria-label="Forward environment">
-                <SelectValue>
-                  {environmentId === null
-                    ? "Select"
-                    : (environmentLabels.get(environmentId) ?? environmentId)}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectPopup alignItemWithTrigger={false}>
-                {forwardableEnvironments.map((environment) => (
-                  <SelectItem
-                    hideIndicator
-                    key={environment.environmentId}
-                    value={environment.environmentId}
-                  >
-                    {environment.label}
-                  </SelectItem>
-                ))}
-              </SelectPopup>
-            </Select>
-            {connectedEnvironments.length === 0 ? (
-              <span className="block pt-1 text-[11px] text-muted-foreground">
-                Connect an environment to start forwarding ports.
-              </span>
-            ) : forwardableEnvironments.length === 0 ? (
-              <span className="block pt-1 text-[11px] text-muted-foreground">
-                Update the connected T3 server to enable port forwarding.
-              </span>
-            ) : null}
-          </label>
-          <label className="space-y-1 text-xs text-muted-foreground">
-            <span className="block">Remote port</span>
-            <Input
-              type="number"
-              min={1}
-              max={65_535}
-              step={1}
-              inputMode="numeric"
-              value={remotePort}
-              onChange={(event) => setRemotePort(event.target.value)}
-              aria-label="Remote port"
-              aria-invalid={parsedRemotePort === null}
-            />
-            {parsedRemotePort === null ? (
-              <span className="block text-[11px] text-destructive">
-                Enter a port from 1 to 65535.
-              </span>
-            ) : null}
-          </label>
-          <label className="space-y-1 text-xs text-muted-foreground">
-            <span className="block">Local port</span>
-            <Input
-              type="number"
-              min={1}
-              max={65_535}
-              step={1}
-              inputMode="numeric"
-              value={localPort}
-              placeholder="Same as remote"
-              onChange={(event) => setLocalPort(event.target.value)}
-              aria-label="Local port"
-              aria-invalid={localPort.trim() !== "" && parsedLocalPort === null}
-            />
-            {localPort.trim() !== "" && parsedLocalPort === null ? (
-              <span className="block text-[11px] text-destructive">
-                Enter a port from 1 to 65535.
-              </span>
-            ) : null}
-          </label>
-          <Button size="sm" disabled={!canCreate} onClick={() => void create()}>
-            {creating ? "Starting…" : "Start"}
-          </Button>
+              Connect an environment to start forwarding ports.
+            </p>
+          ) : forwardableEnvironments.length === 0 ? (
+            <p
+              id="desktop-port-forward-environment-hint"
+              className="text-[11px] text-muted-foreground"
+            >
+              Update the connected T3 server to enable port forwarding.
+            </p>
+          ) : null}
+          {parsedRemotePort === null ? (
+            <p id="desktop-port-forward-remote-port-error" className="text-[11px] text-destructive">
+              Remote port: enter a value from 1 to 65535.
+            </p>
+          ) : null}
+          {localPort.trim() !== "" && parsedLocalPort === null ? (
+            <p id="desktop-port-forward-local-port-error" className="text-[11px] text-destructive">
+              Local port: enter a value from 1 to 65535.
+            </p>
+          ) : null}
         </div>
       </SettingsRow>
       {forwards.map((forward) => (

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -6,6 +6,7 @@ import type {
 import { useEffect, useMemo, useState } from "react";
 
 import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
+import { useServerConfigs } from "../../state/entities";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
@@ -19,6 +20,7 @@ function parsePort(value: string): number | null {
 export function DesktopPortForwardsSettings() {
   const bridge = window.desktopBridge?.portForward;
   const { environments } = useEnvironments();
+  const serverConfigs = useServerConfigs();
   const primaryEnvironment = usePrimaryEnvironment();
   const [environmentId, setEnvironmentId] = useState<EnvironmentId | null>(null);
   const [remotePort, setRemotePort] = useState("3000");
@@ -31,22 +33,31 @@ export function DesktopPortForwardsSettings() {
     () => environments.filter((environment) => environment.connection.phase === "connected"),
     [environments],
   );
+  const forwardableEnvironments = useMemo(
+    () =>
+      connectedEnvironments.filter(
+        (environment) =>
+          serverConfigs.get(environment.environmentId)?.environment.capabilities
+            .tcpPortForwarding === true,
+      ),
+    [connectedEnvironments, serverConfigs],
+  );
 
   useEffect(() => {
     if (
       environmentId !== null &&
-      connectedEnvironments.some((environment) => environment.environmentId === environmentId)
+      forwardableEnvironments.some((environment) => environment.environmentId === environmentId)
     ) {
       return;
     }
-    const primaryConnected = connectedEnvironments.some(
+    const primaryConnected = forwardableEnvironments.some(
       (environment) => environment.environmentId === primaryEnvironment?.environmentId,
     );
     const fallback = primaryConnected
       ? (primaryEnvironment?.environmentId ?? null)
-      : (connectedEnvironments[0]?.environmentId ?? null);
+      : (forwardableEnvironments[0]?.environmentId ?? null);
     setEnvironmentId(fallback);
-  }, [connectedEnvironments, environmentId, primaryEnvironment?.environmentId]);
+  }, [environmentId, forwardableEnvironments, primaryEnvironment?.environmentId]);
 
   useEffect(() => {
     if (bridge === undefined) return;
@@ -137,7 +148,7 @@ export function DesktopPortForwardsSettings() {
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup alignItemWithTrigger={false}>
-                {connectedEnvironments.map((environment) => (
+                {forwardableEnvironments.map((environment) => (
                   <SelectItem
                     hideIndicator
                     key={environment.environmentId}
@@ -151,6 +162,10 @@ export function DesktopPortForwardsSettings() {
             {connectedEnvironments.length === 0 ? (
               <span className="block pt-1 text-[11px] text-muted-foreground">
                 Connect an environment to start forwarding ports.
+              </span>
+            ) : forwardableEnvironments.length === 0 ? (
+              <span className="block pt-1 text-[11px] text-muted-foreground">
+                Update the connected T3 server to enable port forwarding.
               </span>
             ) : null}
           </label>

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -1,0 +1,207 @@
+import type {
+  DesktopPortForwardId,
+  DesktopPortForwardSnapshot,
+  EnvironmentId,
+} from "@t3tools/contracts";
+import { useEffect, useMemo, useState } from "react";
+
+import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { SettingsRow, SettingsSection } from "./settingsLayout";
+
+function parsePort(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : null;
+}
+
+export function DesktopPortForwardsSettings() {
+  const bridge = window.desktopBridge?.portForward;
+  const { environments } = useEnvironments();
+  const primaryEnvironment = usePrimaryEnvironment();
+  const [environmentId, setEnvironmentId] = useState<EnvironmentId | null>(null);
+  const [remotePort, setRemotePort] = useState("3000");
+  const [localPort, setLocalPort] = useState("");
+  const [forwards, setForwards] = useState<ReadonlyArray<DesktopPortForwardSnapshot>>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [stoppingId, setStoppingId] = useState<DesktopPortForwardId | null>(null);
+  const connectedEnvironments = useMemo(
+    () => environments.filter((environment) => environment.connection.phase === "connected"),
+    [environments],
+  );
+
+  useEffect(() => {
+    if (
+      environmentId !== null &&
+      connectedEnvironments.some((environment) => environment.environmentId === environmentId)
+    ) {
+      return;
+    }
+    const primaryConnected = connectedEnvironments.some(
+      (environment) => environment.environmentId === primaryEnvironment?.environmentId,
+    );
+    const fallback = primaryConnected
+      ? (primaryEnvironment?.environmentId ?? null)
+      : (connectedEnvironments[0]?.environmentId ?? null);
+    setEnvironmentId(fallback);
+  }, [connectedEnvironments, environmentId, primaryEnvironment?.environmentId]);
+
+  useEffect(() => {
+    if (bridge === undefined) return;
+    let disposed = false;
+    void bridge.list().then(
+      (next) => {
+        if (!disposed) setForwards(next);
+      },
+      (cause) => {
+        if (!disposed) setError(cause instanceof Error ? cause.message : String(cause));
+      },
+    );
+    const unsubscribe = bridge.onStateChange((next) => setForwards(next));
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [bridge]);
+
+  const labels = useMemo(
+    () =>
+      new Map(environments.map((environment) => [environment.environmentId, environment.label])),
+    [environments],
+  );
+  if (bridge === undefined) return null;
+
+  const parsedRemotePort = parsePort(remotePort);
+  const parsedLocalPort = localPort.trim() === "" ? undefined : parsePort(localPort);
+  const canCreate =
+    environmentId !== null && parsedRemotePort !== null && parsedLocalPort !== null && !creating;
+
+  const create = async () => {
+    if (!canCreate || environmentId === null || parsedRemotePort === null) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await bridge.create({
+        environmentId,
+        remoteHost: "127.0.0.1",
+        remotePort: parsedRemotePort,
+        ...(parsedLocalPort === undefined ? {} : { localPort: parsedLocalPort }),
+      });
+      setForwards((current) =>
+        current.some((forward) => forward.id === created.id) ? current : [...current, created],
+      );
+      setLocalPort("");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const stop = async (id: DesktopPortForwardId) => {
+    setStoppingId(id);
+    setError(null);
+    try {
+      await bridge.stop(id);
+      setForwards((current) => current.filter((forward) => forward.id !== id));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setStoppingId(null);
+    }
+  };
+
+  return (
+    <SettingsSection title="Port forwarding">
+      <SettingsRow
+        title="New TCP forward"
+        description="Expose a remote loopback port on this computer. Leaving the local port blank tries the same port first, then nearby free ports. Forwards last until you stop them or quit T3 Code."
+        status={error === null ? null : <span className="text-destructive">{error}</span>}
+      >
+        <div className="grid gap-2 pb-2 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_auto] sm:items-end">
+          <label className="space-y-1 text-xs text-muted-foreground">
+            Environment
+            <Select
+              value={environmentId ?? ""}
+              onValueChange={(value) => {
+                if (typeof value === "string" && value !== "") {
+                  setEnvironmentId(value as EnvironmentId);
+                }
+              }}
+            >
+              <SelectTrigger className="w-full" aria-label="Forward environment">
+                <SelectValue>
+                  {environmentId === null ? "Select" : (labels.get(environmentId) ?? environmentId)}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup alignItemWithTrigger={false}>
+                {connectedEnvironments.map((environment) => (
+                  <SelectItem
+                    hideIndicator
+                    key={environment.environmentId}
+                    value={environment.environmentId}
+                  >
+                    {environment.label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+            {connectedEnvironments.length === 0 ? (
+              <span className="block pt-1 text-[11px] text-muted-foreground">
+                Connect an environment to start forwarding ports.
+              </span>
+            ) : null}
+          </label>
+          <label className="space-y-1 text-xs text-muted-foreground">
+            Remote port
+            <Input
+              inputMode="numeric"
+              value={remotePort}
+              onChange={(event) => setRemotePort(event.target.value)}
+              aria-label="Remote port"
+            />
+          </label>
+          <label className="space-y-1 text-xs text-muted-foreground">
+            Local port
+            <Input
+              inputMode="numeric"
+              value={localPort}
+              placeholder="Same as remote"
+              onChange={(event) => setLocalPort(event.target.value)}
+              aria-label="Local port"
+            />
+          </label>
+          <Button size="sm" disabled={!canCreate} onClick={() => void create()}>
+            {creating ? "Starting…" : "Start"}
+          </Button>
+        </div>
+      </SettingsRow>
+      {forwards.map((forward) => (
+        <SettingsRow
+          key={forward.id}
+          title={`${forward.localHost}:${forward.localPort}`}
+          description={`${labels.get(forward.environmentId) ?? forward.environmentId} · ${forward.remoteHost}:${forward.remotePort}`}
+          status={
+            forward.lastError === null ? (
+              `${forward.activeConnections} active connection${forward.activeConnections === 1 ? "" : "s"}`
+            ) : (
+              <span className="text-destructive">{forward.lastError}</span>
+            )
+          }
+          control={
+            <Button
+              size="xs"
+              variant="outline"
+              disabled={stoppingId === forward.id}
+              onClick={() => void stop(forward.id)}
+            >
+              Stop
+            </Button>
+          }
+        />
+      ))}
+    </SettingsSection>
+  );
+}

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -76,8 +76,8 @@ export function DesktopPortForwardsSettings() {
       >
         <div className="space-y-1 pb-2">
           <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_auto] sm:items-end">
-            <label className="space-y-1 text-xs text-muted-foreground">
-              <span className="block">Environment</span>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-medium text-foreground">Environment</span>
               <Select
                 value={environmentId ?? ""}
                 onValueChange={(value) => {
@@ -114,8 +114,8 @@ export function DesktopPortForwardsSettings() {
                 </SelectPopup>
               </Select>
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
-              <span className="block">Remote port</span>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-medium text-foreground">Remote port</span>
               <Input
                 type="number"
                 min={1}
@@ -131,8 +131,8 @@ export function DesktopPortForwardsSettings() {
                 }
               />
             </label>
-            <label className="space-y-1 text-xs text-muted-foreground">
-              <span className="block">Local port</span>
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-medium text-foreground">Local port</span>
               <Input
                 type="number"
                 min={1}

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -1,48 +1,34 @@
-import type {
-  DesktopPortForwardId,
-  DesktopPortForwardSnapshot,
-  EnvironmentId,
-} from "@t3tools/contracts";
-import { useEffect, useMemo, useState } from "react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useEffect, useState } from "react";
 
-import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
-import { useServerConfigs } from "../../state/entities";
+import { usePrimaryEnvironment } from "../../state/environments";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { portForwardConnectionSummary } from "../desktop/desktopPortForwardPresentation";
+import {
+  parseDesktopPortForwardPort,
+  useDesktopPortForwards,
+} from "../desktop/useDesktopPortForwards";
 import { SettingsRow, SettingsSection } from "./settingsLayout";
 
-function parsePort(value: string): number | null {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65_535 ? parsed : null;
-}
-
 export function DesktopPortForwardsSettings() {
-  const bridge = window.desktopBridge?.portForward;
-  const { environments } = useEnvironments();
-  const serverConfigs = useServerConfigs();
+  const {
+    available,
+    connectedEnvironments,
+    create: createForward,
+    creating,
+    environmentLabels,
+    error,
+    forwardableEnvironments,
+    forwards,
+    stop,
+    stoppingId,
+  } = useDesktopPortForwards();
   const primaryEnvironment = usePrimaryEnvironment();
   const [environmentId, setEnvironmentId] = useState<EnvironmentId | null>(null);
   const [remotePort, setRemotePort] = useState("3000");
   const [localPort, setLocalPort] = useState("");
-  const [forwards, setForwards] = useState<ReadonlyArray<DesktopPortForwardSnapshot>>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [stoppingId, setStoppingId] = useState<DesktopPortForwardId | null>(null);
-  const connectedEnvironments = useMemo(
-    () => environments.filter((environment) => environment.connection.phase === "connected"),
-    [environments],
-  );
-  const forwardableEnvironments = useMemo(
-    () =>
-      connectedEnvironments.filter(
-        (environment) =>
-          serverConfigs.get(environment.environmentId)?.environment.capabilities
-            .tcpPortForwarding === true,
-      ),
-    [connectedEnvironments, serverConfigs],
-  );
 
   useEffect(() => {
     if (
@@ -60,68 +46,24 @@ export function DesktopPortForwardsSettings() {
     setEnvironmentId(fallback);
   }, [environmentId, forwardableEnvironments, primaryEnvironment?.environmentId]);
 
-  useEffect(() => {
-    if (bridge === undefined) return;
-    let disposed = false;
-    void bridge.list().then(
-      (next) => {
-        if (!disposed) setForwards(next);
-      },
-      (cause) => {
-        if (!disposed) setError(cause instanceof Error ? cause.message : String(cause));
-      },
-    );
-    const unsubscribe = bridge.onStateChange((next) => setForwards(next));
-    return () => {
-      disposed = true;
-      unsubscribe();
-    };
-  }, [bridge]);
+  if (!available) return null;
 
-  const labels = useMemo(
-    () =>
-      new Map(environments.map((environment) => [environment.environmentId, environment.label])),
-    [environments],
-  );
-  if (bridge === undefined) return null;
-
-  const parsedRemotePort = parsePort(remotePort);
-  const parsedLocalPort = localPort.trim() === "" ? undefined : parsePort(localPort);
+  const parsedRemotePort = parseDesktopPortForwardPort(remotePort);
+  const parsedLocalPort =
+    localPort.trim() === "" ? undefined : parseDesktopPortForwardPort(localPort);
   const canCreate =
     environmentId !== null && parsedRemotePort !== null && parsedLocalPort !== null && !creating;
 
   const create = async () => {
     if (!canCreate || environmentId === null || parsedRemotePort === null) return;
-    setCreating(true);
-    setError(null);
-    try {
-      const created = await bridge.create({
-        environmentId,
-        remoteHost: "127.0.0.1",
-        remotePort: parsedRemotePort,
-        ...(parsedLocalPort === undefined ? {} : { localPort: parsedLocalPort }),
-      });
-      setForwards((current) =>
-        current.some((forward) => forward.id === created.id) ? current : [...current, created],
-      );
+    const created = await createForward({
+      environmentId,
+      remoteHost: "127.0.0.1",
+      remotePort: parsedRemotePort,
+      ...(parsedLocalPort === undefined ? {} : { localPort: parsedLocalPort }),
+    });
+    if (created) {
       setLocalPort("");
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const stop = async (id: DesktopPortForwardId) => {
-    setStoppingId(id);
-    setError(null);
-    try {
-      await bridge.stop(id);
-      setForwards((current) => current.filter((forward) => forward.id !== id));
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setStoppingId(null);
     }
   };
 
@@ -145,7 +87,9 @@ export function DesktopPortForwardsSettings() {
             >
               <SelectTrigger className="w-full" aria-label="Forward environment">
                 <SelectValue>
-                  {environmentId === null ? "Select" : (labels.get(environmentId) ?? environmentId)}
+                  {environmentId === null
+                    ? "Select"
+                    : (environmentLabels.get(environmentId) ?? environmentId)}
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup alignItemWithTrigger={false}>
@@ -198,7 +142,7 @@ export function DesktopPortForwardsSettings() {
         <SettingsRow
           key={forward.id}
           title={`${forward.localHost}:${forward.localPort}`}
-          description={`${labels.get(forward.environmentId) ?? forward.environmentId} · ${forward.remoteHost}:${forward.remotePort}`}
+          description={`${environmentLabels.get(forward.environmentId) ?? forward.environmentId} · ${forward.remoteHost}:${forward.remotePort}`}
           status={
             <span className="flex flex-col items-end gap-0.5">
               <span>{portForwardConnectionSummary(forward)}</span>

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -188,10 +188,10 @@ export function DesktopPortForwardsSettings() {
           title={`${forward.localHost}:${forward.localPort}`}
           description={`${environmentLabels.get(forward.environmentId) ?? forward.environmentId} · ${forward.remoteHost}:${forward.remotePort}`}
           status={
-            <span className="flex flex-col items-end gap-0.5">
+            <span className="flex flex-col gap-0.5">
               <span>{portForwardConnectionSummary(forward)}</span>
               {forward.lastError === null ? null : (
-                <span className="max-w-96 text-right text-destructive">{forward.lastError}</span>
+                <span className="max-w-96 text-destructive">{forward.lastError}</span>
               )}
             </span>
           }

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -117,21 +117,41 @@ export function DesktopPortForwardsSettings() {
           <label className="space-y-1 text-xs text-muted-foreground">
             <span className="block">Remote port</span>
             <Input
+              type="number"
+              min={1}
+              max={65_535}
+              step={1}
               inputMode="numeric"
               value={remotePort}
               onChange={(event) => setRemotePort(event.target.value)}
               aria-label="Remote port"
+              aria-invalid={parsedRemotePort === null}
             />
+            {parsedRemotePort === null ? (
+              <span className="block text-[11px] text-destructive">
+                Enter a port from 1 to 65535.
+              </span>
+            ) : null}
           </label>
           <label className="space-y-1 text-xs text-muted-foreground">
             <span className="block">Local port</span>
             <Input
+              type="number"
+              min={1}
+              max={65_535}
+              step={1}
               inputMode="numeric"
               value={localPort}
               placeholder="Same as remote"
               onChange={(event) => setLocalPort(event.target.value)}
               aria-label="Local port"
+              aria-invalid={localPort.trim() !== "" && parsedLocalPort === null}
             />
+            {localPort.trim() !== "" && parsedLocalPort === null ? (
+              <span className="block text-[11px] text-destructive">
+                Enter a port from 1 to 65535.
+              </span>
+            ) : null}
           </label>
           <Button size="sm" disabled={!canCreate} onClick={() => void create()}>
             {creating ? "Starting…" : "Start"}

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -10,6 +10,7 @@ import { useServerConfigs } from "../../state/entities";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { portForwardConnectionSummary } from "../desktop/desktopPortForwardPresentation";
 import { SettingsRow, SettingsSection } from "./settingsLayout";
 
 function parsePort(value: string): number | null {
@@ -199,11 +200,12 @@ export function DesktopPortForwardsSettings() {
           title={`${forward.localHost}:${forward.localPort}`}
           description={`${labels.get(forward.environmentId) ?? forward.environmentId} · ${forward.remoteHost}:${forward.remotePort}`}
           status={
-            forward.lastError === null ? (
-              `${forward.activeConnections} active connection${forward.activeConnections === 1 ? "" : "s"}`
-            ) : (
-              <span className="text-destructive">{forward.lastError}</span>
-            )
+            <span className="flex flex-col items-end gap-0.5">
+              <span>{portForwardConnectionSummary(forward)}</span>
+              {forward.lastError === null ? null : (
+                <span className="max-w-96 text-right text-destructive">{forward.lastError}</span>
+              )}
+            </span>
           }
           control={
             <Button

--- a/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
+++ b/apps/web/src/components/settings/DesktopPortForwardsSettings.tsx
@@ -76,7 +76,7 @@ export function DesktopPortForwardsSettings() {
       >
         <div className="grid gap-2 pb-2 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_auto] sm:items-end">
           <label className="space-y-1 text-xs text-muted-foreground">
-            Environment
+            <span className="block">Environment</span>
             <Select
               value={environmentId ?? ""}
               onValueChange={(value) => {
@@ -115,7 +115,7 @@ export function DesktopPortForwardsSettings() {
             ) : null}
           </label>
           <label className="space-y-1 text-xs text-muted-foreground">
-            Remote port
+            <span className="block">Remote port</span>
             <Input
               inputMode="numeric"
               value={remotePort}
@@ -124,7 +124,7 @@ export function DesktopPortForwardsSettings() {
             />
           </label>
           <label className="space-y-1 text-xs text-muted-foreground">
-            Local port
+            <span className="block">Local port</span>
             <Input
               inputMode="numeric"
               value={localPort}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -108,6 +108,7 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
 function SelectPopup({
   className,
   popupClassName,
+  positionerClassName,
   children,
   side = "bottom",
   sideOffset = 4,
@@ -119,6 +120,7 @@ function SelectPopup({
   ...props
 }: SelectPrimitive.Popup.Props & {
   popupClassName?: string;
+  positionerClassName?: string;
   side?: SelectPrimitive.Positioner.Props["side"];
   sideOffset?: SelectPrimitive.Positioner.Props["sideOffset"];
   align?: SelectPrimitive.Positioner.Props["align"];
@@ -134,7 +136,7 @@ function SelectPopup({
         alignItemWithTrigger={alignItemWithTrigger}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="z-[130] select-none"
+        className={cn("z-[130] select-none", positionerClassName)}
         data-slot="select-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -108,7 +108,6 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
 function SelectPopup({
   className,
   popupClassName,
-  positionerClassName,
   children,
   side = "bottom",
   sideOffset = 4,
@@ -120,7 +119,6 @@ function SelectPopup({
   ...props
 }: SelectPrimitive.Popup.Props & {
   popupClassName?: string;
-  positionerClassName?: string;
   side?: SelectPrimitive.Positioner.Props["side"];
   sideOffset?: SelectPrimitive.Positioner.Props["sideOffset"];
   align?: SelectPrimitive.Positioner.Props["align"];
@@ -136,7 +134,7 @@ function SelectPopup({
         alignItemWithTrigger={alignItemWithTrigger}
         alignOffset={alignOffset}
         anchor={anchor}
-        className={cn("z-[130] select-none", positionerClassName)}
+        className="z-[130] select-none"
         data-slot="select-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/connection/platform.test.ts
+++ b/apps/web/src/connection/platform.test.ts
@@ -15,6 +15,7 @@ import {
   primaryRegistrationToRetainAfterTopologyRead,
   provisionDesktopSshEnvironment,
   readPrimaryEnvironmentTargetResult,
+  resetDesktopPortForwardConnections,
   secondaryRegistrationsToRetainAfterTopologyRead,
   secondaryBearerExpiresAtEpochMs,
   secondaryBearerRefreshAtEpochMs,
@@ -136,6 +137,25 @@ describe("desktop SSH pairing", () => {
       expect(prepared.bearerToken).toBe("bearer-token");
       expect(calls).toEqual(["ensure", "token"]);
       expect(ensurePairingOptions).toEqual([true]);
+    }),
+  );
+});
+
+describe("desktop route transitions", () => {
+  it.effect("resets port-forward bridge connections for the selected environment", () =>
+    Effect.gen(function* () {
+      const resetEnvironmentIds: EnvironmentId[] = [];
+      const bridge = {
+        portForward: {
+          resetEnvironmentConnections: async (environmentId: EnvironmentId) => {
+            resetEnvironmentIds.push(environmentId);
+          },
+        },
+      } as unknown as DesktopBridge;
+
+      yield* resetDesktopPortForwardConnections(bridge, EnvironmentId.make("environment-ssh"));
+
+      expect(resetEnvironmentIds).toEqual([EnvironmentId.make("environment-ssh")]);
     }),
   );
 });

--- a/apps/web/src/connection/platform.test.ts
+++ b/apps/web/src/connection/platform.test.ts
@@ -11,6 +11,7 @@ import * as Effect from "effect/Effect";
 import {
   canRetainCachedPlatformRegistrationAfterRefreshFailure,
   canReuseCachedPlatformRegistration,
+  prepareDesktopSshEnvironment,
   primaryRegistrationToRetainAfterTopologyRead,
   provisionDesktopSshEnvironment,
   readPrimaryEnvironmentTargetResult,
@@ -28,11 +29,18 @@ const TARGET: DesktopSshEnvironmentTarget = {
 
 function makeBridge(
   calls: string[],
-  options?: { readonly failDescriptor?: boolean },
+  options?: {
+    readonly failDescriptor?: boolean;
+    readonly ensurePairingOptions?: Array<boolean | null>;
+  },
 ): DesktopBridge {
   return {
-    ensureSshEnvironment: async (target: DesktopSshEnvironmentTarget) => {
+    ensureSshEnvironment: async (
+      target: DesktopSshEnvironmentTarget,
+      ensureOptions?: { readonly issuePairingToken?: boolean },
+    ) => {
       calls.push("ensure");
+      options?.ensurePairingOptions?.push(ensureOptions?.issuePairingToken ?? null);
       return {
         target,
         httpBaseUrl: "http://127.0.0.1:3201/",
@@ -93,6 +101,41 @@ describe("desktop SSH pairing", () => {
       ).pipe(Effect.flip);
 
       expect(calls).toEqual(["ensure", "descriptor"]);
+    }),
+  );
+
+  it.effect("reuses a cached bearer without requesting or bootstrapping a pairing token", () =>
+    Effect.gen(function* () {
+      const calls: string[] = [];
+      const ensurePairingOptions: Array<boolean | null> = [];
+
+      const prepared = yield* prepareDesktopSshEnvironment(
+        makeBridge(calls, { ensurePairingOptions }),
+        {
+          target: TARGET,
+          bearerToken: "cached-bearer",
+        },
+      );
+
+      expect(prepared.bearerToken).toBe("cached-bearer");
+      expect(calls).toEqual(["ensure"]);
+      expect(ensurePairingOptions).toEqual([false]);
+    }),
+  );
+
+  it.effect("requests and bootstraps a pairing token when no bearer is cached", () =>
+    Effect.gen(function* () {
+      const calls: string[] = [];
+      const ensurePairingOptions: Array<boolean | null> = [];
+
+      const prepared = yield* prepareDesktopSshEnvironment(
+        makeBridge(calls, { ensurePairingOptions }),
+        { target: TARGET },
+      );
+
+      expect(prepared.bearerToken).toBe("bearer-token");
+      expect(calls).toEqual(["ensure", "token"]);
+      expect(ensurePairingOptions).toEqual([true]);
     }),
   );
 });

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -173,6 +173,44 @@ export const provisionDesktopSshEnvironment = Effect.fn(
   };
 });
 
+export const prepareDesktopSshEnvironment = Effect.fn("web.connectionPlatform.ssh.prepareDesktop")(
+  function* (
+    bridge: DesktopBridge,
+    input: {
+      readonly target: DesktopSshEnvironmentTarget;
+      readonly bearerToken?: string;
+    },
+  ) {
+    const bootstrap = yield* Effect.tryPromise({
+      try: () =>
+        bridge.ensureSshEnvironment(input.target, {
+          issuePairingToken: input.bearerToken === undefined,
+        }),
+      catch: sshPreparationError,
+    });
+    if (input.bearerToken !== undefined) {
+      return {
+        bootstrap,
+        bearerToken: input.bearerToken,
+      };
+    }
+    if (bootstrap.pairingToken === null) {
+      return yield* new ConnectionBlockedError({
+        reason: "authentication",
+        detail: "The SSH environment did not issue a pairing credential.",
+      });
+    }
+    const access = yield* Effect.tryPromise({
+      try: () => bridge.bootstrapSshBearerSession(bootstrap.httpBaseUrl, bootstrap.pairingToken!),
+      catch: sshPreparationError,
+    });
+    return {
+      bootstrap,
+      bearerToken: access.access_token,
+    };
+  },
+);
+
 const capabilitiesLayer = Layer.effectContext(
   Effect.sync(() => {
     const presentation = ClientPresentation.of({
@@ -238,28 +276,7 @@ const capabilitiesLayer = Layer.effectContext(
             detail: "SSH environments are only available in the desktop app.",
           });
         }
-        const bootstrap = yield* Effect.tryPromise({
-          try: () =>
-            bridge.ensureSshEnvironment(input.target, {
-              issuePairingToken: true,
-            }),
-          catch: sshPreparationError,
-        });
-        if (bootstrap.pairingToken === null) {
-          return yield* new ConnectionBlockedError({
-            reason: "authentication",
-            detail: "The SSH environment did not issue a pairing credential.",
-          });
-        }
-        const access = yield* Effect.tryPromise({
-          try: () =>
-            bridge.bootstrapSshBearerSession(bootstrap.httpBaseUrl, bootstrap.pairingToken!),
-          catch: sshPreparationError,
-        });
-        return {
-          bootstrap,
-          bearerToken: access.access_token,
-        };
+        return yield* prepareDesktopSshEnvironment(bridge, input);
       }),
       disconnect: Effect.fn("web.connectionPlatform.ssh.disconnect")(function* (target) {
         const bridge = window.desktopBridge;

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -597,8 +597,14 @@ const environmentOwnedDataCleanupLayer = Layer.succeed(
   EnvironmentOwnedDataCleanup,
   EnvironmentOwnedDataCleanup.of({
     clear: (environmentId) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         clearComposerDraftsEnvironment(environmentId);
+        const portForward = window.desktopBridge?.portForward;
+        if (portForward !== undefined) {
+          yield* Effect.promise(() => portForward.stopEnvironment(environmentId)).pipe(
+            Effect.catchCause(() => Effect.void),
+          );
+        }
       }),
   }),
 );

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -2,6 +2,7 @@ import {
   ClientPresentation,
   CloudSession,
   EnvironmentOwnedDataCleanup,
+  EnvironmentRouteTransition,
   PlatformConnectionSource,
   PrimaryEnvironmentAuth,
   RelayDeviceIdentity,
@@ -30,6 +31,7 @@ import {
   type DesktopBridge,
   type DesktopEnvironmentBootstrap,
   type DesktopSshEnvironmentTarget,
+  type EnvironmentId,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
 } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
@@ -609,6 +611,29 @@ const environmentOwnedDataCleanupLayer = Layer.succeed(
   }),
 );
 
+export const resetDesktopPortForwardConnections = Effect.fn(
+  "web.connectionPlatform.resetDesktopPortForwardConnections",
+)(function* (bridge: DesktopBridge | undefined, environmentId: EnvironmentId) {
+  const portForward = bridge?.portForward;
+  if (portForward === undefined) return;
+  yield* Effect.promise(() => portForward.resetEnvironmentConnections(environmentId)).pipe(
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Could not reset desktop port forwards after changing routes.", {
+        environmentId,
+        cause,
+      }),
+    ),
+  );
+});
+
+const environmentRouteTransitionLayer = Layer.succeed(
+  EnvironmentRouteTransition,
+  EnvironmentRouteTransition.of({
+    afterSelected: ({ environmentId }) =>
+      resetDesktopPortForwardConnections(window.desktopBridge, environmentId),
+  }),
+);
+
 const rpcRequestObserverLayer = Layer.succeed(
   EnvironmentRpcRequestObserver,
   EnvironmentRpcRequestObserver.of({
@@ -631,6 +656,7 @@ type ConnectionPlatformLayerSource =
   | typeof capabilitiesLayer
   | typeof platformConnectionSourceLayer
   | typeof environmentOwnedDataCleanupLayer
+  | typeof environmentRouteTransitionLayer
   | typeof rpcRequestObserverLayer;
 
 export const connectionPlatformLayer: Layer.Layer<
@@ -644,5 +670,6 @@ export const connectionPlatformLayer: Layer.Layer<
   capabilitiesLayer,
   platformConnectionSourceLayer,
   environmentOwnedDataCleanupLayer,
+  environmentRouteTransitionLayer,
   rpcRequestObserverLayer,
 );

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -10,6 +10,7 @@ import { makeCatalogBackend, makeCatalogStore } from "./storage";
 const emptyCatalog = {
   schemaVersion: 1,
   targets: [],
+  routes: [],
   profiles: [],
   credentials: [],
   remoteDpopTokens: [],

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -10,6 +10,8 @@ import {
   removeCatalogValue,
   removeConnectionFromCatalog,
   replaceCatalogValue,
+  selectConnectionRouteInCatalog,
+  connectionRoutes,
 } from "@t3tools/client-runtime/platform";
 import { TokenStore } from "@t3tools/client-runtime/authorization";
 import {
@@ -97,7 +99,9 @@ function catalogError(operation: string, cause: unknown) {
 function persistenceError(
   operation:
     | "list-targets"
+    | "list-routes"
     | "register-connection"
+    | "select-connection-route"
     | "remove-connection"
     | "load-shell"
     | "save-shell"
@@ -375,12 +379,20 @@ export const connectionStorageLayer = Layer.effectContext(
         Effect.map((document) => document.targets),
         Effect.mapError((cause) => persistenceError("list-targets", cause)),
       ),
+      listRoutes: catalog.read.pipe(
+        Effect.map(connectionRoutes),
+        Effect.mapError((cause) => persistenceError("list-routes", cause)),
+      ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
+      select: (target) =>
+        catalog
+          .update((document) => selectConnectionRouteInCatalog(document, target))
+          .pipe(Effect.mapError((cause) => persistenceError("select-connection-route", cause))),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -8,6 +8,7 @@ import {
   EnvironmentCacheStore,
   registerConnectionInCatalog,
   removeCatalogValue,
+  removeConnectionRouteFromCatalog,
   removeConnectionFromCatalog,
   replaceCatalogValue,
   selectConnectionRouteInCatalog,
@@ -102,6 +103,7 @@ function persistenceError(
     | "list-routes"
     | "register-connection"
     | "select-connection-route"
+    | "remove-connection-route"
     | "remove-connection"
     | "load-shell"
     | "save-shell"
@@ -393,6 +395,10 @@ export const connectionStorageLayer = Layer.effectContext(
         catalog
           .update((document) => selectConnectionRouteInCatalog(document, target))
           .pipe(Effect.mapError((cause) => persistenceError("select-connection-route", cause))),
+      removeRoute: (target, fallback) =>
+        catalog
+          .update((document) => removeConnectionRouteFromCatalog(document, target, fallback))
+          .pipe(Effect.mapError((cause) => persistenceError("remove-connection-route", cause))),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { ConfirmDialogHost } from "../components/ConfirmDialogHost";
 import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDialog";
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
 import { SshPasswordPromptDialog } from "../components/desktop/SshPasswordPromptDialog";
+import { DesktopPortForwardAuthorizationBridge } from "../components/desktop/DesktopPortForwardAuthorizationBridge";
 import { ProviderUpdateLaunchNotification } from "../components/ProviderUpdateLaunchNotification";
 import { SlowRpcRequestToastCoordinator } from "../components/SlowRpcRequestToastCoordinator";
 import { ThemeEditorHost } from "../components/settings/ThemeEditorHost";
@@ -139,6 +140,7 @@ function RootRouteView() {
         <RelayClientInstallDialog />
         <ConnectOnboardingDialog />
         <SshPasswordPromptDialog />
+        <DesktopPortForwardAuthorizationBridge />
         <ConfirmDialogHost />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />

--- a/apps/web/src/state/session.ts
+++ b/apps/web/src/state/session.ts
@@ -2,6 +2,7 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   createEnvironmentSessionAtoms,
   currentPreparedConnection,
+  refreshCurrentPreparedConnection as refreshRuntimePreparedConnection,
 } from "@t3tools/client-runtime/state/session";
 import { createRuntimeCommand } from "@t3tools/client-runtime/state/runtime";
 import type { EnvironmentId } from "@t3tools/contracts";
@@ -37,8 +38,22 @@ const readCurrentPreparedConnectionCommand = createRuntimeCommand(connectionAtom
   execute: currentPreparedConnection,
 });
 
+const refreshCurrentPreparedConnectionCommand = createRuntimeCommand(connectionAtomRuntime, {
+  label: "environment-prepared-connection:refresh-current",
+  concurrency: { mode: "singleFlight", key: (environmentId: EnvironmentId) => environmentId },
+  execute: (environmentId) => refreshRuntimePreparedConnection(environmentId),
+});
+
 export async function readCurrentPreparedConnection(environmentId: EnvironmentId) {
   const result = await readCurrentPreparedConnectionCommand.run(appAtomRegistry, environmentId);
+  if (result._tag === "Failure") {
+    throw Cause.squash(result.cause);
+  }
+  return Option.getOrNull(result.value);
+}
+
+export async function refreshCurrentPreparedConnection(environmentId: EnvironmentId) {
+  const result = await refreshCurrentPreparedConnectionCommand.run(appAtomRegistry, environmentId);
   if (result._tag === "Failure") {
     throw Cause.squash(result.cause);
   }

--- a/apps/web/src/state/session.ts
+++ b/apps/web/src/state/session.ts
@@ -1,6 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
-import { createEnvironmentSessionAtoms } from "@t3tools/client-runtime/state/session";
+import {
+  createEnvironmentSessionAtoms,
+  currentPreparedConnection,
+} from "@t3tools/client-runtime/state/session";
+import { createRuntimeCommand } from "@t3tools/client-runtime/state/runtime";
 import type { EnvironmentId } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
@@ -25,6 +30,19 @@ export function readPreparedConnection(environmentId: EnvironmentId) {
   return Option.getOrNull(
     appAtomRegistry.get(environmentSession.preparedConnectionValueAtom(environmentId)),
   );
+}
+
+const readCurrentPreparedConnectionCommand = createRuntimeCommand(connectionAtomRuntime, {
+  label: "environment-prepared-connection:read-current",
+  execute: currentPreparedConnection,
+});
+
+export async function readCurrentPreparedConnection(environmentId: EnvironmentId) {
+  const result = await readCurrentPreparedConnectionCommand.run(appAtomRegistry, environmentId);
+  if (result._tag === "Failure") {
+    throw Cause.squash(result.cause);
+  }
+  return Option.getOrNull(result.value);
 }
 
 /**

--- a/apps/web/test/environmentHttpTest.ts
+++ b/apps/web/test/environmentHttpTest.ts
@@ -101,6 +101,7 @@ export async function installEnvironmentHttpTest(scenario: EnvironmentHttpTestSc
             )
             .handle("token", () => unexpectedEndpoint("auth.token"))
             .handle("webSocketTicket", () => unexpectedEndpoint("auth.webSocketTicket"))
+            .handle("tcpPortForwardTicket", () => unexpectedEndpoint("auth.tcpPortForwardTicket"))
             .handle(
               "pairingCredential",
               Effect.fn("test.environment.auth.pairingCredential")(function* ({ payload }) {

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -35,6 +35,14 @@ scope when it changed. `createServiceScope` builds an `EnvironmentSupervisor`
 bound to a closeable scope and connects it; `run` and `runStream` execute caller
 effects with that supervisor provided.
 
+Persisted environments may have multiple routes but exactly one selected target
+per client. `EnvironmentRegistry.routes` publishes the retained route entries.
+`selectRoute` first calls `ConnectionDriver.prepare` while the selected
+supervisor remains live, so authentication and stable environment identity are
+verified before persistence changes. It then swaps the selected entry and
+supervisor. Selection never falls back automatically; a failed preparation
+leaves the existing session and persisted selection untouched.
+
 `EnvironmentSupervisor` owns desired state, retry scheduling, and the active
 session scope. React components do not create connections, transports, retry
 loops, or RPC clients.

--- a/docs/internals/desktop-port-forwarding.md
+++ b/docs/internals/desktop-port-forwarding.md
@@ -100,8 +100,8 @@ per running definition. The current panel shows:
 
 - environment label plus a short environment-ID fingerprint;
 - remote destination and assigned desktop address;
-- running/error status;
-- active connection count;
+- listener, connecting, connected, and error status;
+- connecting and established bridge counts kept separate;
 - manual creation and stop actions.
 
 Copy address, open HTTP service, edit, persistence, and richer lifecycle states

--- a/docs/internals/desktop-port-forwarding.md
+++ b/docs/internals/desktop-port-forwarding.md
@@ -38,6 +38,11 @@ desktop loopback listener
   -> remote loopback service
 ```
 
+The ticket contract represents the remote loopback boundary as `127.0.0.1`,
+not as permission to dial an arbitrary host. At the final bridge boundary, the
+server tries both `127.0.0.1` and `::1` so a service using the platform's
+`localhost` default works whether it selected IPv4 or IPv6.
+
 Use one dedicated WebSocket per accepted TCP connection for the first version.
 This keeps framing, half-close behavior, cancellation, and backpressure simpler
 than a new multiplexing protocol and avoids head-of-line blocking the ordinary

--- a/docs/internals/desktop-port-forwarding.md
+++ b/docs/internals/desktop-port-forwarding.md
@@ -1,7 +1,7 @@
 # Desktop Port Forwarding
 
-> The bridge-first manual forwarding slice is implemented. Persistence,
-> preview discovery actions, and a native SSH driver remain follow-up work.
+> The bridge-first manual forwarding slice is implemented. Persistence and
+> preview discovery actions remain follow-up work.
 
 ## Decision
 
@@ -21,19 +21,15 @@ services on the Internet.
 
 ## Transport
 
-Do not allocate an additional FRP proxy for each forwarded port. The sovereign
-FRP authorization boundary intentionally permits one canonical HTTP proxy per
-environment. Expanding it would require public endpoint allocation, lifecycle
-reconciliation, and materially broader Internet-facing authorization.
-
-Instead, carry forwarding traffic through the environment's selected
-authenticated HTTPS/WSS endpoint:
+Carry forwarding traffic through the environment's selected authenticated
+HTTPS/WSS endpoint. A forward does not allocate another public endpoint or
+broaden the environment's network exposure:
 
 ```text
 desktop loopback listener
   -> Electron PortForwardManager
   -> dedicated authenticated binary WebSocket
-  -> existing T3 environment endpoint and FRP tunnel
+  -> selected T3 environment endpoint
   -> remote T3 TCP bridge
   -> remote loopback service
 ```
@@ -64,8 +60,7 @@ TCP streams are not transparently migratable; the local application must
 reconnect, at which point authorization uses the newly selected route.
 
 The server must advertise an additive `tcpPortForwarding` environment
-capability. The implementation should remain generic T3 behavior rather than
-sovereign-only code:
+capability. The implementation is independent of the selected route:
 
 - T3 Connect environments use the authenticated WebSocket bridge through the
   relay route.
@@ -182,7 +177,7 @@ reconciliation remain.
 2. **Complete:** Dedicated binary WebSocket with bounded flow control and close semantics.
 3. **Partial:** Electron manager with atomic listeners and environment-removal cleanup.
 4. **Partial:** Runtime-only definitions and manual desktop UI; persistence remains.
-5. SSH driver integration behind the same model.
+5. **Complete:** SSH routes use the same authenticated environment bridge.
 6. Failure-recovery, account-switch, revocation, load, and adversarial tests.
 
 A proof of concept is several focused days. A production-quality TCP feature

--- a/docs/internals/desktop-port-forwarding.md
+++ b/docs/internals/desktop-port-forwarding.md
@@ -1,0 +1,168 @@
+# Desktop Port Forwarding
+
+> The bridge-first manual forwarding slice is implemented. Persistence,
+> preview discovery actions, and a native SSH driver remain follow-up work.
+
+## Decision
+
+T3 Code provides environment-scoped local TCP forwarding in the desktop app.
+
+The initial feature maps a loopback listener on the desktop to a loopback TCP
+service on one selected remote environment:
+
+```text
+development  127.0.0.1:3000 -> desktop 127.0.0.1:43001
+primary      127.0.0.1:3000 -> desktop 127.0.0.1:43002
+development  127.0.0.1:5432 -> desktop 127.0.0.1:45432
+```
+
+It is a private client-side tunnel, not a mechanism for publishing remote
+services on the Internet.
+
+## Transport
+
+Do not allocate an additional FRP proxy for each forwarded port. The sovereign
+FRP authorization boundary intentionally permits one canonical HTTP proxy per
+environment. Expanding it would require public endpoint allocation, lifecycle
+reconciliation, and materially broader Internet-facing authorization.
+
+Instead, carry forwarding traffic through the environment's existing
+authenticated HTTPS/WSS endpoint:
+
+```text
+desktop loopback listener
+  -> Electron PortForwardManager
+  -> dedicated authenticated binary WebSocket
+  -> existing T3 environment endpoint and FRP tunnel
+  -> remote T3 TCP bridge
+  -> remote loopback service
+```
+
+Use one dedicated WebSocket per accepted TCP connection for the first version.
+This keeps framing, half-close behavior, cancellation, and backpressure simpler
+than a new multiplexing protocol and avoids head-of-line blocking the ordinary
+T3 control connection. Multiplex only if measured connection counts justify it.
+
+The server must advertise an additive `tcpPortForwarding` environment
+capability. The implementation should remain generic T3 behavior rather than
+sovereign-only code:
+
+- T3 Connect environments use the authenticated WebSocket bridge.
+- SSH environments may use native `ssh -L` behind the same desktop UI.
+- Local environments do not need a tunnel.
+
+## Multi-environment ownership
+
+Electron main owns one process-wide `PortForwardManager`. A forward has a
+stable `forwardId` and is scoped internally by `environmentId`, remote host,
+and remote port. Display labels are never identity: duplicate environment
+labels must remain harmless.
+
+The manager currently owns:
+
+- loopback listeners and atomic port allocation;
+- active socket/WebSocket pairs;
+- runtime-only definitions;
+- account-switch and remote-revocation teardown;
+- per-forward and global connection limits.
+
+Persistence, auto-start, waiting/reconnecting states, and creation
+deduplication remain part of the next lifecycle-focused slice.
+
+A persisted definition should contain at least:
+
+```ts
+interface SavedPortForward {
+  readonly forwardId: string;
+  readonly environmentId: string;
+  readonly remoteHost: "127.0.0.1" | "::1" | "localhost";
+  readonly remotePort: number;
+  readonly preferredLocalPort: number | null;
+  readonly autoStart: boolean;
+  readonly label: string | null;
+}
+```
+
+The assigned local port is device-local runtime state. It should not be synced
+through the relay. Bind the real listener atomically; never probe a free port,
+release it, and bind later. If a requested port is occupied, report a conflict
+or visibly allocate another port—never silently replace an existing mapping.
+
+When an environment is unavailable, retain its saved definition in a waiting
+state. Reconcile it when that exact environment ID returns. Removing or
+revoking an environment and switching accounts must immediately close its
+listeners and all active connections.
+
+## User experience
+
+The desktop Connections settings include a Port forwarding panel with one row
+per running definition. The current panel shows:
+
+- environment label plus a short environment-ID fingerprint;
+- remote destination and assigned desktop address;
+- running/error status;
+- active connection count;
+- manual creation and stop actions.
+
+Copy address, open HTTP service, edit, persistence, and richer lifecycle states
+remain follow-ups.
+
+The remote server already discovers common loopback development ports. Add a
+one-click **Forward to this Mac** action to those results while retaining a
+manual TCP-port form. Prefer the same local and remote port when available;
+allocate a clear alternate when several environments expose the same port.
+
+HTTP-aware host-header rewriting, friendly `*.localhost` names, and reverse
+forwarding are separate follow-ups. The initial primitive remains transparent
+TCP, so applications that require a specific HTTP Host or TLS hostname may
+need an explicit later HTTP mode.
+
+## Security boundary
+
+The first release must be deliberately narrow:
+
+- TCP only; no UDP.
+- Desktop only; web and mobile cannot create operating-system listeners.
+- Bind only desktop loopback, never `0.0.0.0` or a LAN address.
+- Dial only remote loopback, never arbitrary LAN, container-network, or public
+  destinations.
+- Authorize each connection with a short-lived, single-use,
+  environment-scoped ticket bound to destination and expiration.
+- Enforce port validation, bounded buffers, flow control, connection limits,
+  idle timeouts, and deterministic half-close/cancellation behavior.
+- Log metadata and lifecycle only; never log forwarded bytes or credentials.
+- Terminate immediately on sign-out, account switch, environment removal,
+  remote revocation, or authorization expiry.
+
+Arbitrary remote destinations would turn an environment into a network pivot.
+LAN-visible desktop listeners would expose remote services to the desktop's
+network. Both require separate explicit designs and must not arrive as hidden
+options in the initial dialog.
+
+## Existing foundations
+
+- `packages/ssh/src/tunnel.ts` already demonstrates loopback allocation,
+  tunnel supervision, pending-entry deduplication, readiness, and cleanup.
+- The server preview port scanner already finds remote development listeners.
+- Contracts and RPC already support streaming operations and byte arrays.
+- Environment IDs provide stable multi-remote scoping.
+- T3 Connect supplies the authenticated TLS/WSS path.
+- Electron already owns IPC validation and local saved-environment state.
+
+The implemented slice includes the authenticated TCP bridge, binary connection
+protocol, Electron manager, manual UI, bounded flow control, environment-removal
+cleanup, idle timeouts, and connection limits. Persistence and deeper lifecycle
+reconciliation remain.
+
+## Delivery order and estimate
+
+1. **Complete:** Contracts, capability, ticket scope, and remote loopback TCP bridge.
+2. **Complete:** Dedicated binary WebSocket with bounded flow control and close semantics.
+3. **Partial:** Electron manager with atomic listeners and environment-removal cleanup.
+4. **Partial:** Runtime-only definitions and manual desktop UI; persistence remains.
+5. SSH driver integration behind the same model.
+6. Failure-recovery, account-switch, revocation, load, and adversarial tests.
+
+A proof of concept is several focused days. A production-quality TCP feature
+with persistence, reconnect behavior, conflict handling, limits, UI, and
+security verification is approximately two to four focused engineering weeks.

--- a/docs/internals/desktop-port-forwarding.md
+++ b/docs/internals/desktop-port-forwarding.md
@@ -26,7 +26,7 @@ FRP authorization boundary intentionally permits one canonical HTTP proxy per
 environment. Expanding it would require public endpoint allocation, lifecycle
 reconciliation, and materially broader Internet-facing authorization.
 
-Instead, carry forwarding traffic through the environment's existing
+Instead, carry forwarding traffic through the environment's selected
 authenticated HTTPS/WSS endpoint:
 
 ```text
@@ -48,12 +48,24 @@ request is nevertheless rejected, concurrent forward attempts share one
 environment reconnect and retry ticket authorization once with the refreshed
 prepared connection.
 
+Each accepted desktop TCP connection requests its ticket from the current
+`PreparedConnection`, so new bridges follow the selected relay, direct, or SSH
+route. `EnvironmentRegistry.selectRoute` invokes the platform route-transition
+hook only after the candidate has been prepared and installed. Desktop uses
+that hook to advance every affected forward's generation, close its active and
+connecting socket/WebSocket pairs, and retain its loopback listener. Stale
+authorization completions cannot reopen a bridge from the previous generation.
+TCP streams are not transparently migratable; the local application must
+reconnect, at which point authorization uses the newly selected route.
+
 The server must advertise an additive `tcpPortForwarding` environment
 capability. The implementation should remain generic T3 behavior rather than
 sovereign-only code:
 
-- T3 Connect environments use the authenticated WebSocket bridge.
-- SSH environments may use native `ssh -L` behind the same desktop UI.
+- T3 Connect environments use the authenticated WebSocket bridge through the
+  relay route.
+- SSH environments use the same bridge through the desktop-managed SSH HTTP
+  tunnel.
 - Local environments do not need a tunnel.
 
 ## Multi-environment ownership

--- a/docs/internals/desktop-port-forwarding.md
+++ b/docs/internals/desktop-port-forwarding.md
@@ -43,6 +43,11 @@ This keeps framing, half-close behavior, cancellation, and backpressure simpler
 than a new multiplexing protocol and avoids head-of-line blocking the ordinary
 T3 control connection. Multiplex only if measured connection counts justify it.
 
+Relay connections refresh their DPoP credential before it expires. If a ticket
+request is nevertheless rejected, concurrent forward attempts share one
+environment reconnect and retry ticket authorization once with the refreshed
+prepared connection.
+
 The server must advertise an additive `tcpPortForwarding` environment
 capability. The implementation should remain generic T3 behavior rather than
 sovereign-only code:

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -169,12 +169,15 @@ returns local HTTP/WS endpoints. Disconnect closes the tunnel and stops the remo
 launcher started it; a server that was already running (marked `external`) is left running.
 
 Remote discovery checks the user-level `t3code.service` process first, then the SSH environment and
-same-user `/proc` metadata for `T3CODE_HOME` values. Each recorded runtime is accepted only when its
-PID is live and its loopback environment descriptor answers. The discovered base directory is saved
-for `t3 pair --base-dir`, so the pairing credential lands in the database the reused server actually
-reads. The launcher reuses that reported port before considering a new server. This is what prevents
-an SSH access path from creating a second logical environment beside an already-running T3 Connect
-service whose private service environment is not inherited by SSH.
+same-user `/proc` metadata for `T3CODE_HOME` values. It selects the first authoritative runtime whose
+PID is live and whose recorded origin is loopback, then waits for that runtime instead of falling
+through to a lower-priority server when it is temporarily busy. Once tunneled, the client fetches the
+environment descriptor and verifies the stable environment ID before changing routes. The discovered
+base directory is saved for `t3 pair --base-dir`, so a required pairing credential lands in the
+database the reused server actually reads. Normal reconnects and route switches reuse the stored
+bearer credential rather than writing a new pairing record. This is what prevents an SSH access path
+from creating a second logical environment beside an already-running T3 Connect service whose private
+service environment is not inherited by SSH.
 
 The desktop main process owns this because it can spawn SSH, manage prompts, write launch scripts,
 and clean up forwards. The renderer connects through the forwarded URL like any other environment and

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -57,8 +57,10 @@ control plane or a copy of session state.
 | `RelayConnectionTarget`   | Managed T3 Connect relay tunnels.                                        |
 | `SshConnectionTarget`     | Desktop-managed SSH environments.                                        |
 
-Bearer, relay, and SSH are persisted; primary is platform-managed. Note that Tailscale is not a
-separate target kind. A Tailscale URL is paired through the ordinary bearer path in
+Bearer, relay, and SSH routes are persisted; primary is platform-managed. The catalog keeps one
+selected target per environment plus every known route for that stable environment ID. Registering
+an SSH route for an environment already reached through the relay retains both routes instead of
+replacing the relay registration. Note that Tailscale is not a separate target kind. A Tailscale URL is paired through the ordinary bearer path in
 [`onboarding.ts`][onboarding] (`preparePairingRegistration`), which accepts either a pairing URL or a
 host plus pairing code. Tailscale is an endpoint provider and transport, not a distinct runtime
 concept.
@@ -166,6 +168,14 @@ server, opens a local tunnel, checks HTTP readiness, optionally issues a remote 
 returns local HTTP/WS endpoints. Disconnect closes the tunnel and stops the remote server if the
 launcher started it; a server that was already running (marked `external`) is left running.
 
+Remote discovery checks the user-level `t3code.service` process first, then the SSH environment and
+same-user `/proc` metadata for `T3CODE_HOME` values. Each recorded runtime is accepted only when its
+PID is live and its loopback environment descriptor answers. The discovered base directory is saved
+for `t3 pair --base-dir`, so the pairing credential lands in the database the reused server actually
+reads. The launcher reuses that reported port before considering a new server. This is what prevents
+an SSH access path from creating a second logical environment beside an already-running T3 Connect
+service whose private service environment is not inherited by SSH.
+
 The desktop main process owns this because it can spawn SSH, manage prompts, write launch scripts,
 and clean up forwards. The renderer connects through the forwarded URL like any other environment and
 needs no SSH-specific RPC path.
@@ -174,6 +184,13 @@ Failure handling is explicit: SSH auth failure surfaces before an environment is
 failure includes launcher output where available, forwarded-port failure leaves the environment
 disconnected rather than falling back to an unrelated endpoint, and reconnect restores the SSH bridge
 before reconnecting the WebSocket client.
+
+Route selection is manual and device-local. `EnvironmentRegistry.selectRoute` prepares and
+authenticates the candidate while the current supervisor remains active, including verifying its
+environment ID. Only then does it persist the selected target and replace the supervisor. There is
+one active RPC session per environment on a client; an inactive SSH tunnel may remain warm for a
+later manual switch, but it owns no subscriptions. A failed candidate leaves the selected route and
+active session unchanged. Mobile shares the route-capable catalog model but exposes no SSH UI.
 
 ## Launch methods
 

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -208,6 +208,9 @@ Each forward reports **Listening** until a local application connects,
 **connecting** while T3 Code authorizes and opens the remote bridge, and
 **connected** only after that bridge is established. A failed bridge shows its
 error without stopping the loopback listener, so a later connection can retry.
+Long-running relay connections refresh their authorization automatically; if a
+credential is rejected during forwarding, the desktop reconnects that
+environment and retries once.
 
 The forward is TCP-only and can reach only `127.0.0.1` on the remote
 environment. It is not exposed to your LAN or the public Internet. Manual

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -187,6 +187,29 @@ generated runner script, clears stale launcher state, and starts a fresh server 
 discover or reuse a live one. You should not normally need to delete `~/.t3/ssh-launch` or kill `t3`
 processes manually.
 
+### Forward a Remote Port to the Desktop
+
+The desktop app can expose a service listening on an environment's loopback
+interface as a loopback port on your computer. This works with T3 Connect,
+direct HTTPS or Tailscale connections, and desktop-managed SSH environments.
+
+1. Open **Settings** → **Connections** in the desktop app.
+2. Under **Port forwarding**, select an environment.
+3. Enter the remote port. Leave the local port blank to choose an available
+   port automatically. T3 Code first tries the same port, then nearby ports,
+   and finally an operating-system-assigned free port. Enter a local port when
+   you need an exact mapping; an exact-port conflict is reported instead of
+   silently changing it.
+4. Choose **Start** and connect to the displayed `127.0.0.1` address.
+
+For the active environment, the cable icon in the conversation header opens a
+compact version of the same controls and shows how many forwards are running.
+
+The forward is TCP-only and can reach only `127.0.0.1` on the remote
+environment. It is not exposed to your LAN or the public Internet. Manual
+forwards are currently runtime-only: they stop when you quit the desktop app,
+remove the environment, or choose **Stop**.
+
 ## Updating a Remote Server
 
 When the T3 Code web or desktop app and a remote server use different versions, a warning appears in

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -204,6 +204,10 @@ direct HTTPS or Tailscale connections, and desktop-managed SSH environments.
 
 For the active environment, the cable icon in the conversation header opens a
 compact version of the same controls and shows how many forwards are running.
+Each forward reports **Listening** until a local application connects,
+**connecting** while T3 Code authorizes and opens the remote bridge, and
+**connected** only after that bridge is established. A failed bridge shows its
+error without stopping the loopback listener, so a later connection can retry.
 
 The forward is TCP-only and can reach only `127.0.0.1` on the remote
 environment. It is not exposed to your LAN or the public Internet. Manual

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -218,10 +218,11 @@ desktop loopback listener but closes its active TCP sessions; applications that
 reconnect use the newly selected method. Existing TCP streams cannot be moved
 between transports without interruption.
 
-The forward is TCP-only and can reach only `127.0.0.1` on the remote
-environment. It is not exposed to your LAN or the public Internet. Manual
-forwards are currently runtime-only: they stop when you quit the desktop app,
-remove the environment, or choose **Stop**.
+The forward is TCP-only and can reach only the remote environment's loopback
+interface. Services bound to either IPv4 `127.0.0.1` or IPv6 `::1` through
+`localhost` are supported. The forward is not exposed to your LAN or the public
+Internet. Manual forwards are currently runtime-only: they stop when you quit
+the desktop app, remove the environment, or choose **Stop**.
 
 ## Updating a Remote Server
 

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -212,6 +212,12 @@ Long-running relay connections refresh their authorization automatically; if a
 credential is rejected during forwarding, the desktop reconnects that
 environment and retries once.
 
+A forward always uses the connection method currently selected for its
+environment. When you switch between T3 Connect and SSH, T3 Code keeps the
+desktop loopback listener but closes its active TCP sessions; applications that
+reconnect use the newly selected method. Existing TCP streams cannot be moved
+between transports without interruption.
+
 The forward is TCP-only and can reach only `127.0.0.1` on the remote
 environment. It is not exposed to your LAN or the public Internet. Manual
 forwards are currently runtime-only: they stop when you quit the desktop app,

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -136,9 +136,26 @@ After setup, the renderer connects to a local forwarded HTTP/WebSocket endpoint.
 
 SSH launch is a desktop feature because it needs local process and SSH access. Once the environment is paired and saved, it uses the same environment list and connection model as direct LAN, Tailscale, HTTPS, or future tunnel-backed environments.
 
+If the same server is already saved through T3 Connect, adding it through SSH does not create a
+second environment. The desktop keeps both access methods under the server's stable environment
+identity. Choose **T3 Connect** or **SSH** from the environment's connection-method menu. The choice
+is manual and applies only to that desktop; T3 Code does not silently fall back to the other method.
+Before switching, the desktop prepares the selected route and verifies that it reaches the same
+environment, then hands the active session over. If preparation fails, the current connection stays
+active.
+
+All clients still talk to the same T3 server, regardless of their route. A thread created by the
+desktop over SSH is therefore available to mobile over T3 Connect, and server events continue to fan
+out to every connected client.
+
 #### SSH Launch Troubleshooting
 
 The desktop SSH launcher connects with a non-interactive `sh` session, writes a small launcher script under `~/.t3/ssh-launch/<host-key>/`, starts or reuses a remote T3 server, and forwards the remote loopback port back to your desktop.
+
+Before starting another server, the launcher inspects the remote T3 service and running-process
+metadata, then validates the recorded server through its environment descriptor. This lets SSH reuse
+a server started by T3 Connect even when that service uses a private `T3CODE_HOME` that the SSH login
+shell does not inherit; the forwarded remote port is the port reported by that server.
 
 The remote host must have a compatible Node.js runtime. T3 Code uses the server package's `engines.node` requirement:
 
@@ -165,7 +182,10 @@ nvm alias default 24
 
 With mise, asdf, fnm, or nodenv, make sure the tool's shim directory is installed and resolves to a Node version satisfying the range above without an interactive shell.
 
-If reconnecting after an app update fails, retry the SSH launch once. The launcher now compares its generated runner script, stops stale launcher-managed remote servers, clears the SSH launch PID/port state, and starts a fresh remote server. You should not normally need to delete `~/.t3/ssh-launch` or kill `t3` processes manually.
+If reconnecting after an app update fails, use **Connect** to retry. The launcher compares its
+generated runner script, clears stale launcher state, and starts a fresh server only when it cannot
+discover or reuse a live one. You should not normally need to delete `~/.t3/ssh-launch` or kill `t3`
+processes manually.
 
 ## Updating a Remote Server
 

--- a/packages/client-runtime/src/authorization/index.ts
+++ b/packages/client-runtime/src/authorization/index.ts
@@ -1,4 +1,5 @@
 export * from "./remote.ts";
+export * from "./portForward.ts";
 export {
   type AuthorizedRemoteEnvironment,
   type RelayEnvironmentAuthorization,

--- a/packages/client-runtime/src/authorization/portForward.test.ts
+++ b/packages/client-runtime/src/authorization/portForward.test.ts
@@ -1,0 +1,57 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { BearerConnectionTarget } from "../connection/model.ts";
+import { remoteHttpClientLayer } from "../rpc/http.ts";
+import { resolveTcpPortForwardSocketUrl } from "./portForward.ts";
+
+describe("TCP port forward authorization", () => {
+  it.effect("issues a destination-bound bearer ticket and returns the bridge URL", () =>
+    Effect.gen(function* () {
+      const calls: Array<readonly [RequestInfo | URL, RequestInit]> = [];
+      const fetchFn = ((input, init) => {
+        calls.push([input, init ?? {}]);
+        return Promise.resolve(
+          Response.json({
+            ticket: "single-use-ticket",
+            expiresAt: "2026-08-12T12:00:30.000Z",
+          }),
+        );
+      }) satisfies typeof fetch;
+      const environmentId = EnvironmentId.make("environment-a");
+
+      const socketUrl = yield* resolveTcpPortForwardSocketUrl({
+        prepared: {
+          environmentId,
+          label: "Remote",
+          httpBaseUrl: "https://remote.example.com/base",
+          socketUrl: "wss://remote.example.com/ws?wsTicket=control-ticket",
+          httpAuthorization: { _tag: "Bearer", token: "access-token" },
+          target: new BearerConnectionTarget({
+            environmentId,
+            label: "Remote",
+            connectionId: "remote-a",
+          }),
+        },
+        signer: Option.none(),
+        remoteHost: "127.0.0.1",
+        remotePort: 4321,
+      }).pipe(Effect.provide(remoteHttpClientLayer(fetchFn)));
+
+      expect(socketUrl).toBe("wss://remote.example.com/ws/tcp-forward?ticket=single-use-ticket");
+      expect(String(calls[0]?.[0])).toBe("https://remote.example.com/api/auth/tcp-forward-ticket");
+      expect(calls[0]?.[1]).toEqual(
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ authorization: "Bearer access-token" }),
+        }),
+      );
+      const body = calls[0]?.[1].body;
+      expect(typeof body === "string" ? body : new TextDecoder().decode(body as Uint8Array)).toBe(
+        '{"remoteHost":"127.0.0.1","remotePort":4321}',
+      );
+    }),
+  );
+});

--- a/packages/client-runtime/src/authorization/portForward.ts
+++ b/packages/client-runtime/src/authorization/portForward.ts
@@ -1,0 +1,55 @@
+import type { TcpPortForwardHost } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import type * as Option from "effect/Option";
+
+import type { PreparedConnection } from "../connection/model.ts";
+import { environmentEndpointUrl } from "../environment/endpoint.ts";
+import type { ManagedRelayDpopSigner } from "../relay/managedRelay.ts";
+import { executeEnvironmentHttpRequest, makeEnvironmentHttpApiClient } from "../rpc/http.ts";
+import {
+  buildEnvironmentAuthHeaders,
+  withEnvironmentCredentials,
+} from "../state/environmentHttpAuth.ts";
+
+const DEFAULT_TCP_FORWARD_TICKET_TIMEOUT_MS = 10_000;
+
+export const resolveTcpPortForwardSocketUrl = Effect.fn(
+  "clientRuntime.authorization.resolveTcpPortForwardSocketUrl",
+)(function* (input: {
+  readonly prepared: PreparedConnection;
+  readonly signer: Option.Option<ManagedRelayDpopSigner["Service"]>;
+  readonly remoteHost: TcpPortForwardHost;
+  readonly remotePort: number;
+  readonly timeoutMs?: number;
+}) {
+  const requestUrl = environmentEndpointUrl(
+    input.prepared.httpBaseUrl,
+    "/api/auth/tcp-forward-ticket",
+  );
+  const client = yield* makeEnvironmentHttpApiClient(input.prepared.httpBaseUrl);
+  const headers = yield* buildEnvironmentAuthHeaders(
+    input.prepared.httpAuthorization,
+    "POST",
+    requestUrl,
+    input.signer,
+  );
+  const issued = yield* executeEnvironmentHttpRequest(
+    requestUrl,
+    input.timeoutMs ?? DEFAULT_TCP_FORWARD_TICKET_TIMEOUT_MS,
+    withEnvironmentCredentials(
+      input.prepared.httpAuthorization,
+      client.auth.tcpPortForwardTicket({
+        headers,
+        payload: { remoteHost: input.remoteHost, remotePort: input.remotePort },
+      }),
+    ),
+  );
+
+  const socketUrl = new URL(input.prepared.httpBaseUrl);
+  socketUrl.protocol = socketUrl.protocol === "https:" ? "wss:" : "ws:";
+  socketUrl.pathname = "/ws/tcp-forward";
+  socketUrl.search = "";
+  socketUrl.hash = "";
+  socketUrl.searchParams.set("ticket", issued.ticket);
+  return socketUrl.toString();
+});

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -222,6 +222,7 @@ export const make = Effect.gen(function* () {
             httpAuthorization: {
               _tag: "Dpop" as const,
               accessToken: cached.value.accessToken,
+              expiresAtEpochMs: cached.value.expiresAtEpochMs,
             },
           };
         }
@@ -293,6 +294,7 @@ export const make = Effect.gen(function* () {
         httpAuthorization: {
           _tag: "Dpop" as const,
           accessToken: token.accessToken,
+          expiresAtEpochMs: token.expiresAtEpochMs,
         },
       };
     },

--- a/packages/client-runtime/src/connection/catalog.ts
+++ b/packages/client-runtime/src/connection/catalog.ts
@@ -79,6 +79,7 @@ export class SshConnectionRegistration extends Schema.TaggedClass<SshConnectionR
   {
     target: SshConnectionTarget,
     profile: SshConnectionProfile,
+    credential: Schema.optionalKey(BearerConnectionCredential),
   },
 ) {}
 

--- a/packages/client-runtime/src/connection/driver.ts
+++ b/packages/client-runtime/src/connection/driver.ts
@@ -29,6 +29,9 @@ export interface EnvironmentConnectionLease {
 export class ConnectionDriver extends Context.Service<
   ConnectionDriver,
   {
+    readonly prepare: (
+      entry: ConnectionCatalogEntry,
+    ) => Effect.Effect<PreparedConnection, ConnectionAttemptError>;
     readonly connect: (
       entry: ConnectionCatalogEntry,
       reportProgress: (progress: ConnectionDriverProgress) => Effect.Effect<void>,
@@ -39,6 +42,7 @@ export class ConnectionDriver extends Context.Service<
 export const make = Effect.gen(function* () {
   const resolver = yield* ConnectionResolver.ConnectionResolver;
   const sessions = yield* RpcSession.RpcSessionFactory;
+  const prepare = resolver.prepare;
 
   const connect = Effect.fn("ConnectionDriver.connect")(function* (
     entry: ConnectionCatalogEntry,
@@ -50,7 +54,7 @@ export const make = Effect.gen(function* () {
       "connection.target.kind": target._tag,
     });
     yield* reportProgress({ stage: "preparing" });
-    const prepared = yield* resolver.prepare(entry);
+    const prepared = yield* prepare(entry);
     yield* reportProgress({ stage: "opening", prepared });
     const session = yield* sessions.connect(prepared);
     yield* reportProgress({ stage: "synchronizing", prepared });
@@ -58,7 +62,7 @@ export const make = Effect.gen(function* () {
     return { prepared, session } satisfies EnvironmentConnectionLease;
   });
 
-  return ConnectionDriver.of({ connect });
+  return ConnectionDriver.of({ prepare, connect });
 });
 
 export const layer = Layer.effect(ConnectionDriver, make);

--- a/packages/client-runtime/src/connection/index.ts
+++ b/packages/client-runtime/src/connection/index.ts
@@ -28,6 +28,7 @@ export {
   EnvironmentNotRegisteredError,
   EnvironmentRegistry,
   PlatformEnvironmentRemovalError,
+  PlatformEnvironmentRouteSelectionError,
 } from "./registry.ts";
 export { ConnectionResolver } from "./resolver.ts";
 export { EnvironmentSupervisor, type EnvironmentSupervisorOptions } from "./supervisor.ts";

--- a/packages/client-runtime/src/connection/index.ts
+++ b/packages/client-runtime/src/connection/index.ts
@@ -24,6 +24,7 @@ export {
 export * from "./presentation.ts";
 export * as ProfileStore from "./profileStore.ts";
 export {
+  ConnectionRouteNotRegisteredError,
   EnvironmentNotRegisteredError,
   EnvironmentRegistry,
   PlatformEnvironmentRemovalError,

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -123,6 +123,7 @@ export type PreparedHttpAuthorization =
   | {
       readonly _tag: "Dpop";
       readonly accessToken: string;
+      readonly expiresAtEpochMs: number;
     };
 
 export interface PreparedConnection {

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -55,6 +55,18 @@ export type PersistedConnectionTarget = typeof PersistedConnectionTarget.Type;
 
 export type ConnectionTargetKind = ConnectionTarget["_tag"];
 
+export function connectionRouteId(target: ConnectionTarget): string {
+  switch (target._tag) {
+    case "PrimaryConnectionTarget":
+      return `primary:${target.environmentId}`;
+    case "RelayConnectionTarget":
+      return `relay:${target.environmentId}`;
+    case "BearerConnectionTarget":
+    case "SshConnectionTarget":
+      return target.connectionId;
+  }
+}
+
 export type NetworkStatus = "unknown" | "offline" | "online";
 
 export const ConnectionTransientReason = Schema.Literals([

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -251,6 +251,10 @@ describe("connection onboarding", () => {
           connectionId: "ssh:environment-ssh",
           target,
         },
+        credential: {
+          _tag: "BearerConnectionCredential",
+          token: "bearer-token",
+        },
       });
     }),
   );

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -230,6 +230,9 @@ export const prepareSshRegistration = Effect.fn(
       label,
       target: provisioned.bootstrap.target,
     }),
+    credential: new BearerConnectionCredential({
+      token: provisioned.bearerToken,
+    }),
   });
 });
 

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -1010,6 +1010,12 @@ describe("EnvironmentRegistry", () => {
           (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
         ).toEqual(TARGET);
 
+        const routeError = yield* Effect.flip(
+          registry.selectRoute(TARGET.environmentId, connectionRouteId(TARGET)),
+        );
+        expect(routeError._tag).toBe("PlatformEnvironmentRouteSelectionError");
+        expect(routeError.message).toContain("cannot be selected");
+
         const error = yield* Effect.flip(registry.remove(TARGET.environmentId));
         expect(error._tag).toBe("PlatformEnvironmentRemovalError");
         expect(

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -227,6 +227,13 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
               next.set(registration.profile.connectionId, registration.profile);
               return next;
             });
+            if (registration.credential !== undefined) {
+              yield* Ref.update(storedCredentials, (current) => {
+                const next = new Map(current);
+                next.set(registration.target.connectionId, registration.credential!);
+                return next;
+              });
+            }
         }
       }),
     select: (target) =>

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -187,6 +187,13 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     ]),
   );
   const disconnectedSshTargets = yield* Ref.make<ReadonlyArray<DesktopSshEnvironmentTarget>>([]);
+  const routeTransitions = yield* Ref.make<
+    ReadonlyArray<{
+      readonly environmentId: EnvironmentId;
+      readonly previous: ConnectionTarget;
+      readonly selected: ConnectionTarget;
+    }>
+  >([]);
 
   const targetStore = Persistence.ConnectionTargetStore.of({
     list: Ref.get(storedTargets).pipe(Effect.map((targets) => [...targets.values()])),
@@ -411,6 +418,9 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     prepare: () => Effect.die(new Error("SSH preparation is not used.")),
     disconnect: (target) => Ref.update(disconnectedSshTargets, (current) => [...current, target]),
   });
+  const routeTransition = ClientCapabilities.EnvironmentRouteTransition.of({
+    afterSelected: (input) => Ref.update(routeTransitions, (current) => [...current, input]),
+  });
   const driver = ConnectionDriver.ConnectionDriver.of({
     prepare: (entry) =>
       options?.prepareRoute?.(entry.target) ??
@@ -460,6 +470,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         Layer.succeed(ConnectionCredentialStore.ConnectionCredentialStore, credentialStore),
         Layer.succeed(TokenStore.RemoteDpopAccessTokenStore, tokenStore),
         Layer.succeed(ClientCapabilities.SshEnvironmentGateway, sshGateway),
+        Layer.succeed(ClientCapabilities.EnvironmentRouteTransition, routeTransition),
         Layer.succeed(Connectivity.Connectivity, connectivity),
         Layer.succeed(
           ConnectionWakeups.ConnectionWakeups,
@@ -486,6 +497,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     storedCredentials,
     storedRemoteTokens,
     disconnectedSshTargets,
+    routeTransitions,
     networkStatus,
   };
 });
@@ -731,6 +743,19 @@ describe("EnvironmentRegistry", () => {
           (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)?.target,
         ).toEqual(SSH_CONNECTION);
         expect(yield* Ref.get(harness.releasedSessions)).toBe(1);
+        expect(yield* Ref.get(harness.routeTransitions)).toEqual([
+          {
+            environmentId: SSH_CONNECTION.environmentId,
+            previous: SSH_RELAY_TARGET,
+            selected: SSH_CONNECTION,
+          },
+        ]);
+
+        yield* registry.selectRoute(
+          SSH_CONNECTION.environmentId,
+          connectionRouteId(SSH_CONNECTION),
+        );
+        expect(yield* Ref.get(harness.routeTransitions)).toHaveLength(1);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );
@@ -769,6 +794,7 @@ describe("EnvironmentRegistry", () => {
           (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)?.target,
         ).toEqual(SSH_RELAY_TARGET);
         expect(yield* Ref.get(harness.releasedSessions)).toBe(0);
+        expect(yield* Ref.get(harness.routeTransitions)).toEqual([]);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -39,6 +39,7 @@ import {
   type ConnectionTarget,
   type PreparedConnection,
   type SupervisorConnectionState,
+  connectionRouteId,
 } from "./model.ts";
 import * as Persistence from "../platform/persistence.ts";
 import * as ConnectionProfileStore from "./profileStore.ts";
@@ -105,6 +106,10 @@ const SSH_CONNECTION = new SshConnectionTarget({
   label: "SSH environment",
   connectionId: "ssh-connection",
 });
+const SSH_RELAY_TARGET = new RelayConnectionTarget({
+  environmentId: SSH_CONNECTION.environmentId,
+  label: SSH_CONNECTION.label,
+});
 const SSH_PROFILE = new SshConnectionProfile({
   connectionId: SSH_CONNECTION.connectionId,
   environmentId: SSH_CONNECTION.environmentId,
@@ -128,6 +133,10 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   initialProfiles: ReadonlyArray<ConnectionProfile> = [],
   initialCredentials: ReadonlyArray<readonly [string, ConnectionCredential]> = [],
   options?: {
+    readonly initialRoutes?: ReadonlyArray<ConnectionTarget>;
+    readonly prepareRoute?: (
+      target: ConnectionTarget,
+    ) => Effect.Effect<PreparedConnection, ConnectionTransientError>;
     readonly beforeSessionConnect?: (environmentId: EnvironmentId) => Effect.Effect<void>;
     readonly beforeRegistrationRegister?: (
       registration: ConnectionRegistration,
@@ -139,6 +148,14 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
 ) {
   const storedTargets = yield* Ref.make(
     new Map(initialTargets.map((target) => [target.environmentId, target])),
+  );
+  const storedRoutes = yield* Ref.make(
+    new Map(
+      (options?.initialRoutes ?? initialTargets).map((target) => [
+        connectionRouteId(target),
+        target,
+      ]),
+    ),
   );
   const shellCache = yield* Ref.make(new Map([[TARGET.environmentId, CACHED_SNAPSHOT]]));
   const cacheClears = yield* Ref.make<ReadonlyArray<EnvironmentId>>([]);
@@ -173,6 +190,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
 
   const targetStore = Persistence.ConnectionTargetStore.of({
     list: Ref.get(storedTargets).pipe(Effect.map((targets) => [...targets.values()])),
+    listRoutes: Ref.get(storedRoutes).pipe(Effect.map((routes) => [...routes.values()])),
   });
   const registrationStore = Persistence.ConnectionRegistrationStore.of({
     register: (registration) =>
@@ -181,6 +199,11 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
           next.set(registration.target.environmentId, registration.target);
+          return next;
+        });
+        yield* Ref.update(storedRoutes, (current) => {
+          const next = new Map(current);
+          next.set(connectionRouteId(registration.target), registration.target);
           return next;
         });
         switch (registration._tag) {
@@ -206,26 +229,48 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             });
         }
       }),
+    select: (target) =>
+      Ref.update(storedTargets, (current) => {
+        const next = new Map(current);
+        next.set(target.environmentId, target);
+        return next;
+      }),
     remove: (target) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRemove?.(target) ?? Effect.void;
+        const removedConnectionIds = new Set(
+          [...(yield* Ref.get(storedRoutes)).values()]
+            .filter((route) => route.environmentId === target.environmentId)
+            .flatMap((route) =>
+              route._tag === "BearerConnectionTarget" || route._tag === "SshConnectionTarget"
+                ? [route.connectionId]
+                : [],
+            ),
+        );
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
           next.delete(target.environmentId);
           return next;
         });
-        if (target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget") {
-          yield* Ref.update(storedProfiles, (current) => {
-            const next = new Map(current);
-            next.delete(target.connectionId);
-            return next;
-          });
-          yield* Ref.update(storedCredentials, (current) => {
-            const next = new Map(current);
-            next.delete(target.connectionId);
-            return next;
-          });
-        }
+        yield* Ref.update(storedRoutes, (current) => {
+          const next = new Map(current);
+          for (const [routeId, route] of next) {
+            if (route.environmentId === target.environmentId) {
+              next.delete(routeId);
+            }
+          }
+          return next;
+        });
+        yield* Ref.update(storedProfiles, (current) => {
+          const next = new Map(current);
+          for (const connectionId of removedConnectionIds) next.delete(connectionId);
+          return next;
+        });
+        yield* Ref.update(storedCredentials, (current) => {
+          const next = new Map(current);
+          for (const connectionId of removedConnectionIds) next.delete(connectionId);
+          return next;
+        });
         yield* Ref.update(storedRemoteTokens, (current) => {
           const next = new Map(current);
           next.delete(target.environmentId);
@@ -334,6 +379,14 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     disconnect: (target) => Ref.update(disconnectedSshTargets, (current) => [...current, target]),
   });
   const driver = ConnectionDriver.ConnectionDriver.of({
+    prepare: (entry) =>
+      options?.prepareRoute?.(entry.target) ??
+      Effect.succeed({
+        ...PREPARED,
+        environmentId: entry.target.environmentId,
+        label: entry.target.label,
+        target: entry.target,
+      }),
     connect: (entry, reportProgress) =>
       Effect.gen(function* () {
         const target = entry.target;
@@ -594,6 +647,95 @@ describe("EnvironmentRegistry", () => {
         );
         expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
       }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("prepares and verifies a route before replacing the active session", () =>
+    Effect.gen(function* () {
+      const prepareStarted = yield* Deferred.make<void>();
+      const releasePreparation = yield* Deferred.make<void>();
+      const harness = yield* makeHarness([SSH_RELAY_TARGET], [SSH_PROFILE], [], {
+        initialRoutes: [SSH_RELAY_TARGET, SSH_CONNECTION],
+        prepareRoute: (target) =>
+          Deferred.succeed(prepareStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releasePreparation)),
+            Effect.as({
+              ...PREPARED,
+              environmentId: target.environmentId,
+              label: target.label,
+              target,
+            }),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          SSH_RELAY_TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        const selection = yield* Effect.forkChild(
+          registry.selectRoute(SSH_RELAY_TARGET.environmentId, connectionRouteId(SSH_CONNECTION)),
+        );
+        yield* Deferred.await(prepareStarted);
+        expect(yield* Ref.get(harness.releasedSessions)).toBe(0);
+        yield* Deferred.succeed(releasePreparation, undefined);
+        yield* Fiber.join(selection);
+        yield* awaitConnectionState(
+          registry,
+          SSH_CONNECTION.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        expect((yield* Ref.get(harness.storedTargets)).get(SSH_CONNECTION.environmentId)).toEqual(
+          SSH_CONNECTION,
+        );
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)?.target,
+        ).toEqual(SSH_CONNECTION);
+        expect(yield* Ref.get(harness.releasedSessions)).toBe(1);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("keeps the active route when candidate preparation fails", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([SSH_RELAY_TARGET], [SSH_PROFILE], [], {
+        initialRoutes: [SSH_RELAY_TARGET, SSH_CONNECTION],
+        prepareRoute: () =>
+          Effect.fail(
+            new ConnectionTransientError({
+              reason: "remote-unavailable",
+              detail: "SSH is unavailable.",
+            }),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitConnectionState(
+          registry,
+          SSH_RELAY_TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        const failure = yield* Effect.flip(
+          registry.selectRoute(SSH_RELAY_TARGET.environmentId, connectionRouteId(SSH_CONNECTION)),
+        );
+
+        expect(failure).toBeInstanceOf(ConnectionTransientError);
+        expect((yield* Ref.get(harness.storedTargets)).get(SSH_CONNECTION.environmentId)).toEqual(
+          SSH_RELAY_TARGET,
+        );
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)?.target,
+        ).toEqual(SSH_RELAY_TARGET);
+        expect(yield* Ref.get(harness.releasedSessions)).toBe(0);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );
 
@@ -916,7 +1058,7 @@ describe("EnvironmentRegistry", () => {
   it.effect("removes all owned SSH state only on explicit removal", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness(
-        [SSH_CONNECTION],
+        [SSH_RELAY_TARGET],
         [SSH_PROFILE],
         [
           [
@@ -924,6 +1066,7 @@ describe("EnvironmentRegistry", () => {
             new BearerConnectionCredential({ token: "temporary-token" }),
           ],
         ],
+        { initialRoutes: [SSH_RELAY_TARGET, SSH_CONNECTION] },
       );
 
       yield* Effect.gen(function* () {

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -242,6 +242,32 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         next.set(target.environmentId, target);
         return next;
       }),
+    removeRoute: (target, fallback) =>
+      Effect.gen(function* () {
+        yield* options?.beforeRegistrationRemove?.(target) ?? Effect.void;
+        yield* Ref.update(storedTargets, (current) => {
+          const next = new Map(current);
+          if (
+            connectionRouteId(next.get(target.environmentId) ?? fallback) ===
+            connectionRouteId(target)
+          ) {
+            next.set(target.environmentId, fallback);
+          }
+          return next;
+        });
+        yield* Ref.update(storedRoutes, (current) => {
+          const next = new Map(current);
+          next.delete(connectionRouteId(target));
+          return next;
+        });
+        if (target._tag === "RelayConnectionTarget") {
+          yield* Ref.update(storedRemoteTokens, (current) => {
+            const next = new Map(current);
+            next.delete(target.environmentId);
+            return next;
+          });
+        }
+      }),
     remove: (target) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRemove?.(target) ?? Effect.void;
@@ -449,6 +475,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   return {
     layer,
     storedTargets,
+    storedRoutes,
     shellCache,
     cacheClears,
     ownedDataClears,
@@ -838,6 +865,64 @@ describe("EnvironmentRegistry", () => {
         expect(
           (yield* SubscriptionRef.get(registry.entries)).has(BEARER_TARGET.environmentId),
         ).toBe(true);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("removes a remembered relay route without disconnecting the selected SSH route", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness(
+        [SSH_CONNECTION],
+        [SSH_PROFILE],
+        [[SSH_CONNECTION.connectionId, BEARER_CREDENTIAL]],
+        { initialRoutes: [SSH_RELAY_TARGET, SSH_CONNECTION] },
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.removeRelayEnvironments();
+
+        expect((yield* Ref.get(harness.storedTargets)).get(SSH_CONNECTION.environmentId)).toEqual(
+          SSH_CONNECTION,
+        );
+        expect([...(yield* Ref.get(harness.storedRoutes)).values()]).toEqual([SSH_CONNECTION]);
+        expect((yield* Ref.get(harness.storedProfiles)).has(SSH_CONNECTION.connectionId)).toBe(
+          true,
+        );
+        expect((yield* Ref.get(harness.storedCredentials)).has(SSH_CONNECTION.connectionId)).toBe(
+          true,
+        );
+        expect((yield* Ref.get(harness.storedRemoteTokens)).has(SSH_CONNECTION.environmentId)).toBe(
+          false,
+        );
+        expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
+        expect(yield* Ref.get(harness.ownedDataClears)).toEqual([]);
+        expect(yield* Ref.get(harness.disconnectedSshTargets)).toEqual([]);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("falls back to SSH when signing out while the relay route is selected", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness(
+        [SSH_RELAY_TARGET],
+        [SSH_PROFILE],
+        [[SSH_CONNECTION.connectionId, BEARER_CREDENTIAL]],
+        { initialRoutes: [SSH_RELAY_TARGET, SSH_CONNECTION] },
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.removeRelayEnvironments();
+
+        expect((yield* Ref.get(harness.storedTargets)).get(SSH_CONNECTION.environmentId)).toEqual(
+          SSH_CONNECTION,
+        );
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)?.target,
+        ).toEqual(SSH_CONNECTION);
+        expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
+        expect(yield* Ref.get(harness.ownedDataClears)).toEqual([]);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -947,6 +947,13 @@ describe("EnvironmentRegistry", () => {
         expect(
           (yield* SubscriptionRef.get(registry.entries)).get(SSH_CONNECTION.environmentId)?.target,
         ).toEqual(SSH_CONNECTION);
+        expect(yield* Ref.get(harness.routeTransitions)).toEqual([
+          {
+            environmentId: SSH_CONNECTION.environmentId,
+            previous: SSH_RELAY_TARGET,
+            selected: SSH_CONNECTION,
+          },
+        ]);
         expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
         expect(yield* Ref.get(harness.ownedDataClears)).toEqual([]);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -30,6 +30,7 @@ import type {
   NetworkStatus,
   SupervisorConnectionState,
 } from "./model.ts";
+import { connectionRouteId } from "./model.ts";
 import * as Persistence from "../platform/persistence.ts";
 import * as EnvironmentSupervisor from "./supervisor.ts";
 import * as ConnectionDriver from "./driver.ts";
@@ -59,17 +60,43 @@ export class PlatformEnvironmentRemovalError extends Schema.TaggedErrorClass<Pla
   }
 }
 
+export class ConnectionRouteNotRegisteredError extends Schema.TaggedErrorClass<ConnectionRouteNotRegisteredError>()(
+  "ConnectionRouteNotRegisteredError",
+  {
+    environmentId: EnvironmentId,
+    routeId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Route ${this.routeId} is not registered for environment ${this.environmentId}.`;
+  }
+}
+
 export class EnvironmentRegistry extends Context.Service<
   EnvironmentRegistry,
   {
     readonly entries: SubscriptionRef.SubscriptionRef<
       ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>
     >;
+    readonly routes: SubscriptionRef.SubscriptionRef<
+      ReadonlyMap<EnvironmentId, ReadonlyArray<ConnectionCatalogEntry>>
+    >;
     readonly networkStatus: SubscriptionRef.SubscriptionRef<NetworkStatus>;
     readonly start: Effect.Effect<void>;
     readonly register: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly selectRoute: (
+      environmentId: EnvironmentId,
+      routeId: string,
+    ) => Effect.Effect<
+      void,
+      | Persistence.ConnectionPersistenceError
+      | ConnectionAttemptError
+      | EnvironmentNotRegisteredError
+      | ConnectionRouteNotRegisteredError
+      | PlatformEnvironmentRemovalError
+    >;
     readonly registerPlatform: (registration: PrimaryConnectionRegistration) => Effect.Effect<void>;
     readonly reconcilePlatform: (
       registrations: ReadonlyArray<PlatformConnectionRegistration>,
@@ -137,24 +164,41 @@ export const make = Effect.gen(function* () {
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
   const persistedTargets = yield* storage.list;
+  const persistedRoutes = yield* storage.listRoutes;
+  const loadCatalogEntry = Effect.fn("EnvironmentRegistry.loadCatalogEntry")(function* (
+    target: ConnectionTarget,
+  ) {
+    const profile =
+      target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
+        ? yield* profiles.get(target.connectionId)
+        : Option.none();
+    return { target, profile } satisfies ConnectionCatalogEntry;
+  });
   const initialEntries = new Map(
     yield* Effect.forEach(
       persistedTargets,
-      Effect.fn("EnvironmentRegistry.loadCatalogEntry")(function* (target) {
-        const profile =
-          target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
-            ? yield* profiles.get(target.connectionId)
-            : Option.none();
-        return [
-          target.environmentId,
-          { target, profile } satisfies ConnectionCatalogEntry,
-        ] as const;
-      }),
+      (target) =>
+        loadCatalogEntry(target).pipe(
+          Effect.map((entry) => [target.environmentId, entry] as const),
+        ),
       { concurrency: "unbounded" },
     ),
   );
+  const initialRoutes = new Map<EnvironmentId, ReadonlyArray<ConnectionCatalogEntry>>();
+  for (const entry of yield* Effect.forEach(persistedRoutes, loadCatalogEntry, {
+    concurrency: "unbounded",
+  })) {
+    initialRoutes.set(entry.target.environmentId, [
+      ...(initialRoutes.get(entry.target.environmentId) ?? []),
+      entry,
+    ]);
+  }
   const entries =
     yield* SubscriptionRef.make<ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>>(initialEntries);
+  const routes =
+    yield* SubscriptionRef.make<ReadonlyMap<EnvironmentId, ReadonlyArray<ConnectionCatalogEntry>>>(
+      initialRoutes,
+    );
   const networkStatus = yield* SubscriptionRef.make(yield* connectivity.status);
   const serviceScopes = yield* SubscriptionRef.make<
     ReadonlyMap<EnvironmentId, EnvironmentServiceScope>
@@ -403,6 +447,57 @@ export const make = Effect.gen(function* () {
           next.set(environmentId, registration.target);
           return next;
         });
+        yield* SubscriptionRef.update(routes, (current) => {
+          const next = new Map(current);
+          const existing = next.get(environmentId) ?? [];
+          next.set(environmentId, [
+            ...existing.filter(
+              (candidate) =>
+                connectionRouteId(candidate.target) !== connectionRouteId(entry.target),
+            ),
+            entry,
+          ]);
+          return next;
+        });
+        yield* installEntryLocked(entry);
+      }),
+    );
+  });
+
+  const selectRoute = Effect.fn("EnvironmentRegistry.selectRoute")(function* (
+    environmentId: EnvironmentId,
+    routeId: string,
+  ) {
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
+          return yield* new PlatformEnvironmentRemovalError({ environmentId });
+        }
+        yield* getEntry(environmentId);
+        const entry = (yield* SubscriptionRef.get(routes))
+          .get(environmentId)
+          ?.find((candidate) => connectionRouteId(candidate.target) === routeId);
+        if (entry === undefined) {
+          return yield* new ConnectionRouteNotRegisteredError({ environmentId, routeId });
+        }
+        if (entry.target._tag === "PrimaryConnectionTarget") {
+          return yield* new PlatformEnvironmentRemovalError({ environmentId });
+        }
+        const selected = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        if (selected !== undefined && Equal.equals(selected, entry)) {
+          return;
+        }
+
+        // Keep the current session active while credentials, transport, and the
+        // stable environment identity for the candidate route are verified.
+        yield* driver.prepare(entry);
+        yield* registrations.select(entry.target);
+        yield* Ref.update(persistedTargetsByEnvironment, (current) => {
+          const next = new Map(current);
+          next.set(environmentId, entry.target);
+          return next;
+        });
         yield* installEntryLocked(entry);
       }),
     );
@@ -459,6 +554,11 @@ export const make = Effect.gen(function* () {
               ),
             );
           }
+          yield* SubscriptionRef.update(routes, (current) => {
+            const next = new Map(current);
+            next.delete(target.environmentId);
+            return next;
+          });
 
           yield* installEntryLocked(entry, { retainEquivalentRuntime: true });
         }),
@@ -551,10 +651,14 @@ export const make = Effect.gen(function* () {
           });
         }
         const target = (yield* getEntry(environmentId)).target;
-        const profile =
-          target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
-            ? yield* profiles.get(target.connectionId)
-            : Option.none();
+        const sshTargets = ((yield* SubscriptionRef.get(routes)).get(environmentId) ?? []).flatMap(
+          (entry) =>
+            entry.target._tag === "SshConnectionTarget" &&
+            Option.isSome(entry.profile) &&
+            isSshConnectionProfile(entry.profile.value)
+              ? [entry.profile.value.target]
+              : [],
+        );
 
         yield* registrations.remove(target);
         yield* Ref.update(persistedTargetsByEnvironment, (current) => {
@@ -564,6 +668,11 @@ export const make = Effect.gen(function* () {
         });
         yield* closeServiceScope(environmentId);
         yield* SubscriptionRef.update(entries, (current) => {
+          const next = new Map(current);
+          next.delete(environmentId);
+          return next;
+        });
+        yield* SubscriptionRef.update(routes, (current) => {
           const next = new Map(current);
           next.delete(environmentId);
           return next;
@@ -583,21 +692,20 @@ export const make = Effect.gen(function* () {
           { concurrency: "unbounded", discard: true },
         );
 
-        if (
-          target._tag === "SshConnectionTarget" &&
-          Option.isSome(profile) &&
-          isSshConnectionProfile(profile.value)
-        ) {
-          yield* ssh.disconnect(profile.value.target).pipe(
-            Effect.tapError((error) =>
-              Effect.logWarning("Could not disconnect the managed SSH environment.", {
-                environmentId,
-                error,
-              }),
+        yield* Effect.forEach(
+          sshTargets,
+          (sshTarget) =>
+            ssh.disconnect(sshTarget).pipe(
+              Effect.tapError((error) =>
+                Effect.logWarning("Could not disconnect the managed SSH environment.", {
+                  environmentId,
+                  error,
+                }),
+              ),
+              Effect.ignore,
             ),
-            Effect.ignore,
-          );
-        }
+          { discard: true },
+        );
       }),
     );
   });
@@ -659,9 +767,11 @@ export const make = Effect.gen(function* () {
 
   return EnvironmentRegistry.of({
     entries,
+    routes,
     networkStatus,
     start,
     register,
+    selectRoute,
     registerPlatform,
     reconcilePlatform,
     remove,

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -62,6 +62,18 @@ export class PlatformEnvironmentRemovalError extends Schema.TaggedErrorClass<Pla
   }
 }
 
+export class PlatformEnvironmentRouteSelectionError extends Schema.TaggedErrorClass<PlatformEnvironmentRouteSelectionError>()(
+  "PlatformEnvironmentRouteSelectionError",
+  {
+    environmentId: EnvironmentId,
+    routeId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Route ${this.routeId} cannot be selected for platform-managed environment ${this.environmentId}.`;
+  }
+}
+
 export class ConnectionRouteNotRegisteredError extends Schema.TaggedErrorClass<ConnectionRouteNotRegisteredError>()(
   "ConnectionRouteNotRegisteredError",
   {
@@ -97,7 +109,7 @@ export class EnvironmentRegistry extends Context.Service<
       | ConnectionAttemptError
       | EnvironmentNotRegisteredError
       | ConnectionRouteNotRegisteredError
-      | PlatformEnvironmentRemovalError
+      | PlatformEnvironmentRouteSelectionError
     >;
     readonly registerPlatform: (registration: PrimaryConnectionRegistration) => Effect.Effect<void>;
     readonly reconcilePlatform: (
@@ -474,7 +486,7 @@ export const make = Effect.gen(function* () {
       environmentId,
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
-          return yield* new PlatformEnvironmentRemovalError({ environmentId });
+          return yield* new PlatformEnvironmentRouteSelectionError({ environmentId, routeId });
         }
         yield* getEntry(environmentId);
         const entry = (yield* SubscriptionRef.get(routes))
@@ -484,7 +496,7 @@ export const make = Effect.gen(function* () {
           return yield* new ConnectionRouteNotRegisteredError({ environmentId, routeId });
         }
         if (entry.target._tag === "PrimaryConnectionTarget") {
-          return yield* new PlatformEnvironmentRemovalError({ environmentId });
+          return yield* new PlatformEnvironmentRouteSelectionError({ environmentId, routeId });
         }
         const selected = (yield* SubscriptionRef.get(entries)).get(environmentId);
         if (selected !== undefined && Equal.equals(selected, entry)) {
@@ -739,7 +751,7 @@ export const make = Effect.gen(function* () {
         ({ environmentId, relay, fallback }) => {
           if (fallback === undefined) {
             return remove(environmentId).pipe(
-              Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+              Effect.catchTags({ EnvironmentNotRegisteredError: () => Effect.void }),
             );
           }
           return withLeaseLock(
@@ -766,7 +778,7 @@ export const make = Effect.gen(function* () {
               });
               yield* installEntryLocked(fallback);
             }),
-          ).pipe(Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void));
+          ).pipe(Effect.catchTags({ EnvironmentNotRegisteredError: () => Effect.void }));
         },
         {
           concurrency: "unbounded",

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -177,6 +177,7 @@ export const make = Effect.gen(function* () {
   const driver = yield* ConnectionDriver.ConnectionDriver;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
+  const routeTransition = yield* ClientCapabilities.EnvironmentRouteTransition;
   const persistedTargets = yield* storage.list;
   const persistedRoutes = yield* storage.listRoutes;
   const loadCatalogEntry = Effect.fn("EnvironmentRegistry.loadCatalogEntry")(function* (
@@ -488,7 +489,7 @@ export const make = Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
           return yield* new PlatformEnvironmentRouteSelectionError({ environmentId, routeId });
         }
-        yield* getEntry(environmentId);
+        const selected = yield* getEntry(environmentId);
         const entry = (yield* SubscriptionRef.get(routes))
           .get(environmentId)
           ?.find((candidate) => connectionRouteId(candidate.target) === routeId);
@@ -498,8 +499,7 @@ export const make = Effect.gen(function* () {
         if (entry.target._tag === "PrimaryConnectionTarget") {
           return yield* new PlatformEnvironmentRouteSelectionError({ environmentId, routeId });
         }
-        const selected = (yield* SubscriptionRef.get(entries)).get(environmentId);
-        if (selected !== undefined && Equal.equals(selected, entry)) {
+        if (Equal.equals(selected, entry)) {
           return;
         }
 
@@ -513,6 +513,11 @@ export const make = Effect.gen(function* () {
           return next;
         });
         yield* installEntryLocked(entry);
+        yield* routeTransition.afterSelected({
+          environmentId,
+          previous: selected.target,
+          selected: entry.target,
+        });
       }),
     );
   });

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -782,6 +782,11 @@ export const make = Effect.gen(function* () {
                 return next;
               });
               yield* installEntryLocked(fallback);
+              yield* routeTransition.afterSelected({
+                environmentId,
+                previous: selected.target,
+                selected: fallback.target,
+              });
             }),
           ).pipe(Effect.catchTags({ EnvironmentNotRegisteredError: () => Effect.void }));
         },

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -28,6 +28,8 @@ import type {
   ConnectionAttemptError,
   ConnectionTarget,
   NetworkStatus,
+  PersistedConnectionTarget,
+  RelayConnectionTarget,
   SupervisorConnectionState,
 } from "./model.ts";
 import { connectionRouteId } from "./model.ts";
@@ -712,16 +714,60 @@ export const make = Effect.gen(function* () {
 
   const removeRelayEnvironments = Effect.fn("EnvironmentRegistry.removeRelayEnvironments")(
     function* () {
-      const relayEnvironmentIds = [...(yield* SubscriptionRef.get(entries)).values()]
-        .filter((entry) => entry.target._tag === "RelayConnectionTarget")
-        .map((entry) => entry.target.environmentId);
+      const relayEnvironments = [...(yield* SubscriptionRef.get(routes))].flatMap(
+        ([environmentId, environmentRoutes]) => {
+          const relay = environmentRoutes.find(
+            (entry): entry is ConnectionCatalogEntry & { readonly target: RelayConnectionTarget } =>
+              entry.target._tag === "RelayConnectionTarget",
+          );
+          if (relay === undefined) return [];
+          const fallback = environmentRoutes.find(
+            (
+              entry,
+            ): entry is ConnectionCatalogEntry & {
+              readonly target: Exclude<PersistedConnectionTarget, RelayConnectionTarget>;
+            } =>
+              entry.target._tag === "BearerConnectionTarget" ||
+              entry.target._tag === "SshConnectionTarget",
+          );
+          return [{ environmentId, relay, fallback }];
+        },
+      );
 
       yield* Effect.forEach(
-        relayEnvironmentIds,
-        (environmentId) =>
-          remove(environmentId).pipe(
-            Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
-          ),
+        relayEnvironments,
+        ({ environmentId, relay, fallback }) => {
+          if (fallback === undefined) {
+            return remove(environmentId).pipe(
+              Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+            );
+          }
+          return withLeaseLock(
+            environmentId,
+            Effect.gen(function* () {
+              if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
+                return yield* new PlatformEnvironmentRemovalError({ environmentId });
+              }
+              const selected = yield* getEntry(environmentId);
+              yield* registrations.removeRoute(relay.target, fallback.target);
+              yield* SubscriptionRef.update(routes, (current) => {
+                const next = new Map(current);
+                const remaining = (next.get(environmentId) ?? []).filter(
+                  (entry) => connectionRouteId(entry.target) !== connectionRouteId(relay.target),
+                );
+                next.set(environmentId, remaining);
+                return next;
+              });
+              if (selected.target._tag !== "RelayConnectionTarget") return;
+              yield* Ref.update(persistedTargetsByEnvironment, (current) => {
+                const next = new Map(current);
+                next.set(environmentId, fallback.target);
+                return next;
+              });
+              yield* installEntryLocked(fallback);
+            }),
+          ).pipe(Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void));
+        },
         {
           concurrency: "unbounded",
           discard: true,

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -23,6 +23,7 @@ import {
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import {
   BearerConnectionTarget,
+  ConnectionBlockedError,
   ConnectionTransientError,
   PrimaryConnectionTarget,
   RelayConnectionTarget,
@@ -442,6 +443,159 @@ describe("ConnectionResolver", () => {
         (yield* broker.prepare(catalogEntry(target, Option.some(profile)))).socketUrl,
       ).toContain("wsTicket=bearer");
       expect(yield* Ref.get(preparedTargets)).toEqual([SSH_TARGET]);
+    }),
+  );
+
+  it.effect("reuses a cached SSH bearer without requesting a new pairing credential", () =>
+    Effect.gen(function* () {
+      const prepareBearerTokens = yield* Ref.make<ReadonlyArray<string | undefined>>([]);
+      const authorizeBearerTokens = yield* Ref.make<ReadonlyArray<string>>([]);
+      const target = new SshConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "SSH",
+        connectionId: "ssh-1",
+      });
+      const profile = new SshConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId: target.environmentId,
+        label: target.label,
+        target: SSH_TARGET,
+      });
+      const brokerLayer = yield* makeDependencies({
+        profiles: [profile],
+        credentials: [
+          [target.connectionId, new BearerConnectionCredential({ token: "cached-ssh" })],
+        ],
+        prepareSsh: (input) =>
+          Ref.update(prepareBearerTokens, (values) => [...values, input.bearerToken]).pipe(
+            Effect.as({
+              bootstrap: {
+                target: input.target,
+                httpBaseUrl: "http://127.0.0.1:4010",
+                wsBaseUrl: "ws://127.0.0.1:4010",
+                pairingToken: null,
+              },
+              bearerToken: input.bearerToken ?? "unexpected-fresh-token",
+            }),
+          ),
+        authorizeBearer: (input) =>
+          Ref.update(authorizeBearerTokens, (values) => [...values, input.bearerToken]).pipe(
+            Effect.as({
+              environmentId: input.expectedEnvironmentId,
+              label: "SSH",
+              httpBaseUrl: input.httpBaseUrl,
+              socketUrl: "ws://127.0.0.1:4010/ws?wsTicket=cached",
+              httpAuthorization: { _tag: "Bearer" as const, token: input.bearerToken },
+            }),
+          ),
+      });
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      yield* broker.prepare(catalogEntry(target, Option.some(profile)));
+
+      expect(yield* Ref.get(prepareBearerTokens)).toEqual(["cached-ssh"]);
+      expect(yield* Ref.get(authorizeBearerTokens)).toEqual(["cached-ssh"]);
+    }),
+  );
+
+  it.effect("replaces a cached SSH bearer only after authentication rejects it", () =>
+    Effect.gen(function* () {
+      const prepareBearerTokens = yield* Ref.make<ReadonlyArray<string | undefined>>([]);
+      const authorizeBearerTokens = yield* Ref.make<ReadonlyArray<string>>([]);
+      const target = new SshConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "SSH",
+        connectionId: "ssh-1",
+      });
+      const profile = new SshConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId: target.environmentId,
+        label: target.label,
+        target: SSH_TARGET,
+      });
+      const brokerLayer = yield* makeDependencies({
+        profiles: [profile],
+        credentials: [
+          [target.connectionId, new BearerConnectionCredential({ token: "stale-ssh" })],
+        ],
+        prepareSsh: (input) =>
+          Ref.update(prepareBearerTokens, (values) => [...values, input.bearerToken]).pipe(
+            Effect.as({
+              bootstrap: {
+                target: input.target,
+                httpBaseUrl: "http://127.0.0.1:4010",
+                wsBaseUrl: "ws://127.0.0.1:4010",
+                pairingToken: input.bearerToken === undefined ? "pairing-token" : null,
+              },
+              bearerToken: input.bearerToken ?? "fresh-ssh",
+            }),
+          ),
+        authorizeBearer: (input) =>
+          Ref.update(authorizeBearerTokens, (values) => [...values, input.bearerToken]).pipe(
+            Effect.flatMap(() =>
+              input.bearerToken === "stale-ssh"
+                ? Effect.fail(
+                    new ConnectionBlockedError({
+                      reason: "authentication",
+                      detail: "Credential rejected.",
+                    }),
+                  )
+                : Effect.succeed({
+                    environmentId: input.expectedEnvironmentId,
+                    label: "SSH",
+                    httpBaseUrl: input.httpBaseUrl,
+                    socketUrl: "ws://127.0.0.1:4010/ws?wsTicket=fresh",
+                    httpAuthorization: { _tag: "Bearer" as const, token: input.bearerToken },
+                  }),
+            ),
+          ),
+      });
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      yield* broker.prepare(catalogEntry(target, Option.some(profile)));
+
+      expect(yield* Ref.get(prepareBearerTokens)).toEqual(["stale-ssh", undefined]);
+      expect(yield* Ref.get(authorizeBearerTokens)).toEqual(["stale-ssh", "fresh-ssh"]);
+    }),
+  );
+
+  it.effect("does not replace a cached SSH bearer after a transient failure", () =>
+    Effect.gen(function* () {
+      const prepareBearerTokens = yield* Ref.make<ReadonlyArray<string | undefined>>([]);
+      const target = new SshConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "SSH",
+        connectionId: "ssh-1",
+      });
+      const profile = new SshConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId: target.environmentId,
+        label: target.label,
+        target: SSH_TARGET,
+      });
+      const brokerLayer = yield* makeDependencies({
+        profiles: [profile],
+        credentials: [
+          [target.connectionId, new BearerConnectionCredential({ token: "cached-ssh" })],
+        ],
+        prepareSsh: (input) =>
+          Ref.update(prepareBearerTokens, (values) => [...values, input.bearerToken]).pipe(
+            Effect.flatMap(() =>
+              Effect.fail(
+                new ConnectionTransientError({
+                  reason: "timeout",
+                  detail: "SSH endpoint timed out.",
+                }),
+              ),
+            ),
+          ),
+      });
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      const error = yield* Effect.flip(broker.prepare(catalogEntry(target, Option.some(profile))));
+
+      expect(error).toMatchObject({ _tag: "ConnectionTransientError", reason: "timeout" });
+      expect(yield* Ref.get(prepareBearerTokens)).toEqual(["cached-ssh"]);
     }),
   );
 

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -141,6 +141,7 @@ const makeDependencies = Effect.fn("TestConnectionResolver.makeDependencies")((o
             httpAuthorization: {
               _tag: "Dpop" as const,
               accessToken: "dpop-access-token",
+              expiresAtEpochMs: Number.MAX_SAFE_INTEGER,
             },
           }),
         )),
@@ -351,6 +352,7 @@ describe("ConnectionResolver", () => {
               httpAuthorization: {
                 _tag: "Dpop" as const,
                 accessToken: "dpop-access-token",
+                expiresAtEpochMs: Number.MAX_SAFE_INTEGER,
               },
             }),
           ),
@@ -388,6 +390,7 @@ describe("ConnectionResolver", () => {
               httpAuthorization: {
                 _tag: "Dpop" as const,
                 accessToken: "dpop-access-token",
+                expiresAtEpochMs: Number.MAX_SAFE_INTEGER,
               },
             }),
             Effect.withSpan("test.remote.authorizeDpop"),

--- a/packages/client-runtime/src/connection/resolver.ts
+++ b/packages/client-runtime/src/connection/resolver.ts
@@ -195,6 +195,7 @@ const makeRelayBroker = Effect.fn("clientRuntime.connection.broker.makeRelay")(f
 
 const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(function* () {
   const profiles = yield* ConnectionProfileStore.ConnectionProfileStore;
+  const credentials = yield* ConnectionCredentialStore.ConnectionCredentialStore;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
   const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
 
@@ -218,33 +219,56 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
         actual: profile.environmentId,
       });
     }
-    const prepared = yield* ssh.prepare({
-      connectionId: target.connectionId,
-      expectedEnvironmentId: target.environmentId,
-      target: profile.target,
-    });
-    yield* profiles.put(
-      new SshConnectionProfile({
-        connectionId: profile.connectionId,
-        environmentId: profile.environmentId,
-        label: profile.label,
-        target: prepared.bootstrap.target,
-      }),
+    const prepareAndAuthorize = Effect.fn("clientRuntime.connection.broker.ssh.authorize")(
+      function* (bearerToken?: string) {
+        const prepared = yield* ssh.prepare({
+          connectionId: target.connectionId,
+          expectedEnvironmentId: target.environmentId,
+          target: profile.target,
+          ...(bearerToken === undefined ? {} : { bearerToken }),
+        });
+        yield* profiles.put(
+          new SshConnectionProfile({
+            connectionId: profile.connectionId,
+            environmentId: profile.environmentId,
+            label: profile.label,
+            target: prepared.bootstrap.target,
+          }),
+        );
+        const authorized = yield* remote.authorizeBearer({
+          expectedEnvironmentId: target.environmentId,
+          httpBaseUrl: prepared.bootstrap.httpBaseUrl,
+          wsBaseUrl: prepared.bootstrap.wsBaseUrl,
+          bearerToken: prepared.bearerToken,
+        });
+        if (bearerToken === undefined) {
+          yield* credentials.put(
+            target.connectionId,
+            new BearerConnectionCredential({ token: prepared.bearerToken }),
+          );
+        }
+        return {
+          environmentId: authorized.environmentId,
+          label: authorized.label,
+          httpBaseUrl: authorized.httpBaseUrl,
+          socketUrl: authorized.socketUrl,
+          httpAuthorization: authorized.httpAuthorization,
+          target,
+        } satisfies PreparedConnection;
+      },
     );
-    const authorized = yield* remote.authorizeBearer({
-      expectedEnvironmentId: target.environmentId,
-      httpBaseUrl: prepared.bootstrap.httpBaseUrl,
-      wsBaseUrl: prepared.bootstrap.wsBaseUrl,
-      bearerToken: prepared.bearerToken,
-    });
-    return {
-      environmentId: authorized.environmentId,
-      label: authorized.label,
-      httpBaseUrl: authorized.httpBaseUrl,
-      socketUrl: authorized.socketUrl,
-      httpAuthorization: authorized.httpAuthorization,
-      target,
-    } satisfies PreparedConnection;
+
+    const credential = yield* credentials.get(target.connectionId);
+    if (Option.isSome(credential) && isBearerCredential(credential.value)) {
+      return yield* prepareAndAuthorize(credential.value.token).pipe(
+        Effect.catch((error) =>
+          error._tag === "ConnectionBlockedError" && error.reason === "authentication"
+            ? credentials.remove(target.connectionId).pipe(Effect.andThen(prepareAndAuthorize()))
+            : Effect.fail(error),
+        ),
+      );
+    }
+    return yield* prepareAndAuthorize();
   });
 });
 

--- a/packages/client-runtime/src/connection/resolver.ts
+++ b/packages/client-runtime/src/connection/resolver.ts
@@ -261,11 +261,12 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
     const credential = yield* credentials.get(target.connectionId);
     if (Option.isSome(credential) && isBearerCredential(credential.value)) {
       return yield* prepareAndAuthorize(credential.value.token).pipe(
-        Effect.catch((error) =>
-          error._tag === "ConnectionBlockedError" && error.reason === "authentication"
-            ? credentials.remove(target.connectionId).pipe(Effect.andThen(prepareAndAuthorize()))
-            : Effect.fail(error),
-        ),
+        Effect.catchTags({
+          ConnectionBlockedError: (error) =>
+            error.reason === "authentication"
+              ? credentials.remove(target.connectionId).pipe(Effect.andThen(prepareAndAuthorize()))
+              : Effect.fail(error),
+        }),
       );
     }
     return yield* prepareAndAuthorize();

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -1,6 +1,7 @@
 import { EnvironmentId } from "@t3tools/contracts";
 import { RelayClientTracer } from "@t3tools/shared/relayTracing";
 import { describe, expect, it } from "@effect/vitest";
+import * as Clock from "effect/Clock";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -322,6 +323,86 @@ describe("EnvironmentSupervisor", () => {
       });
       expect(yield* Ref.get(harness.prepareCount)).toBe(1);
     }),
+  );
+
+  it.effect("refreshes a live relay connection before its DPoP credential expires", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) =>
+          Clock.currentTimeMillis.pipe(
+            Effect.map((now) => ({
+              ...PREPARED_CONNECTION,
+              target: RELAY_TARGET,
+              httpAuthorization: {
+                _tag: "Dpop" as const,
+                accessToken: `access-token-${attempt}`,
+                expiresAtEpochMs: now + 5 * 60_000,
+              },
+            })),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(RELAY_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* TestClock.adjust(3 * 60_000 + 59_000);
+      expect(yield* Ref.get(harness.prepareCount)).toBe(1);
+
+      yield* TestClock.adjust("1 second");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+      expect(yield* Ref.get(harness.prepareCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("reauthorizes again when the scheduled credential refresh fails transiently", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) =>
+          attempt === 2
+            ? Effect.fail(transient("Reauthorization temporarily unavailable."))
+            : Clock.currentTimeMillis.pipe(
+                Effect.map((now) => ({
+                  ...PREPARED_CONNECTION,
+                  target: RELAY_TARGET,
+                  httpAuthorization: {
+                    _tag: "Dpop" as const,
+                    accessToken: `access-token-${attempt}`,
+                    expiresAtEpochMs: now + 5 * 60_000,
+                  },
+                })),
+              ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(RELAY_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* TestClock.adjust("4 minutes");
+      const failedRefresh = yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      expect(failedRefresh.lastFailure?.message).toBe("Reauthorization temporarily unavailable.");
+      expect(yield* Ref.get(harness.prepareCount)).toBe(2);
+
+      yield* TestClock.adjust("3 seconds");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2,
+      );
+      expect(yield* Ref.get(harness.prepareCount)).toBe(3);
+    }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("resets retries when activation arrives before the network returns", () =>

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -20,6 +20,7 @@ import {
   ConnectionTransientError,
   PrimaryConnectionTarget,
   RelayConnectionTarget,
+  SshConnectionTarget,
   type ConnectionAttemptError,
   type ConnectionTarget,
   type NetworkStatus,
@@ -49,6 +50,15 @@ const TARGET_ENTRY: ConnectionCatalogEntry = {
 
 const RELAY_ENTRY: ConnectionCatalogEntry = {
   target: RELAY_TARGET,
+  profile: Option.none(),
+};
+
+const SSH_ENTRY: ConnectionCatalogEntry = {
+  target: new SshConnectionTarget({
+    environmentId: TARGET.environmentId,
+    label: TARGET.label,
+    connectionId: "ssh:test-environment",
+  }),
   profile: Option.none(),
 };
 
@@ -188,7 +198,10 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
     ),
     Layer.succeed(
       ConnectionDriver.ConnectionDriver,
-      ConnectionDriver.ConnectionDriver.of({ connect }),
+      ConnectionDriver.ConnectionDriver.of({
+        prepare: (entry) => prepare(entry.target),
+        connect,
+      }),
     ),
   );
 
@@ -462,6 +475,31 @@ describe("EnvironmentSupervisor", () => {
           message: "Test environment did not respond during connection setup.",
         },
       });
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("allows SSH launch longer than the standard setup timeout", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: () => Effect.never,
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(SSH_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connecting" && state.stage === "preparing",
+      );
+      yield* TestClock.adjust("119 seconds");
+      expect((yield* SubscriptionRef.get(supervisor.state)).phase).toBe("connecting");
+
+      yield* TestClock.adjust("1 second");
+      const retrying = yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      expect(retrying.lastFailure?.reason).toBe("timeout");
     }).pipe(Effect.provide(TestClock.layer())),
   );
 

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -35,6 +35,7 @@ const SSH_CONNECTION_ESTABLISHMENT_TIMEOUT = "120 seconds";
 const CONNECTION_PROBE_TIMEOUT = "15 seconds";
 const MOBILE_CONNECTION_PROBE_TIMEOUT = "3 seconds";
 const BACKOFF_RESET_AFTER_MS = 30_000;
+const DPOP_REFRESH_SAFETY_MARGIN_MS = 60_000;
 
 interface SupervisorIntent {
   readonly desired: boolean;
@@ -488,6 +489,18 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     }
   });
 
+  const waitForCredentialRefresh = Effect.fnUntraced(function* (prepared: PreparedConnection) {
+    const authorization = prepared.httpAuthorization;
+    if (authorization?._tag !== "Dpop") {
+      return yield* Effect.never;
+    }
+    const now = yield* Clock.currentTimeMillis;
+    yield* Effect.sleep(
+      Math.max(0, authorization.expiresAtEpochMs - DPOP_REFRESH_SAFETY_MARGIN_MS - now),
+    );
+    return true;
+  });
+
   const runAttempt = Effect.fnUntraced(function* (
     attempt: number,
     generation: number,
@@ -596,13 +609,16 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
           }),
         ),
       ),
-      monitorConnectedLease(active.lease).pipe(
-        Effect.mapError(
-          (error): TracedAttemptFailure => ({
-            error,
-            attemptSpan: active.attemptSpan,
-          }),
+      Effect.raceFirst(
+        monitorConnectedLease(active.lease).pipe(
+          Effect.mapError(
+            (error): TracedAttemptFailure => ({
+              error,
+              attemptSpan: active.attemptSpan,
+            }),
+          ),
         ),
+        waitForCredentialRefresh(active.lease.prepared),
       ),
     ).pipe(exitUnlessInterrupted);
     const connectedForMs = (yield* Clock.currentTimeMillis) - connectedAt;

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -31,6 +31,7 @@ import * as ConnectionWakeups from "./wakeups.ts";
 
 const RETRY_DELAYS_MS = [3_000, 4_000, 8_000, 16_000] as const;
 const CONNECTION_ESTABLISHMENT_TIMEOUT = "15 seconds";
+const SSH_CONNECTION_ESTABLISHMENT_TIMEOUT = "120 seconds";
 const CONNECTION_PROBE_TIMEOUT = "15 seconds";
 const MOBILE_CONNECTION_PROBE_TIMEOUT = "3 seconds";
 const BACKOFF_RESET_AFTER_MS = 30_000;
@@ -513,9 +514,11 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
           }),
         ),
       ),
-      Effect.sleep(CONNECTION_ESTABLISHMENT_TIMEOUT).pipe(
-        Effect.as<EstablishmentEvent>({ _tag: "TimedOut" }),
-      ),
+      Effect.sleep(
+        target._tag === "SshConnectionTarget"
+          ? SSH_CONNECTION_ESTABLISHMENT_TIMEOUT
+          : CONNECTION_ESTABLISHMENT_TIMEOUT,
+      ).pipe(Effect.as<EstablishmentEvent>({ _tag: "TimedOut" })),
     ]);
 
     if (establishment._tag === "Interrupted") {

--- a/packages/client-runtime/src/platform/capabilities.ts
+++ b/packages/client-runtime/src/platform/capabilities.ts
@@ -60,6 +60,7 @@ export class SshEnvironmentGateway extends Context.Service<
       readonly connectionId: string;
       readonly expectedEnvironmentId: EnvironmentId;
       readonly target: DesktopSshEnvironmentTarget;
+      readonly bearerToken?: string;
     }) => Effect.Effect<PreparedSshEnvironment, ConnectionAttemptError>;
     readonly disconnect: (
       target: DesktopSshEnvironmentTarget,

--- a/packages/client-runtime/src/platform/capabilities.ts
+++ b/packages/client-runtime/src/platform/capabilities.ts
@@ -6,10 +6,10 @@ import {
   EnvironmentId,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
 import type * as Option from "effect/Option";
 
-import type { ConnectionAttemptError } from "../connection/model.ts";
+import type { ConnectionAttemptError, ConnectionTarget } from "../connection/model.ts";
 
 export interface PreparedSshEnvironment {
   readonly bootstrap: DesktopSshEnvironmentBootstrap;
@@ -67,3 +67,18 @@ export class SshEnvironmentGateway extends Context.Service<
     ) => Effect.Effect<void, ConnectionAttemptError>;
   }
 >()("@t3tools/client-runtime/platform/capabilities/SshEnvironmentGateway") {}
+
+/**
+ * Lets a client surface retire side-channel transports after the selected
+ * route has changed. Core RPC sessions are replaced by EnvironmentRegistry;
+ * platform-owned transports such as desktop port forwards use this hook.
+ */
+export class EnvironmentRouteTransition extends Context.Reference<{
+  readonly afterSelected: (input: {
+    readonly environmentId: EnvironmentId;
+    readonly previous: ConnectionTarget;
+    readonly selected: ConnectionTarget;
+  }) => Effect.Effect<void>;
+}>("@t3tools/client-runtime/platform/capabilities/EnvironmentRouteTransition", {
+  defaultValue: () => ({ afterSelected: () => Effect.void }),
+}) {}

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -22,6 +22,7 @@ export class ConnectionPersistenceError extends Schema.TaggedErrorClass<Connecti
       "list-routes",
       "register-connection",
       "select-connection-route",
+      "remove-connection-route",
       "remove-connection",
       "load-shell",
       "save-shell",
@@ -56,6 +57,10 @@ export class ConnectionRegistrationStore extends Context.Service<
     ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly select: (
       target: PersistedConnectionTarget,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly removeRoute: (
+      target: PersistedConnectionTarget,
+      fallback: PersistedConnectionTarget,
     ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly remove: (target: ConnectionTarget) => Effect.Effect<void, ConnectionPersistenceError>;
   }

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -12,14 +12,16 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import type { ConnectionRegistration } from "../connection/catalog.ts";
-import type { ConnectionTarget } from "../connection/model.ts";
+import type { ConnectionTarget, PersistedConnectionTarget } from "../connection/model.ts";
 
 export class ConnectionPersistenceError extends Schema.TaggedErrorClass<ConnectionPersistenceError>()(
   "ConnectionPersistenceError",
   {
     operation: Schema.Literals([
       "list-targets",
+      "list-routes",
       "register-connection",
+      "select-connection-route",
       "remove-connection",
       "load-shell",
       "save-shell",
@@ -42,6 +44,7 @@ export class ConnectionTargetStore extends Context.Service<
   ConnectionTargetStore,
   {
     readonly list: Effect.Effect<ReadonlyArray<ConnectionTarget>, ConnectionPersistenceError>;
+    readonly listRoutes: Effect.Effect<ReadonlyArray<ConnectionTarget>, ConnectionPersistenceError>;
   }
 >()("@t3tools/client-runtime/platform/persistence/ConnectionTargetStore") {}
 
@@ -50,6 +53,9 @@ export class ConnectionRegistrationStore extends Context.Service<
   {
     readonly register: (
       registration: ConnectionRegistration,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly select: (
+      target: PersistedConnectionTarget,
     ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly remove: (target: ConnectionTarget) => Effect.Effect<void, ConnectionPersistenceError>;
   }

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -21,6 +21,7 @@ import {
   ConnectionCatalogDocument,
   connectionRoutes,
   registerConnectionInCatalog,
+  removeConnectionRouteFromCatalog,
   removeConnectionFromCatalog,
 } from "./storageDocument.ts";
 
@@ -138,6 +139,34 @@ describe("ConnectionCatalogDocument", () => {
     expect(removeConnectionFromCatalog(registered, BEARER_TARGET)).toEqual(
       EMPTY_CONNECTION_CATALOG_DOCUMENT,
     );
+  });
+
+  it("removes a relay route without discarding another route for the environment", () => {
+    const relayTarget = new RelayConnectionTarget({
+      environmentId: ENVIRONMENT_ID,
+      label: "Remote",
+    });
+    const registered = registerConnectionInCatalog(
+      registerConnectionInCatalog(
+        {
+          ...EMPTY_CONNECTION_CATALOG_DOCUMENT,
+          remoteDpopTokens: [REMOTE_TOKEN],
+        },
+        new BearerConnectionRegistration({
+          target: BEARER_TARGET,
+          profile: BEARER_PROFILE,
+          credential: BEARER_CREDENTIAL,
+        }),
+      ),
+      new RelayConnectionRegistration({ target: relayTarget }),
+    );
+
+    expect(removeConnectionRouteFromCatalog(registered, relayTarget, BEARER_TARGET)).toEqual({
+      ...registered,
+      targets: [BEARER_TARGET],
+      routes: [BEARER_TARGET],
+      remoteDpopTokens: [],
+    });
   });
 
   it("persists the normalized SSH profile beside its target", () => {

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -167,4 +167,30 @@ describe("ConnectionCatalogDocument", () => {
     expect(document.profiles).toEqual([profile]);
     expect(document.credentials).toEqual([]);
   });
+
+  it("persists an SSH bearer credential when provisioning supplies one", () => {
+    const target = new SshConnectionTarget({
+      environmentId: ENVIRONMENT_ID,
+      label: "SSH",
+      connectionId: "ssh-1",
+    });
+    const profile = new SshConnectionProfile({
+      connectionId: target.connectionId,
+      environmentId: target.environmentId,
+      label: target.label,
+      target: {
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: "developer",
+        port: 22,
+      },
+    });
+    const credential = new BearerConnectionCredential({ token: "ssh-bearer" });
+    const document = registerConnectionInCatalog(
+      EMPTY_CONNECTION_CATALOG_DOCUMENT,
+      new SshConnectionRegistration({ target, profile, credential }),
+    );
+
+    expect(document.credentials).toEqual([{ connectionId: target.connectionId, credential }]);
+  });
 });

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -222,4 +222,35 @@ describe("ConnectionCatalogDocument", () => {
 
     expect(document.credentials).toEqual([{ connectionId: target.connectionId, credential }]);
   });
+
+  it("preserves an SSH bearer credential when re-registration supplies no replacement", () => {
+    const target = new SshConnectionTarget({
+      environmentId: ENVIRONMENT_ID,
+      label: "SSH",
+      connectionId: "ssh-1",
+    });
+    const profile = new SshConnectionProfile({
+      connectionId: target.connectionId,
+      environmentId: target.environmentId,
+      label: target.label,
+      target: {
+        alias: "devbox",
+        hostname: "devbox.example.test",
+        username: "developer",
+        port: 22,
+      },
+    });
+    const credential = new BearerConnectionCredential({ token: "ssh-bearer" });
+    const registered = registerConnectionInCatalog(
+      EMPTY_CONNECTION_CATALOG_DOCUMENT,
+      new SshConnectionRegistration({ target, profile, credential }),
+    );
+
+    const reRegistered = registerConnectionInCatalog(
+      registered,
+      new SshConnectionRegistration({ target, profile }),
+    );
+
+    expect(reRegistered.credentials).toEqual([{ connectionId: target.connectionId, credential }]);
+  });
 });

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -1,5 +1,6 @@
 import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
+import * as Schema from "effect/Schema";
 
 import * as TokenStore from "../authorization/tokenStore.ts";
 import {
@@ -17,6 +18,8 @@ import {
 } from "../connection/model.ts";
 import {
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
+  ConnectionCatalogDocument,
+  connectionRoutes,
   registerConnectionInCatalog,
   removeConnectionFromCatalog,
 } from "./storageDocument.ts";
@@ -52,6 +55,19 @@ const REMOTE_TOKEN = new TokenStore.RemoteDpopAccessToken({
 });
 
 describe("ConnectionCatalogDocument", () => {
+  it("treats targets from a legacy catalog as its initial routes", () => {
+    const decoded = Schema.decodeUnknownSync(ConnectionCatalogDocument)({
+      schemaVersion: 1,
+      targets: [BEARER_TARGET],
+      profiles: [BEARER_PROFILE],
+      credentials: [],
+      remoteDpopTokens: [],
+    });
+
+    expect(decoded.routes).toEqual([]);
+    expect(connectionRoutes(decoded)).toEqual([BEARER_TARGET]);
+  });
+
   it("registers a bearer connection as one catalog mutation", () => {
     const document = registerConnectionInCatalog(
       EMPTY_CONNECTION_CATALOG_DOCUMENT,
@@ -63,6 +79,7 @@ describe("ConnectionCatalogDocument", () => {
     );
 
     expect(document.targets).toEqual([BEARER_TARGET]);
+    expect(document.routes).toEqual([BEARER_TARGET]);
     expect(document.profiles).toEqual([BEARER_PROFILE]);
     expect(document.credentials).toEqual([
       {
@@ -72,7 +89,7 @@ describe("ConnectionCatalogDocument", () => {
     ]);
   });
 
-  it("replaces obsolete connection metadata without discarding a reusable DPoP token", () => {
+  it("selects a newly registered route without discarding other routes", () => {
     const bearer = registerConnectionInCatalog(
       {
         ...EMPTY_CONNECTION_CATALOG_DOCUMENT,
@@ -94,8 +111,14 @@ describe("ConnectionCatalogDocument", () => {
     );
 
     expect(relay.targets).toEqual([relayTarget]);
-    expect(relay.profiles).toEqual([]);
-    expect(relay.credentials).toEqual([]);
+    expect(relay.routes).toEqual([BEARER_TARGET, relayTarget]);
+    expect(relay.profiles).toEqual([BEARER_PROFILE]);
+    expect(relay.credentials).toEqual([
+      {
+        connectionId: BEARER_TARGET.connectionId,
+        credential: BEARER_CREDENTIAL,
+      },
+    ]);
     expect(relay.remoteDpopTokens).toEqual([REMOTE_TOKEN]);
   });
 
@@ -140,6 +163,7 @@ describe("ConnectionCatalogDocument", () => {
     );
 
     expect(document.targets).toEqual([target]);
+    expect(document.routes).toEqual([target]);
     expect(document.profiles).toEqual([profile]);
     expect(document.credentials).toEqual([]);
   });

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -1,3 +1,4 @@
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import {
@@ -5,7 +6,11 @@ import {
   ConnectionCredential,
   ConnectionProfile,
 } from "../connection/catalog.ts";
-import { type ConnectionTarget, PersistedConnectionTarget } from "../connection/model.ts";
+import {
+  type ConnectionTarget,
+  PersistedConnectionTarget,
+  connectionRouteId,
+} from "../connection/model.ts";
 import * as TokenStore from "../authorization/tokenStore.ts";
 
 export const StoredConnectionCredential = Schema.Struct({
@@ -17,6 +22,9 @@ export type StoredConnectionCredential = typeof StoredConnectionCredential.Type;
 export const ConnectionCatalogDocument = Schema.Struct({
   schemaVersion: Schema.Literal(1),
   targets: Schema.Array(PersistedConnectionTarget),
+  routes: Schema.Array(PersistedConnectionTarget).pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed([])),
+  ),
   profiles: Schema.Array(ConnectionProfile),
   credentials: Schema.Array(StoredConnectionCredential),
   remoteDpopTokens: Schema.Array(TokenStore.RemoteDpopAccessToken),
@@ -26,6 +34,7 @@ export type ConnectionCatalogDocument = typeof ConnectionCatalogDocument.Type;
 export const EMPTY_CONNECTION_CATALOG_DOCUMENT: ConnectionCatalogDocument = Object.freeze({
   schemaVersion: 1,
   targets: [],
+  routes: [],
   profiles: [],
   credentials: [],
   remoteDpopTokens: [],
@@ -59,19 +68,21 @@ function connectionIdOf(target: ConnectionTarget): string | null {
   }
 }
 
-function removeConnectionMetadata(
+export function connectionRoutes(
+  document: ConnectionCatalogDocument,
+): ReadonlyArray<ConnectionCatalogDocument["routes"][number]> {
+  return document.routes.length === 0 && document.targets.length > 0
+    ? document.targets
+    : document.routes;
+}
+
+function removeRouteMetadata(
   document: ConnectionCatalogDocument,
   target: ConnectionTarget,
-  removeRemoteToken: boolean,
 ): ConnectionCatalogDocument {
   const connectionId = connectionIdOf(target);
   return {
     ...document,
-    targets: removeCatalogValue(
-      document.targets,
-      (value) => value.environmentId,
-      target.environmentId,
-    ),
     profiles:
       connectionId === null
         ? document.profiles
@@ -80,13 +91,6 @@ function removeConnectionMetadata(
       connectionId === null
         ? document.credentials
         : removeCatalogValue(document.credentials, (value) => value.connectionId, connectionId),
-    remoteDpopTokens: removeRemoteToken
-      ? removeCatalogValue(
-          document.remoteDpopTokens,
-          (value) => value.environmentId,
-          target.environmentId,
-        )
-      : document.remoteDpopTokens,
   };
 }
 
@@ -95,14 +99,15 @@ export function registerConnectionInCatalog(
   registration: ConnectionRegistration,
 ): ConnectionCatalogDocument {
   const target = registration.target;
-  const previous = document.targets.find(
-    (candidate) => candidate.environmentId === target.environmentId,
+  const routes = connectionRoutes(document);
+  const previous = routes.find(
+    (candidate) => connectionRouteId(candidate) === connectionRouteId(target),
   );
-  const cleaned =
-    previous === undefined ? document : removeConnectionMetadata(document, previous, false);
+  const cleaned = previous === undefined ? document : removeRouteMetadata(document, previous);
   const next: ConnectionCatalogDocument = {
     ...cleaned,
     targets: replaceCatalogValue(cleaned.targets, (value) => value.environmentId, target),
+    routes: replaceCatalogValue(routes, connectionRouteId, target),
   };
 
   switch (registration._tag) {
@@ -137,5 +142,43 @@ export function removeConnectionFromCatalog(
   document: ConnectionCatalogDocument,
   target: ConnectionTarget,
 ): ConnectionCatalogDocument {
-  return removeConnectionMetadata(document, target, true);
+  const environmentRoutes = connectionRoutes(document).filter(
+    (candidate) => candidate.environmentId === target.environmentId,
+  );
+  const connectionIds = new Set(
+    environmentRoutes
+      .map(connectionIdOf)
+      .filter((connectionId): connectionId is string => connectionId !== null),
+  );
+  return {
+    ...document,
+    targets: removeCatalogValue(
+      document.targets,
+      (value) => value.environmentId,
+      target.environmentId,
+    ),
+    routes: connectionRoutes(document).filter(
+      (candidate) => candidate.environmentId !== target.environmentId,
+    ),
+    profiles: document.profiles.filter((profile) => !connectionIds.has(profile.connectionId)),
+    credentials: document.credentials.filter(
+      (credential) => !connectionIds.has(credential.connectionId),
+    ),
+    remoteDpopTokens: removeCatalogValue(
+      document.remoteDpopTokens,
+      (value) => value.environmentId,
+      target.environmentId,
+    ),
+  };
+}
+
+export function selectConnectionRouteInCatalog(
+  document: ConnectionCatalogDocument,
+  target: ConnectionCatalogDocument["routes"][number],
+): ConnectionCatalogDocument {
+  return {
+    ...document,
+    targets: replaceCatalogValue(document.targets, (value) => value.environmentId, target),
+    routes: connectionRoutes(document),
+  };
 }

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -103,6 +103,12 @@ export function registerConnectionInCatalog(
   const previous = routes.find(
     (candidate) => connectionRouteId(candidate) === connectionRouteId(target),
   );
+  const previousCredential =
+    registration._tag === "SshConnectionRegistration" && registration.credential === undefined
+      ? document.credentials.find(
+          (value) => value.connectionId === registration.target.connectionId,
+        )
+      : undefined;
   const cleaned = previous === undefined ? document : removeRouteMetadata(document, previous);
   const next: ConnectionCatalogDocument = {
     ...cleaned,
@@ -136,7 +142,13 @@ export function registerConnectionInCatalog(
         ),
         credentials:
           registration.credential === undefined
-            ? next.credentials
+            ? previousCredential === undefined
+              ? next.credentials
+              : replaceCatalogValue(
+                  next.credentials,
+                  (value) => value.connectionId,
+                  previousCredential,
+                )
             : replaceCatalogValue(next.credentials, (value) => value.connectionId, {
                 connectionId: registration.target.connectionId,
                 credential: registration.credential,

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -134,6 +134,13 @@ export function registerConnectionInCatalog(
           (value) => value.connectionId,
           registration.profile,
         ),
+        credentials:
+          registration.credential === undefined
+            ? next.credentials
+            : replaceCatalogValue(next.credentials, (value) => value.connectionId, {
+                connectionId: registration.target.connectionId,
+                credential: registration.credential,
+              }),
       };
   }
 }

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -179,6 +179,37 @@ export function removeConnectionFromCatalog(
   };
 }
 
+export function removeConnectionRouteFromCatalog(
+  document: ConnectionCatalogDocument,
+  target: ConnectionCatalogDocument["routes"][number],
+  fallback: ConnectionCatalogDocument["routes"][number],
+): ConnectionCatalogDocument {
+  const cleaned = removeRouteMetadata(document, target);
+  const selected = document.targets.find(
+    (candidate) => candidate.environmentId === target.environmentId,
+  );
+  return {
+    ...cleaned,
+    targets:
+      selected !== undefined && connectionRouteId(selected) === connectionRouteId(target)
+        ? replaceCatalogValue(cleaned.targets, (value) => value.environmentId, fallback)
+        : cleaned.targets,
+    routes: connectionRoutes(cleaned).filter(
+      (candidate) =>
+        candidate.environmentId !== target.environmentId ||
+        connectionRouteId(candidate) !== connectionRouteId(target),
+    ),
+    remoteDpopTokens:
+      target._tag === "RelayConnectionTarget"
+        ? removeCatalogValue(
+            cleaned.remoteDpopTokens,
+            (value) => value.environmentId,
+            target.environmentId,
+          )
+        : cleaned.remoteDpopTokens,
+  };
+}
+
 export function selectConnectionRouteInCatalog(
   document: ConnectionCatalogDocument,
   target: ConnectionCatalogDocument["routes"][number],

--- a/packages/client-runtime/src/state/connections.ts
+++ b/packages/client-runtime/src/state/connections.ts
@@ -50,6 +50,27 @@ export function createEnvironmentCatalogAtoms<R, E>(
     Option.getOrElse(AsyncResult.value(get(catalogAtom)), () => EMPTY_ENVIRONMENT_CATALOG_STATE),
   ).pipe(Atom.withLabel("environment-catalog-value"));
 
+  const routesAtom = runtime.atom(
+    Stream.unwrap(
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.map((registry) => SubscriptionRef.changes(registry.routes)),
+      ),
+    ),
+    {
+      initialValue: new Map<
+        EnvironmentIdType,
+        ReadonlyArray<ConnectionCatalogEntry>
+      >() as ReadonlyMap<EnvironmentIdType, ReadonlyArray<ConnectionCatalogEntry>>,
+    },
+  );
+
+  const routesValueAtom = Atom.make((get) =>
+    Option.getOrElse(
+      AsyncResult.value(get(routesAtom)),
+      () => new Map<EnvironmentIdType, ReadonlyArray<ConnectionCatalogEntry>>(),
+    ),
+  ).pipe(Atom.withLabel("environment-catalog-routes-value"));
+
   const networkStatusAtom = runtime.atom(
     Stream.unwrap(
       EnvironmentRegistry.EnvironmentRegistry.pipe(
@@ -97,6 +118,15 @@ export function createEnvironmentCatalogAtoms<R, E>(
         Effect.flatMap((registry) => registry.remove(environmentId)),
       ),
   });
+  const selectRoute = createRuntimeCommand(runtime, {
+    label: "environment-catalog:select-route",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (input: { readonly environmentId: EnvironmentIdType; readonly routeId: string }) =>
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.selectRoute(input.environmentId, input.routeId)),
+      ),
+  });
   const removeRelayEnvironments = createRuntimeCommand(runtime, {
     label: "environment-catalog:remove-relay-environments",
     scheduler: commandScheduler,
@@ -119,10 +149,13 @@ export function createEnvironmentCatalogAtoms<R, E>(
   return {
     catalogAtom,
     catalogValueAtom,
+    routesAtom,
+    routesValueAtom,
     networkStatusAtom,
     networkStatusValueAtom,
     stateAtom,
     register,
+    selectRoute,
     remove,
     removeRelayEnvironments,
     retryNow,

--- a/packages/client-runtime/src/state/session.test.ts
+++ b/packages/client-runtime/src/state/session.test.ts
@@ -1,9 +1,20 @@
+import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 
-import { initialConfigOption } from "./session.ts";
+import {
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
+import * as EnvironmentRegistry from "../connection/registry.ts";
+import * as EnvironmentSupervisor from "../connection/supervisor.ts";
+import type { RpcSession } from "../rpc/session.ts";
+import { currentPreparedConnection, initialConfigOption } from "./session.ts";
 
 class TestConfigError extends Schema.TaggedErrorClass<TestConfigError>()("TestConfigError", {
   message: Schema.String,
@@ -16,6 +27,61 @@ describe("environment session state", () => {
         Effect.fail(new TestConfigError({ message: "temporary failure" })),
       );
       expect(Option.isNone(result)).toBe(true);
+    }),
+  );
+
+  it.effect("reads the live prepared connection without mounting its reactive atom", () =>
+    Effect.gen(function* () {
+      const target = new PrimaryConnectionTarget({
+        environmentId: EnvironmentId.make("environment-1"),
+        label: "Test environment",
+        httpBaseUrl: "https://environment.example.test",
+        wsBaseUrl: "wss://environment.example.test",
+      });
+      const prepared: PreparedConnection = {
+        environmentId: target.environmentId,
+        label: target.label,
+        httpBaseUrl: target.httpBaseUrl,
+        socketUrl: target.wsBaseUrl,
+        httpAuthorization: null,
+        target,
+      };
+      const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+        target,
+        state: yield* SubscriptionRef.make<SupervisorConnectionState>({
+          desired: true,
+          network: "online",
+          phase: "connected",
+          stage: null,
+          attempt: 1,
+          generation: 1,
+          lastFailure: null,
+          retryAt: null,
+        }),
+        session: yield* SubscriptionRef.make<Option.Option<RpcSession>>(Option.none()),
+        prepared: yield* SubscriptionRef.make(Option.some(prepared)),
+        connect: Effect.void,
+        disconnect: Effect.void,
+        retryNow: Effect.void,
+      } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+      const run: EnvironmentRegistry.EnvironmentRegistry["Service"]["run"] = (
+        _environmentId,
+        effect,
+      ) => Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+      const runStream: EnvironmentRegistry.EnvironmentRegistry["Service"]["runStream"] = (
+        _environmentId,
+        stream,
+      ) => Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+      const registry = EnvironmentRegistry.EnvironmentRegistry.of({
+        run,
+        runStream,
+      } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+
+      const result = yield* currentPreparedConnection(target.environmentId).pipe(
+        Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
+      );
+
+      expect(result).toEqual(Option.some(prepared));
     }),
   );
 });

--- a/packages/client-runtime/src/state/session.test.ts
+++ b/packages/client-runtime/src/state/session.test.ts
@@ -14,7 +14,11 @@ import {
 import * as EnvironmentRegistry from "../connection/registry.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import type { RpcSession } from "../rpc/session.ts";
-import { currentPreparedConnection, initialConfigOption } from "./session.ts";
+import {
+  currentPreparedConnection,
+  initialConfigOption,
+  refreshCurrentPreparedConnection,
+} from "./session.ts";
 
 class TestConfigError extends Schema.TaggedErrorClass<TestConfigError>()("TestConfigError", {
   message: Schema.String,
@@ -82,6 +86,85 @@ describe("environment session state", () => {
       );
 
       expect(result).toEqual(Option.some(prepared));
+    }),
+  );
+
+  it.effect("replaces a stale lease and returns the next prepared connection", () =>
+    Effect.gen(function* () {
+      const target = new PrimaryConnectionTarget({
+        environmentId: EnvironmentId.make("environment-1"),
+        label: "Test environment",
+        httpBaseUrl: "https://environment.example.test",
+        wsBaseUrl: "wss://environment.example.test",
+      });
+      const stale: PreparedConnection = {
+        environmentId: target.environmentId,
+        label: target.label,
+        httpBaseUrl: target.httpBaseUrl,
+        socketUrl: `${target.wsBaseUrl}/stale`,
+        httpAuthorization: null,
+        target,
+      };
+      const refreshed: PreparedConnection = {
+        ...stale,
+        socketUrl: `${target.wsBaseUrl}/refreshed`,
+      };
+      const state = yield* SubscriptionRef.make<SupervisorConnectionState>({
+        desired: true,
+        network: "online",
+        phase: "connected",
+        stage: null,
+        attempt: 1,
+        generation: 1,
+        lastFailure: null,
+        retryAt: null,
+      });
+      const prepared = yield* SubscriptionRef.make(Option.some(stale));
+      const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+        target,
+        state,
+        session: yield* SubscriptionRef.make<Option.Option<RpcSession>>(Option.none()),
+        prepared,
+        connect: Effect.void,
+        disconnect: Effect.void,
+        retryNow: Effect.all(
+          [
+            SubscriptionRef.set(prepared, Option.some(refreshed)),
+            SubscriptionRef.set(state, {
+              desired: true,
+              network: "online",
+              phase: "connected",
+              stage: null,
+              attempt: 1,
+              generation: 2,
+              lastFailure: null,
+              retryAt: null,
+            }),
+          ],
+          { discard: true },
+        ),
+      } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+      const run: EnvironmentRegistry.EnvironmentRegistry["Service"]["run"] = (
+        _environmentId,
+        effect,
+      ) => Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+      const runStream: EnvironmentRegistry.EnvironmentRegistry["Service"]["runStream"] = (
+        _environmentId,
+        stream,
+      ) => Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+      const registry = EnvironmentRegistry.EnvironmentRegistry.of({
+        run,
+        runStream,
+        state: () => SubscriptionRef.get(state),
+        stateChanges: () => SubscriptionRef.changes(state),
+        retryNow: () => supervisor.retryNow,
+      } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+
+      const result = yield* refreshCurrentPreparedConnection(target.environmentId, 100).pipe(
+        Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
+      );
+
+      expect(result).toEqual(Option.some(refreshed));
     }),
   );
 });

--- a/packages/client-runtime/src/state/session.ts
+++ b/packages/client-runtime/src/state/session.ts
@@ -1,4 +1,5 @@
 import type { AuthSessionState, EnvironmentId, ServerConfig } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
@@ -46,6 +47,37 @@ export const currentPreparedConnection = Effect.fn("clientRuntime.state.currentP
     );
   },
 );
+
+const DEFAULT_PREPARED_CONNECTION_REFRESH_TIMEOUT_MS = 20_000;
+
+/**
+ * Replaces a live environment lease and waits for the next prepared connection.
+ * This is used by side-channel HTTP operations when a long-lived websocket has
+ * outlasted the credential that originally authorized it.
+ */
+export const refreshCurrentPreparedConnection = Effect.fn(
+  "clientRuntime.state.refreshCurrentPreparedConnection",
+)(function* (environmentId: EnvironmentId, timeoutMs?: number) {
+  const registry = yield* EnvironmentRegistry;
+  const before = yield* registry.state(environmentId);
+  yield* registry.retryNow(environmentId);
+  const settled = yield* registry.stateChanges(environmentId).pipe(
+    Stream.filter(
+      (state) =>
+        state.generation > before.generation &&
+        (state.phase === "connected" || state.phase === "blocked"),
+    ),
+    Stream.runHead,
+    Effect.timeoutOption(
+      Duration.millis(timeoutMs ?? DEFAULT_PREPARED_CONNECTION_REFRESH_TIMEOUT_MS),
+    ),
+    Effect.map(Option.flatten),
+  );
+  if (Option.isNone(settled) || settled.value.phase !== "connected") {
+    return Option.none<PreparedConnection>();
+  }
+  return yield* currentPreparedConnection(environmentId);
+});
 
 // Bounded like the snapshot fetches: a wedged environment must not pin the
 // permissions check (and with it the settings UI) in a loading state for long.

--- a/packages/client-runtime/src/state/session.ts
+++ b/packages/client-runtime/src/state/session.ts
@@ -30,6 +30,23 @@ export function initialConfigOption<E>(
   );
 }
 
+/**
+ * Reads the supervisor's current prepared connection directly. Unlike the
+ * reactive value atom, this does not require a mounted subscriber to have
+ * observed the supervisor stream first.
+ */
+export const currentPreparedConnection = Effect.fn("clientRuntime.state.currentPreparedConnection")(
+  function* (environmentId: EnvironmentId) {
+    const registry = yield* EnvironmentRegistry;
+    return yield* registry.run(
+      environmentId,
+      EnvironmentSupervisor.pipe(
+        Effect.flatMap((supervisor) => SubscriptionRef.get(supervisor.prepared)),
+      ),
+    );
+  },
+);
+
 // Bounded like the snapshot fetches: a wedged environment must not pin the
 // permissions check (and with it the settings UI) in a loading state for long.
 const DEFAULT_SESSION_STATE_TIMEOUT_MS = 6_000;

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -80,6 +80,9 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
       this is false — no update would ever repaint it. Absent on older
       servers, which may still publish, so only an explicit false skips. */
   agentActivityPublishing: Schema.optionalKey(Schema.Boolean),
+  /** Server accepts destination-bound, single-use tickets for TCP forwarding
+      to its own loopback interface. */
+  tcpPortForwarding: Schema.optionalKey(Schema.Boolean),
 });
 export type ExecutionEnvironmentCapabilities = typeof ExecutionEnvironmentCapabilities.Type;
 

--- a/packages/contracts/src/environmentHttp.ts
+++ b/packages/contracts/src/environmentHttp.ts
@@ -26,6 +26,7 @@ import {
 } from "./auth.ts";
 import { AuthSessionId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { ExecutionEnvironmentDescriptor } from "./environment.ts";
+import { TcpPortForwardTicketRequest, TcpPortForwardTicketResult } from "./portForward.ts";
 import {
   ClientOrchestrationCommand,
   DispatchResult,
@@ -82,6 +83,7 @@ export const EnvironmentInternalErrorReason = Schema.Literals([
   "browser_session_cookie_failed",
   "access_token_issuance_failed",
   "websocket_ticket_issuance_failed",
+  "tcp_forward_ticket_issuance_failed",
   "pairing_credential_issuance_failed",
   "pairing_links_load_failed",
   "pairing_link_revoke_failed",
@@ -435,6 +437,14 @@ export class EnvironmentAuthHttpApi extends HttpApiGroup.make("auth")
       headers: OptionalBearerHeaders,
       success: AuthWebSocketTicketResult,
       error: [EnvironmentInternalError],
+    }).middleware(EnvironmentAuthenticatedAuth),
+  )
+  .add(
+    HttpApiEndpoint.post("tcpPortForwardTicket", "/api/auth/tcp-forward-ticket", {
+      headers: OptionalBearerHeaders,
+      payload: TcpPortForwardTicketRequest,
+      success: TcpPortForwardTicketResult,
+      error: [EnvironmentScopeRequiredError, EnvironmentInternalError],
     }).middleware(EnvironmentAuthenticatedAuth),
   )
   .add(

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,6 +6,7 @@ export * from "./environmentHttp.ts";
 export * from "./relayClient.ts";
 export * from "./desktopBootstrap.ts";
 export * from "./remoteAccess.ts";
+export * from "./portForward.ts";
 export * from "./ipc.ts";
 export * from "./terminal.ts";
 export * from "./provider.ts";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -91,6 +91,7 @@ import { EnvironmentId } from "./baseSchemas.ts";
 import { AuthAccessTokenResult, AuthSessionState, AuthWebSocketTicketResult } from "./auth.ts";
 import { AdvertisedEndpoint } from "./remoteAccess.ts";
 import { ExecutionEnvironmentDescriptor } from "./environment.ts";
+import type { DesktopPortForwardBridge } from "./portForward.ts";
 import type { ClientSettings } from "./settings.ts";
 import type { EditorId } from "./editor.ts";
 import type {
@@ -1145,6 +1146,8 @@ export interface DesktopBridge {
   downloadUpdate: () => Promise<DesktopUpdateActionResult>;
   installUpdate: () => Promise<DesktopUpdateActionResult>;
   onUpdateState: (listener: (state: DesktopUpdateState) => void) => () => void;
+  /** Desktop-owned loopback listeners. Optional for desktop/web version skew. */
+  portForward?: DesktopPortForwardBridge;
   /**
    * Desktop-only preview surface. Present iff the renderer is hosted by the
    * Electron desktop build; web builds have `preview === undefined`.

--- a/packages/contracts/src/portForward.ts
+++ b/packages/contracts/src/portForward.ts
@@ -1,0 +1,97 @@
+import * as Schema from "effect/Schema";
+
+import { EnvironmentId, NonNegativeInt, PortSchema, TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+export const TcpPortForwardHost = Schema.Literal("127.0.0.1");
+export type TcpPortForwardHost = typeof TcpPortForwardHost.Type;
+
+export const TcpPort = PortSchema;
+export type TcpPort = typeof TcpPort.Type;
+
+export const TcpPortForwardTicketRequest = Schema.Struct({
+  remoteHost: TcpPortForwardHost,
+  remotePort: TcpPort,
+});
+export type TcpPortForwardTicketRequest = typeof TcpPortForwardTicketRequest.Type;
+
+export const TcpPortForwardTicketResult = Schema.Struct({
+  ticket: TrimmedNonEmptyString,
+  expiresAt: Schema.DateTimeUtc,
+});
+export type TcpPortForwardTicketResult = typeof TcpPortForwardTicketResult.Type;
+
+export const DesktopPortForwardId = Schema.String.pipe(Schema.brand("DesktopPortForwardId"));
+export type DesktopPortForwardId = typeof DesktopPortForwardId.Type;
+
+export const DesktopPortForwardStatus = Schema.Literals(["running", "failed"]);
+export type DesktopPortForwardStatus = typeof DesktopPortForwardStatus.Type;
+
+export const DesktopPortForwardCreateInput = Schema.Struct({
+  environmentId: EnvironmentId,
+  remoteHost: TcpPortForwardHost,
+  remotePort: TcpPort,
+  localPort: Schema.optionalKey(TcpPort),
+});
+export type DesktopPortForwardCreateInput = typeof DesktopPortForwardCreateInput.Type;
+
+export const DesktopPortForwardSnapshot = Schema.Struct({
+  id: DesktopPortForwardId,
+  environmentId: EnvironmentId,
+  localHost: TcpPortForwardHost,
+  localPort: TcpPort,
+  remoteHost: TcpPortForwardHost,
+  remotePort: TcpPort,
+  status: DesktopPortForwardStatus,
+  activeConnections: NonNegativeInt,
+  lastError: Schema.NullOr(Schema.String),
+});
+export type DesktopPortForwardSnapshot = typeof DesktopPortForwardSnapshot.Type;
+
+export const DesktopPortForwardStopInput = Schema.Struct({ id: DesktopPortForwardId });
+export type DesktopPortForwardStopInput = typeof DesktopPortForwardStopInput.Type;
+
+export const DesktopPortForwardStopEnvironmentInput = Schema.Struct({
+  environmentId: EnvironmentId,
+});
+export type DesktopPortForwardStopEnvironmentInput =
+  typeof DesktopPortForwardStopEnvironmentInput.Type;
+
+export const DesktopPortForwardAuthorizationRequest = Schema.Struct({
+  requestId: TrimmedNonEmptyString,
+  forwardId: DesktopPortForwardId,
+  environmentId: EnvironmentId,
+  remoteHost: TcpPortForwardHost,
+  remotePort: TcpPort,
+});
+export type DesktopPortForwardAuthorizationRequest =
+  typeof DesktopPortForwardAuthorizationRequest.Type;
+
+export const DesktopPortForwardAuthorizationResolution = Schema.Struct({
+  requestId: TrimmedNonEmptyString,
+  socketUrl: Schema.NullOr(Schema.String),
+});
+export type DesktopPortForwardAuthorizationResolution =
+  typeof DesktopPortForwardAuthorizationResolution.Type;
+
+/** Binary framing shared by the desktop listener and environment bridge. */
+export const TCP_PORT_FORWARD_FRAME_DATA = 0;
+export const TCP_PORT_FORWARD_FRAME_WRITE_END = 1;
+export const TCP_PORT_FORWARD_FRAME_ACK = 2;
+export const TCP_PORT_FORWARD_FRAME_ERROR = 3;
+export const TCP_PORT_FORWARD_FRAME_CLOSE = 4;
+export const TCP_PORT_FORWARD_INITIAL_CREDIT = 256 * 1024;
+export const TCP_PORT_FORWARD_MAX_DATA_SIZE = 64 * 1024;
+
+export interface DesktopPortForwardBridge {
+  create: (input: DesktopPortForwardCreateInput) => Promise<DesktopPortForwardSnapshot>;
+  list: () => Promise<ReadonlyArray<DesktopPortForwardSnapshot>>;
+  stop: (id: DesktopPortForwardId) => Promise<void>;
+  stopEnvironment: (environmentId: EnvironmentId) => Promise<void>;
+  resolveAuthorization: (requestId: string, socketUrl: string | null) => Promise<void>;
+  onStateChange: (
+    listener: (forwards: ReadonlyArray<DesktopPortForwardSnapshot>) => void,
+  ) => () => void;
+  onAuthorizationRequest: (
+    listener: (request: DesktopPortForwardAuthorizationRequest) => void,
+  ) => () => void;
+}

--- a/packages/contracts/src/portForward.ts
+++ b/packages/contracts/src/portForward.ts
@@ -42,6 +42,7 @@ export const DesktopPortForwardSnapshot = Schema.Struct({
   remoteHost: TcpPortForwardHost,
   remotePort: TcpPort,
   status: DesktopPortForwardStatus,
+  connectingConnections: NonNegativeInt,
   activeConnections: NonNegativeInt,
   lastError: Schema.NullOr(Schema.String),
 });

--- a/packages/contracts/src/portForward.ts
+++ b/packages/contracts/src/portForward.ts
@@ -69,6 +69,7 @@ export type DesktopPortForwardAuthorizationRequest =
 export const DesktopPortForwardAuthorizationResolution = Schema.Struct({
   requestId: TrimmedNonEmptyString,
   socketUrl: Schema.NullOr(Schema.String),
+  error: Schema.optionalKey(TrimmedNonEmptyString),
 });
 export type DesktopPortForwardAuthorizationResolution =
   typeof DesktopPortForwardAuthorizationResolution.Type;
@@ -87,7 +88,11 @@ export interface DesktopPortForwardBridge {
   list: () => Promise<ReadonlyArray<DesktopPortForwardSnapshot>>;
   stop: (id: DesktopPortForwardId) => Promise<void>;
   stopEnvironment: (environmentId: EnvironmentId) => Promise<void>;
-  resolveAuthorization: (requestId: string, socketUrl: string | null) => Promise<void>;
+  resolveAuthorization: (
+    requestId: string,
+    socketUrl: string | null,
+    error?: string,
+  ) => Promise<void>;
   onStateChange: (
     listener: (forwards: ReadonlyArray<DesktopPortForwardSnapshot>) => void,
   ) => () => void;

--- a/packages/contracts/src/portForward.ts
+++ b/packages/contracts/src/portForward.ts
@@ -89,6 +89,7 @@ export interface DesktopPortForwardBridge {
   list: () => Promise<ReadonlyArray<DesktopPortForwardSnapshot>>;
   stop: (id: DesktopPortForwardId) => Promise<void>;
   stopEnvironment: (environmentId: EnvironmentId) => Promise<void>;
+  resetEnvironmentConnections: (environmentId: EnvironmentId) => Promise<void>;
   resolveAuthorization: (
     requestId: string,
     socketUrl: string | null,

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -193,7 +193,9 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), "systemctl --user show t3code.service");
     assert.include(buildRemoteLaunchScript(), 'fs.readdirSync("/proc")');
     assert.include(buildRemoteLaunchScript(), '"server-runtime.json"');
-    assert.include(buildRemoteLaunchScript(), "/.well-known/t3/environment");
+    assert.include(buildRemoteLaunchScript(), 'origin.protocol !== "http:"');
+    assert.notInclude(buildRemoteLaunchScript(), "AbortSignal.timeout(2500)");
+    assert.include(buildRemoteLaunchScript(), "Existing remote T3 server did not become ready");
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
     assert.include(buildRemoteLaunchScript(), "Remote T3 server did not become ready");
     assert.include(buildRemoteLaunchScript(), 'wait_ready "60000"');
@@ -202,16 +204,31 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript({ packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
       buildRemotePairingScript(target),
-      '"$RUNNER_FILE" pair --base-dir "$PAIRING_BASE_DIR" >"$PAIR_OUTPUT_FILE"',
+      '"$RUNNER_FILE" pair --base-dir "$PAIRING_BASE_DIR" >"$PAIR_OUTPUT_FILE" 2>&1',
     );
+    assert.include(buildRemotePairingScript(target), 'if [ -z "$PAIRING_BASE_DIR" ]');
+    assert.notInclude(buildRemotePairingScript(target), '"$RUNNER_FILE" pair >');
+    assert.include(buildRemotePairingScript(target), "grep -q 'database is locked'");
+    assert.include(buildRemotePairingScript(target), 'while [ "$PAIR_ATTEMPT" -lt 5 ]');
+    assert.include(buildRemotePairingScript(target), 'RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"');
+    assert.include(buildRemotePairingScript(target), 'cat >"$RUNNER_NEXT"');
+    assert.include(buildRemotePairingScript(target), 'mv -f "$RUNNER_NEXT" "$RUNNER_FILE"');
+    assert.notInclude(buildRemotePairingScript(target), 'cat >"$RUNNER_FILE"');
+    for (const script of [
+      buildRemoteLaunchScript(),
+      buildRemotePairingScript(target),
+      buildRemoteStopScript(target),
+    ]) {
+      assert.include(script, "acquire_state_lock()");
+      assert.include(script, "release_state_lock()");
+      assert.include(script, "flock -w 120 9");
+      assert.include(script, "acquire_state_lock");
+    }
     assert.include(buildRemotePairingScript(target), 'line.startsWith("Token: ")');
     assert.include(buildRemotePairingScript(target), 'BASE_DIR_FILE="$STATE_DIR/base-dir"');
     assert.notInclude(buildRemotePairingScript(target), "server-home");
     assert.include(buildRemotePairingScript(target, { packageSpec: "t3@nightly" }), "t3@nightly");
-    assert.include(
-      buildRemoteStopScript(target),
-      'if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ]',
-    );
+    assert.include(buildRemoteStopScript(target), 'if [ "$REMOTE_MANAGED" = "external" ]');
     assert.include(buildRemoteStopScript(target), 'kill "$REMOTE_PID" 2>/dev/null || true');
     assert.include(buildRemoteStopScript(target), 'rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"');
     assert.include(
@@ -257,6 +274,42 @@ describe("ssh tunnel scripts", () => {
         assert.doesNotThrow(() => Function(match[1]!));
       }
     }
+  });
+
+  it.effect("emits syntactically valid remote shell scripts", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      for (const script of [
+        buildRemoteLaunchScript(),
+        buildRemotePairingScript(target),
+        buildRemoteStopScript(target),
+      ]) {
+        assert.notMatch(script, /@@[A-Z0-9_]+@@/u);
+        const handle = yield* spawner.spawn(ChildProcess.make("sh", ["-n"]));
+        yield* Stream.make(new TextEncoder().encode(script)).pipe(Stream.run(handle.stdin));
+        const [stderr, exitCode] = yield* Effect.all(
+          [
+            handle.stderr.pipe(
+              Stream.decodeText(),
+              Stream.runFold(
+                () => "",
+                (accumulator, chunk) => accumulator + chunk,
+              ),
+            ),
+            handle.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        );
+        assert.equal(exitCode, 0, stderr);
+      }
+    }).pipe(Effect.provide(NodeServices.layer));
   });
 
   it.effect("accepts launch JSON after remote shell startup noise", () => {
@@ -467,6 +520,84 @@ describe("ssh tunnel scripts", () => {
 
       assert.equal(spawnedCommands.filter((args) => args.includes("-N")).length, 2);
       assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("serializes pairing commands for concurrent ensures of one SSH target", () => {
+    let activePairingCommands = 0;
+    let maximumActivePairingCommands = 0;
+    let pairingCommandCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {});
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773,"serverKind":"external"}\n');
+        }
+        if (args.includes("sh")) {
+          pairingCommandCount += 1;
+          const stdout = Stream.make(
+            new TextEncoder().encode(`{"credential":"PAIR-${pairingCommandCount}"}\n`),
+          );
+          return ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(200 + pairingCommandCount),
+            stdout,
+            stderr: Stream.empty,
+            all: stdout,
+            exitCode: Effect.gen(function* () {
+              activePairingCommands += 1;
+              maximumActivePairingCommands = Math.max(
+                maximumActivePairingCommands,
+                activePairingCommands,
+              );
+              yield* Effect.yieldNow;
+              activePairingCommands -= 1;
+              return ChildProcessSpawner.ExitCode(0);
+            }),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            stdin: Sink.drain,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+            unref: Effect.succeed(Effect.void),
+          });
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      const results = yield* Effect.all(
+        [
+          manager.ensureEnvironment(target, { issuePairingToken: true }),
+          manager.ensureEnvironment(target, { issuePairingToken: true }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      assert.equal(pairingCommandCount, 2);
+      assert.equal(maximumActivePairingCommands, 1);
+      assert.deepEqual(results.map((result) => result.pairingToken).toSorted(), [
+        "PAIR-1",
+        "PAIR-2",
+      ]);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 });

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -221,7 +221,9 @@ describe("ssh tunnel scripts", () => {
     ]) {
       assert.include(script, "acquire_state_lock()");
       assert.include(script, "release_state_lock()");
-      assert.include(script, "flock -w 120 9");
+      assert.include(script, "flock -w 45 9");
+      assert.include(script, 'kill -0 "$STATE_LOCK_OWNER_PID"');
+      assert.include(script, 'STATE_LOCK_WAIT_COUNT" -ge 450');
       assert.include(script, "acquire_state_lock");
     }
     assert.include(buildRemotePairingScript(target), 'line.startsWith("Token: ")');
@@ -231,6 +233,12 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteStopScript(target), 'if [ "$REMOTE_MANAGED" = "external" ]');
     assert.include(buildRemoteStopScript(target), 'kill "$REMOTE_PID" 2>/dev/null || true');
     assert.include(buildRemoteStopScript(target), 'rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"');
+    assert.include(buildRemoteLaunchScript(), "< /dev/null 9>&- &");
+    assert.include(buildRemoteLaunchScript(), 'if [ -n "$LAUNCHED_PID" ]; then');
+    assert.notInclude(
+      buildRemoteLaunchScript(),
+      'discover_running_runtime() {\n  rm -f "$BASE_DIR_FILE"',
+    );
     assert.include(
       buildRemoteLaunchScript(),
       'DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"',

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -188,7 +188,12 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript(), 'kill "$REMOTE_PID" 2>/dev/null || true');
     assert.include(buildRemoteLaunchScript(), "wait_ready");
     assert.include(buildRemoteLaunchScript(), '"$RUNNER_FILE" serve --host 127.0.0.1');
-    assert.include(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
+    assert.notInclude(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
+    assert.include(buildRemoteLaunchScript(), "discover_running_runtime()");
+    assert.include(buildRemoteLaunchScript(), "systemctl --user show t3code.service");
+    assert.include(buildRemoteLaunchScript(), 'fs.readdirSync("/proc")');
+    assert.include(buildRemoteLaunchScript(), '"server-runtime.json"');
+    assert.include(buildRemoteLaunchScript(), "/.well-known/t3/environment");
     assert.notInclude(buildRemoteLaunchScript(), "server-home");
     assert.include(buildRemoteLaunchScript(), "Remote T3 server did not become ready");
     assert.include(buildRemoteLaunchScript(), 'wait_ready "60000"');
@@ -197,9 +202,10 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteLaunchScript({ packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
       buildRemotePairingScript(target),
-      '"$RUNNER_FILE" auth pairing create --base-dir "$PAIRING_BASE_DIR" --json',
+      '"$RUNNER_FILE" pair --base-dir "$PAIRING_BASE_DIR" >"$PAIR_OUTPUT_FILE"',
     );
-    assert.include(buildRemotePairingScript(target), 'PAIRING_BASE_DIR="$DEFAULT_SERVER_HOME"');
+    assert.include(buildRemotePairingScript(target), 'line.startsWith("Token: ")');
+    assert.include(buildRemotePairingScript(target), 'BASE_DIR_FILE="$STATE_DIR/base-dir"');
     assert.notInclude(buildRemotePairingScript(target), "server-home");
     assert.include(buildRemotePairingScript(target, { packageSpec: "t3@nightly" }), "t3@nightly");
     assert.include(
@@ -234,6 +240,23 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript().indexOf('DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port'),
       buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PID" ]'),
     );
+  });
+
+  it("embeds syntactically valid Node scripts", () => {
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    for (const script of [buildRemoteLaunchScript(), buildRemotePairingScript(target)]) {
+      const embeddedScripts = [...script.matchAll(/<<'NODE'\n([\s\S]*?)\nNODE/gu)];
+      assert.isAbove(embeddedScripts.length, 0);
+      for (const match of embeddedScripts) {
+        assert.doesNotThrow(() => Function(match[1]!));
+      }
+    }
   });
 
   it.effect("accepts launch JSON after remote shell startup noise", () => {

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -191,7 +191,8 @@ describe("ssh tunnel scripts", () => {
     assert.notInclude(buildRemoteLaunchScript(), '--base-dir "$DEFAULT_SERVER_HOME"');
     assert.include(buildRemoteLaunchScript(), "discover_running_runtime()");
     assert.include(buildRemoteLaunchScript(), "systemctl --user show t3code.service");
-    assert.include(buildRemoteLaunchScript(), 'fs.readdirSync("/proc")');
+    assert.notInclude(buildRemoteLaunchScript(), 'fs.readdirSync("/proc")');
+    assert.include(buildRemoteLaunchScript(), "knownBaseDirPath");
     assert.include(buildRemoteLaunchScript(), '"server-runtime.json"');
     assert.include(buildRemoteLaunchScript(), 'origin.protocol !== "http:"');
     assert.notInclude(buildRemoteLaunchScript(), "AbortSignal.timeout(2500)");
@@ -222,6 +223,7 @@ describe("ssh tunnel scripts", () => {
       assert.include(script, "acquire_state_lock()");
       assert.include(script, "release_state_lock()");
       assert.include(script, "flock -w 45 9");
+      assert.include(script, 'ln "$STATE_LOCK_OWNER_FILE" "$STATE_LOCK_LINK"');
       assert.include(script, 'kill -0 "$STATE_LOCK_OWNER_PID"');
       assert.include(script, 'STATE_LOCK_WAIT_COUNT" -ge 450');
       assert.include(script, "acquire_state_lock");
@@ -234,6 +236,8 @@ describe("ssh tunnel scripts", () => {
     assert.include(buildRemoteStopScript(target), 'kill "$REMOTE_PID" 2>/dev/null || true');
     assert.include(buildRemoteStopScript(target), 'rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"');
     assert.include(buildRemoteLaunchScript(), "< /dev/null 9>&- &");
+    assert.include(buildRemoteLaunchScript(), 'mv "$DISCOVERED_BASE_DIR_FILE" "$BASE_DIR_FILE"');
+    assert.include(buildRemoteLaunchScript(), 'REMOTE_PORT="$PREVIOUS_REMOTE_PORT"');
     assert.include(buildRemoteLaunchScript(), 'if [ -n "$LAUNCHED_PID" ]; then');
     assert.notInclude(
       buildRemoteLaunchScript(),

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -461,14 +461,30 @@ DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"
 PORT_FILE="$STATE_DIR/port"
 PID_FILE="$STATE_DIR/pid"
 MANAGED_FILE="$STATE_DIR/managed"
+BASE_DIR_FILE="$STATE_DIR/base-dir"
 LOG_FILE="$STATE_DIR/server.log"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
 RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"
 mkdir -p "$STATE_DIR"
+umask 077
+LAUNCHED_PID=""
 cleanup_runner_next() {
   rm -f "$RUNNER_NEXT"
 }
+abort_remote_launch() {
+  if [ -n "$LAUNCHED_PID" ] && kill -0 "$LAUNCHED_PID" 2>/dev/null; then
+    kill "$LAUNCHED_PID" 2>/dev/null || true
+    ABORT_WAIT_COUNT=0
+    while kill -0 "$LAUNCHED_PID" 2>/dev/null && [ "$ABORT_WAIT_COUNT" -lt 20 ]; do
+      ABORT_WAIT_COUNT=$((ABORT_WAIT_COUNT + 1))
+      sleep 0.1
+    done
+  fi
+  rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE" "$BASE_DIR_FILE"
+  exit 1
+}
 trap cleanup_runner_next EXIT
+trap abort_remote_launch HUP INT TERM
 cat >"$RUNNER_NEXT" <<'SH'
 @@T3_RUNNER_SCRIPT@@
 SH
@@ -500,6 +516,87 @@ wait_for_pid_exit() {
     sleep 0.1
   done
 }
+discover_running_runtime() {
+  rm -f "$BASE_DIR_FILE"
+  SERVICE_PID=""
+  if command -v systemctl >/dev/null 2>&1; then
+    SERVICE_PID="$(systemctl --user show t3code.service --property=MainPID --value 2>/dev/null || true)"
+  fi
+  node - "$DEFAULT_SERVER_HOME" "$BASE_DIR_FILE" "$SERVICE_PID" "\${T3CODE_HOME:-}" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const defaultBaseDir = process.argv[2] ?? "";
+const baseDirOutputPath = process.argv[3] ?? "";
+const servicePid = Number.parseInt(process.argv[4] ?? "", 10);
+const environmentBaseDir = process.argv[5] ?? "";
+const candidates = [];
+const seen = new Set();
+const addBaseDir = (value) => {
+  const baseDir = value.trim();
+  if (baseDir.length === 0 || seen.has(baseDir)) return;
+  seen.add(baseDir);
+  candidates.push(baseDir);
+};
+const addBaseDirFromPid = (pid) => {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+  try {
+    const environment = fs.readFileSync(\`/proc/\${pid}/environ\`, "utf8").split("\\0");
+    const value = environment.find((entry) => entry.startsWith("T3CODE_HOME="));
+    if (value) addBaseDir(value.slice("T3CODE_HOME=".length));
+  } catch {}
+};
+
+addBaseDirFromPid(servicePid);
+addBaseDir(environmentBaseDir);
+try {
+  for (const entry of fs.readdirSync("/proc")) {
+    if (/^[1-9][0-9]*$/u.test(entry)) addBaseDirFromPid(Number(entry));
+  }
+} catch {}
+addBaseDir(defaultBaseDir);
+
+const isAlive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && typeof error === "object" && error.code === "EPERM";
+  }
+};
+
+(async () => {
+  for (const baseDir of candidates) {
+    for (const variant of ["userdata", "dev"]) {
+      try {
+        const runtime = JSON.parse(
+          fs.readFileSync(path.join(baseDir, variant, "server-runtime.json"), "utf8"),
+        );
+        const pid = Number(runtime.pid);
+        const port = Number(runtime.port);
+        if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(port) || !isAlive(pid)) {
+          continue;
+        }
+        const response = await fetch(
+          \`http://127.0.0.1:\${port}/.well-known/t3/environment\`,
+          {
+            signal: AbortSignal.timeout(2500),
+          },
+        );
+        if (!response.ok) continue;
+        const descriptor = await response.json();
+        if (!descriptor || typeof descriptor.environmentId !== "string") continue;
+        fs.writeFileSync(baseDirOutputPath, \`\${baseDir}\\n\`, { mode: 0o600 });
+        process.stdout.write(String(port));
+        return;
+      } catch {}
+    }
+  }
+  process.exitCode = 1;
+})().catch(() => {
+  process.exitCode = 1;
+});
+NODE
+}
 resolve_default_runtime_port() {
   node - "$DEFAULT_RUNTIME_FILE" <<'NODE'
 const fs = require("node:fs");
@@ -525,17 +622,23 @@ NODE
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
 REMOTE_PORT="$(cat "$PORT_FILE" 2>/dev/null || true)"
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
+RUNNER_RUNTIME_PORT="$(discover_running_runtime 2>/dev/null || true)"
 DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port 2>/dev/null || true)"
 DEFAULT_RUNTIME_PID=""
 DEFAULT_REMOTE_PORT=""
-if [ -n "$DEFAULT_RUNTIME_INFO" ]; then
+if [ -n "$RUNNER_RUNTIME_PORT" ]; then
+  DEFAULT_REMOTE_PORT="$RUNNER_RUNTIME_PORT"
+elif [ -n "$DEFAULT_RUNTIME_INFO" ]; then
   DEFAULT_RUNTIME_PID="\${DEFAULT_RUNTIME_INFO%% *}"
   DEFAULT_REMOTE_PORT="\${DEFAULT_RUNTIME_INFO#* }"
 fi
 if [ -n "$DEFAULT_REMOTE_PORT" ]; then
+  PREVIOUS_REMOTE_PORT="$REMOTE_PORT"
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
   if wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
-    if [ "$REMOTE_MANAGED" = "managed" ]; then
+    if [ "$REMOTE_MANAGED" = "managed" ] && [ "$PREVIOUS_REMOTE_PORT" = "$DEFAULT_REMOTE_PORT" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
+      printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
+    elif [ "$REMOTE_MANAGED" = "managed" ]; then
       PID_TO_STOP="\${REMOTE_PID:-$DEFAULT_RUNTIME_PID}"
       if [ -n "$PID_TO_STOP" ] && kill -0 "$PID_TO_STOP" 2>/dev/null; then
         kill "$PID_TO_STOP" 2>/dev/null || true
@@ -590,8 +693,10 @@ if [ -z "$REMOTE_PORT" ]; then
     printf 'Failed to find an available port on the remote host. Ensure node is available on PATH.\\n' >&2
     exit 1
   fi
-  nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
+  nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" >>"$LOG_FILE" 2>&1 < /dev/null &
   REMOTE_PID="$!"
+  LAUNCHED_PID="$REMOTE_PID"
+  printf '%s\\n' "\${T3CODE_HOME:-$DEFAULT_SERVER_HOME}" >"$BASE_DIR_FILE"
   printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
   printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
   printf 'managed\\n' >"$MANAGED_FILE"
@@ -604,24 +709,49 @@ if [ -z "$REMOTE_PORT" ]; then
     fi
     kill "$REMOTE_PID" 2>/dev/null || true
     wait_for_pid_exit "$REMOTE_PID"
-    rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
+    LAUNCHED_PID=""
+    rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE" "$BASE_DIR_FILE"
     exit 1
   fi
+  LAUNCHED_PID=""
 fi
 printf '{"remotePort":%s,"serverKind":"%s"}\\n' "$REMOTE_PORT" "\${REMOTE_MANAGED:-managed}"
 `;
 
 export const REMOTE_PAIRING_SCRIPT = `set -eu
 STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
-DEFAULT_SERVER_HOME="$HOME/.t3"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
+BASE_DIR_FILE="$STATE_DIR/base-dir"
+PAIR_OUTPUT_FILE="$STATE_DIR/pair-output.$$"
 mkdir -p "$STATE_DIR"
+umask 077
+cleanup_pair_output() {
+  rm -f "$PAIR_OUTPUT_FILE"
+}
+trap cleanup_pair_output EXIT
 cat >"$RUNNER_FILE" <<'SH'
 @@T3_RUNNER_SCRIPT@@
 SH
 chmod 700 "$RUNNER_FILE"
-PAIRING_BASE_DIR="$DEFAULT_SERVER_HOME"
-"$RUNNER_FILE" auth pairing create --base-dir "$PAIRING_BASE_DIR" --json
+PAIRING_BASE_DIR="$(cat "$BASE_DIR_FILE" 2>/dev/null || true)"
+if [ -n "$PAIRING_BASE_DIR" ]; then
+  "$RUNNER_FILE" pair --base-dir "$PAIRING_BASE_DIR" >"$PAIR_OUTPUT_FILE"
+else
+  "$RUNNER_FILE" pair >"$PAIR_OUTPUT_FILE"
+fi
+node - "$PAIR_OUTPUT_FILE" <<'NODE'
+const fs = require("node:fs");
+const outputPath = process.argv[2] ?? "";
+try {
+  const output = fs.readFileSync(outputPath, "utf8");
+  const tokenLine = output.split(/\\r?\\n/u).findLast((line) => line.startsWith("Token: "));
+  const credential = tokenLine?.slice("Token: ".length).trim() ?? "";
+  if (credential.length === 0) process.exit(1);
+  process.stdout.write(JSON.stringify({ credential }) + "\\n");
+} catch {
+  process.exit(1);
+}
+NODE
 `;
 
 export const REMOTE_STOP_SCRIPT = `set -eu
@@ -629,6 +759,7 @@ STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
 PID_FILE="$STATE_DIR/pid"
 PORT_FILE="$STATE_DIR/port"
 MANAGED_FILE="$STATE_DIR/managed"
+BASE_DIR_FILE="$STATE_DIR/base-dir"
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
 if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
@@ -639,7 +770,7 @@ if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMO
     sleep 0.1
   done
 fi
-rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE"
+rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE" "$BASE_DIR_FILE"
 printf '{"stopped":true}\\n'
 `;
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -17,6 +17,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { HttpClient } from "effect/unstable/http";
@@ -56,7 +57,7 @@ const SSH_READY_PROBE_TIMEOUT_MS = 1_000;
 const TUNNEL_SHUTDOWN_TIMEOUT_MS = 2_000;
 const REMOTE_READY_TIMEOUT_MS = 60_000;
 const REMOTE_LAUNCH_TIMEOUT_MS = 90_000;
-const REMOTE_REUSE_READY_TIMEOUT_MS = 2_000;
+const REMOTE_REUSE_READY_TIMEOUT_MS = 20_000;
 
 export interface RemoteT3RunnerOptions {
   readonly packageSpec?: string;
@@ -452,6 +453,44 @@ printf 'Remote host is missing the t3 CLI and could not install @@T3_PACKAGE_SPE
 exit 1
 `;
 
+const REMOTE_STATE_LOCK_SCRIPT = `acquire_state_lock() {
+  STATE_LOCK_FILE="$STATE_DIR/operation.lock"
+  STATE_LOCK_DIR="$STATE_DIR/operation.lock.d"
+  STATE_LOCK_MODE=""
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$STATE_LOCK_FILE"
+    if ! flock -w 120 9; then
+      printf 'Timed out waiting for another T3 SSH operation to finish.\n' >&2
+      return 1
+    fi
+    STATE_LOCK_MODE="flock"
+    return 0
+  fi
+
+  STATE_LOCK_WAIT_COUNT=0
+  while ! mkdir "$STATE_LOCK_DIR" 2>/dev/null; do
+    STATE_LOCK_WAIT_COUNT=$((STATE_LOCK_WAIT_COUNT + 1))
+    if [ "$STATE_LOCK_WAIT_COUNT" -ge 1200 ]; then
+      printf 'Timed out waiting for another T3 SSH operation to finish.\n' >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  printf '%s\n' "$$" >"$STATE_LOCK_DIR/pid"
+  STATE_LOCK_MODE="mkdir"
+}
+
+release_state_lock() {
+  if [ "\${STATE_LOCK_MODE:-}" = "flock" ]; then
+    flock -u 9 2>/dev/null || true
+    exec 9>&-
+  elif [ "\${STATE_LOCK_MODE:-}" = "mkdir" ]; then
+    rm -f "$STATE_LOCK_DIR/pid"
+    rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
+  fi
+  STATE_LOCK_MODE=""
+}`;
+
 export const REMOTE_LAUNCH_SCRIPT = `set -eu
 @@T3_NODE_ENV_SCRIPT@@
 STATE_KEY="$1"
@@ -467,9 +506,11 @@ RUNNER_FILE="$STATE_DIR/run-t3.sh"
 RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"
 mkdir -p "$STATE_DIR"
 umask 077
+@@T3_STATE_LOCK_SCRIPT@@
 LAUNCHED_PID=""
 cleanup_runner_next() {
   rm -f "$RUNNER_NEXT"
+  release_state_lock
 }
 abort_remote_launch() {
   if [ -n "$LAUNCHED_PID" ] && kill -0 "$LAUNCHED_PID" 2>/dev/null; then
@@ -485,6 +526,7 @@ abort_remote_launch() {
 }
 trap cleanup_runner_next EXIT
 trap abort_remote_launch HUP INT TERM
+acquire_state_lock
 cat >"$RUNNER_NEXT" <<'SH'
 @@T3_RUNNER_SCRIPT@@
 SH
@@ -564,37 +606,28 @@ const isAlive = (pid) => {
   }
 };
 
-(async () => {
-  for (const baseDir of candidates) {
-    for (const variant of ["userdata", "dev"]) {
-      try {
-        const runtime = JSON.parse(
-          fs.readFileSync(path.join(baseDir, variant, "server-runtime.json"), "utf8"),
-        );
-        const pid = Number(runtime.pid);
-        const port = Number(runtime.port);
-        if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(port) || !isAlive(pid)) {
-          continue;
-        }
-        const response = await fetch(
-          \`http://127.0.0.1:\${port}/.well-known/t3/environment\`,
-          {
-            signal: AbortSignal.timeout(2500),
-          },
-        );
-        if (!response.ok) continue;
-        const descriptor = await response.json();
-        if (!descriptor || typeof descriptor.environmentId !== "string") continue;
-        fs.writeFileSync(baseDirOutputPath, \`\${baseDir}\\n\`, { mode: 0o600 });
-        process.stdout.write(String(port));
-        return;
-      } catch {}
-    }
+for (const baseDir of candidates) {
+  for (const variant of ["userdata", "dev"]) {
+    try {
+      const runtime = JSON.parse(
+        fs.readFileSync(path.join(baseDir, variant, "server-runtime.json"), "utf8"),
+      );
+      const pid = Number(runtime.pid);
+      const port = Number(runtime.port);
+      if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(port) || !isAlive(pid)) {
+        continue;
+      }
+      const origin = new URL(String(runtime.origin ?? ""));
+      if (origin.protocol !== "http:" || !["127.0.0.1", "localhost"].includes(origin.hostname)) {
+        continue;
+      }
+      fs.writeFileSync(baseDirOutputPath, \`\${baseDir}\\n\`, { mode: 0o600 });
+      process.stdout.write(String(port));
+      process.exit(0);
+    } catch {}
   }
-  process.exitCode = 1;
-})().catch(() => {
-  process.exitCode = 1;
-});
+}
+process.exitCode = 1;
 NODE
 }
 resolve_default_runtime_port() {
@@ -657,9 +690,8 @@ if [ -n "$DEFAULT_REMOTE_PORT" ]; then
       REMOTE_MANAGED="external"
     fi
   else
-    REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
-    REMOTE_PORT="$(cat "$PORT_FILE" 2>/dev/null || true)"
-    REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
+    printf 'Existing remote T3 server did not become ready on 127.0.0.1:%s.\n' "$REMOTE_PORT" >&2
+    exit 1
   fi
 fi
 if [ "$REMOTE_MANAGED" = "external" ]; then
@@ -721,23 +753,44 @@ printf '{"remotePort":%s,"serverKind":"%s"}\\n' "$REMOTE_PORT" "\${REMOTE_MANAGE
 export const REMOTE_PAIRING_SCRIPT = `set -eu
 STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
+RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"
 BASE_DIR_FILE="$STATE_DIR/base-dir"
 PAIR_OUTPUT_FILE="$STATE_DIR/pair-output.$$"
 mkdir -p "$STATE_DIR"
 umask 077
-cleanup_pair_output() {
-  rm -f "$PAIR_OUTPUT_FILE"
+@@T3_STATE_LOCK_SCRIPT@@
+cleanup_pairing_files() {
+  rm -f "$PAIR_OUTPUT_FILE" "$RUNNER_NEXT"
+  release_state_lock
 }
-trap cleanup_pair_output EXIT
-cat >"$RUNNER_FILE" <<'SH'
+trap cleanup_pairing_files EXIT
+acquire_state_lock
+cat >"$RUNNER_NEXT" <<'SH'
 @@T3_RUNNER_SCRIPT@@
 SH
-chmod 700 "$RUNNER_FILE"
+chmod 700 "$RUNNER_NEXT"
+mv -f "$RUNNER_NEXT" "$RUNNER_FILE"
 PAIRING_BASE_DIR="$(cat "$BASE_DIR_FILE" 2>/dev/null || true)"
-if [ -n "$PAIRING_BASE_DIR" ]; then
-  "$RUNNER_FILE" pair --base-dir "$PAIRING_BASE_DIR" >"$PAIR_OUTPUT_FILE"
-else
-  "$RUNNER_FILE" pair >"$PAIR_OUTPUT_FILE"
+if [ -z "$PAIRING_BASE_DIR" ]; then
+  printf 'SSH environment state is missing its T3 base directory. Retry the connection.\n' >&2
+  exit 1
+fi
+PAIR_ATTEMPT=0
+PAIR_SUCCEEDED=0
+while [ "$PAIR_ATTEMPT" -lt 5 ]; do
+  PAIR_ATTEMPT=$((PAIR_ATTEMPT + 1))
+  if "$RUNNER_FILE" pair --base-dir "$PAIRING_BASE_DIR" >"$PAIR_OUTPUT_FILE" 2>&1; then
+    PAIR_SUCCEEDED=1
+    break
+  fi
+  if ! grep -q 'database is locked' "$PAIR_OUTPUT_FILE"; then
+    break
+  fi
+  sleep 0.2
+done
+if [ "$PAIR_SUCCEEDED" -ne 1 ]; then
+  printf 'Remote T3 server could not issue an SSH pairing credential.\n' >&2
+  exit 1
 fi
 node - "$PAIR_OUTPUT_FILE" <<'NODE'
 const fs = require("node:fs");
@@ -760,9 +813,21 @@ PID_FILE="$STATE_DIR/pid"
 PORT_FILE="$STATE_DIR/port"
 MANAGED_FILE="$STATE_DIR/managed"
 BASE_DIR_FILE="$STATE_DIR/base-dir"
+mkdir -p "$STATE_DIR"
+umask 077
+@@T3_STATE_LOCK_SCRIPT@@
+cleanup_stop() {
+  release_state_lock
+}
+trap cleanup_stop EXIT
+acquire_state_lock
 REMOTE_MANAGED="$(cat "$MANAGED_FILE" 2>/dev/null || true)"
 REMOTE_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
-if [ "$REMOTE_MANAGED" != "external" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
+if [ "$REMOTE_MANAGED" = "external" ]; then
+  printf '{"stopped":true}\n'
+  exit 0
+fi
+if [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
   kill "$REMOTE_PID" 2>/dev/null || true
   WAIT_COUNT=0
   while kill -0 "$REMOTE_PID" 2>/dev/null && [ "$WAIT_COUNT" -lt 20 ]; do
@@ -809,6 +874,7 @@ export function buildRemoteLaunchScript(input?: RemoteT3RunnerOptions): string {
     T3_RUNNER_SCRIPT: stripTrailingNewlines(buildRemoteT3RunnerScript(input)),
     T3_PICK_PORT_SCRIPT: stripTrailingNewlines(REMOTE_PICK_PORT_SCRIPT),
     T3_WAIT_READY_SCRIPT: stripTrailingNewlines(REMOTE_WAIT_READY_SCRIPT),
+    T3_STATE_LOCK_SCRIPT: stripTrailingNewlines(REMOTE_STATE_LOCK_SCRIPT),
     T3_DEFAULT_REMOTE_PORT: String(DEFAULT_REMOTE_PORT),
     T3_REMOTE_PORT_SCAN_WINDOW: String(REMOTE_PORT_SCAN_WINDOW),
     T3_READY_TIMEOUT_MS: String(REMOTE_READY_TIMEOUT_MS),
@@ -824,12 +890,14 @@ export function buildRemotePairingScript(
   return applyScriptPlaceholders(REMOTE_PAIRING_SCRIPT, {
     T3_STATE_KEY: remoteStateKey(target),
     T3_RUNNER_SCRIPT: stripTrailingNewlines(buildRemoteT3RunnerScript(input)),
+    T3_STATE_LOCK_SCRIPT: stripTrailingNewlines(REMOTE_STATE_LOCK_SCRIPT),
   });
 }
 
 export function buildRemoteStopScript(target: DesktopSshEnvironmentTarget): string {
   return applyScriptPlaceholders(REMOTE_STOP_SCRIPT, {
     T3_STATE_KEY: remoteStateKey(target),
+    T3_STATE_LOCK_SCRIPT: stripTrailingNewlines(REMOTE_STATE_LOCK_SCRIPT),
   });
 }
 
@@ -1308,6 +1376,15 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>
   >();
   const authSecrets = new Map<string, string>();
+  const pairingSemaphores = new Map<string, Semaphore.Semaphore>();
+
+  const pairingSemaphoreFor = (key: string) => {
+    const existing = pairingSemaphores.get(key);
+    if (existing !== undefined) return existing;
+    const semaphore = Semaphore.makeUnsafe(1);
+    pairingSemaphores.set(key, semaphore);
+    return semaphore;
+  };
 
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
     entry: SshTunnelEntry,
@@ -1588,7 +1665,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         remotePort: entry.remotePort,
       });
       const readinessExit = yield* Effect.exit(
-        waitForHttpReady({ baseUrl: entry.httpBaseUrl, timeoutMs: 2_000 }),
+        waitForHttpReady({ baseUrl: entry.httpBaseUrl, timeoutMs: SSH_READY_TIMEOUT_MS }),
       );
       if (Exit.isSuccess(readinessExit)) {
         yield* Effect.logDebug("ssh.environment.tunnel.reused", {
@@ -1683,11 +1760,13 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const entry = yield* ensureTunnelEntry(key, resolvedTarget, runner);
 
     const pairingResult = requestOptions?.issuePairingToken
-      ? yield* runWithSshAuth({
-          key,
-          target: entry.target,
-          operation: (authOptions) => issueRemotePairingToken(entry.target, authOptions, runner),
-        })
+      ? yield* pairingSemaphoreFor(key).withPermit(
+          runWithSshAuth({
+            key,
+            target: entry.target,
+            operation: (authOptions) => issueRemotePairingToken(entry.target, authOptions, runner),
+          }),
+        )
       : null;
     const pairingToken = pairingResult?.credential ?? null;
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -455,7 +455,8 @@ exit 1
 
 const REMOTE_STATE_LOCK_SCRIPT = `acquire_state_lock() {
   STATE_LOCK_FILE="$STATE_DIR/operation.lock"
-  STATE_LOCK_DIR="$STATE_DIR/operation.lock.d"
+  STATE_LOCK_LINK="$STATE_DIR/operation.lock.link"
+  STATE_LOCK_OWNER_FILE="$STATE_DIR/operation.lock.owner.$$"
   STATE_LOCK_MODE=""
   if command -v flock >/dev/null 2>&1; then
     exec 9>"$STATE_LOCK_FILE"
@@ -468,43 +469,38 @@ const REMOTE_STATE_LOCK_SCRIPT = `acquire_state_lock() {
   fi
 
   STATE_LOCK_WAIT_COUNT=0
-  STATE_LOCK_MISSING_PID_COUNT=0
-  while ! mkdir "$STATE_LOCK_DIR" 2>/dev/null; do
-    STATE_LOCK_OWNER_PID="$(cat "$STATE_LOCK_DIR/pid" 2>/dev/null || true)"
+  printf '%s\n' "$$" >"$STATE_LOCK_OWNER_FILE"
+  while ! ln "$STATE_LOCK_OWNER_FILE" "$STATE_LOCK_LINK" 2>/dev/null; do
+    STATE_LOCK_OWNER_PID="$(cat "$STATE_LOCK_LINK" 2>/dev/null || true)"
     if [ -n "$STATE_LOCK_OWNER_PID" ]; then
-      STATE_LOCK_MISSING_PID_COUNT=0
       if ! kill -0 "$STATE_LOCK_OWNER_PID" 2>/dev/null; then
-        rm -f "$STATE_LOCK_DIR/pid"
-        rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
-        continue
-      fi
-    else
-      STATE_LOCK_MISSING_PID_COUNT=$((STATE_LOCK_MISSING_PID_COUNT + 1))
-      if [ "$STATE_LOCK_MISSING_PID_COUNT" -ge 10 ]; then
-        rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
-        STATE_LOCK_MISSING_PID_COUNT=0
+        rm -f "$STATE_LOCK_LINK"
         continue
       fi
     fi
     STATE_LOCK_WAIT_COUNT=$((STATE_LOCK_WAIT_COUNT + 1))
     if [ "$STATE_LOCK_WAIT_COUNT" -ge 450 ]; then
       printf 'Timed out waiting for another T3 SSH operation to finish.\n' >&2
+      rm -f "$STATE_LOCK_OWNER_FILE"
       return 1
     fi
     sleep 0.1
   done
-  printf '%s\n' "$$" >"$STATE_LOCK_DIR/pid"
-  STATE_LOCK_MODE="mkdir"
+  rm -f "$STATE_LOCK_OWNER_FILE"
+  STATE_LOCK_MODE="link"
 }
 
 release_state_lock() {
   if [ "\${STATE_LOCK_MODE:-}" = "flock" ]; then
     flock -u 9 2>/dev/null || true
     exec 9>&-
-  elif [ "\${STATE_LOCK_MODE:-}" = "mkdir" ]; then
-    rm -f "$STATE_LOCK_DIR/pid"
-    rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
+  elif [ "\${STATE_LOCK_MODE:-}" = "link" ]; then
+    STATE_LOCK_OWNER_PID="$(cat "$STATE_LOCK_LINK" 2>/dev/null || true)"
+    if [ "$STATE_LOCK_OWNER_PID" = "$$" ]; then
+      rm -f "$STATE_LOCK_LINK"
+    fi
   fi
+  rm -f "\${STATE_LOCK_OWNER_FILE:-}"
   STATE_LOCK_MODE=""
 }`;
 
@@ -521,12 +517,13 @@ BASE_DIR_FILE="$STATE_DIR/base-dir"
 LOG_FILE="$STATE_DIR/server.log"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
 RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"
+DISCOVERED_BASE_DIR_FILE="$STATE_DIR/base-dir.next.$$"
 mkdir -p "$STATE_DIR"
 umask 077
 @@T3_STATE_LOCK_SCRIPT@@
 LAUNCHED_PID=""
 cleanup_runner_next() {
-  rm -f "$RUNNER_NEXT"
+  rm -f "$RUNNER_NEXT" "$DISCOVERED_BASE_DIR_FILE"
   release_state_lock
 }
 abort_remote_launch() {
@@ -582,13 +579,14 @@ discover_running_runtime() {
   if command -v systemctl >/dev/null 2>&1; then
     SERVICE_PID="$(systemctl --user show t3code.service --property=MainPID --value 2>/dev/null || true)"
   fi
-  node - "$DEFAULT_SERVER_HOME" "$BASE_DIR_FILE" "$SERVICE_PID" "\${T3CODE_HOME:-}" <<'NODE'
+  node - "$DEFAULT_SERVER_HOME" "$BASE_DIR_FILE" "$DISCOVERED_BASE_DIR_FILE" "$SERVICE_PID" "\${T3CODE_HOME:-}" <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
 const defaultBaseDir = process.argv[2] ?? "";
-const baseDirOutputPath = process.argv[3] ?? "";
-const servicePid = Number.parseInt(process.argv[4] ?? "", 10);
-const environmentBaseDir = process.argv[5] ?? "";
+const knownBaseDirPath = process.argv[3] ?? "";
+const baseDirOutputPath = process.argv[4] ?? "";
+const servicePid = Number.parseInt(process.argv[5] ?? "", 10);
+const environmentBaseDir = process.argv[6] ?? "";
 const candidates = [];
 const seen = new Set();
 const addBaseDir = (value) => {
@@ -606,13 +604,11 @@ const addBaseDirFromPid = (pid) => {
   } catch {}
 };
 
-addBaseDirFromPid(servicePid);
 addBaseDir(environmentBaseDir);
 try {
-  for (const entry of fs.readdirSync("/proc")) {
-    if (/^[1-9][0-9]*$/u.test(entry)) addBaseDirFromPid(Number(entry));
-  }
+  addBaseDir(fs.readFileSync(knownBaseDirPath, "utf8"));
 } catch {}
+addBaseDirFromPid(servicePid);
 addBaseDir(defaultBaseDir);
 
 const isAlive = (pid) => {
@@ -682,11 +678,15 @@ if [ -n "$RUNNER_RUNTIME_PORT" ]; then
 elif [ -n "$DEFAULT_RUNTIME_INFO" ]; then
   DEFAULT_RUNTIME_PID="\${DEFAULT_RUNTIME_INFO%% *}"
   DEFAULT_REMOTE_PORT="\${DEFAULT_RUNTIME_INFO#* }"
+  printf '%s\n' "$DEFAULT_SERVER_HOME" >"$DISCOVERED_BASE_DIR_FILE"
 fi
 if [ -n "$DEFAULT_REMOTE_PORT" ]; then
   PREVIOUS_REMOTE_PORT="$REMOTE_PORT"
   REMOTE_PORT="$DEFAULT_REMOTE_PORT"
   if wait_ready "@@T3_REUSE_READY_TIMEOUT_MS@@"; then
+    if [ -f "$DISCOVERED_BASE_DIR_FILE" ]; then
+      mv "$DISCOVERED_BASE_DIR_FILE" "$BASE_DIR_FILE"
+    fi
     if [ "$REMOTE_MANAGED" = "managed" ] && [ "$PREVIOUS_REMOTE_PORT" = "$DEFAULT_REMOTE_PORT" ] && [ -n "$REMOTE_PID" ] && kill -0 "$REMOTE_PID" 2>/dev/null; then
       printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
     elif [ "$REMOTE_MANAGED" = "managed" ]; then
@@ -709,7 +709,10 @@ if [ -n "$DEFAULT_REMOTE_PORT" ]; then
     fi
   else
     printf 'Existing remote T3 server did not become ready on 127.0.0.1:%s.\n' "$REMOTE_PORT" >&2
-    exit 1
+    REMOTE_PORT="$PREVIOUS_REMOTE_PORT"
+    DEFAULT_REMOTE_PORT=""
+    DEFAULT_RUNTIME_PID=""
+    rm -f "$DISCOVERED_BASE_DIR_FILE"
   fi
 fi
 if [ "$REMOTE_MANAGED" = "external" ]; then

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -459,7 +459,7 @@ const REMOTE_STATE_LOCK_SCRIPT = `acquire_state_lock() {
   STATE_LOCK_MODE=""
   if command -v flock >/dev/null 2>&1; then
     exec 9>"$STATE_LOCK_FILE"
-    if ! flock -w 120 9; then
+    if ! flock -w 45 9; then
       printf 'Timed out waiting for another T3 SSH operation to finish.\n' >&2
       return 1
     fi
@@ -468,9 +468,26 @@ const REMOTE_STATE_LOCK_SCRIPT = `acquire_state_lock() {
   fi
 
   STATE_LOCK_WAIT_COUNT=0
+  STATE_LOCK_MISSING_PID_COUNT=0
   while ! mkdir "$STATE_LOCK_DIR" 2>/dev/null; do
+    STATE_LOCK_OWNER_PID="$(cat "$STATE_LOCK_DIR/pid" 2>/dev/null || true)"
+    if [ -n "$STATE_LOCK_OWNER_PID" ]; then
+      STATE_LOCK_MISSING_PID_COUNT=0
+      if ! kill -0 "$STATE_LOCK_OWNER_PID" 2>/dev/null; then
+        rm -f "$STATE_LOCK_DIR/pid"
+        rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
+        continue
+      fi
+    else
+      STATE_LOCK_MISSING_PID_COUNT=$((STATE_LOCK_MISSING_PID_COUNT + 1))
+      if [ "$STATE_LOCK_MISSING_PID_COUNT" -ge 10 ]; then
+        rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
+        STATE_LOCK_MISSING_PID_COUNT=0
+        continue
+      fi
+    fi
     STATE_LOCK_WAIT_COUNT=$((STATE_LOCK_WAIT_COUNT + 1))
-    if [ "$STATE_LOCK_WAIT_COUNT" -ge 1200 ]; then
+    if [ "$STATE_LOCK_WAIT_COUNT" -ge 450 ]; then
       printf 'Timed out waiting for another T3 SSH operation to finish.\n' >&2
       return 1
     fi
@@ -521,7 +538,9 @@ abort_remote_launch() {
       sleep 0.1
     done
   fi
-  rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE" "$BASE_DIR_FILE"
+  if [ -n "$LAUNCHED_PID" ]; then
+    rm -f "$PID_FILE" "$PORT_FILE" "$MANAGED_FILE" "$BASE_DIR_FILE"
+  fi
   exit 1
 }
 trap cleanup_runner_next EXIT
@@ -559,7 +578,6 @@ wait_for_pid_exit() {
   done
 }
 discover_running_runtime() {
-  rm -f "$BASE_DIR_FILE"
   SERVICE_PID=""
   if command -v systemctl >/dev/null 2>&1; then
     SERVICE_PID="$(systemctl --user show t3code.service --property=MainPID --value 2>/dev/null || true)"
@@ -725,7 +743,7 @@ if [ -z "$REMOTE_PORT" ]; then
     printf 'Failed to find an available port on the remote host. Ensure node is available on PATH.\\n' >&2
     exit 1
   fi
-  nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" >>"$LOG_FILE" 2>&1 < /dev/null &
+  nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" >>"$LOG_FILE" 2>&1 < /dev/null 9>&- &
   REMOTE_PID="$!"
   LAUNCHED_PID="$REMOTE_PID"
   printf '%s\\n' "\${T3CODE_HOME:-$DEFAULT_SERVER_HOME}" >"$BASE_DIR_FILE"


### PR DESCRIPTION
Depends on #7921. Until that PR lands, GitHub includes its three routing commits in this comparison; the port-forwarding feature itself is the seven commits after `a14598386`.

## What Changed

- Add an optional port-forwarding capability and typed HTTP/WebSocket contracts.
- Add a server-side, authenticated binary WebSocket-to-TCP bridge with short-lived authorization tickets.
- Add Electron loopback listeners, IPC/preload integration, connection limits, flow control, and lifecycle cleanup.
- Add desktop controls in the chat header and Settings, plus authorization refresh through the existing session.
- Follow the environment's selected connection route and reset active streams safely when that route changes.
- Support IPv4 and IPv6 localhost targets on the remote environment.

## Why

Remote development often exposes an environment-local HTTP server, database, or debugger that the user needs on their desktop. This provides that path without exposing an unauthenticated listener or introducing another external tunnel dependency.

This is intentionally one complete cross-surface feature PR: contracts, server transport, client authorization, Electron lifecycle, and desktop UI must agree for the feature to be usable and capability-gated during version skew.

## Security and Lifecycle

- Local listeners bind only to `127.0.0.1`.
- Remote destinations are restricted to localhost, trying `127.0.0.1` and `::1`.
- Authorization tickets are single-use, destination-bound, parent-session-bound, and expire after 30 seconds.
- The endpoint requires `terminal:operate`; active bridges follow parent-session revocation and expiration.
- Connection, frame-size, initial-credit, and idle-time limits bound resource use.
- Forward definitions are runtime-only: closing/restarting desktop removes them, with no persistence or autostart.
- A server restart closes active streams. Route changes keep the local listener but close streams so local clients reconnect through the selected route.

## UI Changes

Adds a port-forward control to the desktop chat header and management under Settings → Connections. The feature is desktop-only; mobile receives only compatible shared contracts and no forwarding UI.

Screenshots will be added before this draft is marked ready for review.

## Verification

- 112 focused tests passed across desktop IPC/manager, server bridge/tickets, client authorization/connection/session, and web controls/platform.
- Typechecks passed for contracts, client-runtime, server, desktop, and web packages.
- `git diff --check` passes against the routing branch.
- No database migration is required.

## Checklist

- [x] This PR is focused on one end-to-end port-forwarding feature
- [x] I explained what changed, why, and the security/lifecycle boundaries
- [ ] I included screenshots for the desktop UI changes
- [x] No animation or motion behavior changed

Prepared with GPT-5.6-Sol via the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add desktop remote port forwarding, multi-route environments, and SSH runtime reuse
> - Adds desktop TCP port forwarding over authenticated WebSockets. The server issues single-use tickets via `/api/auth/tcp-forward-ticket`, and the desktop app bridges local TCP sockets to remote targets. UI controls added to settings and chat header.
> - Introduces multi-route connection environments. `EnvironmentRegistry` now tracks and publishes multiple available routes (e.g., Relay, SSH) per environment. Users can switch active routes from the settings UI.
> - Improves SSH remote runtime management. Remote launch and pairing scripts now use an inter-process lock, discover and reuse existing managed runtimes, and the client caches SSH bearer tokens, only re-pairing if the token is rejected.
> - Adds proactive DPoP credential refresh in the supervisor, waking up before expiry to reauthorize.
> - Risk: Catalog persistence changes add a `routes` array to `ConnectionCatalogDocument`; legacy documents fall back to treating `targets` as routes. SSH script changes (`buildRemoteLaunchScript`, `buildRemotePairingScript`) alter remote shell behavior and reuse logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 986953d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (single-use tickets, session revocation, DPoP expiry), a new WebSocket-to-TCP bridge, and connection-catalog persistence. Mis-handling tickets, destinations, or route selection could expose remote loopback services or drop live sessions.
> 
> **Overview**
> Adds **desktop-only TCP port forwarding**: a local `127.0.0.1` listener is bridged to a remote loopback port over a dedicated authenticated WebSocket. The server advertises `tcpPortForwarding`, issues destination-bound single-use tickets (`/api/auth/tcp-forward-ticket`, `terminal:operate`), and dials `127.0.0.1` then `::1`. Electron owns listeners, credit-based framing, connection limits, and cleanup; the renderer authorizes each accepted socket through the current prepared connection.
> 
> UI: cable control in the chat header and a Connections settings panel to start/stop runtime-only forwards. Route changes keep the listener but close in-flight streams so reconnects use the newly selected path.
> 
> Also persists **multiple routes per environment** (selected `targets` plus `routes`). Users can switch T3 Connect vs SSH (and similar) from settings after a prepare-and-verify step; failed switches leave the live session unchanged. SSH prepare can reuse a cached bearer instead of always pairing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986953d36f02fc3cac2d8a305a4ccf21e5478804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->