### PR TITLE
fix(server): detect GitHub Enterprise remotes that gh is signed in to

### DIFF
--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -396,3 +396,115 @@ it("reports an update hint instead of unauthenticated when gh predates --json", 
     /2\.81\.0/,
   );
 });
+
+const authStatusJson = (
+  accounts: ReadonlyArray<{
+    readonly host: string;
+    readonly login: string;
+    readonly state?: string;
+    readonly active?: boolean;
+  }>,
+): string =>
+  JSON.stringify({
+    hosts: Object.fromEntries(
+      accounts.map((account) => [
+        account.host,
+        [
+          {
+            state: account.state ?? "success",
+            active: account.active ?? false,
+            host: account.host,
+            login: account.login,
+            tokenSource: "keyring",
+            gitProtocol: "https",
+          },
+        ],
+      ]),
+    ),
+  });
+
+const refineUnknownRemote = (input: { readonly host: string; readonly stdout: string }) =>
+  GitHubSourceControlProvider.discovery.refineUnknownRemote?.({
+    cwd: "/repo",
+    context: {
+      provider: {
+        kind: "unknown",
+        name: input.host,
+        baseUrl: `https://${input.host}`,
+      },
+      remoteName: "origin",
+      remoteUrl: `https://${input.host}/org/repo.git`,
+    },
+    auth: processResult(input.stdout),
+  });
+
+it("refines unknown remotes that gh is signed in to, whether or not the account is active", () => {
+  assert.deepStrictEqual(
+    refineUnknownRemote({
+      host: "git.example.edu",
+      stdout: authStatusJson([
+        { host: "github.com", login: "active-user", active: true },
+        { host: "git.example.edu", login: "enterprise-user" },
+      ]),
+    }),
+    {
+      kind: "github",
+      name: "GitHub Self-Hosted",
+      baseUrl: "https://git.example.edu",
+    },
+  );
+});
+
+it("leaves unknown remotes alone when gh has no working account for the host", () => {
+  assert.strictEqual(
+    refineUnknownRemote({
+      host: "git.example.edu",
+      stdout: authStatusJson([
+        { host: "git.example.edu", login: "enterprise-user", state: "failure" },
+      ]),
+    }),
+    null,
+  );
+
+  assert.strictEqual(
+    refineUnknownRemote({
+      host: "git.example.edu",
+      stdout: authStatusJson([{ host: "github.com", login: "active-user", active: true }]),
+    }),
+    null,
+  );
+});
+
+it("refines unknown remotes on non-standard ports against gh's bare hostnames", () => {
+  assert.deepStrictEqual(
+    refineUnknownRemote({
+      host: "git.example.edu:8443",
+      stdout: authStatusJson([{ host: "git.example.edu", login: "enterprise-user" }]),
+    }),
+    {
+      kind: "github",
+      name: "GitHub Self-Hosted",
+      baseUrl: "https://git.example.edu:8443",
+    },
+  );
+});
+
+it("ignores stderr noise when refining, so gh warnings do not break host matching", () => {
+  const provider = GitHubSourceControlProvider.discovery.refineUnknownRemote?.({
+    cwd: "/repo",
+    context: {
+      provider: {
+        kind: "unknown",
+        name: "git.example.edu",
+        baseUrl: "https://git.example.edu",
+      },
+      remoteName: "origin",
+      remoteUrl: "https://git.example.edu/org/repo.git",
+    },
+    auth: processResult(authStatusJson([{ host: "git.example.edu", login: "enterprise-user" }]), {
+      stderr: "warning: ignored diagnostic from gh\n",
+    }),
+  });
+
+  assert.strictEqual(provider?.kind, "github");
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -7,6 +7,7 @@ import {
   type ChangeRequest,
   type ChangeRequestState,
 } from "@t3tools/contracts";
+import { parseHostName } from "@t3tools/shared/sourceControl";
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
@@ -18,6 +19,7 @@ import {
   providerAuth,
   type SourceControlAuthProbeInput,
   type SourceControlCliDiscoverySpec,
+  type SourceControlUnknownRemoteRefinementInput,
 } from "./SourceControlProviderDiscovery.ts";
 
 function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeRequest {
@@ -92,6 +94,30 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   });
 }
 
