### PR TITLE
fix(server): append terminal history output

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -740,6 +740,44 @@ it.layer(
     }),
   );
 
+  it.effect("publishes output before a concurrent clear", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      const outputStarted = yield* Deferred.make<void>();
+      const releaseOutput = yield* Deferred.make<void>();
+      const publishedEvents = yield* Ref.make<ReadonlyArray<"output" | "cleared">>([]);
+      const unsubscribe = yield* manager.subscribe((event) =>
+        Effect.gen(function* () {
+          if (event.type === "output") {
+            yield* Deferred.succeed(outputStarted, undefined);
+            yield* Deferred.await(releaseOutput);
+            yield* Ref.update(publishedEvents, (events) => [...events, "output"]);
+          } else if (event.type === "cleared") {
+            yield* Ref.update(publishedEvents, (events) => [...events, "cleared"]);
+          }
+        }),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      process.emitData("before clear\n");
+      yield* Deferred.await(outputStarted);
+
+      const clearFiber = yield* manager
+        .clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID })
+        .pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(releaseOutput, undefined);
+      yield* Fiber.join(clearFiber);
+
+      expect(yield* Ref.get(publishedEvents)).toEqual(["output", "cleared"]);
+    }),
+  );
+
   it.effect("restarts terminal with empty transcript and respawns pty", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, logsDir } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1242,6 +1242,24 @@ it.layer(
     }),
   );
 
+  it.effect("preserves Unicode split across terminal output chunks", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("before \ud83d");
+      process.emitData("\ude00 after\r");
+      yield* manager.close({ threadId: "thread-1" });
+
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(
+        "before 😀 after\r",
+      );
+    }),
+  );
+
   it.effect("strips replay-unsafe terminal query and reply sequences from persisted history", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1909,6 +1909,57 @@ it.layer(
     }),
   );
 
+  it.effect("discards failed persistence state when an inactive session is evicted", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const failedWrite = yield* Deferred.make<void>();
+      const exited = yield* Deferred.make<void>();
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: "terminal-history",
+      });
+      let rejectHistoryWrites = true;
+      const failingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (path, contents, options) => {
+          if (path.endsWith(".log") && rejectHistoryWrites) {
+            return Deferred.succeed(failedWrite, undefined).pipe(
+              Effect.andThen(Effect.fail(cause)),
+            );
+          }
+          return fileSystem.writeFileString(path, contents, options);
+        },
+      });
+      const { manager, ptyAdapter } = yield* createManager(100, {
+        maxRetainedInactiveSessions: 1,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem));
+      const unsubscribe = yield* manager.subscribe((event) =>
+        event.type === "exited" && event.threadId === "thread-1"
+          ? Deferred.succeed(exited, undefined)
+          : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      yield* manager.open(openInput({ threadId: "thread-1" }));
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("discarded after eviction\n");
+      yield* Deferred.await(failedWrite);
+      process.emitExit({ exitCode: 0, signal: 0 });
+      yield* Deferred.await(exited);
+      yield* manager.open(openInput({ threadId: "thread-2" }));
+
+      rejectHistoryWrites = false;
+      const reopened = yield* manager.open(openInput({ threadId: "thread-1" }));
+
+      expect(reopened.history).toBe("");
+    }),
+  );
+
   it.effect("migrates legacy transcript filenames to terminal-scoped history path on open", () =>
     Effect.gen(function* () {
       const { manager, logsDir } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -756,9 +756,9 @@ it.layer(
           if (event.type === "output") {
             yield* Deferred.succeed(outputStarted, undefined);
             yield* Deferred.await(releaseOutput);
-            yield* Ref.update(publishedEvents, (events) => [...events, "output"]);
+            yield* Ref.update(publishedEvents, (events) => events.concat("output"));
           } else if (event.type === "cleared") {
-            yield* Ref.update(publishedEvents, (events) => [...events, "cleared"]);
+            yield* Ref.update(publishedEvents, (events) => events.concat("cleared"));
           }
         }),
       );

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -785,31 +785,36 @@ it.layer(
 
   it.effect("flushes output queued while close waits for the thread lock", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, logsDir } = yield* createManager();
+      const fileSystem = yield* FileSystem.FileSystem;
+      const clearWriteStarted = yield* Deferred.make<void>();
+      const releaseClearWrite = yield* Deferred.make<void>();
+      const blockingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (path, contents, options) => {
+          if (path.endsWith(".log") && contents === "" && options?.flag === "w") {
+            return Deferred.succeed(clearWriteStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseClearWrite)),
+              Effect.andThen(fileSystem.writeFileString(path, contents, options)),
+            );
+          }
+          return fileSystem.writeFileString(path, contents, options);
+        },
+      });
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
+        Effect.provideService(FileSystem.FileSystem, blockingFileSystem),
+      );
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
       if (!process) return;
 
-      const clearPublished = yield* Deferred.make<void>();
-      const releaseClear = yield* Deferred.make<void>();
-      const unsubscribe = yield* manager.subscribe((event) =>
-        event.type === "cleared"
-          ? Deferred.succeed(clearPublished, undefined).pipe(
-              Effect.andThen(Deferred.await(releaseClear)),
-            )
-          : Effect.void,
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
-
       const clearFiber = yield* manager
         .clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID })
         .pipe(Effect.forkScoped);
-      yield* Deferred.await(clearPublished);
+      yield* Deferred.await(clearWriteStarted);
       const closeFiber = yield* manager.close({ threadId: "thread-1" }).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
       process.emitData("last output before close\r");
-      yield* Deferred.succeed(releaseClear, undefined);
+      yield* Deferred.succeed(releaseClearWrite, undefined);
       yield* Fiber.join(clearFiber);
       yield* Fiber.join(closeFiber);
 
@@ -836,7 +841,7 @@ it.layer(
     }),
   );
 
-  it.effect("drops delayed output from a closed session after recreation", () =>
+  it.effect("delivers delayed output before close and recreation", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
       yield* manager.open(openInput());
@@ -885,13 +890,14 @@ it.layer(
           deleteHistory: true,
         })
         .pipe(Effect.andThen(manager.restart(restartInput())), Effect.forkScoped);
-      yield* Deferred.await(restartedDelivered);
       yield* Deferred.succeed(releaseOutput, undefined);
       yield* Fiber.join(recreateFiber);
       yield* Deferred.await(outputFinished);
+      yield* Deferred.await(restartedDelivered);
 
       expect((yield* Ref.get(attachEvents)).map((event) => event.type)).toEqual([
         "snapshot",
+        "output",
         "closed",
         "restarted",
       ]);
@@ -1492,6 +1498,24 @@ it.layer(
 
       const opened = yield* manager.open(openInput());
       const expected = oversizedHistory.slice(-12);
+
+      expect(opened.history).toBe(expected);
+      expect(yield* readFileString(historyPath)).toBe(expected);
+    }),
+  );
+
+  it.effect("retains a bounded oversized line that ends with a newline", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager(100, {
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
+      const historyPath = yield* historyLogPath(logsDir);
+      const oversizedHistory = `${"x".repeat(40)}\n`;
+      const expected = Buffer.from(oversizedHistory).subarray(-12).toString();
+      yield* writeFileString(historyPath, oversizedHistory);
+
+      const opened = yield* manager.open(openInput());
 
       expect(opened.history).toBe(expected);
       expect(yield* readFileString(historyPath)).toBe(expected);

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -2235,19 +2235,11 @@ it.layer(
         };
       }).pipe(Effect.forkScoped);
       yield* Effect.yieldNow;
-      const outputDelivered = yield* Deferred.make<void>();
-      const unsubscribe = yield* manager.subscribe((event) =>
-        event.type === "output" && event.data === "saved during shutdown\r"
-          ? Deferred.succeed(outputDelivered, undefined)
-          : Effect.void,
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
       process.emitData("saved during shutdown\r");
-      yield* Effect.yieldNow;
-      yield* TestClock.adjust("40 millis");
-      yield* Deferred.await(outputDelivered);
 
       const closeScope = yield* Scope.close(scope, Exit.void).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("40 millis");
       yield* Fiber.join(terminateStartedFiber);
       yield* TestClock.adjust("10 millis");
       yield* Fiber.join(closeScope);

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -740,7 +740,7 @@ it.layer(
     }),
   );
 
-  it.effect("publishes output before a concurrent clear", () =>
+  it.effect("drops delayed output published after a concurrent clear", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
       yield* manager.open(openInput());
@@ -750,19 +750,32 @@ it.layer(
 
       const outputStarted = yield* Deferred.make<void>();
       const releaseOutput = yield* Deferred.make<void>();
-      const publishedEvents = yield* Ref.make<ReadonlyArray<"output" | "cleared">>([]);
-      const unsubscribe = yield* manager.subscribe((event) =>
+      const outputFinished = yield* Deferred.make<void>();
+      const clearedDelivered = yield* Deferred.make<void>();
+      const blockerUnsubscribe = yield* manager.subscribe((event) =>
         Effect.gen(function* () {
           if (event.type === "output") {
             yield* Deferred.succeed(outputStarted, undefined);
             yield* Deferred.await(releaseOutput);
-            yield* Ref.update(publishedEvents, (events) => events.concat("output"));
-          } else if (event.type === "cleared") {
-            yield* Ref.update(publishedEvents, (events) => events.concat("cleared"));
           }
         }),
       );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+      yield* Effect.addFinalizer(() => Effect.sync(blockerUnsubscribe));
+
+      const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
+      const attachUnsubscribe = yield* manager.attachStream(openInput(), (event) =>
+        Ref.update(attachEvents, (events) => [...events, event]).pipe(
+          Effect.andThen(
+            event.type === "cleared" ? Deferred.succeed(clearedDelivered, undefined) : Effect.void,
+          ),
+        ),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(attachUnsubscribe));
+
+      const observerUnsubscribe = yield* manager.subscribe((event) =>
+        event.type === "output" ? Deferred.succeed(outputFinished, undefined) : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(observerUnsubscribe));
 
       process.emitData("before clear\n");
       yield* Deferred.await(outputStarted);
@@ -770,11 +783,15 @@ it.layer(
       const clearFiber = yield* manager
         .clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID })
         .pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
+      yield* Deferred.await(clearedDelivered);
       yield* Deferred.succeed(releaseOutput, undefined);
       yield* Fiber.join(clearFiber);
+      yield* Deferred.await(outputFinished);
 
-      expect(yield* Ref.get(publishedEvents)).toEqual(["output", "cleared"]);
+      expect((yield* Ref.get(attachEvents)).map((event) => event.type)).toEqual([
+        "snapshot",
+        "cleared",
+      ]);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1982,6 +1982,43 @@ it.layer(
     }),
   );
 
+  it.effect("does not duplicate pending output between attach history and live events", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
+        ptyAdapter: new FakePtyAdapter("async"),
+      });
+      yield* manager.open(openInput());
+
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("pending\n");
+
+      const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
+      const unsubscribe = yield* manager.attachStream(openInput(), (event) =>
+        Ref.update(attachEvents, (events) => [...events, event]),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      yield* waitFor(
+        Effect.map(getEvents, (events) =>
+          events.some((event) => event.type === "output" && event.data === "pending\n"),
+        ),
+        "1200 millis",
+      );
+
+      const replayedText = (yield* Ref.get(attachEvents))
+        .map((event) => {
+          if (event.type === "snapshot") return event.snapshot.history;
+          if (event.type === "output") return event.data;
+          return "";
+        })
+        .join("");
+      expect(replayedText.split("pending\n")).toHaveLength(2);
+    }),
+  );
+
   it.effect("preserves queued PTY output ordering through exit callbacks", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, getEvents } = yield* createManager({

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1439,6 +1439,49 @@ it.layer(
     }),
   );
 
+  it.effect("retains failed history across repeated retries without a session", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const failedWrite = yield* Deferred.make<void>();
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: "terminal-history",
+      });
+      let rejectHistoryWrites = true;
+      const recoveringFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (path, contents, options) => {
+          if (path.endsWith(".log") && rejectHistoryWrites) {
+            return Deferred.succeed(failedWrite, undefined).pipe(
+              Effect.andThen(Effect.fail(cause)),
+            );
+          }
+          return fileSystem.writeFileString(path, contents, options);
+        },
+      });
+      const { manager, ptyAdapter } = yield* createManager(100).pipe(
+        Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
+      );
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("survives repeated retry\n");
+      yield* Deferred.await(failedWrite);
+      yield* manager.close({ threadId: "thread-1" });
+      yield* manager.close({ threadId: "thread-1" });
+
+      rejectHistoryWrites = false;
+      yield* manager.close({ threadId: "thread-1" });
+      const reopened = yield* manager.open(openInput());
+
+      expect(reopened.history).toBe("survives repeated retry\n");
+    }),
+  );
+
   it.effect("recovers a failed truncate with the latest capped history", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -781,6 +781,41 @@ it.layer(
     }),
   );
 
+  it.effect("flushes output queued while close waits for the thread lock", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      const clearPublished = yield* Deferred.make<void>();
+      const releaseClear = yield* Deferred.make<void>();
+      const unsubscribe = yield* manager.subscribe((event) =>
+        event.type === "cleared"
+          ? Deferred.succeed(clearPublished, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseClear)),
+            )
+          : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      const clearFiber = yield* manager
+        .clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(clearPublished);
+      const closeFiber = yield* manager.close({ threadId: "thread-1" }).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      process.emitData("last output before close\r");
+      yield* Deferred.succeed(releaseClear, undefined);
+      yield* Fiber.join(clearFiber);
+      yield* Fiber.join(closeFiber);
+
+      const historyPath = yield* historyLogPath(logsDir);
+      expect(yield* readFileString(historyPath)).toBe("last output before close\r");
+    }),
+  );
+
   it.effect("drops delayed output from a closed session after recreation", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -1291,7 +1326,7 @@ it.layer(
     }),
   );
 
-  it.effect("retries a failed history append before close completes", () =>
+  it.effect("recovers a partially written history append before close completes", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const failedAppend = yield* Deferred.make<void>();
@@ -1312,9 +1347,12 @@ it.layer(
             shouldFailAppend
           ) {
             shouldFailAppend = false;
-            return Deferred.succeed(failedAppend, undefined).pipe(
-              Effect.andThen(Effect.fail(cause)),
-            );
+            return fileSystem
+              .writeFileString(path, contents.slice(0, 4), options)
+              .pipe(
+                Effect.andThen(Deferred.succeed(failedAppend, undefined)),
+                Effect.andThen(Effect.fail(cause)),
+              );
           }
           return fileSystem.writeFileString(path, contents, options);
         },

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -203,6 +203,8 @@ const multiTerminalHistoryLogPath = (
   );
 
 interface CreateManagerOptions {
+  historyTargetBytes?: number;
+  historyMaxBytes?: number;
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: (terminalPid: number) => Effect.Effect<{
@@ -242,6 +244,12 @@ const createManager = (
       const manager = yield* TerminalManager.makeWithOptions({
         logsDir,
         historyLineLimit,
+        ...(options.historyTargetBytes !== undefined
+          ? { historyTargetBytes: options.historyTargetBytes }
+          : {}),
+        ...(options.historyMaxBytes !== undefined
+          ? { historyMaxBytes: options.historyMaxBytes }
+          : {}),
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
         ...(options.env !== undefined ? { env: options.env } : {}),
@@ -443,6 +451,26 @@ it.layer(
     Effect.flatMap(Effect.service(FileSystem.FileSystem), (fs) =>
       fs.writeFileString(filePath, contents),
     );
+
+  interface RecordedHistoryWrite {
+    readonly contents: string;
+    readonly flag: FileSystem.OpenFlag | undefined;
+  }
+
+  function recordHistoryWrites(
+    fileSystem: FileSystem.FileSystem,
+    writes: Array<RecordedHistoryWrite>,
+  ): FileSystem.FileSystem {
+    return FileSystem.FileSystem.of({
+      ...fileSystem,
+      writeFileString: (path, contents, options) =>
+        Effect.sync(() => {
+          if (path.endsWith(".log")) {
+            writes.push({ contents, flag: options?.flag });
+          }
+        }).pipe(Effect.andThen(fileSystem.writeFileString(path, contents, options))),
+    });
+  }
 
   it.effect("reports a missing cwd without an artificial cause", () =>
     Effect.gen(function* () {
@@ -1087,6 +1115,72 @@ it.layer(
       const reopened = yield* manager.open(openInput());
       const nonEmptyLines = reopened.history.split("\n").filter((line) => line.length > 0);
       expect(nonEmptyLines).toEqual(["line2", "line3", "line4"]);
+    }),
+  );
+
+  it.effect("appends normal terminal history writes", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const writes: Array<RecordedHistoryWrite> = [];
+      const { manager, ptyAdapter } = yield* createManager(100).pipe(
+        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
+      );
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("first redraw\r");
+      process.emitData("second redraw\r");
+      yield* manager.close({ threadId: "thread-1" });
+
+      expect(writes.length).toBeGreaterThan(0);
+      expect(writes.every((write) => write.flag === "a")).toBe(true);
+      expect(writes.map((write) => write.contents).join("")).toBe("first redraw\rsecond redraw\r");
+    }),
+  );
+
+  it.effect("compacts carriage-return redraw history at the byte limit", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const writes: Array<RecordedHistoryWrite> = [];
+      const { manager, ptyAdapter, logsDir } = yield* createManager(100, {
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      }).pipe(
+        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
+      );
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("old-one\r");
+      process.emitData("old-two\r");
+      process.emitData("new-one\rnew-two\r");
+      yield* manager.close({ threadId: "thread-1" });
+
+      const historyPath = yield* historyLogPath(logsDir);
+      const persisted = yield* readFileString(historyPath);
+      expect(persisted).toBe("new-two\r");
+      expect(Buffer.byteLength(persisted)).toBeLessThanOrEqual(12);
+      expect(writes.some((write) => write.flag === "w")).toBe(true);
+    }),
+  );
+
+  it.effect("compacts oversized existing terminal history on open", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager(100, {
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
+      const historyPath = yield* historyLogPath(logsDir);
+      yield* writeFileString(historyPath, "old-one\rold-two\rnew-one\rnew-two\r");
+
+      const opened = yield* manager.open(openInput());
+
+      expect(opened.history).toBe("new-two\r");
+      expect(yield* readFileString(historyPath)).toBe("new-two\r");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
@@ -1137,6 +1138,51 @@ it.layer(
       expect(writes.length).toBeGreaterThan(0);
       expect(writes.every((write) => write.flag === "a")).toBe(true);
       expect(writes.map((write) => write.contents).join("")).toBe("first redraw\rsecond redraw\r");
+    }),
+  );
+
+  it.effect("retries a failed history append before close completes", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const failedAppend = yield* Deferred.make<void>();
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: "terminal-history",
+      });
+      let shouldFailAppend = true;
+      const recoveringFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (path, contents, options) => {
+          if (
+            path.endsWith(".log") &&
+            options?.flag === "a" &&
+            contents.length > 0 &&
+            shouldFailAppend
+          ) {
+            shouldFailAppend = false;
+            return Deferred.succeed(failedAppend, undefined).pipe(
+              Effect.andThen(Effect.fail(cause)),
+            );
+          }
+          return fileSystem.writeFileString(path, contents, options);
+        },
+      });
+      const { manager, ptyAdapter, logsDir } = yield* createManager(100).pipe(
+        Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
+      );
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("survives retry\r");
+      yield* Deferred.await(failedAppend);
+      yield* manager.close({ threadId: "thread-1" });
+
+      const historyPath = yield* historyLogPath(logsDir);
+      expect(yield* readFileString(historyPath)).toBe("survives retry\r");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -723,6 +723,23 @@ it.layer(
     }),
   );
 
+  it.effect("does not persist output after a concurrent clear", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("stale redraw\r");
+      yield* manager.clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID });
+      yield* manager.close({ threadId: "thread-1" });
+
+      const historyPath = yield* historyLogPath(logsDir);
+      expect(yield* readFileString(historyPath)).toBe("");
+    }),
+  );
+
   it.effect("restarts terminal with empty transcript and respawns pty", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, logsDir } = yield* createManager();
