### PR TITLE
feat(usage): include OpenCodex activity

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -463,10 +463,12 @@ function UsageCoverageNotice(props: {
     props.merged.staleEnvironments.includes(environment.environmentId),
   );
   const duplicateSources = props.merged.duplicateSources;
+  const incompleteSources = props.merged.incompleteSources;
   if (
     failed.length === 0 &&
     stale.length === 0 &&
     duplicateSources.length === 0 &&
+    incompleteSources.length === 0 &&
     !props.isPartial
   ) {
     return null;
@@ -487,6 +489,15 @@ function UsageCoverageNotice(props: {
       {stale.map((environment) => (
         <Text key={environment.environmentId} className="text-sm text-foreground-muted">
           {environment.label} runs an older server version and is excluded from totals.
+        </Text>
+      ))}
+      {incompleteSources.map((source) => (
+        <Text
+          key={`${source.environmentId}:${source.provider}`}
+          className="text-sm text-foreground-muted"
+        >
+          {source.environmentLabel}&apos;s {PROVIDER_LABEL[source.provider]} usage{" "}
+          {source.status === "failed" ? "could not be read." : "is incomplete."}
         </Text>
       ))}
       {duplicateSources.length > 0 ? (

--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,21 +5,24 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "opencodex"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  opencodex: "OpenCodex",
 };
 
 /**
  * Claude's brand orange holds in both themes; Codex is neutral and must flip
- * with the theme or its bars vanish against the matching background.
+ * with the theme or its bars vanish against the matching background. OpenCodex's
+ * purple accent remains legible in both themes.
  */
 export function useProviderColors(): Record<UsageProviderKind, string> {
   const { themeAppearance: scheme } = useAppearancePreferences();
   return {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
+    opencodex: scheme === "dark" ? "#D39CFF" : "#8B2BE2",
   };
 }

--- a/apps/mobile/src/state/usage.ts
+++ b/apps/mobile/src/state/usage.ts
@@ -78,6 +78,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
+        contractVersion: input.contractVersion,
         sinceDay: input.sinceDay,
         untilDay: input.untilDay,
         timeZone: input.timeZone,
@@ -86,6 +87,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
         untilTime: input.untilTime,
       }),
     [
+      input.contractVersion,
       input.sinceDay,
       input.untilDay,
       input.timeZone,

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  classifyUsageSourceExistence,
+  negotiateUsageContractVersion,
+  resolveOpenCodexHome,
+  summarizeSourceReadFailures,
+} from "./UsageService.ts";
+
+describe("classifyUsageSourceExistence", () => {
+  it("keeps I/O failures distinct from missing sources", () => {
+    expect(classifyUsageSourceExistence(true)).toBe("present");
+    expect(classifyUsageSourceExistence(false)).toBe("missing");
+    expect(classifyUsageSourceExistence(null)).toBe("failed");
+  });
+});
+
+describe("resolveOpenCodexHome", () => {
+  it("prefers OPENCODEX_HOME", () => {
+    expect(
+      resolveOpenCodexHome({ OPENCODEX_HOME: "/custom/opencodex" }, "/home/user/.opencodex"),
+    ).toBe("/custom/opencodex");
+  });
+
+  it("uses the standard OpenCodex home by default", () => {
+    expect(resolveOpenCodexHome({}, "/home/user/.opencodex")).toBe("/home/user/.opencodex");
+  });
+});
+
+describe("negotiateUsageContractVersion", () => {
+  it("keeps v4 responses decodable for legacy clients", () => {
+    expect(negotiateUsageContractVersion(undefined)).toBe(4);
+    expect(negotiateUsageContractVersion(4)).toBe(4);
+  });
+
+  it("serves OpenCodex only to compatible clients", () => {
+    expect(negotiateUsageContractVersion(5)).toBe(5);
+    expect(negotiateUsageContractVersion(6)).toBe(5);
+  });
+});
+
+describe("summarizeSourceReadFailures", () => {
+  it("distinguishes healthy, partial, and failed stores", () => {
+    expect(summarizeSourceReadFailures(1, 0)).toEqual({ status: "ok", message: null });
+    expect(summarizeSourceReadFailures(2, 1)).toEqual({
+      status: "partial",
+      message: "1 usage file could not be read.",
+    });
+    expect(summarizeSourceReadFailures(1, 1)).toEqual({
+      status: "failed",
+      message: "1 usage file could not be read.",
+    });
+  });
+});

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -21,6 +21,7 @@ import {
   type UsageSummaryInput,
   UsageReadError,
 } from "@t3tools/contracts";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
@@ -43,11 +44,13 @@ import {
   listTranscriptFiles,
   readDirectoryVolumeId,
   readTranscriptRecords,
+  statUsageFile,
 } from "./usageTranscriptReader.ts";
 import {
   decodeScanCache,
   dedupeWithinFile,
   encodeScanCache,
+  isReusableCachedFile,
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
@@ -66,6 +69,9 @@ const RATES_TTL_MS = 24 * 60 * 60 * 1000;
 const MTIME_SLACK_MS = 36 * 60 * 60 * 1000;
 const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+/** Clients predating OpenCodex omit their supported response contract. */
+const PRE_OPENCODEX_USAGE_CONTRACT_VERSION = 4 as const;
+
 /** Longest window the UI offers, plus slack. Older entries are pruned. */
 const CACHE_RETENTION_DAYS = 90;
 
@@ -74,6 +80,12 @@ const RatesCacheFile = Schema.Struct({
   fetchedAtMs: Schema.Number,
   document: Schema.Unknown,
 });
+
+interface TranscriptSource {
+  readonly provider: UsageProviderKind;
+  readonly dir: string;
+  readonly file?: string;
+}
 const decodeRatesCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(RatesCacheFile as unknown as Schema.Codec<typeof RatesCacheFile.Type>),
 );
@@ -93,13 +105,45 @@ export class UsageService extends Context.Service<
   }
 >()("t3/usage/UsageService") {}
 
+export function resolveOpenCodexHome(
+  environment: Readonly<Record<string, string | undefined>>,
+  defaultHome: string,
+): string {
+  return environment["OPENCODEX_HOME"]?.trim() || defaultHome;
+}
+
+export function negotiateUsageContractVersion(
+  requestedVersion: number | undefined,
+): typeof PRE_OPENCODEX_USAGE_CONTRACT_VERSION | typeof USAGE_CONTRACT_VERSION {
+  return requestedVersion !== undefined && requestedVersion >= USAGE_CONTRACT_VERSION
+    ? USAGE_CONTRACT_VERSION
+    : PRE_OPENCODEX_USAGE_CONTRACT_VERSION;
+}
+
+export type UsageSourceExistence = "present" | "missing" | "failed";
+
+export function classifyUsageSourceExistence(exists: boolean | null): UsageSourceExistence {
+  return exists === null ? "failed" : exists ? "present" : "missing";
+}
+
+export function summarizeSourceReadFailures(
+  totalFiles: number,
+  failedFiles: number,
+): Pick<UsageSource, "status" | "message"> {
+  if (failedFiles === 0) return { status: "ok", message: null };
+  return {
+    status: failedFiles === totalFiles ? "failed" : "partial",
+    message: `${failedFiles} usage file${failedFiles === 1 ? "" : "s"} could not be read.`,
+  };
+}
+
 /** Empty summary, for suites that only need the RPC surface to resolve. */
 export const layerTest = Layer.succeed(
   UsageService,
   UsageService.of({
     readSummary: (input) =>
       Effect.succeed({
-        contractVersion: USAGE_CONTRACT_VERSION,
+        contractVersion: negotiateUsageContractVersion(input.contractVersion),
         readAt: "1970-01-01T00:00:00.000Z",
         timeZone: input.timeZone,
         sinceDay: input.sinceDay,
@@ -123,6 +167,7 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
+  const hostEnvironment = yield* HostProcessEnvironment;
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
@@ -219,10 +264,18 @@ export const make = Effect.gen(function* () {
     const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
 
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+    const opencodexHome = resolveOpenCodexHome(
+      hostEnvironment,
+      path.join(NodeOS.homedir(), ".opencodex"),
+    );
+    const opencodexUsageLog = path.join(opencodexHome, "usage.jsonl");
+
+    const sources: readonly TranscriptSource[] = [
+      { provider: "claude", dir: claudeDir },
+      { provider: "codex", dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      { provider: "opencodex", dir: opencodexHome, file: opencodexUsageLog },
     ];
+    return sources;
   });
 
   /**
@@ -263,34 +316,39 @@ export const make = Effect.gen(function* () {
     size: number,
     mtimeMs: number,
     provider: UsageProviderKind,
-  ): Effect.Effect<readonly UsageRecord[]> =>
+    opencodexSinceMs: number,
+  ): Effect.Effect<readonly UsageRecord[] | null> =>
     Effect.gen(function* () {
       const cached = fileCache.get(filePath);
       // Provider is part of the identity: if both providers were ever pointed
       // at one directory, a hit parsed by the other parser must not be reused.
-      if (
-        cached &&
-        cached.size === size &&
-        cached.mtimeMs === mtimeMs &&
-        cached.provider === provider
-      ) {
+      if (cached && isReusableCachedFile(cached, { size, mtimeMs, provider }, opencodexSinceMs)) {
         return cached.records;
       }
 
-      const parsed = yield* Effect.promise(() => readTranscriptRecords(filePath, provider));
+      const parsed = yield* Effect.promise(() =>
+        readTranscriptRecords(filePath, provider, opencodexSinceMs),
+      );
       // A read failure is not an empty transcript: caching it under this
       // (size, mtime) would silently drop the file's usage until it changes.
-      if (parsed === null) return [];
+      if (parsed === null) return null;
       // Stored already de-duplicated within the file, which is 99% of all
       // duplicates. The aggregator still runs the cross-file dedupe pass.
       const records = dedupeWithinFile(parsed);
 
-      fileCache.set(filePath, { size, mtimeMs, provider, records });
+      fileCache.set(filePath, {
+        size,
+        mtimeMs,
+        provider,
+        completeFromMs: provider === "opencodex" ? opencodexSinceMs : null,
+        records,
+      });
       cacheDirty = true;
       return records;
     });
 
   const readSummary = Effect.fn("UsageService.readSummary")(function* (input: UsageSummaryInput) {
+    const contractVersion = negotiateUsageContractVersion(input.contractVersion);
     if (input.sinceDay > input.untilDay) {
       return yield* new UsageReadError({
         reason: "invalidWindow",
@@ -323,13 +381,20 @@ export const make = Effect.gen(function* () {
     }
 
     const startedAtMs = yield* Clock.currentTimeMillis;
+    const retentionCutoffMs = startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
     yield* ensureRates();
     yield* ensureScanCacheLoaded;
 
     const hostId = NodeOS.hostname();
     // The home resolvers ask for `Path` themselves; satisfy them from the
     // instance we already hold so `readSummary` stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    const resolvedDirs = yield* resolveTranscriptDirs().pipe(
+      Effect.provideService(Path.Path, path),
+    );
+    const dirs =
+      contractVersion >= USAGE_CONTRACT_VERSION
+        ? resolvedDirs
+        : resolvedDirs.filter((source) => source.provider !== "opencodex");
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -353,36 +418,63 @@ export const make = Effect.gen(function* () {
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
-    for (const { provider, dir } of dirs) {
+    for (const source of dirs) {
+      const { provider, dir } = source;
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
-        .exists(dir)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+        .exists(source.file ?? dir)
+        .pipe(Effect.catchCause(() => Effect.succeed(null)));
+      const existence = classifyUsageSourceExistence(exists);
 
-      if (!exists) {
+      if (existence !== "present") {
         sources.push({
           fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-          status: "missing",
+          status: existence,
           scannedFiles: 0,
           skippedFiles: 0,
           malformedRecords: 0,
           distinctSessions: 0,
-          message: "No transcript directory on this environment.",
+          message:
+            existence === "failed"
+              ? source.file === undefined
+                ? "Transcript directory could not be inspected."
+                : "Usage store could not be inspected."
+              : source.file === undefined
+                ? "No transcript directory on this environment."
+                : "No usage store on this environment.",
         });
         continue;
       }
 
-      walkedRoots.push(dir);
-      const files = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
+      const listing = yield* Effect.promise(async () => {
+        if (source.file === undefined) return listTranscriptFiles(dir, windowStartMs);
+        const files = await statUsageFile(source.file, windowStartMs);
+        return files === null ? { files: [], failedEntries: 1 } : { files, failedEntries: 0 };
+      });
+      const files = listing.files;
+      // Only a complete listing proves that an absent cached path was deleted.
+      // Any failure keeps the warm cache available for the next retry.
+      if (listing.failedEntries === 0) walkedRoots.push(dir);
       let scannedFiles = 0;
       let skippedFiles = 0;
+      let failedFiles = listing.failedEntries;
       // Distinct per directory. Buckets carry per-cell session counts, but a
       // session spans days and models, so clients total this figure instead.
       const sessionIds = new Set<string>();
 
       for (const file of files) {
         livePaths.add(file.path);
-        const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        const records = yield* readFileRecords(
+          file.path,
+          file.size,
+          file.mtimeMs,
+          provider,
+          windowStartMs,
+        );
+        if (records === null) {
+          failedFiles += 1;
+          continue;
+        }
         if (records.length === 0) {
           skippedFiles += 1;
           continue;
@@ -397,14 +489,18 @@ export const make = Effect.gen(function* () {
         }
       }
 
+      const readHealth = summarizeSourceReadFailures(
+        files.length + listing.failedEntries,
+        failedFiles,
+      );
       sources.push({
         fingerprint: { hostId, provider, resolvedHomePath: dir, volumeId },
-        status: "ok",
+        status: readHealth.status,
         scannedFiles,
         skippedFiles,
         malformedRecords: 0,
         distinctSessions: sessionIds.size,
-        message: null,
+        message: readHealth.message,
       });
     }
 
@@ -412,7 +508,7 @@ export const make = Effect.gen(function* () {
       livePaths,
       walkedRoots,
       windowStartMs,
-      retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      retentionCutoffMs,
     });
     if (pruned > 0) cacheDirty = true;
     yield* persistScanCache();
@@ -422,7 +518,7 @@ export const make = Effect.gen(function* () {
     const finishedAtMs = yield* Clock.currentTimeMillis;
 
     return {
-      contractVersion: USAGE_CONTRACT_VERSION,
+      contractVersion,
       readAt: DateTime.formatIso(readAt),
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -4,6 +4,7 @@ import {
   decodeScanCache,
   dedupeWithinFile,
   encodeScanCache,
+  isReusableCachedFile,
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
@@ -31,7 +32,13 @@ function record(overrides: Partial<UsageRecord> = {}): UsageRecord {
 function cacheWith(entries: readonly [string, number, readonly UsageRecord[]][]): ScanCache {
   const cache: ScanCache = new Map();
   for (const [path, mtimeMs, records] of entries) {
-    cache.set(path, { size: records.length * 10, mtimeMs, provider: "claude", records });
+    cache.set(path, {
+      size: records.length * 10,
+      mtimeMs,
+      provider: "claude",
+      completeFromMs: null,
+      records,
+    });
   }
   return cache;
 }
@@ -57,6 +64,31 @@ describe("scan cache round trip", () => {
 
     expect(encoded.models).toEqual(["claude-fable-5"]);
     expect(encoded.sessions).toEqual(["session-a"]);
+  });
+
+  it("round-trips an OpenCodex ledger entry with its coverage bound", () => {
+    const opencodexRecord = record({
+      provider: "opencodex",
+      model: "openai/gpt-5.4",
+      sessionId: "opencodex-session",
+      dedupeKey: "opencodex:1",
+    });
+    const original: ScanCache = new Map([
+      [
+        "/home/user/.opencodex/usage.jsonl",
+        {
+          size: 42,
+          mtimeMs: 200,
+          provider: "opencodex",
+          completeFromMs: 1_786_000_000_000,
+          records: [opencodexRecord],
+        },
+      ],
+    ]);
+
+    expect(decodeScanCache(JSON.parse(JSON.stringify(encodeScanCache(original))))).toEqual(
+      original,
+    );
   });
 
   it("treats a corrupt or foreign document as an empty cache", () => {
@@ -105,6 +137,28 @@ describe("scan cache round trip", () => {
 
     const restored = decodeScanCache(JSON.parse(JSON.stringify(poisoned)));
     expect(restored.has("/a.jsonl")).toBe(false);
+  });
+});
+
+describe("isReusableCachedFile", () => {
+  const entry = {
+    size: 42,
+    mtimeMs: 100,
+    provider: "opencodex" as const,
+    completeFromMs: 1_000,
+    records: [record({ provider: "opencodex" })],
+  };
+
+  it("reuses a broad OpenCodex scan for a narrower request", () => {
+    expect(
+      isReusableCachedFile(entry, { size: 42, mtimeMs: 100, provider: "opencodex" }, 2_000),
+    ).toBe(true);
+  });
+
+  it("rejects a narrow OpenCodex scan for a broader request", () => {
+    expect(
+      isReusableCachedFile(entry, { size: 42, mtimeMs: 100, provider: "opencodex" }, 500),
+    ).toBe(false);
   });
 });
 

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -18,18 +18,33 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 
 import type { UsageRecord } from "./usageTranscripts.ts";
 
-// v2: Codex fork-copy suppression changed what a file parses to, so v1
-// entries would keep serving double-counted records forever.
-export const USAGE_SCAN_CACHE_VERSION = 2 as const;
+// v3: OpenCodex scans are window-bounded and carry a per-entry coverage bound;
+// v2 entries cannot prove which rows they include.
+export const USAGE_SCAN_CACHE_VERSION = 3 as const;
 
 export interface CachedFile {
   readonly size: number;
   readonly mtimeMs: number;
   readonly provider: UsageProviderKind;
+  /** Null for whole-file formats; earliest row included for windowed stores. */
+  readonly completeFromMs: number | null;
   readonly records: readonly UsageRecord[];
 }
 
 export type ScanCache = Map<string, CachedFile>;
+
+export function isReusableCachedFile(
+  entry: CachedFile,
+  fingerprint: Pick<CachedFile, "size" | "mtimeMs" | "provider">,
+  requestedFromMs: number,
+): boolean {
+  return (
+    entry.size === fingerprint.size &&
+    entry.mtimeMs === fingerprint.mtimeMs &&
+    entry.provider === fingerprint.provider &&
+    (entry.completeFromMs === null || entry.completeFromMs <= requestedFromMs)
+  );
+}
 
 /**
  * Row layout for the serialised form. Positional and interned rather than
@@ -53,6 +68,7 @@ interface SerializedFile {
   readonly s: number;
   readonly m: number;
   readonly p: UsageProviderKind;
+  readonly c?: number;
   readonly r: readonly SerializedRecord[];
 }
 
@@ -85,6 +101,7 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
       s: entry.size,
       m: entry.mtimeMs,
       p: entry.provider,
+      ...(entry.completeFromMs === null ? {} : { c: entry.completeFromMs }),
       r: entry.records.map((record) => [
         record.timestampMs,
         intern(models, modelIndex, record.model),
@@ -134,10 +151,12 @@ export function decodeScanCache(document: unknown): ScanCache {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
-    if (entry.p !== "claude" && entry.p !== "codex") continue;
+    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "opencodex") continue;
     if (!isRecordArray(entry.r)) continue;
 
     const provider: UsageProviderKind = entry.p;
+    const completeFromMs = typeof entry.c === "number" && Number.isFinite(entry.c) ? entry.c : null;
+    if (provider === "opencodex" && completeFromMs === null) continue;
     const records: UsageRecord[] = [];
     // Any corrupt row disqualifies the whole entry. Keeping the survivors
     // under the original (size, mtime) would read as a valid warm hit and the
@@ -194,7 +213,7 @@ export function decodeScanCache(document: unknown): ScanCache {
     }
 
     if (corrupt) continue;
-    cache.set(path, { size: entry.s, mtimeMs: entry.m, provider, records });
+    cache.set(path, { size: entry.s, mtimeMs: entry.m, provider, completeFromMs, records });
   }
 
   return cache;

--- a/apps/server/src/usage/usageTranscriptReader.test.ts
+++ b/apps/server/src/usage/usageTranscriptReader.test.ts
@@ -1,0 +1,116 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  listTranscriptFiles,
+  readTranscriptRecords,
+  statUsageFile,
+} from "./usageTranscriptReader.ts";
+
+function createOpenCodexLedger(lines: readonly string[]): {
+  readonly filePath: string;
+  readonly cleanup: () => void;
+} {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-opencodex-usage-"));
+  const filePath = NodePath.join(dir, "usage.jsonl");
+  NodeFS.writeFileSync(filePath, `${lines.join("\n")}\n`);
+  return {
+    filePath,
+    cleanup: () => NodeFS.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("readTranscriptRecords for opencodex", () => {
+  it("streams only measurable rows inside the requested window", async () => {
+    const cutoffMs = 1_786_000_000_000;
+    const before = JSON.stringify({
+      requestId: "before",
+      timestamp: cutoffMs - 1,
+      provider: "openai",
+      model: "gpt-5.4",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+    const inside = JSON.stringify({
+      requestId: "req-2",
+      timestamp: cutoffMs,
+      provider: "openai-p372059",
+      model: "gpt-5.4",
+      conversationId: "session-a",
+      usage: {
+        inputTokens: 1_050,
+        outputTokens: 45,
+        reasoningOutputTokens: 12,
+        cachedInputTokens: 900,
+        cacheReadInputTokens: 900,
+        cacheCreationInputTokens: 30,
+      },
+    });
+    const { filePath, cleanup } = createOpenCodexLedger([before, "{broken", inside]);
+
+    try {
+      expect(await readTranscriptRecords(filePath, "opencodex", cutoffMs)).toEqual([
+        {
+          provider: "opencodex",
+          timestampMs: cutoffMs,
+          model: "openai/gpt-5.4",
+          sessionId: "session-a",
+          totals: {
+            uncachedInputTokens: 120,
+            cachedInputTokens: 900,
+            cacheCreationTokens: 30,
+            outputTokens: 45,
+            reasoningTokens: 12,
+          },
+          reportedCostUsd: null,
+          dedupeKey: "opencodex:req-2",
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("does not turn read failures into cacheable empty usage", async () => {
+    expect(
+      await readTranscriptRecords(
+        NodePath.join(NodeOS.tmpdir(), "t3-opencodex-no-such-dir", "usage.jsonl"),
+        "opencodex",
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it("fingerprints the append-only ledger", async () => {
+    const { filePath, cleanup } = createOpenCodexLedger([]);
+    try {
+      const stats = NodeFS.statSync(filePath);
+      expect(await statUsageFile(filePath, 0)).toEqual([
+        { path: filePath, size: stats.size, mtimeMs: stats.mtimeMs },
+      ]);
+      expect(await statUsageFile(filePath, stats.mtimeMs + 1)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("distinguishes a stat failure from an empty in-window ledger", async () => {
+    expect(
+      await statUsageFile(
+        NodePath.join(NodeOS.tmpdir(), "t3-opencodex-missing-stat", "usage.jsonl"),
+        0,
+      ),
+    ).toBeNull();
+  });
+
+  it("reports a transcript root that disappears before the walk", async () => {
+    const missingRoot = NodePath.join(NodeOS.tmpdir(), "t3-usage-missing-transcript-root");
+    expect(await listTranscriptFiles(missingRoot, 0)).toEqual({
+      files: [],
+      failedEntries: 1,
+    });
+  });
+});

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -1,4 +1,4 @@
-// @effect-diagnostics nodeBuiltinImport:off
+// @effect-diagnostics nodeBuiltinImport:off globalTimers:off -- Raw filesystem readers and the worker watchdog run below the Effect service boundary.
 /**
  * Raw filesystem access for transcript scanning.
  *
@@ -13,7 +13,10 @@
 import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
+import * as NodeProcess from "node:process";
 import * as NodeReadline from "node:readline";
+import * as NodeTimers from "node:timers";
+import * as NodeWorkerThreads from "node:worker_threads";
 
 import type { UsageProviderKind } from "@t3tools/contracts";
 
@@ -22,13 +25,148 @@ import {
   mightCarryUsage,
   parseClaudeLine,
   parseCodexLine,
+  parseOpenCodexUsageEntry,
   type UsageRecord,
 } from "./usageTranscripts.ts";
+
+/** Bound a corrupt or unexpectedly expensive ledger scan. */
+const OPENCODEX_WORKER_WALL_TIMEOUT_MS = 30_000;
+
+interface OpenCodexWorkerRequest {
+  readonly filePath: string;
+  readonly sinceMs: number;
+}
+
+type OpenCodexWorkerMessage =
+  | { readonly kind: "chunk"; readonly rows: readonly Record<string, unknown>[] }
+  | { readonly kind: "done" }
+  | { readonly kind: "failed" };
+
+type OpenCodexWorkerResponse =
+  | { readonly kind: "rows"; readonly rows: readonly Record<string, unknown>[] }
+  | { readonly kind: "failed" };
+
+// OpenCodex's canonical ledger can grow to tens of megabytes. Stream and parse
+// it off the WebSocket server's event loop without adding a separate bundle
+// entry: this constant worker program is embedded in the server chunk.
+const OPENCODEX_WORKER_SOURCE = String.raw`
+const NodeFS = require("node:fs");
+const NodeReadline = require("node:readline");
+const { parentPort, workerData } = require("node:worker_threads");
+
+async function readRows() {
+  let rows = [];
+  try {
+    const lines = NodeReadline.createInterface({
+      input: NodeFS.createReadStream(workerData.filePath, { encoding: "utf8" }),
+      crlfDelay: Infinity,
+    });
+    for await (const line of lines) {
+      if (!line.includes('"timestamp"') || !line.includes('"usage"')) continue;
+      try {
+        const parsed = JSON.parse(line);
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          typeof parsed.timestamp !== "number" ||
+          parsed.timestamp < workerData.sinceMs ||
+          typeof parsed.usage !== "object" ||
+          parsed.usage === null
+        ) {
+          continue;
+        }
+        rows.push({
+          requestId: parsed.requestId,
+          timestamp: parsed.timestamp,
+          provider: parsed.provider,
+          model: parsed.model,
+          resolvedModel: parsed.resolvedModel,
+          conversationId: parsed.conversationId,
+          usage: parsed.usage,
+        });
+        if (rows.length >= 1000) {
+          parentPort.postMessage({ kind: "chunk", rows });
+          rows = [];
+        }
+      } catch {
+        // The ledger is user-owned and append-only. Ignore an isolated corrupt
+        // line while preserving all valid usage around it.
+      }
+    }
+    if (rows.length > 0) parentPort.postMessage({ kind: "chunk", rows });
+  } catch {
+    throw new Error("OpenCodex usage ledger could not be read");
+  }
+}
+
+void readRows()
+  .then(() => parentPort.postMessage({ kind: "done" }))
+  .catch(() => parentPort.postMessage({ kind: "failed" }));
+`;
+
+function runOpenCodexWorker(
+  request: OpenCodexWorkerRequest,
+): Promise<OpenCodexWorkerResponse | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timeout: ReturnType<typeof NodeTimers.setTimeout> | undefined;
+    const rows: Record<string, unknown>[] = [];
+    const settle = (value: OpenCodexWorkerResponse | null) => {
+      if (settled) return;
+      settled = true;
+      if (timeout !== undefined) NodeTimers.clearTimeout(timeout);
+      resolve(value);
+    };
+
+    try {
+      const worker = new NodeWorkerThreads.Worker(OPENCODEX_WORKER_SOURCE, {
+        eval: true,
+        workerData: request,
+        // `--input-type` only describes eval/stdin in the parent process. If
+        // inherited it incorrectly turns this explicit CommonJS worker into an
+        // ES module where `require` is unavailable.
+        execArgv: NodeProcess.execArgv.filter((argument) => !argument.startsWith("--input-type")),
+      });
+      worker.on("message", (message: OpenCodexWorkerMessage) => {
+        if (message.kind === "chunk") {
+          rows.push(...message.rows);
+          return;
+        }
+        settle(message.kind === "done" ? { kind: "rows", rows } : { kind: "failed" });
+      });
+      worker.once("error", () => settle(null));
+      // A large structured-clone payload can still be queued when the worker's
+      // clean exit event arrives. Let the message win that race; the watchdog
+      // covers the impossible "exit 0 without a message" case.
+      worker.once("exit", (code) => {
+        if (code !== 0) settle(null);
+      });
+      timeout = NodeTimers.setTimeout(() => {
+        void worker.terminate();
+        settle(null);
+      }, OPENCODEX_WORKER_WALL_TIMEOUT_MS);
+      timeout.unref();
+    } catch {
+      settle(null);
+    }
+  });
+}
 
 export interface TranscriptFile {
   readonly path: string;
   readonly size: number;
   readonly mtimeMs: number;
+}
+
+export interface TranscriptListing {
+  readonly files: readonly TranscriptFile[];
+  readonly failedEntries: number;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { readonly code?: unknown }).code)
+    : undefined;
 }
 
 /**
@@ -41,14 +179,19 @@ export interface TranscriptFile {
 export async function listTranscriptFiles(
   root: string,
   sinceMs: number,
-): Promise<readonly TranscriptFile[]> {
+): Promise<TranscriptListing> {
   const found: TranscriptFile[] = [];
+  let failedEntries = 0;
 
-  const walk = async (dir: string): Promise<void> => {
+  const walk = async (dir: string, isRoot = false): Promise<void> => {
     let entries;
     try {
       entries = await NodeFSP.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      // A nested entry may rotate away between its parent readdir and this
+      // walk. The root disappearing after the caller's existence check is a
+      // real source failure, as is any permission or I/O error.
+      if (isRoot || errorCode(error) !== "ENOENT") failedEntries += 1;
       return;
     }
     for (const entry of entries) {
@@ -63,14 +206,33 @@ export async function listTranscriptFiles(
         if (stats.mtimeMs >= sinceMs) {
           found.push({ path: child, size: stats.size, mtimeMs: stats.mtimeMs });
         }
-      } catch {
-        // Vanished between readdir and stat.
+      } catch (error) {
+        // Vanishing between readdir and stat is benign rotation; other errors
+        // mean coverage is partial.
+        if (errorCode(error) !== "ENOENT") failedEntries += 1;
       }
     }
   };
 
-  await walk(root);
-  return found;
+  await walk(root, true);
+  return { files: found, failedEntries };
+}
+
+/**
+ * Stats a single append-only usage ledger for cache invalidation.
+ */
+export async function statUsageFile(
+  filePath: string,
+  sinceMs: number,
+): Promise<readonly TranscriptFile[] | null> {
+  try {
+    const stats = await NodeFSP.stat(filePath);
+    return stats.mtimeMs >= sinceMs
+      ? [{ path: filePath, size: stats.size, mtimeMs: stats.mtimeMs }]
+      : [];
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -89,6 +251,25 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
   }
 }
 
+/** Reads OpenCodex's canonical, per-request token accounting rows. */
+async function readOpenCodexUsageRecords(
+  filePath: string,
+  sinceMs: number,
+): Promise<readonly UsageRecord[] | null> {
+  const result = await runOpenCodexWorker({
+    filePath,
+    sinceMs,
+  });
+  if (result?.kind !== "rows") return null;
+
+  const records: UsageRecord[] = [];
+  for (const row of result.rows) {
+    const record = parseOpenCodexUsageEntry(row);
+    if (record !== null) records.push(record);
+  }
+  return records;
+}
+
 /**
  * Streams one transcript and returns the usage records it contains, or `null`
  * when the file could not be read.
@@ -105,7 +286,10 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
 export async function readTranscriptRecords(
   filePath: string,
   provider: UsageProviderKind,
+  opencodexSinceMs = 0,
 ): Promise<readonly UsageRecord[] | null> {
+  if (provider === "opencodex") return readOpenCodexUsageRecords(filePath, opencodexSinceMs);
+
   const records: UsageRecord[] = [];
   const codexState = initialCodexScanState();
 

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "@effect/vitest";
 
 import {
   initialCodexScanState,
+  normalizeOpenCodexProvider,
   parseClaudeLine,
   parseCodexLine,
+  parseOpenCodexUsageEntry,
   totalTokens,
 } from "./usageTranscripts.ts";
 
@@ -233,6 +235,105 @@ describe("parseCodexLine", () => {
       );
       expect(record).not.toBeNull();
     });
+  });
+});
+
+describe("parseOpenCodexUsageEntry", () => {
+  it("splits inclusive input and normalizes account-scoped providers", () => {
+    expect(
+      parseOpenCodexUsageEntry({
+        requestId: "req-17",
+        conversationId: "session-a",
+        provider: "openai-p372059",
+        model: "gpt-5.4",
+        resolvedModel: "gpt-5.4-mini",
+        timestamp: 1_786_000_000_000,
+        usage: {
+          inputTokens: 1_050,
+          outputTokens: 45,
+          reasoningOutputTokens: 12,
+          // Historical rows may combine reads and writes here.
+          cachedInputTokens: 930,
+          cacheCreationInputTokens: 30,
+        },
+      }),
+    ).toEqual({
+      provider: "opencodex",
+      timestampMs: 1_786_000_000_000,
+      model: "openai/gpt-5.4-mini",
+      sessionId: "session-a",
+      totals: {
+        uncachedInputTokens: 120,
+        cachedInputTokens: 900,
+        cacheCreationTokens: 30,
+        outputTokens: 45,
+        reasoningTokens: 12,
+      },
+      reportedCostUsd: null,
+      dedupeKey: "opencodex:req-17",
+    });
+  });
+
+  it("prefers explicit cache reads and caps corrupt detail within inclusive input", () => {
+    const record = parseOpenCodexUsageEntry({
+      provider: "zhipu-bigmodel-coding",
+      model: "glm-4.7",
+      timestamp: 1_786_000_001_000,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 5,
+        cachedInputTokens: 99,
+        cacheReadInputTokens: 80,
+        cacheCreationInputTokens: 80,
+        reasoningOutputTokens: 12,
+      },
+    });
+
+    expect(record?.model).toBe("zhipu-bigmodel-coding/glm-4.7");
+    expect(record?.totals).toEqual({
+      uncachedInputTokens: 0,
+      cachedInputTokens: 20,
+      cacheCreationTokens: 80,
+      outputTokens: 5,
+      reasoningTokens: 5,
+    });
+  });
+
+  it("uses the top-level final usage exactly once instead of summing attempts", () => {
+    const record = parseOpenCodexUsageEntry({
+      provider: "chatgpt",
+      model: "gpt-5.4",
+      timestamp: 1_786_000_002_000,
+      usage: { inputTokens: 10, outputTokens: 5 },
+      attempts: [{ usage: { inputTokens: 10_000, outputTokens: 5_000 } }],
+    });
+
+    expect(record?.model).toBe("openai/gpt-5.4");
+    expect(record?.totals.uncachedInputTokens).toBe(10);
+    expect(record?.totals.outputTokens).toBe(5);
+  });
+
+  it("drops rows without measurable top-level usage", () => {
+    expect(
+      parseOpenCodexUsageEntry({
+        requestId: "unreported",
+        provider: "openai",
+        model: "gpt-5.4",
+        timestamp: 1_786_000_003_000,
+        attempts: [{ usage: { inputTokens: 10, outputTokens: 5 } }],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeOpenCodexProvider", () => {
+  it("collapses canonical account suffixes without truncating ordinary provider ids", () => {
+    expect(normalizeOpenCodexProvider("openai-main")).toBe("openai");
+    expect(normalizeOpenCodexProvider("openai-p372059")).toBe("openai");
+    expect(normalizeOpenCodexProvider("chatgpt")).toBe("openai");
+    expect(normalizeOpenCodexProvider("chatgpt-main")).toBe("openai");
+    expect(normalizeOpenCodexProvider("openai-multi-pabcdef")).toBe("openai");
+    expect(normalizeOpenCodexProvider("zhipu-bigmodel-coding")).toBe("zhipu-bigmodel-coding");
   });
 });
 

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -324,6 +324,18 @@ describe("parseOpenCodexUsageEntry", () => {
       }),
     ).toBeNull();
   });
+
+  it("drops timestamps outside JavaScript's Date range", () => {
+    expect(
+      parseOpenCodexUsageEntry({
+        requestId: "bad-time",
+        provider: "openai",
+        model: "gpt-5.4",
+        timestamp: 1e100,
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("normalizeOpenCodexProvider", () => {

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -30,6 +30,9 @@ const EMPTY_TOTALS: UsageTokenTotals = {
   reasoningTokens: 0,
 };
 
+/** Inclusive upper bound accepted by JavaScript's Date time clip. */
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
+
 function int(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
 }
@@ -329,7 +332,7 @@ export function normalizeOpenCodexProvider(provider: string): string {
 /** Maps one canonical row from OpenCodex's append-only `usage.jsonl` ledger. */
 export function parseOpenCodexUsageEntry(row: Record<string, unknown>): UsageRecord | null {
   const timestampMs = int(row["timestamp"]);
-  if (timestampMs === 0) return null;
+  if (timestampMs === 0 || timestampMs > MAX_DATE_TIMESTAMP_MS) return null;
 
   const rawUsage = row["usage"];
   if (typeof rawUsage !== "object" || rawUsage === null) return null;

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -68,7 +68,16 @@ export function totalTokens(totals: UsageTokenTotals): number {
  * an order of magnitude.
  */
 export function mightCarryUsage(line: string, provider: UsageProviderKind): boolean {
-  return provider === "claude" ? line.includes('"usage"') : line.includes('"token_count"');
+  switch (provider) {
+    case "claude":
+      return line.includes('"usage"');
+    case "codex":
+      return line.includes('"token_count"');
+    case "opencodex":
+      // The OpenCodex ledger is parsed in a worker so its append-only JSONL file
+      // never blocks the server event loop.
+      return false;
+  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -294,6 +303,81 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
     // Events surviving the fork-copy suppression above are unique to this
     // rollout, so they need no global dedup.
     dedupeKey: null,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* OpenCodex                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/** Mirrors OpenCodex's account-suffix normalization for usage presentation. */
+export function normalizeOpenCodexProvider(provider: string): string {
+  const canonical = (value: string) =>
+    value === "chatgpt" || value === "openai-multi" ? "openai" : value;
+  const direct = canonical(provider);
+  if (direct !== provider) return direct;
+
+  const cut = provider.lastIndexOf("-");
+  if (cut <= 0) return direct;
+
+  const suffix = provider.slice(cut + 1);
+  return suffix === "main" || /^p[0-9a-f]{6}$/i.test(suffix)
+    ? canonical(provider.slice(0, cut))
+    : direct;
+}
+
+/** Maps one canonical row from OpenCodex's append-only `usage.jsonl` ledger. */
+export function parseOpenCodexUsageEntry(row: Record<string, unknown>): UsageRecord | null {
+  const timestampMs = int(row["timestamp"]);
+  if (timestampMs === 0) return null;
+
+  const rawUsage = row["usage"];
+  if (typeof rawUsage !== "object" || rawUsage === null) return null;
+  const usage = rawUsage as Record<string, unknown>;
+
+  // OpenCodex stores total input inclusive of both cache categories. Cap the
+  // detail fields so malformed or legacy rows cannot make uncached input
+  // negative or inflate the total beyond `inputTokens`.
+  const inputTokens = int(usage["inputTokens"]);
+  const cacheCreationTokens = Math.min(inputTokens, int(usage["cacheCreationInputTokens"]));
+  const explicitCacheRead = usage["cacheReadInputTokens"];
+  const legacyCachedInput = int(usage["cachedInputTokens"]);
+  const cacheReadCandidate =
+    typeof explicitCacheRead === "number" && Number.isFinite(explicitCacheRead)
+      ? int(explicitCacheRead)
+      : typeof usage["cacheCreationInputTokens"] === "number"
+        ? Math.max(0, legacyCachedInput - cacheCreationTokens)
+        : legacyCachedInput;
+  const cachedInputTokens = Math.min(inputTokens - cacheCreationTokens, cacheReadCandidate);
+  const outputTokens = int(usage["outputTokens"]);
+  const totals: UsageTokenTotals = {
+    uncachedInputTokens: inputTokens - cachedInputTokens - cacheCreationTokens,
+    cachedInputTokens,
+    cacheCreationTokens,
+    outputTokens,
+    reasoningTokens: Math.min(outputTokens, int(usage["reasoningOutputTokens"])),
+  };
+  if (totalTokens(totals) === 0) return null;
+
+  const rawProvider = typeof row["provider"] === "string" ? row["provider"].trim() : "";
+  const provider = normalizeOpenCodexProvider(rawProvider) || "unknown";
+  const resolvedModel = typeof row["resolvedModel"] === "string" ? row["resolvedModel"].trim() : "";
+  const requestedModel = typeof row["model"] === "string" ? row["model"].trim() : "";
+  const rawModel = resolvedModel || requestedModel || "unknown";
+  const model =
+    provider === "unknown" || rawModel.includes("/") ? rawModel : `${provider}/${rawModel}`;
+  const requestId = typeof row["requestId"] === "string" ? row["requestId"].trim() : "";
+
+  return {
+    provider: "opencodex",
+    timestampMs,
+    model,
+    sessionId: typeof row["conversationId"] === "string" ? row["conversationId"] : "",
+    totals,
+    // The ledger persists usage, not billed cost. Price it with the shared
+    // LiteLLM table just like Codex transcripts.
+    reportedCostUsd: null,
+    dedupeKey: requestId.length > 0 ? `opencodex:${requestId}` : null,
   };
 }
 

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -484,6 +484,39 @@ export const Zed: Icon = (props) => {
   );
 };
 
+/** OpenCodex terminal mark, adapted from the project's official app icon. */
+export const OpenCodex: Icon = ({ className, ...props }) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    className={cn("text-[color:var(--usage-provider-opencodex)]", className)}
+    fill="none"
+  >
+    <path
+      d="M8.1 3.45A8.7 8.7 0 0 1 12 2.55a8.7 8.7 0 0 1 3.9.9M15.9 20.55a8.7 8.7 0 0 1-3.9.9 8.7 8.7 0 0 1-3.9-.9"
+      stroke="currentColor"
+      strokeWidth="1.35"
+      strokeLinecap="round"
+    />
+    <path
+      d="M5.55 6.15c-1.25 0-1.6.7-1.6 1.65v1.1c0 .95-.35 1.45-1.15 1.65.8.2 1.15.7 1.15 1.65v1.1c0 .95.35 1.65 1.6 1.65M18.45 6.15c1.25 0 1.6.7 1.6 1.65v1.1c0 .95.35 1.45 1.15 1.65-.8.2-1.15.7-1.15 1.65v1.1c0 .95-.35 1.65-1.6 1.65"
+      stroke="currentColor"
+      strokeWidth="1.45"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="m8.55 8.6 2.35 3.4-2.35 3.4M13.15 15.4h3.05"
+      stroke="currentColor"
+      strokeWidth="1.55"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="2.55" r="0.8" fill="currentColor" />
+    <circle cx="12" cy="21.45" r="0.8" fill="currentColor" />
+  </svg>
+);
+
 export const OpenAI: Icon = ({ className, ...props }) => (
   <svg
     {...props}

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -54,19 +54,21 @@ vi.mock("../WorkspacePageContainer", () => ({ WorkspacePageContainer: "main" }))
 vi.mock("../WorkspacePageHeader", () => ({ WorkspacePageHeader: "header" }));
 vi.mock("./UsageProviderChart", () => ({ UsageProviderChart: "div" }));
 vi.mock("./usageProviders", () => ({
-  PROVIDER_ORDER: ["codex", "claude"],
+  PROVIDER_ORDER: ["codex", "claude", "opencodex"],
   PROVIDER_PRESENTATION: {
     codex: { color: "white", label: "Codex", mark: "span" },
     claude: { color: "orange", label: "Claude Code", mark: "span" },
+    opencodex: { color: "blue", label: "OpenCodex", mark: "span" },
   },
 }));
 
 import { UsagePage } from "./UsagePage";
 
-const providerTotals = (codex: number, claude: number) =>
+const providerTotals = (codex: number, claude: number, opencodex: number) =>
   new Map([
     ["codex", { costUsd: codex, totalTokens: codex * 1_000 }],
     ["claude", { costUsd: claude, totalTokens: claude * 1_000 }],
+    ["opencodex", { costUsd: opencodex, totalTokens: opencodex * 1_000 }],
   ] as const);
 
 beforeEach(() => {
@@ -79,14 +81,14 @@ beforeEach(() => {
           hourStart: "2026-08-10T13:37:00.000Z",
           costUsd: 13,
           totalTokens: 13_000,
-          byProvider: providerTotals(7, 6),
+          byProvider: providerTotals(7, 6, 0),
         },
         {
           day: "2026-08-11",
           hourStart: "2026-08-11T11:37:00.000Z",
           costUsd: 11,
           totalTokens: 11_000,
-          byProvider: providerTotals(6, 5),
+          byProvider: providerTotals(6, 4, 1),
         },
       ],
     },
@@ -105,6 +107,47 @@ describe("UsagePage hourly breakdown", () => {
     expect(body.match(/<tr/g)).toHaveLength(2);
     expect(body).toContain("$11.00");
     expect(body).toContain("$13.00");
+    expect(markup).toContain("OpenCodex");
+    expect(body).toContain("$1.00");
     expect(body.indexOf("$11.00")).toBeLessThan(body.indexOf("$13.00"));
+  });
+
+  it("warns when the OpenCodex store could not be read", () => {
+    testState.useUsage.mockReturnValue({
+      merged: {
+        ...mergeUsage([], USAGE_CONTRACT_VERSION),
+        incompleteSources: [
+          {
+            environmentId: "env-a",
+            environmentLabel: "Local",
+            provider: "opencodex",
+            status: "failed",
+            message: "1 usage file could not be read.",
+          },
+        ],
+      },
+      environments: [],
+      isPending: false,
+      isPartial: false,
+      refresh: vi.fn(),
+    });
+
+    expect(renderToStaticMarkup(<UsagePage />)).toContain(
+      "Local&#x27;s OpenCodex usage could not be read.",
+    );
+  });
+
+  it("spans the empty time table across every provider column", () => {
+    testState.useUsage.mockReturnValue({
+      merged: mergeUsage([], USAGE_CONTRACT_VERSION),
+      environments: [],
+      isPending: false,
+      isPartial: false,
+      refresh: vi.fn(),
+    });
+
+    expect(renderToStaticMarkup(<UsagePage />)).toMatch(
+      /<td colSpan="6" class="py-6 text-center text-muted-foreground">No activity in this window\.<\/td>/,
+    );
   });
 });

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -2,7 +2,7 @@ import type { UsageProviderKind } from "@t3tools/contracts";
 import { CheckIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { DailyTotals, HourlyTotals } from "@t3tools/shared/usageMerge";
+import type { DailyTotals, HourlyTotals, MergedUsage } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
 import { cn } from "../../lib/utils";
@@ -207,6 +207,7 @@ export function UsagePage() {
                 <UsageCoverageNotice
                   environments={environments}
                   duplicateSources={merged.duplicateSources}
+                  incompleteSources={merged.incompleteSources}
                   staleEnvironments={merged.staleEnvironments}
                 />
 
@@ -390,7 +391,10 @@ export function UsagePage() {
                       <tbody>
                         {breakdownPeriods.length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                            <td
+                              colSpan={PROVIDER_ORDER.length + 3}
+                              className="py-6 text-center text-muted-foreground"
+                            >
                               No activity in this window.
                             </td>
                           </tr>
@@ -457,25 +461,32 @@ function Metric({ label, value }: { readonly label: string; readonly value: stri
 }
 
 /**
- * Says plainly when the totals are incomplete: an environment that failed, or
- * one whose transcripts another environment already reported. Environments
- * that are still answering never reach this notice; the page shows the
- * loading skeleton until every one is terminal.
+ * Says plainly when the totals are incomplete: an environment or provider
+ * source failed, or another environment already reported the same transcripts.
+ * Environments that are still answering never reach this notice; the page
+ * shows the loading skeleton until every one is terminal.
  */
 function UsageCoverageNotice({
   environments,
   duplicateSources,
+  incompleteSources,
   staleEnvironments,
 }: {
   readonly environments: readonly EnvironmentUsageStatus[];
   readonly duplicateSources: readonly string[];
+  readonly incompleteSources: MergedUsage["incompleteSources"];
   readonly staleEnvironments: readonly string[];
 }) {
   const failed = environments.filter((environment) => environment.error !== null);
   const stale = environments.filter((environment) =>
     staleEnvironments.includes(environment.environmentId),
   );
-  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0) {
+  if (
+    failed.length === 0 &&
+    stale.length === 0 &&
+    duplicateSources.length === 0 &&
+    incompleteSources.length === 0
+  ) {
     return null;
   }
 
@@ -487,6 +498,12 @@ function UsageCoverageNotice({
       {stale.map((environment) => (
         <span key={environment.label}>
           {environment.label} runs an older server version and is excluded from totals.
+        </span>
+      ))}
+      {incompleteSources.map((source) => (
+        <span key={`${source.environmentId}:${source.provider}`}>
+          {source.environmentLabel}&apos;s {PROVIDER_PRESENTATION[source.provider].label} usage{" "}
+          {source.status === "failed" ? "could not be read." : "is incomplete."}
         </span>
       ))}
       {duplicateSources.length > 0 ? (

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -85,6 +85,7 @@ describe("buildDayColumns", () => {
     expect(first?.bands).toEqual([
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
+      { provider: "opencodex", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, type Icon, OpenCodex, OpenAI } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -23,6 +23,11 @@ export const PROVIDER_PRESENTATION = {
     label: "Claude Code",
     color: "#d97757",
     mark: ClaudeAI,
+  },
+  opencodex: {
+    label: "OpenCodex",
+    color: "var(--usage-provider-opencodex)",
+    mark: OpenCodex,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -111,6 +111,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --workspace-native-controls-inset: 0px;
   --workspace-titlebar-control-size: 1.75rem;
   --workspace-titlebar-control-gap: 0.75rem;
+  --usage-provider-opencodex: #8b2be2;
 
   @variant dark {
     --appearance-contrast-target: white;
@@ -118,6 +119,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --app-scrollbar-thumb-hover: rgb(255 255 255 / 12%);
     --glass-blur: 16px;
     --glass-saturation: 1.08;
+    --usage-provider-opencodex: #d39cff;
   }
 }
 

--- a/apps/web/src/state/usage.ts
+++ b/apps/web/src/state/usage.ts
@@ -75,6 +75,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
   const windowKey = useMemo(
     () =>
       JSON.stringify({
+        contractVersion: input.contractVersion,
         sinceDay: input.sinceDay,
         untilDay: input.untilDay,
         timeZone: input.timeZone,
@@ -83,6 +84,7 @@ export function useUsage(input: UsageSummaryInput): UsageView {
         untilTime: input.untilTime,
       }),
     [
+      input.contractVersion,
       input.sinceDay,
       input.untilDay,
       input.timeZone,

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,10 +1,15 @@
 # Review usage
 
-The Usage page combines Codex and Claude Code activity from your connected environments. It reads
-the providers' local session history and shows API-equivalent token cost, processed tokens, cache
-savings, provider shares, and model breakdowns. Subscription billing is separate from the raw token
-cost shown here.
+The Usage page combines Codex, Claude Code, and OpenCodex activity from your connected environments. It
+reads the providers' local usage history and shows API-equivalent token cost, processed tokens,
+cache savings, provider shares, and model breakdowns. Subscription billing is separate from the raw
+token cost shown here. OpenCodex reads its canonical `~/.opencodex/usage.jsonl` ledger (or the
+directory selected by `OPENCODEX_HOME`), shared by its command-line and desktop/tray surfaces.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the
 headline and chart, and refreshing rescans every connected environment.
+
+If an environment cannot read one of its provider stores, the page keeps any available usage and
+shows that coverage is incomplete. A healthy environment reading the same physical store can
+supply the missing coverage without double counting it.

--- a/packages/contracts/src/usage.test.ts
+++ b/packages/contracts/src/usage.test.ts
@@ -1,0 +1,39 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { UsageDay, UsageSummaryInput } from "./usage.ts";
+
+const LegacyUsageSummaryInput = Schema.Struct({
+  sinceDay: UsageDay,
+  untilDay: UsageDay,
+  timeZone: Schema.String,
+});
+const decodeUsageSummaryInput = Schema.decodeUnknownSync(UsageSummaryInput);
+const decodeLegacyUsageSummaryInput = Schema.decodeUnknownSync(LegacyUsageSummaryInput);
+
+describe("UsageSummaryInput version negotiation", () => {
+  it("accepts a legacy request with no advertised contract", () => {
+    const decoded = decodeUsageSummaryInput({
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      timeZone: "UTC",
+    });
+
+    expect(decoded.contractVersion).toBeUndefined();
+  });
+
+  it("lets an old server ignore a new client's advertised contract", () => {
+    const decoded = decodeLegacyUsageSummaryInput({
+      contractVersion: 5,
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      timeZone: "UTC",
+    });
+
+    expect(decoded).toEqual({
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      timeZone: "UTC",
+    });
+  });
+});

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -1,11 +1,11 @@
 /**
  * Usage reporting contract.
  *
- * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`) rather than
- * relying on T3 Code's own orchestration projections, so usage stays complete
- * even for turns that were never driven through T3 Code. This mirrors the
- * approach `ccusage` takes.
+ * Each environment scans the provider CLIs' own on-disk usage stores
+ * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`, OpenCodex's
+ * `~/.opencodex/usage.jsonl`) rather than relying on T3 Code's
+ * own orchestration projections, so usage stays complete even for turns that
+ * were never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
  * buckets. Raw transcript records never cross the wire.
@@ -21,9 +21,9 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "opencodex"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**
@@ -161,6 +161,11 @@ export const UsagePricing = Schema.Struct({
 export type UsagePricing = typeof UsagePricing.Type;
 
 export const UsageSummaryInput = Schema.Struct({
+  /**
+   * Highest response contract the client can decode. Omitted clients receive
+   * the pre-OpenCodex v4 shape so rolling upgrades remain wire-compatible.
+   */
+  contractVersion: Schema.optional(Schema.Number),
   /** Inclusive first day of the window, in `timeZone`. */
   sinceDay: UsageDay,
   /** Inclusive last day of the window, in `timeZone`. */

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics globalDate:off -- A fixed instant keeps calendar-window assertions deterministic.
+import { USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -50,6 +51,10 @@ describe("hourly usage formatting", () => {
   it("builds an exact minute-aligned 24-hour request", () => {
     const window = makeWindow(1, new Date("2026-08-11T12:37:42.123Z"), "hour");
 
+    expect(window.contractVersion).toBe(USAGE_CONTRACT_VERSION);
+    expect(makeWindow(30, new Date("2026-08-11T12:37:42.123Z")).contractVersion).toBe(
+      USAGE_CONTRACT_VERSION,
+    );
     expect(window.resolution).toBe("hour");
     expect(window.sinceTime).toBe("2026-08-10T12:37:00.000Z");
     expect(window.untilTime).toBe("2026-08-11T12:37:00.000Z");

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -4,7 +4,12 @@
  *
  * @module usageFormat
  */
-import { UsageDay, type UsageResolution, type UsageSummaryInput } from "@t3tools/contracts";
+import {
+  USAGE_CONTRACT_VERSION,
+  UsageDay,
+  type UsageResolution,
+  type UsageSummaryInput,
+} from "@t3tools/contracts";
 
 const CURRENCY = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -208,6 +213,7 @@ export function makeWindow(
     const sinceTime = new Date(sinceTimeMs);
     const untilTime = new Date(untilTimeMs);
     return {
+      contractVersion: USAGE_CONTRACT_VERSION,
       sinceDay: UsageDay.make(format.format(sinceTime)),
       untilDay: UsageDay.make(format.format(untilTime)),
       timeZone,
@@ -224,6 +230,7 @@ export function makeWindow(
     .map((part) => Number.parseInt(part, 10));
   const start = new Date(Date.UTC(year, month - 1, dayOfMonth - (days - 1)));
   return {
+    contractVersion: USAGE_CONTRACT_VERSION,
     sinceDay: UsageDay.make(start.toISOString().slice(0, 10)),
     untilDay: UsageDay.make(untilDay),
     timeZone,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -4,6 +4,7 @@ import {
   type UsageBucket,
   type UsageDay,
   type UsageProviderKind,
+  type UsageSourceStatus,
   type UsageSummary,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
@@ -40,6 +41,8 @@ function summary(
     homePath: string;
     volumeId?: string;
     distinctSessions?: number;
+    status?: UsageSourceStatus;
+    message?: string | null;
   }[],
   contractVersion: number = USAGE_CONTRACT_VERSION,
 ): UsageSummary {
@@ -57,12 +60,12 @@ function summary(
         resolvedHomePath: source.homePath,
         volumeId: source.volumeId ?? `vol-${source.hostId}`,
       },
-      status: "ok" as const,
+      status: source.status ?? "ok",
       scannedFiles: 1,
       skippedFiles: 0,
       malformedRecords: 0,
       distinctSessions: source.distinctSessions ?? 1,
-      message: null,
+      message: source.message ?? null,
     })),
     pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 10 },
     scanDurationMs: 1,
@@ -167,6 +170,76 @@ describe("mergeUsage", () => {
 
     expect(merged.costUsd).toBe(10);
     expect(merged.staleEnvironments).toEqual(["env-b"]);
+  });
+
+  it("reports incomplete sources and excludes a fully failed provider", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ provider: "opencodex", model: "openai/gpt-5.4", costUsd: 7 }),
+              bucket({ provider: "claude", costUsd: 3 }),
+            ],
+            [
+              {
+                provider: "opencodex",
+                hostId: "mac",
+                homePath: "/a/.opencodex",
+                status: "failed",
+                message: "1 usage file could not be read.",
+              },
+              {
+                provider: "claude",
+                hostId: "mac",
+                homePath: "/a/.claude",
+                status: "partial",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(3);
+    expect(merged.incompleteSources.map((source) => source.provider)).toEqual([
+      "opencodex",
+      "claude",
+    ]);
+  });
+
+  it("prefers a complete OpenCodex duplicate without a false coverage gap", () => {
+    const shared = {
+      provider: "opencodex" as const,
+      hostId: "mac",
+      homePath: "/a/.opencodex",
+      volumeId: "16777220:1234",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket({ provider: "opencodex", model: "openai/gpt-5.4", costUsd: 3 })],
+            [{ ...shared, status: "partial" }],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ provider: "opencodex", model: "openai/gpt-5.4", costUsd: 7 })],
+            [{ ...shared, status: "ok" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(7);
+    expect(merged.contributingEnvironments).toEqual(["env-b"]);
+    expect(merged.incompleteSources).toEqual([]);
   });
 
   it("derives provider shares and cost quality", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -61,6 +61,14 @@ export interface CostQuality {
   readonly cacheSavingsUsd: number;
 }
 
+export interface IncompleteUsageSource {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly provider: UsageProviderKind;
+  readonly status: "partial" | "failed";
+  readonly message: string | null;
+}
+
 export interface MergedUsage {
   readonly costUsd: number;
   readonly uncachedInputTokens: number;
@@ -78,6 +86,8 @@ export interface MergedUsage {
   readonly costQuality: CostQuality;
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
+  /** Provider stores that could not be read completely. */
+  readonly incompleteSources: readonly IncompleteUsageSource[];
   readonly contributingEnvironments: readonly EnvironmentId[];
   readonly staleEnvironments: readonly EnvironmentId[];
 }
@@ -103,10 +113,10 @@ function fingerprintKey(fingerprint: UsageSourceFingerprint): string {
  * Decides which environment owns each physical transcript directory.
  *
  * Several environments on one machine (worktree servers, for instance) resolve
- * the same provider home and would otherwise double count every token. The
- * first environment in a stable order claims a fingerprint; the rest have that
- * provider's buckets dropped. Environments are sorted by id so the winner does
- * not change between renders.
+ * the same provider home and would otherwise double count every token. A complete
+ * source wins over a partial duplicate; ties are sorted by
+ * environment id so the owner does not change between renders. Fully failed
+ * and missing sources cannot own a fingerprint.
  */
 function claimSources(environments: readonly EnvironmentUsage[]): {
   readonly ownerByFingerprint: ReadonlyMap<string, EnvironmentId>;
@@ -115,18 +125,25 @@ function claimSources(environments: readonly EnvironmentUsage[]): {
   const ownerByFingerprint = new Map<string, EnvironmentId>();
   const duplicates: string[] = [];
 
-  const ordered = [...environments].sort((a, b) => a.environmentId.localeCompare(b.environmentId));
+  const candidates = environments
+    .flatMap((environment) =>
+      environment.summary.sources.flatMap((source) =>
+        source.status === "missing" || source.status === "failed" ? [] : [{ environment, source }],
+      ),
+    )
+    .sort((a, b) => {
+      const statusOrder =
+        Number(a.source.status === "partial") - Number(b.source.status === "partial");
+      return statusOrder || a.environment.environmentId.localeCompare(b.environment.environmentId);
+    });
 
-  for (const environment of ordered) {
-    for (const source of environment.summary.sources) {
-      if (source.status === "missing") continue;
-      const key = fingerprintKey(source.fingerprint);
-      if (ownerByFingerprint.has(key)) {
-        duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
-        continue;
-      }
-      ownerByFingerprint.set(key, environment.environmentId);
+  for (const { environment, source } of candidates) {
+    const key = fingerprintKey(source.fingerprint);
+    if (ownerByFingerprint.has(key)) {
+      duplicates.push(`${environment.label}: ${source.fingerprint.resolvedHomePath}`);
+      continue;
     }
+    ownerByFingerprint.set(key, environment.environmentId);
   }
 
   return { ownerByFingerprint, duplicates };
@@ -143,7 +160,7 @@ function ownedContribution(
   const ownedProviders = new Set<UsageProviderKind>();
   const sessionsByProvider = new Map<UsageProviderKind, number>();
   for (const source of environment.summary.sources) {
-    if (source.status === "missing") continue;
+    if (source.status === "missing" || source.status === "failed") continue;
     const key = fingerprintKey(source.fingerprint);
     if (ownerByFingerprint.get(key) === environment.environmentId) {
       const provider = source.fingerprint.provider;
@@ -193,6 +210,7 @@ const EMPTY_MERGED: MergedUsage = {
     cacheSavingsUsd: 0,
   },
   duplicateSources: [],
+  incompleteSources: [],
   contributingEnvironments: [],
   staleEnvironments: [],
 };
@@ -221,6 +239,21 @@ export function mergeUsage(
   }
 
   const { ownerByFingerprint, duplicates } = claimSources(current);
+  const incompleteSources: IncompleteUsageSource[] = [];
+  for (const environment of current) {
+    for (const source of environment.summary.sources) {
+      if (source.status !== "partial" && source.status !== "failed") continue;
+      const owner = ownerByFingerprint.get(fingerprintKey(source.fingerprint));
+      if (owner !== undefined && owner !== environment.environmentId) continue;
+      incompleteSources.push({
+        environmentId: environment.environmentId,
+        environmentLabel: environment.label,
+        provider: source.fingerprint.provider,
+        status: source.status,
+        message: source.message,
+      });
+    }
+  }
 
   let costUsd = 0;
   let uncachedInputTokens = 0;
@@ -411,6 +444,7 @@ export function mergeUsage(
       cacheSavingsUsd,
     },
     duplicateSources: duplicates,
+    incompleteSources,
     contributingEnvironments,
     staleEnvironments,
   };


### PR DESCRIPTION
## What Changed

- Add OpenCodex as a first-class Usage provider across the contracts, server, web, and mobile clients.
- Read the canonical `OPENCODEX_HOME/usage.jsonl` ledger in a bounded worker, with 90-day window coverage metadata, durable cache reuse, request-id deduplication, and incomplete-source reporting.
- Normalize OpenCodex account-scoped provider labels and inclusive cache accounting before pricing through the existing LiteLLM rate table.
- Preserve rolling-upgrade compatibility: legacy clients receive v4 while compatible clients negotiate v5.

## Why

OpenCodex already records authoritative per-request token usage for its command-line and desktop/tray surfaces, but T3 Code does not currently include that activity. Reading the provider-owned ledger keeps usage complete even when requests were not initiated by T3 Code and avoids summing retry attempts twice.

## UI Changes

The Usage page gains an OpenCodex provider mark, chart series, table column, model breakdown, and explicit partial/failed-store notice on web and mobile. Screenshots are omitted because the populated view depends on private local usage history; there is no motion or interaction change.

## Validation

- 10 focused usage test files: 92/92 tests passed
- Typechecks passed for `t3`, `@t3tools/web`, `@t3tools/mobile`, `@t3tools/contracts`, and `@t3tools/shared`
- Focused lint, formatting, and `git diff --check` passed for all 25 changed files
- Real local ledger validation: 88,479,120 bytes, 57,954 in-window records, 67 models, 651 sessions; 799 ms cold scan with a 13 ms maximum event-loop timer gap

## Merge ordering

This branch is independently compatible with current `main` and uses usage contract v5. PRs #7877, #7904, #7936, and this PR each add a v5 provider independently; whichever merges later must rebase and advance the combined contract/cache migration as needed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] No animation/interaction change requires a video

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenCodex activity to usage tracking and bump contract to v5
> - Integrates OpenCodex as a new usage provider across the server, web, and mobile clients
> - Parses OpenCodex JSONL ledgers in a dedicated worker thread with a 30s timeout in [usageTranscriptReader.ts](https://github.com/pingdotgg/t3code/pull/7939/files#diff-abfb6e6193baf30b1461a91349257b617fc266915d75b17a73ca21ccd1041d08) to avoid blocking the server event loop
> - Introduces contract version negotiation in [UsageService.ts](https://github.com/pingdotgg/t3code/pull/7939/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) to serve v5 to compatible clients while maintaining backward compatibility with v4
> - Updates the merge logic in [usageMerge.ts](https://github.com/pingdotgg/t3code/pull/7939/files#diff-143d7ed21cccd3774754bd4f261d302d61b7997008db82ed56a3920e176a57b3) to track partial or failed usage sources, and surfaces these states as warnings in the web and mobile UIs
> - Risk: Existing v2 usage scan caches are invalidated and rebuilt as v3 in [usageScanCache.ts](https://github.com/pingdotgg/t3code/pull/7939/files#diff-ca3f710ebaf0cd708cedab20134ea19de9a81237223250d0402fa68c37498806) due to new OpenCodex coverage bounds
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9057972.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the usage contract, on-disk scan cache (v2→v3), and merge ownership of duplicate stores, which can change reported totals. Also introduces an eval’d worker to parse large ledgers off the event loop.
> 
> **Overview**
> Adds **OpenCodex** to usage reporting: clients advertise contract v5, the server reads `OPENCODEX_HOME/usage.jsonl` (default `~/.opencodex`), and web/mobile charts, tables, and legends include the new provider.
> 
> The server parses the append-only ledger in a bounded worker, splits inclusive cache tokens, normalizes account-scoped provider ids, and prices via the existing LiteLLM table. Scan cache v3 stores a coverage bound so a narrower OpenCodex window can reuse a broader scan. Legacy clients still get v4 responses with OpenCodex omitted.
> 
> Source health is now `ok` / `partial` / `failed` instead of treating I/O errors as missing. Merge prefers a complete duplicate over a partial one, drops fully failed stores from totals, and surfaces `incompleteSources` in the coverage notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9057972f6084cba30885b96f01344fa5eccdfc8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->