### PR TITLE
feat(web): show project attention in switcher

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -17,6 +17,7 @@ import {
   isSidebarNestedLinkClick,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  resolveProjectAttentionStatus,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -1174,6 +1175,89 @@ describe("resolveThreadStatusPill", () => {
         },
       }),
     ).toMatchObject({ label: "Completed", pulse: false });
+  });
+});
+
+describe("resolveProjectAttentionStatus", () => {
+  const makeStatusThread = (
+    overrides: Partial<Parameters<typeof resolveProjectAttentionStatus>[0][number]> = {},
+  ): Parameters<typeof resolveProjectAttentionStatus>[0][number] => ({
+    hasActionableProposedPlan: false,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    interactionMode: "default",
+    latestTurn: makeLatestTurn(),
+    lastVisitedAt: "2026-03-09T10:04:00.000Z",
+    session: {
+      threadId: ThreadId.make("thread-project-status"),
+      status: "ready",
+      providerName: "Codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      runtimeMode: DEFAULT_RUNTIME_MODE,
+      activeTurnId: null,
+      lastError: null,
+      updatedAt: "2026-03-09T10:05:00.000Z",
+    },
+    backgroundLiveness: null,
+    ...overrides,
+  });
+
+  it("returns null when project threads have no attention state", () => {
+    expect(
+      resolveProjectAttentionStatus([
+        makeStatusThread({ lastVisitedAt: "2026-03-09T10:06:00.000Z" }),
+        makeStatusThread({
+          session: {
+            ...makeStatusThread().session!,
+            status: "running",
+          },
+        }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("surfaces failed before input and unseen completion", () => {
+    expect(
+      resolveProjectAttentionStatus([
+        makeStatusThread(),
+        makeStatusThread({ hasPendingUserInput: true }),
+        makeStatusThread({
+          hasPendingUserInput: true,
+          session: {
+            ...makeStatusThread().session!,
+            status: "error",
+          },
+        }),
+      ]),
+    ).toBe("failed");
+  });
+
+  it("surfaces input before unseen completion", () => {
+    expect(
+      resolveProjectAttentionStatus([
+        makeStatusThread(),
+        makeStatusThread({ hasPendingUserInput: true }),
+      ]),
+    ).toBe("input");
+  });
+
+  it("surfaces an unseen completion as done", () => {
+    expect(resolveProjectAttentionStatus([makeStatusThread()])).toBe("done");
+  });
+
+  it("keeps never-visited historical completions read", () => {
+    expect(
+      resolveProjectAttentionStatus([makeStatusThread({ lastVisitedAt: undefined })]),
+    ).toBeNull();
+  });
+
+  it("does not turn approval or background work into switcher attention", () => {
+    expect(
+      resolveProjectAttentionStatus([
+        makeStatusThread({ hasPendingApprovals: true }),
+        makeStatusThread({ backgroundLiveness: "working" }),
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -474,6 +474,8 @@ export type SidebarThreadStatus =
   | "failed"
   | "ready";
 
+export type ProjectAttentionStatus = "failed" | "input" | "done";
+
 type SidebarThreadStatusInput = Pick<
   SidebarThreadSummary,
   "hasPendingApprovals" | "hasPendingUserInput" | "session" | "backgroundLiveness"
@@ -503,6 +505,24 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
     return "monitoring";
   }
   return "ready";
+}
+
+export function resolveProjectAttentionStatus(
+  threads: ReadonlyArray<ThreadStatusInput>,
+): ProjectAttentionStatus | null {
+  let hasInput = false;
+  let hasDone = false;
+
+  for (const thread of threads) {
+    if (thread.session?.status === "error") return "failed";
+    if (thread.hasPendingUserInput) hasInput = true;
+    const status = resolveSidebarThreadStatus(thread);
+    if (status === "ready" && hasUnseenCompletion(thread)) hasDone = true;
+  }
+
+  if (hasInput) return "input";
+  if (hasDone) return "done";
+  return null;
 }
 
 /** NaN-safe Date.parse for sort comparators: a malformed timestamp must not

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -67,6 +67,7 @@ import {
   type ReactNode,
 } from "react";
 import { useParams, useRouter } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
 
 import {
   isAtomCommandInterrupted,
@@ -131,6 +132,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   planPinnedReorder,
+  resolveProjectAttentionStatus,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
@@ -141,6 +143,7 @@ import {
   sortPinnedThreadsForSidebar,
   sortSettledThreadsForSidebar,
   sortThreadsForSidebar,
+  type ProjectAttentionStatus,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
@@ -194,6 +197,92 @@ const SETTLED_TAIL_PAGE_COUNT = 25;
 // Keep the v2 key so existing preferences survive the v2-to-default rename.
 const SETTLED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:settled-expanded";
 const SNOOZED_SHELF_EXPANDED_KEY = "t3code:sidebar-v2:snoozed-expanded";
+const EMPTY_PROJECT_ATTENTION_THREADS: readonly EnvironmentThreadShell[] = [];
+
+const PROJECT_ATTENTION_PRESENTATION: Record<
+  ProjectAttentionStatus,
+  { label: string; dotClassName: string }
+> = {
+  failed: { label: "Failed", dotClassName: "bg-red-500 dark:bg-red-400" },
+  input: { label: "Awaiting input", dotClassName: "bg-indigo-500 dark:bg-indigo-300" },
+  done: { label: "Done", dotClassName: "bg-emerald-500 dark:bg-emerald-300" },
+};
+
+const ProjectScopeMenuItem = memo(function ProjectScopeMenuItem(props: {
+  project: SidebarProjectSnapshot;
+  attentionThreads: readonly EnvironmentThreadShell[];
+  onProjectSettings: (
+    event: ReactMouseEvent<HTMLButtonElement>,
+    project: SidebarProjectSnapshot,
+  ) => void;
+}) {
+  const { attentionThreads, onProjectSettings, project } = props;
+  const lastVisitedAts = useUiStateStore(
+    useShallow((state) =>
+      attentionThreads.map(
+        (thread) =>
+          state.threadLastVisitedAtById[
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))
+          ] ?? null,
+      ),
+    ),
+  );
+  const attentionStatus = useMemo(
+    () =>
+      resolveProjectAttentionStatus(
+        attentionThreads.map((thread, index) => ({
+          ...thread,
+          lastVisitedAt: lastVisitedAts[index] ?? undefined,
+        })),
+      ),
+    [attentionThreads, lastVisitedAts],
+  );
+  const presentation = attentionStatus ? PROJECT_ATTENTION_PRESENTATION[attentionStatus] : null;
+
+  return (
+    <MenuRadioItem
+      value={project.projectKey}
+      closeOnClick
+      aria-label={
+        presentation ? `${project.displayName}, ${presentation.label}` : project.displayName
+      }
+      className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+    >
+      <span className="relative inline-flex size-4 shrink-0">
+        <ProjectFavicon
+          environmentId={project.environmentId}
+          cwd={project.workspaceRoot}
+          faviconPath={project.faviconPath}
+          className="size-4 shrink-0"
+        />
+        {presentation ? (
+          <span
+            aria-hidden="true"
+            data-testid={`project-attention-${attentionStatus}`}
+            className={cn(
+              "pointer-events-none absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2 ring-popover",
+              presentation.dotClassName,
+            )}
+          />
+        ) : null}
+      </span>
+      <span className="min-w-0 truncate text-sm">{project.displayName}</span>
+      <Button
+        size="icon-xs"
+        variant="ghost-muted"
+        aria-label={`Project settings for ${project.displayName}`}
+        title={`Project settings for ${project.displayName}`}
+        className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          onProjectSettings(event, project);
+        }}
+      >
+        <SettingsIcon className="size-3.5" />
+      </Button>
+    </MenuRadioItem>
+  );
+});
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -1912,6 +2001,18 @@ export default function Sidebar() {
       ),
     [projectGroups],
   );
+  const logicalProjectKeyByPhysicalKey = useMemo<Map<string, string>>(
+    () =>
+      new Map(
+        projectGroups.flatMap((group) =>
+          group.memberProjectRefs.map(
+            (projectRef) =>
+              [`${projectRef.environmentId}:${projectRef.projectId}`, group.projectKey] as const,
+          ),
+        ),
+      ),
+    [projectGroups],
+  );
 
   // now is quantized to the minute so effectiveSettled memoization doesn't
   // churn on every render; auto-settle thresholds are day-granular anyway.
@@ -2010,6 +2111,7 @@ export default function Sidebar() {
     snoozedThreads,
     settledThreads,
     snoozeNow,
+    projectAttentionThreadsByKey,
   } = useMemo(() => {
     const now = `${nowMinute}:00.000Z`;
     // Snooze classification uses a REAL clock, not the quantized minute:
@@ -2018,17 +2120,17 @@ export default function Sidebar() {
     // memo exactly at the next wake boundary.
     void snoozeWakeTick;
     const preciseNow = new Date().toISOString();
-    const visible = threads.filter(
-      (thread) =>
-        thread.archivedAt === null &&
-        (scopedProjectKeys === null ||
-          scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
-    );
     const pinned: EnvironmentThreadShell[] = [];
     const active: EnvironmentThreadShell[] = [];
     const snoozed: EnvironmentThreadShell[] = [];
     const settled: EnvironmentThreadShell[] = [];
-    for (const thread of visible) {
+    const attentionThreadsByProjectKey = new Map<string, EnvironmentThreadShell[]>();
+    for (const thread of threads) {
+      if (thread.archivedAt !== null) continue;
+      const physicalProjectKey = `${thread.environmentId}:${thread.projectId}`;
+      const visibleInCurrentScope =
+        scopedProjectKeys === null || scopedProjectKeys.has(physicalProjectKey);
+      if (!visibleInCurrentScope && !projectScopeMenuOpen) continue;
       // Threads on servers without the settlement capability (old server,
       // or descriptor not loaded yet) never classify as settled: the user
       // could neither un-settle nor pin them, so auto-settling them would
@@ -2043,13 +2145,36 @@ export default function Sidebar() {
         snapshot != null && (thread.worktreePath === null || snapshot.branch === thread.branch)
           ? snapshot.pr
           : null;
+      const isSnoozed = supportsSnooze && effectiveSnoozed(thread, { now: preciseNow });
+      const isSettled =
+        !isSnoozed &&
+        thread.pinnedAt === null &&
+        supportsSettlement &&
+        effectiveSettled(thread, {
+          now,
+          autoSettleAfterDays,
+          autoSettleOnMerge,
+          changeRequest,
+        });
+      if (projectScopeMenuOpen && !isSnoozed && !isSettled) {
+        const logicalProjectKey = logicalProjectKeyByPhysicalKey.get(physicalProjectKey);
+        if (logicalProjectKey !== undefined) {
+          const projectThreads = attentionThreadsByProjectKey.get(logicalProjectKey);
+          if (projectThreads) {
+            projectThreads.push(thread);
+          } else {
+            attentionThreadsByProjectKey.set(logicalProjectKey, [thread]);
+          }
+        }
+      }
+      if (!visibleInCurrentScope) continue;
       // Snooze outranks everything, including a pin: "hide until Tuesday"
       // temporarily suspends "keep on top". The pin survives underneath —
       // and so does its pinOrderKey, so on wake the thread reappears at
       // its exact slot in the pinned block. (For unpinned threads
       // this is also the snooze-beats-auto-settle rule: the wake time is a
       // stronger statement about when the thread matters again.)
-      if (supportsSnooze && effectiveSnoozed(thread, { now: preciseNow })) {
+      if (isSnoozed) {
         snoozed.push(thread);
         // A pin otherwise overrides the lifecycle: pinned threads never
         // auto-settle out of sight. (The decider clears settled state on
@@ -2057,15 +2182,7 @@ export default function Sidebar() {
         // arise from stale or raced writes.)
       } else if (thread.pinnedAt != null) {
         pinned.push(thread);
-      } else if (
-        supportsSettlement &&
-        effectiveSettled(thread, {
-          now,
-          autoSettleAfterDays,
-          autoSettleOnMerge,
-          changeRequest,
-        })
-      ) {
+      } else if (isSettled) {
         settled.push(thread);
       } else {
         active.push(thread);
@@ -2096,12 +2213,15 @@ export default function Sidebar() {
       ),
       settledThreads: sortSettledThreadsForSidebar(settled),
       snoozeNow: preciseNow,
+      projectAttentionThreadsByKey: attentionThreadsByProjectKey,
     };
   }, [
     autoSettleAfterDays,
     autoSettleOnMerge,
     changeRequestSnapshotByKey,
+    logicalProjectKeyByPhysicalKey,
     nowMinute,
+    projectScopeMenuOpen,
     scopedProjectKeys,
     serverConfigs,
     snoozeWakeTick,
@@ -3520,38 +3640,17 @@ export default function Sidebar() {
                         <FolderIcon className="size-4 shrink-0" />
                         <span className="min-w-0 truncate text-sm">All projects</span>
                       </MenuRadioItem>
-                      {projectGroups.map((project) => {
-                        const scopeKey = project.projectKey;
-                        return (
-                          <MenuRadioItem
-                            key={scopeKey}
-                            value={scopeKey}
-                            closeOnClick
-                            className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
-                          >
-                            <ProjectFavicon
-                              environmentId={project.environmentId}
-                              cwd={project.workspaceRoot}
-                              faviconPath={project.faviconPath}
-                              className="size-4 shrink-0"
-                            />
-                            <span className="min-w-0 truncate text-sm">{project.displayName}</span>
-                            <Button
-                              size="icon-xs"
-                              variant="ghost-muted"
-                              aria-label={`Project settings for ${project.displayName}`}
-                              title={`Project settings for ${project.displayName}`}
-                              className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => {
-                                void handleProjectSettings(event, project);
-                              }}
-                            >
-                              <SettingsIcon className="size-3.5" />
-                            </Button>
-                          </MenuRadioItem>
-                        );
-                      })}
+                      {projectGroups.map((project) => (
+                        <ProjectScopeMenuItem
+                          key={project.projectKey}
+                          project={project}
+                          attentionThreads={
+                            projectAttentionThreadsByKey.get(project.projectKey) ??
+                            EMPTY_PROJECT_ATTENTION_THREADS
+                          }
+                          onProjectSettings={handleProjectSettings}
+                        />
+                      ))}
                     </MenuRadioGroup>
                   </MenuPopup>
                 </Menu>

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -12,6 +12,13 @@ If reordering is unavailable for one environment, update the T3 Code server runn
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
 
+## Project attention dots
+
+On web and desktop, the project picker marks projects that contain a failed thread, a thread that
+awaits input, or an unread completion. Failed threads take priority over input requests, and input
+requests take priority over completions. The dot disappears after you address the state or settle
+the thread. Mobile uses its native text-only project filter.
+
 ## Environment artwork
 
 Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in


### PR DESCRIPTION
Closes #7954.

## Problem

The project switcher hides attention states in other projects. Users have to change the project filter or return to **All projects** to find a failed thread, an input request, or an unread completion.

## Fix

- Add a static status dot to each affected project icon in the current web and desktop project switcher.
- Roll up only failed, awaiting-input, and unread-completion states, with `failed > input > done` precedence.
- Reuse the sidebar's settled and snoozed lifecycle decisions so settled, archived, and deliberately hidden threads do not produce stale dots.
- Subscribe each project row only to its own visit markers, and compute cross-project status only while the switcher is open.
- Include the status in each menu item's accessible name.

Mobile keeps its native text-only project filter, which has no project-icon slot.

## UI changes

| Before | After |
| --- | --- |
| ![Project switcher without attention dots](https://github.com/sethwebster/t3code/releases/download/pr-7955-evidence/t3-project-switcher-before.png) | ![Project switcher with failed, input, and done dots](https://github.com/sethwebster/t3code/releases/download/pr-7955-evidence/t3-project-switcher-after.png) |

## Verification

- `pnpm exec vp test run apps/web/src/components/Sidebar.logic.test.ts` (111 tests)
- `pnpm exec vp run --filter @t3tools/web typecheck`
- targeted `vp lint` for the changed TypeScript files
- `pnpm exec vp run --filter @t3tools/web build`
- isolated real-app pass at 1024 x 720 in dark mode
  - failed, input, and done dots render with distinct colors
  - a settled-only project has no dot
  - menu item names expose `Failed`, `Awaiting input`, and `Done`

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar switcher change with isolated status rollup and tests; no auth, data, or API surface changes.
> 
> **Overview**
> The web/desktop project switcher now shows a status dot on projects that need attention outside the current filter, so users can find failures, input requests, and unread completions without switching to **All projects**.
> 
> Dots roll up only `failed`, `input`, and `done` (unread completion), in that order. Approvals, background work, settled/snoozed/archived threads, and never-visited historical completions do not light a dot. Cross-project status is computed only while the menu is open; each row subscribes only to its own visit markers. Accessible names include the status label. Mobile stays text-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd52c74d804d7c49b3a00ac597c0645253a72b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add project attention dots to the sidebar project switcher
> - Adds `resolveProjectAttentionStatus` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/7955/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) which reduces a list of threads to a single attention status with precedence: `failed` > `input` > `done`, or `null` when no attention applies.
> - Adds the `ProjectScopeMenuItem` component in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7955/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that renders a colored dot and aria-label per project when attention is present, and a settings button.
> - Updates the sidebar partitioning memo to gather per-project thread sets (including out-of-scope threads while the project menu is open) so attention can be computed for every project.
> - Documents the new indicators in [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/7955/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a).
> - Behavioral Change: the sidebar now iterates all non-archived threads when the project scope menu is open (not just in-scope ones) to populate `projectAttentionThreadsByKey`; out-of-scope threads remain hidden in the main lists but are processed for attention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbd52c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->