+// A GitHub Enterprise host is named by whoever installed it, so hostname guessing misses
+// installs like `git.example.edu`. When detection lands on `unknown`, let a host `gh` is
+// signed in to claim the remote. Any signed-in account counts rather than only the host's
+// active one, so a second login on the same host still resolves the remote; whether `gh`
+// knows the host at all is the question, not which account is currently selected.
+function refineUnknownGitHubRemote(input: SourceControlUnknownRemoteRefinementInput) {
+  // Unknown contexts carry the raw remote host in `name`, which keeps any port, while `gh`
+  // keys its hosts by bare hostname.
+  const host = parseHostName(input.context.provider.name);
+  const authenticated = parseGitHubAuthStatus(input.auth.stdout).accounts.some(
+    (account) => account.authenticated && parseHostName(account.host) === host,
+  );
+
+  if (!authenticated) {
+    return null;
+  }
+
+  return {
+    kind: "github",
+    name: "GitHub Self-Hosted",
+    baseUrl: input.context.provider.baseUrl,
+  } as const;
+}
+
 export const discovery = {
   type: "cli",
   kind: "github",
@@ -100,6 +126,7 @@ export const discovery = {
   versionArgs: ["--version"],
   authArgs: ["auth", "status", "--json", "hosts"],
   parseAuth: parseGitHubAuth,
+  refineUnknownRemote: refineUnknownGitHubRemote,
   installHint:
     "Install the GitHub command-line tool (`gh`) via https://cli.github.com/ or your package manager (for example `brew install gh`).",
 } satisfies SourceControlCliDiscoverySpec;

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -203,6 +203,54 @@ self-hosted.example.test
   }),
 );
 
