### PR TITLE
feat(usage): include Kimi Code activity

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -463,10 +463,12 @@ function UsageCoverageNotice(props: {
     props.merged.staleEnvironments.includes(environment.environmentId),
   );
   const duplicateSources = props.merged.duplicateSources;
+  const incompleteSources = props.merged.incompleteSources;
   if (
     failed.length === 0 &&
     stale.length === 0 &&
     duplicateSources.length === 0 &&
+    incompleteSources.length === 0 &&
     !props.isPartial
   ) {
     return null;
@@ -487,6 +489,15 @@ function UsageCoverageNotice(props: {
       {stale.map((environment) => (
         <Text key={environment.environmentId} className="text-sm text-foreground-muted">
           {environment.label} runs an older server version and is excluded from totals.
+        </Text>
+      ))}
+      {incompleteSources.map((source) => (
+        <Text
+          key={`${source.environmentId}:${source.provider}:${source.sourcePath}`}
+          className="text-sm text-foreground-muted"
+        >
+          {source.environmentLabel}&apos;s {PROVIDER_LABEL[source.provider]} usage{" "}
+          {source.status === "failed" ? "could not be read." : "is incomplete."}
         </Text>
       ))}
       {duplicateSources.length > 0 ? (

--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,21 +5,24 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "kimi"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  kimi: "Kimi Code",
 };
 
 /**
  * Claude's brand orange holds in both themes; Codex is neutral and must flip
- * with the theme or its bars vanish against the matching background.
+ * with the theme or its bars vanish against the matching background. Kimi's
+ * violet is adjusted per theme to keep chart bands legible.
  */
 export function useProviderColors(): Record<UsageProviderKind, string> {
   const { themeAppearance: scheme } = useAppearancePreferences();
   return {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
+    kimi: scheme === "dark" ? "#A89CFF" : "#5B4FD6",
   };
 }

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -78,6 +78,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
+        contractVersion: input.contractVersion,
         sinceDay: input.sinceDay,
         untilDay: input.untilDay,
         timeZone: input.timeZone,
@@ -86,6 +87,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
         untilTime: input.untilTime,
       }),
     [
+      input.contractVersion,
       input.sinceDay,
       input.untilDay,
       input.timeZone,

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  negotiateUsageContractVersion,
+  resolveKimiCodeHome,
+  summarizeSourceReadFailures,
+} from "./UsageService.ts";
+
+describe("resolveKimiCodeHome", () => {
+  it("prefers KIMI_CODE_HOME", () => {
+    expect(resolveKimiCodeHome({ KIMI_CODE_HOME: "/custom/kimi" }, "/home/user/.kimi-code")).toBe(
+      "/custom/kimi",
+    );
+  });
+
+  it("uses the standard TUI home by default", () => {
+    expect(resolveKimiCodeHome({}, "/home/user/.kimi-code")).toBe("/home/user/.kimi-code");
+  });
+});
+
+describe("negotiateUsageContractVersion", () => {
+  it("keeps v4 responses decodable for legacy clients", () => {
+    expect(negotiateUsageContractVersion(undefined)).toBe(4);
+    expect(negotiateUsageContractVersion(4)).toBe(4);
+  });
+
+  it("serves Kimi Code only to compatible clients", () => {
+    expect(negotiateUsageContractVersion(5)).toBe(5);
+    expect(negotiateUsageContractVersion(6)).toBe(5);
+  });
+});
+
+describe("summarizeSourceReadFailures", () => {
+  it("distinguishes healthy, partial, and failed stores", () => {
+    expect(summarizeSourceReadFailures(1, 0)).toEqual({ status: "ok", message: null });
+    expect(summarizeSourceReadFailures(2, 1)).toEqual({
+      status: "partial",
+      message: "1 usage file could not be read.",
+    });
+    expect(summarizeSourceReadFailures(1, 1)).toEqual({
+      status: "failed",
+      message: "1 usage file could not be read.",
+    });
+  });
+});

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -21,7 +21,7 @@ import {
   type UsageSummaryInput,
   UsageReadError,
 } from "@t3tools/contracts";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
@@ -160,6 +160,7 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
+  const hostEnvironment = yield* HostProcessEnvironment;
   const hostPlatform = yield* HostProcessPlatform;
 
   const fileCache: ScanCache = new Map();
@@ -258,8 +259,8 @@ export const make = Effect.gen(function* () {
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
 
     const homeDir = NodeOS.homedir();
-    const kimiCodeHome = resolveKimiCodeHome(process.env, path.join(homeDir, ".kimi-code"));
-    const kimiDesktopDataDir = resolveKimiDesktopDataDir(process.env, hostPlatform, homeDir);
+    const kimiCodeHome = resolveKimiCodeHome(hostEnvironment, path.join(homeDir, ".kimi-code"));
+    const kimiDesktopDataDir = resolveKimiDesktopDataDir(hostEnvironment, hostPlatform, homeDir);
 
     const sources: readonly TranscriptSource[] = [
       { provider: "claude", dir: claudeDir },
@@ -278,7 +279,16 @@ export const make = Effect.gen(function* () {
         ),
       },
     ];
-    return sources;
+    const seenKimiDirs = new Set<string>();
+    return sources.filter((source) => {
+      if (source.provider !== "kimi") return true;
+
+      const resolvedDir = path.resolve(source.dir);
+      if (seenKimiDirs.has(resolvedDir)) return false;
+
+      seenKimiDirs.add(resolvedDir);
+      return true;
+    });
   });
 
   /**

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -279,8 +279,16 @@ export const make = Effect.gen(function* () {
         ),
       },
     ];
+    const canonicalSources = yield* Effect.forEach(sources, (source) =>
+      source.provider === "kimi"
+        ? fileSystem.realPath(source.dir).pipe(
+            Effect.map((dir) => ({ ...source, dir })),
+            Effect.orElseSucceed(() => ({ ...source, dir: path.resolve(source.dir) })),
+          )
+        : Effect.succeed(source),
+    );
     const seenKimiDirs = new Set<string>();
-    return sources.filter((source) => {
+    return canonicalSources.filter((source) => {
       if (source.provider !== "kimi") return true;
 
       const resolvedDir = path.resolve(source.dir);
@@ -484,7 +492,7 @@ export const make = Effect.gen(function* () {
         for (const record of records) {
           // Only sessions that contributed in-window count: the mtime slack
           // admits boundary files whose records fall outside the range.
-          if (aggregator.add(record) && record.sessionId.length > 0) {
+          if (aggregator.add(record, dir) && record.sessionId.length > 0) {
             sessionIds.add(record.sessionId);
           }
         }

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -21,6 +21,7 @@ import {
   type UsageSummaryInput,
   UsageReadError,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
@@ -43,11 +44,13 @@ import {
   listTranscriptFiles,
   readDirectoryVolumeId,
   readTranscriptRecords,
+  resolveKimiDesktopDataDir,
 } from "./usageTranscriptReader.ts";
 import {
   decodeScanCache,
   dedupeWithinFile,
   encodeScanCache,
+  isReusableCachedFile,
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
@@ -66,6 +69,9 @@ const RATES_TTL_MS = 24 * 60 * 60 * 1000;
 const MTIME_SLACK_MS = 36 * 60 * 60 * 1000;
 const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+/** Clients predating Kimi Code omit their supported response contract. */
+const PRE_KIMI_USAGE_CONTRACT_VERSION = 4 as const;
+
 /** Longest window the UI offers, plus slack. Older entries are pruned. */
 const CACHE_RETENTION_DAYS = 90;
 
@@ -74,6 +80,11 @@ const RatesCacheFile = Schema.Struct({
   fetchedAtMs: Schema.Number,
   document: Schema.Unknown,
 });
+
+interface TranscriptSource {
+  readonly provider: UsageProviderKind;
+  readonly dir: string;
+}
 const decodeRatesCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(RatesCacheFile as unknown as Schema.Codec<typeof RatesCacheFile.Type>),
 );
@@ -93,13 +104,39 @@ export class UsageService extends Context.Service<
   }
 >()("t3/usage/UsageService") {}
 
+export function resolveKimiCodeHome(
+  environment: Readonly<Record<string, string | undefined>>,
+  defaultHome: string,
+): string {
+  return environment["KIMI_CODE_HOME"]?.trim() || defaultHome;
+}
+
+export function negotiateUsageContractVersion(
+  requestedVersion: number | undefined,
+): typeof PRE_KIMI_USAGE_CONTRACT_VERSION | typeof USAGE_CONTRACT_VERSION {
+  return requestedVersion !== undefined && requestedVersion >= USAGE_CONTRACT_VERSION
+    ? USAGE_CONTRACT_VERSION
+    : PRE_KIMI_USAGE_CONTRACT_VERSION;
+}
+
+export function summarizeSourceReadFailures(
+  totalFiles: number,
+  failedFiles: number,
+): Pick<UsageSource, "status" | "message"> {
+  if (failedFiles === 0) return { status: "ok", message: null };
+  return {
+    status: failedFiles === totalFiles ? "failed" : "partial",
+    message: `${failedFiles} usage file${failedFiles === 1 ? "" : "s"} could not be read.`,
+  };
+}
+
 /** Empty summary, for suites that only need the RPC surface to resolve. */
 export const layerTest = Layer.succeed(
   UsageService,
   UsageService.of({
     readSummary: (input) =>
       Effect.succeed({
-        contractVersion: USAGE_CONTRACT_VERSION,
+        contractVersion: negotiateUsageContractVersion(input.contractVersion),
         readAt: "1970-01-01T00:00:00.000Z",
         timeZone: input.timeZone,
         sinceDay: input.sinceDay,
@@ -123,6 +160,7 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
+  const hostPlatform = yield* HostProcessPlatform;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -219,10 +257,28 @@ export const make = Effect.gen(function* () {
     const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
 
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+    const homeDir = NodeOS.homedir();
+    const kimiCodeHome = resolveKimiCodeHome(process.env, path.join(homeDir, ".kimi-code"));
+    const kimiDesktopDataDir = resolveKimiDesktopDataDir(process.env, hostPlatform, homeDir);
+
+    const sources: readonly TranscriptSource[] = [
+      { provider: "claude", dir: claudeDir },
+      { provider: "codex", dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      { provider: "kimi", dir: path.join(kimiCodeHome, "sessions") },
+      {
+        provider: "kimi",
+        dir: path.join(
+          kimiDesktopDataDir,
+          "daimon-share",
+          "daimon",
+          "runtime",
+          "kimi-code",
+          "home",
+          "sessions",
+        ),
+      },
     ];
+    return sources;
   });
 
   /**
@@ -263,34 +319,39 @@ export const make = Effect.gen(function* () {
     size: number,
     mtimeMs: number,
     provider: UsageProviderKind,
-  ): Effect.Effect<readonly UsageRecord[]> =>
+    kimiSinceMs: number,
+  ): Effect.Effect<readonly UsageRecord[] | null> =>
     Effect.gen(function* () {
       const cached = fileCache.get(filePath);
       // Provider is part of the identity: if both providers were ever pointed
       // at one directory, a hit parsed by the other parser must not be reused.
-      if (
-        cached &&
-        cached.size === size &&
-        cached.mtimeMs === mtimeMs &&
-        cached.provider === provider
-      ) {
+      if (cached && isReusableCachedFile(cached, { size, mtimeMs, provider }, kimiSinceMs)) {
         return cached.records;
       }
 
-      const parsed = yield* Effect.promise(() => readTranscriptRecords(filePath, provider));
+      const parsed = yield* Effect.promise(() =>
+        readTranscriptRecords(filePath, provider, kimiSinceMs),
+      );
       // A read failure is not an empty transcript: caching it under this
       // (size, mtime) would silently drop the file's usage until it changes.
-      if (parsed === null) return [];
+      if (parsed === null) return null;
       // Stored already de-duplicated within the file, which is 99% of all
       // duplicates. The aggregator still runs the cross-file dedupe pass.
       const records = dedupeWithinFile(parsed);
 
-      fileCache.set(filePath, { size, mtimeMs, provider, records });
+      fileCache.set(filePath, {
+        size,
+        mtimeMs,
+        provider,
+        completeFromMs: provider === "kimi" ? kimiSinceMs : null,
+        records,
+      });
       cacheDirty = true;
       return records;
     });
 
   const readSummary = Effect.fn("UsageService.readSummary")(function* (input: UsageSummaryInput) {
+    const contractVersion = negotiateUsageContractVersion(input.contractVersion);
     if (input.sinceDay > input.untilDay) {
       return yield* new UsageReadError({
         reason: "invalidWindow",
@@ -323,13 +384,20 @@ export const make = Effect.gen(function* () {
     }
 
     const startedAtMs = yield* Clock.currentTimeMillis;
+    const retentionCutoffMs = startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
     yield* ensureRates();
     yield* ensureScanCacheLoaded;
 
     const hostId = NodeOS.hostname();
     // The home resolvers ask for `Path` themselves; satisfy them from the
     // instance we already hold so `readSummary` stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    const resolvedDirs = yield* resolveTranscriptDirs().pipe(
+      Effect.provideService(Path.Path, path),
+    );
+    const dirs =
+      contractVersion >= USAGE_CONTRACT_VERSION
+        ? resolvedDirs
+        : resolvedDirs.filter((source) => source.provider !== "kimi");
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -353,7 +421,8 @@ export const make = Effect.gen(function* () {
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
-    for (const { provider, dir } of dirs) {
+    for (const source of dirs) {
+      const { provider, dir } = source;
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
         .exists(dir)
@@ -372,17 +441,31 @@ export const make = Effect.gen(function* () {
         continue;
       }
 
-      walkedRoots.push(dir);
-      const files = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
+      const listing = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
+      const files = listing.files;
+      // Only a complete listing proves that an absent cached path was deleted.
+      // Any failure keeps the warm cache available for the next retry.
+      if (listing.failedEntries === 0) walkedRoots.push(dir);
       let scannedFiles = 0;
       let skippedFiles = 0;
+      let failedFiles = listing.failedEntries;
       // Distinct per directory. Buckets carry per-cell session counts, but a
       // session spans days and models, so clients total this figure instead.
       const sessionIds = new Set<string>();
 
       for (const file of files) {
         livePaths.add(file.path);
-        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        const records = yield* readFileRecords(
+          file.path,
+          file.size,
+          file.mtimeMs,
+          provider,
+          windowStartMs,
+        );
+        if (records === null) {
+          failedFiles += 1;
+          continue;
+        }
         if (records.length === 0) {
           skippedFiles += 1;
           continue;
@@ -397,14 +480,18 @@ export const make = Effect.gen(function* () {
         }
       }
 
+      const readHealth = summarizeSourceReadFailures(
+        files.length + listing.failedEntries,
+        failedFiles,
+      );
       sources.push({
         fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-        status: "ok",
+        status: readHealth.status,
         scannedFiles,
         skippedFiles,
         malformedRecords: 0,
         distinctSessions: sessionIds.size,
-        message: null,
+        message: readHealth.message,
       });
     }
 
@@ -412,7 +499,7 @@ export const make = Effect.gen(function* () {
       livePaths,
       walkedRoots,
       windowStartMs,
-      retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      retentionCutoffMs,
     });
     if (pruned > 0) cacheDirty = true;
     yield* persistScanCache();
@@ -422,7 +509,7 @@ export const make = Effect.gen(function* () {
     const finishedAtMs = yield* Clock.currentTimeMillis;
 
     return {
-      contractVersion: USAGE_CONTRACT_VERSION,
+      contractVersion,
       readAt: DateTime.formatIso(readAt),
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -84,6 +84,7 @@ const RatesCacheFile = Schema.Struct({
 interface TranscriptSource {
   readonly provider: UsageProviderKind;
   readonly dir: string;
+  readonly inspectionFailed?: boolean;
 }
 const decodeRatesCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(RatesCacheFile as unknown as Schema.Codec<typeof RatesCacheFile.Type>),
@@ -283,7 +284,13 @@ export const make = Effect.gen(function* () {
       source.provider === "kimi"
         ? fileSystem.realPath(source.dir).pipe(
             Effect.map((dir) => ({ ...source, dir })),
-            Effect.orElseSucceed(() => ({ ...source, dir: path.resolve(source.dir) })),
+            Effect.catch((error) =>
+              Effect.succeed({
+                ...source,
+                dir: path.resolve(source.dir),
+                inspectionFailed: error.reason._tag !== "NotFound",
+              }),
+            ),
           )
         : Effect.succeed(source),
     );
@@ -442,19 +449,22 @@ export const make = Effect.gen(function* () {
     for (const source of dirs) {
       const { provider, dir } = source;
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
-      const exists = yield* fileSystem
-        .exists(dir)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      const exists = source.inspectionFailed
+        ? null
+        : yield* fileSystem.exists(dir).pipe(Effect.catchCause(() => Effect.succeed(null)));
 
-      if (!exists) {
+      if (exists !== true) {
         sources.push({
           fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-          status: "missing",
+          status: exists === null ? "failed" : "missing",
           scannedFiles: 0,
           skippedFiles: 0,
           malformedRecords: 0,
           distinctSessions: 0,
-          message: "No transcript directory on this environment.",
+          message:
+            exists === null
+              ? "Transcript directory could not be inspected."
+              : "No transcript directory on this environment.",
         });
         continue;
       }

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -94,6 +94,22 @@ describe("UsageAggregator", () => {
     expect(result.buckets[0]?.totals.outputTokens).toBe(100);
   });
 
+  it("keeps physical sources separate for cross-environment ownership", () => {
+    const aggregator = new UsageAggregator({
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+    });
+    aggregator.add(record(), "/home/user/.kimi-code/sessions");
+    aggregator.add(record(), "/home/user/kimi-desktop/sessions");
+
+    expect(aggregator.finish().buckets.map((bucket) => bucket.sourcePath)).toEqual([
+      "/home/user/.kimi-code/sessions",
+      "/home/user/kimi-desktop/sessions",
+    ]);
+  });
+
   it("buckets by the day in the requested time zone", () => {
     const utc = aggregate([record()], "UTC");
     const losAngeles = aggregate([record()], "America/Los_Angeles");

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -1,6 +1,6 @@
 // @effect-diagnostics globalDate:off
 /**
- * Folds parsed transcript records into `(day, hourStart?, provider, model)`
+ * Folds parsed transcript records into `(day, hourStart?, provider, sourcePath?, model)`
  * buckets.
  *
  * `Intl.DateTimeFormat` is the only reliable way to resolve a wall-clock day in
@@ -111,7 +111,7 @@ export class UsageAggregator {
    * can derive per-window facts (distinct sessions, for one) from the records
    * that landed rather than everything the mtime prefilter happened to admit.
    */
-  add(record: UsageRecord): boolean {
+  add(record: UsageRecord, sourcePath = ""): boolean {
     if (record.dedupeKey !== null) {
       if (this.#seen.has(record.dedupeKey)) {
         this.#duplicatesDropped += 1;
@@ -145,7 +145,7 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}`;
+    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${sourcePath}\u0000${record.model}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -180,11 +180,13 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
+      const [day = "", hourStart = "", provider = "", sourcePath = "", model = ""] =
+        key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
         provider: provider as UsageBucket["provider"],
+        ...(sourcePath === "" ? {} : { sourcePath }),
         model,
         totals: bucket.totals,
         costUsd: bucket.costUsd,
@@ -201,6 +203,7 @@ export class UsageAggregator {
         a.day.localeCompare(b.day) ||
         (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
         a.provider.localeCompare(b.provider) ||
+        (a.sourcePath ?? "").localeCompare(b.sourcePath ?? "") ||
         a.model.localeCompare(b.model),
     );
 

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -4,6 +4,7 @@ import {
   decodeScanCache,
   dedupeWithinFile,
   encodeScanCache,
+  isReusableCachedFile,
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
@@ -31,7 +32,13 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
 function cacheWith(entries: readonly [string, number, readonly UsageRecord[]][]): ScanCache {
   const cache: ScanCache = new Map();
   for (const [path, mtimeMs, records] of entries) {
-    cache.set(path, { size: records.length * 10, mtimeMs, provider: "claude", records });
+    cache.set(path, {
+      size: records.length * 10,
+      mtimeMs,
+      provider: "claude",
+      completeFromMs: null,
+      records,
+    });
   }
   return cache;
 }
@@ -57,6 +64,31 @@ describe("scan cache round trip", () => {
 
     expect(encoded.models).toEqual(["claude-fable-5"]);
     expect(encoded.sessions).toEqual(["session-a"]);
+  });
+
+  it("round-trips a Kimi Code wire transcript with its coverage bound", () => {
+    const kimiRecord = record({
+      provider: "kimi",
+      model: "kimi-code/k3",
+      sessionId: "kimi-session",
+      dedupeKey: null,
+    });
+    const original: ScanCache = new Map([
+      [
+        "/home/user/.kimi-code/sessions/wd_demo/session-a/agents/main/wire.jsonl",
+        {
+          size: 42,
+          mtimeMs: 200,
+          provider: "kimi",
+          completeFromMs: 1_786_000_000_000,
+          records: [kimiRecord],
+        },
+      ],
+    ]);
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(encodeScanCache(original))))).toEqual(
+      original,
+    );
   });
 
   it("treats a corrupt or foreign document as an empty cache", () => {
@@ -105,6 +137,28 @@ describe("scan cache round trip", () => {
 
     const restored = decodeScanCache(JSON.parse(JSON.stringify(poisoned)));
     expect(restored.has("/a.jsonl")).toBe(false);
+  });
+});
+
+describe("isReusableCachedFile", () => {
+  const entry = {
+    size: 42,
+    mtimeMs: 100,
+    provider: "kimi" as const,
+    completeFromMs: 1_000,
+    records: [record({ provider: "kimi" })],
+  };
+
+  it("reuses a broad Kimi Code scan for a narrower request", () => {
+    expect(isReusableCachedFile(entry, { size: 42, mtimeMs: 100, provider: "kimi" }, 2_000)).toBe(
+      true,
+    );
+  });
+
+  it("rejects a narrow Kimi Code scan for a broader request", () => {
+    expect(isReusableCachedFile(entry, { size: 42, mtimeMs: 100, provider: "kimi" }, 500)).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -18,18 +18,33 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 
 import type { UsageRecord } from "./usageTranscripts.ts";
 
-// v2: Codex fork-copy suppression changed what a file parses to, so v1
-// entries would keep serving double-counted records forever.
-export const USAGE_SCAN_CACHE_VERSION = 2 as const;
+// v3: Kimi Code scans are window-bounded and carry a per-entry coverage bound;
+// v2 entries cannot prove which rows they include.
+export const USAGE_SCAN_CACHE_VERSION = 3 as const;
 
 export interface CachedFile {
   readonly size: number;
   readonly mtimeMs: number;
   readonly provider: UsageProviderKind;
+  /** Null for whole-file formats; earliest row included for windowed stores. */
+  readonly completeFromMs: number | null;
   readonly records: readonly UsageRecord[];
 }
 
 export type ScanCache = Map<string, CachedFile>;
+
+export function isReusableCachedFile(
+  entry: CachedFile,
+  fingerprint: Pick<CachedFile, "size" | "mtimeMs" | "provider">,
+  requestedFromMs: number,
+): boolean {
+  return (
+    entry.size === fingerprint.size &&
+    entry.mtimeMs === fingerprint.mtimeMs &&
+    entry.provider === fingerprint.provider &&
+    (entry.completeFromMs === null || entry.completeFromMs <= requestedFromMs)
+  );
+}
 
 /**
  * Row layout for the serialised form. Positional and interned rather than
@@ -53,6 +68,7 @@ interface SerializedFile {
   readonly s: number;
   readonly m: number;
   readonly p: UsageProviderKind;
+  readonly c?: number;
   readonly r: readonly SerializedRecord[];
 }
 
@@ -85,6 +101,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
       s: entry.size,
       m: entry.mtimeMs,
       p: entry.provider,
+      ...(entry.completeFromMs === null ? {} : { c: entry.completeFromMs }),
       r: entry.records.map((record) => [
         record.timestampMs,
         intern(models, modelIndex, record.model),
@@ -134,10 +151,12 @@ export function decodeScanCache(document: unknown): ScanCache {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
-    if (entry.p !== "claude" && entry.p !== "codex") continue;
+    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "kimi") continue;
     if (!isRecordArray(entry.r)) continue;
 
     const provider: UsageProviderKind = entry.p;
+    const completeFromMs = typeof entry.c === "number" && Number.isFinite(entry.c) ? entry.c : null;
+    if (provider === "kimi" && completeFromMs === null) continue;
     const records: UsageRecord[] = [];
     // Any corrupt row disqualifies the whole entry. Keeping the survivors
     // under the original (size, mtime) would read as a valid warm hit and the
@@ -194,7 +213,7 @@ export function decodeScanCache(document: unknown): ScanCache {
     }
 
     if (corrupt) continue;
-    cache.set(path, { size: entry.s, mtimeMs: entry.m, provider, records });
+    cache.set(path, { size: entry.s, mtimeMs: entry.m, provider, completeFromMs, records });
   }
 
   return cache;

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -1,0 +1,183 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  kimiSessionIdFromTranscriptPath,
+  listTranscriptFiles,
+  readTranscriptRecords,
+  resolveKimiDesktopDataDir,
+} from "./usageTranscriptReader.ts";
+
+function createKimiTranscript(lines: readonly string[]): {
+  readonly filePath: string;
+  readonly cleanup: () => void;
+} {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-kimi-usage-"));
+  const filePath = NodePath.join(
+    dir,
+    "sessions",
+    "wd_demo_123",
+    "session-123",
+    "agents",
+    "main",
+    "wire.jsonl",
+  );
+  NodeFS.mkdirSync(NodePath.dirname(filePath), { recursive: true });
+  NodeFS.writeFileSync(filePath, `${lines.join("\n")}\n`);
+  return { filePath, cleanup: () => NodeFS.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function usageRecord(input: {
+  readonly time: number;
+  readonly scope?: string;
+  readonly model?: string;
+  readonly inputOther?: number;
+  readonly inputCacheRead?: number;
+  readonly inputCacheCreation?: number;
+  readonly output?: number;
+}): string {
+  return JSON.stringify({
+    type: "usage.record",
+    model: input.model ?? "kimi-code/k3",
+    usage: {
+      inputOther: input.inputOther ?? 100,
+      inputCacheRead: input.inputCacheRead ?? 200,
+      inputCacheCreation: input.inputCacheCreation ?? 30,
+      output: input.output ?? 40,
+    },
+    usageScope: input.scope ?? "turn",
+    time: input.time,
+  });
+}
+
+describe("readTranscriptRecords for Kimi Code", () => {
+  it("reads turn-scoped usage and respects the requested coverage bound", async () => {
+    const { filePath, cleanup } = createKimiTranscript([
+      JSON.stringify({ type: "metadata", created_at: 1_000 }),
+      usageRecord({ time: 1_500, inputOther: 999 }),
+      usageRecord({ time: 2_000 }),
+      usageRecord({ time: 2_500, scope: "session", inputOther: 999 }),
+      "not-json",
+    ]);
+    try {
+      expect(await readTranscriptRecords(filePath, "kimi", 2_000)).toEqual([
+        {
+          provider: "kimi",
+          timestampMs: 2_000,
+          model: "kimi-code/k3",
+          sessionId: "session-123",
+          totals: {
+            uncachedInputTokens: 100,
+            cachedInputTokens: 200,
+            cacheCreationTokens: 30,
+            outputTokens: 40,
+            reasoningTokens: 0,
+          },
+          reportedCostUsd: null,
+          dedupeKey: null,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returns null when a transcript cannot be read", async () => {
+    expect(
+      await readTranscriptRecords(
+        NodePath.join(NodeOS.tmpdir(), "t3-kimi-no-such-dir", "wire.jsonl"),
+        "kimi",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("kimiSessionIdFromTranscriptPath", () => {
+  it("extracts the session id from TUI, desktop, and subagent paths", () => {
+    expect(
+      kimiSessionIdFromTranscriptPath(
+        NodePath.join("home", "sessions", "wd_demo", "session-a", "agents", "main", "wire.jsonl"),
+      ),
+    ).toBe("session-a");
+    expect(
+      kimiSessionIdFromTranscriptPath(
+        NodePath.join(
+          "kimi-desktop",
+          "runtime",
+          "kimi-code",
+          "home",
+          "sessions",
+          "wd_demo",
+          "conv-b",
+          "agents",
+          "agent-2",
+          "wire.jsonl",
+        ),
+      ),
+    ).toBe("conv-b");
+  });
+});
+
+describe("resolveKimiDesktopDataDir", () => {
+  it("prefers an explicit desktop data directory", () => {
+    expect(
+      resolveKimiDesktopDataDir(
+        { KIMI_DESKTOP_DATA_DIR: "/custom/desktop" },
+        "linux",
+        "/home/user",
+      ),
+    ).toBe("/custom/desktop");
+  });
+
+  it("uses Electron's platform data roots", () => {
+    expect(
+      resolveKimiDesktopDataDir(
+        { APPDATA: "C:\\Users\\me\\AppData\\Roaming" },
+        "win32",
+        "C:\\Users\\me",
+      ),
+    ).toBe(NodePath.join("C:\\Users\\me\\AppData\\Roaming", "kimi-desktop"));
+    expect(resolveKimiDesktopDataDir({}, "darwin", "/Users/me")).toBe(
+      NodePath.join("/Users/me", "Library", "Application Support", "kimi-desktop"),
+    );
+    expect(resolveKimiDesktopDataDir({ XDG_CONFIG_HOME: "/xdg" }, "linux", "/home/me")).toBe(
+      NodePath.join("/xdg", "kimi-desktop"),
+    );
+  });
+
+  it("falls back to the conventional Windows and Linux data roots", () => {
+    expect(resolveKimiDesktopDataDir({}, "win32", "C:\\Users\\me")).toBe(
+      NodePath.join("C:\\Users\\me", "AppData", "Roaming", "kimi-desktop"),
+    );
+    expect(resolveKimiDesktopDataDir({}, "linux", "/home/me")).toBe(
+      NodePath.join("/home/me", ".config", "kimi-desktop"),
+    );
+  });
+});
+
+describe("listTranscriptFiles", () => {
+  it("reports a missing root as a failed listing", async () => {
+    const listing = await listTranscriptFiles(
+      NodePath.join(NodeOS.tmpdir(), "t3-kimi-listing-missing"),
+      0,
+    );
+    expect(listing).toEqual({ files: [], failedEntries: 1 });
+  });
+
+  it("lists recent wire transcripts and ignores non-jsonl files", async () => {
+    const { filePath, cleanup } = createKimiTranscript([usageRecord({ time: 2_000 })]);
+    NodeFS.writeFileSync(NodePath.join(NodePath.dirname(filePath), "state.json"), "{}");
+    try {
+      const root = NodePath.join(NodePath.dirname(filePath), "..", "..", "..");
+      const listing = await listTranscriptFiles(root, 0);
+      expect(listing.failedEntries).toBe(0);
+      expect(listing.files.map((file) => file.path)).toEqual([filePath]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -22,6 +22,7 @@ import {
   mightCarryUsage,
   parseClaudeLine,
   parseCodexLine,
+  parseKimiLine,
   type UsageRecord,
 } from "./usageTranscripts.ts";
 
@@ -29,6 +30,39 @@ export interface TranscriptFile {
   readonly path: string;
   readonly size: number;
   readonly mtimeMs: number;
+}
+
+export interface TranscriptListing {
+  readonly files: readonly TranscriptFile[];
+  readonly failedEntries: number;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { readonly code?: unknown }).code)
+    : undefined;
+}
+
+export function resolveKimiDesktopDataDir(
+  environment: Readonly<Record<string, string | undefined>>,
+  platform: NodeJS.Platform,
+  homeDir: string,
+): string {
+  const override = environment["KIMI_DESKTOP_DATA_DIR"]?.trim();
+  if (override) return override;
+  if (platform === "win32") {
+    return NodePath.join(
+      environment["APPDATA"]?.trim() || NodePath.join(homeDir, "AppData", "Roaming"),
+      "kimi-desktop",
+    );
+  }
+  if (platform === "darwin") {
+    return NodePath.join(homeDir, "Library", "Application Support", "kimi-desktop");
+  }
+  return NodePath.join(
+    environment["XDG_CONFIG_HOME"]?.trim() || NodePath.join(homeDir, ".config"),
+    "kimi-desktop",
+  );
 }
 
 /**
@@ -41,14 +75,19 @@ export interface TranscriptFile {
 export async function listTranscriptFiles(
   root: string,
   sinceMs: number,
-): Promise<readonly TranscriptFile[]> {
+): Promise<TranscriptListing> {
   const found: TranscriptFile[] = [];
+  let failedEntries = 0;
 
-  const walk = async (dir: string): Promise<void> => {
+  const walk = async (dir: string, isRoot = false): Promise<void> => {
     let entries;
     try {
       entries = await NodeFSP.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      // A nested entry may rotate away between its parent readdir and this
+      // walk. The root disappearing after the caller's existence check is a
+      // real source failure, as is any permission or I/O error.
+      if (isRoot || errorCode(error) !== "ENOENT") failedEntries += 1;
       return;
     }
     for (const entry of entries) {
@@ -63,14 +102,16 @@ export async function listTranscriptFiles(
         if (stats.mtimeMs >= sinceMs) {
           found.push({ path: child, size: stats.size, mtimeMs: stats.mtimeMs });
         }
-      } catch {
-        // Vanished between readdir and stat.
+      } catch (error) {
+        // Vanishing between readdir and stat is benign rotation; other errors
+        // mean coverage is partial.
+        if (errorCode(error) !== "ENOENT") failedEntries += 1;
       }
     }
   };
 
-  await walk(root);
-  return found;
+  await walk(root, true);
+  return { files: found, failedEntries };
 }
 
 /**
@@ -89,6 +130,12 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
   }
 }
 
+export function kimiSessionIdFromTranscriptPath(filePath: string): string {
+  const parts = NodePath.normalize(filePath).split(NodePath.sep);
+  const sessionsIndex = parts.lastIndexOf("sessions");
+  return sessionsIndex >= 0 ? (parts[sessionsIndex + 2] ?? "") : "";
+}
+
 /**
  * Streams one transcript and returns the usage records it contains, or `null`
  * when the file could not be read.
@@ -105,9 +152,11 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
 export async function readTranscriptRecords(
   filePath: string,
   provider: UsageProviderKind,
+  kimiSinceMs = 0,
 ): Promise<readonly UsageRecord[] | null> {
   const records: UsageRecord[] = [];
   const codexState = initialCodexScanState();
+  const kimiSessionId = provider === "kimi" ? kimiSessionIdFromTranscriptPath(filePath) : "";
 
   try {
     const lines = NodeReadline.createInterface({
@@ -126,6 +175,13 @@ export async function readTranscriptRecords(
         }
         const record = parseCodexLine(line, codexState);
         if (record !== null) records.push(record);
+        continue;
+      }
+
+      if (provider === "kimi") {
+        if (!mightCarryUsage(line, provider)) continue;
+        const record = parseKimiLine(line, kimiSessionId);
+        if (record !== null && record.timestampMs >= kimiSinceMs) records.push(record);
         continue;
       }
 

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -4,6 +4,7 @@ import {
   initialCodexScanState,
   parseClaudeLine,
   parseCodexLine,
+  parseKimiLine,
   totalTokens,
 } from "./usageTranscripts.ts";
 
@@ -233,6 +234,58 @@ describe("parseCodexLine", () => {
       );
       expect(record).not.toBeNull();
     });
+  });
+});
+
+describe("parseKimiLine", () => {
+  it("keeps uncached input separate from both cache categories", () => {
+    expect(
+      parseKimiLine(
+        JSON.stringify({
+          type: "usage.record",
+          model: "kimi-code/k3",
+          usage: {
+            inputOther: 120,
+            output: 45,
+            inputCacheRead: 900,
+            inputCacheCreation: 30,
+          },
+          usageScope: "turn",
+          time: 1_786_000_000_000,
+        }),
+        "session-a",
+      ),
+    ).toEqual({
+      provider: "kimi",
+      timestampMs: 1_786_000_000_000,
+      model: "kimi-code/k3",
+      sessionId: "session-a",
+      totals: {
+        uncachedInputTokens: 120,
+        cachedInputTokens: 900,
+        cacheCreationTokens: 30,
+        outputTokens: 45,
+        reasoningTokens: 0,
+      },
+      reportedCostUsd: null,
+      dedupeKey: null,
+    });
+  });
+
+  it("rejects cumulative, malformed, and empty usage records", () => {
+    const valid = {
+      type: "usage.record",
+      model: "kimi-code/k3",
+      usage: { inputOther: 0, output: 0, inputCacheRead: 0, inputCacheCreation: 0 },
+      usageScope: "turn",
+      time: 1_786_000_002_000,
+    };
+    expect(
+      parseKimiLine(JSON.stringify({ ...valid, usageScope: "session" }), "session-b"),
+    ).toBeNull();
+    expect(parseKimiLine(JSON.stringify({ ...valid, model: "" }), "session-b")).toBeNull();
+    expect(parseKimiLine(JSON.stringify(valid), "session-b")).toBeNull();
+    expect(parseKimiLine("not-json", "session-b")).toBeNull();
   });
 });
 

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -68,7 +68,14 @@ export function totalTokens(totals: UsageTokenTotals): number {
  * an order of magnitude.
  */
 export function mightCarryUsage(line: string, provider: UsageProviderKind): boolean {
-  return provider === "claude" ? line.includes('"usage"') : line.includes('"token_count"');
+  switch (provider) {
+    case "claude":
+      return line.includes('"usage"');
+    case "codex":
+      return line.includes('"token_count"');
+    case "kimi":
+      return line.includes('"usage.record"');
+  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -293,6 +300,50 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     reportedCostUsd: null,
     // Events surviving the fork-copy suppression above are unique to this
     // rollout, so they need no global dedup.
+    dedupeKey: null,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Kimi Code                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/** Parses one turn-scoped `usage.record` from a Kimi Code wire transcript. */
+export function parseKimiLine(line: string, sessionId: string): UsageRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record["type"] !== "usage.record" || record["usageScope"] !== "turn") return null;
+
+  const timestampMs = int(record["time"]);
+  const model = typeof record["model"] === "string" ? record["model"].trim() : "";
+  const usage = record["usage"];
+  if (timestampMs === 0 || model.length === 0 || typeof usage !== "object" || usage === null) {
+    return null;
+  }
+  const usageRecord = usage as Record<string, unknown>;
+  const totals: UsageTokenTotals = {
+    uncachedInputTokens: int(usageRecord["inputOther"]),
+    cachedInputTokens: int(usageRecord["inputCacheRead"]),
+    cacheCreationTokens: int(usageRecord["inputCacheCreation"]),
+    outputTokens: int(usageRecord["output"]),
+    // Kimi Code does not currently break thinking tokens out from output.
+    reasoningTokens: 0,
+  };
+  if (totalTokens(totals) === 0) return null;
+
+  return {
+    provider: "kimi",
+    timestampMs,
+    model,
+    sessionId,
+    totals,
+    reportedCostUsd: null,
     dedupeKey: null,
   };
 }

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -484,6 +484,20 @@ export const Zed: Icon = (props) => {
   );
 };
 
+/** Official Kimi Code mark, shared by the TUI and desktop surfaces. */
+export const KimiCode: Icon = ({ className, ...props }) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    className={cn("text-[#6c5ce7] dark:text-[#a89cff]", className)}
+    fill="none"
+  >
+    <rect x="3" y="4.5" width="18" height="13" rx="2.2" stroke="currentColor" strokeWidth="1.6" />
+    <rect x="9.6" y="8" width="1.4" height="2.6" rx="0.45" fill="currentColor" />
+    <rect x="15.6" y="8" width="1.4" height="2.6" rx="0.45" fill="currentColor" />
+  </svg>
+);
+
 export const OpenAI: Icon = ({ className, ...props }) => (
   <svg
     {...props}

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -489,7 +489,7 @@ export const KimiCode: Icon = ({ className, ...props }) => (
   <svg
     {...props}
     viewBox="0 0 24 24"
-    className={cn("text-[#6c5ce7] dark:text-[#a89cff]", className)}
+    className={cn("text-[color:var(--usage-provider-kimi)]", className)}
     fill="none"
   >
     <rect x="3" y="4.5" width="18" height="13" rx="2.2" stroke="currentColor" strokeWidth="1.6" />

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -54,19 +54,21 @@ vi.mock("../WorkspacePageContainer", () => ({ WorkspacePageContainer: "main" }))
 vi.mock("../WorkspacePageHeader", () => ({ WorkspacePageHeader: "header" }));
 vi.mock("./UsageProviderChart", () => ({ UsageProviderChart: "div" }));
 vi.mock("./usageProviders", () => ({
-  PROVIDER_ORDER: ["codex", "claude"],
+  PROVIDER_ORDER: ["codex", "claude", "kimi"],
   PROVIDER_PRESENTATION: {
     codex: { color: "white", label: "Codex", mark: "span" },
     claude: { color: "orange", label: "Claude Code", mark: "span" },
+    kimi: { color: "violet", label: "Kimi Code", mark: "span" },
   },
 }));
 
 import { UsagePage } from "./UsagePage";
 
-const providerTotals = (codex: number, claude: number) =>
+const providerTotals = (codex: number, claude: number, kimi: number) =>
   new Map([
     ["codex", { costUsd: codex, totalTokens: codex * 1_000 }],
     ["claude", { costUsd: claude, totalTokens: claude * 1_000 }],
+    ["kimi", { costUsd: kimi, totalTokens: kimi * 1_000 }],
   ] as const);
 
 beforeEach(() => {
@@ -79,14 +81,14 @@ beforeEach(() => {
           hourStart: "2026-08-10T13:37:00.000Z",
           costUsd: 13,
           totalTokens: 13_000,
-          byProvider: providerTotals(7, 6),
+          byProvider: providerTotals(7, 6, 0),
         },
         {
           day: "2026-08-11",
           hourStart: "2026-08-11T11:37:00.000Z",
           costUsd: 11,
           totalTokens: 11_000,
-          byProvider: providerTotals(6, 5),
+          byProvider: providerTotals(6, 4, 1),
         },
       ],
     },
@@ -105,6 +107,48 @@ describe("UsagePage hourly breakdown", () => {
     expect(body.match(/<tr/g)).toHaveLength(2);
     expect(body).toContain("$11.00");
     expect(body).toContain("$13.00");
+    expect(markup).toContain("Kimi Code");
+    expect(body).toContain("$1.00");
     expect(body.indexOf("$11.00")).toBeLessThan(body.indexOf("$13.00"));
+  });
+
+  it("warns when the Kimi Code store could not be read", () => {
+    testState.useUsage.mockReturnValue({
+      merged: {
+        ...mergeUsage([], USAGE_CONTRACT_VERSION),
+        incompleteSources: [
+          {
+            environmentId: "env-a",
+            environmentLabel: "Local",
+            provider: "kimi",
+            sourcePath: "/home/user/.kimi-code/sessions",
+            status: "failed",
+            message: "1 usage file could not be read.",
+          },
+        ],
+      },
+      environments: [],
+      isPending: false,
+      isPartial: false,
+      refresh: vi.fn(),
+    });
+
+    expect(renderToStaticMarkup(<UsagePage />)).toContain(
+      "Local&#x27;s Kimi Code usage could not be read.",
+    );
+  });
+
+  it("spans the empty time table across every provider column", () => {
+    testState.useUsage.mockReturnValue({
+      merged: mergeUsage([], USAGE_CONTRACT_VERSION),
+      environments: [],
+      isPending: false,
+      isPartial: false,
+      refresh: vi.fn(),
+    });
+
+    expect(renderToStaticMarkup(<UsagePage />)).toMatch(
+      /<td colSpan="6" class="py-6 text-center text-muted-foreground">No activity in this window\.<\/td>/,
+    );
   });
 });

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -2,7 +2,7 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
+import type { DailyTotals, HourlyTotals, MergedUsage } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
 import { cn } from "../../lib/utils";
@@ -207,6 +207,7 @@ export function UsagePage() {
                 <UsageCoverageNotice
                   environments={environments}
                   duplicateSources={merged.duplicateSources}
+                  incompleteSources={merged.incompleteSources}
                   staleEnvironments={merged.staleEnvironments}
                 />
 
@@ -390,7 +391,10 @@ export function UsagePage() {
                       <tbody>
                         {breakdownPeriods.length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                            <td
+                              colSpan={PROVIDER_ORDER.length + 3}
+                              className="py-6 text-center text-muted-foreground"
+                            >
                               No activity in this window.
                             </td>
                           </tr>
@@ -457,25 +461,32 @@ function Metric({ label, value }: { readonly label: string; readonly value: stri
 }
 
 /**
- * Says plainly when the totals are incomplete: an environment that failed, or
- * one whose transcripts another environment already reported. Environments
- * that are still answering never reach this notice; the page shows the
- * loading skeleton until every one is terminal.
+ * Says plainly when the totals are incomplete: an environment or provider
+ * source failed, or another environment already reported the same transcripts.
+ * Environments that are still answering never reach this notice; the page
+ * shows the loading skeleton until every one is terminal.
  */
 function UsageCoverageNotice({
   environments,
   duplicateSources,
+  incompleteSources,
   staleEnvironments,
 }: {
   readonly environments: readonly EnvironmentUsageStatus[];
   readonly duplicateSources: readonly string[];
+  readonly incompleteSources: MergedUsage["incompleteSources"];
   readonly staleEnvironments: readonly string[];
 }) {
   const failed = environments.filter((environment) => environment.error !== null);
   const stale = environments.filter((environment) =>
     staleEnvironments.includes(environment.environmentId),
   );
-  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0) {
+  if (
+    failed.length === 0 &&
+    stale.length === 0 &&
+    duplicateSources.length === 0 &&
+    incompleteSources.length === 0
+  ) {
     return null;
   }
 
@@ -487,6 +498,12 @@ function UsageCoverageNotice({
       {stale.map((environment) => (
         <span key={environment.label}>
           {environment.label} runs an older server version and is excluded from totals.
+        </span>
+      ))}
+      {incompleteSources.map((source) => (
+        <span key={`${source.environmentId}:${source.provider}:${source.sourcePath}`}>
+          {source.environmentLabel}&apos;s {PROVIDER_PRESENTATION[source.provider].label} usage{" "}
+          {source.status === "failed" ? "could not be read." : "is incomplete."}
         </span>
       ))}
       {duplicateSources.length > 0 ? (

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -85,6 +85,7 @@ describe("buildDayColumns", () => {
     expect(first?.bands).toEqual([
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
+      { provider: "kimi", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, type Icon, KimiCode, OpenAI } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -23,6 +23,11 @@ export const PROVIDER_PRESENTATION = {
     label: "Claude Code",
     color: "#d97757",
     mark: ClaudeAI,
+  },
+  kimi: {
+    label: "Kimi Code",
+    color: "var(--usage-provider-kimi)",
+    mark: KimiCode,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -111,6 +111,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --workspace-native-controls-inset: 0px;
   --workspace-titlebar-control-size: 1.75rem;
   --workspace-titlebar-control-gap: 0.75rem;
+  --usage-provider-kimi: #5b4fd6;
 
   @variant dark {
     --appearance-contrast-target: white;
@@ -118,6 +119,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --app-scrollbar-thumb-hover: rgb(255 255 255 / 12%);
     --glass-blur: 16px;
     --glass-saturation: 1.08;
+    --usage-provider-kimi: #a89cff;
   }
 }
 

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -75,6 +75,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
+        contractVersion: input.contractVersion,
         sinceDay: input.sinceDay,
         untilDay: input.untilDay,
         timeZone: input.timeZone,
@@ -83,6 +84,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
         untilTime: input.untilTime,
       }),
     [
+      input.contractVersion,
       input.sinceDay,
       input.untilDay,
       input.timeZone,

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,10 +1,15 @@
 # Review usage
 
-The Usage page combines Codex and Claude Code activity from your connected environments. It reads
-the providers' local session history and shows API-equivalent token cost, processed tokens, cache
-savings, provider shares, and model breakdowns. Subscription billing is separate from the raw token
-cost shown here.
+The Usage page combines Codex, Claude Code, and Kimi Code activity from your connected environments. It
+reads the providers' local usage history and shows API-equivalent token cost, processed tokens,
+cache savings, provider shares, and model breakdowns. Subscription billing is separate from the raw
+token cost shown here. Kimi Code's terminal UI and desktop app use separate session homes; T3 Code
+scans both and combines their turn-scoped usage without double counting shared environments.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.
+
+If an environment cannot read one of its provider stores, the page keeps any available usage and
+shows that coverage is incomplete. A healthy environment reading the same physical store can
+supply the missing coverage without double counting it.

--- a/packages/contracts/src/usage.test.ts
+++ b/packages/contracts/src/usage.test.ts
@@ -1,0 +1,39 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { UsageDay, UsageSummaryInput } from "./usage.ts";
+
+const LegacyUsageSummaryInput = Schema.Struct({
+  sinceDay: UsageDay,
+  untilDay: UsageDay,
+  timeZone: Schema.String,
+});
+const decodeUsageSummaryInput = Schema.decodeUnknownSync(UsageSummaryInput);
+const decodeLegacyUsageSummaryInput = Schema.decodeUnknownSync(LegacyUsageSummaryInput);
+
+describe("UsageSummaryInput version negotiation", () => {
+  it("accepts a legacy request with no advertised contract", () => {
+    const decoded = decodeUsageSummaryInput({
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      timeZone: "UTC",
+    });
+
+    expect(decoded.contractVersion).toBeUndefined();
+  });
+
+  it("lets an old server ignore a new client's advertised contract", () => {
+    const decoded = decodeLegacyUsageSummaryInput({
+      contractVersion: 5,
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      timeZone: "UTC",
+    });
+
+    expect(decoded).toEqual({
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      timeZone: "UTC",
+    });
+  });
+});

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -7,7 +7,7 @@
  * own orchestration projections, so usage stays complete even for turns that
  * were never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
- * Environments return pre-aggregated `(day, hourStart?, provider, model)`
+ * Environments return pre-aggregated `(day, hourStart?, provider, sourcePath?, model)`
  * buckets. Raw transcript records never cross the wire.
  *
  * @module usage
@@ -71,7 +71,7 @@ export const UsageTokenTotals = Schema.Struct({
 export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 
 /**
- * One `(day, hourStart?, provider, model)` cell. `hourStart` is the UTC start
+ * One `(day, hourStart?, provider, sourcePath?, model)` cell. `hourStart` is the UTC start
  * instant of a rolling bucket and is present only for hourly requests.
  *
  * `costUsd` is the raw API-equivalent cost of these tokens. It is not money
@@ -83,6 +83,8 @@ export const UsageBucket = Schema.Struct({
   day: UsageDay,
   hourStart: Schema.optional(TrimmedNonEmptyString),
   provider: UsageProviderKind,
+  /** Resolved provider store that produced this bucket, for cross-environment de-duplication. */
+  sourcePath: Schema.optional(TrimmedNonEmptyString),
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,
   costUsd: Schema.Number,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -1,11 +1,11 @@
 /**
  * Usage reporting contract.
  *
- * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`) rather than
- * relying on T3 Code's own orchestration projections, so usage stays complete
- * even for turns that were never driven through T3 Code. This mirrors the
- * approach `ccusage` takes.
+ * Each environment scans the provider CLIs' own on-disk usage stores
+ * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`, and Kimi
+ * Code's `sessions/<workspace>/<session>/agents/<agent>/wire.jsonl`) rather than relying on T3 Code's
+ * own orchestration projections, so usage stays complete even for turns that
+ * were never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
  * buckets. Raw transcript records never cross the wire.
@@ -21,9 +21,9 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "kimi"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**
@@ -161,6 +161,11 @@ export const UsagePricing = Schema.Struct({
 export type UsagePricing = typeof UsagePricing.Type;
 
 export const UsageSummaryInput = Schema.Struct({
+  /**
+   * Highest response contract the client can decode. Omitted clients receive
+   * the pre-Kimi Code v4 shape so rolling upgrades remain wire-compatible.
+   */
+  contractVersion: Schema.optional(Schema.Number),
   /** Inclusive first day of the window, in `timeZone`. */
   sinceDay: UsageDay,
   /** Inclusive last day of the window, in `timeZone`. */

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics globalDate:off -- A fixed instant keeps calendar-window assertions deterministic.
+import { USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -50,6 +51,10 @@ describe("hourly usage formatting", () => {
   it("builds an exact minute-aligned 24-hour request", () => {
     const window = makeWindow(1, new Date("2026-08-11T12:37:42.123Z"), "hour");
 
+    expect(window.contractVersion).toBe(USAGE_CONTRACT_VERSION);
+    expect(makeWindow(30, new Date("2026-08-11T12:37:42.123Z")).contractVersion).toBe(
+      USAGE_CONTRACT_VERSION,
+    );
     expect(window.resolution).toBe("hour");
     expect(window.sinceTime).toBe("2026-08-10T12:37:00.000Z");
     expect(window.untilTime).toBe("2026-08-11T12:37:00.000Z");

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -4,7 +4,12 @@
  *
  * @module usageFormat
  */
-import { UsageDay, type UsageResolution, type UsageSummaryInput } from "@t3tools/contracts";
+import {
+  USAGE_CONTRACT_VERSION,
+  UsageDay,
+  type UsageResolution,
+  type UsageSummaryInput,
+} from "@t3tools/contracts";
 
 const CURRENCY = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -208,6 +213,7 @@ export function makeWindow(
     const sinceTime = new Date(sinceTimeMs);
     const untilTime = new Date(untilTimeMs);
     return {
+      contractVersion: USAGE_CONTRACT_VERSION,
       sinceDay: UsageDay.make(format.format(sinceTime)),
       untilDay: UsageDay.make(format.format(untilTime)),
       timeZone,
@@ -224,6 +230,7 @@ export function makeWindow(
     .map((part) => Number.parseInt(part, 10));
   const start = new Date(Date.UTC(year, month - 1, dayOfMonth - (days - 1)));
   return {
+    contractVersion: USAGE_CONTRACT_VERSION,
     sinceDay: UsageDay.make(start.toISOString().slice(0, 10)),
     untilDay: UsageDay.make(untilDay),
     timeZone,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -207,6 +207,71 @@ describe("mergeUsage", () => {
     expect(merged.incompleteSources.map((source) => source.provider)).toEqual(["kimi", "claude"]);
   });
 
+  it("rolls multiple Kimi stores into one provider-level coverage status", () => {
+    const mixed = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 4 })],
+            [
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/a/.kimi-code/sessions",
+                status: "ok",
+              },
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/a/kimi-desktop/sessions",
+                volumeId: "desktop-volume",
+                status: "failed",
+                message: "1 usage file could not be read.",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(mixed.incompleteSources).toEqual([
+      expect.objectContaining({ provider: "kimi", status: "partial" }),
+    ]);
+
+    const failed = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [],
+            [
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/a/.kimi-code/sessions",
+                status: "failed",
+              },
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/a/kimi-desktop/sessions",
+                volumeId: "desktop-volume",
+                status: "failed",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(failed.incompleteSources).toEqual([
+      expect.objectContaining({ provider: "kimi", status: "failed" }),
+    ]);
+  });
+
   it("prefers a complete Kimi Code duplicate without a false coverage gap", () => {
     const shared = {
       provider: "kimi" as const,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -458,6 +458,68 @@ describe("mergeUsage", () => {
     expect(merged.duplicateSources).toEqual(["env-b: /shared/.kimi-code/sessions"]);
   });
 
+  it("reports a losing environment's unique failed Kimi store", () => {
+    const sharedTui = {
+      provider: "kimi" as const,
+      hostId: "mac",
+      homePath: "/shared/.kimi-code/sessions",
+      volumeId: "shared-tui",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({
+                provider: "kimi",
+                sourcePath: sharedTui.homePath,
+                model: "kimi-code/k3",
+                costUsd: 2,
+              }),
+            ],
+            [sharedTui],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [
+              bucket({
+                provider: "kimi",
+                sourcePath: sharedTui.homePath,
+                model: "kimi-code/k3",
+                costUsd: 2,
+              }),
+            ],
+            [
+              { ...sharedTui, status: "partial" },
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/machine-b/kimi-desktop",
+                volumeId: "desktop-b",
+                status: "failed",
+                message: "1 usage file could not be read.",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(2);
+    expect(merged.incompleteSources).toEqual([
+      expect.objectContaining({
+        environmentId: "env-b",
+        provider: "kimi",
+        sourcePath: "/machine-b/kimi-desktop",
+        status: "failed",
+      }),
+    ]);
+  });
+
   it("prefers a complete Kimi Code duplicate without a false coverage gap", () => {
     const shared = {
       provider: "kimi" as const,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -272,7 +272,7 @@ describe("mergeUsage", () => {
     ]);
   });
 
-  it("chooses one environment when Kimi store winners would otherwise split", () => {
+  it("keeps split Kimi source winners without double counting attributed buckets", () => {
     const tui = {
       provider: "kimi" as const,
       hostId: "mac",
@@ -290,14 +290,40 @@ describe("mergeUsage", () => {
         environment(
           "env-a",
           summary(
-            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 3 })],
+            [
+              bucket({
+                provider: "kimi",
+                sourcePath: tui.homePath,
+                model: "kimi-code/k3",
+                costUsd: 1,
+              }),
+              bucket({
+                provider: "kimi",
+                sourcePath: desktop.homePath,
+                model: "kimi-code/k3",
+                costUsd: 2,
+              }),
+            ],
             [tui, { ...desktop, status: "partial" }],
           ),
         ),
         environment(
           "env-b",
           summary(
-            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 })],
+            [
+              bucket({
+                provider: "kimi",
+                sourcePath: tui.homePath,
+                model: "kimi-code/k3",
+                costUsd: 1,
+              }),
+              bucket({
+                provider: "kimi",
+                sourcePath: desktop.homePath,
+                model: "kimi-code/k3",
+                costUsd: 2,
+              }),
+            ],
             [{ ...tui, status: "partial" }, desktop],
           ),
         ),
@@ -306,7 +332,7 @@ describe("mergeUsage", () => {
     );
 
     expect(merged.costUsd).toBe(3);
-    expect(merged.contributingEnvironments).toEqual(["env-a"]);
+    expect(merged.contributingEnvironments).toEqual(["env-a", "env-b"]);
     expect(merged.providers.find((provider) => provider.provider === "kimi")?.sessions).toBe(2);
   });
 
@@ -359,7 +385,7 @@ describe("mergeUsage", () => {
     expect(merged.duplicateSources).toEqual([]);
   });
 
-  it("reports only fingerprints the winning environment actually shares", () => {
+  it("retains unique stores while de-duplicating one shared Kimi store", () => {
     const sharedTui = {
       provider: "kimi" as const,
       hostId: "mac",
@@ -371,7 +397,20 @@ describe("mergeUsage", () => {
         environment(
           "env-a",
           summary(
-            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 3 })],
+            [
+              bucket({
+                provider: "kimi",
+                sourcePath: sharedTui.homePath,
+                model: "kimi-code/k3",
+                costUsd: 2,
+              }),
+              bucket({
+                provider: "kimi",
+                sourcePath: "/machine-a/kimi-desktop",
+                model: "kimi-code/k3",
+                costUsd: 3,
+              }),
+            ],
             [
               sharedTui,
               {
@@ -386,7 +425,20 @@ describe("mergeUsage", () => {
         environment(
           "env-b",
           summary(
-            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 })],
+            [
+              bucket({
+                provider: "kimi",
+                sourcePath: sharedTui.homePath,
+                model: "kimi-code/k3",
+                costUsd: 2,
+              }),
+              bucket({
+                provider: "kimi",
+                sourcePath: "/machine-b/kimi-desktop",
+                model: "kimi-code/k3",
+                costUsd: 7,
+              }),
+            ],
             [
               { ...sharedTui, status: "partial" },
               {
@@ -402,7 +454,7 @@ describe("mergeUsage", () => {
       USAGE_CONTRACT_VERSION,
     );
 
-    expect(merged.costUsd).toBe(3);
+    expect(merged.costUsd).toBe(12);
     expect(merged.duplicateSources).toEqual(["env-b: /shared/.kimi-code/sessions"]);
   });
 

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -310,6 +310,102 @@ describe("mergeUsage", () => {
     expect(merged.providers.find((provider) => provider.provider === "kimi")?.sessions).toBe(2);
   });
 
+  it("does not connect missing Kimi homes across same-named machines", () => {
+    const missing = {
+      provider: "kimi" as const,
+      hostId: "same-hostname",
+      homePath: "/home/user/.kimi-code/sessions",
+      volumeId: "",
+      status: "missing" as const,
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 3 })],
+            [
+              missing,
+              {
+                provider: "kimi",
+                hostId: "same-hostname",
+                homePath: "/machine-a/kimi-desktop",
+                volumeId: "machine-a-volume",
+              },
+            ],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 })],
+            [
+              missing,
+              {
+                provider: "kimi",
+                hostId: "same-hostname",
+                homePath: "/machine-b/kimi-desktop",
+                volumeId: "machine-b-volume",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(10);
+    expect(merged.contributingEnvironments).toEqual(["env-a", "env-b"]);
+    expect(merged.duplicateSources).toEqual([]);
+  });
+
+  it("reports only fingerprints the winning environment actually shares", () => {
+    const sharedTui = {
+      provider: "kimi" as const,
+      hostId: "mac",
+      homePath: "/shared/.kimi-code/sessions",
+      volumeId: "shared-tui",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 3 })],
+            [
+              sharedTui,
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/machine-a/kimi-desktop",
+                volumeId: "desktop-a",
+              },
+            ],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 })],
+            [
+              { ...sharedTui, status: "partial" },
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/machine-b/kimi-desktop",
+                volumeId: "desktop-b",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(3);
+    expect(merged.duplicateSources).toEqual(["env-b: /shared/.kimi-code/sessions"]);
+  });
+
   it("prefers a complete Kimi Code duplicate without a false coverage gap", () => {
     const shared = {
       provider: "kimi" as const,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -272,6 +272,44 @@ describe("mergeUsage", () => {
     ]);
   });
 
+  it("chooses one environment when Kimi store winners would otherwise split", () => {
+    const tui = {
+      provider: "kimi" as const,
+      hostId: "mac",
+      homePath: "/a/.kimi-code/sessions",
+      volumeId: "tui-volume",
+    };
+    const desktop = {
+      provider: "kimi" as const,
+      hostId: "mac",
+      homePath: "/a/kimi-desktop/sessions",
+      volumeId: "desktop-volume",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 3 })],
+            [tui, { ...desktop, status: "partial" }],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 })],
+            [{ ...tui, status: "partial" }, desktop],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(3);
+    expect(merged.contributingEnvironments).toEqual(["env-a"]);
+    expect(merged.providers.find((provider) => provider.provider === "kimi")?.sessions).toBe(2);
+  });
+
   it("prefers a complete Kimi Code duplicate without a false coverage gap", () => {
     const shared = {
       provider: "kimi" as const,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -4,6 +4,7 @@ import {
   type UsageBucket,
   type UsageDay,
   type UsageProviderKind,
+  type UsageSourceStatus,
   type UsageSummary,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
@@ -40,6 +41,8 @@ function summary(
     homePath: string;
     volumeId?: string;
     distinctSessions?: number;
+    status?: UsageSourceStatus;
+    message?: string | null;
   }[],
   contractVersion: number = USAGE_CONTRACT_VERSION,
 ): UsageSummary {
@@ -57,12 +60,12 @@ function summary(
         resolvedHomePath: source.homePath,
         volumeId: source.volumeId ?? `vol-${source.hostId}`,
       },
-      status: "ok" as const,
+      status: source.status ?? "ok",
       scannedFiles: 1,
       skippedFiles: 0,
       malformedRecords: 0,
       distinctSessions: source.distinctSessions ?? 1,
-      message: null,
+      message: source.message ?? null,
     })),
     pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 10 },
     scanDurationMs: 1,
@@ -167,6 +170,73 @@ describe("mergeUsage", () => {
 
     expect(merged.costUsd).toBe(10);
     expect(merged.staleEnvironments).toEqual(["env-b"]);
+  });
+
+  it("reports incomplete sources and excludes a fully failed provider", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 }),
+              bucket({ provider: "claude", costUsd: 3 }),
+            ],
+            [
+              {
+                provider: "kimi",
+                hostId: "mac",
+                homePath: "/a/.kimi-code/sessions",
+                status: "failed",
+                message: "1 usage file could not be read.",
+              },
+              {
+                provider: "claude",
+                hostId: "mac",
+                homePath: "/a/.claude",
+                status: "partial",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(3);
+    expect(merged.incompleteSources.map((source) => source.provider)).toEqual(["kimi", "claude"]);
+  });
+
+  it("prefers a complete Kimi Code duplicate without a false coverage gap", () => {
+    const shared = {
+      provider: "kimi" as const,
+      hostId: "mac",
+      homePath: "/a/.kimi-code/sessions",
+      volumeId: "16777220:1234",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 3 })],
+            [{ ...shared, status: "partial" }],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ provider: "kimi", model: "kimi-code/k3", costUsd: 7 })],
+            [{ ...shared, status: "ok" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(7);
+    expect(merged.contributingEnvironments).toEqual(["env-b"]);
+    expect(merged.incompleteSources).toEqual([]);
   });
 
   it("derives provider shares and cost quality", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -151,6 +151,7 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
     const environmentsByFingerprint = new Map<string, EnvironmentId[]>();
     for (const candidate of candidates) {
       for (const source of candidate.sources) {
+        if (source.status === "missing" || source.fingerprint.volumeId.length === 0) continue;
         const key = fingerprintKey(source.fingerprint);
         const owners = environmentsByFingerprint.get(key) ?? [];
         owners.push(candidate.environment.environmentId);
@@ -202,9 +203,19 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
       ownedEnvironmentProviders.add(
         environmentProviderKey(winner.environment.environmentId, provider),
       );
+      const winnerFingerprints = new Set(
+        winner.sources
+          .filter((source) => source.status !== "missing" && source.fingerprint.volumeId.length > 0)
+          .map((source) => fingerprintKey(source.fingerprint)),
+      );
       for (const candidate of ranked) {
         for (const source of candidate.sources) {
-          if (candidate.environment.environmentId !== winner.environment.environmentId) {
+          if (
+            candidate.environment.environmentId !== winner.environment.environmentId &&
+            source.status !== "missing" &&
+            source.fingerprint.volumeId.length > 0 &&
+            winnerFingerprints.has(fingerprintKey(source.fingerprint))
+          ) {
             duplicates.push(
               `${candidate.environment.label}: ${source.fingerprint.resolvedHomePath}`,
             );

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -141,12 +141,13 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
   const exactCandidates = environments
     .flatMap((environment) =>
       environment.summary.sources.flatMap((source) =>
-        source.status === "missing" || source.status === "failed" ? [] : [{ environment, source }],
+        source.status === "missing" ? [] : [{ environment, source }],
       ),
     )
     .sort((a, b) => {
-      const statusOrder =
-        Number(a.source.status === "partial") - Number(b.source.status === "partial");
+      const rank = (status: "ok" | "partial" | "failed" | "missing") =>
+        status === "ok" ? 0 : status === "partial" ? 1 : status === "failed" ? 2 : 3;
+      const statusOrder = rank(a.source.status) - rank(b.source.status);
       return statusOrder || a.environment.environmentId.localeCompare(b.environment.environmentId);
     });
   for (const { environment, source } of exactCandidates) {
@@ -275,6 +276,8 @@ function ownedContribution(
         const source = sourceByPath.get(`${bucket.provider}\0${bucket.sourcePath}`);
         return (
           source !== undefined &&
+          source.status !== "missing" &&
+          source.status !== "failed" &&
           ownerByFingerprint.get(sourceClaimKey(source.fingerprint, environment.environmentId)) ===
             environment.environmentId
         );

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -61,6 +61,15 @@ export interface CostQuality {
   readonly cacheSavingsUsd: number;
 }
 
+export interface IncompleteUsageSource {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly provider: UsageProviderKind;
+  readonly sourcePath: string;
+  readonly status: "partial" | "failed";
+  readonly message: string | null;
+}
+
 export interface MergedUsage {
   readonly costUsd: number;
   readonly uncachedInputTokens: number;
@@ -78,6 +87,8 @@ export interface MergedUsage {
   readonly costQuality: CostQuality;
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
+  /** Provider stores that could not be read completely. */
+  readonly incompleteSources: readonly IncompleteUsageSource[];
   readonly contributingEnvironments: readonly EnvironmentId[];
   readonly staleEnvironments: readonly EnvironmentId[];
 }
@@ -103,10 +114,10 @@ function fingerprintKey(fingerprint: UsageSourceFingerprint): string {
  * Decides which environment owns each physical transcript directory.
  *
  * Several environments on one machine (worktree servers, for instance) resolve
- * the same provider home and would otherwise double count every token. The
- * first environment in a stable order claims a fingerprint; the rest have that
- * provider's buckets dropped. Environments are sorted by id so the winner does
- * not change between renders.
+ * the same provider home and would otherwise double count every token. A complete
+ * source wins over a partial duplicate; ties are sorted by
+ * environment id so the owner does not change between renders. Fully failed
+ * and missing sources cannot own a fingerprint.
  */
 function claimSources(environments: readonly EnvironmentUsage[]): {
   readonly ownerByFingerprint: ReadonlyMap<string, EnvironmentId>;
@@ -115,18 +126,25 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
   const ownerByFingerprint = new Map<string, EnvironmentId>();
   const duplicates: string[] = [];
 
-  const ordered = [...environments].sort((a, b) => a.environmentId.localeCompare(b.environmentId));
+  const candidates = environments
+    .flatMap((environment) =>
+      environment.summary.sources.flatMap((source) =>
+        source.status === "missing" || source.status === "failed" ? [] : [{ environment, source }],
+      ),
+    )
+    .sort((a, b) => {
+      const statusOrder =
+        Number(a.source.status === "partial") - Number(b.source.status === "partial");
+      return statusOrder || a.environment.environmentId.localeCompare(b.environment.environmentId);
+    });
 
-  for (const environment of ordered) {
-    for (const source of environment.summary.sources) {
-      if (source.status === "missing") continue;
-      const key = fingerprintKey(source.fingerprint);
-      if (ownerByFingerprint.has(key)) {
-        duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
-        continue;
-      }
-      ownerByFingerprint.set(key, environment.environmentId);
+  for (const { environment, source } of candidates) {
+    const key = fingerprintKey(source.fingerprint);
+    if (ownerByFingerprint.has(key)) {
+      duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
+      continue;
     }
+    ownerByFingerprint.set(key, environment.environmentId);
   }
 
   return { ownerByFingerprint, duplicates };
@@ -143,7 +161,7 @@ function ownedContribution(
   const ownedProviders = new Set<UsageProviderKind>();
   const sessionsByProvider = new Map<UsageProviderKind, number>();
   for (const source of environment.summary.sources) {
-    if (source.status === "missing") continue;
+    if (source.status === "missing" || source.status === "failed") continue;
     const key = fingerprintKey(source.fingerprint);
     if (ownerByFingerprint.get(key) === environment.environmentId) {
       const provider = source.fingerprint.provider;
@@ -193,6 +211,7 @@ const EMPTY_MERGED: MergedUsage = {
     cacheSavingsUsd: 0,
   },
   duplicateSources: [],
+  incompleteSources: [],
   contributingEnvironments: [],
   staleEnvironments: [],
 };
@@ -221,6 +240,22 @@ export function mergeUsage(
   }
 
   const { ownerByFingerprint, duplicates } = claimSources(current);
+  const incompleteSources: IncompleteUsageSource[] = [];
+  for (const environment of current) {
+    for (const source of environment.summary.sources) {
+      if (source.status !== "partial" && source.status !== "failed") continue;
+      const owner = ownerByFingerprint.get(fingerprintKey(source.fingerprint));
+      if (owner !== undefined && owner !== environment.environmentId) continue;
+      incompleteSources.push({
+        environmentId: environment.environmentId,
+        environmentLabel: environment.label,
+        provider: source.fingerprint.provider,
+        sourcePath: source.fingerprint.resolvedHomePath,
+        status: source.status,
+        message: source.message,
+      });
+    }
+  }
 
   let costUsd = 0;
   let uncachedInputTokens = 0;
@@ -411,6 +446,7 @@ export function mergeUsage(
       cacheSavingsUsd,
     },
     duplicateSources: duplicates,
+    incompleteSources,
     contributingEnvironments,
     staleEnvironments,
   };

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -114,22 +114,49 @@ function environmentProviderKey(environmentId: EnvironmentId, provider: UsagePro
   return `${environmentId}\0${provider}`;
 }
 
+function sourceClaimKey(fingerprint: UsageSourceFingerprint, environmentId: EnvironmentId): string {
+  const key = fingerprintKey(fingerprint);
+  return fingerprint.volumeId.length > 0 ? key : `${key}\0${environmentId}`;
+}
+
 /**
  * Decides which environment owns each connected provider-source group.
  *
  * Several environments on one machine (worktree servers, for instance) resolve
- * the same provider home and would otherwise double count every token. Buckets
- * do not retain source attribution, so environments connected by any shared
- * fingerprint must choose one owner for all of that provider's sources. The
- * environment with the most complete/readable stores wins; ties are sorted by
- * environment id so ownership does not change between renders.
+ * the same provider home and would otherwise double count every token. Current
+ * buckets carry source attribution and are claimed exactly; the connected-group
+ * winner is the conservative fallback for an older/unattributed bucket. The
+ * environment with the most complete/readable stores wins that fallback; ties
+ * are sorted by environment id so ownership does not change between renders.
  */
 function claimSources(environments: readonly EnvironmentUsage[]): {
+  readonly ownerByFingerprint: ReadonlyMap<string, EnvironmentId>;
   readonly ownedEnvironmentProviders: ReadonlySet<string>;
   readonly duplicates: readonly string[];
 } {
+  const ownerByFingerprint = new Map<string, EnvironmentId>();
   const ownedEnvironmentProviders = new Set<string>();
   const duplicates: string[] = [];
+
+  const exactCandidates = environments
+    .flatMap((environment) =>
+      environment.summary.sources.flatMap((source) =>
+        source.status === "missing" || source.status === "failed" ? [] : [{ environment, source }],
+      ),
+    )
+    .sort((a, b) => {
+      const statusOrder =
+        Number(a.source.status === "partial") - Number(b.source.status === "partial");
+      return statusOrder || a.environment.environmentId.localeCompare(b.environment.environmentId);
+    });
+  for (const { environment, source } of exactCandidates) {
+    const key = sourceClaimKey(source.fingerprint, environment.environmentId);
+    if (ownerByFingerprint.has(key)) {
+      duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
+    } else {
+      ownerByFingerprint.set(key, environment.environmentId);
+    }
+  }
 
   for (const provider of new Set(
     environments.flatMap((environment) =>
@@ -203,48 +230,37 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
       ownedEnvironmentProviders.add(
         environmentProviderKey(winner.environment.environmentId, provider),
       );
-      const winnerFingerprints = new Set(
-        winner.sources
-          .filter((source) => source.status !== "missing" && source.fingerprint.volumeId.length > 0)
-          .map((source) => fingerprintKey(source.fingerprint)),
-      );
-      for (const candidate of ranked) {
-        for (const source of candidate.sources) {
-          if (
-            candidate.environment.environmentId !== winner.environment.environmentId &&
-            source.status !== "missing" &&
-            source.fingerprint.volumeId.length > 0 &&
-            winnerFingerprints.has(fingerprintKey(source.fingerprint))
-          ) {
-            duplicates.push(
-              `${candidate.environment.label}: ${source.fingerprint.resolvedHomePath}`,
-            );
-          }
-        }
-      }
     }
   }
 
-  return { ownedEnvironmentProviders, duplicates };
+  return { ownerByFingerprint, ownedEnvironmentProviders, duplicates };
 }
 
 /** Sources this environment owns after fingerprint claims, plus their buckets. */
 function ownedContribution(
   environment: EnvironmentUsage,
+  ownerByFingerprint: ReadonlyMap<string, EnvironmentId>,
   ownedEnvironmentProviders: ReadonlySet<string>,
 ): {
   readonly buckets: readonly UsageBucket[];
   readonly sessionsByProvider: ReadonlyMap<UsageProviderKind, number>;
 } {
-  const ownedProviders = new Set<UsageProviderKind>();
   const sessionsByProvider = new Map<UsageProviderKind, number>();
+  const readableProviders = new Set<UsageProviderKind>();
+  const sourceByPath = new Map(
+    environment.summary.sources.map((source) => [
+      `${source.fingerprint.provider}\0${source.fingerprint.resolvedHomePath}`,
+      source,
+    ]),
+  );
   for (const source of environment.summary.sources) {
     if (source.status === "missing" || source.status === "failed") continue;
     const provider = source.fingerprint.provider;
+    readableProviders.add(provider);
     if (
-      ownedEnvironmentProviders.has(environmentProviderKey(environment.environmentId, provider))
+      ownerByFingerprint.get(sourceClaimKey(source.fingerprint, environment.environmentId)) ===
+      environment.environmentId
     ) {
-      ownedProviders.add(provider);
       // Distinct within a directory. Summing per-bucket session counts instead
       // would count a session once per day and model it spans.
       sessionsByProvider.set(
@@ -254,7 +270,21 @@ function ownedContribution(
     }
   }
   return {
-    buckets: environment.summary.buckets.filter((bucket) => ownedProviders.has(bucket.provider)),
+    buckets: environment.summary.buckets.filter((bucket) => {
+      if (bucket.sourcePath !== undefined) {
+        const source = sourceByPath.get(`${bucket.provider}\0${bucket.sourcePath}`);
+        return (
+          source !== undefined &&
+          ownerByFingerprint.get(sourceClaimKey(source.fingerprint, environment.environmentId)) ===
+            environment.environmentId
+        );
+      }
+      return (
+        ownedEnvironmentProviders.has(
+          environmentProviderKey(environment.environmentId, bucket.provider),
+        ) && readableProviders.has(bucket.provider)
+      );
+    }),
     sessionsByProvider,
   };
 }
@@ -318,7 +348,7 @@ export function mergeUsage(
     }
   }
 
-  const { ownedEnvironmentProviders, duplicates } = claimSources(current);
+  const { ownerByFingerprint, ownedEnvironmentProviders, duplicates } = claimSources(current);
   const providerCoverage = new Map<
     string,
     {
@@ -333,10 +363,15 @@ export function mergeUsage(
   >();
   for (const environment of current) {
     for (const source of environment.summary.sources) {
+      const exactOwner = ownerByFingerprint.get(
+        sourceClaimKey(source.fingerprint, environment.environmentId),
+      );
+      const ownsFallback = ownedEnvironmentProviders.has(
+        environmentProviderKey(environment.environmentId, source.fingerprint.provider),
+      );
       if (
-        !ownedEnvironmentProviders.has(
-          environmentProviderKey(environment.environmentId, source.fingerprint.provider),
-        )
+        (exactOwner !== undefined && exactOwner !== environment.environmentId) ||
+        (exactOwner === undefined && !ownsFallback)
       ) {
         continue;
       }
@@ -415,6 +450,7 @@ export function mergeUsage(
   for (const environment of current) {
     const { buckets, sessionsByProvider } = ownedContribution(
       environment,
+      ownerByFingerprint,
       ownedEnvironmentProviders,
     );
     if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -110,50 +110,117 @@ function fingerprintKey(fingerprint: UsageSourceFingerprint): string {
   ].join(" ");
 }
 
+function environmentProviderKey(environmentId: EnvironmentId, provider: UsageProviderKind): string {
+  return `${environmentId}\0${provider}`;
+}
+
 /**
- * Decides which environment owns each physical transcript directory.
+ * Decides which environment owns each connected provider-source group.
  *
  * Several environments on one machine (worktree servers, for instance) resolve
- * the same provider home and would otherwise double count every token. A complete
- * source wins over a partial duplicate; ties are sorted by
- * environment id so the owner does not change between renders. Fully failed
- * and missing sources cannot own a fingerprint.
+ * the same provider home and would otherwise double count every token. Buckets
+ * do not retain source attribution, so environments connected by any shared
+ * fingerprint must choose one owner for all of that provider's sources. The
+ * environment with the most complete/readable stores wins; ties are sorted by
+ * environment id so ownership does not change between renders.
  */
 function claimSources(environments: readonly EnvironmentUsage[]): {
-  readonly ownerByFingerprint: ReadonlyMap<string, EnvironmentId>;
+  readonly ownedEnvironmentProviders: ReadonlySet<string>;
   readonly duplicates: readonly string[];
 } {
-  const ownerByFingerprint = new Map<string, EnvironmentId>();
+  const ownedEnvironmentProviders = new Set<string>();
   const duplicates: string[] = [];
 
-  const candidates = environments
-    .flatMap((environment) =>
-      environment.summary.sources.flatMap((source) =>
-        source.status === "missing" || source.status === "failed" ? [] : [{ environment, source }],
-      ),
-    )
-    .sort((a, b) => {
-      const statusOrder =
-        Number(a.source.status === "partial") - Number(b.source.status === "partial");
-      return statusOrder || a.environment.environmentId.localeCompare(b.environment.environmentId);
+  for (const provider of new Set(
+    environments.flatMap((environment) =>
+      environment.summary.sources.map((source) => source.fingerprint.provider),
+    ),
+  )) {
+    const candidates = environments.flatMap((environment) => {
+      const sources = environment.summary.sources.filter(
+        (source) => source.fingerprint.provider === provider,
+      );
+      return sources.length === 0 ? [] : [{ environment, sources }];
     });
-
-  for (const { environment, source } of candidates) {
-    const key = fingerprintKey(source.fingerprint);
-    if (ownerByFingerprint.has(key)) {
-      duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
-      continue;
+    const byEnvironment = new Map(
+      candidates.map((candidate) => [candidate.environment.environmentId, candidate]),
+    );
+    const adjacent = new Map<EnvironmentId, Set<EnvironmentId>>(
+      candidates.map((candidate) => [candidate.environment.environmentId, new Set()]),
+    );
+    const environmentsByFingerprint = new Map<string, EnvironmentId[]>();
+    for (const candidate of candidates) {
+      for (const source of candidate.sources) {
+        const key = fingerprintKey(source.fingerprint);
+        const owners = environmentsByFingerprint.get(key) ?? [];
+        owners.push(candidate.environment.environmentId);
+        environmentsByFingerprint.set(key, owners);
+      }
     }
-    ownerByFingerprint.set(key, environment.environmentId);
+    for (const owners of environmentsByFingerprint.values()) {
+      const first = owners[0];
+      if (first === undefined) continue;
+      for (const owner of owners.slice(1)) {
+        adjacent.get(first)?.add(owner);
+        adjacent.get(owner)?.add(first);
+      }
+    }
+
+    const visited = new Set<EnvironmentId>();
+    for (const environmentId of [...byEnvironment.keys()].sort()) {
+      if (visited.has(environmentId)) continue;
+      const component: EnvironmentId[] = [];
+      const pending = [environmentId];
+      while (pending.length > 0) {
+        const current = pending.pop();
+        if (current === undefined || visited.has(current)) continue;
+        visited.add(current);
+        component.push(current);
+        for (const neighbor of adjacent.get(current) ?? []) pending.push(neighbor);
+      }
+
+      const ranked = component
+        .map((id) => byEnvironment.get(id))
+        .filter((candidate): candidate is NonNullable<typeof candidate> => candidate !== undefined)
+        .sort((a, b) => {
+          const aOk = a.sources.filter((source) => source.status === "ok").length;
+          const bOk = b.sources.filter((source) => source.status === "ok").length;
+          const aReadable = a.sources.filter(
+            (source) => source.status === "ok" || source.status === "partial",
+          ).length;
+          const bReadable = b.sources.filter(
+            (source) => source.status === "ok" || source.status === "partial",
+          ).length;
+          return (
+            bOk - aOk ||
+            bReadable - aReadable ||
+            a.environment.environmentId.localeCompare(b.environment.environmentId)
+          );
+        });
+      const winner = ranked[0];
+      if (winner === undefined) continue;
+      ownedEnvironmentProviders.add(
+        environmentProviderKey(winner.environment.environmentId, provider),
+      );
+      for (const candidate of ranked) {
+        for (const source of candidate.sources) {
+          if (candidate.environment.environmentId !== winner.environment.environmentId) {
+            duplicates.push(
+              `${candidate.environment.label}: ${source.fingerprint.resolvedHomePath}`,
+            );
+          }
+        }
+      }
+    }
   }
 
-  return { ownerByFingerprint, duplicates };
+  return { ownedEnvironmentProviders, duplicates };
 }
 
 /** Sources this environment owns after fingerprint claims, plus their buckets. */
 function ownedContribution(
   environment: EnvironmentUsage,
-  ownerByFingerprint: ReadonlyMap<string, EnvironmentId>,
+  ownedEnvironmentProviders: ReadonlySet<string>,
 ): {
   readonly buckets: readonly UsageBucket[];
   readonly sessionsByProvider: ReadonlyMap<UsageProviderKind, number>;
@@ -162,9 +229,10 @@ function ownedContribution(
   const sessionsByProvider = new Map<UsageProviderKind, number>();
   for (const source of environment.summary.sources) {
     if (source.status === "missing" || source.status === "failed") continue;
-    const key = fingerprintKey(source.fingerprint);
-    if (ownerByFingerprint.get(key) === environment.environmentId) {
-      const provider = source.fingerprint.provider;
+    const provider = source.fingerprint.provider;
+    if (
+      ownedEnvironmentProviders.has(environmentProviderKey(environment.environmentId, provider))
+    ) {
       ownedProviders.add(provider);
       // Distinct within a directory. Summing per-bucket session counts instead
       // would count a session once per day and model it spans.
@@ -239,7 +307,7 @@ export function mergeUsage(
     }
   }
 
-  const { ownerByFingerprint, duplicates } = claimSources(current);
+  const { ownedEnvironmentProviders, duplicates } = claimSources(current);
   const providerCoverage = new Map<
     string,
     {
@@ -254,8 +322,13 @@ export function mergeUsage(
   >();
   for (const environment of current) {
     for (const source of environment.summary.sources) {
-      const owner = ownerByFingerprint.get(fingerprintKey(source.fingerprint));
-      if (owner !== undefined && owner !== environment.environmentId) continue;
+      if (
+        !ownedEnvironmentProviders.has(
+          environmentProviderKey(environment.environmentId, source.fingerprint.provider),
+        )
+      ) {
+        continue;
+      }
       if (source.status === "missing") continue;
 
       const key = `${environment.environmentId}\0${source.fingerprint.provider}`;
@@ -329,7 +402,10 @@ export function mergeUsage(
   const contributingEnvironments: EnvironmentId[] = [];
 
   for (const environment of current) {
-    const { buckets, sessionsByProvider } = ownedContribution(environment, ownerByFingerprint);
+    const { buckets, sessionsByProvider } = ownedContribution(
+      environment,
+      ownedEnvironmentProviders,
+    );
     if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
 
     for (const [providerKind, providerSessions] of sessionsByProvider) {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -240,22 +240,53 @@ export function mergeUsage(
   }
 
   const { ownerByFingerprint, duplicates } = claimSources(current);
-  const incompleteSources: IncompleteUsageSource[] = [];
+  const providerCoverage = new Map<
+    string,
+    {
+      environmentId: EnvironmentId;
+      environmentLabel: string;
+      provider: UsageProviderKind;
+      sourcePath: string;
+      message: string | null;
+      hasReadableSource: boolean;
+      hasProblem: boolean;
+    }
+  >();
   for (const environment of current) {
     for (const source of environment.summary.sources) {
-      if (source.status !== "partial" && source.status !== "failed") continue;
       const owner = ownerByFingerprint.get(fingerprintKey(source.fingerprint));
       if (owner !== undefined && owner !== environment.environmentId) continue;
-      incompleteSources.push({
+      if (source.status === "missing") continue;
+
+      const key = `${environment.environmentId}\0${source.fingerprint.provider}`;
+      const coverage = providerCoverage.get(key) ?? {
         environmentId: environment.environmentId,
         environmentLabel: environment.label,
         provider: source.fingerprint.provider,
         sourcePath: source.fingerprint.resolvedHomePath,
-        status: source.status,
-        message: source.message,
-      });
+        message: null,
+        hasReadableSource: false,
+        hasProblem: false,
+      };
+      if (source.status === "ok" || source.status === "partial") {
+        coverage.hasReadableSource = true;
+      }
+      if (source.status === "partial" || source.status === "failed") {
+        if (!coverage.hasProblem) {
+          coverage.sourcePath = source.fingerprint.resolvedHomePath;
+          coverage.message = source.message;
+        }
+        coverage.hasProblem = true;
+      }
+      providerCoverage.set(key, coverage);
     }
   }
+  const incompleteSources: IncompleteUsageSource[] = [...providerCoverage.values()]
+    .filter((coverage) => coverage.hasProblem)
+    .map(({ hasReadableSource, hasProblem: _, ...coverage }) => ({
+      ...coverage,
+      status: hasReadableSource ? "partial" : "failed",
+    }));
 
   let costUsd = 0;
   let uncachedInputTokens = 0;


### PR DESCRIPTION
## Problem

T3 Code's Usage page does not include Kimi Code activity. Kimi Code's terminal UI and desktop app persist turn-scoped usage under separate session homes, so both surfaces are missing from provider totals, charts, and model breakdowns.

## What changed

- scan turn-scoped `usage.record` events from Kimi Code wire transcripts
- cover the Kimi Code TUI home and the platform-specific Kimi Desktop runtime home
- support `KIMI_CODE_HOME` and `KIMI_DESKTOP_DATA_DIR` overrides
- preserve uncached input, cache reads/writes, output, sessions, and models
- cache window-bounded transcript results without reusing narrow scans for wider requests
- propagate transcript walk/read failures into per-provider coverage health
- negotiate v4/v5 responses so rolling client and server upgrades remain decodable
- add Kimi Code presentation on web and mobile, plus user documentation

## Verification

- 10 focused usage test files: 96 tests passed
- targeted server, contracts, shared, web, and mobile typechecks passed
- focused lint, formatting, and `git diff --check` passed
- validated against local TUI and Desktop stores: 98 wire files across 14 sessions produced 6,073 turn-scoped usage records with expected models and token categories

## Merge order

This PR, #7877, #7904, and #7939 independently target the current v4 usage contract and each introduces v5. Every PR merged after the first must be rebased and advance the combined contract version before merge.

The available before/after usage captures contain private local totals, so they are not attached to this Draft.

Built with Codex (GPT-5).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Kimi Code provider to usage tracking
> - Adds `kimi` to the `UsageProviderKind` schema and bumps `USAGE_CONTRACT_VERSION` to 5, allowing the server and UI to track Kimi Code transcript activity.
> - The server parses Kimi `.jsonl` lines via `parseKimiLine` and discovers directories using `resolveTranscriptDirs`, covering both TUI and desktop paths.
> - Uses `negotiateUsageContractVersion` to fall back to the pre-Kimi contract (v4) when the client does not request v5, maintaining backward compatibility.
> - Updates `UsageAggregator` and `usageMerge` to split usage by physical `sourcePath`, enabling better cross-environment de-duplication.
> - Risk: Bumps `USAGE_SCAN_CACHE_VERSION` to 3, which invalidates existing scan caches and forces repopulation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc732f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the usage contract, scan cache, and cross-environment source ownership. A cache version bump forces a one-time cold rescan; merge logic changes can alter which environment’s totals win.
> 
> **Overview**
> Adds **Kimi Code** to usage totals by scanning TUI (`KIMI_CODE_HOME` / `~/.kimi-code`) and Desktop session homes, parsing turn-scoped `usage.record` lines, and showing the provider on web and mobile.
> 
> Bumps the usage contract to **v5** (`kimi` + optional `sourcePath`). Clients advertise `contractVersion`; servers still emit v4 without Kimi for older clients. Scan cache is **v3** with a `completeFromMs` bound so windowed Kimi scans are not reused for wider windows.
> 
> Walk/read failures now mark sources `partial`/`failed` instead of looking healthy. Merge claims stores by physical path, prefers the more complete environment, and surfaces `incompleteSources` in the coverage notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc732f73dd3db1c70a5c8cbd58f78c96e1056e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


