### PR TITLE
fix(mobile): preserve markdown image dimensions

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -199,6 +199,7 @@ function MessageAttachmentImage(props: {
 
 function ThreadMarkdownImageView(props: {
   readonly uri: string | null;
+  readonly sourceKey: string;
   readonly unavailable: boolean;
   readonly alt: string | null;
   readonly onPressImage: (uri: string) => void;
@@ -210,6 +211,9 @@ function ThreadMarkdownImageView(props: {
 
   useEffect(() => {
     setSourceSize(null);
+  }, [props.sourceKey]);
+
+  useEffect(() => {
     setFailedUri(null);
   }, [props.uri]);
 
@@ -310,6 +314,7 @@ function ThreadMarkdownImage(props: {
   return (
     <ThreadMarkdownImageView
       uri={assetUrl._tag === "Success" ? assetUrl.url : null}
+      sourceKey={props.path}
       unavailable={assetUrl._tag === "Failure"}
       alt={props.alt}
       onPressImage={props.onPressImage}
@@ -321,6 +326,7 @@ function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) 
   return (
     <ThreadMarkdownImageView
       uri={null}
+      sourceKey="unavailable"
       unavailable
       alt={props.alt}
       onPressImage={() => undefined}
@@ -1573,6 +1579,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
         return (
           <ThreadMarkdownImageView
             uri={imageSource.uri}
+            sourceKey={imageSource.uri}
             unavailable={false}
             alt={image.alt}
             onPressImage={(uri) => setExpandedImage({ uri })}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -105,6 +105,7 @@ import {
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
 import { useAssetUrl, useAssetUrlState } from "../../state/assets";
 import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
+import { MARKDOWN_IMAGE_MAX_WIDTH, resolveMarkdownImageDisplaySize } from "./markdownImageSize";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   includeOrderedLists: Platform.OS === "android",
@@ -196,30 +197,43 @@ function MessageAttachmentImage(props: {
   );
 }
 
-/** Markdown image whose src is a workspace file — loads through a signed asset URL. */
-function ThreadMarkdownImage(props: {
-  readonly environmentId: EnvironmentId;
-  readonly threadId: ThreadId;
-  readonly path: string;
+function ThreadMarkdownImageView(props: {
+  readonly uri: string | null;
+  readonly unavailable: boolean;
   readonly alt: string | null;
   readonly onPressImage: (uri: string) => void;
 }) {
   const codeBackground = useThemeColor("--color-md-code-bg");
+  const [availableWidth, setAvailableWidth] = useState(0);
+  const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
   const [failedUri, setFailedUri] = useState<string | null>(null);
-  const assetUrl = useAssetUrlState(props.environmentId, {
-    _tag: "workspace-file",
-    threadId: props.threadId,
-    path: props.path,
-  });
-  const uri = assetUrl._tag === "Success" ? assetUrl.url : null;
-  const failed = assetUrl._tag === "Failure" || (uri !== null && failedUri === uri);
+
+  useEffect(() => {
+    setSourceSize(null);
+    setFailedUri(null);
+  }, [props.uri]);
+
+  const displaySize =
+    sourceSize === null
+      ? null
+      : resolveMarkdownImageDisplaySize({
+          sourceWidth: sourceSize.width,
+          sourceHeight: sourceSize.height,
+          availableWidth,
+        });
+  const failed = props.unavailable || (props.uri !== null && failedUri === props.uri);
+  const placeholderWidth =
+    availableWidth > 0 ? Math.min(availableWidth, MARKDOWN_IMAGE_MAX_WIDTH) : "100%";
 
   return (
-    <View style={{ gap: 6 }}>
-      {uri === null || failed ? (
+    <View
+      onLayout={(event) => setAvailableWidth(event.nativeEvent.layout.width)}
+      style={{ alignSelf: "stretch", gap: 6 }}
+    >
+      {props.uri === null || failed ? (
         <View
           style={{
-            width: "100%",
+            width: placeholderWidth,
             aspectRatio: 16 / 9,
             borderRadius: 10,
             backgroundColor: codeBackground,
@@ -238,20 +252,36 @@ function ThreadMarkdownImage(props: {
           accessibilityRole="imagebutton"
           accessibilityLabel={props.alt ?? "Markdown image"}
           activeOpacity={0.7}
-          onPress={() => props.onPressImage(uri)}
+          onPress={() => props.onPressImage(props.uri!)}
+          style={{ alignSelf: "flex-start" }}
         >
-          <Image
-            source={{ uri }}
-            resizeMode="contain"
-            accessible={false}
-            onError={() => setFailedUri(uri)}
+          <View
             style={{
-              width: "100%",
-              aspectRatio: 16 / 9,
+              ...(displaySize ?? { width: placeholderWidth, aspectRatio: 16 / 9 }),
               borderRadius: 10,
               backgroundColor: codeBackground,
+              alignItems: "center",
+              justifyContent: "center",
+              overflow: "hidden",
             }}
-          />
+          >
+            <Image
+              source={{ uri: props.uri }}
+              resizeMode="contain"
+              accessible={false}
+              onLoad={(event) => {
+                const { width, height } = event.nativeEvent.source;
+                setSourceSize({ width, height });
+              }}
+              onError={() => setFailedUri(props.uri)}
+              style={{
+                width: "100%",
+                height: "100%",
+                opacity: displaySize === null ? 0 : 1,
+              }}
+            />
+            {displaySize === null ? <ActivityIndicator style={StyleSheet.absoluteFill} /> : null}
+          </View>
         </TouchableOpacity>
       )}
       {props.alt ? (
@@ -263,28 +293,38 @@ function ThreadMarkdownImage(props: {
   );
 }
 
-function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) {
-  const codeBackground = useThemeColor("--color-md-code-bg");
+/** Markdown image whose src is a workspace file — loads through a signed asset URL. */
+function ThreadMarkdownImage(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly path: string;
+  readonly alt: string | null;
+  readonly onPressImage: (uri: string) => void;
+}) {
+  const assetUrl = useAssetUrlState(props.environmentId, {
+    _tag: "workspace-file",
+    threadId: props.threadId,
+    path: props.path,
+  });
+
   return (
-    <View style={{ gap: 6 }}>
-      <View
-        style={{
-          width: "100%",
-          aspectRatio: 16 / 9,
-          borderRadius: 10,
-          backgroundColor: codeBackground,
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <Text className="text-xs text-foreground-muted">Image unavailable</Text>
-      </View>
-      {props.alt ? (
-        <Text selectable className="text-xs text-foreground-muted">
-          {props.alt}
-        </Text>
-      ) : null}
-    </View>
+    <ThreadMarkdownImageView
+      uri={assetUrl._tag === "Success" ? assetUrl.url : null}
+      unavailable={assetUrl._tag === "Failure"}
+      alt={props.alt}
+      onPressImage={props.onPressImage}
+    />
+  );
+}
+
+function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) {
+  return (
+    <ThreadMarkdownImageView
+      uri={null}
+      unavailable
+      alt={props.alt}
+      onPressImage={() => undefined}
+    />
   );
 }
 
@@ -1530,7 +1570,14 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     (image) => {
       const imageSource = classifyMarkdownImageSource(image.href, props.workspaceRoot ?? null);
       if (imageSource._tag === "Direct") {
-        return null;
+        return (
+          <ThreadMarkdownImageView
+            uri={imageSource.uri}
+            unavailable={false}
+            alt={image.alt}
+            onPressImage={(uri) => setExpandedImage({ uri })}
+          />
+        );
       }
       if (imageSource._tag === "Blocked") {
         return <ThreadMarkdownImageUnavailable alt={image.alt} />;

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -40,6 +40,7 @@ import {
   type ColorValue,
   useWindowDimensions,
   View,
+  type ViewStyle,
 } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 import ImageViewing from "react-native-image-viewing";
@@ -208,6 +209,8 @@ function ThreadMarkdownImageView(props: {
   const [availableWidth, setAvailableWidth] = useState(0);
   const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
   const [failedUri, setFailedUri] = useState<string | null>(null);
+  const activeUriRef = useRef(props.uri);
+  activeUriRef.current = props.uri;
 
   useEffect(() => {
     setSourceSize(null);
@@ -226,8 +229,9 @@ function ThreadMarkdownImageView(props: {
           availableWidth,
         });
   const failed = props.unavailable || (props.uri !== null && failedUri === props.uri);
-  const placeholderWidth =
+  const placeholderWidth: ViewStyle["width"] =
     availableWidth > 0 ? Math.min(availableWidth, MARKDOWN_IMAGE_MAX_WIDTH) : "100%";
+  const frameStyle: ViewStyle = displaySize ?? { width: placeholderWidth, aspectRatio: 16 / 9 };
 
   return (
     <View
@@ -237,8 +241,7 @@ function ThreadMarkdownImageView(props: {
       {props.uri === null || failed ? (
         <View
           style={{
-            width: placeholderWidth,
-            aspectRatio: 16 / 9,
+            ...frameStyle,
             borderRadius: 10,
             backgroundColor: codeBackground,
             alignItems: "center",
@@ -261,7 +264,7 @@ function ThreadMarkdownImageView(props: {
         >
           <View
             style={{
-              ...(displaySize ?? { width: placeholderWidth, aspectRatio: 16 / 9 }),
+              ...frameStyle,
               borderRadius: 10,
               backgroundColor: codeBackground,
               alignItems: "center",
@@ -274,6 +277,7 @@ function ThreadMarkdownImageView(props: {
               resizeMode="contain"
               accessible={false}
               onLoad={(event) => {
+                if (activeUriRef.current !== props.uri) return;
                 const { width, height } = event.nativeEvent.source;
                 setSourceSize({ width, height });
               }}

--- a/apps/mobile/src/features/threads/markdownImageSize.test.ts
+++ b/apps/mobile/src/features/threads/markdownImageSize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  MARKDOWN_IMAGE_MAX_HEIGHT,
+  MARKDOWN_IMAGE_MAX_WIDTH,
+  resolveMarkdownImageDisplaySize,
+} from "./markdownImageSize";
+
+describe("resolveMarkdownImageDisplaySize", () => {
+  it("keeps small images at their intrinsic size", () => {
+    expect(
+      resolveMarkdownImageDisplaySize({
+        sourceWidth: 96,
+        sourceHeight: 96,
+        availableWidth: 332,
+      }),
+    ).toEqual({ width: 96, height: 96 });
+  });
+
+  it("fits wide images to the available chat width", () => {
+    expect(
+      resolveMarkdownImageDisplaySize({
+        sourceWidth: 960,
+        sourceHeight: 540,
+        availableWidth: 332,
+      }),
+    ).toEqual({ width: 332, height: 186.75 });
+  });
+
+  it("caps wide images at 480 points on larger screens", () => {
+    expect(
+      resolveMarkdownImageDisplaySize({
+        sourceWidth: 960,
+        sourceHeight: 540,
+        availableWidth: 900,
+      }),
+    ).toEqual({ width: MARKDOWN_IMAGE_MAX_WIDTH, height: 270 });
+  });
+
+  it("caps tall images by height without changing their aspect ratio", () => {
+    expect(
+      resolveMarkdownImageDisplaySize({
+        sourceWidth: 400,
+        sourceHeight: 800,
+        availableWidth: 332,
+      }),
+    ).toEqual({ width: 240, height: MARKDOWN_IMAGE_MAX_HEIGHT });
+  });
+
+  it("rejects dimensions that cannot produce a stable layout", () => {
+    expect(
+      resolveMarkdownImageDisplaySize({ sourceWidth: 0, sourceHeight: 100, availableWidth: 332 }),
+    ).toBeNull();
+    expect(
+      resolveMarkdownImageDisplaySize({
+        sourceWidth: 100,
+        sourceHeight: Number.NaN,
+        availableWidth: 332,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/threads/markdownImageSize.ts
+++ b/apps/mobile/src/features/threads/markdownImageSize.ts
@@ -1,0 +1,37 @@
+export const MARKDOWN_IMAGE_MAX_WIDTH = 480;
+export const MARKDOWN_IMAGE_MAX_HEIGHT = 480;
+
+export interface MarkdownImageDisplaySize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Keeps small images intrinsic while fitting larger images inside the chat viewport. */
+export function resolveMarkdownImageDisplaySize(input: {
+  readonly sourceWidth: number;
+  readonly sourceHeight: number;
+  readonly availableWidth: number;
+}): MarkdownImageDisplaySize | null {
+  if (
+    !Number.isFinite(input.sourceWidth) ||
+    !Number.isFinite(input.sourceHeight) ||
+    !Number.isFinite(input.availableWidth) ||
+    input.sourceWidth <= 0 ||
+    input.sourceHeight <= 0 ||
+    input.availableWidth <= 0
+  ) {
+    return null;
+  }
+
+  const scale = Math.min(
+    1,
+    input.availableWidth / input.sourceWidth,
+    MARKDOWN_IMAGE_MAX_WIDTH / input.sourceWidth,
+    MARKDOWN_IMAGE_MAX_HEIGHT / input.sourceHeight,
+  );
+
+  return {
+    width: input.sourceWidth * scale,
+    height: input.sourceHeight * scale,
+  };
+}


### PR DESCRIPTION
Markdown images on mobile always used a full-width 16:9 frame. That enlarged small images and distorted tall ones.

This reads each loaded image's intrinsic dimensions and fits it inside the chat viewport with 480-point width and height limits. Workspace and remote Markdown images use the same renderer, keep their aspect ratio, and still open in the existing full-screen viewer.

## Before and after

| Before: every image filled a 16:9 frame | After: small images keep their intrinsic size |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-7940/87f4346a287c-screenshot_optimized_035f6766-c429-4d45-8d72-7ac0067aad87.jpg" width="320" alt="Before: small Markdown images stretched to full-width 16:9 frames on iOS" /> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-7940/7023c3147ddd-screenshot_optimized_c0359c2c-1f31-4730-836d-6fd19de0fa97.jpg" width="320" alt="After: small Markdown images keep their intrinsic dimensions on iOS" /> |

Tall images preserve their aspect ratio and stop at the 480-point height limit.

<img src="https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-7940/8c752c207a8a-screenshot_optimized_5c589a54-5049-4963-80b4-dcf3435ceda4.jpg" width="320" alt="After: portrait Markdown image preserves its aspect ratio and stops at 480 points on iOS" />

## Testing

- `pnpm exec vp test run apps/mobile/src/features/threads/markdownImageSize.test.ts` (5 tests)
- `pnpm --filter @t3tools/mobile typecheck`
- `pnpm exec vp lint apps/mobile/src/features/threads/ThreadFeed.tsx apps/mobile/src/features/threads/markdownImageSize.ts apps/mobile/src/features/threads/markdownImageSize.test.ts`
- iPhone 17 Pro on iOS 26.5: checked intrinsic 96-point and 320-point images, wide and portrait limits, and tap to expand

Built with GPT-5.6 Sol in T3 Code using the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image rendering in mobile thread messages.
  * Markdown images now scale proportionally to fit available space, with width and height limits.
  * Images use consistent framing while loading and after loading.

* **Bug Fixes**
  * Fixed stale image load events from previous image sources affecting the current image.
  * Fixed image sizing for small, wide, tall, and invalid-dimension images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ThreadFeed image layout, which can change row heights and scroll measurement. Also starts rendering previously skipped remote/direct markdown images.
> 
> **Overview**
> Markdown images in the mobile thread feed no longer stretch into a full-width 16:9 box. After load, they keep intrinsic size and aspect ratio, scaled to the chat width with a **480pt** width/height cap.
> 
> Workspace, remote/direct, and unavailable images share one renderer (`ThreadMarkdownImageView`) with a 16:9 placeholder until dimensions are known. Direct `https`/`data`/`blob` images now render inline and open the existing full-screen viewer instead of being dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92f72ffef965280a23c58e03b5b3f6a3918c96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown image rendering to preserve intrinsic dimensions in `ThreadFeed`
> - Adds `resolveMarkdownImageDisplaySize` in [markdownImageSize.ts](https://github.com/pingdotgg/t3code/pull/7940/files#diff-18e0efcb1755ea77fb29e70ff23e0f709463c3d6e6291fdb3df15c2a536c63dd) with `MARKDOWN_IMAGE_MAX_WIDTH` and `MARKDOWN_IMAGE_MAX_HEIGHT` caps of 480, computing a uniform scale factor from available width and intrinsic source size.
> - Introduces `ThreadMarkdownImageView` in [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/7940/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) which measures available width, loads intrinsic size via `Image.onLoad`, renders a loading placeholder, and applies opacity 0 until display size is resolved.
> - Refactors `ThreadMarkdownImage` and `ThreadMarkdownImageUnavailable` to delegate rendering to `ThreadMarkdownImageView`, removing duplicate sizing and placeholder logic.
> - Direct-linked markdown images now render in threads and are tappable to open the image viewer; previously they did not render at all.
> - Behavioral Change: workspace-file images render with intrinsic sizing up to 480×480 instead of a fixed 16:9 container; direct images that were previously hidden now appear.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e92f72f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->