### PR TITLE
fix(web): stop phrasing unknown provider auth as a verification failure

### DIFF
--- a/apps/web/src/components/settings/providerStatus.test.ts
+++ b/apps/web/src/components/settings/providerStatus.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vite-plus/test";
+import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+
+import type { ServerProvider } from "@t3tools/contracts";
+
+import { getProviderSummary } from "./providerStatus";
+
+const makeProvider = (overrides: Partial<ServerProvider> = {}): ServerProvider => ({
+  instanceId: ProviderInstanceId.make("grok"),
+  driver: ProviderDriverKind.make("grok"),
+  enabled: true,
+  installed: true,
+  version: "1.0.5",
+  status: "ready",
+  auth: { status: "unknown" },
+  checkedAt: "2026-08-23T00:00:00.000Z",
+  models: [],
+  slashCommands: [],
+  skills: [],
+  ...overrides,
+});
+
+describe("getProviderSummary", () => {
+  it("does not phrase unknown auth as a failure for ready providers", () => {
+    const summary = getProviderSummary(makeProvider());
+    expect(summary.headline).toBe("Available");
+    expect(summary.detail).toBe("Installed and ready. Authentication status was not reported.");
+  });
+
+  it("prefers the server-supplied message over the fallback detail", () => {
+    const summary = getProviderSummary(
+      makeProvider({ message: "Grok CLI is ready to accept sessions." }),
+    );
+    expect(summary.detail).toBe("Grok CLI is ready to accept sessions.");
+  });
+
+  it("still reports authenticated providers with their auth label", () => {
+    const summary = getProviderSummary(makeProvider({ auth: { status: "authenticated" } }));
+    expect(summary.headline).toContain("Authenticated");
+  });
+});

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -76,7 +76,7 @@ export function getProviderSummary(provider: ServerProvider | undefined) {
   }
   return {
     headline: "Available",
-    detail: provider.message ?? "Installed and ready, but authentication could not be verified.",
+    detail: provider.message ?? "Installed and ready. Authentication status was not reported.",
   };
 }
 


### PR DESCRIPTION
Providers whose health check fully succeeds but never reports an auth result render this detail on every cycle: "Installed and ready, but authentication could not be verified." Nothing failed. The status is unknown, and the copy reads as an auth failure. Grok hits this every five minutes (#7932).

Reworded the final fallback in `getProviderSummary`. Server-supplied messages still take precedence, and all other branches are untouched.

Before: `Installed and ready, but authentication could not be verified.`
After: `Installed and ready. Authentication status was not reported.`

Adds a focused test covering the fallback branch. Happy to attach real before/after captures if wanted.

Work done by ox-alpha (opencode harness).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy-only change in provider status text plus unit tests; no auth or backend behavior changes.
> 
> **Overview**
> Ready providers with unknown auth no longer look like they failed verification. The fallback detail in `getProviderSummary` now says authentication was not reported instead of implying a check failed.
> 
> Server-supplied messages still win. Adds tests for the fallback, message override, and authenticated headline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d7fe15d59499a2e9245e0bd34a4eafa1008bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reword unknown provider auth detail in `getProviderSummary` to not imply verification failure
> Changes the fallback detail string for available-but-unverified providers from 'Installed and ready, but authentication could not be verified.' to 'Installed and ready. Authentication status was not reported.' Adds tests in [providerStatus.test.ts](https://github.com/pingdotgg/t3code/pull/7934/files#diff-fe24578357c64585e13f49b9a6d1019673b9dac5f4d126d84ec4d6881b7d6748) covering the fallback case, server-supplied message override, and authenticated provider headline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03d7fe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->