### PR TITLE
fix(shared): read PATH from nushell login shells

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -186,6 +186,53 @@ describe("readEnvironmentFromLoginShell", () => {
       CUSTOM_VAR: "  padded value  ",
     });
   });
+
+  it("sends a nushell-compatible probe when the login shell is nushell", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(() => ["__T3CODE_ENV_PATH_START__", "/a:/b", "__T3CODE_ENV_PATH_END__"].join("\n"));
+
+    expect(readEnvironmentFromLoginShell("/bin/nu", ["PATH"], execFile)).toEqual({
+      PATH: "/a:/b",
+    });
+
+    const script = execFile.mock.calls[0]?.[1]?.[1];
+    // Nushell has no `||` operator and rejects the POSIX probe at parse time.
+    expect(script).toBeDefined();
+    expect(script).not.toContain("||");
+    expect(script).toContain("try { printenv PATH } catch { print '' }");
+  });
+
+  it("detects nushell regardless of case or a .exe suffix", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(() => "");
+
+    readEnvironmentFromLoginShell("C:\\Program Files\\nu\\NU.EXE", ["PATH"], execFile);
+    const script = execFile.mock.calls[0]?.[1]?.[1];
+    expect(script).not.toContain("||");
+  });
+
+  it("keeps the POSIX probe for non-nushell shells", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(() => "");
+
+    readEnvironmentFromLoginShell("/bin/zsh", ["PATH"], execFile);
+    expect(execFile.mock.calls[0]?.[1]?.[1]).toContain("printenv PATH || true");
+  });
 });
 
 describe("listLoginShellCandidates", () => {

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -233,6 +233,19 @@ describe("readEnvironmentFromLoginShell", () => {
     readEnvironmentFromLoginShell("/bin/zsh", ["PATH"], execFile);
     expect(execFile.mock.calls[0]?.[1]?.[1]).toContain("printenv PATH || true");
   });
+
+  it("keeps the POSIX probe for shells whose name merely contains nu", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(() => "");
+
+    readEnvironmentFromLoginShell("/usr/bin/nushell-compat", ["PATH"], execFile);
+    expect(execFile.mock.calls[0]?.[1]?.[1]).toContain("printenv PATH || true");
+  });
 });
 
 describe("listLoginShellCandidates", () => {

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -261,6 +261,35 @@ function buildEnvironmentCaptureCommand(names: ReadonlyArray<string>): string {
     .join("; ");
 }
 
+function buildNushellEnvironmentCaptureCommand(names: ReadonlyArray<string>): string {
+  return names
+    .map((name) => {
+      if (!SHELL_ENV_NAME_PATTERN.test(name)) {
+        throw new Error(`Unsupported environment variable name: ${name}`);
+      }
+
+      // Nushell has no `||` operator and rejects the POSIX probe at parse
+      // time; `try`/`catch` with an empty print keeps missing variables
+      // silent so the marker extraction stays unchanged.
+      return [
+        `print '${envCaptureStart(name)}'`,
+        `try { printenv ${name} } catch { print '' }`,
+        `print '${envCaptureEnd(name)}'`,
+      ].join("; ");
+    })
+    .join("; ");
+}
+
+/**
+ * Nushell cannot run the POSIX environment probe, so its login shells need
+ * their own capture command. Matches the `nu` binary regardless of case and
+ * Windows `.exe` suffixes.
+ */
+function isNushellPath(shell: string): boolean {
+  const basename = shell.split(/[\\/]/u).at(-1)?.toLowerCase() ?? "";
+  return basename.replace(/\.exe$/u, "").startsWith("nu");
+}
+
 function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): string {
   return [
     "$ErrorActionPreference = 'Stop'",
@@ -312,7 +341,10 @@ export const readEnvironmentFromLoginShell: ShellEnvironmentReader = (
     return {};
   }
 
-  const output = execFile(shell, ["-ilc", buildEnvironmentCaptureCommand(names)], {
+  const captureCommand = isNushellPath(shell)
+    ? buildNushellEnvironmentCaptureCommand(names)
+    : buildEnvironmentCaptureCommand(names);
+  const output = execFile(shell, ["-ilc", captureCommand], {
     encoding: "utf8",
     timeout: 5000,
   });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -282,12 +282,12 @@ function buildNushellEnvironmentCaptureCommand(names: ReadonlyArray<string>): st
 
 /**
  * Nushell cannot run the POSIX environment probe, so its login shells need
- * their own capture command. Matches the `nu` binary regardless of case and
- * Windows `.exe` suffixes.
+ * their own capture command. Matches the `nu` binary exactly, regardless of
+ * case and Windows `.exe` suffixes.
  */
 function isNushellPath(shell: string): boolean {
   const basename = shell.split(/[\\/]/u).at(-1)?.toLowerCase() ?? "";
-  return basename.replace(/\.exe$/u, "").startsWith("nu");
+  return basename.replace(/\.exe$/u, "") === "nu";
 }
 
 function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): string {


### PR DESCRIPTION
## What changed

`packages/shared/src/shell.ts`: when the login shell is nushell (basename `nu`, case-insensitive, `.exe` tolerated), the environment capture probe switches from the POSIX form to a nushell-flavored one:

```
print '__T3CODE_ENV_PATH_START__'; try { printenv PATH } catch { print '' }; print '__T3CODE_ENV_PATH_END__'
```

Same marker shape and statement structure as the POSIX probe, so `extractEnvironmentValue` is untouched. Non-nu shells keep the exact original command.

New tests: nu probe selection (with the no-`||` regression assertion), `.exe`/casing tolerance, and a guard that zsh keeps the POSIX probe. Failing-test-first — both nu cases failed before the change.

## Why

Fixes #7846. Nushell has no `||` operator and rejects the current probe at parse time (`nu::parser::shell_oror`), so on machines with `/bin/nu` as login shell the captured PATH was dropped entirely — nvm-managed node and cargo binaries failed to resolve inside t3 while terminals worked fine. The probe shape in this PR is the variant verified against a real nushell in the issue.

Shared-package only; no server/web behavior changes for POSIX or Windows shells.

## Verification

- `packages/shared` suite: 363/363 passing
- Scoped typecheck clean

--
Worked by ox-alpha via opencode (x-preview-f-free).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login-shell command generation used to capture PATH and other env vars, which affects tool discovery. Detection is basename-based and POSIX/Windows probes are unchanged.
> 
> **Overview**
> Fixes login-shell environment capture for **nushell** (`nu`), which previously rejected the POSIX probe (`printenv … || true`) at parse time and dropped PATH entirely.
> 
> `readEnvironmentFromLoginShell` now detects a `nu` binary (case-insensitive, `.exe` allowed, basename must be exactly `nu`) and emits a `try { printenv … } catch { print '' }` probe with the same start/end markers. Other shells keep the original POSIX command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04288406404319dd98ca633708eb10e8dfa1b5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nushell support to `readEnvironmentFromLoginShell`
> - Adds `isNushellPath` helper to detect the `nu` binary (case-insensitive, ignoring `.exe` suffix) and `buildNushellEnvironmentCaptureCommand` to emit a Nushell-compatible capture script using try/catch instead of the POSIX `||` operator
> - `readEnvironmentFromLoginShell` now selects the Nushell or POSIX capture command based on the detected shell path; all other behavior is unchanged
> - Adds tests covering Nushell detection, probe selection, and correct fallback for non-Nushell shells
> - Behavioral Change: shells whose basename is exactly `nu` (case-insensitive, with optional `.exe`) now receive a different exec script; shells whose name merely contains the substring `nu` still use the POSIX probe
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0428840.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->