### PR TITLE
fix(clients): reconnect after credentials fail during remote server updates

### DIFF
--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -124,6 +124,30 @@ describe("update restart reconnect nudges", () => {
       yield* Fiber.join(fiber);
     }).pipe(Effect.provide(TestClock.layer())),
   );
+
+  it.effect("retries rejected credentials only while the update restart is in progress", () =>
+    Effect.gen(function* () {
+      const retries = yield* Ref.make(0);
+
+      yield* nudgeReconnectDuringUpdateRestart({
+        stateChanges: Stream.fromIterable([
+          { phase: "blocked", lastFailure: { reason: "permission" } },
+          {
+            phase: "blocked",
+            lastFailure: {
+              reason: "authentication",
+              detail: "The environment credential is invalid.",
+            },
+          },
+          { phase: "blocked", lastFailure: { reason: "configuration" } },
+        ]),
+        retryNow: Ref.update(retries, (count) => count + 1),
+        interval: Duration.zero,
+      });
+
+      expect(yield* Ref.get(retries)).toBe(1);
+    }),
+  );
 });
 
 describe("server state projection", () => {

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -160,16 +160,30 @@ export function validateServerUpdateReadyEvent(
  * each nudge is the pacer: a connection that fails instantly re-enters backoff
  * immediately and would otherwise spin a tight retry loop.
  *
+ * A newly restarted server can also reject the first environment credential.
+ * Authentication blocks need the same paced retry during this known restart;
+ * permission and configuration failures remain blocked.
+ *
  * Callers fork this as a child of the update command so it is interrupted as
  * soon as the update settles, whether it succeeds, fails, or times out.
  */
 export function nudgeReconnectDuringUpdateRestart(input: {
-  readonly stateChanges: Stream.Stream<{ readonly phase: string }, unknown>;
+  readonly stateChanges: Stream.Stream<
+    {
+      readonly phase: string;
+      readonly lastFailure?: { readonly reason: string } | null;
+    },
+    unknown
+  >;
   readonly retryNow: Effect.Effect<void>;
   readonly interval?: Duration.Duration;
 }): Effect.Effect<void> {
   return input.stateChanges.pipe(
-    Stream.filter((state) => state.phase === "backoff"),
+    Stream.filter(
+      (state) =>
+        state.phase === "backoff" ||
+        (state.phase === "blocked" && state.lastFailure?.reason === "authentication"),
+    ),
     Stream.runForEach(() =>
       Effect.sleep(input.interval ?? Duration.seconds(1)).pipe(Effect.andThen(input.retryNow)),
     ),


### PR DESCRIPTION
Remote server updates on macOS can briefly reject an environment credential after the new server starts. The connection supervisor then blocks, and the update recovery loop never retries it.

Retry authentication failures once per second while an update is resuming. Permission and configuration failures remain blocked.

Tests: 55 focused client runtime, authorization, and connection supervisor tests pass.

Built with GPT-5.6 Sol using Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reconnect retry during server updates, including authentication-blocked states. The extra retries are limited to the update-resume window and exclude permission/configuration failures.
> 
> **Overview**
> During a remote server update restart, reconnect nudges now also fire when the supervisor is **blocked on authentication**, not only while it is in backoff.
> 
> A newly restarted server can reject the first environment credential and leave the client stuck. `nudgeReconnectDuringUpdateRestart` now retries those auth blocks on the same ~1s cadence used for backoff. Permission and configuration failures stay blocked. A unit test covers that only authentication blocks are retried.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208a63d433e1abd6315a736ebef2ddb57fad9383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `nudgeReconnectDuringUpdateRestart` to retry on authentication blocks
> - Expands `nudgeReconnectDuringUpdateRestart` in [server.ts](https://github.com/pingdotgg/t3code/pull/7953/files#diff-e89d2e49b487037c2e7108610cb27c1e8ad8800a8f2e66427f7e783a4fc1d428) to schedule paced retries for states blocked by `authentication` errors during remote server update restarts.
> - Broadens the filter from only `phase === "backoff"` to also include `phase === "blocked"` when `lastFailure?.reason === "authentication"`.
> - Behavioral Change: permission and configuration failures are explicitly excluded from retries and will no longer trigger reconnect nudges.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 208a63d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->