### PR TITLE
fix(mobile): isolate markdown image requests

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -308,7 +308,7 @@ function ThreadMarkdownImageRequest(props: {
         onError={props.onError}
         style={{ width: "100%", height: "100%", opacity: loaded ? 1 : 0 }}
       />
-      {loaded ? null : <ActivityIndicator style={StyleSheet.absoluteFill} />}
+      {loaded ? null : <View pointerEvents="none" style={StyleSheet.absoluteFill} />}
     </>
   );
 }

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -270,23 +270,12 @@ function ThreadMarkdownImageView(props: {
               overflow: "hidden",
             }}
           >
-            <Image
+            <ThreadMarkdownImageRequest
               key={props.uri}
-              source={{ uri: props.uri }}
-              resizeMode="contain"
-              accessible={false}
-              onLoad={(event) => {
-                const { width, height } = event.nativeEvent.source;
-                setSourceSize({ width, height });
-              }}
+              uri={props.uri}
+              onLoad={setSourceSize}
               onError={() => setFailedUri(props.uri)}
-              style={{
-                width: "100%",
-                height: "100%",
-                opacity: displaySize === null ? 0 : 1,
-              }}
             />
-            {displaySize === null ? <ActivityIndicator style={StyleSheet.absoluteFill} /> : null}
           </View>
         </TouchableOpacity>
       )}
@@ -296,6 +285,31 @@ function ThreadMarkdownImageView(props: {
         </Text>
       ) : null}
     </View>
+  );
+}
+
+function ThreadMarkdownImageRequest(props: {
+  readonly uri: string;
+  readonly onLoad: (sourceSize: { width: number; height: number }) => void;
+  readonly onError: () => void;
+}) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <>
+      <Image
+        source={{ uri: props.uri }}
+        resizeMode="contain"
+        accessible={false}
+        onLoad={(event) => {
+          setLoaded(true);
+          props.onLoad(event.nativeEvent.source);
+        }}
+        onError={props.onError}
+        style={{ width: "100%", height: "100%", opacity: loaded ? 1 : 0 }}
+      />
+      {loaded ? null : <ActivityIndicator style={StyleSheet.absoluteFill} />}
+    </>
   );
 }
 

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -209,8 +209,6 @@ function ThreadMarkdownImageView(props: {
   const [availableWidth, setAvailableWidth] = useState(0);
   const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
   const [failedUri, setFailedUri] = useState<string | null>(null);
-  const activeUriRef = useRef(props.uri);
-  activeUriRef.current = props.uri;
 
   useEffect(() => {
     setSourceSize(null);
@@ -273,11 +271,11 @@ function ThreadMarkdownImageView(props: {
             }}
           >
             <Image
+              key={props.uri}
               source={{ uri: props.uri }}
               resizeMode="contain"
               accessible={false}
               onLoad={(event) => {
-                if (activeUriRef.current !== props.uri) return;
                 const { width, height } = event.nativeEvent.source;
                 setSourceSize({ width, height });
               }}

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -308,7 +308,14 @@ function ThreadMarkdownImageRequest(props: {
         onError={props.onError}
         style={{ width: "100%", height: "100%", opacity: loaded ? 1 : 0 }}
       />
-      {loaded ? null : <View pointerEvents="none" style={StyleSheet.absoluteFill} />}
+      {loaded ? null : (
+        <View
+          pointerEvents="none"
+          style={[StyleSheet.absoluteFill, { alignItems: "center", justifyContent: "center" }]}
+        >
+          <Text className="text-xs text-foreground-muted">Loading image…</Text>
+        </View>
+      )}
     </>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only markdown image loading in the thread feed; no auth, data, or API changes.
> 
> **Overview**
> Fixes stale or racing markdown images when the URI changes by remounting a dedicated `ThreadMarkdownImageRequest` keyed on `uri`, instead of guarding `onLoad` with a shared `activeUriRef`.
> 
> Each request now owns its own loaded state, stays invisible until load, and shows a non-interactive “Loading image…” overlay in place of the spinner. Parent still receives source size and error callbacks for layout and failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84391fa5630b8d19858a2c73b788334c627b94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate markdown image loading in `ThreadMarkdownImageView` via `ThreadMarkdownImageRequest`
> - Introduces `ThreadMarkdownImageRequest`, a child `<Image>` component keyed by `uri` that owns its own loaded state, opacity fade-in, and a centered "Loading image…" overlay until `onLoad` fires
> - Removes the `activeUriRef` guard and inline `ActivityIndicator` from `ThreadMarkdownImageView`; `onLoad` now receives `{width, height}` directly from `event.nativeEvent.source`, and errors forward through `onError`
> - Behavioral Change: the spinner overlay is replaced by a text "Loading image…" overlay, and opacity is controlled inside `ThreadMarkdownImageRequest` rather than `ThreadMarkdownImageView`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a84391f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image updates in thread feeds when image sources change.
  * Images remain hidden until fully loaded, with a centered, non-interactive loading message displayed beforehand.
  * Preserved image sizing and error handling, including correct forwarding of load dimensions and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->