### PR TITLE
feat(web): recall sent prompts with arrow keys

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -263,6 +263,7 @@ import {
 } from "../state/entities";
 import { environmentShell } from "../state/shell";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
+import { buildComposerPromptHistoryEntries } from "./chat/composerPromptHistory";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
@@ -2606,13 +2607,24 @@ function ChatViewContent(props: ChatViewProps) {
     if (optimisticUserMessages.length === 0) {
       return serverMessagesWithPreviewHandoff;
     }
-    const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
+    const optimisticMessagesById = new Map(
+      optimisticUserMessages.map((message) => [message.id, message] as const),
+    );
+    const acknowledgedMessages = serverMessagesWithPreviewHandoff.map((message) => {
+      const promptHistoryText = optimisticMessagesById.get(message.id)?.promptHistoryText;
+      return promptHistoryText === undefined ? message : { ...message, promptHistoryText };
+    });
+    const serverIds = new Set(acknowledgedMessages.map((message) => message.id));
     const pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
     if (pendingMessages.length === 0) {
-      return serverMessagesWithPreviewHandoff;
+      return acknowledgedMessages;
     }
-    return [...serverMessagesWithPreviewHandoff, ...pendingMessages];
+    return [...acknowledgedMessages, ...pendingMessages];
   }, [attachmentPreviewHandoffByMessageId, displayServerMessages, optimisticUserMessages]);
