### PR TITLE
fix(mobile): fall back to current checkout for non-git projects

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -21,6 +21,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { resolveSendableThreadEnvMode } from "@t3tools/shared/threadEnvMode";
 
 import { ComposerEditor, type ComposerEditorHandle } from "../../components/ComposerEditor";
 import {
@@ -651,10 +652,16 @@ export function NewTaskDraftScreen(props: {
         selectedEnvironmentServerConfig,
         draft.modelSelection ?? null,
       ) ?? flow.selectedModel;
-    const workspaceMode = draft.workspaceSelection?.mode ?? flow.workspaceMode;
-    const selectedBranchName = draft.workspaceSelection?.branch ?? flow.selectedBranchName;
-    const selectedWorktreePath =
-      draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath;
+    const workspaceMode = resolveSendableThreadEnvMode({
+      requestedMode: draft.workspaceSelection?.mode ?? flow.workspaceMode,
+      isGitRepo: flow.isGitRepo,
+    });
+    const selectedBranchName = flow.isGitRepo
+      ? (draft.workspaceSelection?.branch ?? flow.selectedBranchName)
+      : null;
+    const selectedWorktreePath = flow.isGitRepo
+      ? (draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath)
+      : null;
     const startFromOrigin = draft.workspaceSelection?.startFromOrigin ?? flow.startFromOrigin;
     const runtimeMode = draft.runtimeMode ?? flow.runtimeMode;
     const interactionMode = flow.planModeEnabled
@@ -666,7 +673,10 @@ export function NewTaskDraftScreen(props: {
       !modelSelection ||
       initialMessageText.length === 0 ||
       flow.submitting ||
-      (workspaceMode === "worktree" && !selectedBranchName)
+      (workspaceMode === "worktree" && !selectedBranchName) ||
+      // A connected send must not trust the provisional repo status; a queued
+      // task is re-checked when the outbox drains it.
+      (workspaceMode === "worktree" && environmentConnected && !flow.gitStatusSettled)
     ) {
       return;
     }
@@ -805,7 +815,8 @@ export function NewTaskDraftScreen(props: {
     isIncomingShareReady &&
     !isImportingShare &&
     !flow.submitting &&
-    !(flow.workspaceMode === "worktree" && !flow.selectedBranchName);
+    !(flow.workspaceMode === "worktree" && !flow.selectedBranchName) &&
+    !(flow.workspaceMode === "worktree" && environmentConnected && !flow.gitStatusSettled);
   const promptEditor = (
     <ComposerEditor
       ref={promptInputRef}
@@ -927,9 +938,13 @@ export function NewTaskDraftScreen(props: {
   const workspaceControls = (
     <View className="flex-row items-center gap-1 px-2">
       <ComposerInlineControl
-        accessibilityHint={`Switches to ${flow.workspaceMode === "local" ? "a new worktree" : "the current checkout"}`}
+        accessibilityHint={
+          flow.isGitRepo
+            ? `Switches to ${flow.workspaceMode === "local" ? "a new worktree" : "the current checkout"}`
+            : "Worktrees need a git repository"
+        }
         accessibilityLabel={workspaceLabel}
-        disabled={isIncomingShareTransferPending}
+        disabled={isIncomingShareTransferPending || !flow.isGitRepo}
         iconNode={
           <NewTaskWorkspaceIcon
             workspaceMode={flow.workspaceMode}
@@ -942,15 +957,17 @@ export function NewTaskDraftScreen(props: {
         showChevron={false}
       />
 
-      <ComposerInlineControl
-        accessibilityLabel={`${flow.workspaceMode === "worktree" ? "Base branch" : "Branch"}: ${selectedBranchLabel}`}
-        chevronDirection="right"
-        disabled={isIncomingShareTransferPending}
-        icon="arrow.triangle.branch"
-        label={showBranchLoading ? "Loading branches…" : selectedBranchLabel}
-        maxWidth={190}
-        onPress={() => openContextPicker("NewTaskBranch")}
-      />
+      {flow.isGitRepo ? (
+        <ComposerInlineControl
+          accessibilityLabel={`${flow.workspaceMode === "worktree" ? "Base branch" : "Branch"}: ${selectedBranchLabel}`}
+          chevronDirection="right"
+          disabled={isIncomingShareTransferPending}
+          icon="arrow.triangle.branch"
+          label={showBranchLoading ? "Loading branches…" : selectedBranchLabel}
+          maxWidth={190}
+          onPress={() => openContextPicker("NewTaskBranch")}
+        />
+      ) : null}
     </View>
   );
 

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -78,6 +78,7 @@ import {
 } from "../home/homeThreadList";
 import { useMobileProjectGroupingSettings } from "../../state/project-grouping";
 import { resolvePendingTaskInteractionMode } from "./legacy-plan-mode";
+import { isProjectThreadGitStatusSettled } from "./projectThreadCreationValidation";
 import { useLegacyPlanModeState } from "./use-legacy-plan-mode-enabled";
 import {
   resolveNewTaskBranchWorktreePath,
@@ -390,9 +391,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   // against. Detached HEAD and non-repository projects report no ref, so this
   // stays null instead of fabricating a branch. The status family is
   // deduplicated per (environmentId, cwd) with the thread rows.
+  const hasProjectWorkspaceRoot = selectedProject !== null && selectedProject.workspaceRoot !== "";
   const projectGitStatus = useEnvironmentQuery(
     // The empty-string check also skips the stand-in project's workspaceRoot.
-    selectedProject !== null && selectedProject.workspaceRoot !== ""
+    hasProjectWorkspaceRoot
       ? vcsEnvironment.status({
           environmentId: selectedProject.environmentId,
           input: { cwd: selectedProject.workspaceRoot },
@@ -405,7 +407,11 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   // the send path waits on `gitStatusSettled` instead of trusting the default.
   // A failed status read counts as settled: the send goes ahead with the
   // default and the server reports the real error instead of a silent block.
-  const gitStatusSettled = projectGitStatus.data !== null || projectGitStatus.error !== null;
+  const gitStatusSettled = isProjectThreadGitStatusSettled({
+    hasWorkspaceRoot: hasProjectWorkspaceRoot,
+    hasData: projectGitStatus.data !== null,
+    hasError: projectGitStatus.error !== null,
+  });
   const isGitRepo = projectGitStatus.data?.isRepo ?? true;
   const defaultWorkspaceMode: WorkspaceMode = resolveDefaultThreadEnvMode({
     projectSetting: selectedProject?.defaultThreadEnvMode,

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -21,6 +21,7 @@ import { parseT3ProjectFile } from "@t3tools/shared/t3ProjectFile";
 import {
   isDefaultThreadEnvModeSettled,
   resolveDefaultThreadEnvMode,
+  resolveSendableThreadEnvMode,
 } from "@t3tools/shared/threadEnvMode";
 import * as Arr from "effect/Array";
 import { pipe } from "effect/Function";
@@ -126,6 +127,12 @@ type NewTaskFlowContextValue = {
   readonly selectedProjectKey: string | null;
   readonly selectedModelKey: string | null;
   readonly workspaceMode: WorkspaceMode;
+  /** False once the project's git status reports no repository; worktree
+      mode is then unavailable and the composer hides its branch controls. */
+  readonly isGitRepo: boolean;
+  /** True once the project's git status has arrived. `isGitRepo` is a
+      provisional true before that, so a worktree send must wait for it. */
+  readonly gitStatusSettled: boolean;
   readonly selectedBranchName: string | null;
   readonly selectedWorktreePath: string | null;
   readonly startFromOrigin: boolean;
@@ -376,6 +383,30 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     if (t3ProjectFileData === null || t3ProjectFileData.truncated) return null;
     return parseT3ProjectFile(t3ProjectFileData.contents)?.defaultThreadEnvMode ?? null;
   }, [t3ProjectFileData]);
+  // The ref actually checked out in the project root, serialized onto new
+  // local threads. It comes from the live status stream rather than listRefs'
+  // `current` flag, which is served from a cache that can lag an out-of-band
+  // `git switch` by minutes — and from the same value the PR badge compares
+  // against. Detached HEAD and non-repository projects report no ref, so this
+  // stays null instead of fabricating a branch. The status family is
+  // deduplicated per (environmentId, cwd) with the thread rows.
+  const projectGitStatus = useEnvironmentQuery(
+    // The empty-string check also skips the stand-in project's workspaceRoot.
+    selectedProject !== null && selectedProject.workspaceRoot !== ""
+      ? vcsEnvironment.status({
+          environmentId: selectedProject.environmentId,
+          input: { cwd: selectedProject.workspaceRoot },
+        })
+      : null,
+  );
+  const currentCheckoutBranchName = projectGitStatus.data?.refName ?? null;
+  // Worktree mode needs a repository. Default true while the status loads so
+  // switching projects does not flash Current checkout before it settles;
+  // the send path waits on `gitStatusSettled` instead of trusting the default.
+  // A failed status read counts as settled: the send goes ahead with the
+  // default and the server reports the real error instead of a silent block.
+  const gitStatusSettled = projectGitStatus.data !== null || projectGitStatus.error !== null;
+  const isGitRepo = projectGitStatus.data?.isRepo ?? true;
   const defaultWorkspaceMode: WorkspaceMode = resolveDefaultThreadEnvMode({
     projectSetting: selectedProject?.defaultThreadEnvMode,
     projectFile: t3ProjectFileDefaultMode,
@@ -389,9 +420,18 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     projectSetting: selectedProject?.defaultThreadEnvMode,
     projectFilePending: t3ProjectFileQuery.isPending,
   });
-  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode;
-  const selectedBranchName = selectedProjectDraft.workspaceSelection?.branch ?? null;
-  const selectedWorktreePath = selectedProjectDraft.workspaceSelection?.worktreePath ?? null;
+  const workspaceMode = resolveSendableThreadEnvMode({
+    requestedMode: selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode,
+    isGitRepo,
+  });
+  // A non-repository has no branches or worktrees, so a persisted selection
+  // from before the status arrived is stale metadata rather than a choice.
+  const selectedBranchName = isGitRepo
+    ? (selectedProjectDraft.workspaceSelection?.branch ?? null)
+    : null;
+  const selectedWorktreePath = isGitRepo
+    ? (selectedProjectDraft.workspaceSelection?.worktreePath ?? null)
+    : null;
   // Keep the user's explicit choice separate from the resolved display value:
   // only the explicit flag is ever written back to the draft, so the resolved
   // value keeps tracking the server setting when the config loads late.
@@ -555,22 +595,6 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       ),
     [allBranchRefs],
   );
-  // The ref actually checked out in the project root, serialized onto new
-  // local threads. It comes from the live status stream rather than listRefs'
-  // `current` flag, which is served from a cache that can lag an out-of-band
-  // `git switch` by minutes — and from the same value the PR badge compares
-  // against. Detached HEAD and non-repository projects report no ref, so this
-  // stays null instead of fabricating a branch. The status family is
-  // deduplicated per (environmentId, cwd) with the thread rows.
-  const projectGitStatus = useEnvironmentQuery(
-    branchTarget.environmentId !== null && branchTarget.cwd !== null
-      ? vcsEnvironment.status({
-          environmentId: branchTarget.environmentId,
-          input: { cwd: branchTarget.cwd },
-        })
-      : null,
-  );
-  const currentCheckoutBranchName = projectGitStatus.data?.refName ?? null;
 
   const filteredBranches = useMemo(() => {
     const query = branchQuery.trim().toLowerCase();
@@ -844,8 +868,12 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       }
       const workspaceSelection = draft.workspaceSelection;
       // Fall back to the resolved mode (server default) so queued tasks drain
-      // with the same mode the composer displayed.
-      const mode = workspaceSelection?.mode ?? workspaceMode;
+      // with the same mode the composer displayed. A non-git project drains
+      // as local even if the draft persisted worktree mode.
+      const mode = resolveSendableThreadEnvMode({
+        requestedMode: workspaceSelection?.mode ?? workspaceMode,
+        isGitRepo,
+      });
       // When the selection is the stand-in built from the queued snapshot,
       // persist the original (possibly absent) snapshot values — the
       // stand-in's placeholder title/workspaceRoot must never be written back
@@ -881,8 +909,9 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           // queued local task drains days later against whatever is checked
           // out then, so recording a queue-time guess would pin a stale label
           // to a thread that ran somewhere else.
-          branch: workspaceSelection?.branch ?? null,
-          worktreePath: mode === "worktree" ? null : (workspaceSelection?.worktreePath ?? null),
+          branch: isGitRepo ? (workspaceSelection?.branch ?? null) : null,
+          worktreePath:
+            mode === "worktree" || !isGitRepo ? null : (workspaceSelection?.worktreePath ?? null),
           // The draft only carries the flag when the user touched it; fall
           // back to the resolved default (server settings) so queued tasks
           // drain with the same origin mode the composer displayed.
@@ -896,6 +925,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [
       editingPendingProject,
       editingPendingTask,
+      isGitRepo,
       selectedEnvironmentServerConfig,
       selectedModel,
       selectedProject,
@@ -1019,6 +1049,8 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       hasMoreBranches,
       availableBranches,
       currentCheckoutBranchName,
+      isGitRepo,
+      gitStatusSettled,
       runtimeMode,
       interactionMode,
       planModeEnabled,
@@ -1067,6 +1099,8 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       buildPendingTaskMessage,
       cancelEditingPendingTask,
       currentCheckoutBranchName,
+      isGitRepo,
+      gitStatusSettled,
       editingPendingTask,
       environments,
       expandedProvider,

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts
@@ -1,6 +1,44 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveProjectThreadCreationBranch } from "./projectThreadCreationValidation";
+import {
+  isProjectThreadGitStatusSettled,
+  resolveProjectThreadCreationBranch,
+} from "./projectThreadCreationValidation";
+
+describe("isProjectThreadGitStatusSettled", () => {
+  it("settles when a queued-task stand-in has no workspace root", () => {
+    expect(
+      isProjectThreadGitStatusSettled({
+        hasWorkspaceRoot: false,
+        hasData: false,
+        hasError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("waits while a real workspace status query is loading", () => {
+    expect(
+      isProjectThreadGitStatusSettled({
+        hasWorkspaceRoot: true,
+        hasData: false,
+        hasError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    { hasData: true, hasError: false },
+    { hasData: false, hasError: true },
+  ])("settles when the workspace query completes: %o", ({ hasData, hasError }) => {
+    expect(
+      isProjectThreadGitStatusSettled({
+        hasWorkspaceRoot: true,
+        hasData,
+        hasError,
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("resolveProjectThreadCreationBranch", () => {
   it("uses the live checkout for an untouched local draft label and recorded branch", () => {

--- a/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
+++ b/apps/mobile/src/features/threads/projectThreadCreationValidation.ts
@@ -32,6 +32,14 @@ export const ProjectThreadCreationValidationError = Schema.Union([
 ]);
 export type ProjectThreadCreationValidationError = typeof ProjectThreadCreationValidationError.Type;
 
+export function isProjectThreadGitStatusSettled(input: {
+  readonly hasWorkspaceRoot: boolean;
+  readonly hasData: boolean;
+  readonly hasError: boolean;
+}): boolean {
+  return !input.hasWorkspaceRoot || input.hasData || input.hasError;
+}
+
 /**
  * Branch recorded on a thread created from the new-task composer. An explicit
  * picker choice always wins. An untouched current-checkout draft records the

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -15,6 +15,7 @@ import {
   type ProviderInteractionMode as ProviderInteractionModeType,
   type RuntimeMode as RuntimeModeType,
 } from "@t3tools/contracts";
+import { resolveSendableThreadEnvMode } from "@t3tools/shared/threadEnvMode";
 import * as Schema from "effect/Schema";
 
 import { DraftComposerImageAttachmentSchema } from "../lib/composer-image-schema";
@@ -64,6 +65,12 @@ export interface QueuedThreadCreation {
   readonly branch: string | null;
   readonly worktreePath: string | null;
   readonly startFromOrigin?: boolean;
+}
+
+export interface QueuedThreadCreationWorkspace {
+  readonly workspaceMode: "local" | "worktree";
+  readonly branch: string | null;
+  readonly worktreePath: string | null;
 }
 
 export interface QueuedThreadMessage {
@@ -144,6 +151,24 @@ export function flattenQueuedThreadMessages(
 
 export function threadOutboxRetryDelayMs(attempt: number): number {
   return Math.min(1_000 * 2 ** Math.max(0, attempt - 1), THREAD_OUTBOX_MAX_RETRY_DELAY_MS);
+}
+
+export function resolveQueuedThreadCreationWorkspace(
+  creation: QueuedThreadCreationWorkspace,
+  isGitRepo: boolean | null,
+): QueuedThreadCreationWorkspace {
+  const workspaceMode = resolveSendableThreadEnvMode({
+    requestedMode: creation.workspaceMode,
+    // Unknown status preserves the queued mode and lets the server decide.
+    isGitRepo: isGitRepo !== false,
+  });
+  return workspaceMode === creation.workspaceMode
+    ? creation
+    : {
+        workspaceMode,
+        branch: null,
+        worktreePath: null,
+      };
 }
 
 export type ThreadOutboxDeliveryAction = "wait" | "remove" | "send";

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -446,6 +446,8 @@ describe("thread outbox", () => {
     await manager.enqueue(message);
     const edited = { ...message, text: "edited" };
     await expect(manager.update(edited)).resolves.toBe(true);
+    await expect(manager.confirmQueued(message)).resolves.toBe(false);
+    await expect(manager.confirmQueued(edited)).resolves.toBe(true);
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
       "environment-1:thread-1": [edited],
     });
@@ -455,6 +457,43 @@ describe("thread outbox", () => {
     await expect(manager.update({ ...message, text: "stale flush" })).resolves.toBe(false);
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({});
     expect(stored.size).toBe(0);
+    registry.dispose();
+  });
+
+  it("waits for a saved edit before confirming a captured payload", async () => {
+    const registry = AtomRegistry.make();
+    let writeCount = 0;
+    let releaseEditWrite!: () => void;
+    const editWrite = new Promise<void>((resolve) => {
+      releaseEditWrite = resolve;
+    });
+    const manager = createThreadOutboxManager({
+      registry,
+      storage: {
+        load: async () => [],
+        write: async () => {
+          writeCount += 1;
+          if (writeCount === 2) {
+            await editWrite;
+          }
+        },
+        remove: async () => undefined,
+      },
+    });
+    const message = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+    const edited = { ...message, text: "edited" };
+
+    await manager.enqueue(message);
+    const update = manager.update(edited);
+    const staleConfirmation = manager.confirmQueued(message);
+    releaseEditWrite();
+
+    await expect(update).resolves.toBe(true);
+    await expect(staleConfirmation).resolves.toBe(false);
+    await expect(manager.confirmQueued(edited)).resolves.toBe(true);
     registry.dispose();
   });
 

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -15,6 +15,7 @@ import {
   groupQueuedThreadMessages,
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
+  resolveQueuedThreadCreationWorkspace,
   resolveThreadOutboxDeliveryAction,
   resolveThreadOutboxFailureAction,
   resolveQueuedThreadSettings,
@@ -589,6 +590,22 @@ describe("thread outbox", () => {
       false,
     );
     expect(isQueuedThreadCreationSendable(base)).toBe(false);
+  });
+
+  it("falls back queued worktree creation only for a known non-repository", () => {
+    const workspace = {
+      workspaceMode: "worktree",
+      branch: "main",
+      worktreePath: "/tmp/worktree",
+    } as const;
+
+    expect(resolveQueuedThreadCreationWorkspace(workspace, false)).toEqual({
+      workspaceMode: "local",
+      branch: null,
+      worktreePath: null,
+    });
+    expect(resolveQueuedThreadCreationWorkspace(workspace, true)).toBe(workspace);
+    expect(resolveQueuedThreadCreationWorkspace(workspace, null)).toBe(workspace);
   });
 
   it("retries transport failures but drops deterministic command failures", () => {

--- a/apps/mobile/src/state/use-atom-query-runner.ts
+++ b/apps/mobile/src/state/use-atom-query-runner.ts
@@ -1,20 +1,21 @@
 import { RegistryContext } from "@effect/atom-react";
 import {
   executeAtomQuery,
-  type AtomCommandOptions,
   type AtomCommandResult,
+  type AtomQueryOptions,
 } from "@t3tools/client-runtime/state/runtime";
 import { AsyncResult, type Atom } from "effect/unstable/reactivity";
 import { useCallback, useContext } from "react";
 
 export function useAtomQueryRunner<T, A, E>(
   family: (target: T) => Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  options?: string | AtomCommandOptions,
+  options?: string | AtomQueryOptions,
 ): (target: T) => Promise<AtomCommandResult<A, E>> {
   const registry = useContext(RegistryContext);
   const explicitLabel = typeof options === "string" ? options : options?.label;
   const reportFailure = typeof options === "string" ? true : (options?.reportFailure ?? true);
   const reportDefect = typeof options === "string" ? true : (options?.reportDefect ?? true);
+  const timeoutMs = typeof options === "string" ? undefined : options?.timeoutMs;
 
   return useCallback(
     (target: T) => {
@@ -23,8 +24,9 @@ export function useAtomQueryRunner<T, A, E>(
         label: explicitLabel ?? atom.label?.[0] ?? "atom query",
         reportFailure,
         reportDefect,
+        timeoutMs,
       });
     },
-    [explicitLabel, family, registry, reportDefect, reportFailure],
+    [explicitLabel, family, registry, reportDefect, reportFailure, timeoutMs],
   );
 }

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -38,7 +38,9 @@ import {
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
 import { threadEnvironment } from "./threads";
+import { vcsEnvironment } from "./vcs";
 import { useAtomCommand } from "./use-atom-command";
+import { useAtomQueryRunner } from "./use-atom-query-runner";
 import {
   editingQueuedMessageIdsAtom,
   useThreadOutboxMessages,
@@ -87,6 +89,7 @@ function settingsCommandId(message: QueuedThreadMessage, setting: string): Comma
 
 export function useThreadOutboxDrain(): void {
   const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
+  const readVcsStatus = useAtomQueryRunner(vcsEnvironment.status, { reportFailure: false });
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
@@ -256,6 +259,31 @@ export function useThreadOutboxDrain(): void {
         return false;
       }
       const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
+      // A task queued before its project's git status was known may still
+      // carry worktree mode. A non-repository cannot host a worktree, so
+      // re-check here and drain it as local, the same fallback the composer
+      // applies online. An unreadable status keeps the queued mode and lets
+      // the server decide.
+      let workspaceMode = creation.workspaceMode;
+      let branch = creation.branch;
+      let worktreePath = creation.worktreePath;
+      if (workspaceMode === "worktree") {
+        const status = await readVcsStatus({
+          environmentId: queuedMessage.environmentId,
+          input: { cwd: projectCwd },
+        });
+        // The edit-lock guard ran before this await; the user may have opened
+        // the queued row meanwhile. Defer to the next drain pass (true skips
+        // the failure/backoff path) rather than sending a payload being edited.
+        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
+          return true;
+        }
+        if (AsyncResult.isSuccess(status) && status.value !== null && !status.value.isRepo) {
+          workspaceMode = "local";
+          branch = null;
+          worktreePath = null;
+        }
+      }
       const deliveryResult = await startTurn({
         environmentId: queuedMessage.environmentId,
         input: buildProjectThreadStartTurnInput({
@@ -270,16 +298,16 @@ export function useThreadOutboxDrain(): void {
           modelSelection,
           runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
           interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
-          workspaceMode: creation.workspaceMode,
-          branch: creation.branch,
-          worktreePath: creation.worktreePath,
+          workspaceMode,
+          branch,
+          worktreePath,
           startFromOrigin: creation.startFromOrigin ?? false,
           worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
         }),
       });
       return completeDelivery(deliveryResult);
     },
-    [makeDeliveryHelpers, startTurn],
+    [makeDeliveryHelpers, readVcsStatus, startTurn],
   );
 
   useEffect(() => {

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -29,11 +29,13 @@ import {
 import {
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
+  resolveQueuedThreadCreationWorkspace,
   resolveThreadOutboxDeliveryAction,
   resolveThreadOutboxFailureAction,
   resolveQueuedThreadSettings,
   threadOutboxRetryDelayMs,
   type QueuedThreadCreation,
+  type QueuedThreadCreationWorkspace,
   type QueuedThreadMessage,
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
@@ -89,7 +91,10 @@ function settingsCommandId(message: QueuedThreadMessage, setting: string): Comma
 
 export function useThreadOutboxDrain(): void {
   const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
-  const readVcsStatus = useAtomQueryRunner(vcsEnvironment.status, { reportFailure: false });
+  const readVcsStatus = useAtomQueryRunner(vcsEnvironment.status, {
+    reportFailure: false,
+    timeoutMs: 10_000,
+  });
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
@@ -264,10 +269,8 @@ export function useThreadOutboxDrain(): void {
       // re-check here and drain it as local, the same fallback the composer
       // applies online. An unreadable status keeps the queued mode and lets
       // the server decide.
-      let workspaceMode = creation.workspaceMode;
-      let branch = creation.branch;
-      let worktreePath = creation.worktreePath;
-      if (workspaceMode === "worktree") {
+      let workspace: QueuedThreadCreationWorkspace = creation;
+      if (workspace.workspaceMode === "worktree") {
         const status = await readVcsStatus({
           environmentId: queuedMessage.environmentId,
           input: { cwd: projectCwd },
@@ -278,11 +281,9 @@ export function useThreadOutboxDrain(): void {
         if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
           return true;
         }
-        if (AsyncResult.isSuccess(status) && status.value !== null && !status.value.isRepo) {
-          workspaceMode = "local";
-          branch = null;
-          worktreePath = null;
-        }
+        const isGitRepo =
+          AsyncResult.isSuccess(status) && status.value !== null ? status.value.isRepo : null;
+        workspace = resolveQueuedThreadCreationWorkspace(creation, isGitRepo);
       }
       const deliveryResult = await startTurn({
         environmentId: queuedMessage.environmentId,
@@ -298,9 +299,9 @@ export function useThreadOutboxDrain(): void {
           modelSelection,
           runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
           interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
-          workspaceMode,
-          branch,
-          worktreePath,
+          workspaceMode: workspace.workspaceMode,
+          branch: workspace.branch,
+          worktreePath: workspace.worktreePath,
           startFromOrigin: creation.startFromOrigin ?? false,
           worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
         }),

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -275,10 +275,13 @@ export function useThreadOutboxDrain(): void {
           environmentId: queuedMessage.environmentId,
           input: { cwd: projectCwd },
         });
-        // The edit-lock guard ran before this await; the user may have opened
-        // the queued row meanwhile. Defer to the next drain pass (true skips
-        // the failure/backoff path) rather than sending a payload being edited.
-        if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]) {
+        // The edit-lock and queued-payload guards ran before this await. Defer
+        // if editing started or a saved edit replaced the captured payload.
+        const messageStillCurrent = await confirmThreadOutboxMessageQueued(queuedMessage);
+        if (
+          !messageStillCurrent ||
+          appAtomRegistry.get(editingQueuedMessageIdsAtom)[queuedMessage.messageId]
+        ) {
           return true;
         }
         const isGitRepo =

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -10,6 +10,7 @@ import {
   type ThreadId,
   type TurnId,
 } from "@t3tools/contracts";
+import { resolveSendableThreadEnvMode } from "@t3tools/shared/threadEnvMode";
 import { type ChatMessage, type SessionPhase, type Thread, type ThreadShell } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
@@ -296,7 +297,10 @@ export function resolveSendEnvMode(input: {
   requestedEnvMode: DraftThreadEnvMode;
   isGitRepo: boolean;
 }): DraftThreadEnvMode {
-  return input.isGitRepo ? input.requestedEnvMode : "local";
+  return resolveSendableThreadEnvMode({
+    requestedMode: input.requestedEnvMode,
+    isGitRepo: input.isGitRepo,
+  });
 }
 
 export function resolveBackgroundDraftWorkspaceOptions(input: {

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -296,6 +296,21 @@ describe("executeAtomQuery", () => {
 
     registry.dispose();
   });
+
+  it("interrupts a query that exceeds its configured timeout", async () => {
+    const atom = Atom.make(Effect.never).pipe(Atom.withLabel("hung query"));
+    const registry = AtomRegistry.make();
+
+    const result = await executeAtomQuery(registry, atom, {
+      timeoutMs: 1,
+    });
+
+    expect(AsyncResult.isFailure(result)).toBe(true);
+    if (AsyncResult.isFailure(result)) {
+      expect(isAtomCommandInterrupted(result)).toBe(true);
+    }
+    registry.dispose();
+  });
 });
 
 describe("runtime command runner", () => {

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -1,5 +1,6 @@
 import { EnvironmentId, type EnvironmentId as EnvironmentIdType } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
@@ -72,6 +73,10 @@ export interface AtomCommandOptions {
   readonly label?: string;
   readonly reportFailure?: boolean;
   readonly reportDefect?: boolean;
+}
+
+export interface AtomQueryOptions extends AtomCommandOptions {
+  readonly timeoutMs?: number;
 }
 
 export interface AtomCommandReporter {
@@ -329,7 +334,7 @@ export async function executeAtomCommand<A, E>(
 export async function executeAtomQuery<A, E>(
   registry: AtomRegistry.AtomRegistry,
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
-  options: AtomCommandOptions = {},
+  options: AtomQueryOptions = {},
   reporter: AtomCommandReporter = console,
 ): Promise<AtomCommandResult<A, E>> {
   const query = Effect.scoped(
@@ -340,7 +345,19 @@ export async function executeAtomQuery<A, E>(
       });
     }),
   );
-  return executeAtomCommand(() => Effect.runPromiseExit(query), options, reporter);
+  const boundedQuery =
+    options.timeoutMs === undefined
+      ? query
+      : query.pipe(
+          Effect.timeoutOption(Duration.millis(options.timeoutMs)),
+          Effect.flatMap(
+            Option.match({
+              onNone: () => Effect.interrupt,
+              onSome: Effect.succeed,
+            }),
+          ),
+        );
+  return executeAtomCommand(() => Effect.runPromiseExit(boundedQuery), options, reporter);
 }
 
 export function createRuntimeCommand<R, ER, W, A, E>(

--- a/packages/shared/src/threadEnvMode.test.ts
+++ b/packages/shared/src/threadEnvMode.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { isDefaultThreadEnvModeSettled, resolveDefaultThreadEnvMode } from "./threadEnvMode.ts";
+import {
+  isDefaultThreadEnvModeSettled,
+  resolveDefaultThreadEnvMode,
+  resolveSendableThreadEnvMode,
+} from "./threadEnvMode.ts";
 
 describe("resolveDefaultThreadEnvMode", () => {
   it("prefers the project setting over t3.json over the global default", () => {
@@ -61,5 +65,23 @@ describe("isDefaultThreadEnvModeSettled", () => {
         projectFilePending: false,
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolveSendableThreadEnvMode", () => {
+  it("keeps worktree mode only for git repositories", () => {
+    expect(resolveSendableThreadEnvMode({ requestedMode: "worktree", isGitRepo: true })).toBe(
+      "worktree",
+    );
+    expect(resolveSendableThreadEnvMode({ requestedMode: "worktree", isGitRepo: false })).toBe(
+      "local",
+    );
+  });
+
+  it("leaves local mode alone", () => {
+    expect(resolveSendableThreadEnvMode({ requestedMode: "local", isGitRepo: true })).toBe("local");
+    expect(resolveSendableThreadEnvMode({ requestedMode: "local", isGitRepo: false })).toBe(
+      "local",
+    );
   });
 });

--- a/packages/shared/src/threadEnvMode.ts
+++ b/packages/shared/src/threadEnvMode.ts
@@ -34,3 +34,16 @@ export function isDefaultThreadEnvModeSettled(sources: {
     !sources.projectFilePending
   );
 }
+
+/**
+ * Worktree mode needs a git repository. A project that is not a repository
+ * resolves to local no matter what the defaults or a persisted draft say,
+ * so a non-git project never lands in the base-branch guard. Web and mobile
+ * both route their send path through this so the clients cannot disagree.
+ */
+export function resolveSendableThreadEnvMode(input: {
+  readonly requestedMode: ThreadEnvMode;
+  readonly isGitRepo: boolean;
+}): ThreadEnvMode {
+  return input.isGitRepo ? input.requestedMode : "local";
+}


### PR DESCRIPTION
Closes #7926

## Android before and after

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/2f6b35d4-b7cb-4dfb-bd3b-b3b344f387c1" alt="Before: New worktree leaves the branch loader active and Queue task disabled" width="360"> | <img src="https://github.com/user-attachments/assets/cad445c8-b7ec-45ae-92aa-2c9f5888fe5c" alt="After: Current checkout is forced and the branch control is removed" width="360"> |

## Problem

With the default thread env mode set to New worktree, the mobile new-task flow cannot start a task for a project that is not a git repository: the branch control shows `Choose branch` with nothing to choose and Start stays disabled. Desktop already resolves this case to Current checkout through `resolveSendEnvMode`; mobile resolved its default without looking at the project's git status.

## Fix

- Add `resolveSendableThreadEnvMode` to `@t3tools/shared/threadEnvMode` and make the web `resolveSendEnvMode` delegate to it, so both clients apply the same rule.
- Mobile `new-task-flow-provider.tsx` reads the project's `vcs.status` before resolving the workspace mode, exposes `isGitRepo` and `gitStatusSettled`, and clears stale branch and worktree metadata for a non-repository.
- `NewTaskDraftScreen.tsx` applies the same fallback on the send path, disables the workspace toggle with a matching accessibility hint, and hides the branch control when the project is not a repository. A connected worktree send waits for the git status to settle instead of trusting the provisional default; offline queueing still works.
- `use-thread-outbox-drain.ts` re-checks repository status before replaying a queued worktree task, bounds that query to 10 seconds so one hung read cannot block the global outbox, preserves worktree mode when status is unknown, routes known non-repositories through the shared fallback, and re-confirms the exact queued payload plus edit lock after the await so a saved edit cannot dispatch stale text or attachments.

## Verification

- Original focused suites across shared thread-env mode, web logic, mobile state, and mobile thread creation: 195 tests passed.
- Review follow-up: `vp test run packages/client-runtime/src/state/runtime.test.ts apps/mobile/src/state/thread-outbox.test.ts packages/shared/src/threadEnvMode.test.ts apps/mobile/src/features/threads/projectThreadCreationValidation.test.ts`: 4 files and 55 tests passed. After the latest review, `vp test run apps/mobile/src/state/thread-outbox.test.ts`: 1 file and 22 tests passed.
- Typechecks passed in `packages/shared`, `apps/web`, and `apps/mobile` for the original fix. Mobile and client-runtime typechecks passed again after the bounded-query review follow-up. Mobile typecheck, targeted lint, and format passed again after the stale-payload guard.
- Reproduced the non-git project flow on the same Android emulator at 1080 x 1920. Before, New worktree leaves the branch loader active and Queue task disabled. After, Current checkout is forced and the branch control is removed.

Claude Fable 5 in Claude Code, with three Codex review passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread creation and outbox drain: worktree tasks can be rewritten to local after a VCS check, and query timeouts now interrupt atom queries. A hung status read can delay a queued worktree send by up to 10s.
> 
> **Overview**
> Mobile new-task no longer gets stuck in worktree mode for projects that are not git repos. Shared `resolveSendableThreadEnvMode` forces `local` when `isGitRepo` is false; web `resolveSendEnvMode` now uses the same helper.
> 
> The composer reads VCS status, treats repo as true until status settles (to avoid a checkout flash), then hides the branch picker and disables the workspace toggle. Connected worktree sends wait for status; offline queueing still works. Stale branch/worktree metadata is cleared for non-repos.
> 
> Queued worktree creations re-check repo status on drain (10s query timeout). Known non-repos drain as local; unknown status keeps the queued mode. After the await, drain re-confirms the payload so an in-flight edit is not sent. `executeAtomQuery` gains optional `timeoutMs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4933663decb31dc2379583585225da2af24c2847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile worktree mode to fall back to local for non-git projects
> - Adds shared `resolveSendableThreadEnvMode` which coerces worktree mode to `local` when `isGitRepo` is false; web and mobile clients route send paths through this single decision point
> - Mobile `NewTaskFlowProvider` queries VCS status for the selected project, exposes `isGitRepo` and `gitStatusSettled` to consumers, and clears `selectedBranchName`/`selectedWorktreePath` for non-repos
> - `NewTaskDraftScreen` hides the branch picker and disables the workspace toggle for non-repo projects, and blocks sending when git status is unsettled while connected
> - Outbox drain (`useThreadOutboxDrain`) reads VCS status with a 10s timeout before sending queued worktree messages, coercing to local and clearing branch/worktree for known non-repos; skips dispatch if the message enters edit state during the await
> - `executeAtomQuery` gains optional `timeoutMs` that interrupts the query via `Effect.interrupt` on timeout
> - Risk: `executeAtomQuery` now maps timeouts to interrupted failures — callers checking for interruption may see timeout-induced interrupts; the new 10s VCS status timeout in `useThreadOutboxDrain` could delay queued worktree sends by up to 10s before fallback
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dd7f915. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