+it.effect("routes authenticated GitHub Enterprise remotes without relying on host naming", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "https://git.example.edu/org/repo.git" }],
+      process: {
+        run: () =>
+          Effect.succeed(
+            processOutput(
+              JSON.stringify({
+                hosts: {
+                  "github.com": [
+                    {
+                      state: "success",
+                      active: true,
+                      host: "github.com",
+                      login: "active-user",
+                      tokenSource: "keyring",
+                      gitProtocol: "https",
+                    },
+                  ],
+                  "git.example.edu": [
+                    {
+                      state: "success",
+                      active: false,
+                      host: "git.example.edu",
+                      login: "enterprise-user",
+                      tokenSource: "keyring",
+                      gitProtocol: "https",
+                    },
+                  ],
+                },
+              }),
+            ),
+          ),
+      },
+    });
+
+    const handle = yield* registry.resolveHandle({ cwd: "/repo" });
+
+    assert.strictEqual(handle.provider.kind, "github");
+    assert.deepStrictEqual(handle.context?.provider, {
+      kind: "github",
+      name: "GitHub Self-Hosted",
+      baseUrl: "https://git.example.edu",
+    });
+  }),
+);
+
 it.effect("refines the caller-selected remote instead of choosing another configured remote", () =>
   Effect.gen(function* () {
     const registry = yield* makeRegistry({

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -79,6 +79,10 @@ Run a quick **Rescan** after setting up a new machine or changing credentials.
 
 You can now clone, publish, and create pull requests.
 
+**GitHub Enterprise Server** works the same way, whatever your install is called. Sign in with
+`gh auth login --hostname git.example.com`, and T3 Code recognizes projects on that host as GitHub
+even when the hostname says nothing about GitHub.
+
 ### For GitLab
 
 1. Install the GitLab CLI:

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -122,6 +122,18 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
     ).toBe("unknown");
   });
 
+  it("leaves enterprise hosts without a provider label unknown for CLI refinement", () => {
+    // GitHub Enterprise hosts are named by the customer, so hostname matching cannot see
+    // them. Detection reports `unknown` and the provider CLIs settle it during refinement.
+    const remoteUrl = "https://git.example.edu/org/repo.git";
+
+    expect(detectSourceControlProviderFromRemoteUrl(remoteUrl)).toEqual({
+      kind: "unknown",
+      name: "git.example.edu",
+      baseUrl: "https://git.example.edu",
+    });
+  });
+
   it("detects SSH remotes with non-git SSH users (e.g. gitlab@, deploy@)", () => {
     expect(
       detectSourceControlProviderFromRemoteUrl("gitlab@gitlab.example.com:group/project.git")?.kind,

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -158,7 +158,12 @@ function parseRemoteHost(remoteUrl: string): string | null {
   }
 }
 
-function parseHostName(host: string): string {
+/**
+ * Normalizes a remote host to its bare hostname, dropping any port. Provider CLIs report
+ * hosts inconsistently — `gh` keys by bare hostname while a remote may carry `:8443` — so
+ * comparisons against CLI output go through here.
+ */
+export function parseHostName(host: string): string {
   try {
     return new URL(`https://${host}`).hostname.toLowerCase();
   } catch {


### PR DESCRIPTION
## What Changed

`GitHubSourceControlProvider`'s discovery spec now implements `refineUnknownRemote`, the hook GitLab already used to claim hosts that hostname matching cannot identify. When a remote is detected as `kind: "unknown"`, `gh auth status --json hosts` is consulted, and any host `gh` is signed in to claims that remote as GitHub.

- `apps/server/src/sourceControl/GitHubSourceControlProvider.ts` — the refiner, +27 lines
- `packages/shared/src/sourceControl.ts` — export the existing `parseHostName` so both sides of the host comparison drop ports
- Tests — detection precondition in `packages/shared`, five refiner cases in `GitHubSourceControlProvider.test.ts`, one end-to-end `resolveHandle` case in `SourceControlProviderRegistry.test.ts`
- One paragraph in `docs/user/source-control.md`

Nothing changes for hosts that already resolve. `refineUnknownRemoteProvider` returns early unless the kind is `unknown`, so `github.com` and `github.*` remotes never reach the new code and spawn no extra process.

## Why

A GitHub Enterprise Server hostname is chosen by whoever installed it. `isGitHubHost` matches only `github.com` or a host carrying `github` as a dot-separated DNS label, so an install at `git.example.edu` or `code.acme.tld` falls through every branch to `kind: "unknown"`. No provider is registered under `"unknown"`, so `unsupportedProvider` is returned and every operation fails:

```
Source control provider unknown failed in listChangeRequests:
No unknown source control provider is registered.
```

The PR panel stays empty and that message repeats on every status refresh, through `VcsStatusBroadcaster.refreshStatus` → `remoteStatus` → `readRemoteStatus` → `lookupStatusPr` → `findLatestPrForHeadContext` → `listChangeRequests`. `gh` resolves the PR correctly from the same cwd the whole time.

The recovery path for exactly this case already exists: `refineUnknownRemoteProvider` runs each CLI's auth command and lets a provider claim the host by name. GitLab implements `refineUnknownRemote`; GitHub did not, so `isCliRemoteRefinementSpec` filtered the GitHub spec out and `gh` was never asked. Net effect was that GitLab self-hosted on an arbitrary domain worked while GitHub Enterprise on an arbitrary domain did not — which reads as unintended, since the contracts already model `github.com` and a GHES install as separate identities under one provider kind.

Everything needed was already in place: `authArgs` is already `["auth", "status", "--json", "hosts"]`, and `parseGitHubAuthStatus` already decodes that JSON per host. No new parsing, no new process invocation, no config surface.

Two details worth a reviewer's attention:

- Matching accepts any **authenticated** account on the host rather than the **active** one. `gh` keeps one active account per host, so gating on `active` would fail a user with two logins on the same GHES host who has switched to the other.
- The `unknown` context carries the raw remote host in `provider.name`, which retains `:port`, while `gh` keys hosts by bare hostname — so both sides go through `parseHostName`. GitLab's refiner deliberately still compares the raw name: `glab` reports hosts *with* the port, and there are existing tests for `localhost:8080` and `self-hosted.example.test:8443`.

## Verification

`vp test run` across the four affected source-control test files: 46 tests pass. Targeted lint and typecheck are clean for `apps/server` and `packages/shared`.

Also exercised against a real machine with `gh` signed in to both `github.com` and a GHES install at once:

| remote | result |
| --- | --- |
| `https://github.com/pingdotgg/t3code.git` | detected `github` by hostname; refiner never consulted |
| `https://<ghes-host>/org/repo.git` | detected `unknown`, refined to `github` / `GitHub Self-Hosted` |
| a third host with no `gh` account | stays `null`; not claimed |

One pre-existing limitation this PR does **not** address: with two hosts signed in, the Settings → Source Control row still reports a single identity, because `parseGitHubAuth` collapses the account list through `findAuthenticatedGitHubAccount`. That is display-only and does not affect which account serves PR lookup. Widening it would mean changing `SourceControlProviderAuth` in `packages/contracts`, which belongs in its own PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — n/a, no UI changes
- [x] I included a video for animation/interaction changes — n/a, no motion or interaction changes

---

Model: Claude Opus 5. Harness: Claude Code, driven from T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider detection for unknown remotes using CLI auth status. Mis-matching a host could route GitHub operations to the wrong provider, but the path only runs for `unknown` remotes and requires a signed-in `gh` account.
> 
> **Overview**
> GitHub Enterprise remotes whose hostnames do not contain `github` (e.g. `git.example.edu`) are now claimed as GitHub when `gh` has a signed-in account for that host, instead of staying `unknown` and failing every PR operation.
> 
> GitHub discovery now implements `refineUnknownRemote`, matching GitLab’s existing hook. Any authenticated account on the host counts (not only the active one). Host comparison goes through exported `parseHostName` so remotes with ports still match `gh`’s bare hostnames. Hosts already classified by name are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2640c9716c50d33aadb728136a629393a7d6716e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect GitHub Enterprise remotes that `gh` is signed in to via `refineUnknownRemote`
> - Adds `refineUnknownGitHubRemote` to [GitHubSourceControlProvider.ts](https://github.com/pingdotgg/t3code/pull/7958/files#diff-e0f205b78b622887367441bbfc3eb4e71dfcda583b3e98e45ad9a7c72f8002bc), which parses `gh auth status` stdout and maps an 'unknown' remote to a GitHub provider when any authenticated account matches the remote's host.
> - Exports `parseHostName` from [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/7958/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d) to normalize hosts (dropping ports) for matching against `gh`'s bare hostname keys.
> - Wires `refineUnknownRemote` into the `discovery` object so unknown remotes are refined during discovery.
> - Updates [docs/user/source-control.md](https://github.com/pingdotgg/t3code/pull/7958/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05) to document GitHub Enterprise Server recognition via `gh` authentication.
> - Risk: non-standard-port remotes match `gh`'s bare hostname but preserve the original port in `baseUrl`; verify `refineUnknownGitHubRemote` port handling in [GitHubSourceControlProvider.ts](https://github.com/pingdotgg/t3code/pull/7958/files#diff-e0f205b78b622887367441bbfc3eb4e71dfcda583b3e98e45ad9a7c72f8002bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2640c97. 3 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/sourceControl/GitHubSourceControlProvider.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 107](https://github.com/pingdotgg/t3code/blob/2640c9716c50d33aadb728136a629393a7d6716e/apps/server/src/sourceControl/GitHubSourceControlProvider.ts#L107): `refineUnknownGitHubRemote` drops the remote's port before matching it to a `gh` host. If one hostname serves GitHub Enterprise and another provider on a different port (for example, `example.com` for GHES and `example.com:8443` for GitLab), an authenticated `gh` entry for `example.com` makes the unknown remote on port 8443 get incorrectly claimed as GitHub. The returned provider then routes operations to the wrong CLI; preserve or otherwise validate the remote port before claiming it. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->