+  const composerPromptHistoryEntries = useMemo(
+    () => buildComposerPromptHistoryEntries(timelineMessages),
+    [timelineMessages],
+  );
   const timelineEntries = useMemo(
     () =>
       deriveTimelineEntries(
@@ -5322,6 +5334,7 @@ function ChatViewContent(props: ChatViewProps) {
         id: messageIdForSend,
         role: "user",
         text: outgoingMessageText,
+        promptHistoryText: trimmed,
         ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
         turnId: null,
         createdAt: messageCreatedAt,
@@ -5827,6 +5840,7 @@ function ChatViewContent(props: ChatViewProps) {
           id: messageIdForSend,
           role: "user",
           text: outgoingMessageText,
+          promptHistoryText: trimmed,
           turnId: null,
           createdAt: messageCreatedAt,
           updatedAt: messageCreatedAt,
@@ -6626,6 +6640,7 @@ function ChatViewContent(props: ChatViewProps) {
                             activeThreadId={activeThreadId}
                             activeThreadEnvironmentId={activeThread?.environmentId}
                             activeThread={activeThread}
+                            promptHistoryEntries={composerPromptHistoryEntries}
                             isServerThread={isServerThread}
                             isLocalDraftThread={isLocalDraftThread}
                             forceExpandedOnMobile={forceExpandedMobileComposer && isDraftHeroState}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5308,6 +5308,7 @@ function ChatViewContent(props: ChatViewProps) {
       mimeType: image.mimeType,
       sizeBytes: image.sizeBytes,
       previewUrl: image.previewUrl,
+      file: image.file,
     }));
     const shouldAnchorFirstMessage =
       activeThread.latestTurn === null &&

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -263,7 +263,10 @@ import {
 } from "../state/entities";
 import { environmentShell } from "../state/shell";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
-import { buildComposerPromptHistoryEntries } from "./chat/composerPromptHistory";
+import {
+  buildComposerPromptHistoryEntries,
+  preserveComposerPromptHistoryAttachmentFiles,
+} from "./chat/composerPromptHistory";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
@@ -2611,8 +2614,19 @@ function ChatViewContent(props: ChatViewProps) {
       optimisticUserMessages.map((message) => [message.id, message] as const),
     );
     const acknowledgedMessages = serverMessagesWithPreviewHandoff.map((message) => {
-      const promptHistoryText = optimisticMessagesById.get(message.id)?.promptHistoryText;
-      return promptHistoryText === undefined ? message : { ...message, promptHistoryText };
+      const optimisticMessage = optimisticMessagesById.get(message.id);
+      if (!optimisticMessage) return message;
+      const attachments = message.attachments
+        ? preserveComposerPromptHistoryAttachmentFiles(
+            message.attachments,
+            optimisticMessage.attachments ?? [],
+          )
+        : message.attachments;
+      return {
+        ...message,
+        promptHistoryText: optimisticMessage.promptHistoryText,
+        ...(attachments ? { attachments } : {}),
+      };
     });
     const serverIds = new Set(acknowledgedMessages.map((message) => message.id));
     const pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -869,6 +869,7 @@ export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
   focusAtEnd: () => void;
+  isCaretOnVisualEdge: (edge: "start" | "end") => boolean;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -1677,6 +1678,52 @@ function ComposerPromptEditorInner({
     return snapshot;
   }, [editor]);
 
+  const isCaretOnVisualEdge = useCallback(
+    (edge: "start" | "end"): boolean => {
+      const snapshot = readSnapshot();
+      if (snapshot.value.length === 0) return true;
+
+      const beforeCaret = snapshot.value.slice(0, snapshot.expandedCursor);
+      const afterCaret = snapshot.value.slice(snapshot.expandedCursor);
+      if (edge === "start" ? beforeCaret.includes("\n") : afterCaret.includes("\n")) {
+        return false;
+      }
+
+      const rootElement = editor.getRootElement();
+      const selection = window.getSelection();
+      const anchorNode = selection?.anchorNode;
+      if (
+        !rootElement ||
+        !selection ||
+        !selection.isCollapsed ||
+        selection.rangeCount === 0 ||
+        !anchorNode ||
+        !rootElement.contains(anchorNode)
+      ) {
+        return false;
+      }
+
+      const range = selection.getRangeAt(0);
+      if (typeof range.getBoundingClientRect !== "function") return false;
+      let caretRect = range.getBoundingClientRect();
+      if (caretRect.height === 0) {
+        const container = range.startContainer;
+        const element = container instanceof HTMLElement ? container : container.parentElement;
+        if (!element) return false;
+        caretRect = element.getBoundingClientRect();
+      }
+
+      const edgeElement =
+        edge === "start" ? rootElement.firstElementChild : rootElement.lastElementChild;
+      const edgeRect = (edgeElement ?? rootElement).getBoundingClientRect();
+      const threshold = (caretRect.height || 20) / 2;
+      return edge === "start"
+        ? caretRect.top - edgeRect.top < threshold
+        : edgeRect.bottom - caretRect.bottom < threshold;
+    },
+    [editor, readSnapshot],
+  );
+
   useImperativeHandle(
     editorRef,
     () => ({
@@ -1692,9 +1739,10 @@ function ComposerPromptEditorInner({
           ),
         );
       },
+      isCaretOnVisualEdge,
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
+    [focusAt, isCaretOnVisualEdge, readSnapshot],
   );
 
   const handleEditorChange = useCallback((editorState: EditorState) => {

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -865,6 +865,34 @@ function collectTerminalContextIds(node: LexicalNode): string[] {
   return [];
 }
 
+function composerCaretLineRect(range: Range): DOMRect | null {
+  const collapsedRect = Array.from(range.getClientRects()).find((rect) => rect.height > 0);
+  if (collapsedRect) return collapsedRect;
+
+  const container = range.startContainer;
+  if (container.nodeType === Node.TEXT_NODE) {
+    const textNode = container as Text;
+    if (textNode.data.length > 0) {
+      const probeStart = Math.min(range.startOffset, textNode.data.length - 1);
+      const probeRange = document.createRange();
+      probeRange.setStart(textNode, probeStart);
+      probeRange.setEnd(textNode, probeStart + 1);
+      const probeRect = Array.from(probeRange.getClientRects()).find((rect) => rect.height > 0);
+      if (probeRect) return probeRect;
+      const boundingRect = probeRange.getBoundingClientRect();
+      if (boundingRect.height > 0) return boundingRect;
+    }
+    return null;
+  }
+
+  if (container instanceof HTMLElement && container.textContent?.length === 0) {
+    const emptyLineRect = container.getBoundingClientRect();
+    return emptyLineRect.height > 0 ? emptyLineRect : null;
+  }
+
+  return null;
+}
+
 export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
@@ -1704,14 +1732,8 @@ function ComposerPromptEditorInner({
       }
 
       const range = selection.getRangeAt(0);
-      if (typeof range.getBoundingClientRect !== "function") return false;
-      let caretRect = range.getBoundingClientRect();
-      if (caretRect.height === 0) {
-        const container = range.startContainer;
-        const element = container instanceof HTMLElement ? container : container.parentElement;
-        if (!element) return false;
-        caretRect = element.getBoundingClientRect();
-      }
+      const caretRect = composerCaretLineRect(range);
+      if (!caretRect) return false;
 
       const edgeElement =
         edge === "start" ? rootElement.firstElementChild : rootElement.lastElementChild;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -105,8 +105,10 @@ import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
 import { ComposerControl, ComposerControlIcon, ComposerSelectControl } from "./ComposerControl";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
 import {
+  type ComposerPromptHistoryAttachment,
   type ComposerPromptHistoryEntry,
   findComposerPromptHistoryOffset,
+  materializeComposerPromptHistoryAttachments,
   navigateComposerPromptHistory,
 } from "./composerPromptHistory";
 import { searchSlashCommandItems } from "./composerSlashCommandSearch";
@@ -325,6 +327,12 @@ const terminalContextIdListsEqual = (
   ids: ReadonlyArray<string>,
 ): boolean =>
   contexts.length === ids.length && contexts.every((context, index) => context.id === ids[index]);
+
+const composerImageIdListsEqual = (
+  images: ReadonlyArray<ComposerImageAttachment>,
+  ids: ReadonlyArray<string>,
+): boolean =>
+  images.length === ids.length && images.every((image, index) => image.id === ids[index]);
 
 function isInsideComposerFloatingLayer(element: Element): boolean {
   return element.closest(COMPOSER_FLOATING_LAYER_SELECTOR) !== null;
@@ -1026,8 +1034,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const stashPulseKeyRef = useRef(0);
   const stashPulseTimeoutRef = useRef<number | null>(null);
   const promptHistoryDraftRef = useRef("");
+  const promptHistoryDraftAttachmentsRef = useRef<ReadonlyArray<ComposerPromptHistoryAttachment>>(
+    [],
+  );
   const promptHistoryEntryIdRef = useRef<string | null>(null);
+  const promptHistoryRecallAttachmentIdsRef = useRef<ReadonlyArray<string> | null>(null);
   const promptHistoryRecallRef = useRef<string | null>(null);
+  const promptHistoryApplyGenerationRef = useRef(0);
+  const promptHistoryApplyPendingRef = useRef(false);
   /**
    * Snapshots currently being encoded, keyed by target+prompt+image ids.
    * Keyed rather than boolean so a genuinely different prompt (or a different
@@ -1324,9 +1338,31 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [composerDraftTarget, setComposerDraftPrompt],
   );
 
+  const replaceComposerPromptAndImages = useCallback(
+    (nextPrompt: string, nextImages: ComposerImageAttachment[]) => {
+      clearComposerDraftPromptAndImages(composerDraftTarget);
+      if (nextPrompt.length > 0) {
+        setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+      }
+      if (nextImages.length > 0) {
+        addComposerDraftImages(composerDraftTarget, nextImages);
+      }
+    },
+    [
+      addComposerDraftImages,
+      clearComposerDraftPromptAndImages,
+      composerDraftTarget,
+      setComposerDraftPrompt,
+    ],
+  );
+
   const leaveComposerPromptHistory = useCallback(() => {
+    promptHistoryApplyGenerationRef.current += 1;
+    promptHistoryApplyPendingRef.current = false;
     promptHistoryDraftRef.current = "";
+    promptHistoryDraftAttachmentsRef.current = [];
     promptHistoryEntryIdRef.current = null;
+    promptHistoryRecallAttachmentIdsRef.current = null;
     promptHistoryRecallRef.current = null;
     setPromptHistoryOffset(null);
   }, []);
@@ -1337,31 +1373,64 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       nextEntryId: string | null,
       nextOffset: number | null,
       nextDraft: string,
+      nextAttachments: ReadonlyArray<ComposerPromptHistoryAttachment>,
+      nextDraftAttachments: ReadonlyArray<ComposerPromptHistoryAttachment>,
     ) => {
-      promptHistoryDraftRef.current = nextDraft;
-      promptHistoryEntryIdRef.current = nextEntryId;
-      promptHistoryRecallRef.current = nextOffset === null ? null : nextPrompt;
-      setPromptHistoryOffset(nextOffset);
-      promptRef.current = nextPrompt;
-      setPrompt(nextPrompt);
-      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
-      setComposerTrigger(null);
+      const generation = promptHistoryApplyGenerationRef.current + 1;
+      promptHistoryApplyGenerationRef.current = generation;
+      promptHistoryApplyPendingRef.current = true;
+
+      void materializeComposerPromptHistoryAttachments(nextAttachments)
+        .then((nextImages) => {
+          if (promptHistoryApplyGenerationRef.current !== generation) {
+            for (const image of nextImages) {
+              URL.revokeObjectURL(image.previewUrl);
+            }
+            return;
+          }
+
+          promptHistoryApplyPendingRef.current = false;
+          promptHistoryDraftRef.current = nextDraft;
+          promptHistoryDraftAttachmentsRef.current = nextDraftAttachments;
+          promptHistoryEntryIdRef.current = nextEntryId;
+          promptHistoryRecallAttachmentIdsRef.current =
+            nextOffset === null ? null : nextImages.map((image) => image.id);
+          promptHistoryRecallRef.current = nextOffset === null ? null : nextPrompt;
+          setPromptHistoryOffset(nextOffset);
+          promptRef.current = nextPrompt;
+          replaceComposerPromptAndImages(nextPrompt, nextImages);
+          setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+          setComposerTrigger(null);
+        })
+        .catch(() => {
+          if (promptHistoryApplyGenerationRef.current !== generation) return;
+          promptHistoryApplyPendingRef.current = false;
+          toastManager.add({
+            type: "error",
+            title: "Could not restore prompt attachments",
+            description: "One or more images are no longer available.",
+          });
+        });
     },
-    [promptRef, setPrompt],
+    [promptRef, replaceComposerPromptAndImages],
   );
 
   useEffect(() => {
+    promptHistoryApplyGenerationRef.current += 1;
+    promptHistoryApplyPendingRef.current = false;
     promptHistoryDraftRef.current = "";
+    promptHistoryDraftAttachmentsRef.current = [];
     promptHistoryEntryIdRef.current = null;
+    promptHistoryRecallAttachmentIdsRef.current = null;
     promptHistoryRecallRef.current = null;
     setPromptHistoryOffset(null);
 
     return () => {
       if (promptHistoryEntryIdRef.current !== null) {
-        setComposerDraftPrompt(composerDraftTarget, promptHistoryDraftRef.current);
+        replaceComposerPromptAndImages(promptHistoryDraftRef.current, []);
       }
     };
-  }, [composerDraftTarget, setComposerDraftPrompt]);
+  }, [composerDraftTarget, replaceComposerPromptAndImages]);
 
   useEffect(() => {
     const recalledPrompt = promptHistoryRecallRef.current;
@@ -1370,11 +1439,34 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [leaveComposerPromptHistory, prompt]);
 
   useEffect(() => {
+    if (promptHistoryApplyPendingRef.current) {
+      promptHistoryApplyGenerationRef.current += 1;
+      promptHistoryApplyPendingRef.current = false;
+      return;
+    }
+    const recalledAttachmentIds = promptHistoryRecallAttachmentIdsRef.current;
+    if (
+      recalledAttachmentIds === null ||
+      composerImageIdListsEqual(composerImages, recalledAttachmentIds)
+    ) {
+      return;
+    }
+    leaveComposerPromptHistory();
+  }, [composerImages, leaveComposerPromptHistory]);
+
+  useEffect(() => {
     const entryId = promptHistoryEntryIdRef.current;
     if (entryId === null) return;
     const nextOffset = findComposerPromptHistoryOffset(promptHistoryEntries, entryId);
     if (nextOffset === null) {
-      applyComposerPromptHistory(promptHistoryDraftRef.current, null, null, "");
+      applyComposerPromptHistory(
+        promptHistoryDraftRef.current,
+        null,
+        null,
+        "",
+        promptHistoryDraftAttachmentsRef.current,
+        [],
+      );
       return;
     }
     setPromptHistoryOffset(nextOffset);
@@ -1676,6 +1768,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       cursorAdjacentToMention: boolean,
       terminalContextIds: string[],
     ) => {
+      if (promptHistoryApplyPendingRef.current) {
+        promptHistoryApplyGenerationRef.current += 1;
+        promptHistoryApplyPendingRef.current = false;
+      }
       if (
         promptHistoryRecallRef.current !== null &&
         nextPrompt !== promptHistoryRecallRef.current
@@ -2062,6 +2158,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
     }
     if ((key === "ArrowUp" || key === "ArrowDown") && !composerMenuOpenRef.current) {
+      if (promptHistoryApplyPendingRef.current) {
+        return true;
+      }
+      const recalledAttachmentIds = promptHistoryRecallAttachmentIdsRef.current;
+      const composerImagesMatchHistory =
+        promptHistoryOffset === null
+          ? composerImages.length === 0
+          : recalledAttachmentIds !== null &&
+            composerImageIdListsEqual(composerImages, recalledAttachmentIds);
       if (
         !isComposerApprovalState &&
         !activePendingProgress &&
@@ -2071,7 +2176,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         !event.metaKey &&
         !event.ctrlKey &&
         !event.isComposing &&
-        composerImages.length === 0 &&
+        composerImagesMatchHistory &&
         composerTerminalContexts.length === 0 &&
         composerElementContexts.length === 0 &&
         composerPreviewAnnotations.length === 0 &&
@@ -2088,7 +2193,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             entries: promptHistoryEntries,
             offset: promptHistoryOffset,
             currentPrompt: promptRef.current,
+            currentAttachments: composerImages,
             draft: promptHistoryDraftRef.current,
+            draftAttachments: promptHistoryDraftAttachmentsRef.current,
           });
           if (navigation) {
             applyComposerPromptHistory(
@@ -2096,6 +2203,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               navigation.entryId,
               navigation.offset,
               navigation.draft,
+              navigation.attachments,
+              navigation.draftAttachments,
             );
             return true;
           }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -108,6 +108,7 @@ import {
   type ComposerPromptHistoryAttachment,
   type ComposerPromptHistoryEntry,
   findComposerPromptHistoryOffset,
+  isUnmodifiedComposerPromptHistoryKey,
   materializeComposerPromptHistoryAttachments,
   navigateComposerPromptHistory,
   restoreComposerPromptHistoryDraft,
@@ -1455,6 +1456,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [composerDraftTarget, replaceComposerPromptAndImages]);
 
   useEffect(() => {
+    if (promptHistoryApplyPendingRef.current) {
+      leaveComposerPromptHistory();
+      return;
+    }
     const recalledPrompt = promptHistoryRecallRef.current;
     if (recalledPrompt === null || prompt === recalledPrompt) return;
     leaveComposerPromptHistory();
@@ -1462,8 +1467,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   useEffect(() => {
     if (promptHistoryApplyPendingRef.current) {
-      promptHistoryApplyGenerationRef.current += 1;
-      promptHistoryApplyPendingRef.current = false;
+      leaveComposerPromptHistory();
       return;
     }
     const recalledAttachmentIds = promptHistoryRecallAttachmentIdsRef.current;
@@ -2180,7 +2184,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
     }
     if ((key === "ArrowUp" || key === "ArrowDown") && !composerMenuOpenRef.current) {
-      if (promptHistoryApplyPendingRef.current) {
+      const isUnmodifiedHistoryKey = isUnmodifiedComposerPromptHistoryKey(event);
+      if (isUnmodifiedHistoryKey && promptHistoryApplyPendingRef.current) {
         return true;
       }
       const recalledAttachmentIds = promptHistoryRecallAttachmentIdsRef.current;
@@ -2193,11 +2198,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         !isComposerApprovalState &&
         !activePendingProgress &&
         pendingUserInputs.length === 0 &&
-        !event.shiftKey &&
-        !event.altKey &&
-        !event.metaKey &&
-        !event.ctrlKey &&
-        !event.isComposing &&
+        isUnmodifiedHistoryKey &&
         composerImagesMatchHistory &&
         composerTerminalContexts.length === 0 &&
         composerElementContexts.length === 0 &&
@@ -3385,14 +3386,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 <div
                   data-chat-composer-image-attachments="true"
                   className={cn(
-                    "grid transition-[grid-template-rows,margin-bottom,opacity] duration-200 ease-out motion-reduce:transition-none",
+                    "grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none",
                     visibleComposerImages.length > 0
-                      ? "mb-3 grid-rows-[1fr] opacity-100"
-                      : "mb-0 grid-rows-[0fr] opacity-0",
+                      ? "grid-rows-[1fr] opacity-100"
+                      : "grid-rows-[0fr] opacity-0",
                   )}
                 >
                   <div className="min-h-0 overflow-hidden">
-                    <div className="flex flex-wrap gap-2">
+                    <div className="mb-3 flex flex-wrap gap-2">
                       {visibleComposerImages.map((image) => (
                         <div
                           key={image.id}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1441,6 +1441,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setPromptHistoryOffset(null);
 
     return () => {
+      promptHistoryApplyGenerationRef.current += 1;
+      promptHistoryApplyPendingRef.current = false;
       if (promptHistoryEntryIdRef.current !== null) {
         replaceComposerPromptAndImages(promptHistoryDraftRef.current, []);
       }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -110,6 +110,7 @@ import {
   findComposerPromptHistoryOffset,
   materializeComposerPromptHistoryAttachments,
   navigateComposerPromptHistory,
+  restoreComposerPromptHistoryDraft,
 } from "./composerPromptHistory";
 import { searchSlashCommandItems } from "./composerSlashCommandSearch";
 import {
@@ -1444,7 +1445,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       promptHistoryApplyGenerationRef.current += 1;
       promptHistoryApplyPendingRef.current = false;
       if (promptHistoryEntryIdRef.current !== null) {
-        replaceComposerPromptAndImages(promptHistoryDraftRef.current, []);
+        void restoreComposerPromptHistoryDraft(
+          promptHistoryDraftRef.current,
+          promptHistoryDraftAttachmentsRef.current,
+          replaceComposerPromptAndImages,
+        );
       }
     };
   }, [composerDraftTarget, replaceComposerPromptAndImages]);

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -105,6 +105,7 @@ import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
 import { ComposerControl, ComposerControlIcon, ComposerSelectControl } from "./ComposerControl";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
 import {
+  type ComposerPromptHistoryEntry,
   findComposerPromptHistoryOffset,
   navigateComposerPromptHistory,
 } from "./composerPromptHistory";
@@ -541,7 +542,7 @@ export interface ChatComposerProps {
   activeThreadId: ThreadId | null;
   activeThreadEnvironmentId: EnvironmentId | undefined;
   activeThread: Thread | undefined;
-  promptHistoryEntries: readonly string[];
+  promptHistoryEntries: readonly ComposerPromptHistoryEntry[];
   isServerThread: boolean;
   isLocalDraftThread: boolean;
   forceExpandedOnMobile: boolean;
@@ -1025,6 +1026,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const stashPulseKeyRef = useRef(0);
   const stashPulseTimeoutRef = useRef<number | null>(null);
   const promptHistoryDraftRef = useRef("");
+  const promptHistoryEntryIdRef = useRef<string | null>(null);
   const promptHistoryRecallRef = useRef<string | null>(null);
   /**
    * Snapshots currently being encoded, keyed by target+prompt+image ids.
@@ -1324,13 +1326,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   const leaveComposerPromptHistory = useCallback(() => {
     promptHistoryDraftRef.current = "";
+    promptHistoryEntryIdRef.current = null;
     promptHistoryRecallRef.current = null;
     setPromptHistoryOffset(null);
   }, []);
 
   const applyComposerPromptHistory = useCallback(
-    (nextPrompt: string, nextOffset: number | null, nextDraft: string) => {
+    (
+      nextPrompt: string,
+      nextEntryId: string | null,
+      nextOffset: number | null,
+      nextDraft: string,
+    ) => {
       promptHistoryDraftRef.current = nextDraft;
+      promptHistoryEntryIdRef.current = nextEntryId;
       promptHistoryRecallRef.current = nextOffset === null ? null : nextPrompt;
       setPromptHistoryOffset(nextOffset);
       promptRef.current = nextPrompt;
@@ -1343,11 +1352,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   useEffect(() => {
     promptHistoryDraftRef.current = "";
+    promptHistoryEntryIdRef.current = null;
     promptHistoryRecallRef.current = null;
     setPromptHistoryOffset(null);
 
     return () => {
-      if (promptHistoryRecallRef.current !== null) {
+      if (promptHistoryEntryIdRef.current !== null) {
         setComposerDraftPrompt(composerDraftTarget, promptHistoryDraftRef.current);
       }
     };
@@ -1360,11 +1370,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [leaveComposerPromptHistory, prompt]);
 
   useEffect(() => {
-    const recalledPrompt = promptHistoryRecallRef.current;
-    if (recalledPrompt === null) return;
-    const nextOffset = findComposerPromptHistoryOffset(promptHistoryEntries, recalledPrompt);
+    const entryId = promptHistoryEntryIdRef.current;
+    if (entryId === null) return;
+    const nextOffset = findComposerPromptHistoryOffset(promptHistoryEntries, entryId);
     if (nextOffset === null) {
-      applyComposerPromptHistory(promptHistoryDraftRef.current, null, "");
+      applyComposerPromptHistory(promptHistoryDraftRef.current, null, null, "");
       return;
     }
     setPromptHistoryOffset(nextOffset);
@@ -2081,7 +2091,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             draft: promptHistoryDraftRef.current,
           });
           if (navigation) {
-            applyComposerPromptHistory(navigation.prompt, navigation.offset, navigation.draft);
+            applyComposerPromptHistory(
+              navigation.prompt,
+              navigation.entryId,
+              navigation.offset,
+              navigation.draft,
+            );
             return true;
           }
         }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1387,36 +1387,44 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       promptHistoryApplyGenerationRef.current = generation;
       promptHistoryApplyPendingRef.current = true;
 
-      void materializeComposerPromptHistoryAttachments(nextAttachments)
-        .then((nextImages) => {
-          if (promptHistoryApplyGenerationRef.current !== generation) {
-            for (const image of nextImages) {
-              URL.revokeObjectURL(image.previewUrl);
-            }
-            return;
+      const commitHistorySnapshot = (
+        nextImages: ComposerImageAttachment[],
+        failedAttachmentCount: number,
+      ) => {
+        if (promptHistoryApplyGenerationRef.current !== generation) {
+          for (const image of nextImages) {
+            URL.revokeObjectURL(image.previewUrl);
           }
+          return;
+        }
 
-          promptHistoryApplyPendingRef.current = false;
-          promptHistoryDraftRef.current = nextDraft;
-          promptHistoryDraftAttachmentsRef.current = nextDraftAttachments;
-          promptHistoryEntryIdRef.current = nextEntryId;
-          promptHistoryRecallAttachmentIdsRef.current =
-            nextOffset === null ? null : nextImages.map((image) => image.id);
-          promptHistoryRecallRef.current = nextOffset === null ? null : nextPrompt;
-          setPromptHistoryOffset(nextOffset);
-          promptRef.current = nextPrompt;
-          replaceComposerPromptAndImages(nextPrompt, nextImages);
-          setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
-          setComposerTrigger(null);
+        promptHistoryApplyPendingRef.current = false;
+        promptHistoryDraftRef.current = nextDraft;
+        promptHistoryDraftAttachmentsRef.current = nextDraftAttachments;
+        promptHistoryEntryIdRef.current = nextEntryId;
+        promptHistoryRecallAttachmentIdsRef.current =
+          nextOffset === null ? null : nextImages.map((image) => image.id);
+        promptHistoryRecallRef.current = nextOffset === null ? null : nextPrompt;
+        setPromptHistoryOffset(nextOffset);
+        promptRef.current = nextPrompt;
+        replaceComposerPromptAndImages(nextPrompt, nextImages);
+        setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+        setComposerTrigger(null);
+        if (failedAttachmentCount > 0) {
+          toastManager.add({
+            type: "warning",
+            title: "Some prompt attachments could not be restored",
+            description: "The prompt text and available images were restored.",
+          });
+        }
+      };
+
+      void materializeComposerPromptHistoryAttachments(nextAttachments)
+        .then(({ attachments, failedAttachmentCount }) => {
+          commitHistorySnapshot(attachments, failedAttachmentCount);
         })
         .catch(() => {
-          if (promptHistoryApplyGenerationRef.current !== generation) return;
-          promptHistoryApplyPendingRef.current = false;
-          toastManager.add({
-            type: "error",
-            title: "Could not restore prompt attachments",
-            description: "One or more images are no longer available.",
-          });
+          commitHistorySnapshot([], nextAttachments.length);
         });
     },
     [promptRef, replaceComposerPromptAndImages],

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -104,6 +104,10 @@ import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
 import { ComposerControl, ComposerControlIcon, ComposerSelectControl } from "./ComposerControl";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
+import {
+  findComposerPromptHistoryOffset,
+  navigateComposerPromptHistory,
+} from "./composerPromptHistory";
 import { searchSlashCommandItems } from "./composerSlashCommandSearch";
 import {
   getComposerPromptInjectionState,
@@ -537,6 +541,7 @@ export interface ChatComposerProps {
   activeThreadId: ThreadId | null;
   activeThreadEnvironmentId: EnvironmentId | undefined;
   activeThread: Thread | undefined;
+  promptHistoryEntries: readonly string[];
   isServerThread: boolean;
   isLocalDraftThread: boolean;
   forceExpandedOnMobile: boolean;
@@ -649,6 +654,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThreadId,
     activeThreadEnvironmentId: _activeThreadEnvironmentId,
     activeThread,
+    promptHistoryEntries,
     isServerThread: _isServerThread,
     isLocalDraftThread: _isLocalDraftThread,
     forceExpandedOnMobile,
@@ -991,6 +997,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const [composerMenuAnchor, setComposerMenuAnchor] = useState<HTMLDivElement | null>(null);
   const [isStashMenuOpen, setIsStashMenuOpen] = useState(false);
   const [isTasksDrawerOpen, setIsTasksDrawerOpen] = useState(false);
+  const [promptHistoryOffset, setPromptHistoryOffset] = useState<number | null>(null);
   const [dismissedTasksTurnId, setDismissedTasksTurnId] = useState<TurnId | null>(null);
   const [stashPulse, setStashPulse] = useState<{ key: number; active: boolean }>({
     key: 0,
@@ -1017,6 +1024,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const mobileComposerExpandInFlightRef = useRef(false);
   const stashPulseKeyRef = useRef(0);
   const stashPulseTimeoutRef = useRef<number | null>(null);
+  const promptHistoryDraftRef = useRef("");
+  const promptHistoryRecallRef = useRef<string | null>(null);
   /**
    * Snapshots currently being encoded, keyed by target+prompt+image ids.
    * Keyed rather than boolean so a genuinely different prompt (or a different
@@ -1312,6 +1321,54 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     },
     [composerDraftTarget, setComposerDraftPrompt],
   );
+
+  const leaveComposerPromptHistory = useCallback(() => {
+    promptHistoryDraftRef.current = "";
+    promptHistoryRecallRef.current = null;
+    setPromptHistoryOffset(null);
+  }, []);
+
+  const applyComposerPromptHistory = useCallback(
+    (nextPrompt: string, nextOffset: number | null, nextDraft: string) => {
+      promptHistoryDraftRef.current = nextDraft;
+      promptHistoryRecallRef.current = nextOffset === null ? null : nextPrompt;
+      setPromptHistoryOffset(nextOffset);
+      promptRef.current = nextPrompt;
+      setPrompt(nextPrompt);
+      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+      setComposerTrigger(null);
+    },
+    [promptRef, setPrompt],
+  );
+
+  useEffect(() => {
+    promptHistoryDraftRef.current = "";
+    promptHistoryRecallRef.current = null;
+    setPromptHistoryOffset(null);
+
+    return () => {
+      if (promptHistoryRecallRef.current !== null) {
+        setComposerDraftPrompt(composerDraftTarget, promptHistoryDraftRef.current);
+      }
+    };
+  }, [composerDraftTarget, setComposerDraftPrompt]);
+
+  useEffect(() => {
+    const recalledPrompt = promptHistoryRecallRef.current;
+    if (recalledPrompt === null || prompt === recalledPrompt) return;
+    leaveComposerPromptHistory();
+  }, [leaveComposerPromptHistory, prompt]);
+
+  useEffect(() => {
+    const recalledPrompt = promptHistoryRecallRef.current;
+    if (recalledPrompt === null) return;
+    const nextOffset = findComposerPromptHistoryOffset(promptHistoryEntries, recalledPrompt);
+    if (nextOffset === null) {
+      applyComposerPromptHistory(promptHistoryDraftRef.current, null, "");
+      return;
+    }
+    setPromptHistoryOffset(nextOffset);
+  }, [applyComposerPromptHistory, promptHistoryEntries]);
 
   const addComposerImage = useCallback(
     (image: ComposerImageAttachment) => {
@@ -1609,6 +1666,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       cursorAdjacentToMention: boolean,
       terminalContextIds: string[],
     ) => {
+      if (
+        promptHistoryRecallRef.current !== null &&
+        nextPrompt !== promptHistoryRecallRef.current
+      ) {
+        leaveComposerPromptHistory();
+      }
       if (activePendingProgress?.activeQuestion && pendingUserInputs.length > 0) {
         setComposerCursor(nextCursor);
         setComposerTrigger(
@@ -1645,6 +1708,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       composerDraftTarget,
       composerTerminalContexts,
       setComposerDraftTerminalContexts,
+      leaveComposerPromptHistory,
     ],
   );
 
@@ -1985,6 +2049,42 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       if ((key === "Enter" || key === "Tab") && selectedItem) {
         onSelectComposerItem(selectedItem);
         return true;
+      }
+    }
+    if ((key === "ArrowUp" || key === "ArrowDown") && !composerMenuOpenRef.current) {
+      if (
+        !isComposerApprovalState &&
+        !activePendingProgress &&
+        pendingUserInputs.length === 0 &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.isComposing &&
+        composerImages.length === 0 &&
+        composerTerminalContexts.length === 0 &&
+        composerElementContexts.length === 0 &&
+        composerPreviewAnnotations.length === 0 &&
+        composerReviewComments.length === 0
+      ) {
+        const direction = key === "ArrowUp" ? "backward" : "forward";
+        const visualEdge = key === "ArrowUp" ? "start" : "end";
+        const canNavigateFromCaret =
+          promptHistoryOffset === null ||
+          composerEditorRef.current?.isCaretOnVisualEdge(visualEdge) === true;
+        if (canNavigateFromCaret) {
+          const navigation = navigateComposerPromptHistory({
+            direction,
+            entries: promptHistoryEntries,
+            offset: promptHistoryOffset,
+            currentPrompt: promptRef.current,
+            draft: promptHistoryDraftRef.current,
+          });
+          if (navigation) {
+            applyComposerPromptHistory(navigation.prompt, navigation.offset, navigation.draft);
+            return true;
+          }
+        }
       }
     }
     const submissionIntent =

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1214,6 +1214,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => new Set(nonPersistedComposerImageIds),
     [nonPersistedComposerImageIds],
   );
+  const visibleComposerImages = useMemo(
+    () =>
+      composerImages.filter(
+        (image) => !composerPreviewAnnotations.some((annotation) => annotation.id === image.id),
+      ),
+    [composerImages, composerPreviewAnnotations],
+  );
 
   const isComposerApprovalState = activePendingApproval !== null;
   const activePendingUserInput = pendingUserInputs[0] ?? null;
@@ -3358,21 +3365,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 )}
 
               {!isComposerCollapsedMobile &&
-                !isComposerApprovalState &&
-                pendingUserInputs.length === 0 &&
-                composerImages.some(
-                  (image) =>
-                    !composerPreviewAnnotations.some((annotation) => annotation.id === image.id),
-                ) && (
-                  <div className="mb-3 flex flex-wrap gap-2">
-                    {composerImages
-                      .filter(
-                        (image) =>
-                          !composerPreviewAnnotations.some(
-                            (annotation) => annotation.id === image.id,
-                          ),
-                      )
-                      .map((image) => (
+              !isComposerApprovalState &&
+              pendingUserInputs.length === 0 ? (
+                <div
+                  data-chat-composer-image-attachments="true"
+                  className={cn(
+                    "grid transition-[grid-template-rows,margin-bottom,opacity] duration-200 ease-out motion-reduce:transition-none",
+                    visibleComposerImages.length > 0
+                      ? "mb-3 grid-rows-[1fr] opacity-100"
+                      : "mb-0 grid-rows-[0fr] opacity-0",
+                  )}
+                >
+                  <div className="min-h-0 overflow-hidden">
+                    <div className="flex flex-wrap gap-2">
+                      {visibleComposerImages.map((image) => (
                         <div
                           key={image.id}
                           className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
@@ -3432,8 +3438,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           </Button>
                         </div>
                       ))}
+                    </div>
                   </div>
-                )}
+                </div>
+              ) : null}
 
               <div className="relative">
                 <ComposerPromptEditor

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -81,7 +81,7 @@ describe("recallableComposerPrompt", () => {
 });
 
 describe("buildComposerPromptHistoryEntries", () => {
-  it("includes optimistic prompt text and collapses consecutive duplicates", () => {
+  it("includes optimistic prompt text and keeps stable message identities", () => {
     expect(
       buildComposerPromptHistoryEntries([
         { id: "assistant-1", role: "assistant", text: "Answer" },
@@ -95,6 +95,7 @@ describe("buildComposerPromptHistoryEntries", () => {
         },
       ]),
     ).toEqual([
+      { id: "user-1", prompt: "First" },
       { id: "user-2", prompt: "First" },
       { id: "user-3", prompt: "Second as typed" },
     ]);

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -19,6 +19,7 @@ import {
   navigateComposerPromptHistory,
   preserveComposerPromptHistoryAttachmentFiles,
   recallableComposerPrompt,
+  restoreComposerPromptHistoryDraft,
 } from "./composerPromptHistory";
 
 const terminalContext: TerminalContextSelection = {
@@ -353,6 +354,44 @@ describe("materializeComposerPromptHistoryAttachments", () => {
         },
       ]),
     ).resolves.toEqual({ attachments: [], failedAttachmentCount: 1 });
+  });
+});
+
+describe("restoreComposerPromptHistoryDraft", () => {
+  it("restores draft images with fresh preview URLs after leaving history", async () => {
+    const file = new File(["draft image"], "draft.png", { type: "image/png" });
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:restored-draft");
+    const replaceDraft = vi.fn();
+
+    await expect(
+      restoreComposerPromptHistoryDraft(
+        "unfinished draft",
+        [
+          {
+            type: "image",
+            id: "draft-image",
+            name: file.name,
+            mimeType: file.type,
+            sizeBytes: file.size,
+            previewUrl: "blob:revoked-draft",
+            file,
+          },
+        ],
+        replaceDraft,
+      ),
+    ).resolves.toBe(0);
+
+    expect(replaceDraft).toHaveBeenCalledWith("unfinished draft", [
+      {
+        type: "image",
+        id: "draft-image",
+        name: file.name,
+        mimeType: file.type,
+        sizeBytes: file.size,
+        previewUrl: "blob:restored-draft",
+        file,
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -361,7 +361,7 @@ describe("preserveComposerPromptHistoryAttachmentFiles", () => {
     const file = new File(["image bytes"], "diagram.png", { type: "image/png" });
     const serverAttachment = {
       type: "image" as const,
-      id: "image-1",
+      id: "server-image-1",
       name: file.name,
       mimeType: file.type,
       sizeBytes: file.size,
@@ -371,7 +371,14 @@ describe("preserveComposerPromptHistoryAttachmentFiles", () => {
     expect(
       preserveComposerPromptHistoryAttachmentFiles(
         [serverAttachment],
-        [{ ...serverAttachment, previewUrl: "blob:optimistic", file }],
+        [
+          {
+            ...serverAttachment,
+            id: "optimistic-image-1",
+            previewUrl: "blob:optimistic",
+            file,
+          },
+        ],
       ),
     ).toEqual([{ ...serverAttachment, file }]);
   });

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -17,6 +17,7 @@ import {
   findComposerPromptHistoryOffset,
   materializeComposerPromptHistoryAttachments,
   navigateComposerPromptHistory,
+  preserveComposerPromptHistoryAttachmentFiles,
   recallableComposerPrompt,
 } from "./composerPromptHistory";
 
@@ -323,17 +324,55 @@ describe("materializeComposerPromptHistoryAttachments", () => {
           file,
         },
       ]),
-    ).resolves.toEqual([
-      {
-        type: "image",
-        id: "image-1",
-        name: file.name,
-        mimeType: file.type,
-        sizeBytes: file.size,
-        previewUrl: "blob:recalled",
-        file,
-      },
-    ]);
+    ).resolves.toEqual({
+      attachments: [
+        {
+          type: "image",
+          id: "image-1",
+          name: file.name,
+          mimeType: file.type,
+          sizeBytes: file.size,
+          previewUrl: "blob:recalled",
+          file,
+        },
+      ],
+      failedAttachmentCount: 0,
+    });
     expect(createObjectUrl).toHaveBeenCalledWith(file);
+  });
+
+  it("reports an unavailable image without rejecting text recall", async () => {
+    await expect(
+      materializeComposerPromptHistoryAttachments([
+        {
+          type: "image",
+          id: "missing-image",
+          name: "missing.png",
+          mimeType: "image/png",
+          sizeBytes: 10,
+        },
+      ]),
+    ).resolves.toEqual({ attachments: [], failedAttachmentCount: 1 });
+  });
+});
+
+describe("preserveComposerPromptHistoryAttachmentFiles", () => {
+  it("carries a local file onto the acknowledged server attachment", () => {
+    const file = new File(["image bytes"], "diagram.png", { type: "image/png" });
+    const serverAttachment = {
+      type: "image" as const,
+      id: "image-1",
+      name: file.name,
+      mimeType: file.type,
+      sizeBytes: file.size,
+      previewUrl: "/api/assets/image-1",
+    };
+
+    expect(
+      preserveComposerPromptHistoryAttachmentFiles(
+        [serverAttachment],
+        [{ ...serverAttachment, previewUrl: "blob:optimistic", file }],
+      ),
+    ).toEqual([{ ...serverAttachment, file }]);
   });
 });

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -1,0 +1,151 @@
+import type { PreviewAnnotationPayload } from "@t3tools/contracts";
+import { applyClaudePromptEffortPrefix } from "@t3tools/shared/model";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  appendElementContextsToPrompt,
+  type ElementContextSelection,
+} from "../../lib/elementContext";
+import { appendPreviewAnnotationPrompt } from "../../lib/previewAnnotation";
+import {
+  appendTerminalContextsToPrompt,
+  type TerminalContextSelection,
+} from "../../lib/terminalContext";
+import { appendReviewCommentsToPrompt, buildFileReviewComment } from "../../reviewCommentContext";
+import {
+  buildComposerPromptHistoryEntries,
+  findComposerPromptHistoryOffset,
+  navigateComposerPromptHistory,
+  recallableComposerPrompt,
+} from "./composerPromptHistory";
+
+const terminalContext: TerminalContextSelection = {
+  terminalId: "terminal-1",
+  terminalLabel: "Terminal 1",
+  lineStart: 1,
+  lineEnd: 2,
+  text: "git status\nOn branch main",
+};
+
+const elementContext: ElementContextSelection = {
+  pageUrl: "https://example.com",
+  pageTitle: "Example",
+  tagName: "button",
+  selector: "button.submit",
+  htmlPreview: "<button>Save</button>",
+  componentName: "SubmitButton",
+  source: null,
+  styles: "display: block;",
+};
+
+const previewAnnotation: PreviewAnnotationPayload = {
+  id: "annotation-1",
+  pageUrl: "https://example.com",
+  pageTitle: "Example",
+  comment: "Move the button.",
+  elements: [],
+  regions: [],
+  strokes: [],
+  styleChanges: [],
+  screenshot: null,
+  createdAt: "2026-08-22T12:00:00.000Z",
+};
+
+describe("recallableComposerPrompt", () => {
+  it("removes send-only payloads from a stored user message", () => {
+    let message = appendTerminalContextsToPrompt("Fix the submit button", [terminalContext]);
+    message = appendElementContextsToPrompt(message, [elementContext]);
+    message = appendPreviewAnnotationPrompt(message, previewAnnotation);
+    message = appendReviewCommentsToPrompt(message, [
+      buildFileReviewComment({
+        id: "comment-1",
+        filePath: "src/button.tsx",
+        startLine: 1,
+        endLine: 1,
+        text: "Keep this configurable.",
+        contents: "export const Button = () => null;",
+      }),
+    ]);
+    message = applyClaudePromptEffortPrefix(message, "ultrathink");
+
+    expect(recallableComposerPrompt(message)).toBe("Fix the submit button");
+  });
+
+  it("does not expose the synthetic image-only prompt", () => {
+    expect(
+      recallableComposerPrompt(
+        "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]",
+      ),
+    ).toBe("");
+  });
+});
+
+describe("buildComposerPromptHistoryEntries", () => {
+  it("includes optimistic prompt text and collapses consecutive duplicates", () => {
+    expect(
+      buildComposerPromptHistoryEntries([
+        { role: "assistant", text: "Answer" },
+        { role: "user", text: "First" },
+        { role: "user", text: "First" },
+        {
+          role: "user",
+          text: "Ultrathink:\nSecond",
+          promptHistoryText: "Second as typed",
+        },
+      ]),
+    ).toEqual(["First", "Second as typed"]);
+  });
+});
+
+describe("navigateComposerPromptHistory", () => {
+  const entries = ["First", "Second", "Third"];
+
+  it("walks backward and restores the unsent draft when walking forward", () => {
+    const latest = navigateComposerPromptHistory({
+      direction: "backward",
+      entries,
+      offset: null,
+      currentPrompt: "",
+      draft: "",
+    });
+    expect(latest).toEqual({ offset: 0, draft: "", prompt: "Third" });
+
+    const older = navigateComposerPromptHistory({
+      direction: "backward",
+      entries,
+      offset: latest?.offset ?? null,
+      currentPrompt: latest?.prompt ?? "",
+      draft: latest?.draft ?? "",
+    });
+    expect(older).toEqual({ offset: 1, draft: "", prompt: "Second" });
+
+    expect(
+      navigateComposerPromptHistory({
+        direction: "forward",
+        entries,
+        offset: 0,
+        currentPrompt: "Third",
+        draft: "unfinished draft",
+      }),
+    ).toEqual({ offset: null, draft: "", prompt: "unfinished draft" });
+  });
+
+  it("does not enter history when the composer contains text", () => {
+    expect(
+      navigateComposerPromptHistory({
+        direction: "backward",
+        entries,
+        offset: null,
+        currentPrompt: "keep editing",
+        draft: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("findComposerPromptHistoryOffset", () => {
+  it("signals when a recalled entry disappears from a refreshed timeline", () => {
+    expect(findComposerPromptHistoryOffset(["First", "Third"], "Second")).toBeNull();
+    expect(findComposerPromptHistoryOffset(["First", "Second", "Third"], "Second")).toBe(1);
+  });
+});

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -15,6 +15,7 @@ import { appendReviewCommentsToPrompt, buildFileReviewComment } from "../../revi
 import {
   buildComposerPromptHistoryEntries,
   findComposerPromptHistoryOffset,
+  isUnmodifiedComposerPromptHistoryKey,
   materializeComposerPromptHistoryAttachments,
   navigateComposerPromptHistory,
   preserveComposerPromptHistoryAttachmentFiles,
@@ -294,6 +295,29 @@ describe("navigateComposerPromptHistory", () => {
       attachments: [],
     });
   });
+});
+
+describe("isUnmodifiedComposerPromptHistoryKey", () => {
+  const unmodifiedKey = {
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    isComposing: false,
+  };
+
+  it("accepts an unmodified key", () => {
+    expect(isUnmodifiedComposerPromptHistoryKey(unmodifiedKey)).toBe(true);
+  });
+
+  it.each(["shiftKey", "altKey", "metaKey", "ctrlKey", "isComposing"] as const)(
+    "leaves %s key handling to the editor",
+    (modifier) => {
+      expect(isUnmodifiedComposerPromptHistoryKey({ ...unmodifiedKey, [modifier]: true })).toBe(
+        false,
+      );
+    },
+  );
 });
 
 describe("findComposerPromptHistoryOffset", () => {

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -1,6 +1,6 @@
 import type { PreviewAnnotationPayload } from "@t3tools/contracts";
 import { applyClaudePromptEffortPrefix } from "@t3tools/shared/model";
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   appendElementContextsToPrompt,
@@ -15,6 +15,7 @@ import { appendReviewCommentsToPrompt, buildFileReviewComment } from "../../revi
 import {
   buildComposerPromptHistoryEntries,
   findComposerPromptHistoryOffset,
+  materializeComposerPromptHistoryAttachments,
   navigateComposerPromptHistory,
   recallableComposerPrompt,
 } from "./composerPromptHistory";
@@ -50,6 +51,10 @@ const previewAnnotation: PreviewAnnotationPayload = {
   screenshot: null,
   createdAt: "2026-08-22T12:00:00.000Z",
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("recallableComposerPrompt", () => {
   it("removes send-only payloads from a stored user message", () => {
@@ -95,18 +100,83 @@ describe("buildComposerPromptHistoryEntries", () => {
         },
       ]),
     ).toEqual([
-      { id: "user-1", prompt: "First" },
-      { id: "user-2", prompt: "First" },
-      { id: "user-3", prompt: "Second as typed" },
+      { id: "user-1", prompt: "First", attachments: [] },
+      { id: "user-2", prompt: "First", attachments: [] },
+      { id: "user-3", prompt: "Second as typed", attachments: [] },
+    ]);
+  });
+
+  it("keeps image attachments with the sent prompt", () => {
+    const attachment = {
+      type: "image" as const,
+      id: "image-1",
+      name: "diagram.png",
+      mimeType: "image/png",
+      sizeBytes: 128,
+      previewUrl: "blob:diagram",
+    };
+
+    expect(
+      buildComposerPromptHistoryEntries([
+        {
+          id: "user-with-image",
+          role: "user",
+          text: "Explain this diagram",
+          attachments: [attachment],
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "user-with-image",
+        prompt: "Explain this diagram",
+        attachments: [attachment],
+      },
+    ]);
+  });
+
+  it("keeps an image-only message in history", () => {
+    expect(
+      buildComposerPromptHistoryEntries([
+        {
+          id: "image-only",
+          role: "user",
+          text: "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]",
+          attachments: [
+            {
+              type: "image",
+              id: "image-only-1",
+              name: "photo.png",
+              mimeType: "image/png",
+              sizeBytes: 64,
+              previewUrl: "blob:photo",
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "image-only",
+        prompt: "",
+        attachments: [
+          {
+            type: "image",
+            id: "image-only-1",
+            name: "photo.png",
+            mimeType: "image/png",
+            sizeBytes: 64,
+            previewUrl: "blob:photo",
+          },
+        ],
+      },
     ]);
   });
 });
 
 describe("navigateComposerPromptHistory", () => {
   const entries = [
-    { id: "first", prompt: "First" },
-    { id: "second", prompt: "Second" },
-    { id: "third", prompt: "Third" },
+    { id: "first", prompt: "First", attachments: [] },
+    { id: "second", prompt: "Second", attachments: [] },
+    { id: "third", prompt: "Third", attachments: [] },
   ];
 
   it("walks backward and restores the unsent draft when walking forward", () => {
@@ -117,7 +187,14 @@ describe("navigateComposerPromptHistory", () => {
       currentPrompt: "",
       draft: "",
     });
-    expect(latest).toEqual({ entryId: "third", offset: 0, draft: "", prompt: "Third" });
+    expect(latest).toEqual({
+      entryId: "third",
+      offset: 0,
+      draft: "",
+      draftAttachments: [],
+      prompt: "Third",
+      attachments: [],
+    });
 
     const older = navigateComposerPromptHistory({
       direction: "backward",
@@ -126,7 +203,14 @@ describe("navigateComposerPromptHistory", () => {
       currentPrompt: latest?.prompt ?? "",
       draft: latest?.draft ?? "",
     });
-    expect(older).toEqual({ entryId: "second", offset: 1, draft: "", prompt: "Second" });
+    expect(older).toEqual({
+      entryId: "second",
+      offset: 1,
+      draft: "",
+      draftAttachments: [],
+      prompt: "Second",
+      attachments: [],
+    });
 
     expect(
       navigateComposerPromptHistory({
@@ -136,7 +220,14 @@ describe("navigateComposerPromptHistory", () => {
         currentPrompt: "Third",
         draft: "unfinished draft",
       }),
-    ).toEqual({ entryId: null, offset: null, draft: "", prompt: "unfinished draft" });
+    ).toEqual({
+      entryId: null,
+      offset: null,
+      draft: "",
+      draftAttachments: [],
+      prompt: "unfinished draft",
+      attachments: [],
+    });
   });
 
   it("does not enter history when the composer contains text", () => {
@@ -162,16 +253,87 @@ describe("navigateComposerPromptHistory", () => {
       }),
     ).toBeNull();
   });
+
+  it("moves attachments through history and clears them past the newest entry", () => {
+    const attachment = {
+      type: "image" as const,
+      id: "history-image",
+      name: "history.png",
+      mimeType: "image/png",
+      sizeBytes: 32,
+      previewUrl: "blob:history",
+    };
+    const entry = { id: "with-image", prompt: "Look here", attachments: [attachment] };
+
+    const recalled = navigateComposerPromptHistory({
+      direction: "backward",
+      entries: [entry],
+      offset: null,
+      currentPrompt: "",
+      currentAttachments: [],
+      draft: "",
+      draftAttachments: [],
+    });
+    expect(recalled?.attachments).toEqual([attachment]);
+
+    expect(
+      navigateComposerPromptHistory({
+        direction: "forward",
+        entries: [entry],
+        offset: recalled?.offset ?? null,
+        currentPrompt: recalled?.prompt ?? "",
+        currentAttachments: recalled?.attachments ?? [],
+        draft: recalled?.draft ?? "",
+        draftAttachments: recalled?.draftAttachments ?? [],
+      }),
+    ).toMatchObject({
+      offset: null,
+      prompt: "",
+      attachments: [],
+    });
+  });
 });
 
 describe("findComposerPromptHistoryOffset", () => {
   it("tracks the recalled message when duplicate prompt text exists", () => {
     const entries = [
-      { id: "older-a", prompt: "A" },
-      { id: "middle-b", prompt: "B" },
-      { id: "newer-a", prompt: "A" },
+      { id: "older-a", prompt: "A", attachments: [] },
+      { id: "middle-b", prompt: "B", attachments: [] },
+      { id: "newer-a", prompt: "A", attachments: [] },
     ];
     expect(findComposerPromptHistoryOffset(entries, "older-a")).toBe(2);
     expect(findComposerPromptHistoryOffset(entries, "missing")).toBeNull();
+  });
+});
+
+describe("materializeComposerPromptHistoryAttachments", () => {
+  it("creates a fresh preview URL for an in-memory file", async () => {
+    const file = new File(["image bytes"], "diagram.png", { type: "image/png" });
+    const createObjectUrl = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:recalled");
+
+    await expect(
+      materializeComposerPromptHistoryAttachments([
+        {
+          type: "image",
+          id: "image-1",
+          name: file.name,
+          mimeType: file.type,
+          sizeBytes: file.size,
+          previewUrl: "blob:sent",
+          file,
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "image",
+        id: "image-1",
+        name: file.name,
+        mimeType: file.type,
+        sizeBytes: file.size,
+        previewUrl: "blob:recalled",
+        file,
+      },
+    ]);
+    expect(createObjectUrl).toHaveBeenCalledWith(file);
   });
 });

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -84,21 +84,29 @@ describe("buildComposerPromptHistoryEntries", () => {
   it("includes optimistic prompt text and collapses consecutive duplicates", () => {
     expect(
       buildComposerPromptHistoryEntries([
-        { role: "assistant", text: "Answer" },
-        { role: "user", text: "First" },
-        { role: "user", text: "First" },
+        { id: "assistant-1", role: "assistant", text: "Answer" },
+        { id: "user-1", role: "user", text: "First" },
+        { id: "user-2", role: "user", text: "First" },
         {
+          id: "user-3",
           role: "user",
           text: "Ultrathink:\nSecond",
           promptHistoryText: "Second as typed",
         },
       ]),
-    ).toEqual(["First", "Second as typed"]);
+    ).toEqual([
+      { id: "user-2", prompt: "First" },
+      { id: "user-3", prompt: "Second as typed" },
+    ]);
   });
 });
 
 describe("navigateComposerPromptHistory", () => {
-  const entries = ["First", "Second", "Third"];
+  const entries = [
+    { id: "first", prompt: "First" },
+    { id: "second", prompt: "Second" },
+    { id: "third", prompt: "Third" },
+  ];
 
   it("walks backward and restores the unsent draft when walking forward", () => {
     const latest = navigateComposerPromptHistory({
@@ -108,7 +116,7 @@ describe("navigateComposerPromptHistory", () => {
       currentPrompt: "",
       draft: "",
     });
-    expect(latest).toEqual({ offset: 0, draft: "", prompt: "Third" });
+    expect(latest).toEqual({ entryId: "third", offset: 0, draft: "", prompt: "Third" });
 
     const older = navigateComposerPromptHistory({
       direction: "backward",
@@ -117,7 +125,7 @@ describe("navigateComposerPromptHistory", () => {
       currentPrompt: latest?.prompt ?? "",
       draft: latest?.draft ?? "",
     });
-    expect(older).toEqual({ offset: 1, draft: "", prompt: "Second" });
+    expect(older).toEqual({ entryId: "second", offset: 1, draft: "", prompt: "Second" });
 
     expect(
       navigateComposerPromptHistory({
@@ -127,7 +135,7 @@ describe("navigateComposerPromptHistory", () => {
         currentPrompt: "Third",
         draft: "unfinished draft",
       }),
-    ).toEqual({ offset: null, draft: "", prompt: "unfinished draft" });
+    ).toEqual({ entryId: null, offset: null, draft: "", prompt: "unfinished draft" });
   });
 
   it("does not enter history when the composer contains text", () => {
@@ -144,8 +152,13 @@ describe("navigateComposerPromptHistory", () => {
 });
 
 describe("findComposerPromptHistoryOffset", () => {
-  it("signals when a recalled entry disappears from a refreshed timeline", () => {
-    expect(findComposerPromptHistoryOffset(["First", "Third"], "Second")).toBeNull();
-    expect(findComposerPromptHistoryOffset(["First", "Second", "Third"], "Second")).toBe(1);
+  it("tracks the recalled message when duplicate prompt text exists", () => {
+    const entries = [
+      { id: "older-a", prompt: "A" },
+      { id: "middle-b", prompt: "B" },
+      { id: "newer-a", prompt: "A" },
+    ];
+    expect(findComposerPromptHistoryOffset(entries, "older-a")).toBe(2);
+    expect(findComposerPromptHistoryOffset(entries, "missing")).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/composerPromptHistory.test.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.test.ts
@@ -149,6 +149,18 @@ describe("navigateComposerPromptHistory", () => {
       }),
     ).toBeNull();
   });
+
+  it("leaves ArrowUp to the editor at the oldest recalled prompt", () => {
+    expect(
+      navigateComposerPromptHistory({
+        direction: "backward",
+        entries,
+        offset: entries.length - 1,
+        currentPrompt: "First",
+        draft: "",
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("findComposerPromptHistoryOffset", () => {

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -237,3 +237,18 @@ export async function materializeComposerPromptHistoryAttachments(
   }
   return { attachments: materialized, failedAttachmentCount };
 }
+
+export async function restoreComposerPromptHistoryDraft(
+  prompt: string,
+  attachments: ReadonlyArray<ComposerPromptHistoryAttachment>,
+  replaceDraft: (
+    prompt: string,
+    attachments: Awaited<
+      ReturnType<typeof materializeComposerPromptHistoryAttachments>
+    >["attachments"],
+  ) => void,
+): Promise<number> {
+  const materialized = await materializeComposerPromptHistoryAttachments(attachments);
+  replaceDraft(prompt, materialized.attachments);
+  return materialized.failedAttachmentCount;
+}

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -116,7 +116,8 @@ export function navigateComposerPromptHistory(input: {
 
   if (input.direction === "backward") {
     if (input.offset === null && input.currentPrompt.length > 0) return null;
-    const offset = Math.min((input.offset ?? -1) + 1, input.entries.length - 1);
+    if (input.offset !== null && input.offset >= input.entries.length - 1) return null;
+    const offset = (input.offset ?? -1) + 1;
     const entry = input.entries[input.entries.length - 1 - offset];
     if (!entry) return null;
     return {

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -1,0 +1,130 @@
+import { extractTrailingElementContexts } from "../../lib/elementContext";
+import { extractTrailingPreviewAnnotation } from "../../lib/previewAnnotation";
+import { extractTrailingTerminalContexts } from "../../lib/terminalContext";
+import { parseReviewCommentMessageSegments } from "../../reviewCommentContext";
+
+const CLAUDE_ULTRATHINK_PREFIX = "Ultrathink:\n";
+const IMAGE_ONLY_BOOTSTRAP_PROMPT =
+  "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+
+export interface ComposerPromptHistoryMessage {
+  readonly role: string;
+  readonly text: string;
+  readonly promptHistoryText?: string | undefined;
+}
+
+export interface ComposerPromptHistoryNavigation {
+  readonly offset: number | null;
+  readonly draft: string;
+  readonly prompt: string;
+}
+
+function stripTrailingReviewComments(prompt: string): string {
+  const segments = parseReviewCommentMessageSegments(prompt);
+  if (!segments.some((segment) => segment.kind === "review-comment")) {
+    return prompt;
+  }
+  return segments
+    .filter((segment) => segment.kind === "text")
+    .map((segment) => segment.text)
+    .join("")
+    .trimEnd();
+}
+
+export function recallableComposerPrompt(messageText: string): string {
+  let prompt = messageText.trim();
+  if (prompt.startsWith(CLAUDE_ULTRATHINK_PREFIX)) {
+    prompt = prompt.slice(CLAUDE_ULTRATHINK_PREFIX.length);
+  }
+
+  while (prompt.length > 0) {
+    const withoutReviewComments = stripTrailingReviewComments(prompt);
+    if (withoutReviewComments !== prompt) {
+      prompt = withoutReviewComments;
+      continue;
+    }
+
+    const previewAnnotation = extractTrailingPreviewAnnotation(prompt);
+    if (previewAnnotation.annotation) {
+      prompt = previewAnnotation.promptText;
+      continue;
+    }
+
+    const elementContexts = extractTrailingElementContexts(prompt);
+    if (elementContexts.contextCount > 0) {
+      prompt = elementContexts.promptText;
+      continue;
+    }
+
+    const terminalContexts = extractTrailingTerminalContexts(prompt);
+    if (terminalContexts.contextCount > 0) {
+      prompt = terminalContexts.promptText;
+      continue;
+    }
+
+    break;
+  }
+
+  const trimmedPrompt = prompt.trim();
+  return trimmedPrompt === IMAGE_ONLY_BOOTSTRAP_PROMPT ? "" : trimmedPrompt;
+}
+
+export function buildComposerPromptHistoryEntries(
+  messages: ReadonlyArray<ComposerPromptHistoryMessage>,
+): string[] {
+  const entries: string[] = [];
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const prompt =
+      message.promptHistoryText === undefined
+        ? recallableComposerPrompt(message.text)
+        : message.promptHistoryText.trim();
+    if (prompt.length === 0 || entries.at(-1) === prompt) continue;
+    entries.push(prompt);
+  }
+  return entries;
+}
+
+export function findComposerPromptHistoryOffset(
+  entries: ReadonlyArray<string>,
+  recalledPrompt: string,
+): number | null {
+  const entryIndex = entries.lastIndexOf(recalledPrompt);
+  return entryIndex < 0 ? null : entries.length - 1 - entryIndex;
+}
+
+export function navigateComposerPromptHistory(input: {
+  readonly direction: "backward" | "forward";
+  readonly entries: ReadonlyArray<string>;
+  readonly offset: number | null;
+  readonly currentPrompt: string;
+  readonly draft: string;
+}): ComposerPromptHistoryNavigation | null {
+  if (input.entries.length === 0) return null;
+
+  if (input.direction === "backward") {
+    if (input.offset === null && input.currentPrompt.length > 0) return null;
+    const offset = Math.min((input.offset ?? -1) + 1, input.entries.length - 1);
+    return {
+      offset,
+      draft: input.offset === null ? input.currentPrompt : input.draft,
+      prompt: input.entries[input.entries.length - 1 - offset] ?? "",
+    };
+  }
+
+  if (input.offset === null) return null;
+  if (input.offset === 0) {
+    return {
+      offset: null,
+      draft: "",
+      prompt: input.draft,
+    };
+  }
+
+  const offset = input.offset - 1;
+  return {
+    offset,
+    draft: input.draft,
+    prompt: input.entries[input.entries.length - 1 - offset] ?? "",
+  };
+}

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -8,12 +8,19 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
 
 export interface ComposerPromptHistoryMessage {
+  readonly id: string;
   readonly role: string;
   readonly text: string;
   readonly promptHistoryText?: string | undefined;
 }
 
+export interface ComposerPromptHistoryEntry {
+  readonly id: string;
+  readonly prompt: string;
+}
+
 export interface ComposerPromptHistoryNavigation {
+  readonly entryId: string | null;
   readonly offset: number | null;
   readonly draft: string;
   readonly prompt: string;
@@ -71,31 +78,36 @@ export function recallableComposerPrompt(messageText: string): string {
 
 export function buildComposerPromptHistoryEntries(
   messages: ReadonlyArray<ComposerPromptHistoryMessage>,
-): string[] {
-  const entries: string[] = [];
+): ComposerPromptHistoryEntry[] {
+  const entries: ComposerPromptHistoryEntry[] = [];
   for (const message of messages) {
     if (message.role !== "user") continue;
     const prompt =
       message.promptHistoryText === undefined
         ? recallableComposerPrompt(message.text)
         : message.promptHistoryText.trim();
-    if (prompt.length === 0 || entries.at(-1) === prompt) continue;
-    entries.push(prompt);
+    if (prompt.length === 0) continue;
+    const entry = { id: message.id, prompt };
+    if (entries.at(-1)?.prompt === prompt) {
+      entries[entries.length - 1] = entry;
+      continue;
+    }
+    entries.push(entry);
   }
   return entries;
 }
 
 export function findComposerPromptHistoryOffset(
-  entries: ReadonlyArray<string>,
-  recalledPrompt: string,
+  entries: ReadonlyArray<ComposerPromptHistoryEntry>,
+  entryId: string,
 ): number | null {
-  const entryIndex = entries.lastIndexOf(recalledPrompt);
+  const entryIndex = entries.findIndex((entry) => entry.id === entryId);
   return entryIndex < 0 ? null : entries.length - 1 - entryIndex;
 }
 
 export function navigateComposerPromptHistory(input: {
   readonly direction: "backward" | "forward";
-  readonly entries: ReadonlyArray<string>;
+  readonly entries: ReadonlyArray<ComposerPromptHistoryEntry>;
   readonly offset: number | null;
   readonly currentPrompt: string;
   readonly draft: string;
@@ -105,16 +117,20 @@ export function navigateComposerPromptHistory(input: {
   if (input.direction === "backward") {
     if (input.offset === null && input.currentPrompt.length > 0) return null;
     const offset = Math.min((input.offset ?? -1) + 1, input.entries.length - 1);
+    const entry = input.entries[input.entries.length - 1 - offset];
+    if (!entry) return null;
     return {
+      entryId: entry.id,
       offset,
       draft: input.offset === null ? input.currentPrompt : input.draft,
-      prompt: input.entries[input.entries.length - 1 - offset] ?? "",
+      prompt: entry.prompt,
     };
   }
 
   if (input.offset === null) return null;
   if (input.offset === 0) {
     return {
+      entryId: null,
       offset: null,
       draft: "",
       prompt: input.draft,
@@ -122,9 +138,12 @@ export function navigateComposerPromptHistory(input: {
   }
 
   const offset = input.offset - 1;
+  const entry = input.entries[input.entries.length - 1 - offset];
+  if (!entry) return null;
   return {
+    entryId: entry.id,
     offset,
     draft: input.draft,
-    prompt: input.entries[input.entries.length - 1 - offset] ?? "",
+    prompt: entry.prompt,
   };
 }

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -123,8 +123,9 @@ export function preserveComposerPromptHistoryAttachmentFiles(
   const optimisticAttachmentsById = new Map(
     optimisticAttachments.map((attachment) => [attachment.id, attachment] as const),
   );
-  return attachments.map((attachment) => {
-    const file = optimisticAttachmentsById.get(attachment.id)?.file;
+  return attachments.map((attachment, index) => {
+    const file =
+      optimisticAttachmentsById.get(attachment.id)?.file ?? optimisticAttachments[index]?.file;
     return file ? { ...attachment, file } : attachment;
   });
 }

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -2,6 +2,7 @@ import { extractTrailingElementContexts } from "../../lib/elementContext";
 import { extractTrailingPreviewAnnotation } from "../../lib/previewAnnotation";
 import { extractTrailingTerminalContexts } from "../../lib/terminalContext";
 import { parseReviewCommentMessageSegments } from "../../reviewCommentContext";
+import type { ChatImageAttachment } from "../../types";
 
 const CLAUDE_ULTRATHINK_PREFIX = "Ultrathink:\n";
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
@@ -115,6 +116,19 @@ export function findComposerPromptHistoryOffset(
   return entryIndex < 0 ? null : entries.length - 1 - entryIndex;
 }
 
+export function preserveComposerPromptHistoryAttachmentFiles(
+  attachments: ReadonlyArray<ChatImageAttachment>,
+  optimisticAttachments: ReadonlyArray<ChatImageAttachment>,
+): ChatImageAttachment[] {
+  const optimisticAttachmentsById = new Map(
+    optimisticAttachments.map((attachment) => [attachment.id, attachment] as const),
+  );
+  return attachments.map((attachment) => {
+    const file = optimisticAttachmentsById.get(attachment.id)?.file;
+    return file ? { ...attachment, file } : attachment;
+  });
+}
+
 export function navigateComposerPromptHistory(input: {
   readonly direction: "backward" | "forward";
   readonly entries: ReadonlyArray<ComposerPromptHistoryEntry>;
@@ -176,23 +190,25 @@ export function navigateComposerPromptHistory(input: {
 
 export async function materializeComposerPromptHistoryAttachments(
   attachments: ReadonlyArray<ComposerPromptHistoryAttachment>,
-): Promise<
-  Array<
+): Promise<{
+  readonly attachments: Array<
     ComposerPromptHistoryAttachment & {
       readonly previewUrl: string;
       readonly file: File;
     }
-  >
-> {
+  >;
+  readonly failedAttachmentCount: number;
+}> {
   const materialized: Array<
     ComposerPromptHistoryAttachment & {
       readonly previewUrl: string;
       readonly file: File;
     }
   > = [];
+  let failedAttachmentCount = 0;
 
-  try {
-    for (const attachment of attachments) {
+  for (const attachment of attachments) {
+    try {
       let file = attachment.file;
       if (!file) {
         if (!attachment.previewUrl) {
@@ -214,12 +230,9 @@ export async function materializeComposerPromptHistoryAttachments(
         previewUrl: URL.createObjectURL(file),
         file,
       });
+    } catch {
+      failedAttachmentCount += 1;
     }
-    return materialized;
-  } catch (error) {
-    for (const attachment of materialized) {
-      URL.revokeObjectURL(attachment.previewUrl);
-    }
-    throw error;
   }
+  return { attachments: materialized, failedAttachmentCount };
 }

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -41,6 +41,16 @@ export interface ComposerPromptHistoryNavigation {
   readonly attachments: ReadonlyArray<ComposerPromptHistoryAttachment>;
 }
 
+export function isUnmodifiedComposerPromptHistoryKey(input: {
+  readonly shiftKey: boolean;
+  readonly altKey: boolean;
+  readonly metaKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly isComposing: boolean;
+}): boolean {
+  return !input.shiftKey && !input.altKey && !input.metaKey && !input.ctrlKey && !input.isComposing;
+}
+
 function stripTrailingReviewComments(prompt: string): string {
   const segments = parseReviewCommentMessageSegments(prompt);
   if (!segments.some((segment) => segment.kind === "review-comment")) {

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -87,12 +87,7 @@ export function buildComposerPromptHistoryEntries(
         ? recallableComposerPrompt(message.text)
         : message.promptHistoryText.trim();
     if (prompt.length === 0) continue;
-    const entry = { id: message.id, prompt };
-    if (entries.at(-1)?.prompt === prompt) {
-      entries[entries.length - 1] = entry;
-      continue;
-    }
-    entries.push(entry);
+    entries.push({ id: message.id, prompt });
   }
   return entries;
 }

--- a/apps/web/src/components/chat/composerPromptHistory.ts
+++ b/apps/web/src/components/chat/composerPromptHistory.ts
@@ -11,19 +11,33 @@ export interface ComposerPromptHistoryMessage {
   readonly id: string;
   readonly role: string;
   readonly text: string;
+  readonly attachments?: ReadonlyArray<ComposerPromptHistoryAttachment> | undefined;
   readonly promptHistoryText?: string | undefined;
+}
+
+export interface ComposerPromptHistoryAttachment {
+  readonly type: "image";
+  readonly id: string;
+  readonly name: string;
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+  readonly previewUrl?: string | undefined;
+  readonly file?: File | undefined;
 }
 
 export interface ComposerPromptHistoryEntry {
   readonly id: string;
   readonly prompt: string;
+  readonly attachments: ReadonlyArray<ComposerPromptHistoryAttachment>;
 }
 
 export interface ComposerPromptHistoryNavigation {
   readonly entryId: string | null;
   readonly offset: number | null;
   readonly draft: string;
+  readonly draftAttachments: ReadonlyArray<ComposerPromptHistoryAttachment>;
   readonly prompt: string;
+  readonly attachments: ReadonlyArray<ComposerPromptHistoryAttachment>;
 }
 
 function stripTrailingReviewComments(prompt: string): string {
@@ -86,8 +100,9 @@ export function buildComposerPromptHistoryEntries(
       message.promptHistoryText === undefined
         ? recallableComposerPrompt(message.text)
         : message.promptHistoryText.trim();
-    if (prompt.length === 0) continue;
-    entries.push({ id: message.id, prompt });
+    const attachments = message.attachments ?? [];
+    if (prompt.length === 0 && attachments.length === 0) continue;
+    entries.push({ id: message.id, prompt, attachments });
   }
   return entries;
 }
@@ -105,12 +120,21 @@ export function navigateComposerPromptHistory(input: {
   readonly entries: ReadonlyArray<ComposerPromptHistoryEntry>;
   readonly offset: number | null;
   readonly currentPrompt: string;
+  readonly currentAttachments?: ReadonlyArray<ComposerPromptHistoryAttachment>;
   readonly draft: string;
+  readonly draftAttachments?: ReadonlyArray<ComposerPromptHistoryAttachment>;
 }): ComposerPromptHistoryNavigation | null {
   if (input.entries.length === 0) return null;
+  const currentAttachments = input.currentAttachments ?? [];
+  const draftAttachments = input.draftAttachments ?? [];
 
   if (input.direction === "backward") {
-    if (input.offset === null && input.currentPrompt.length > 0) return null;
+    if (
+      input.offset === null &&
+      (input.currentPrompt.length > 0 || currentAttachments.length > 0)
+    ) {
+      return null;
+    }
     if (input.offset !== null && input.offset >= input.entries.length - 1) return null;
     const offset = (input.offset ?? -1) + 1;
     const entry = input.entries[input.entries.length - 1 - offset];
@@ -119,7 +143,9 @@ export function navigateComposerPromptHistory(input: {
       entryId: entry.id,
       offset,
       draft: input.offset === null ? input.currentPrompt : input.draft,
+      draftAttachments: input.offset === null ? currentAttachments : draftAttachments,
       prompt: entry.prompt,
+      attachments: entry.attachments,
     };
   }
 
@@ -129,7 +155,9 @@ export function navigateComposerPromptHistory(input: {
       entryId: null,
       offset: null,
       draft: "",
+      draftAttachments: [],
       prompt: input.draft,
+      attachments: draftAttachments,
     };
   }
 
@@ -140,6 +168,58 @@ export function navigateComposerPromptHistory(input: {
     entryId: entry.id,
     offset,
     draft: input.draft,
+    draftAttachments,
     prompt: entry.prompt,
+    attachments: entry.attachments,
   };
+}
+
+export async function materializeComposerPromptHistoryAttachments(
+  attachments: ReadonlyArray<ComposerPromptHistoryAttachment>,
+): Promise<
+  Array<
+    ComposerPromptHistoryAttachment & {
+      readonly previewUrl: string;
+      readonly file: File;
+    }
+  >
+> {
+  const materialized: Array<
+    ComposerPromptHistoryAttachment & {
+      readonly previewUrl: string;
+      readonly file: File;
+    }
+  > = [];
+
+  try {
+    for (const attachment of attachments) {
+      let file = attachment.file;
+      if (!file) {
+        if (!attachment.previewUrl) {
+          throw new Error(`Attachment ${attachment.id} has no readable source`);
+        }
+        const response = await fetch(attachment.previewUrl);
+        if (!response.ok) {
+          throw new Error(`Attachment ${attachment.id} could not be downloaded`);
+        }
+        const blob = await response.blob();
+        file = new File([blob], attachment.name, {
+          type: attachment.mimeType || blob.type,
+        });
+      }
+
+      materialized.push({
+        ...attachment,
+        sizeBytes: file.size,
+        previewUrl: URL.createObjectURL(file),
+        file,
+      });
+    }
+    return materialized;
+  } catch (error) {
+    for (const attachment of materialized) {
+      URL.revokeObjectURL(attachment.previewUrl);
+    }
+    throw error;
+  }
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -33,6 +33,8 @@ export interface ThreadTerminalGroup {
 
 export interface ChatImageAttachment extends ContractChatImageAttachment {
   readonly previewUrl?: string;
+  /** Present while the attachment still has a local composer source. */
+  readonly file?: File;
 }
 
 export type ChatAttachment = ChatImageAttachment;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -39,6 +39,8 @@ export type ChatAttachment = ChatImageAttachment;
 
 export interface ChatMessage extends Omit<OrchestrationMessage, "attachments"> {
   readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
+  /** Exact composer text retained while an optimistic user message is in the local timeline. */
+  readonly promptHistoryText?: string | undefined;
 }
 
 export type ProposedPlan = OrchestrationProposedPlan;

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -6,9 +6,10 @@ multiple messages, then send again in the same thread.
 
 On desktop, press `Up` in an empty composer to recall the latest prompt from the active thread.
 Press `Up` again to move backward through earlier prompts. Press `Down` to move forward, or to
-return to the empty composer after the newest prompt. Arrow keys keep moving the caret inside a
-multiline prompt until the caret reaches the first or last visible line. Editing a recalled prompt
-turns it into a new draft without changing the sent message.
+return to the empty composer after the newest prompt. Recalled prompts include their image
+attachments. Arrow keys keep moving the caret inside a multiline prompt until the caret reaches the
+first or last visible line. Editing a recalled prompt turns it into a new draft without changing the
+sent message.
 
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -4,6 +4,12 @@ Messages can contain up to 120,000 characters. If a draft is longer, T3 Code kee
 composer and shows how many characters need to be removed. Shorten the draft or split it into
 multiple messages, then send again in the same thread.
 
+On desktop, press `Up` in an empty composer to recall the latest prompt from the active thread.
+Press `Up` again to move backward through earlier prompts. Press `Down` to move forward, or to
+return to the empty composer after the newest prompt. Arrow keys keep moving the caret inside a
+multiline prompt until the caret reaches the first or last visible line. Editing a recalled prompt
+turns it into a new draft without changing the sent message.
+
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New


### PR DESCRIPTION
Closes #7951. Supersedes #4336.

## Problem

Re-running or editing a recent prompt requires copying it from the timeline. The earlier implementation no longer applies cleanly to the current Lexical composer and leaves three review findings unresolved.

## Fix

- Build per-thread history from the combined server and optimistic message list.
- Recall the exact just-sent composer text while its optimistic message is active.
- Strip terminal, element, preview, review, image-only, and provider-injected payloads from loaded history entries.
- Let ArrowUp and ArrowDown navigate only from an empty composer or an active history session.
- Preserve normal multiline caret movement until the caret reaches the first or last visible line.
- Exit history mode on edit and restore the draft if a recalled entry disappears or the user leaves the thread.
- Keep history inactive for autocomplete, IME composition, modified key presses, pending input, approvals, and attached context.

Desktop inherits this web behavior. Mobile, providers, the server, and wire contracts do not change.

## Verification

- `pnpm --dir apps/web exec vp test run src/components/chat/composerPromptHistory.test.ts src/components/ComposerPromptEditor.test.ts src/components/ChatView.logic.test.ts --project unit` (54 tests)
- `pnpm exec vp run --filter @t3tools/web typecheck`
- targeted `vp lint` for the touched TypeScript files
- targeted `vp fmt --check` for all touched files

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer keyboard handling, optimistic message merge, and local File/blob rematerialization for attachments. Bugs could steal arrow-key caret movement or leak/lose draft images.
> 
> **Overview**
> Lets users recall earlier prompts from the active thread with unmodified ArrowUp/ArrowDown in an empty composer (or when the caret is on the first/last visual line). Recalled entries restore image attachments and the unsent draft when walking forward.
> 
> History is built from the combined timeline, using `promptHistoryText` on optimistic messages so just-sent text is recalled before server payloads (contexts, ultrathink, image-only bootstrap) are stripped. Local `File` handles are kept on acknowledged attachments so images can be rematerialized.
> 
> Navigation stays off during menus, IME, modifiers, approvals, pending input, and extra composer context. Editing a recalled prompt exits history without changing the sent message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67ba9f3c275ef7cb5601d6d63cfc72555190f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ArrowUp/ArrowDown prompt history recall to `ChatComposer`
> - Adds desktop prompt history navigation: pressing ArrowUp in an empty composer (caret on first visual line) recalls older prompts; ArrowDown moves forward and restores the in-progress draft at the end
> - Recalled prompts restore their image attachments by reusing local `File` handles or fetching from preview URLs; failed attachment loads show a toast warning and continue with successful ones
> - Server-acknowledged user messages now carry `promptHistoryText` and preserve local `File` handles on attachments so history stays accurate after reconciliation
> - Adds `isCaretOnVisualEdge` to `ComposerPromptEditorHandle` so the composer can detect caret position on the first/last visible line before intercepting arrow keys
> - Image attachments render in a collapsing/expanding grid container; images referenced by preview annotations are excluded from the visible attachment list
> - Risk: `ChatImageAttachment` gains optional `file?: File` and `ChatMessage` gains optional `promptHistoryText?: string`; consumers of these types in [types.ts](https://github.com/pingdotgg/t3code/pull/7952/files#diff-59e19478e70bd3aa7e00ae04151c579d60e20e6e2d638e4f90ccda763cbcc14f) should be checked for serialization or persistence assumptions about these fields
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b67ba9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->