@@ -1227,6 +1244,24 @@ it.layer(
 
       expect(opened.history).toBe("new-two\r");
       expect(yield* readFileString(historyPath)).toBe("new-two\r");
+    }),
+  );
+
+  it.effect("retains a bounded suffix from oversized history without line breaks", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager(100, {
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
+      const historyPath = yield* historyLogPath(logsDir);
+      const oversizedHistory = "abcdefghijklmnopqrstuvwxyz0123456789";
+      yield* writeFileString(historyPath, oversizedHistory);
+
+      const opened = yield* manager.open(openInput());
+      const expected = oversizedHistory.slice(-12);
+
+      expect(opened.history).toBe(expected);
+      expect(yield* readFileString(historyPath)).toBe(expected);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -26,7 +26,7 @@ import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
-import { expect, vi } from "vite-plus/test";
+import { expect } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
 import * as TerminalManager from "./Manager.ts";
@@ -44,7 +44,6 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   writeFailure: unknown | undefined;
   resizeFailure: unknown | undefined;
   killObserver: ((signal: string | undefined) => void) | undefined;
-  dataUnsubscribeObserver: (() => void) | undefined;
   private readonly dataListeners = new Set<(data: string) => void>();
   private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
   killed = false;
@@ -76,7 +75,6 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   onData(callback: (data: string) => void): () => void {
     this.dataListeners.add(callback);
     return () => {
-      this.dataUnsubscribeObserver?.();
       this.dataListeners.delete(callback);
     };
   }
@@ -221,6 +219,7 @@ interface CreateManagerOptions {
   processKillGraceMs?: number;
   maxRetainedInactiveSessions?: number;
   ptyAdapter?: FakePtyAdapter;
+  managerScope?: Scope.Scope;
 }
 
 interface ManagerFixture {
@@ -232,7 +231,6 @@ interface ManagerFixture {
 }
 
 const createManager = (
-  historyLineLimit = 5,
   options: CreateManagerOptions = {},
 ): Effect.Effect<
   ManagerFixture,
@@ -246,9 +244,8 @@ const createManager = (
       const logsDir = join(baseDir, "userdata", "logs", "terminals");
       const ptyAdapter = options.ptyAdapter ?? new FakePtyAdapter();
 
-      const manager = yield* TerminalManager.makeWithOptions({
+      const managerEffect = TerminalManager.makeWithOptions({
         logsDir,
-        historyLineLimit,
         ...(options.historyTargetBytes !== undefined
           ? { historyTargetBytes: options.historyTargetBytes }
           : {}),
@@ -269,6 +266,9 @@ const createManager = (
           ? { maxRetainedInactiveSessions: options.maxRetainedInactiveSessions }
           : {}),
       });
+      const manager = yield* options.managerScope === undefined
+        ? managerEffect
+        : managerEffect.pipe(Effect.provideService(Scope.Scope, options.managerScope));
       const eventsRef = yield* Ref.make<ReadonlyArray<TerminalEvent>>([]);
       const unsubscribe = yield* manager.subscribe((event) =>
         Ref.update(eventsRef, (events) => [...events, event]),
@@ -336,7 +336,7 @@ it.layer(
     }),
   );
 
-  it.effect("keeps attach streams live when a terminal id is closed and recreated", () =>
+  it.effect("keeps attach streams live when a terminal id is closed and reopened", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
       const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
@@ -351,52 +351,13 @@ it.layer(
         deleteHistory: true,
       });
       yield* manager.open(openInput());
-      yield* manager.close({
-        threadId: "thread-1",
-        terminalId: DEFAULT_TERMINAL_ID,
-        deleteHistory: true,
-      });
-      yield* manager.restart(restartInput());
 
       const events = yield* Ref.get(attachEvents);
-      expect(events.map((event) => event.type)).toEqual([
-        "snapshot",
-        "closed",
-        "snapshot",
-        "closed",
-        "restarted",
-      ]);
+      expect(events.map((event) => event.type)).toEqual(["snapshot", "closed", "snapshot"]);
       expect(
-        events
-          .filter((event) => event.type === "snapshot" || event.type === "restarted")
-          .map((event) => event.snapshot.status),
-      ).toEqual(["running", "running", "running"]);
-      expect(ptyAdapter.spawnInputs).toHaveLength(3);
-    }),
-  );
-
-  it.effect("delivers reopen errors after a terminal id is closed", () =>
-    Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager();
-      const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
-      const unsubscribe = yield* manager.attachStream(openInput(), (event) =>
-        Ref.update(attachEvents, (events) => [...events, event]),
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
-
-      yield* manager.close({
-        threadId: "thread-1",
-        terminalId: DEFAULT_TERMINAL_ID,
-        deleteHistory: true,
-      });
-      ptyAdapter.spawnFailures.push(new Error("permission denied"));
-      yield* manager.restart(restartInput());
-
-      expect((yield* Ref.get(attachEvents)).map((event) => event.type)).toEqual([
-        "snapshot",
-        "closed",
-        "error",
-      ]);
+        events.filter((event) => event.type === "snapshot").map((event) => event.snapshot.status),
+      ).toEqual(["running", "running"]);
+      expect(ptyAdapter.spawnInputs).toHaveLength(2);
     }),
   );
 
@@ -501,20 +462,19 @@ it.layer(
     readonly flag: FileSystem.OpenFlag | undefined;
   }
 
-  function recordHistoryWrites(
+  const recordHistoryWrites = (
     fileSystem: FileSystem.FileSystem,
     writes: Array<RecordedHistoryWrite>,
-  ): FileSystem.FileSystem {
-    return FileSystem.FileSystem.of({
+  ): FileSystem.FileSystem =>
+    FileSystem.FileSystem.of({
       ...fileSystem,
-      writeFileString: (path, contents, options) =>
+      writeFileString: (filePath, contents, options) =>
         Effect.sync(() => {
-          if (path.endsWith(".log")) {
+          if (filePath.endsWith(".log")) {
             writes.push({ contents, flag: options?.flag });
           }
-        }).pipe(Effect.andThen(fileSystem.writeFileString(path, contents, options))),
+        }).pipe(Effect.andThen(fileSystem.writeFileString(filePath, contents, options))),
     });
-  }
 
   it.effect("reports a missing cwd without an artificial cause", () =>
     Effect.gen(function* () {
@@ -577,7 +537,7 @@ it.layer(
 
   it.effect("supports asynchronous PTY spawn effects", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
 
@@ -763,183 +723,6 @@ it.layer(
             event.terminalId === DEFAULT_TERMINAL_ID,
         ),
       ).toBe(true);
-    }),
-  );
-
-  it.effect("does not persist output after a concurrent clear", () =>
-    Effect.gen(function* () {
-      const { manager, ptyAdapter, logsDir } = yield* createManager();
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("stale redraw\r");
-      yield* manager.clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID });
-      yield* manager.close({ threadId: "thread-1" });
-
-      const historyPath = yield* historyLogPath(logsDir);
-      expect(yield* readFileString(historyPath)).toBe("");
-    }),
-  );
-
-  it.effect("flushes output queued while close waits for the thread lock", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const clearWriteStarted = yield* Deferred.make<void>();
-      const releaseClearWrite = yield* Deferred.make<void>();
-      const blockingFileSystem = FileSystem.FileSystem.of({
-        ...fileSystem,
-        writeFileString: (path, contents, options) => {
-          if (path.endsWith(".log") && contents === "" && options?.flag === "w") {
-            return Deferred.succeed(clearWriteStarted, undefined).pipe(
-              Effect.andThen(Deferred.await(releaseClearWrite)),
-              Effect.andThen(fileSystem.writeFileString(path, contents, options)),
-            );
-          }
-          return fileSystem.writeFileString(path, contents, options);
-        },
-      });
-      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
-        Effect.provideService(FileSystem.FileSystem, blockingFileSystem),
-      );
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      const clearFiber = yield* manager
-        .clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID })
-        .pipe(Effect.forkScoped);
-      yield* Deferred.await(clearWriteStarted);
-      const closeFiber = yield* manager.close({ threadId: "thread-1" }).pipe(Effect.forkScoped);
-      process.emitData("last output before close\r");
-      yield* Deferred.succeed(releaseClearWrite, undefined);
-      yield* Fiber.join(clearFiber);
-      yield* Fiber.join(closeFiber);
-
-      const historyPath = yield* historyLogPath(logsDir);
-      expect(yield* readFileString(historyPath)).toBe("last output before close\r");
-    }),
-  );
-
-  it.effect("flushes output received while close unsubscribes from the PTY", () =>
-    Effect.gen(function* () {
-      const { manager, ptyAdapter, logsDir } = yield* createManager();
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.dataUnsubscribeObserver = () => {
-        process.emitData("last output during close\r");
-      };
-      yield* manager.close({ threadId: "thread-1" });
-
-      const historyPath = yield* historyLogPath(logsDir);
-      expect(yield* readFileString(historyPath)).toBe("last output during close\r");
-    }),
-  );
-
-  it.effect("delivers delayed output before close and recreation", () =>
-    Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager();
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      const outputStarted = yield* Deferred.make<void>();
-      const releaseOutput = yield* Deferred.make<void>();
-      const outputFinished = yield* Deferred.make<void>();
-      const restartedDelivered = yield* Deferred.make<void>();
-      const blockerUnsubscribe = yield* manager.subscribe((event) =>
-        Effect.gen(function* () {
-          if (event.type === "output") {
-            yield* Deferred.succeed(outputStarted, undefined);
-            yield* Deferred.await(releaseOutput);
-          }
-        }),
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(blockerUnsubscribe));
-
-      const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
-      const attachUnsubscribe = yield* manager.attachStream(openInput(), (event) =>
-        Ref.update(attachEvents, (events) => [...events, event]).pipe(
-          Effect.andThen(
-            event.type === "restarted"
-              ? Deferred.succeed(restartedDelivered, undefined)
-              : Effect.void,
-          ),
-        ),
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(attachUnsubscribe));
-
-      const observerUnsubscribe = yield* manager.subscribe((event) =>
-        event.type === "output" ? Deferred.succeed(outputFinished, undefined) : Effect.void,
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(observerUnsubscribe));
-
-      process.emitData("before recreation\n");
-      yield* Deferred.await(outputStarted);
-
-      const recreateFiber = yield* manager
-        .close({
-          threadId: "thread-1",
-          terminalId: DEFAULT_TERMINAL_ID,
-          deleteHistory: true,
-        })
-        .pipe(Effect.andThen(manager.restart(restartInput())), Effect.forkScoped);
-      yield* Deferred.succeed(releaseOutput, undefined);
-      yield* Fiber.join(recreateFiber);
-      yield* Deferred.await(outputFinished);
-      yield* Deferred.await(restartedDelivered);
-
-      expect((yield* Ref.get(attachEvents)).map((event) => event.type)).toEqual([
-        "snapshot",
-        "output",
-        "closed",
-        "restarted",
-      ]);
-    }),
-  );
-
-  it.effect("allows event subscribers to call terminal lifecycle methods", () =>
-    Effect.gen(function* () {
-      const { manager } = yield* createManager();
-      const eventTypes: TerminalEvent["type"][] = [];
-      let ranLifecycleMethods = false;
-      let reopened = false;
-
-      const unsubscribe = yield* manager.subscribe((event) =>
-        Effect.gen(function* () {
-          eventTypes.push(event.type);
-
-          if (event.type === "started" && ranLifecycleMethods === false) {
-            ranLifecycleMethods = true;
-            yield* manager.clear({
-              threadId: event.threadId,
-              terminalId: event.terminalId,
-            });
-            yield* manager.restart(restartInput());
-            yield* manager.close({
-              threadId: event.threadId,
-              terminalId: event.terminalId,
-            });
-            return;
-          }
-
-          if (event.type === "closed" && reopened === false) {
-            reopened = true;
-            yield* manager.open(openInput());
-          }
-        }).pipe(Effect.orDie),
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
-
-      yield* manager.open(openInput());
-
-      expect(eventTypes).toEqual(["started", "cleared", "restarted", "closed", "started"]);
     }),
   );
 
@@ -1141,7 +924,7 @@ it.layer(
         readonly childCommand: string | null;
         readonly processIds: ReadonlyArray<number>;
       } = { hasRunningSubprocess: false, childCommand: null, processIds: [] };
-      const { manager, getEvents } = yield* createManager(5, {
+      const { manager, getEvents } = yield* createManager({
         subprocessInspector: () => Effect.succeed(inspect),
         subprocessPollIntervalMs: 20,
       });
@@ -1180,7 +963,7 @@ it.layer(
   it.effect("does not invoke subprocess polling until a terminal session is running", () =>
     Effect.gen(function* () {
       let checks = 0;
-      const { manager } = yield* createManager(5, {
+      const { manager } = yield* createManager({
         subprocessInspector: () => {
           checks += 1;
           return Effect.succeed({
@@ -1228,7 +1011,7 @@ it.layer(
           }),
       };
 
-      const { manager, getEvents } = yield* createManager(5, {
+      const { manager, getEvents } = yield* createManager({
         subprocessPollIntervalMs: 20,
       }).pipe(
         Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
@@ -1289,7 +1072,7 @@ it.layer(
           }),
       };
 
-      const { manager, getEvents } = yield* createManager(5, {
+      const { manager, getEvents } = yield* createManager({
         subprocessPollIntervalMs: 20,
       }).pipe(
         Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
@@ -1322,28 +1105,11 @@ it.layer(
     }),
   );
 
-  it.effect("caps persisted history to configured line limit", () =>
-    Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(3);
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("line1\nline2\nline3\nline4\n");
-      yield* manager.close({ threadId: "thread-1" });
-
-      const reopened = yield* manager.open(openInput());
-      const nonEmptyLines = reopened.history.split("\n").filter((line) => line.length > 0);
-      expect(nonEmptyLines).toEqual(["line2", "line3", "line4"]);
-    }),
-  );
-
-  it.effect("appends normal terminal history writes", () =>
+  it.effect("appends normal terminal output without rewriting history", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const writes: Array<RecordedHistoryWrite> = [];
-      const { manager, ptyAdapter } = yield* createManager(100).pipe(
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
         Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
       );
       yield* manager.open(openInput());
@@ -1351,47 +1117,83 @@ it.layer(
       expect(process).toBeDefined();
       if (!process) return;
 
-      process.emitData("first redraw\r");
-      process.emitData("second redraw\r");
+      const output = Array.from({ length: 100 }, (_, index) => `redraw ${index}\r`).join("");
+      for (let index = 0; index < 100; index += 1) {
+        process.emitData(`redraw ${index}\r`);
+      }
       yield* manager.close({ threadId: "thread-1" });
 
-      expect(writes.length).toBeGreaterThan(0);
+      expect(writes.length).toBeLessThan(100);
       expect(writes.every((write) => write.flag === "a")).toBe(true);
-      expect(writes.map((write) => write.contents).join("")).toBe("first redraw\rsecond redraw\r");
+      expect(writes.map((write) => write.contents).join("")).toBe(output);
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(output);
     }),
   );
 
-  it.effect("does not rescan coalesced history payloads", () =>
+  it.effect("uses truncation only for clear and restart resets", () =>
     Effect.gen(function* () {
-      const byteLength = vi.spyOn(Buffer, "byteLength");
-      yield* Effect.addFinalizer(() => Effect.sync(() => byteLength.mockRestore()));
-      const lastOutputDelivered = yield* Deferred.make<void>();
-      const { manager, ptyAdapter } = yield* createManager(100);
-      const unsubscribe = yield* manager.subscribe((event) =>
-        event.type === "output" && event.data === "c"
-          ? Deferred.succeed(lastOutputDelivered, undefined)
-          : Effect.void,
+      const fileSystem = yield* FileSystem.FileSystem;
+      const writes: Array<RecordedHistoryWrite> = [];
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
+        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
       );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+      yield* manager.open(openInput());
+      const firstProcess = ptyAdapter.processes[0];
+      expect(firstProcess).toBeDefined();
+      if (!firstProcess) return;
+
+      firstProcess.emitData("before clear\r");
+      yield* manager.clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID });
+      firstProcess.emitData("before restart\r");
+      yield* manager.restart(restartInput());
+
+      expect(writes.filter((write) => write.flag === "w")).toEqual([
+        { contents: "", flag: "w" },
+        { contents: "", flag: "w" },
+      ]);
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe("");
+    }),
+  );
+
+  it.effect("compacts carriage-return history at the configured byte limit", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager({
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
       if (!process) return;
 
-      process.emitData("a");
-      process.emitData("b");
-      process.emitData("c");
-      yield* Deferred.await(lastOutputDelivered);
-
-      expect(byteLength).not.toHaveBeenCalledWith("ab");
-      expect(byteLength).not.toHaveBeenCalledWith("bc");
-      expect(byteLength).not.toHaveBeenCalledWith("abc");
-      byteLength.mockRestore();
+      process.emitData("old-one\r");
+      process.emitData("old-two\r");
+      process.emitData("new-one\rnew-two\r");
       yield* manager.close({ threadId: "thread-1" });
+
+      const persisted = yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString));
+      expect(persisted).toBe("new-two\r");
+      expect(Buffer.byteLength(persisted)).toBeLessThanOrEqual(12);
     }),
   );
 
-  it.effect("recovers a partially written history append before close completes", () =>
+  it.effect("compacts oversized existing history on open", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager({
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
+      const filePath = yield* historyLogPath(logsDir);
+      yield* writeFileString(filePath, "old-one\rold-two\rnew-one\rnew-two\r");
+
+      const opened = yield* manager.open(openInput());
+
+      expect(opened.history).toBe("new-two\r");
+      expect(yield* readFileString(filePath)).toBe("new-two\r");
+    }),
+  );
+
+  it.effect("recovers a partially written append with bounded history", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const failedAppend = yield* Deferred.make<void>();
@@ -1404,25 +1206,25 @@ it.layer(
       let shouldFailAppend = true;
       const recoveringFileSystem = FileSystem.FileSystem.of({
         ...fileSystem,
-        writeFileString: (path, contents, options) => {
+        writeFileString: (filePath, contents, options) => {
           if (
-            path.endsWith(".log") &&
+            filePath.endsWith(".log") &&
             options?.flag === "a" &&
             contents.length > 0 &&
             shouldFailAppend
           ) {
             shouldFailAppend = false;
             return fileSystem
-              .writeFileString(path, contents.slice(0, 4), options)
+              .writeFileString(filePath, contents.slice(0, 4), options)
               .pipe(
                 Effect.andThen(Deferred.succeed(failedAppend, undefined)),
                 Effect.andThen(Effect.fail(cause)),
               );
           }
-          return fileSystem.writeFileString(path, contents, options);
+          return fileSystem.writeFileString(filePath, contents, options);
         },
       });
-      const { manager, ptyAdapter, logsDir } = yield* createManager(100).pipe(
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
         Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
       );
       yield* manager.open(openInput());
@@ -1430,193 +1232,13 @@ it.layer(
       expect(process).toBeDefined();
       if (!process) return;
 
-      process.emitData("survives retry\r");
+      process.emitData("survives recovery\r");
       yield* Deferred.await(failedAppend);
       yield* manager.close({ threadId: "thread-1" });
 
-      const historyPath = yield* historyLogPath(logsDir);
-      expect(yield* readFileString(historyPath)).toBe("survives retry\r");
-    }),
-  );
-
-  it.effect("retains failed history across repeated retries without a session", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const failedWrite = yield* Deferred.make<void>();
-      const cause = PlatformError.systemError({
-        _tag: "PermissionDenied",
-        module: "FileSystem",
-        method: "writeFileString",
-        pathOrDescriptor: "terminal-history",
-      });
-      let rejectHistoryWrites = true;
-      const recoveringFileSystem = FileSystem.FileSystem.of({
-        ...fileSystem,
-        writeFileString: (path, contents, options) => {
-          if (path.endsWith(".log") && rejectHistoryWrites) {
-            return Deferred.succeed(failedWrite, undefined).pipe(
-              Effect.andThen(Effect.fail(cause)),
-            );
-          }
-          return fileSystem.writeFileString(path, contents, options);
-        },
-      });
-      const { manager, ptyAdapter } = yield* createManager(100).pipe(
-        Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(
+        "survives recovery\r",
       );
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("survives repeated retry\n");
-      yield* Deferred.await(failedWrite);
-      yield* manager.close({ threadId: "thread-1" });
-      yield* manager.close({ threadId: "thread-1" });
-
-      rejectHistoryWrites = false;
-      yield* manager.close({ threadId: "thread-1" });
-      const reopened = yield* manager.open(openInput());
-
-      expect(reopened.history).toBe("survives repeated retry\n");
-    }),
-  );
-
-  it.effect("recovers a failed truncate with the latest capped history", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const failedTruncate = yield* Deferred.make<void>();
-      const cause = PlatformError.systemError({
-        _tag: "PermissionDenied",
-        module: "FileSystem",
-        method: "writeFileString",
-        pathOrDescriptor: "terminal-history",
-      });
-      let shouldFailTruncate = true;
-      const recoveringFileSystem = FileSystem.FileSystem.of({
-        ...fileSystem,
-        writeFileString: (path, contents, options) => {
-          if (path.endsWith(".log") && options?.flag === "w" && shouldFailTruncate) {
-            shouldFailTruncate = false;
-            return Deferred.succeed(failedTruncate, undefined).pipe(
-              Effect.andThen(Effect.fail(cause)),
-            );
-          }
-          return fileSystem.writeFileString(path, contents, options);
-        },
-      });
-      const { manager, ptyAdapter, logsDir } = yield* createManager(1, {
-        historyTargetBytes: 4,
-        historyMaxBytes: 12,
-      }).pipe(Effect.provideService(FileSystem.FileSystem, recoveringFileSystem));
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("old-long-line");
-      yield* Deferred.await(failedTruncate);
-      process.emitData("\nnew\n");
-      yield* manager.close({ threadId: "thread-1" });
-
-      const historyPath = yield* historyLogPath(logsDir);
-      expect(yield* readFileString(historyPath)).toBe("new\n");
-    }),
-  );
-
-  it.effect("compacts carriage-return redraw history at the byte limit", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const writes: Array<RecordedHistoryWrite> = [];
-      const { manager, ptyAdapter, logsDir } = yield* createManager(100, {
-        historyTargetBytes: 12,
-        historyMaxBytes: 24,
-      }).pipe(
-        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
-      );
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("old-one\r");
-      process.emitData("old-two\r");
-      process.emitData("new-one\rnew-two\r");
-      yield* manager.close({ threadId: "thread-1" });
-
-      const historyPath = yield* historyLogPath(logsDir);
-      const persisted = yield* readFileString(historyPath);
-      expect(persisted).toBe("new-two\r");
-      expect(Buffer.byteLength(persisted)).toBeLessThanOrEqual(12);
-      expect(writes.some((write) => write.flag === "w")).toBe(true);
-    }),
-  );
-
-  it.effect("compacts oversized existing terminal history on open", () =>
-    Effect.gen(function* () {
-      const { manager, logsDir } = yield* createManager(100, {
-        historyTargetBytes: 12,
-        historyMaxBytes: 24,
-      });
-      const historyPath = yield* historyLogPath(logsDir);
-      yield* writeFileString(historyPath, "old-one\rold-two\rnew-one\rnew-two\r");
-
-      const opened = yield* manager.open(openInput());
-
-      expect(opened.history).toBe("new-two\r");
-      expect(yield* readFileString(historyPath)).toBe("new-two\r");
-    }),
-  );
-
-  it.effect("retains a bounded suffix from oversized history without line breaks", () =>
-    Effect.gen(function* () {
-      const { manager, logsDir } = yield* createManager(100, {
-        historyTargetBytes: 12,
-        historyMaxBytes: 24,
-      });
-      const historyPath = yield* historyLogPath(logsDir);
-      const oversizedHistory = "abcdefghijklmnopqrstuvwxyz0123456789";
-      yield* writeFileString(historyPath, oversizedHistory);
-
-      const opened = yield* manager.open(openInput());
-      const expected = oversizedHistory.slice(-12);
-
-      expect(opened.history).toBe(expected);
-      expect(yield* readFileString(historyPath)).toBe(expected);
-    }),
-  );
-
-  it.effect("retains a bounded oversized line that ends with a newline", () =>
-    Effect.gen(function* () {
-      const { manager, logsDir } = yield* createManager(100, {
-        historyTargetBytes: 12,
-        historyMaxBytes: 24,
-      });
-      const historyPath = yield* historyLogPath(logsDir);
-      const oversizedHistory = `${"x".repeat(40)}\n`;
-      const expected = Buffer.from(oversizedHistory).subarray(-12).toString();
-      yield* writeFileString(historyPath, oversizedHistory);
-
-      const opened = yield* manager.open(openInput());
-
-      expect(opened.history).toBe(expected);
-      expect(yield* readFileString(historyPath)).toBe(expected);
-    }),
-  );
-
-  it.effect("retains a complete line when the byte cutoff follows a newline", () =>
-    Effect.gen(function* () {
-      const { manager, logsDir } = yield* createManager(100, {
-        historyTargetBytes: 8,
-        historyMaxBytes: 10,
-      });
-      const historyPath = yield* historyLogPath(logsDir);
-      yield* writeFileString(historyPath, "xx\naa\nbb\ncc");
-
-      const opened = yield* manager.open(openInput());
-
-      expect(opened.history).toBe("aa\nbb\ncc");
-      expect(yield* readFileString(historyPath)).toBe("aa\nbb\ncc");
     }),
   );
 
@@ -1789,47 +1411,6 @@ it.layer(
     }),
   );
 
-  it.effect("does not restore failed writes after deleting all thread history", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const failedWrite = yield* Deferred.make<void>();
-      const cause = PlatformError.systemError({
-        _tag: "PermissionDenied",
-        module: "FileSystem",
-        method: "writeFileString",
-        pathOrDescriptor: "terminal-history",
-      });
-      let writesFail = true;
-      const recoveringFileSystem = FileSystem.FileSystem.of({
-        ...fileSystem,
-        writeFileString: (path, contents, options) => {
-          if (path.endsWith(".log") && writesFail) {
-            return Deferred.succeed(failedWrite, undefined).pipe(
-              Effect.andThen(Effect.fail(cause)),
-            );
-          }
-          return fileSystem.writeFileString(path, contents, options);
-        },
-      });
-      const { manager, ptyAdapter } = yield* createManager().pipe(
-        Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
-      );
-      yield* manager.open(openInput());
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("must stay deleted\r");
-      yield* Deferred.await(failedWrite);
-      yield* manager.close({ threadId: "thread-1" });
-      yield* manager.close({ threadId: "thread-1", deleteHistory: true });
-      writesFail = false;
-
-      const reopened = yield* manager.open(openInput());
-      expect(reopened.history).toBe("");
-    }),
-  );
-
   it.effect("closes all terminals for a thread when close omits terminalId", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, logsDir } = yield* createManager();
@@ -1878,7 +1459,7 @@ it.layer(
 
   it.effect("escalates terminal shutdown to SIGKILL when process does not exit in time", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, { processKillGraceMs: 10 });
+      const { manager, ptyAdapter } = yield* createManager({ processKillGraceMs: 10 });
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
@@ -1911,7 +1492,7 @@ it.layer(
 
   it.effect("evicts oldest inactive terminal sessions when retention limit is exceeded", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, logsDir, getEvents } = yield* createManager(5, {
+      const { manager, ptyAdapter, logsDir, getEvents } = yield* createManager({
         maxRetainedInactiveSessions: 1,
       });
 
@@ -1952,57 +1533,6 @@ it.layer(
     }),
   );
 
-  it.effect("discards failed persistence state when an inactive session is evicted", () =>
-    Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const failedWrite = yield* Deferred.make<void>();
-      const exited = yield* Deferred.make<void>();
-      const cause = PlatformError.systemError({
-        _tag: "PermissionDenied",
-        module: "FileSystem",
-        method: "writeFileString",
-        pathOrDescriptor: "terminal-history",
-      });
-      let rejectHistoryWrites = true;
-      const failingFileSystem = FileSystem.FileSystem.of({
-        ...fileSystem,
-        writeFileString: (path, contents, options) => {
-          if (path.endsWith(".log") && rejectHistoryWrites) {
-            return Deferred.succeed(failedWrite, undefined).pipe(
-              Effect.andThen(Effect.fail(cause)),
-            );
-          }
-          return fileSystem.writeFileString(path, contents, options);
-        },
-      });
-      const { manager, ptyAdapter } = yield* createManager(100, {
-        maxRetainedInactiveSessions: 1,
-      }).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem));
-      const unsubscribe = yield* manager.subscribe((event) =>
-        event.type === "exited" && event.threadId === "thread-1"
-          ? Deferred.succeed(exited, undefined)
-          : Effect.void,
-      );
-      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
-
-      yield* manager.open(openInput({ threadId: "thread-1" }));
-      const process = ptyAdapter.processes[0];
-      expect(process).toBeDefined();
-      if (!process) return;
-
-      process.emitData("discarded after eviction\n");
-      yield* Deferred.await(failedWrite);
-      process.emitExit({ exitCode: 0, signal: 0 });
-      yield* Deferred.await(exited);
-      yield* manager.open(openInput({ threadId: "thread-2" }));
-
-      rejectHistoryWrites = false;
-      const reopened = yield* manager.open(openInput({ threadId: "thread-1" }));
-
-      expect(reopened.history).toBe("");
-    }),
-  );
-
   it.effect("migrates legacy transcript filenames to terminal-scoped history path on open", () =>
     Effect.gen(function* () {
       const { manager, logsDir } = yield* createManager();
@@ -2025,7 +1555,7 @@ it.layer(
       const platform = yield* HostProcessPlatform;
       const missingShell =
         platform === "win32" ? "C:\\definitely\\missing-shell.exe" : "/definitely/missing-shell -l";
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         shellResolver: () => missingShell,
       });
       ptyAdapter.spawnFailures.push(new Error("posix_spawnp failed."));
@@ -2059,7 +1589,7 @@ it.layer(
 
   it.effect("prefers PowerShell over ComSpec for Windows terminals", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           ComSpec: "C:\\Windows\\System32\\cmd.exe",
           PATH: "C:\\Windows\\System32",
@@ -2081,7 +1611,7 @@ it.layer(
   it.effect("falls back to built-in PowerShell by absolute path on Windows", () =>
     Effect.gen(function* () {
       const ptyAdapter = new FakePtyAdapter();
-      const { manager } = yield* createManager(5, {
+      const { manager } = yield* createManager({
         ptyAdapter,
         shellResolver: () => "C:\\missing\\custom-shell.exe",
         env: {
@@ -2109,7 +1639,7 @@ it.layer(
 
   it.effect("filters app runtime env variables from terminal sessions", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           PORT: "5173",
           T3CODE_PORT: "3773",
@@ -2134,7 +1664,7 @@ it.layer(
   it.effect("strips AppImage runtime env from terminal sessions", () =>
     Effect.gen(function* () {
       const appDir = "/tmp/.mount_T3Codeabc123";
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           APPIMAGE: "/home/user/T3-Code.AppImage",
           APPDIR: appDir,
@@ -2175,7 +1705,7 @@ it.layer(
 
   it.effect("leaves the environment untouched when not launched from an AppImage", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           PATH: "/usr/local/bin:/usr/bin:/bin",
           LD_LIBRARY_PATH: "/home/user/.local/lib",
@@ -2220,7 +1750,7 @@ it.layer(
   it.effect("starts zsh with prompt spacer disabled to avoid `%` end markers", () =>
     Effect.gen(function* () {
       if ((yield* HostProcessPlatform) === "win32") return;
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         shellResolver: () => "/bin/zsh",
       });
       yield* manager.open(openInput());
@@ -2234,7 +1764,7 @@ it.layer(
 
   it.effect("bridges PTY callbacks back into Effect-managed event streaming", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, getEvents } = yield* createManager(5, {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
 
@@ -2256,7 +1786,7 @@ it.layer(
 
   it.effect("pushes PTY callbacks to direct event subscribers", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
       const subscriberEvents = yield* Ref.make<ReadonlyArray<TerminalEvent>>([]);
@@ -2360,7 +1890,7 @@ it.layer(
     "streams attach snapshots followed by live events without duplicate start snapshots",
     () =>
       Effect.gen(function* () {
-        const { manager, ptyAdapter } = yield* createManager(5, {
+        const { manager, ptyAdapter } = yield* createManager({
           ptyAdapter: new FakePtyAdapter("async"),
         });
         const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
@@ -2399,7 +1929,7 @@ it.layer(
 
   it.effect("buffers attach output delivered during the initial snapshot callback", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
       yield* manager.open(openInput());
@@ -2436,7 +1966,7 @@ it.layer(
 
   it.effect("preserves queued PTY output ordering through exit callbacks", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, getEvents } = yield* createManager(5, {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
 
@@ -2487,44 +2017,33 @@ it.layer(
 
   it.effect("scoped runtime shutdown flushes history and stops active terminals", () =>
     Effect.gen(function* () {
-      const fileSystem = yield* FileSystem.FileSystem;
-      const writes: Array<RecordedHistoryWrite> = [];
       const scope = yield* Scope.make("sequential");
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter, logsDir } = yield* createManager({
         processKillGraceMs: 10,
-      }).pipe(
-        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
-        Effect.provideService(Scope.Scope, scope),
-      );
+        managerScope: scope,
+      });
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
       if (!process) return;
-      const terminateStartedFiber = yield* Effect.callback<void>((resume) => {
+      const sigtermSent = yield* Effect.callback<void>((resume) => {
         process.killObserver = (signal) => {
           if (signal === "SIGTERM") {
             resume(Effect.void);
           }
         };
       }).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
-      process.emitData("saved during shutdown\r");
+      const output = "x".repeat(64 * 1024);
+      process.emitData(output);
 
       const closeScope = yield* Scope.close(scope, Exit.void).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
-      yield* TestClock.adjust("40 millis");
-      yield* Fiber.join(terminateStartedFiber);
+      yield* Fiber.join(sigtermSent);
       yield* TestClock.adjust("10 millis");
       yield* Fiber.join(closeScope);
 
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(output);
       assert.equal(process.killSignals[0], "SIGTERM");
       expect(process.killSignals).toContain("SIGKILL");
-      expect(
-        writes
-          .filter((write) => write.flag === "a")
-          .map((write) => write.contents)
-          .join(""),
-      ).toBe("saved during shutdown\r");
     }).pipe(Effect.provide(TestClock.layer())),
   );
 });

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1522,6 +1522,22 @@ it.layer(
     }),
   );
 
+  it.effect("retains a complete line when the byte cutoff follows a newline", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager(100, {
+        historyTargetBytes: 8,
+        historyMaxBytes: 10,
+      });
+      const historyPath = yield* historyLogPath(logsDir);
+      yield* writeFileString(historyPath, "xx\naa\nbb\ncc");
+
+      const opened = yield* manager.open(openInput());
+
+      expect(opened.history).toBe("aa\nbb\ncc");
+      expect(yield* readFileString(historyPath)).toBe("aa\nbb\ncc");
+    }),
+  );
+
   it.effect("strips replay-unsafe terminal query and reply sequences from persisted history", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -904,6 +904,45 @@ it.layer(
     }),
   );
 
+  it.effect("allows event subscribers to call terminal lifecycle methods", () =>
+    Effect.gen(function* () {
+      const { manager } = yield* createManager();
+      const eventTypes: TerminalEvent["type"][] = [];
+      let ranLifecycleMethods = false;
+      let reopened = false;
+
+      const unsubscribe = yield* manager.subscribe((event) =>
+        Effect.gen(function* () {
+          eventTypes.push(event.type);
+
+          if (event.type === "started" && ranLifecycleMethods === false) {
+            ranLifecycleMethods = true;
+            yield* manager.clear({
+              threadId: event.threadId,
+              terminalId: event.terminalId,
+            });
+            yield* manager.restart(restartInput());
+            yield* manager.close({
+              threadId: event.threadId,
+              terminalId: event.terminalId,
+            });
+            return;
+          }
+
+          if (event.type === "closed" && reopened === false) {
+            reopened = true;
+            yield* manager.open(openInput());
+          }
+        }).pipe(Effect.orDie),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      yield* manager.open(openInput());
+
+      expect(eventTypes).toEqual(["started", "cleared", "restarted", "closed", "started"]);
+    }),
+  );
+
   it.effect("restarts terminal with empty transcript and respawns pty", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, logsDir } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -26,7 +26,7 @@ import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
-import { expect } from "vite-plus/test";
+import { expect, vi } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
 import * as TerminalManager from "./Manager.ts";
@@ -43,6 +43,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   readonly pid: number;
   writeFailure: unknown | undefined;
   resizeFailure: unknown | undefined;
+  killObserver: ((signal: string | undefined) => void) | undefined;
   private readonly dataListeners = new Set<(data: string) => void>();
   private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
   killed = false;
@@ -68,6 +69,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   kill(signal?: string): void {
     this.killed = true;
     this.killSignals.push(signal);
+    this.killObserver?.(signal);
   }
 
   onData(callback: (data: string) => void): () => void {
@@ -368,6 +370,31 @@ it.layer(
           .map((event) => event.snapshot.status),
       ).toEqual(["running", "running", "running"]);
       expect(ptyAdapter.spawnInputs).toHaveLength(3);
+    }),
+  );
+
+  it.effect("delivers reopen errors after a terminal id is closed", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
+      const unsubscribe = yield* manager.attachStream(openInput(), (event) =>
+        Ref.update(attachEvents, (events) => [...events, event]),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      yield* manager.close({
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        deleteHistory: true,
+      });
+      ptyAdapter.spawnFailures.push(new Error("permission denied"));
+      yield* manager.restart(restartInput());
+
+      expect((yield* Ref.get(attachEvents)).map((event) => event.type)).toEqual([
+        "snapshot",
+        "closed",
+        "error",
+      ]);
     }),
   );
 
@@ -754,7 +781,7 @@ it.layer(
     }),
   );
 
-  it.effect("drops delayed output published after a concurrent clear", () =>
+  it.effect("drops delayed output from a closed session after recreation", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
       yield* manager.open(openInput());
@@ -765,7 +792,7 @@ it.layer(
       const outputStarted = yield* Deferred.make<void>();
       const releaseOutput = yield* Deferred.make<void>();
       const outputFinished = yield* Deferred.make<void>();
-      const clearedDelivered = yield* Deferred.make<void>();
+      const restartedDelivered = yield* Deferred.make<void>();
       const blockerUnsubscribe = yield* manager.subscribe((event) =>
         Effect.gen(function* () {
           if (event.type === "output") {
@@ -780,7 +807,9 @@ it.layer(
       const attachUnsubscribe = yield* manager.attachStream(openInput(), (event) =>
         Ref.update(attachEvents, (events) => [...events, event]).pipe(
           Effect.andThen(
-            event.type === "cleared" ? Deferred.succeed(clearedDelivered, undefined) : Effect.void,
+            event.type === "restarted"
+              ? Deferred.succeed(restartedDelivered, undefined)
+              : Effect.void,
           ),
         ),
       );
@@ -791,20 +820,25 @@ it.layer(
       );
       yield* Effect.addFinalizer(() => Effect.sync(observerUnsubscribe));
 
-      process.emitData("before clear\n");
+      process.emitData("before recreation\n");
       yield* Deferred.await(outputStarted);
 
-      const clearFiber = yield* manager
-        .clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID })
-        .pipe(Effect.forkScoped);
-      yield* Deferred.await(clearedDelivered);
+      const recreateFiber = yield* manager
+        .close({
+          threadId: "thread-1",
+          terminalId: DEFAULT_TERMINAL_ID,
+          deleteHistory: true,
+        })
+        .pipe(Effect.andThen(manager.restart(restartInput())), Effect.forkScoped);
+      yield* Deferred.await(restartedDelivered);
       yield* Deferred.succeed(releaseOutput, undefined);
-      yield* Fiber.join(clearFiber);
+      yield* Fiber.join(recreateFiber);
       yield* Deferred.await(outputFinished);
 
       expect((yield* Ref.get(attachEvents)).map((event) => event.type)).toEqual([
         "snapshot",
-        "cleared",
+        "closed",
+        "restarted",
       ]);
     }),
   );
@@ -1224,6 +1258,36 @@ it.layer(
       expect(writes.length).toBeGreaterThan(0);
       expect(writes.every((write) => write.flag === "a")).toBe(true);
       expect(writes.map((write) => write.contents).join("")).toBe("first redraw\rsecond redraw\r");
+    }),
+  );
+
+  it.effect("does not rescan coalesced history payloads", () =>
+    Effect.gen(function* () {
+      const byteLength = vi.spyOn(Buffer, "byteLength");
+      yield* Effect.addFinalizer(() => Effect.sync(() => byteLength.mockRestore()));
+      const lastOutputDelivered = yield* Deferred.make<void>();
+      const { manager, ptyAdapter } = yield* createManager(100);
+      const unsubscribe = yield* manager.subscribe((event) =>
+        event.type === "output" && event.data === "c"
+          ? Deferred.succeed(lastOutputDelivered, undefined)
+          : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("a");
+      process.emitData("b");
+      process.emitData("c");
+      yield* Deferred.await(lastOutputDelivered);
+
+      expect(byteLength).not.toHaveBeenCalledWith("ab");
+      expect(byteLength).not.toHaveBeenCalledWith("bc");
+      expect(byteLength).not.toHaveBeenCalledWith("abc");
+      byteLength.mockRestore();
+      yield* manager.close({ threadId: "thread-1" });
     }),
   );
 
@@ -2148,24 +2212,54 @@ it.layer(
     }),
   );
 
-  it.effect("scoped runtime shutdown stops active terminals cleanly", () =>
+  it.effect("scoped runtime shutdown flushes history and stops active terminals", () =>
     Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const writes: Array<RecordedHistoryWrite> = [];
       const scope = yield* Scope.make("sequential");
       const { manager, ptyAdapter } = yield* createManager(5, {
         processKillGraceMs: 10,
-      }).pipe(Effect.provideService(Scope.Scope, scope));
+      }).pipe(
+        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
+        Effect.provideService(Scope.Scope, scope),
+      );
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
       if (!process) return;
+      const terminateStartedFiber = yield* Effect.callback<void>((resume) => {
+        process.killObserver = (signal) => {
+          if (signal === "SIGTERM") {
+            resume(Effect.void);
+          }
+        };
+      }).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      const outputDelivered = yield* Deferred.make<void>();
+      const unsubscribe = yield* manager.subscribe((event) =>
+        event.type === "output" && event.data === "saved during shutdown\r"
+          ? Deferred.succeed(outputDelivered, undefined)
+          : Effect.void,
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+      process.emitData("saved during shutdown\r");
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("40 millis");
+      yield* Deferred.await(outputDelivered);
 
       const closeScope = yield* Scope.close(scope, Exit.void).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
+      yield* Fiber.join(terminateStartedFiber);
       yield* TestClock.adjust("10 millis");
       yield* Fiber.join(closeScope);
 
       assert.equal(process.killSignals[0], "SIGTERM");
       expect(process.killSignals).toContain("SIGKILL");
+      expect(
+        writes
+          .filter((write) => write.flag === "a")
+          .map((write) => write.contents)
+          .join(""),
+      ).toBe("saved during shutdown\r");
     }).pipe(Effect.provide(TestClock.layer())),
   );
 });

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -332,7 +332,7 @@ it.layer(
     }),
   );
 
-  it.effect("keeps attach streams live when a terminal id is closed and reopened", () =>
+  it.effect("keeps attach streams live when a terminal id is closed and recreated", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
       const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
@@ -347,13 +347,27 @@ it.layer(
         deleteHistory: true,
       });
       yield* manager.open(openInput());
+      yield* manager.close({
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        deleteHistory: true,
+      });
+      yield* manager.restart(restartInput());
 
       const events = yield* Ref.get(attachEvents);
-      expect(events.map((event) => event.type)).toEqual(["snapshot", "closed", "snapshot"]);
+      expect(events.map((event) => event.type)).toEqual([
+        "snapshot",
+        "closed",
+        "snapshot",
+        "closed",
+        "restarted",
+      ]);
       expect(
-        events.filter((event) => event.type === "snapshot").map((event) => event.snapshot.status),
-      ).toEqual(["running", "running"]);
-      expect(ptyAdapter.spawnInputs).toHaveLength(2);
+        events
+          .filter((event) => event.type === "snapshot" || event.type === "restarted")
+          .map((event) => event.snapshot.status),
+      ).toEqual(["running", "running", "running"]);
+      expect(ptyAdapter.spawnInputs).toHaveLength(3);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -1434,6 +1434,47 @@ it.layer(
     }),
   );
 
+  it.effect("does not restore failed writes after deleting all thread history", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const failedWrite = yield* Deferred.make<void>();
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: "terminal-history",
+      });
+      let writesFail = true;
+      const recoveringFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (path, contents, options) => {
+          if (path.endsWith(".log") && writesFail) {
+            return Deferred.succeed(failedWrite, undefined).pipe(
+              Effect.andThen(Effect.fail(cause)),
+            );
+          }
+          return fileSystem.writeFileString(path, contents, options);
+        },
+      });
+      const { manager, ptyAdapter } = yield* createManager().pipe(
+        Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
+      );
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("must stay deleted\r");
+      yield* Deferred.await(failedWrite);
+      yield* manager.close({ threadId: "thread-1" });
+      yield* manager.close({ threadId: "thread-1", deleteHistory: true });
+      writesFail = false;
+
+      const reopened = yield* manager.open(openInput());
+      expect(reopened.history).toBe("");
+    }),
+  );
+
   it.effect("closes all terminals for a thread when close omits terminalId", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, logsDir } = yield* createManager();

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -44,6 +44,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   writeFailure: unknown | undefined;
   resizeFailure: unknown | undefined;
   killObserver: ((signal: string | undefined) => void) | undefined;
+  dataUnsubscribeObserver: (() => void) | undefined;
   private readonly dataListeners = new Set<(data: string) => void>();
   private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
   killed = false;
@@ -75,6 +76,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   onData(callback: (data: string) => void): () => void {
     this.dataListeners.add(callback);
     return () => {
+      this.dataUnsubscribeObserver?.();
       this.dataListeners.delete(callback);
     };
   }
@@ -816,6 +818,24 @@ it.layer(
     }),
   );
 
+  it.effect("flushes output received while close unsubscribes from the PTY", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.dataUnsubscribeObserver = () => {
+        process.emitData("last output during close\r");
+      };
+      yield* manager.close({ threadId: "thread-1" });
+
+      const historyPath = yield* historyLogPath(logsDir);
+      expect(yield* readFileString(historyPath)).toBe("last output during close\r");
+    }),
+  );
+
   it.effect("drops delayed output from a closed session after recreation", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter } = yield* createManager();
@@ -1371,6 +1391,48 @@ it.layer(
 
       const historyPath = yield* historyLogPath(logsDir);
       expect(yield* readFileString(historyPath)).toBe("survives retry\r");
+    }),
+  );
+
+  it.effect("recovers a failed truncate with the latest capped history", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const failedTruncate = yield* Deferred.make<void>();
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: "terminal-history",
+      });
+      let shouldFailTruncate = true;
+      const recoveringFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (path, contents, options) => {
+          if (path.endsWith(".log") && options?.flag === "w" && shouldFailTruncate) {
+            shouldFailTruncate = false;
+            return Deferred.succeed(failedTruncate, undefined).pipe(
+              Effect.andThen(Effect.fail(cause)),
+            );
+          }
+          return fileSystem.writeFileString(path, contents, options);
+        },
+      });
+      const { manager, ptyAdapter, logsDir } = yield* createManager(1, {
+        historyTargetBytes: 4,
+        historyMaxBytes: 12,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, recoveringFileSystem));
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("old-long-line");
+      yield* Deferred.await(failedTruncate);
+      process.emitData("\nnew\n");
+      yield* manager.close({ threadId: "thread-1" });
+
+      const historyPath = yield* historyLogPath(logsDir);
+      expect(yield* readFileString(historyPath)).toBe("new\n");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -275,6 +275,7 @@ interface HistoryWrite {
 }
 
 interface PersistHistoryRequest extends HistoryWrite {
+  authoritativeHistory: string;
   contentsBytes: number;
   immediate: boolean;
 }
@@ -292,6 +293,7 @@ function mergePersistHistoryRequests(
   const contents = `${current.contents}${next.contents}`;
   const contentsBytes = current.contentsBytes + next.contentsBytes;
   return {
+    authoritativeHistory: next.authoritativeHistory,
     contents,
     contentsBytes,
     mode: current.mode,
@@ -1437,10 +1439,18 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     merge: mergePersistHistoryRequests,
     process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
       const failedRequest = failedPersistByKey.get(sessionKey);
-      const nextRequest =
+      const nextRequest: PersistHistoryRequest =
         failedRequest === undefined
           ? request
-          : mergePersistHistoryRequests({ ...failedRequest, immediate: false }, request);
+          : failedRequest.mode === "append"
+            ? {
+                ...request,
+                contents: request.authoritativeHistory,
+                contentsBytes: Buffer.byteLength(request.authoritativeHistory),
+                mode: "truncate",
+                immediate: true,
+              }
+            : mergePersistHistoryRequests({ ...failedRequest, immediate: false }, request);
       if (!nextRequest.immediate) {
         yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
       }
@@ -1490,10 +1500,12 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   ) {
     const sessionKey = toSessionKey(threadId, terminalId);
     yield* drainPersist(threadId, terminalId);
-    if (!failedPersistByKey.has(sessionKey)) {
+    const failedRequest = failedPersistByKey.get(sessionKey);
+    if (failedRequest === undefined) {
       return;
     }
     yield* persistWorker.enqueue(sessionKey, {
+      authoritativeHistory: failedRequest.authoritativeHistory,
       contents: "",
       contentsBytes: 0,
       mode: "append",
@@ -1506,13 +1518,34 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     threadId: string,
     terminalId: string,
     request: HistoryWrite,
+    authoritativeHistory: string,
   ) {
     const contentsBytes = Buffer.byteLength(request.contents);
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       ...request,
+      authoritativeHistory,
       contentsBytes,
       immediate: contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
     });
+  });
+
+  const queuePendingProcessHistory = Effect.fn("terminal.queuePendingProcessHistory")(function* (
+    session: TerminalSessionState,
+  ) {
+    for (
+      let index = session.pendingProcessEventIndex;
+      index < session.pendingProcessEvents.length;
+      index += 1
+    ) {
+      const event = session.pendingProcessEvents[index];
+      if (!event || event.type === "exit") {
+        break;
+      }
+      const historyWrite = applyHistoryOutput(session, event.data);
+      if (historyWrite !== null) {
+        yield* queuePersist(session.threadId, session.terminalId, historyWrite, session.history);
+      }
+    }
   });
 
   const flushPersist = Effect.fn("terminal.flushPersist")(function* (
@@ -1522,6 +1555,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   ) {
     const sessionKey = toSessionKey(threadId, terminalId);
     yield* persistWorker.enqueue(sessionKey, {
+      authoritativeHistory: history,
       contents: "",
       contentsBytes: 0,
       mode: "append",
@@ -1532,6 +1566,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       return;
     }
     yield* persistWorker.enqueue(sessionKey, {
+      authoritativeHistory: history,
       contents: history,
       contentsBytes: Buffer.byteLength(history),
       mode: "truncate",
@@ -1546,6 +1581,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     contents: string,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
+      authoritativeHistory: contents,
       contents,
       contentsBytes: Buffer.byteLength(contents),
       mode: "truncate",
@@ -1861,6 +1897,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               nextAction.threadId,
               nextAction.terminalId,
               nextAction.historyWrite,
+              session.history,
             );
           }
           return nextAction;
@@ -2124,6 +2161,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const session = yield* getSession(threadId, terminalId);
 
     if (Option.isSome(session)) {
+      yield* queuePendingProcessHistory(session.value);
       yield* stopProcess(session.value);
       yield* unregisterTerminal({ threadId, terminalId });
       yield* flushPersist(threadId, terminalId, session.value.history);
@@ -2291,20 +2329,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           Effect.gen(function* () {
             const process = session.process;
             cleanupProcessHandles(session);
-            for (
-              let index = session.pendingProcessEventIndex;
-              index < session.pendingProcessEvents.length;
-              index += 1
-            ) {
-              const event = session.pendingProcessEvents[index];
-              if (!event || event.type === "exit") {
-                break;
-              }
-              const historyWrite = applyHistoryOutput(session, event.data);
-              if (historyWrite !== null) {
-                yield* queuePersist(session.threadId, session.terminalId, historyWrite);
-              }
-            }
+            yield* queuePendingProcessHistory(session);
             session.process = null;
             session.pid = null;
             session.hasRunningSubprocess = false;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1865,6 +1865,26 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               nextAction.historyWrite,
             );
           }
+
+          if (nextAction.type === "output") {
+            yield* publishEvent({
+              type: "output",
+              threadId: nextAction.threadId,
+              terminalId: nextAction.terminalId,
+              sequence: nextAction.sequence,
+              data: nextAction.data,
+            });
+          } else if (nextAction.type === "exit") {
+            yield* publishEvent({
+              type: "exited",
+              threadId: nextAction.threadId,
+              terminalId: nextAction.terminalId,
+              sequence: nextAction.sequence,
+              exitCode: nextAction.exitCode,
+              exitSignal: nextAction.exitSignal,
+            });
+          }
+
           return nextAction;
         }),
       );
@@ -1874,13 +1894,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       if (action.type === "output") {
-        yield* publishEvent({
-          type: "output",
-          threadId: action.threadId,
-          terminalId: action.terminalId,
-          sequence: action.sequence,
-          data: action.data,
-        });
         continue;
       }
 
@@ -1888,14 +1901,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       yield* unregisterTerminal({
         threadId: action.threadId,
         terminalId: action.terminalId,
-      });
-      yield* publishEvent({
-        type: "exited",
-        threadId: action.threadId,
-        terminalId: action.terminalId,
-        sequence: action.sequence,
-        exitCode: action.exitCode,
-        exitSignal: action.exitSignal,
       });
       yield* evictInactiveSessionsIfNeeded();
       return;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -35,7 +35,6 @@ import {
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
-import * as Chunk from "effect/Chunk";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -75,7 +74,6 @@ export {
   TerminalWriteError,
 };
 
-const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
 const DEFAULT_HISTORY_TARGET_BYTES = 8 * 1024 * 1024;
 const DEFAULT_HISTORY_MAX_BYTES = 12 * 1024 * 1024;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
@@ -250,7 +248,7 @@ export interface TerminalSessionState {
   status: TerminalSessionStatus;
   pid: number | null;
   history: string;
-  persistedHistoryBytes: number;
+  historyBytes: number;
   pendingHistoryControlSequence: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
@@ -281,37 +279,6 @@ interface PersistHistoryRequest extends HistoryWrite {
   immediate: boolean;
 }
 
-function mergePersistHistoryRequests(
-  current: PersistHistoryRequest,
-  next: PersistHistoryRequest,
-): PersistHistoryRequest {
-  if (next.mode === "truncate") {
-    return {
-      ...next,
-      immediate: current.immediate || next.immediate,
-    };
-  }
-  const contentsBytes = current.contentsBytes + next.contentsBytes;
-  if (current.mode === "truncate") {
-    return {
-      authoritativeHistory: next.authoritativeHistory,
-      contents: next.authoritativeHistory,
-      contentsBytes,
-      mode: "truncate",
-      immediate:
-        current.immediate || next.immediate || contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
-    };
-  }
-  const contents = `${current.contents}${next.contents}`;
-  return {
-    authoritativeHistory: next.authoritativeHistory,
-    contents,
-    contentsBytes,
-    mode: current.mode,
-    immediate: current.immediate || next.immediate || contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
-  };
-}
-
 type PendingProcessEvent =
   | { type: "output"; data: string }
   | { type: "exit"; event: PtyAdapter.PtyExitEvent };
@@ -323,7 +290,6 @@ type DrainProcessEventAction =
       threadId: string;
       terminalId: string;
       sequence: number;
-      historyWrite: HistoryWrite | null;
       data: string;
     }
   | {
@@ -450,6 +416,16 @@ function isDuplicateAttachSnapshotEvent(
         event.snapshot.threadId === initialSnapshot.threadId &&
         event.snapshot.terminalId === initialSnapshot.terminalId &&
         event.snapshot.updatedAt <= initialSnapshot.updatedAt;
+}
+
+function advanceEventSequence(session: TerminalSessionState): {
+  readonly updatedAt: string;
+  readonly sequence: number;
+} {
+  const updatedAt = DateTime.formatIso(DateTime.nowUnsafe());
+  session.eventSequence += 1;
+  session.updatedAt = updatedAt;
+  return { updatedAt, sequence: session.eventSequence };
 }
 
 function cleanupProcessHandles(session: TerminalSessionState): void {
@@ -816,18 +792,6 @@ const windowsProcessTableSnapshot = Effect.fn("terminal.windowsProcessTableSnaps
   },
 );
 
-function capHistory(history: string, maxLines: number): string {
-  if (history.length === 0) return history;
-  const hasTrailingNewline = history.endsWith("\n");
-  const lines = history.split("\n");
-  if (hasTrailingNewline) {
-    lines.pop();
-  }
-  if (lines.length <= maxLines) return history;
-  const capped = lines.slice(lines.length - maxLines).join("\n");
-  return hasTrailingNewline ? `${capped}\n` : capped;
-}
-
 function capHistoryByBytes(history: string, targetBytes: number): string {
   const encoded = Buffer.from(history);
   if (encoded.byteLength <= targetBytes) return history;
@@ -836,6 +800,7 @@ function capHistoryByBytes(history: string, targetBytes: number): string {
   while (start < encoded.byteLength && ((encoded[start] ?? 0) & 0xc0) === 0x80) {
     start += 1;
   }
+
   const suffix = encoded.subarray(start).toString();
   const previousByte = start > 0 ? encoded[start - 1] : undefined;
   if (previousByte === 0x0a || (previousByte === 0x0d && encoded[start] !== 0x0a)) {
@@ -1172,7 +1137,6 @@ function normalizedRuntimeEnv(
 
 interface TerminalManagerOptions {
   logsDir: string;
-  historyLineLimit?: number;
   historyTargetBytes?: number;
   historyMaxBytes?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
@@ -1212,38 +1176,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const path = yield* Path.Path;
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
-  let terminalEventSequence = 0;
-
-  const advanceEventSequence = (session: TerminalSessionState) => {
-    const updatedAt = DateTime.formatIso(DateTime.nowUnsafe());
-    terminalEventSequence += 1;
-    session.eventSequence = terminalEventSequence;
-    session.updatedAt = updatedAt;
-    return { updatedAt, sequence: session.eventSequence };
-  };
+  const runSync = Effect.runSyncWith(context);
 
   const logsDir = options.logsDir;
-  const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
   const historyTargetBytes = options.historyTargetBytes ?? DEFAULT_HISTORY_TARGET_BYTES;
   const historyMaxBytes = options.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES;
-
-  const applyHistoryOutput = (session: TerminalSessionState, data: string): HistoryWrite | null => {
-    const sanitized = sanitizeTerminalHistoryChunk(session.pendingHistoryControlSequence, data);
-    session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
-    if (sanitized.visibleText.length === 0) {
-      return null;
-    }
-
-    session.history = capHistory(`${session.history}${sanitized.visibleText}`, historyLineLimit);
-    session.persistedHistoryBytes += Buffer.byteLength(sanitized.visibleText);
-    if (session.persistedHistoryBytes <= historyMaxBytes) {
-      return { contents: sanitized.visibleText, mode: "append" };
-    }
-
-    session.history = capHistoryByBytes(session.history, historyTargetBytes);
-    session.persistedHistoryBytes = Buffer.byteLength(session.history);
-    return { contents: session.history, mode: "truncate" };
-  };
   const platform = yield* HostProcessPlatform;
   // Terminals must inherit the user's full environment (minus the blocklist
   // applied in createTerminalSpawnEnv) — an allowlist here silently strips
@@ -1299,31 +1236,25 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
     });
 
-  let terminalEventWorkerFiberId: number | null = null;
-  const terminalEventWorker = yield* makeKeyedCoalescingWorker<
-    string,
-    Chunk.Chunk<TerminalEvent>,
-    never,
-    never
-  >({
-    merge: Chunk.appendAll,
-    process: Effect.fn("terminal.publishEventWorker")(function* (_threadId, events) {
-      terminalEventWorkerFiberId = yield* Effect.fiberId;
-      yield* Effect.forEach(events, publishEvent, { discard: true });
-    }),
-  });
-
-  const enqueueTerminalEvent = (event: TerminalEvent) =>
-    terminalEventWorker.enqueue(event.threadId, Chunk.of(event));
-
-  const drainTerminalEvents = Effect.fn("terminal.drainTerminalEvents")(function* (
-    threadId: string,
-  ) {
-    if ((yield* Effect.fiberId) === terminalEventWorkerFiberId) {
-      return;
+  const applyHistoryOutput = (session: TerminalSessionState, data: string): HistoryWrite | null => {
+    const sanitized = sanitizeTerminalHistoryChunk(session.pendingHistoryControlSequence, data);
+    session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
+    if (sanitized.visibleText.length === 0) {
+      return null;
     }
-    yield* terminalEventWorker.drainKey(threadId);
-  });
+
+    const visibleBytes = Buffer.byteLength(sanitized.visibleText);
+    const nextHistory = `${session.history}${sanitized.visibleText}`;
+    if (session.historyBytes + visibleBytes <= historyMaxBytes) {
+      session.history = nextHistory;
+      session.historyBytes += visibleBytes;
+      return { contents: sanitized.visibleText, mode: "append" };
+    }
+
+    session.history = capHistoryByBytes(nextHistory, historyTargetBytes);
+    session.historyBytes = Buffer.byteLength(session.history);
+    return { contents: session.history, mode: "truncate" };
+  };
 
   const historyPath = (threadId: string, terminalId: string) => {
     const threadPart = toSafeThreadId(threadId);
@@ -1471,30 +1402,30 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     yield* registerKillFiber(process, fiber);
   });
 
-  const failedPersistByKey = new Map<string, PersistHistoryRequest>();
-  const discardedPersistKeys = new Set<string>();
   const persistWorker = yield* makeKeyedCoalescingWorker<
     string,
     PersistHistoryRequest,
     never,
     never
   >({
-    merge: mergePersistHistoryRequests,
+    merge: (current, next) => {
+      if (next.mode === "truncate") {
+        return next;
+      }
+
+      const contents = `${current.contents}${next.contents}`;
+      const contentsBytes = current.contentsBytes + next.contentsBytes;
+      return {
+        authoritativeHistory: next.authoritativeHistory,
+        contents,
+        contentsBytes,
+        mode: current.mode,
+        immediate:
+          current.immediate || next.immediate || contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
+      };
+    },
     process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
-      const failedRequest = failedPersistByKey.get(sessionKey);
-      const nextRequest: PersistHistoryRequest =
-        failedRequest === undefined
-          ? request
-          : failedRequest.mode === "append"
-            ? {
-                ...request,
-                contents: request.authoritativeHistory,
-                contentsBytes: Buffer.byteLength(request.authoritativeHistory),
-                mode: "truncate",
-                immediate: true,
-              }
-            : mergePersistHistoryRequests({ ...failedRequest, immediate: false }, request);
-      if (!nextRequest.immediate) {
+      if (!request.immediate) {
         yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
       }
 
@@ -1503,141 +1434,73 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         return;
       }
 
+      const nextPath = historyPath(threadId, terminalId);
       yield* fileSystem
-        .writeFileString(historyPath(threadId, terminalId), nextRequest.contents, {
-          flag: nextRequest.mode === "append" ? "a" : "w",
+        .writeFileString(nextPath, request.contents, {
+          flag: request.mode === "append" ? "a" : "w",
         })
         .pipe(
-          Effect.matchEffect({
-            onFailure: (error) =>
-              modifyManagerState((state) => {
-                if (discardedPersistKeys.has(sessionKey)) {
-                  failedPersistByKey.delete(sessionKey);
-                } else {
-                  failedPersistByKey.set(sessionKey, nextRequest);
-                }
-                return [undefined, state] as const;
-              }).pipe(
-                Effect.andThen(
-                  Effect.logWarning("failed to persist terminal history", {
+          Effect.catch((error) => {
+            if (request.mode === "truncate") {
+              return Effect.logWarning("failed to persist terminal history", {
+                threadId,
+                terminalId,
+                error,
+              });
+            }
+
+            return fileSystem
+              .writeFileString(nextPath, request.authoritativeHistory, { flag: "w" })
+              .pipe(
+                Effect.catch((fallbackError) =>
+                  Effect.logWarning("failed to recover terminal history append", {
                     threadId,
                     terminalId,
                     error,
+                    fallbackError,
                   }),
                 ),
-              ),
-            onSuccess: () =>
-              Effect.sync(() => {
-                failedPersistByKey.delete(sessionKey);
-              }),
+              );
           }),
         );
     }),
   });
 
-  const drainPersist = Effect.fn("terminal.drainPersist")(function* (
-    threadId: string,
-    terminalId: string,
-  ) {
-    yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
-  });
-
-  const retryFailedPersist = Effect.fn("terminal.retryFailedPersist")(function* (
-    threadId: string,
-    terminalId: string,
-  ) {
-    const sessionKey = toSessionKey(threadId, terminalId);
-    yield* drainPersist(threadId, terminalId);
-    const failedRequest = failedPersistByKey.get(sessionKey);
-    if (failedRequest === undefined) {
-      discardedPersistKeys.delete(sessionKey);
-      return;
-    }
-    yield* persistWorker.enqueue(sessionKey, {
-      authoritativeHistory: failedRequest.authoritativeHistory,
-      contents: "",
-      contentsBytes: 0,
-      mode: "append",
-      immediate: true,
-    });
-    yield* drainPersist(threadId, terminalId);
-    discardedPersistKeys.delete(sessionKey);
-  });
-
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
     threadId: string,
     terminalId: string,
-    request: HistoryWrite,
+    write: HistoryWrite,
     authoritativeHistory: string,
   ) {
-    const contentsBytes = Buffer.byteLength(request.contents);
+    const contentsBytes = Buffer.byteLength(write.contents);
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      ...request,
+      ...write,
       authoritativeHistory,
       contentsBytes,
       immediate: contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
     });
   });
 
-  const queuePendingProcessHistory = Effect.fn("terminal.queuePendingProcessHistory")(function* (
-    session: TerminalSessionState,
+  const flushPersist = Effect.fn("terminal.flushPersist")(function* (
+    threadId: string,
+    terminalId: string,
   ) {
-    for (
-      let index = session.pendingProcessEventIndex;
-      index < session.pendingProcessEvents.length;
-      index += 1
-    ) {
-      const event = session.pendingProcessEvents[index];
-      if (!event || event.type === "exit") {
-        break;
-      }
-      const historyWrite = applyHistoryOutput(session, event.data);
-      if (historyWrite !== null) {
-        yield* queuePersist(session.threadId, session.terminalId, historyWrite, session.history);
-      }
-    }
+    yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
   });
 
-  const flushPersist = Effect.fn("terminal.flushPersist")(function* (
+  const persistHistory = Effect.fn("terminal.persistHistory")(function* (
     threadId: string,
     terminalId: string,
     history: string,
   ) {
-    const sessionKey = toSessionKey(threadId, terminalId);
-    yield* persistWorker.enqueue(sessionKey, {
-      authoritativeHistory: history,
-      contents: "",
-      contentsBytes: 0,
-      mode: "append",
-      immediate: true,
-    });
-    yield* drainPersist(threadId, terminalId);
-    if (!failedPersistByKey.has(sessionKey)) {
-      return;
-    }
-    yield* persistWorker.enqueue(sessionKey, {
+    yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       authoritativeHistory: history,
       contents: history,
       contentsBytes: Buffer.byteLength(history),
       mode: "truncate",
       immediate: true,
     });
-    yield* drainPersist(threadId, terminalId);
-  });
-
-  const resetPersistedHistory = Effect.fn("terminal.resetPersistedHistory")(function* (
-    threadId: string,
-    terminalId: string,
-    contents: string,
-  ) {
-    yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      authoritativeHistory: contents,
-      contents,
-      contentsBytes: Buffer.byteLength(contents),
-      mode: "truncate",
-      immediate: true,
-    });
-    yield* drainPersist(threadId, terminalId);
+    yield* flushPersist(threadId, terminalId);
   });
 
   const readHistory = Effect.fn("terminal.readHistory")(function* (
@@ -1661,11 +1524,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             (cause) => new TerminalHistoryError({ operation: "read", threadId, terminalId, cause }),
           ),
         );
-      const lineCapped = capHistory(raw, historyLineLimit);
       const capped =
-        Buffer.byteLength(lineCapped) > historyMaxBytes
-          ? capHistoryByBytes(lineCapped, historyTargetBytes)
-          : lineCapped;
+        Buffer.byteLength(raw) > historyMaxBytes ? capHistoryByBytes(raw, historyTargetBytes) : raw;
       if (capped !== raw) {
         yield* fileSystem
           .writeFileString(nextPath, capped)
@@ -1705,11 +1565,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             new TerminalHistoryError({ operation: "migrate", threadId, terminalId, cause }),
         ),
       );
-    const lineCapped = capHistory(raw, historyLineLimit);
     const capped =
-      Buffer.byteLength(lineCapped) > historyMaxBytes
-        ? capHistoryByBytes(lineCapped, historyTargetBytes)
-        : lineCapped;
+      Buffer.byteLength(raw) > historyMaxBytes ? capHistoryByBytes(raw, historyTargetBytes) : raw;
     yield* fileSystem
       .writeFileString(nextPath, capped)
       .pipe(
@@ -1733,7 +1590,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     threadId: string,
     terminalId: string,
   ) {
-    failedPersistByKey.delete(toSessionKey(threadId, terminalId));
     yield* fileSystem.remove(historyPath(threadId, terminalId), { force: true }).pipe(
       Effect.catch((error) =>
         Effect.logWarning("failed to delete terminal history", {
@@ -1759,12 +1615,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const deleteAllHistoryForThread = Effect.fn("terminal.deleteAllHistoryForThread")(function* (
     threadId: string,
   ) {
-    const sessionPrefix = `${threadId}\u0000`;
-    for (const sessionKey of failedPersistByKey.keys()) {
-      if (sessionKey.startsWith(sessionPrefix)) {
-        failedPersistByKey.delete(sessionKey);
-      }
-    }
     const threadPrefix = `${toSafeThreadId(threadId)}_`;
     const entries = yield* fileSystem
       .readDirectory(logsDir, { recursive: false })
@@ -1840,13 +1690,12 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
   const evictInactiveSessionsIfNeeded = Effect.fn("terminal.evictInactiveSessionsIfNeeded")(
     function* () {
-      const evictedSessionKeys = yield* modifyManagerState((state) => {
-        const evictedSessionKeys: Array<string> = [];
+      yield* modifyManagerState((state) => {
         const inactiveSessions = [...state.sessions.values()].filter(
           (session) => session.status !== "running",
         );
         if (inactiveSessions.length <= maxRetainedInactiveSessions) {
-          return [evictedSessionKeys, state] as const;
+          return [undefined, state] as const;
         }
 
         inactiveSessions.sort(
@@ -1862,27 +1711,10 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         for (const session of inactiveSessions.slice(0, toEvict)) {
           const key = toSessionKey(session.threadId, session.terminalId);
           sessions.delete(key);
-          failedPersistByKey.delete(key);
-          discardedPersistKeys.add(key);
-          evictedSessionKeys.push(key);
         }
 
-        return [evictedSessionKeys, { ...state, sessions }] as const;
+        return [undefined, { ...state, sessions }] as const;
       });
-
-      yield* Effect.forEach(
-        evictedSessionKeys,
-        (sessionKey) => persistWorker.drainKey(sessionKey),
-        { concurrency: "unbounded", discard: true },
-      ).pipe(
-        Effect.ensuring(
-          Effect.sync(() => {
-            for (const sessionKey of evictedSessionKeys) {
-              discardedPersistKeys.delete(sessionKey);
-            }
-          }),
-        ),
-      );
     },
   );
 
@@ -1891,111 +1723,82 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     expectedPid: number,
   ) {
     while (true) {
-      const action = yield* withThreadLock(
-        session.threadId,
-        Effect.gen(function* () {
-          const nextAction: DrainProcessEventAction = yield* Effect.sync(() => {
-            if (session.pid !== expectedPid || !session.process || session.status !== "running") {
-              session.pendingProcessEvents = [];
-              session.pendingProcessEventIndex = 0;
-              session.processEventDrainRunning = false;
-              return { type: "idle" } as const;
-            }
+      const action: DrainProcessEventAction = yield* Effect.sync(() => {
+        if (session.pid !== expectedPid || !session.process || session.status !== "running") {
+          session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+          session.processEventDrainRunning = false;
+          return { type: "idle" } as const;
+        }
 
-            const nextEvent = session.pendingProcessEvents[session.pendingProcessEventIndex];
-            if (!nextEvent) {
-              session.pendingProcessEvents = [];
-              session.pendingProcessEventIndex = 0;
-              session.processEventDrainRunning = false;
-              return { type: "idle" } as const;
-            }
+        const nextEvent = session.pendingProcessEvents[session.pendingProcessEventIndex];
+        if (!nextEvent) {
+          session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+          session.processEventDrainRunning = false;
+          return { type: "idle" } as const;
+        }
 
-            session.pendingProcessEventIndex += 1;
-            if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
-              session.pendingProcessEvents = [];
-              session.pendingProcessEventIndex = 0;
-            }
+        session.pendingProcessEventIndex += 1;
+        if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
+          session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+        }
 
-            if (nextEvent.type === "output") {
-              const historyWrite = applyHistoryOutput(session, nextEvent.data);
-              const eventStamp = advanceEventSequence(session);
+        if (nextEvent.type === "output") {
+          const eventStamp = advanceEventSequence(session);
 
-              return {
-                type: "output",
-                threadId: session.threadId,
-                terminalId: session.terminalId,
-                sequence: eventStamp.sequence,
-                historyWrite,
-                data: nextEvent.data,
-              } as const;
-            }
+          return {
+            type: "output",
+            threadId: session.threadId,
+            terminalId: session.terminalId,
+            sequence: eventStamp.sequence,
+            data: nextEvent.data,
+          } as const;
+        }
 
-            const process = session.process;
-            cleanupProcessHandles(session);
-            session.process = null;
-            session.pid = null;
-            session.hasRunningSubprocess = false;
-            session.childCommandLabel = null;
-            session.status = "exited";
-            session.pendingHistoryControlSequence = "";
-            session.pendingProcessEvents = [];
-            session.pendingProcessEventIndex = 0;
-            session.processEventDrainRunning = false;
-            session.exitCode = Number.isInteger(nextEvent.event.exitCode)
-              ? nextEvent.event.exitCode
-              : null;
-            session.exitSignal = Number.isInteger(nextEvent.event.signal)
-              ? nextEvent.event.signal
-              : null;
-            const eventStamp = advanceEventSequence(session);
+        const process = session.process;
+        cleanupProcessHandles(session);
+        session.process = null;
+        session.pid = null;
+        session.hasRunningSubprocess = false;
+        session.childCommandLabel = null;
+        session.status = "exited";
+        session.pendingHistoryControlSequence = "";
+        session.pendingProcessEvents = [];
+        session.pendingProcessEventIndex = 0;
+        session.processEventDrainRunning = false;
+        session.exitCode = Number.isInteger(nextEvent.event.exitCode)
+          ? nextEvent.event.exitCode
+          : null;
+        session.exitSignal = Number.isInteger(nextEvent.event.signal)
+          ? nextEvent.event.signal
+          : null;
+        const eventStamp = advanceEventSequence(session);
 
-            return {
-              type: "exit",
-              process,
-              threadId: session.threadId,
-              terminalId: session.terminalId,
-              sequence: eventStamp.sequence,
-              exitCode: session.exitCode,
-              exitSignal: session.exitSignal,
-            } as const;
-          });
-
-          if (nextAction.type === "output" && nextAction.historyWrite !== null) {
-            yield* queuePersist(
-              nextAction.threadId,
-              nextAction.terminalId,
-              nextAction.historyWrite,
-              session.history,
-            );
-          }
-          if (nextAction.type === "output") {
-            yield* enqueueTerminalEvent({
-              type: "output",
-              threadId: nextAction.threadId,
-              terminalId: nextAction.terminalId,
-              sequence: nextAction.sequence,
-              data: nextAction.data,
-            });
-          } else if (nextAction.type === "exit") {
-            yield* enqueueTerminalEvent({
-              type: "exited",
-              threadId: nextAction.threadId,
-              terminalId: nextAction.terminalId,
-              sequence: nextAction.sequence,
-              exitCode: nextAction.exitCode,
-              exitSignal: nextAction.exitSignal,
-            });
-          }
-          return nextAction;
-        }),
-      );
+        return {
+          type: "exit",
+          process,
+          threadId: session.threadId,
+          terminalId: session.terminalId,
+          sequence: eventStamp.sequence,
+          exitCode: session.exitCode,
+          exitSignal: session.exitSignal,
+        } as const;
+      });
 
       if (action.type === "idle") {
         return;
       }
 
       if (action.type === "output") {
-        yield* drainTerminalEvents(action.threadId);
+        yield* publishEvent({
+          type: "output",
+          threadId: action.threadId,
+          terminalId: action.terminalId,
+          sequence: action.sequence,
+          data: action.data,
+        });
         continue;
       }
 
@@ -2004,7 +1807,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         threadId: action.threadId,
         terminalId: action.terminalId,
       });
-      yield* drainTerminalEvents(action.threadId);
+      yield* flushPersist(action.threadId, action.terminalId);
+      yield* publishEvent({
+        type: "exited",
+        threadId: action.threadId,
+        terminalId: action.terminalId,
+        sequence: action.sequence,
+        exitCode: action.exitCode,
+        exitSignal: action.exitSignal,
+      });
       yield* evictInactiveSessionsIfNeeded();
       return;
     }
@@ -2140,6 +1951,17 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
             const processPid = ptyProcess.pid;
             const unsubscribeData = ptyProcess.onData((data) => {
+              if (!session.process || session.status !== "running" || session.pid !== processPid) {
+                return;
+              }
+
+              const historyWrite = applyHistoryOutput(session, data);
+              if (historyWrite !== null) {
+                runSync(
+                  queuePersist(session.threadId, session.terminalId, historyWrite, session.history),
+                );
+              }
+
               if (!enqueueProcessEvent(session, processPid, { type: "output", data })) {
                 return;
               }
@@ -2166,7 +1988,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               return [undefined, state] as const;
             });
 
-            yield* enqueueTerminalEvent({
+            yield* publishEvent({
               type: eventType,
               threadId: session.threadId,
               terminalId: session.terminalId,
@@ -2209,7 +2031,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       yield* evictInactiveSessionsIfNeeded();
 
       const message = error.message;
-      yield* enqueueTerminalEvent({
+      yield* publishEvent({
         type: "error",
         threadId: session.threadId,
         terminalId: session.terminalId,
@@ -2232,16 +2054,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   ) {
     const key = toSessionKey(threadId, terminalId);
     const session = yield* getSession(threadId, terminalId);
+    const closedEventSequence = Option.isSome(session) ? session.value.eventSequence + 1 : 0;
 
     if (Option.isSome(session)) {
-      cleanupProcessHandles(session.value);
-      yield* queuePendingProcessHistory(session.value);
       yield* stopProcess(session.value);
       yield* unregisterTerminal({ threadId, terminalId });
-      yield* flushPersist(threadId, terminalId, session.value.history);
-    } else {
-      yield* retryFailedPersist(threadId, terminalId);
     }
+
+    yield* flushPersist(threadId, terminalId);
 
     const removed = yield* modifyManagerState((state) => {
       if (!state.sessions.has(key)) {
@@ -2253,10 +2073,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     });
 
     if (removed) {
-      const closedEventSequence = Option.isSome(session)
-        ? advanceEventSequence(session.value).sequence
-        : 0;
-      yield* enqueueTerminalEvent({
+      yield* publishEvent({
         type: "closed",
         threadId,
         terminalId,
@@ -2322,46 +2139,40 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         processIds: next.processIds,
       });
       const nextChildLabel = next.hasRunningSubprocess ? next.childCommand : null;
-      yield* withThreadLock(
-        session.threadId,
-        Effect.gen(function* () {
-          const event = yield* modifyManagerState((state) => {
-            const liveSession: Option.Option<TerminalSessionState> = Option.fromNullishOr(
-              state.sessions.get(toSessionKey(session.threadId, session.terminalId)),
-            );
-            if (
-              Option.isNone(liveSession) ||
-              liveSession.value.status !== "running" ||
-              liveSession.value.pid !== terminalPid ||
-              (liveSession.value.hasRunningSubprocess === next.hasRunningSubprocess &&
-                liveSession.value.childCommandLabel === nextChildLabel)
-            ) {
-              return [Option.none(), state] as const;
-            }
+      const event = yield* modifyManagerState((state) => {
+        const liveSession: Option.Option<TerminalSessionState> = Option.fromNullishOr(
+          state.sessions.get(toSessionKey(session.threadId, session.terminalId)),
+        );
+        if (
+          Option.isNone(liveSession) ||
+          liveSession.value.status !== "running" ||
+          liveSession.value.pid !== terminalPid ||
+          (liveSession.value.hasRunningSubprocess === next.hasRunningSubprocess &&
+            liveSession.value.childCommandLabel === nextChildLabel)
+        ) {
+          return [Option.none(), state] as const;
+        }
 
-            liveSession.value.hasRunningSubprocess = next.hasRunningSubprocess;
-            liveSession.value.childCommandLabel = nextChildLabel;
-            const eventStamp = advanceEventSequence(liveSession.value);
+        liveSession.value.hasRunningSubprocess = next.hasRunningSubprocess;
+        liveSession.value.childCommandLabel = nextChildLabel;
+        const eventStamp = advanceEventSequence(liveSession.value);
 
-            return [
-              Option.some({
-                type: "activity" as const,
-                threadId: liveSession.value.threadId,
-                terminalId: liveSession.value.terminalId,
-                sequence: eventStamp.sequence,
-                hasRunningSubprocess: next.hasRunningSubprocess,
-                label: terminalWireLabel(liveSession.value),
-              }),
-              state,
-            ] as const;
-          });
+        return [
+          Option.some({
+            type: "activity" as const,
+            threadId: liveSession.value.threadId,
+            terminalId: liveSession.value.terminalId,
+            sequence: eventStamp.sequence,
+            hasRunningSubprocess: next.hasRunningSubprocess,
+            label: terminalWireLabel(liveSession.value),
+          }),
+          state,
+        ] as const;
+      });
 
-          if (Option.isSome(event)) {
-            yield* enqueueTerminalEvent(event.value);
-          }
-        }),
-      );
-      yield* drainTerminalEvents(session.threadId);
+      if (Option.isSome(event)) {
+        yield* publishEvent(event.value);
+      }
     });
 
     yield* Effect.forEach(runningSessions, checkSubprocessActivity, {
@@ -2404,29 +2215,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       const cleanupSession = Effect.fn("terminal.cleanupSession")(function* (
         session: TerminalSessionState,
       ) {
-        const cleanup = yield* withThreadLock(
-          session.threadId,
-          Effect.gen(function* () {
-            const process = session.process;
-            cleanupProcessHandles(session);
-            yield* queuePendingProcessHistory(session);
-            session.process = null;
-            session.pid = null;
-            session.hasRunningSubprocess = false;
-            session.childCommandLabel = null;
-            session.status = "exited";
-            session.pendingHistoryControlSequence = "";
-            session.pendingProcessEvents = [];
-            session.pendingProcessEventIndex = 0;
-            session.processEventDrainRunning = false;
-            return { history: session.history, process };
-          }),
-        );
-        if (cleanup.process) {
-          yield* clearKillFiber(cleanup.process);
-          yield* runKillEscalation(cleanup.process, session.threadId, session.terminalId);
-        }
-        yield* flushPersist(session.threadId, session.terminalId, cleanup.history);
+        cleanupProcessHandles(session);
+        yield* flushPersist(session.threadId, session.terminalId);
+        if (!session.process) return;
+        yield* clearKillFiber(session.process);
+        yield* runKillEscalation(session.process, session.threadId, session.terminalId);
       });
 
       yield* Effect.forEach(sessions, cleanupSession, {
@@ -2443,7 +2236,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const sessionKey = toSessionKey(input.threadId, terminalId);
     const existing = yield* getSession(input.threadId, terminalId);
     if (Option.isNone(existing)) {
-      yield* retryFailedPersist(input.threadId, terminalId);
+      yield* flushPersist(input.threadId, terminalId);
       const history = yield* readHistory(input.threadId, terminalId);
       const cols = input.cols ?? DEFAULT_OPEN_COLS;
       const rows = input.rows ?? DEFAULT_OPEN_ROWS;
@@ -2455,7 +2248,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         status: "starting",
         pid: null,
         history,
-        persistedHistoryBytes: Buffer.byteLength(history),
+        historyBytes: Buffer.byteLength(history),
         pendingHistoryControlSequence: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
@@ -2517,30 +2310,22 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.worktreePath = nextWorktreePath;
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.history = "";
-      liveSession.persistedHistoryBytes = 0;
+      liveSession.historyBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainRunning = false;
-      yield* resetPersistedHistory(
-        liveSession.threadId,
-        liveSession.terminalId,
-        liveSession.history,
-      );
+      yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
     } else if (liveSession.status === "exited" || liveSession.status === "error") {
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.worktreePath = nextWorktreePath;
       liveSession.history = "";
-      liveSession.persistedHistoryBytes = 0;
+      liveSession.historyBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainRunning = false;
-      yield* resetPersistedHistory(
-        liveSession.threadId,
-        liveSession.terminalId,
-        liveSession.history,
-      );
+      yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
     }
 
     if (!liveSession.process) {
@@ -2571,9 +2356,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   });
 
   const open: TerminalManager["Service"]["open"] = (input) =>
-    withThreadLock(input.threadId, openLocked(input)).pipe(
-      Effect.tap(() => drainTerminalEvents(input.threadId)),
-    );
+    withThreadLock(input.threadId, openLocked(input));
 
   const openOrAttachForStream = (input: TerminalAttachInput) =>
     withThreadLock(
@@ -2623,7 +2406,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         return snapshot(session);
       }),
-    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
+    );
 
   const readAllTerminalMetadata = () =>
     readManagerState.pipe(
@@ -2657,23 +2440,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
   const attachStream: TerminalManager["Service"]["attachStream"] = (input, listener) => {
     let unsubscribe: (() => void) | null = null;
-    let initialSnapshot: TerminalSessionSnapshot | null = null;
-    let lastSequence: number | null = null;
-
-    const shouldDeliver = (event: TerminalEvent): boolean => {
-      if (event.sequence !== undefined) {
-        if (lastSequence !== null && event.sequence <= lastSequence) {
-          return false;
-        }
-        lastSequence = event.sequence;
-      } else if (
-        initialSnapshot !== null &&
-        isDuplicateAttachSnapshotEvent(event, initialSnapshot)
-      ) {
-        return false;
-      }
-      return true;
-    };
 
     return Effect.gen(function* () {
       const bufferedEvents: TerminalEvent[] = [];
@@ -2689,15 +2455,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           return Effect.void;
         }
 
-        if (!shouldDeliver(event)) {
-          return Effect.void;
-        }
         const attachEvent = terminalEventToAttachEvent(event);
         return attachEvent ? listener(attachEvent) : Effect.void;
       });
 
-      initialSnapshot = yield* openOrAttachForStream(input);
-      lastSequence = initialSnapshot.sequence ?? null;
+      const initialSnapshot = yield* openOrAttachForStream(input);
 
       yield* listener({
         type: "snapshot",
@@ -2705,7 +2467,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       });
 
       for (const event of bufferedEvents) {
-        if (!shouldDeliver(event)) {
+        if (isDuplicateAttachSnapshotEvent(event, initialSnapshot)) {
           continue;
         }
 
@@ -2864,21 +2626,21 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const terminalId = input.terminalId;
         const session = yield* requireSession(input.threadId, terminalId);
         session.history = "";
-        session.persistedHistoryBytes = 0;
+        session.historyBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
         const eventStamp = advanceEventSequence(session);
-        yield* resetPersistedHistory(input.threadId, terminalId, session.history);
-        yield* enqueueTerminalEvent({
+        yield* persistHistory(input.threadId, terminalId, session.history);
+        yield* publishEvent({
           type: "cleared",
           threadId: input.threadId,
           terminalId,
           sequence: eventStamp.sequence,
         });
       }),
-    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
+    );
 
   const restart: TerminalManager["Service"]["restart"] = (input) =>
     withThreadLock(
@@ -2892,8 +2654,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const existingSession = yield* getSession(input.threadId, terminalId);
         let session: TerminalSessionState;
         if (Option.isNone(existingSession)) {
-          yield* persistWorker.drainKey(sessionKey);
-          discardedPersistKeys.delete(sessionKey);
           const cols = input.cols ?? DEFAULT_OPEN_COLS;
           const rows = input.rows ?? DEFAULT_OPEN_ROWS;
           session = {
@@ -2904,7 +2664,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             status: "starting",
             pid: null,
             history: "",
-            persistedHistoryBytes: 0,
+            historyBytes: 0,
             pendingHistoryControlSequence: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
@@ -2941,12 +2701,12 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const rows = input.rows ?? session.rows;
 
         session.history = "";
-        session.persistedHistoryBytes = 0;
+        session.historyBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
-        yield* resetPersistedHistory(input.threadId, terminalId, session.history);
+        yield* persistHistory(input.threadId, terminalId, session.history);
         yield* startSession(
           session,
           {
@@ -2962,7 +2722,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         );
         return snapshot(session);
       }),
-    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
+    );
 
   const close: TerminalManager["Service"]["close"] = (input) =>
     withThreadLock(
@@ -2984,7 +2744,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           yield* deleteAllHistoryForThread(input.threadId);
         }
       }),
-    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
+    );
 
   return TerminalManager.of({
     open,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1472,6 +1472,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   });
 
   const failedPersistByKey = new Map<string, PersistHistoryRequest>();
+  const discardedPersistKeys = new Set<string>();
   const persistWorker = yield* makeKeyedCoalescingWorker<
     string,
     PersistHistoryRequest,
@@ -1510,10 +1511,10 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           Effect.matchEffect({
             onFailure: (error) =>
               modifyManagerState((state) => {
-                if (state.sessions.has(sessionKey)) {
-                  failedPersistByKey.set(sessionKey, nextRequest);
-                } else {
+                if (discardedPersistKeys.has(sessionKey)) {
                   failedPersistByKey.delete(sessionKey);
+                } else {
+                  failedPersistByKey.set(sessionKey, nextRequest);
                 }
                 return [undefined, state] as const;
               }).pipe(
@@ -1549,6 +1550,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     yield* drainPersist(threadId, terminalId);
     const failedRequest = failedPersistByKey.get(sessionKey);
     if (failedRequest === undefined) {
+      discardedPersistKeys.delete(sessionKey);
       return;
     }
     yield* persistWorker.enqueue(sessionKey, {
@@ -1559,6 +1561,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       immediate: true,
     });
     yield* drainPersist(threadId, terminalId);
+    discardedPersistKeys.delete(sessionKey);
   });
 
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
@@ -1837,12 +1840,13 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
   const evictInactiveSessionsIfNeeded = Effect.fn("terminal.evictInactiveSessionsIfNeeded")(
     function* () {
-      yield* modifyManagerState((state) => {
+      const evictedSessionKeys = yield* modifyManagerState((state) => {
+        const evictedSessionKeys: Array<string> = [];
         const inactiveSessions = [...state.sessions.values()].filter(
           (session) => session.status !== "running",
         );
         if (inactiveSessions.length <= maxRetainedInactiveSessions) {
-          return [undefined, state] as const;
+          return [evictedSessionKeys, state] as const;
         }
 
         inactiveSessions.sort(
@@ -1859,10 +1863,26 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           const key = toSessionKey(session.threadId, session.terminalId);
           sessions.delete(key);
           failedPersistByKey.delete(key);
+          discardedPersistKeys.add(key);
+          evictedSessionKeys.push(key);
         }
 
-        return [undefined, { ...state, sessions }] as const;
+        return [evictedSessionKeys, { ...state, sessions }] as const;
       });
+
+      yield* Effect.forEach(
+        evictedSessionKeys,
+        (sessionKey) => persistWorker.drainKey(sessionKey),
+        { concurrency: "unbounded", discard: true },
+      ).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            for (const sessionKey of evictedSessionKeys) {
+              discardedPersistKeys.delete(sessionKey);
+            }
+          }),
+        ),
+      );
     },
   );
 
@@ -2872,6 +2892,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const existingSession = yield* getSession(input.threadId, terminalId);
         let session: TerminalSessionState;
         if (Option.isNone(existingSession)) {
+          yield* persistWorker.drainKey(sessionKey);
+          discardedPersistKeys.delete(sessionKey);
           const cols = input.cols ?? DEFAULT_OPEN_COLS;
           const rows = input.rows ?? DEFAULT_OPEN_ROWS;
           session = {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -275,6 +275,7 @@ interface HistoryWrite {
 }
 
 interface PersistHistoryRequest extends HistoryWrite {
+  contentsBytes: number;
   immediate: boolean;
 }
 
@@ -289,13 +290,12 @@ function mergePersistHistoryRequests(
     };
   }
   const contents = `${current.contents}${next.contents}`;
+  const contentsBytes = current.contentsBytes + next.contentsBytes;
   return {
     contents,
+    contentsBytes,
     mode: current.mode,
-    immediate:
-      current.immediate ||
-      next.immediate ||
-      Buffer.byteLength(contents) >= DEFAULT_PERSIST_CHUNK_BYTES,
+    immediate: current.immediate || next.immediate || contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
   };
 }
 
@@ -437,16 +437,6 @@ function isDuplicateAttachSnapshotEvent(
         event.snapshot.threadId === initialSnapshot.threadId &&
         event.snapshot.terminalId === initialSnapshot.terminalId &&
         event.snapshot.updatedAt <= initialSnapshot.updatedAt;
-}
-
-function advanceEventSequence(session: TerminalSessionState): {
-  readonly updatedAt: string;
-  readonly sequence: number;
-} {
-  const updatedAt = DateTime.formatIso(DateTime.nowUnsafe());
-  session.eventSequence += 1;
-  session.updatedAt = updatedAt;
-  return { updatedAt, sequence: session.eventSequence };
 }
 
 function cleanupProcessHandles(session: TerminalSessionState): void {
@@ -1204,6 +1194,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const path = yield* Path.Path;
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
+  let terminalEventSequence = 0;
+
+  const advanceEventSequence = (session: TerminalSessionState) => {
+    const updatedAt = DateTime.formatIso(DateTime.nowUnsafe());
+    terminalEventSequence += 1;
+    session.eventSequence = terminalEventSequence;
+    session.updatedAt = updatedAt;
+    return { updatedAt, sequence: session.eventSequence };
+  };
 
   const logsDir = options.logsDir;
   const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
@@ -1410,7 +1409,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     yield* registerKillFiber(process, fiber);
   });
 
-  const failedPersistByKey = new Map<string, HistoryWrite>();
+  const failedPersistByKey = new Map<string, PersistHistoryRequest>();
   const persistWorker = yield* makeKeyedCoalescingWorker<
     string,
     PersistHistoryRequest,
@@ -1478,6 +1477,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     }
     yield* persistWorker.enqueue(sessionKey, {
       contents: "",
+      contentsBytes: 0,
       mode: "append",
       immediate: true,
     });
@@ -1489,9 +1489,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     terminalId: string,
     request: HistoryWrite,
   ) {
+    const contentsBytes = Buffer.byteLength(request.contents);
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       ...request,
-      immediate: Buffer.byteLength(request.contents) >= DEFAULT_PERSIST_CHUNK_BYTES,
+      contentsBytes,
+      immediate: contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
     });
   });
 
@@ -1503,6 +1505,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const sessionKey = toSessionKey(threadId, terminalId);
     yield* persistWorker.enqueue(sessionKey, {
       contents: "",
+      contentsBytes: 0,
       mode: "append",
       immediate: true,
     });
@@ -1512,6 +1515,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     }
     yield* persistWorker.enqueue(sessionKey, {
       contents: history,
+      contentsBytes: Buffer.byteLength(history),
       mode: "truncate",
       immediate: true,
     });
@@ -1525,6 +1529,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
       contents,
+      contentsBytes: Buffer.byteLength(contents),
       mode: "truncate",
       immediate: true,
     });
@@ -2124,7 +2129,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   ) {
     const key = toSessionKey(threadId, terminalId);
     const session = yield* getSession(threadId, terminalId);
-    const closedEventSequence = Option.isSome(session) ? session.value.eventSequence + 1 : 0;
 
     if (Option.isSome(session)) {
       yield* stopProcess(session.value);
@@ -2144,6 +2148,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     });
 
     if (removed) {
+      const closedEventSequence = Option.isSome(session)
+        ? advanceEventSequence(session.value).sequence
+        : 0;
       yield* publishEvent({
         type: "closed",
         threadId,
@@ -2286,12 +2293,28 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       const cleanupSession = Effect.fn("terminal.cleanupSession")(function* (
         session: TerminalSessionState,
       ) {
-        cleanupProcessHandles(session);
-        if (session.process) {
-          yield* clearKillFiber(session.process);
-          yield* runKillEscalation(session.process, session.threadId, session.terminalId);
+        const cleanup = yield* withThreadLock(
+          session.threadId,
+          Effect.sync(() => {
+            const process = session.process;
+            cleanupProcessHandles(session);
+            session.process = null;
+            session.pid = null;
+            session.hasRunningSubprocess = false;
+            session.childCommandLabel = null;
+            session.status = "exited";
+            session.pendingHistoryControlSequence = "";
+            session.pendingProcessEvents = [];
+            session.pendingProcessEventIndex = 0;
+            session.processEventDrainRunning = false;
+            return { history: session.history, process };
+          }),
+        );
+        if (cleanup.process) {
+          yield* clearKillFiber(cleanup.process);
+          yield* runKillEscalation(cleanup.process, session.threadId, session.terminalId);
         }
-        yield* flushPersist(session.threadId, session.terminalId, session.history);
+        yield* flushPersist(session.threadId, session.terminalId, cleanup.history);
       });
 
       yield* Effect.forEach(sessions, cleanupSession, {
@@ -2522,18 +2545,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     let unsubscribe: (() => void) | null = null;
     let initialSnapshot: TerminalSessionSnapshot | null = null;
     let lastSequence: number | null = null;
-    let sessionClosed = false;
 
     const shouldDeliver = (event: TerminalEvent): boolean => {
-      if (sessionClosed) {
-        if (event.type !== "started" && event.type !== "restarted") {
-          return false;
-        }
-        sessionClosed = false;
-        lastSequence = event.sequence ?? null;
-        return true;
-      }
-
       if (event.sequence !== undefined) {
         if (lastSequence !== null && event.sequence <= lastSequence) {
           return false;
@@ -2544,10 +2557,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         isDuplicateAttachSnapshotEvent(event, initialSnapshot)
       ) {
         return false;
-      }
-
-      if (event.type === "closed") {
-        sessionClosed = true;
       }
       return true;
     };

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1509,8 +1509,13 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         .pipe(
           Effect.matchEffect({
             onFailure: (error) =>
-              Effect.sync(() => {
-                failedPersistByKey.set(sessionKey, nextRequest);
+              modifyManagerState((state) => {
+                if (state.sessions.has(sessionKey)) {
+                  failedPersistByKey.set(sessionKey, nextRequest);
+                } else {
+                  failedPersistByKey.delete(sessionKey);
+                }
+                return [undefined, state] as const;
               }).pipe(
                 Effect.andThen(
                   Effect.logWarning("failed to persist terminal history", {
@@ -1853,6 +1858,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         for (const session of inactiveSessions.slice(0, toEvict)) {
           const key = toSessionKey(session.threadId, session.terminalId);
           sessions.delete(key);
+          failedPersistByKey.delete(key);
         }
 
         return [undefined, { ...state, sessions }] as const;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -266,7 +266,8 @@ export interface TerminalSessionState {
 }
 
 interface PersistHistoryRequest {
-  history: string;
+  contents: string;
+  mode: "append" | "truncate";
   immediate: boolean;
 }
 
@@ -281,7 +282,7 @@ type DrainProcessEventAction =
       threadId: string;
       terminalId: string;
       sequence: number;
-      history: string | null;
+      historyDelta: string;
       data: string;
     }
   | {
@@ -1358,10 +1359,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     never,
     never
   >({
-    merge: (current, next) => ({
-      history: next.history,
-      immediate: current.immediate || next.immediate,
-    }),
+    merge: (current, next) =>
+      next.mode === "truncate"
+        ? next
+        : {
+            contents: `${current.contents}${next.contents}`,
+            mode: current.mode,
+            immediate: current.immediate || next.immediate,
+          },
     process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
       if (!request.immediate) {
         yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
@@ -1372,46 +1377,64 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         return;
       }
 
-      yield* fileSystem.writeFileString(historyPath(threadId, terminalId), request.history).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to persist terminal history", {
-            threadId,
-            terminalId,
-            error,
-          }),
-        ),
-      );
+      yield* fileSystem
+        .writeFileString(historyPath(threadId, terminalId), request.contents, {
+          flag: request.mode === "append" ? "a" : "w",
+        })
+        .pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("failed to persist terminal history", {
+              threadId,
+              terminalId,
+              error,
+            }),
+          ),
+        );
     }),
   });
 
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
+    contents: string,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      history,
+      contents,
+      mode: "append",
       immediate: false,
     });
   });
 
-  const flushPersist = Effect.fn("terminal.flushPersist")(function* (
+  const drainPersist = Effect.fn("terminal.drainPersist")(function* (
     threadId: string,
     terminalId: string,
   ) {
     yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
   });
 
-  const persistHistory = Effect.fn("terminal.persistHistory")(function* (
+  const flushPersist = Effect.fn("terminal.flushPersist")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      history,
+      contents: "",
+      mode: "append",
       immediate: true,
     });
-    yield* flushPersist(threadId, terminalId);
+    yield* drainPersist(threadId, terminalId);
+  });
+
+  const resetPersistedHistory = Effect.fn("terminal.resetPersistedHistory")(function* (
+    threadId: string,
+    terminalId: string,
+    contents: string,
+  ) {
+    yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
+      contents,
+      mode: "truncate",
+      immediate: true,
+    });
+    yield* drainPersist(threadId, terminalId);
   });
 
   const readHistory = Effect.fn("terminal.readHistory")(function* (
@@ -1673,7 +1696,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             threadId: session.threadId,
             terminalId: session.terminalId,
             sequence: eventStamp.sequence,
-            history: sanitized.visibleText.length > 0 ? session.history : null,
+            historyDelta: sanitized.visibleText,
             data: nextEvent.data,
           } as const;
         }
@@ -1713,8 +1736,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       if (action.type === "output") {
-        if (action.history !== null) {
-          yield* queuePersist(action.threadId, action.terminalId, action.history);
+        if (action.historyDelta.length > 0) {
+          yield* queuePersist(action.threadId, action.terminalId, action.historyDelta);
         }
 
         yield* publishEvent({
@@ -1972,10 +1995,10 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     if (Option.isSome(session)) {
       yield* stopProcess(session.value);
       yield* unregisterTerminal({ threadId, terminalId });
-      yield* persistHistory(threadId, terminalId, session.value.history);
+      yield* flushPersist(threadId, terminalId);
+    } else {
+      yield* drainPersist(threadId, terminalId);
     }
-
-    yield* flushPersist(threadId, terminalId);
 
     const removed = yield* modifyManagerState((state) => {
       if (!state.sessions.has(key)) {
@@ -2130,9 +2153,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session: TerminalSessionState,
       ) {
         cleanupProcessHandles(session);
-        if (!session.process) return;
-        yield* clearKillFiber(session.process);
-        yield* runKillEscalation(session.process, session.threadId, session.terminalId);
+        yield* drainPersist(session.threadId, session.terminalId);
+        if (session.process) {
+          yield* clearKillFiber(session.process);
+          yield* runKillEscalation(session.process, session.threadId, session.terminalId);
+        }
       });
 
       yield* Effect.forEach(sessions, cleanupSession, {
@@ -2149,7 +2174,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const sessionKey = toSessionKey(input.threadId, terminalId);
     const existing = yield* getSession(input.threadId, terminalId);
     if (Option.isNone(existing)) {
-      yield* flushPersist(input.threadId, terminalId);
+      yield* drainPersist(input.threadId, terminalId);
       const history = yield* readHistory(input.threadId, terminalId);
       const cols = input.cols ?? DEFAULT_OPEN_COLS;
       const rows = input.rows ?? DEFAULT_OPEN_ROWS;
@@ -2226,7 +2251,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainRunning = false;
-      yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
+      yield* resetPersistedHistory(
+        liveSession.threadId,
+        liveSession.terminalId,
+        liveSession.history,
+      );
     } else if (liveSession.status === "exited" || liveSession.status === "error") {
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.worktreePath = nextWorktreePath;
@@ -2235,7 +2264,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainRunning = false;
-      yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
+      yield* resetPersistedHistory(
+        liveSession.threadId,
+        liveSession.terminalId,
+        liveSession.history,
+      );
     }
 
     if (!liveSession.process) {
@@ -2541,7 +2574,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
         const eventStamp = advanceEventSequence(session);
-        yield* persistHistory(input.threadId, terminalId, session.history);
+        yield* resetPersistedHistory(input.threadId, terminalId, session.history);
         yield* publishEvent({
           type: "cleared",
           threadId: input.threadId,
@@ -2613,7 +2646,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainRunning = false;
-        yield* persistHistory(input.threadId, terminalId, session.history);
+        yield* resetPersistedHistory(input.threadId, terminalId, session.history);
         yield* startSession(
           session,
           {

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -2526,7 +2526,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
     const shouldDeliver = (event: TerminalEvent): boolean => {
       if (sessionClosed) {
-        if (event.type !== "started") {
+        if (event.type !== "started" && event.type !== "restarted") {
           return false;
         }
         sessionClosed = false;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -278,6 +278,27 @@ interface PersistHistoryRequest extends HistoryWrite {
   immediate: boolean;
 }
 
+function mergePersistHistoryRequests(
+  current: PersistHistoryRequest,
+  next: PersistHistoryRequest,
+): PersistHistoryRequest {
+  if (next.mode === "truncate") {
+    return {
+      ...next,
+      immediate: current.immediate || next.immediate,
+    };
+  }
+  const contents = `${current.contents}${next.contents}`;
+  return {
+    contents,
+    mode: current.mode,
+    immediate:
+      current.immediate ||
+      next.immediate ||
+      Buffer.byteLength(contents) >= DEFAULT_PERSIST_CHUNK_BYTES,
+  };
+}
+
 type PendingProcessEvent =
   | { type: "output"; data: string }
   | { type: "exit"; event: PtyAdapter.PtyExitEvent };
@@ -1389,31 +1410,21 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     yield* registerKillFiber(process, fiber);
   });
 
+  const failedPersistByKey = new Map<string, HistoryWrite>();
   const persistWorker = yield* makeKeyedCoalescingWorker<
     string,
     PersistHistoryRequest,
     never,
     never
   >({
-    merge: (current, next) => {
-      if (next.mode === "truncate") {
-        return {
-          ...next,
-          immediate: current.immediate || next.immediate,
-        };
-      }
-      const contents = `${current.contents}${next.contents}`;
-      return {
-        contents,
-        mode: current.mode,
-        immediate:
-          current.immediate ||
-          next.immediate ||
-          Buffer.byteLength(contents) >= DEFAULT_PERSIST_CHUNK_BYTES,
-      };
-    },
+    merge: mergePersistHistoryRequests,
     process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
-      if (!request.immediate) {
+      const failedRequest = failedPersistByKey.get(sessionKey);
+      const nextRequest =
+        failedRequest === undefined
+          ? request
+          : mergePersistHistoryRequests({ ...failedRequest, immediate: false }, request);
+      if (!nextRequest.immediate) {
         yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
       }
 
@@ -1423,19 +1434,54 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       yield* fileSystem
-        .writeFileString(historyPath(threadId, terminalId), request.contents, {
-          flag: request.mode === "append" ? "a" : "w",
+        .writeFileString(historyPath(threadId, terminalId), nextRequest.contents, {
+          flag: nextRequest.mode === "append" ? "a" : "w",
         })
         .pipe(
-          Effect.catch((error) =>
-            Effect.logWarning("failed to persist terminal history", {
-              threadId,
-              terminalId,
-              error,
-            }),
-          ),
+          Effect.matchEffect({
+            onFailure: (error) =>
+              Effect.sync(() => {
+                failedPersistByKey.set(sessionKey, nextRequest);
+              }).pipe(
+                Effect.andThen(
+                  Effect.logWarning("failed to persist terminal history", {
+                    threadId,
+                    terminalId,
+                    error,
+                  }),
+                ),
+              ),
+            onSuccess: () =>
+              Effect.sync(() => {
+                failedPersistByKey.delete(sessionKey);
+              }),
+          }),
         );
     }),
+  });
+
+  const drainPersist = Effect.fn("terminal.drainPersist")(function* (
+    threadId: string,
+    terminalId: string,
+  ) {
+    yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
+  });
+
+  const retryFailedPersist = Effect.fn("terminal.retryFailedPersist")(function* (
+    threadId: string,
+    terminalId: string,
+  ) {
+    const sessionKey = toSessionKey(threadId, terminalId);
+    yield* drainPersist(threadId, terminalId);
+    if (!failedPersistByKey.has(sessionKey)) {
+      return;
+    }
+    yield* persistWorker.enqueue(sessionKey, {
+      contents: "",
+      mode: "append",
+      immediate: true,
+    });
+    yield* drainPersist(threadId, terminalId);
   });
 
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
@@ -1449,20 +1495,24 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     });
   });
 
-  const drainPersist = Effect.fn("terminal.drainPersist")(function* (
-    threadId: string,
-    terminalId: string,
-  ) {
-    yield* persistWorker.drainKey(toSessionKey(threadId, terminalId));
-  });
-
   const flushPersist = Effect.fn("terminal.flushPersist")(function* (
     threadId: string,
     terminalId: string,
+    history: string,
   ) {
-    yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
+    const sessionKey = toSessionKey(threadId, terminalId);
+    yield* persistWorker.enqueue(sessionKey, {
       contents: "",
       mode: "append",
+      immediate: true,
+    });
+    yield* drainPersist(threadId, terminalId);
+    if (!failedPersistByKey.has(sessionKey)) {
+      return;
+    }
+    yield* persistWorker.enqueue(sessionKey, {
+      contents: history,
+      mode: "truncate",
       immediate: true,
     });
     yield* drainPersist(threadId, terminalId);
@@ -1574,6 +1624,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     threadId: string,
     terminalId: string,
   ) {
+    failedPersistByKey.delete(toSessionKey(threadId, terminalId));
     yield* fileSystem.remove(historyPath(threadId, terminalId), { force: true }).pipe(
       Effect.catch((error) =>
         Effect.logWarning("failed to delete terminal history", {
@@ -2062,9 +2113,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     if (Option.isSome(session)) {
       yield* stopProcess(session.value);
       yield* unregisterTerminal({ threadId, terminalId });
-      yield* flushPersist(threadId, terminalId);
+      yield* flushPersist(threadId, terminalId, session.value.history);
     } else {
-      yield* drainPersist(threadId, terminalId);
+      yield* retryFailedPersist(threadId, terminalId);
     }
 
     const removed = yield* modifyManagerState((state) => {
@@ -2220,11 +2271,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session: TerminalSessionState,
       ) {
         cleanupProcessHandles(session);
-        yield* drainPersist(session.threadId, session.terminalId);
         if (session.process) {
           yield* clearKillFiber(session.process);
           yield* runKillEscalation(session.process, session.threadId, session.terminalId);
         }
+        yield* flushPersist(session.threadId, session.terminalId, session.history);
       });
 
       yield* Effect.forEach(sessions, cleanupSession, {
@@ -2241,7 +2292,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const sessionKey = toSessionKey(input.threadId, terminalId);
     const existing = yield* getSession(input.threadId, terminalId);
     if (Option.isNone(existing)) {
-      yield* drainPersist(input.threadId, terminalId);
+      yield* retryFailedPersist(input.threadId, terminalId);
       const history = yield* readHistory(input.threadId, terminalId);
       const cols = input.cols ?? DEFAULT_OPEN_COLS;
       const rows = input.rows ?? DEFAULT_OPEN_ROWS;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -290,8 +290,18 @@ function mergePersistHistoryRequests(
       immediate: current.immediate || next.immediate,
     };
   }
-  const contents = `${current.contents}${next.contents}`;
   const contentsBytes = current.contentsBytes + next.contentsBytes;
+  if (current.mode === "truncate") {
+    return {
+      authoritativeHistory: next.authoritativeHistory,
+      contents: next.authoritativeHistory,
+      contentsBytes,
+      mode: "truncate",
+      immediate:
+        current.immediate || next.immediate || contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
+    };
+  }
+  const contents = `${current.contents}${next.contents}`;
   return {
     authoritativeHistory: next.authoritativeHistory,
     contents,
@@ -2161,6 +2171,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const session = yield* getSession(threadId, terminalId);
 
     if (Option.isSome(session)) {
+      cleanupProcessHandles(session.value);
       yield* queuePendingProcessHistory(session.value);
       yield* stopProcess(session.value);
       yield* unregisterTerminal({ threadId, terminalId });

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -249,6 +249,8 @@ export interface TerminalSessionState {
   pid: number | null;
   history: string;
   historyBytes: number;
+  persistenceHistory: string;
+  persistenceHistoryBytes: number;
   pendingHistoryControlSequence: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
@@ -280,7 +282,7 @@ interface PersistHistoryRequest extends HistoryWrite {
 }
 
 type PendingProcessEvent =
-  | { type: "output"; data: string }
+  | { type: "output"; data: string; visibleText: string }
   | { type: "exit"; event: PtyAdapter.PtyExitEvent };
 
 type DrainProcessEventAction =
@@ -1240,24 +1242,33 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
     });
 
-  const applyHistoryOutput = (session: TerminalSessionState, data: string): HistoryWrite | null => {
+  const applyHistoryOutput = (
+    session: TerminalSessionState,
+    data: string,
+  ): { visibleText: string; write: HistoryWrite | null } => {
     const sanitized = sanitizeTerminalHistoryChunk(session.pendingHistoryControlSequence, data);
     session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
     if (sanitized.visibleText.length === 0) {
-      return null;
+      return { visibleText: "", write: null };
     }
 
     const visibleBytes = Buffer.byteLength(sanitized.visibleText);
-    const nextHistory = `${session.history}${sanitized.visibleText}`;
-    if (session.historyBytes + visibleBytes <= historyMaxBytes) {
-      session.history = nextHistory;
-      session.historyBytes += visibleBytes;
-      return { contents: sanitized.visibleText, mode: "append" };
+    const nextHistory = `${session.persistenceHistory}${sanitized.visibleText}`;
+    if (session.persistenceHistoryBytes + visibleBytes <= historyMaxBytes) {
+      session.persistenceHistory = nextHistory;
+      session.persistenceHistoryBytes += visibleBytes;
+      return {
+        visibleText: sanitized.visibleText,
+        write: { contents: sanitized.visibleText, mode: "append" },
+      };
     }
 
-    session.history = capHistoryByBytes(nextHistory, historyTargetBytes);
-    session.historyBytes = Buffer.byteLength(session.history);
-    return { contents: session.history, mode: "truncate" };
+    session.persistenceHistory = capHistoryByBytes(nextHistory, historyTargetBytes);
+    session.persistenceHistoryBytes = Buffer.byteLength(session.persistenceHistory);
+    return {
+      visibleText: sanitized.visibleText,
+      write: { contents: session.persistenceHistory, mode: "truncate" },
+    };
   };
 
   const historyPath = (threadId: string, terminalId: string) => {
@@ -1750,6 +1761,17 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         }
 
         if (nextEvent.type === "output") {
+          if (nextEvent.visibleText.length > 0) {
+            const visibleBytes = Buffer.byteLength(nextEvent.visibleText);
+            const nextHistory = `${session.history}${nextEvent.visibleText}`;
+            if (session.historyBytes + visibleBytes <= historyMaxBytes) {
+              session.history = nextHistory;
+              session.historyBytes += visibleBytes;
+            } else {
+              session.history = capHistoryByBytes(nextHistory, historyTargetBytes);
+              session.historyBytes = Buffer.byteLength(session.history);
+            }
+          }
           const eventStamp = advanceEventSequence(session);
 
           return {
@@ -1959,14 +1981,25 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
                 return;
               }
 
-              const historyWrite = applyHistoryOutput(session, data);
-              if (historyWrite !== null) {
+              const historyOutput = applyHistoryOutput(session, data);
+              if (historyOutput.write !== null) {
                 runSync(
-                  queuePersist(session.threadId, session.terminalId, historyWrite, session.history),
+                  queuePersist(
+                    session.threadId,
+                    session.terminalId,
+                    historyOutput.write,
+                    session.persistenceHistory,
+                  ),
                 );
               }
 
-              if (!enqueueProcessEvent(session, processPid, { type: "output", data })) {
+              if (
+                !enqueueProcessEvent(session, processPid, {
+                  type: "output",
+                  data,
+                  visibleText: historyOutput.visibleText,
+                })
+              ) {
                 return;
               }
               runFork(drainProcessEvents(session, processPid));
@@ -2253,6 +2286,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         pid: null,
         history,
         historyBytes: Buffer.byteLength(history),
+        persistenceHistory: history,
+        persistenceHistoryBytes: Buffer.byteLength(history),
         pendingHistoryControlSequence: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
@@ -2315,6 +2350,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.history = "";
       liveSession.historyBytes = 0;
+      liveSession.persistenceHistory = "";
+      liveSession.persistenceHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2325,6 +2362,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.worktreePath = nextWorktreePath;
       liveSession.history = "";
       liveSession.historyBytes = 0;
+      liveSession.persistenceHistory = "";
+      liveSession.persistenceHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2631,6 +2670,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const session = yield* requireSession(input.threadId, terminalId);
         session.history = "";
         session.historyBytes = 0;
+        session.persistenceHistory = "";
+        session.persistenceHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
@@ -2669,6 +2710,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             pid: null,
             history: "",
             historyBytes: 0,
+            persistenceHistory: "",
+            persistenceHistoryBytes: 0,
             pendingHistoryControlSequence: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
@@ -2706,6 +2749,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         session.history = "";
         session.historyBytes = 0;
+        session.persistenceHistory = "";
+        session.persistenceHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -75,7 +75,10 @@ export {
 };
 
 const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
+const DEFAULT_HISTORY_TARGET_BYTES = 8 * 1024 * 1024;
+const DEFAULT_HISTORY_MAX_BYTES = 12 * 1024 * 1024;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
+const DEFAULT_PERSIST_CHUNK_BYTES = 64 * 1024;
 const DEFAULT_SUBPROCESS_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_PROCESS_KILL_GRACE_MS = 1_000;
 const DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS = 128;
@@ -246,6 +249,7 @@ export interface TerminalSessionState {
   status: TerminalSessionStatus;
   pid: number | null;
   history: string;
+  persistedHistoryBytes: number;
   pendingHistoryControlSequence: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
@@ -265,9 +269,12 @@ export interface TerminalSessionState {
   runtimeEnv: Record<string, string> | null;
 }
 
-interface PersistHistoryRequest {
+interface HistoryWrite {
   contents: string;
   mode: "append" | "truncate";
+}
+
+interface PersistHistoryRequest extends HistoryWrite {
   immediate: boolean;
 }
 
@@ -282,7 +289,7 @@ type DrainProcessEventAction =
       threadId: string;
       terminalId: string;
       sequence: number;
-      historyDelta: string;
+      historyWrite: HistoryWrite | null;
       data: string;
     }
   | {
@@ -797,6 +804,31 @@ function capHistory(history: string, maxLines: number): string {
   return hasTrailingNewline ? `${capped}\n` : capped;
 }
 
+function capHistoryByBytes(history: string, targetBytes: number): string {
+  const encoded = Buffer.from(history);
+  if (encoded.byteLength <= targetBytes) return history;
+
+  let start = encoded.byteLength - targetBytes;
+  while (start < encoded.byteLength && ((encoded[start] ?? 0) & 0xc0) === 0x80) {
+    start += 1;
+  }
+  const suffix = encoded.subarray(start).toString();
+
+  const newlineIndex = suffix.indexOf("\n");
+  const carriageReturnIndex = suffix.indexOf("\r");
+  const boundaryIndex =
+    newlineIndex === -1
+      ? carriageReturnIndex
+      : carriageReturnIndex === -1
+        ? newlineIndex
+        : Math.min(newlineIndex, carriageReturnIndex);
+  if (boundaryIndex === -1) return "";
+
+  const boundaryLength =
+    suffix[boundaryIndex] === "\r" && suffix[boundaryIndex + 1] === "\n" ? 2 : 1;
+  return suffix.slice(boundaryIndex + boundaryLength);
+}
+
 function isCsiFinalByte(codePoint: number): boolean {
   return codePoint >= 0x40 && codePoint <= 0x7e;
 }
@@ -1112,6 +1144,8 @@ function normalizedRuntimeEnv(
 interface TerminalManagerOptions {
   logsDir: string;
   historyLineLimit?: number;
+  historyTargetBytes?: number;
+  historyMaxBytes?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
@@ -1152,6 +1186,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
   const logsDir = options.logsDir;
   const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
+  const historyTargetBytes = options.historyTargetBytes ?? DEFAULT_HISTORY_TARGET_BYTES;
+  const historyMaxBytes = options.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES;
   const platform = yield* HostProcessPlatform;
   // Terminals must inherit the user's full environment (minus the blocklist
   // applied in createTerminalSpawnEnv) — an allowlist here silently strips
@@ -1359,14 +1395,23 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     never,
     never
   >({
-    merge: (current, next) =>
-      next.mode === "truncate"
-        ? next
-        : {
-            contents: `${current.contents}${next.contents}`,
-            mode: current.mode,
-            immediate: current.immediate || next.immediate,
-          },
+    merge: (current, next) => {
+      if (next.mode === "truncate") {
+        return {
+          ...next,
+          immediate: current.immediate || next.immediate,
+        };
+      }
+      const contents = `${current.contents}${next.contents}`;
+      return {
+        contents,
+        mode: current.mode,
+        immediate:
+          current.immediate ||
+          next.immediate ||
+          Buffer.byteLength(contents) >= DEFAULT_PERSIST_CHUNK_BYTES,
+      };
+    },
     process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
       if (!request.immediate) {
         yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
@@ -1396,12 +1441,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
     threadId: string,
     terminalId: string,
-    contents: string,
+    request: HistoryWrite,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      contents,
-      mode: "append",
-      immediate: false,
+      ...request,
+      immediate: Buffer.byteLength(request.contents) >= DEFAULT_PERSIST_CHUNK_BYTES,
     });
   });
 
@@ -1458,7 +1502,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             (cause) => new TerminalHistoryError({ operation: "read", threadId, terminalId, cause }),
           ),
         );
-      const capped = capHistory(raw, historyLineLimit);
+      const lineCapped = capHistory(raw, historyLineLimit);
+      const capped =
+        Buffer.byteLength(lineCapped) > historyMaxBytes
+          ? capHistoryByBytes(lineCapped, historyTargetBytes)
+          : lineCapped;
       if (capped !== raw) {
         yield* fileSystem
           .writeFileString(nextPath, capped)
@@ -1498,7 +1546,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             new TerminalHistoryError({ operation: "migrate", threadId, terminalId, cause }),
         ),
       );
-    const capped = capHistory(raw, historyLineLimit);
+    const lineCapped = capHistory(raw, historyLineLimit);
+    const capped =
+      Buffer.byteLength(lineCapped) > historyMaxBytes
+        ? capHistoryByBytes(lineCapped, historyTargetBytes)
+        : lineCapped;
     yield* fileSystem
       .writeFileString(nextPath, capped)
       .pipe(
@@ -1683,11 +1735,26 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             nextEvent.data,
           );
           session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
+          let historyWrite: HistoryWrite | null = null;
           if (sanitized.visibleText.length > 0) {
             session.history = capHistory(
               `${session.history}${sanitized.visibleText}`,
               historyLineLimit,
             );
+            session.persistedHistoryBytes += Buffer.byteLength(sanitized.visibleText);
+            if (session.persistedHistoryBytes > historyMaxBytes) {
+              session.history = capHistoryByBytes(session.history, historyTargetBytes);
+              session.persistedHistoryBytes = Buffer.byteLength(session.history);
+              historyWrite = {
+                contents: session.history,
+                mode: "truncate",
+              };
+            } else {
+              historyWrite = {
+                contents: sanitized.visibleText,
+                mode: "append",
+              };
+            }
           }
           const eventStamp = advanceEventSequence(session);
 
@@ -1696,7 +1763,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             threadId: session.threadId,
             terminalId: session.terminalId,
             sequence: eventStamp.sequence,
-            historyDelta: sanitized.visibleText,
+            historyWrite,
             data: nextEvent.data,
           } as const;
         }
@@ -1736,8 +1803,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       if (action.type === "output") {
-        if (action.historyDelta.length > 0) {
-          yield* queuePersist(action.threadId, action.terminalId, action.historyDelta);
+        if (action.historyWrite !== null) {
+          yield* queuePersist(action.threadId, action.terminalId, action.historyWrite);
         }
 
         yield* publishEvent({
@@ -2186,6 +2253,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         status: "starting",
         pid: null,
         history,
+        persistedHistoryBytes: Buffer.byteLength(history),
         pendingHistoryControlSequence: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
@@ -2247,6 +2315,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.worktreePath = nextWorktreePath;
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.history = "";
+      liveSession.persistedHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2260,6 +2329,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.worktreePath = nextWorktreePath;
       liveSession.history = "";
+      liveSession.persistedHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
@@ -2569,6 +2639,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const terminalId = input.terminalId;
         const session = yield* requireSession(input.threadId, terminalId);
         session.history = "";
+        session.persistedHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
@@ -2606,6 +2677,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             status: "starting",
             pid: null,
             history: "",
+            persistedHistoryBytes: 0,
             pendingHistoryControlSequence: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
@@ -2642,6 +2714,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const rows = input.rows ?? session.rows;
 
         session.history = "";
+        session.persistedHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -35,6 +35,7 @@ import {
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
+import * as Chunk from "effect/Chunk";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -849,6 +850,7 @@ function capHistoryByBytes(history: string, targetBytes: number): string {
 
   const boundaryLength =
     suffix[boundaryIndex] === "\r" && suffix[boundaryIndex + 1] === "\n" ? 2 : 1;
+  if (boundaryIndex + boundaryLength === suffix.length) return suffix;
   return suffix.slice(boundaryIndex + boundaryLength);
 }
 
@@ -1292,6 +1294,23 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         yield* listener(event).pipe(Effect.ignoreCause({ log: true }));
       }
     });
+
+  const terminalEventWorker = yield* makeKeyedCoalescingWorker<
+    string,
+    Chunk.Chunk<TerminalEvent>,
+    never,
+    never
+  >({
+    merge: Chunk.appendAll,
+    process: Effect.fn("terminal.publishEventWorker")(function* (_threadId, events) {
+      yield* Effect.forEach(events, publishEvent, { discard: true });
+    }),
+  });
+
+  const enqueueTerminalEvent = (event: TerminalEvent) =>
+    terminalEventWorker.enqueue(event.threadId, Chunk.of(event));
+
+  const drainTerminalEvents = (threadId: string) => terminalEventWorker.drainKey(threadId);
 
   const historyPath = (threadId: string, terminalId: string) => {
     const threadPart = toSafeThreadId(threadId);
@@ -1910,6 +1929,24 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               session.history,
             );
           }
+          if (nextAction.type === "output") {
+            yield* enqueueTerminalEvent({
+              type: "output",
+              threadId: nextAction.threadId,
+              terminalId: nextAction.terminalId,
+              sequence: nextAction.sequence,
+              data: nextAction.data,
+            });
+          } else if (nextAction.type === "exit") {
+            yield* enqueueTerminalEvent({
+              type: "exited",
+              threadId: nextAction.threadId,
+              terminalId: nextAction.terminalId,
+              sequence: nextAction.sequence,
+              exitCode: nextAction.exitCode,
+              exitSignal: nextAction.exitSignal,
+            });
+          }
           return nextAction;
         }),
       );
@@ -1919,13 +1956,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       if (action.type === "output") {
-        yield* publishEvent({
-          type: "output",
-          threadId: action.threadId,
-          terminalId: action.terminalId,
-          sequence: action.sequence,
-          data: action.data,
-        });
+        yield* drainTerminalEvents(action.threadId);
         continue;
       }
 
@@ -1934,14 +1965,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         threadId: action.threadId,
         terminalId: action.terminalId,
       });
-      yield* publishEvent({
-        type: "exited",
-        threadId: action.threadId,
-        terminalId: action.terminalId,
-        sequence: action.sequence,
-        exitCode: action.exitCode,
-        exitSignal: action.exitSignal,
-      });
+      yield* drainTerminalEvents(action.threadId);
       yield* evictInactiveSessionsIfNeeded();
       return;
     }
@@ -2103,7 +2127,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               return [undefined, state] as const;
             });
 
-            yield* publishEvent({
+            yield* enqueueTerminalEvent({
               type: eventType,
               threadId: session.threadId,
               terminalId: session.terminalId,
@@ -2146,7 +2170,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       yield* evictInactiveSessionsIfNeeded();
 
       const message = error.message;
-      yield* publishEvent({
+      yield* enqueueTerminalEvent({
         type: "error",
         threadId: session.threadId,
         terminalId: session.terminalId,
@@ -2193,7 +2217,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       const closedEventSequence = Option.isSome(session)
         ? advanceEventSequence(session.value).sequence
         : 0;
-      yield* publishEvent({
+      yield* enqueueTerminalEvent({
         type: "closed",
         threadId,
         terminalId,
@@ -2259,40 +2283,46 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         processIds: next.processIds,
       });
       const nextChildLabel = next.hasRunningSubprocess ? next.childCommand : null;
-      const event = yield* modifyManagerState((state) => {
-        const liveSession: Option.Option<TerminalSessionState> = Option.fromNullishOr(
-          state.sessions.get(toSessionKey(session.threadId, session.terminalId)),
-        );
-        if (
-          Option.isNone(liveSession) ||
-          liveSession.value.status !== "running" ||
-          liveSession.value.pid !== terminalPid ||
-          (liveSession.value.hasRunningSubprocess === next.hasRunningSubprocess &&
-            liveSession.value.childCommandLabel === nextChildLabel)
-        ) {
-          return [Option.none(), state] as const;
-        }
+      yield* withThreadLock(
+        session.threadId,
+        Effect.gen(function* () {
+          const event = yield* modifyManagerState((state) => {
+            const liveSession: Option.Option<TerminalSessionState> = Option.fromNullishOr(
+              state.sessions.get(toSessionKey(session.threadId, session.terminalId)),
+            );
+            if (
+              Option.isNone(liveSession) ||
+              liveSession.value.status !== "running" ||
+              liveSession.value.pid !== terminalPid ||
+              (liveSession.value.hasRunningSubprocess === next.hasRunningSubprocess &&
+                liveSession.value.childCommandLabel === nextChildLabel)
+            ) {
+              return [Option.none(), state] as const;
+            }
 
-        liveSession.value.hasRunningSubprocess = next.hasRunningSubprocess;
-        liveSession.value.childCommandLabel = nextChildLabel;
-        const eventStamp = advanceEventSequence(liveSession.value);
+            liveSession.value.hasRunningSubprocess = next.hasRunningSubprocess;
+            liveSession.value.childCommandLabel = nextChildLabel;
+            const eventStamp = advanceEventSequence(liveSession.value);
 
-        return [
-          Option.some({
-            type: "activity" as const,
-            threadId: liveSession.value.threadId,
-            terminalId: liveSession.value.terminalId,
-            sequence: eventStamp.sequence,
-            hasRunningSubprocess: next.hasRunningSubprocess,
-            label: terminalWireLabel(liveSession.value),
-          }),
-          state,
-        ] as const;
-      });
+            return [
+              Option.some({
+                type: "activity" as const,
+                threadId: liveSession.value.threadId,
+                terminalId: liveSession.value.terminalId,
+                sequence: eventStamp.sequence,
+                hasRunningSubprocess: next.hasRunningSubprocess,
+                label: terminalWireLabel(liveSession.value),
+              }),
+              state,
+            ] as const;
+          });
 
-      if (Option.isSome(event)) {
-        yield* publishEvent(event.value);
-      }
+          if (Option.isSome(event)) {
+            yield* enqueueTerminalEvent(event.value);
+          }
+        }),
+      );
+      yield* drainTerminalEvents(session.threadId);
     });
 
     yield* Effect.forEach(runningSessions, checkSubprocessActivity, {
@@ -2502,7 +2532,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   });
 
   const open: TerminalManager["Service"]["open"] = (input) =>
-    withThreadLock(input.threadId, openLocked(input));
+    withThreadLock(input.threadId, openLocked(input)).pipe(
+      Effect.tap(() => drainTerminalEvents(input.threadId)),
+    );
 
   const openOrAttachForStream = (input: TerminalAttachInput) =>
     withThreadLock(
@@ -2552,7 +2584,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
         return snapshot(session);
       }),
-    );
+    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
 
   const readAllTerminalMetadata = () =>
     readManagerState.pipe(
@@ -2800,14 +2832,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.processEventDrainRunning = false;
         const eventStamp = advanceEventSequence(session);
         yield* resetPersistedHistory(input.threadId, terminalId, session.history);
-        yield* publishEvent({
+        yield* enqueueTerminalEvent({
           type: "cleared",
           threadId: input.threadId,
           terminalId,
           sequence: eventStamp.sequence,
         });
       }),
-    );
+    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
 
   const restart: TerminalManager["Service"]["restart"] = (input) =>
     withThreadLock(
@@ -2889,7 +2921,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         );
         return snapshot(session);
       }),
-    );
+    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
 
   const close: TerminalManager["Service"]["close"] = (input) =>
     withThreadLock(
@@ -2911,7 +2943,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           yield* deleteAllHistoryForThread(input.threadId);
         }
       }),
-    );
+    ).pipe(Effect.tap(() => drainTerminalEvents(input.threadId)));
 
   return TerminalManager.of({
     open,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1650,6 +1650,12 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const deleteAllHistoryForThread = Effect.fn("terminal.deleteAllHistoryForThread")(function* (
     threadId: string,
   ) {
+    const sessionPrefix = `${threadId}\u0000`;
+    for (const sessionKey of failedPersistByKey.keys()) {
+      if (sessionKey.startsWith(sessionPrefix)) {
+        failedPersistByKey.delete(sessionKey);
+      }
+    }
     const threadPrefix = `${toSafeThreadId(threadId)}_`;
     const entries = yield* fileSystem
       .readDirectory(logsDir, { recursive: false })

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -837,6 +837,10 @@ function capHistoryByBytes(history: string, targetBytes: number): string {
     start += 1;
   }
   const suffix = encoded.subarray(start).toString();
+  const previousByte = start > 0 ? encoded[start - 1] : undefined;
+  if (previousByte === 0x0a || (previousByte === 0x0d && encoded[start] !== 0x0a)) {
+    return suffix;
+  }
 
   const newlineIndex = suffix.indexOf("\n");
   const carriageReturnIndex = suffix.indexOf("\r");

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -843,7 +843,7 @@ function capHistoryByBytes(history: string, targetBytes: number): string {
       : carriageReturnIndex === -1
         ? newlineIndex
         : Math.min(newlineIndex, carriageReturnIndex);
-  if (boundaryIndex === -1) return "";
+  if (boundaryIndex === -1) return suffix;
 
   const boundaryLength =
     suffix[boundaryIndex] === "\r" && suffix[boundaryIndex + 1] === "\n" ? 2 : 1;
@@ -1758,106 +1758,116 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     expectedPid: number,
   ) {
     while (true) {
-      const action: DrainProcessEventAction = yield* Effect.sync(() => {
-        if (session.pid !== expectedPid || !session.process || session.status !== "running") {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
-          session.processEventDrainRunning = false;
-          return { type: "idle" } as const;
-        }
-
-        const nextEvent = session.pendingProcessEvents[session.pendingProcessEventIndex];
-        if (!nextEvent) {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
-          session.processEventDrainRunning = false;
-          return { type: "idle" } as const;
-        }
-
-        session.pendingProcessEventIndex += 1;
-        if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
-          session.pendingProcessEvents = [];
-          session.pendingProcessEventIndex = 0;
-        }
-
-        if (nextEvent.type === "output") {
-          const sanitized = sanitizeTerminalHistoryChunk(
-            session.pendingHistoryControlSequence,
-            nextEvent.data,
-          );
-          session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
-          let historyWrite: HistoryWrite | null = null;
-          if (sanitized.visibleText.length > 0) {
-            session.history = capHistory(
-              `${session.history}${sanitized.visibleText}`,
-              historyLineLimit,
-            );
-            session.persistedHistoryBytes += Buffer.byteLength(sanitized.visibleText);
-            if (session.persistedHistoryBytes > historyMaxBytes) {
-              session.history = capHistoryByBytes(session.history, historyTargetBytes);
-              session.persistedHistoryBytes = Buffer.byteLength(session.history);
-              historyWrite = {
-                contents: session.history,
-                mode: "truncate",
-              };
-            } else {
-              historyWrite = {
-                contents: sanitized.visibleText,
-                mode: "append",
-              };
+      const action = yield* withThreadLock(
+        session.threadId,
+        Effect.gen(function* () {
+          const nextAction: DrainProcessEventAction = yield* Effect.sync(() => {
+            if (session.pid !== expectedPid || !session.process || session.status !== "running") {
+              session.pendingProcessEvents = [];
+              session.pendingProcessEventIndex = 0;
+              session.processEventDrainRunning = false;
+              return { type: "idle" } as const;
             }
+
+            const nextEvent = session.pendingProcessEvents[session.pendingProcessEventIndex];
+            if (!nextEvent) {
+              session.pendingProcessEvents = [];
+              session.pendingProcessEventIndex = 0;
+              session.processEventDrainRunning = false;
+              return { type: "idle" } as const;
+            }
+
+            session.pendingProcessEventIndex += 1;
+            if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
+              session.pendingProcessEvents = [];
+              session.pendingProcessEventIndex = 0;
+            }
+
+            if (nextEvent.type === "output") {
+              const sanitized = sanitizeTerminalHistoryChunk(
+                session.pendingHistoryControlSequence,
+                nextEvent.data,
+              );
+              session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
+              let historyWrite: HistoryWrite | null = null;
+              if (sanitized.visibleText.length > 0) {
+                session.history = capHistory(
+                  `${session.history}${sanitized.visibleText}`,
+                  historyLineLimit,
+                );
+                session.persistedHistoryBytes += Buffer.byteLength(sanitized.visibleText);
+                if (session.persistedHistoryBytes > historyMaxBytes) {
+                  session.history = capHistoryByBytes(session.history, historyTargetBytes);
+                  session.persistedHistoryBytes = Buffer.byteLength(session.history);
+                  historyWrite = {
+                    contents: session.history,
+                    mode: "truncate",
+                  };
+                } else {
+                  historyWrite = {
+                    contents: sanitized.visibleText,
+                    mode: "append",
+                  };
+                }
+              }
+              const eventStamp = advanceEventSequence(session);
+
+              return {
+                type: "output",
+                threadId: session.threadId,
+                terminalId: session.terminalId,
+                sequence: eventStamp.sequence,
+                historyWrite,
+                data: nextEvent.data,
+              } as const;
+            }
+
+            const process = session.process;
+            cleanupProcessHandles(session);
+            session.process = null;
+            session.pid = null;
+            session.hasRunningSubprocess = false;
+            session.childCommandLabel = null;
+            session.status = "exited";
+            session.pendingHistoryControlSequence = "";
+            session.pendingProcessEvents = [];
+            session.pendingProcessEventIndex = 0;
+            session.processEventDrainRunning = false;
+            session.exitCode = Number.isInteger(nextEvent.event.exitCode)
+              ? nextEvent.event.exitCode
+              : null;
+            session.exitSignal = Number.isInteger(nextEvent.event.signal)
+              ? nextEvent.event.signal
+              : null;
+            const eventStamp = advanceEventSequence(session);
+
+            return {
+              type: "exit",
+              process,
+              threadId: session.threadId,
+              terminalId: session.terminalId,
+              sequence: eventStamp.sequence,
+              exitCode: session.exitCode,
+              exitSignal: session.exitSignal,
+            } as const;
+          });
+
+          if (nextAction.type === "output" && nextAction.historyWrite !== null) {
+            yield* queuePersist(
+              nextAction.threadId,
+              nextAction.terminalId,
+              nextAction.historyWrite,
+            );
           }
-          const eventStamp = advanceEventSequence(session);
-
-          return {
-            type: "output",
-            threadId: session.threadId,
-            terminalId: session.terminalId,
-            sequence: eventStamp.sequence,
-            historyWrite,
-            data: nextEvent.data,
-          } as const;
-        }
-
-        const process = session.process;
-        cleanupProcessHandles(session);
-        session.process = null;
-        session.pid = null;
-        session.hasRunningSubprocess = false;
-        session.childCommandLabel = null;
-        session.status = "exited";
-        session.pendingHistoryControlSequence = "";
-        session.pendingProcessEvents = [];
-        session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
-        session.exitCode = Number.isInteger(nextEvent.event.exitCode)
-          ? nextEvent.event.exitCode
-          : null;
-        session.exitSignal = Number.isInteger(nextEvent.event.signal)
-          ? nextEvent.event.signal
-          : null;
-        const eventStamp = advanceEventSequence(session);
-
-        return {
-          type: "exit",
-          process,
-          threadId: session.threadId,
-          terminalId: session.terminalId,
-          sequence: eventStamp.sequence,
-          exitCode: session.exitCode,
-          exitSignal: session.exitSignal,
-        } as const;
-      });
+          return nextAction;
+        }),
+      );
 
       if (action.type === "idle") {
         return;
       }
 
       if (action.type === "output") {
-        if (action.historyWrite !== null) {
-          yield* queuePersist(action.threadId, action.terminalId, action.historyWrite);
-        }
-
         yield* publishEvent({
           type: "output",
           threadId: action.threadId,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1018,6 +1018,10 @@ function sanitizeTerminalHistoryChunk(
       continue;
     }
 
+    if (codePoint >= 0xd800 && codePoint <= 0xdbff && index + 1 === input.length) {
+      return { visibleText, pendingControlSequence: input.slice(index) };
+    }
+
     append(input[index] ?? "");
     index += 1;
   }

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1299,6 +1299,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
     });
 
+  let terminalEventWorkerFiberId: number | null = null;
   const terminalEventWorker = yield* makeKeyedCoalescingWorker<
     string,
     Chunk.Chunk<TerminalEvent>,
@@ -1307,6 +1308,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   >({
     merge: Chunk.appendAll,
     process: Effect.fn("terminal.publishEventWorker")(function* (_threadId, events) {
+      terminalEventWorkerFiberId = yield* Effect.fiberId;
       yield* Effect.forEach(events, publishEvent, { discard: true });
     }),
   });
@@ -1314,7 +1316,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const enqueueTerminalEvent = (event: TerminalEvent) =>
     terminalEventWorker.enqueue(event.threadId, Chunk.of(event));
 
-  const drainTerminalEvents = (threadId: string) => terminalEventWorker.drainKey(threadId);
+  const drainTerminalEvents = Effect.fn("terminal.drainTerminalEvents")(function* (
+    threadId: string,
+  ) {
+    if ((yield* Effect.fiberId) === terminalEventWorkerFiberId) {
+      return;
+    }
+    yield* terminalEventWorker.drainKey(threadId);
+  });
 
   const historyPath = (threadId: string, terminalId: string) => {
     const threadPart = toSafeThreadId(threadId);

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1208,6 +1208,24 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
   const historyTargetBytes = options.historyTargetBytes ?? DEFAULT_HISTORY_TARGET_BYTES;
   const historyMaxBytes = options.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES;
+
+  const applyHistoryOutput = (session: TerminalSessionState, data: string): HistoryWrite | null => {
+    const sanitized = sanitizeTerminalHistoryChunk(session.pendingHistoryControlSequence, data);
+    session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
+    if (sanitized.visibleText.length === 0) {
+      return null;
+    }
+
+    session.history = capHistory(`${session.history}${sanitized.visibleText}`, historyLineLimit);
+    session.persistedHistoryBytes += Buffer.byteLength(sanitized.visibleText);
+    if (session.persistedHistoryBytes <= historyMaxBytes) {
+      return { contents: sanitized.visibleText, mode: "append" };
+    }
+
+    session.history = capHistoryByBytes(session.history, historyTargetBytes);
+    session.persistedHistoryBytes = Buffer.byteLength(session.history);
+    return { contents: session.history, mode: "truncate" };
+  };
   const platform = yield* HostProcessPlatform;
   // Terminals must inherit the user's full environment (minus the blocklist
   // applied in createTerminalSpawnEnv) — an allowlist here silently strips
@@ -1795,32 +1813,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             }
 
             if (nextEvent.type === "output") {
-              const sanitized = sanitizeTerminalHistoryChunk(
-                session.pendingHistoryControlSequence,
-                nextEvent.data,
-              );
-              session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
-              let historyWrite: HistoryWrite | null = null;
-              if (sanitized.visibleText.length > 0) {
-                session.history = capHistory(
-                  `${session.history}${sanitized.visibleText}`,
-                  historyLineLimit,
-                );
-                session.persistedHistoryBytes += Buffer.byteLength(sanitized.visibleText);
-                if (session.persistedHistoryBytes > historyMaxBytes) {
-                  session.history = capHistoryByBytes(session.history, historyTargetBytes);
-                  session.persistedHistoryBytes = Buffer.byteLength(session.history);
-                  historyWrite = {
-                    contents: session.history,
-                    mode: "truncate",
-                  };
-                } else {
-                  historyWrite = {
-                    contents: sanitized.visibleText,
-                    mode: "append",
-                  };
-                }
-              }
+              const historyWrite = applyHistoryOutput(session, nextEvent.data);
               const eventStamp = advanceEventSequence(session);
 
               return {
@@ -2295,9 +2288,23 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       ) {
         const cleanup = yield* withThreadLock(
           session.threadId,
-          Effect.sync(() => {
+          Effect.gen(function* () {
             const process = session.process;
             cleanupProcessHandles(session);
+            for (
+              let index = session.pendingProcessEventIndex;
+              index < session.pendingProcessEvents.length;
+              index += 1
+            ) {
+              const event = session.pendingProcessEvents[index];
+              if (!event || event.type === "exit") {
+                break;
+              }
+              const historyWrite = applyHistoryOutput(session, event.data);
+              if (historyWrite !== null) {
+                yield* queuePersist(session.threadId, session.terminalId, historyWrite);
+              }
+            }
             session.process = null;
             session.pid = null;
             session.hasRunningSubprocess = false;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -1865,26 +1865,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               nextAction.historyWrite,
             );
           }
-
-          if (nextAction.type === "output") {
-            yield* publishEvent({
-              type: "output",
-              threadId: nextAction.threadId,
-              terminalId: nextAction.terminalId,
-              sequence: nextAction.sequence,
-              data: nextAction.data,
-            });
-          } else if (nextAction.type === "exit") {
-            yield* publishEvent({
-              type: "exited",
-              threadId: nextAction.threadId,
-              terminalId: nextAction.terminalId,
-              sequence: nextAction.sequence,
-              exitCode: nextAction.exitCode,
-              exitSignal: nextAction.exitSignal,
-            });
-          }
-
           return nextAction;
         }),
       );
@@ -1894,6 +1874,13 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       if (action.type === "output") {
+        yield* publishEvent({
+          type: "output",
+          threadId: action.threadId,
+          terminalId: action.terminalId,
+          sequence: action.sequence,
+          data: action.data,
+        });
         continue;
       }
 
@@ -1901,6 +1888,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       yield* unregisterTerminal({
         threadId: action.threadId,
         terminalId: action.terminalId,
+      });
+      yield* publishEvent({
+        type: "exited",
+        threadId: action.threadId,
+        terminalId: action.terminalId,
+        sequence: action.sequence,
+        exitCode: action.exitCode,
+        exitSignal: action.exitSignal,
       });
       yield* evictInactiveSessionsIfNeeded();
       return;
@@ -2525,6 +2520,37 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
   const attachStream: TerminalManager["Service"]["attachStream"] = (input, listener) => {
     let unsubscribe: (() => void) | null = null;
+    let initialSnapshot: TerminalSessionSnapshot | null = null;
+    let lastSequence: number | null = null;
+    let sessionClosed = false;
+
+    const shouldDeliver = (event: TerminalEvent): boolean => {
+      if (sessionClosed) {
+        if (event.type !== "started") {
+          return false;
+        }
+        sessionClosed = false;
+        lastSequence = event.sequence ?? null;
+        return true;
+      }
+
+      if (event.sequence !== undefined) {
+        if (lastSequence !== null && event.sequence <= lastSequence) {
+          return false;
+        }
+        lastSequence = event.sequence;
+      } else if (
+        initialSnapshot !== null &&
+        isDuplicateAttachSnapshotEvent(event, initialSnapshot)
+      ) {
+        return false;
+      }
+
+      if (event.type === "closed") {
+        sessionClosed = true;
+      }
+      return true;
+    };
 
     return Effect.gen(function* () {
       const bufferedEvents: TerminalEvent[] = [];
@@ -2540,11 +2566,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           return Effect.void;
         }
 
+        if (!shouldDeliver(event)) {
+          return Effect.void;
+        }
         const attachEvent = terminalEventToAttachEvent(event);
         return attachEvent ? listener(attachEvent) : Effect.void;
       });
 
-      const initialSnapshot = yield* openOrAttachForStream(input);
+      initialSnapshot = yield* openOrAttachForStream(input);
+      lastSequence = initialSnapshot.sequence ?? null;
 
       yield* listener({
         type: "snapshot",
@@ -2552,7 +2582,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       });
 
       for (const event of bufferedEvents) {
-        if (isDuplicateAttachSnapshotEvent(event, initialSnapshot)) {
+        if (!shouldDeliver(event)) {
           continue;
         }
 


### PR DESCRIPTION
## What Changed

Terminal history persistence now appends new sanitized output instead of rewriting the complete history file after every PTY update.

Queued output deltas are coalesced in order. Clear and restart still truncate the history file, while close drains pending append writes.

## Why

Programs with frequent carriage-return redraws caused the server to repeatedly rewrite the growing terminal history file, producing excessive disk writes.

Appending only new output keeps persistence proportional to the PTY output size while preserving history loading, ANSI sanitization, and reset behavior.

## Demo

https://github.com/user-attachments/assets/e32ff7db-7f8a-428a-8f1c-18018d22baff

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal history persistence, compaction, and shutdown flush paths; failed appends and oversized files can rewrite logs, so bugs could lose or duplicate transcript data.
> 
> **Overview**
> Stops rewriting the full terminal history file on every PTY chunk. Normal output is **appended** and coalesced (debounced, 64KB flush), so carriage-return redraws no longer cause unbounded disk writes.
> 
> History is now capped by **bytes** (`8MB` target / `12MB` max) via `capHistoryByBytes`, which trims on UTF-8 and newline/CR boundaries. Compaction and **clear/restart** still truncate. Failed appends rewrite the authoritative history; oversized files compact on open.
> 
> Also buffers split Unicode surrogates, flushes pending writes on exit/close/shutdown, and applies history on the PTY callback so attach snapshots do not duplicate pending output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24fc2d542b92d747fcc393ff7c35c93f1b695b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Append terminal history output and switch to byte-based limits in `TerminalManager`
> - Replaces line-based `historyLineLimit` with byte-based `historyTargetBytes` and `historyMaxBytes` in `TerminalManagerOptions`; normal output is now persisted via append-only writes with debounced batching, while clear/restart/compaction use truncate writes
> - Adds `capHistoryByBytes` to trim history to byte limits without splitting multibyte UTF-8 characters, preferring newline/CR boundaries
> - Fixes `sanitizeTerminalHistoryChunk` to buffer a dangling UTF-16 high surrogate so surrogate pairs split across PTY chunks are not corrupted
> - Flushes persistence before emitting exited/closing events and during scoped runtime shutdown; failed appends are recovered by rewriting the authoritative history with a truncate write
> - Risk: `DrainProcessEventAction.output` no longer carries a `history` field — internal consumers that read it must use `visibleText` instead; oversized existing history files are truncated on open
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24fc2d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->