### PR TITLE
fix(server): stop completed Codex threads from staying stuck on working

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -513,6 +513,67 @@ function startLifecycleRuntime() {
 }
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
+  it.effect("does not reactivate an idle child after a parent interaction", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 3)).pipe(
+        Effect.forkChild,
+      );
+
+      const childEvent = (id: string, method: string, payload: Record<string, unknown>) => ({
+        id: asEventId(id),
+        kind: "notification" as const,
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method,
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        payload,
+      });
+
+      yield* runtime.emit(
+        childEvent("evt-child-running", "collabAgent/turnStarted", {
+          agentThreadId: "child-1",
+          agentPath: "/root/audit",
+        }),
+      );
+      yield* runtime.emit(
+        childEvent("evt-child-idle", "collabAgent/turnCompleted", {
+          agentThreadId: "child-1",
+          agentPath: "/root/audit",
+          turn: { status: "completed" },
+        }),
+      );
+      yield* runtime.emit(
+        childEvent("evt-child-interacted", "collabAgent/activity", {
+          agentThreadId: "child-1",
+          agentPath: "/root/audit",
+          activityKind: "interacted",
+        }),
+      );
+      yield* runtime.emit(
+        childEvent("evt-other-child-running", "collabAgent/turnStarted", {
+          agentThreadId: "child-2",
+          agentPath: "/root/other",
+        }),
+      );
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      NodeAssert.deepStrictEqual(
+        events.map((event) =>
+          event.type === "task.updated"
+            ? { taskId: event.payload.taskId, status: event.payload.status }
+            : { type: event.type },
+        ),
+        [
+          { taskId: "child-1", status: "running" },
+          { taskId: "child-1", status: "idle" },
+          { taskId: "child-2", status: "running" },
+        ],
+      );
+    }),
+  );
+
   it.effect("maps completed agent message items to canonical item.completed events", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -590,14 +590,9 @@ function mapCollabAgentEvent(
           },
         ];
       }
-      // interacted → the child is (again) actively driven.
-      return [
-        {
-          ...base,
-          type: "task.updated",
-          payload: { taskId, status: "running", ...statusLinkage },
-        },
-      ];
+      // Reading a child's result also emits "interacted" after its turn is idle.
+      // Only the child's turn or thread lifecycle can prove it resumed work.
+      return [];
     }
     case "collabAgent/turnStarted":
       return [


### PR DESCRIPTION
Completed Codex threads could stay stuck on "Working" because reading a finished subagent result marked the idle subagent as running again.

Ignore those interaction events when deriving subagent status. Real child turns and explicit active-status events still mark subagents as running.

Tests: 46 focused tests passed. Server typecheck passed.

Model: GPT-5.6 Sol. Harness: Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how collab subagent status is derived from provider events, which can leave tasks idle or running incorrectly if other activity kinds are still needed to mark work as resumed. Scope is a small mapping change with a regression test.
> 
> **Overview**
> Stops completed Codex threads from staying stuck on **Working** when a parent reads a finished subagent result.
> 
> `collabAgent/activity` with `activityKind: "interacted"` no longer maps to `task.updated` `running`. Idle children stay idle unless a real child turn or thread lifecycle event proves they resumed. Adds a lifecycle test covering idle → interacted → other child running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db85d831d4074cbbbe6c1975b7fa2421f9c10df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop `CodexAdapter` parent interaction from reactivating idle child tasks
> - Fixes a bug where completed Codex child threads stayed stuck on `running` because a parent `interacted` activity event incorrectly transitioned an idle child back to `running`
> - `mapCollabAgentEvent` in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/7937/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) now returns an empty array for the `collabAgent/activity` case with `activityKind === "interacted"`; only turn or thread lifecycle events can transition a child to `running`
> - Adds a regression test in [CodexAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/7937/files#diff-663e3d780fd51d280579d76e348513d7a984c58fa267fb77a31ea2bd72821087) verifying that a parent `interacted` activity does not emit a reactivation event for an idle child
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db85d83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->