### PR TITLE
fix(contracts): reject project script ids that cannot form keybinding commands

### DIFF
--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -75,12 +75,19 @@ export const STATIC_KEYBINDING_COMMANDS = [
   ...THREAD_KEYBINDING_COMMANDS,
 ] as const;
 
+/**
+ * Identifier portion of a script run command (`script.<id>.run`). The web
+ * client rebuilds that command during keybinding wiring, so any id persisted
+ * by the server must satisfy this constraint or thread views throw.
+ */
+export const ProjectScriptId = Schema.NonEmptyString.check(
+  Schema.isMaxLength(MAX_SCRIPT_ID_LENGTH),
+  Schema.isPattern(/^[a-z0-9][a-z0-9-]*$/),
+);
+
 export const SCRIPT_RUN_COMMAND_PATTERN = Schema.TemplateLiteral([
   Schema.Literal("script."),
-  Schema.NonEmptyString.check(
-    Schema.isMaxLength(MAX_SCRIPT_ID_LENGTH),
-    Schema.isPattern(/^[a-z0-9][a-z0-9-]*$/),
-  ),
+  ProjectScriptId,
   Schema.Literal(".run"),
 ]);
 

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -221,6 +221,49 @@ it.effect("rejects command fields that become empty after trim", () =>
   }),
 );
 
+it.effect("rejects project scripts whose ids cannot form keybinding commands", () =>
+  Effect.gen(function* () {
+    // The web client rebuilds `script.<id>.run` keybinding commands while
+    // rendering; an id outside the pattern's constraint crashes thread
+    // views, so the server must refuse to persist it.
+    const result = yield* Effect.exit(
+      decodeProjectMetaUpdatedPayload({
+        projectId: "project-1",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        scripts: [
+          {
+            id: "123e4567-e89b-42d3-a456-426614174000",
+            name: "Setup",
+            command: "echo hi",
+            icon: "configure",
+            runOnWorktreeCreate: false,
+          },
+        ],
+      }),
+    );
+    assert.strictEqual(result._tag, "Failure");
+  }),
+);
+
+it.effect("accepts project scripts with conforming ids", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeProjectMetaUpdatedPayload({
+      projectId: "project-1",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      scripts: [
+        {
+          id: "run-setup",
+          name: "Setup",
+          command: "echo hi",
+          icon: "configure",
+          runOnWorktreeCreate: false,
+        },
+      ],
+    });
+    assert.strictEqual(parsed.scripts?.[0]?.id, "run-setup");
+  }),
+);
+
 it.effect("decodes thread.turn.start defaults for provider and runtime mode", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadTurnStartCommand({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -23,6 +23,7 @@ import {
   TurnId,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
+import { ProjectScriptId } from "./keybindings.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -207,7 +208,12 @@ export const ProjectScriptIcon = Schema.Literals([
 export type ProjectScriptIcon = typeof ProjectScriptIcon.Type;
 
 export const ProjectScript = Schema.Struct({
-  id: TrimmedNonEmptyString,
+  /**
+   * Must satisfy the script-id constraint from the keybinding command
+   * pattern (`script.<id>.run`); the web client rebuilds that command while
+   * rendering, so a non-conforming id persisted here crashes thread views.
+   */
+  id: ProjectScriptId,
   name: TrimmedNonEmptyString,
   command: TrimmedNonEmptyString,
   icon: ProjectScriptIcon,


### PR DESCRIPTION
## What changed

`packages/contracts`: the identifier portion of `SCRIPT_RUN_COMMAND_PATTERN` is extracted into an exported `ProjectScriptId` schema (single source of truth), and `ProjectScript.id` now uses it instead of `TrimmedNonEmptyString`. Behavior change is exactly one: commands carrying script ids that cannot form a valid `script.<id>.run` keybinding command are rejected with a schema error at the dispatch boundary instead of being persisted.

Two new tests in `orchestration.test.ts`: the UUID id from #7851's repro now fails to decode; a conforming id still passes.

## Why

Fixes #7851, using its first suggested direction. The web client calls `commandForProjectScript(script.id)` (`SCRIPT_RUN_COMMAND_PATTERN.make("script." + id + ".run")`) while rendering thread views and Settings → Projects. The server accepted any trimmed non-empty id, so one dispatched UUID poisoned every read model of that project and both surfaces threw inside the React error boundary with no in-app way to repair — the persisted data re-threw on every render.

Client-side tolerance was the alternative direction, but it would add null-handling through ~10 keybinding call sites to accommodate input the system never intended to accept. Rejecting at the schema keeps orchestration pure and the client dumb. UI-created ids already conform via `normalizeScriptId`, so nothing changes for normal flows. Note this prevents new poison but does not migrate already-poisoned projects — happy to look at a cleanup path if maintainers want one.

## Verification

- Failing-test-first: with the old schema stashed, the UUID test fails (server accepts the poison), passes after
- contracts suite 268/268 · server orchestration suite 273/273 · web projectScripts suites 13/13
- Scoped typecheck clean

--
Worked by ox-alpha via opencode (x-preview-f-free).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens decode of project scripts and related events/commands. Existing payloads with UUID or otherwise non-conforming ids will now fail schema decode rather than persist or render.
> 
> **Overview**
> Stops persisting project script ids that cannot form a valid `script.<id>.run` keybinding. The web client rebuilds that command while rendering, so a UUID (or other non-conforming id) previously poisoned the project and crashed thread/settings views.
> 
> Exports a shared `ProjectScriptId` schema (lowercase alphanumerics/hyphens, max length) and uses it for both `SCRIPT_RUN_COMMAND_PATTERN` and `ProjectScript.id`. Tests cover rejecting a UUID and accepting a conforming id.
> 
> Does not migrate already-poisoned projects; it only blocks new ones. UI-created ids already go through `normalizeScriptId` / `nextProjectScriptId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5999a9629caf7cbddfaab8175a227d1f24cd5df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject project script IDs that cannot form keybinding commands
> Adds a `ProjectScriptId` schema that enforces lowercase alphanumerics and hyphens (starting alphanumeric, within `MAX_SCRIPT_ID_LENGTH`). Changes `ProjectScript.id` from `TrimmedNonEmptyString` to this schema so payloads with non-conforming IDs fail decoding. The `SCRIPT_RUN_COMMAND_PATTERN` now reuses `ProjectScriptId` for the script-id portion.
> - Risk: `ProjectScript.id` decoding now rejects IDs like UUIDs or strings with uppercase/underscores; existing payloads with such IDs will fail to decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5999a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->