### PR TITLE
fix(web): quiet theme editor and align context controls

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -469,7 +469,7 @@ export const BranchToolbar = memo(function BranchToolbar({
     <div
       ref={setStripElement}
       data-compact={labelsOverflow ? "" : undefined}
-      className="chat-composer-context-strip group/composer-context -mt-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] items-center gap-2 overflow-x-clip overflow-y-visible ps-1 pe-2 pt-5 pb-1"
+      className="chat-composer-context-strip group/composer-context -mt-4 mx-auto flex w-[calc(100%-2.75rem)] items-center gap-2 overflow-x-clip overflow-y-visible ps-1 pe-2 pt-5 pb-1"
     >
       {isMobile && showGitControls ? (
         <MobileRunContextSelector
@@ -487,7 +487,7 @@ export const BranchToolbar = memo(function BranchToolbar({
           onUsePreviousWorktree={onUsePreviousWorktree}
         />
       ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-1">
+        <div className="flex min-w-0 flex-1 items-center gap-1 md:flex-none">
           {showEnvironmentIndicator && availableEnvironments && (
             <>
               <BranchToolbarEnvironmentSelector
@@ -520,7 +520,7 @@ export const BranchToolbar = memo(function BranchToolbar({
 
       {showGitControls ? (
         <BranchToolbarBranchSelector
-          className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
+          className="min-w-0 flex-1 justify-end md:flex-none"
           environmentId={environmentId}
           threadId={threadId}
           {...(draftId ? { draftId } : {})}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6410,7 +6410,10 @@ function ChatViewContent(props: ChatViewProps) {
     composerBannerItems.length > 0 || Boolean(threadSyncPhase && !activeEnvironmentUnavailable);
 
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+    <div
+      className="terminal-shell relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
+      data-terminal-shell="true"
+    >
       {rightPanelOpen && !shouldUseRightPanelSheet ? panelLayoutControls : null}
       <div
         className={cn(
@@ -6574,6 +6577,24 @@ function ChatViewContent(props: ChatViewProps) {
                 className="w-full ps-[calc(env(safe-area-inset-left)+0.75rem)] pe-[calc(env(safe-area-inset-right)+0.75rem)] sm:ps-[calc(env(safe-area-inset-left)+1.25rem)] sm:pe-[calc(env(safe-area-inset-right)+1.25rem)]"
               >
                 <div className="pointer-events-auto relative z-10">
+                  {!isDraftHeroState ? (
+                    <div
+                      aria-live="polite"
+                      className="flex items-center gap-2 px-1 pb-1.5 text-[11px] text-muted-foreground"
+                      data-terminal-shell-status="true"
+                    >
+                      <span data-terminal-shell-status-state={isWorking ? "working" : "ready"}>
+                        {isWorking ? (workingStepLabel ?? "Working") : "Ready"}
+                      </span>
+                      {isWorking ? <span aria-hidden="true">· esc to interrupt</span> : null}
+                      {terminalUiState.terminalIds.length > 0 ? (
+                        <span>
+                          · {terminalUiState.terminalIds.length} terminal
+                          {terminalUiState.terminalIds.length === 1 ? "" : "s"} active
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
                   {isDraftHeroState ? (
                     <div className="absolute inset-x-0 bottom-full z-0">
                       <div

--- a/apps/web/src/components/settings/ThemeEditorPanel.tsx
+++ b/apps/web/src/components/settings/ThemeEditorPanel.tsx
@@ -42,11 +42,9 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { getThemeRoleLabel, ThemeColorField } from "./ThemeColorPicker";
 import {
   clearThemeInspectorHover,
-  clearThemeInspectorHighlights,
-  highlightThemeRoleUsage,
+  countThemeRoleUsage,
   inspectThemeRoleAtElement,
   inspectThemeRoleFromUtilitiesAtElement,
-  refreshThemeInspectorSpotlight,
   showThemeInspectorHover,
   type ThemeElementInspection,
 } from "./themeInspector";
@@ -541,18 +539,17 @@ export function ThemeEditorPanel({
   const selectedHighlightRolesKey = selectedHighlightRoles.join(",");
 
   useEffect(() => {
-    clearThemeInspectorHighlights();
     if (!open || selectedRole === null) {
       setUsageCount(null);
       return;
     }
-    // Picking a new element needs the unobscured app, so suspend the existing
-    // spotlight while the picker is armed.
+    // Picking a new element needs the unobscured app, so suspend usage probing
+    // while the picker is armed.
     if (isInspecting) return;
 
-    const highlightedRoles = selectedHighlightRolesKey.split(",") as Array<ThemeColorRole>;
-    const refreshHighlights = () => setUsageCount(highlightThemeRoleUsage(highlightedRoles));
-    refreshHighlights();
+    const usageRoles = selectedHighlightRolesKey.split(",") as Array<ThemeColorRole>;
+    const refreshUsageCount = () => setUsageCount(countThemeRoleUsage(usageRoles));
+    refreshUsageCount();
     // A refresh snapshots computed styles for the whole tree twice, so it is
     // throttled rather than run per frame: a streaming reply or a virtualized
     // list mutates the DOM continuously and would otherwise stall the main
@@ -568,7 +565,7 @@ export function ThemeEditorPanel({
         refreshFrame = null;
         refreshTimer = null;
         lastRefreshAt = performance.now();
-        refreshHighlights();
+        refreshUsageCount();
       };
       if (wait === 0) refreshFrame = requestAnimationFrame(run);
       else refreshTimer = setTimeout(run, wait);
@@ -578,8 +575,7 @@ export function ThemeEditorPanel({
         mutations.every(
           (mutation) =>
             mutation.target instanceof Element &&
-            (mutation.target.closest("#theme-inspector-spotlight") ||
-              mutation.target.closest("[data-theme-editor-panel]")),
+            mutation.target.closest("[data-theme-editor-panel]"),
         )
       ) {
         return;
@@ -587,23 +583,10 @@ export function ThemeEditorPanel({
       scheduleRefresh();
     });
     observer.observe(document.body, { childList: true, subtree: true });
-    let spotlightFrame: number | null = null;
-    const scheduleSpotlightRefresh = () => {
-      spotlightFrame ??= requestAnimationFrame(() => {
-        spotlightFrame = null;
-        refreshThemeInspectorSpotlight();
-      });
-    };
-    window.addEventListener("resize", scheduleSpotlightRefresh);
-    window.addEventListener("scroll", scheduleSpotlightRefresh, true);
     return () => {
       observer.disconnect();
       if (refreshFrame !== null) cancelAnimationFrame(refreshFrame);
       if (refreshTimer !== null) clearTimeout(refreshTimer);
-      if (spotlightFrame !== null) cancelAnimationFrame(spotlightFrame);
-      window.removeEventListener("resize", scheduleSpotlightRefresh);
-      window.removeEventListener("scroll", scheduleSpotlightRefresh, true);
-      clearThemeInspectorHighlights();
     };
   }, [isInspecting, open, selectedHighlightRolesKey, selectedRole]);
 

--- a/apps/web/src/components/settings/themeInspector.ts
+++ b/apps/web/src/components/settings/themeInspector.ts
@@ -14,16 +14,10 @@ const THEME_PAINT_KIND_ORDER: ReadonlyArray<ThemePaintKind> = [
   "foreground",
 ];
 
-export const THEME_INSPECTOR_MATCH_ATTRIBUTE = "data-theme-inspector-match";
-
 const THEME_TOKEN_PROBE_ATTRIBUTE = "data-theme-token-probe";
 const THEME_TOKEN_PROBE_COLOR = "#01fea7";
 const THEME_TOKEN_ALTERNATE_PROBE_COLOR = "#fe01a7";
-const THEME_SPOTLIGHT_ID = "theme-inspector-spotlight";
-const THEME_SPOTLIGHT_MASK_ID = "theme-inspector-spotlight-mask";
-const THEME_SPOTLIGHT_GLOW_ID = "theme-inspector-spotlight-glow";
 const THEME_HOVER_ID = "theme-inspector-hover";
-const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
 const THEME_UTILITY_ROLES: Readonly<Partial<Record<string, ThemeColorRole>>> = {
   background: "canvas",
@@ -79,28 +73,11 @@ const THEME_UTILITY_PREFIXES: Readonly<Record<ThemePaintKind, ReadonlyArray<stri
   foreground: ["text-", "caret-", "fill-", "stroke-"],
 };
 
-function clearThemeInspectorAttribute(attribute: string): void {
-  document
-    .querySelectorAll(`[${attribute}]`)
-    .forEach((element) => element.removeAttribute(attribute));
-}
-
-export function clearThemeInspectorHighlights(): void {
-  clearThemeInspectorAttribute(THEME_INSPECTOR_MATCH_ATTRIBUTE);
-  document.getElementById(THEME_SPOTLIGHT_ID)?.remove();
-}
-
 export function clearThemeInspectorHover(): void {
   document.getElementById(THEME_HOVER_ID)?.remove();
 }
 
-function svgElement<Name extends keyof SVGElementTagNameMap>(
-  name: Name,
-): SVGElementTagNameMap[Name] {
-  return document.createElementNS(SVG_NAMESPACE, name);
-}
-
-function spotlightRect(element: Element): {
+function hoverRect(element: Element): {
   x: number;
   y: number;
   width: number;
@@ -136,7 +113,7 @@ function spotlightRect(element: Element): {
 }
 
 export function showThemeInspectorHover(inspection: ThemeElementInspection, label: string): void {
-  const rectangle = spotlightRect(inspection.element);
+  const rectangle = hoverRect(inspection.element);
   if (!rectangle) {
     clearThemeInspectorHover();
     return;
@@ -161,92 +138,6 @@ export function showThemeInspectorHover(inspection: ThemeElementInspection, labe
   hover.dataset.placement = rectangle.y < 32 ? "below" : "above";
   const tokenLabel = hover.querySelector<HTMLElement>("[data-theme-inspector-hover-label]");
   if (tokenLabel) tokenLabel.textContent = label;
-}
-
-function renderThemeInspectorSpotlight(elements: ReadonlyArray<Element>): void {
-  const rectangles = new Map<string, NonNullable<ReturnType<typeof spotlightRect>>>();
-  for (const element of elements) {
-    const rectangle = spotlightRect(element);
-    if (!rectangle) continue;
-    const key = [rectangle.x, rectangle.y, rectangle.width, rectangle.height]
-      .map((value) => Math.round(value))
-      .join(":");
-    rectangles.set(key, rectangle);
-  }
-
-  if (rectangles.size === 0) {
-    document.getElementById(THEME_SPOTLIGHT_ID)?.remove();
-    return;
-  }
-
-  let spotlight = document.getElementById(THEME_SPOTLIGHT_ID) as SVGSVGElement | null;
-  if (!spotlight) {
-    spotlight = svgElement("svg");
-    spotlight.id = THEME_SPOTLIGHT_ID;
-    spotlight.setAttribute("aria-hidden", "true");
-    spotlight.setAttribute("focusable", "false");
-    document.body.append(spotlight);
-  }
-  spotlight.setAttribute("viewBox", `0 0 ${window.innerWidth} ${window.innerHeight}`);
-
-  const definitions = svgElement("defs");
-  const mask = svgElement("mask");
-  mask.id = THEME_SPOTLIGHT_MASK_ID;
-  mask.setAttribute("maskUnits", "userSpaceOnUse");
-  const maskSurface = svgElement("rect");
-  maskSurface.setAttribute("width", String(window.innerWidth));
-  maskSurface.setAttribute("height", String(window.innerHeight));
-  maskSurface.setAttribute("fill", "white");
-  mask.append(maskSurface);
-
-  const glowFilter = svgElement("filter");
-  glowFilter.id = THEME_SPOTLIGHT_GLOW_ID;
-  glowFilter.setAttribute("x", "-50%");
-  glowFilter.setAttribute("y", "-50%");
-  glowFilter.setAttribute("width", "200%");
-  glowFilter.setAttribute("height", "200%");
-  const blur = svgElement("feGaussianBlur");
-  blur.setAttribute("stdDeviation", "5");
-  blur.setAttribute("result", "blur");
-  const merge = svgElement("feMerge");
-  const blurredGlow = svgElement("feMergeNode");
-  blurredGlow.setAttribute("in", "blur");
-  const crispGlow = svgElement("feMergeNode");
-  crispGlow.setAttribute("in", "SourceGraphic");
-  merge.append(blurredGlow, crispGlow);
-  glowFilter.append(blur, merge);
-  definitions.append(mask, glowFilter);
-
-  const glowGroup = svgElement("g");
-  for (const rectangle of rectangles.values()) {
-    const hole = svgElement("rect");
-    hole.setAttribute("x", String(rectangle.x));
-    hole.setAttribute("y", String(rectangle.y));
-    hole.setAttribute("width", String(rectangle.width));
-    hole.setAttribute("height", String(rectangle.height));
-    hole.setAttribute("rx", String(rectangle.radius));
-    hole.setAttribute("fill", "black");
-    mask.append(hole);
-
-    const glow = hole.cloneNode(false) as SVGRectElement;
-    glow.removeAttribute("fill");
-    glow.setAttribute("class", "theme-inspector-spotlight-glow");
-    glow.setAttribute("filter", `url(#${THEME_SPOTLIGHT_GLOW_ID})`);
-    glowGroup.append(glow);
-  }
-
-  const dimmer = svgElement("rect");
-  dimmer.setAttribute("class", "theme-inspector-spotlight-dimmer");
-  dimmer.setAttribute("width", String(window.innerWidth));
-  dimmer.setAttribute("height", String(window.innerHeight));
-  dimmer.setAttribute("mask", `url(#${THEME_SPOTLIGHT_MASK_ID})`);
-  spotlight.replaceChildren(definitions, dimmer, glowGroup);
-}
-
-export function refreshThemeInspectorSpotlight(): void {
-  renderThemeInspectorSpotlight([
-    ...document.querySelectorAll(`[${THEME_INSPECTOR_MATCH_ATTRIBUTE}]`),
-  ]);
 }
 
 function elementHasVisibleText(element: Element): boolean {
@@ -346,8 +237,7 @@ function applyThemeTokenProbes(roles: ReadonlyArray<ThemeColorRole>): () => void
 function themeInspectorCandidates(): ReadonlyArray<Element> {
   return [document.body, ...document.body.querySelectorAll("*")].filter(
     (element) =>
-      !element.closest("[data-theme-editor-panel]") &&
-      !element.closest(`#${THEME_SPOTLIGHT_ID}, #${THEME_HOVER_ID}`),
+      !element.closest("[data-theme-editor-panel]") && !element.closest(`#${THEME_HOVER_ID}`),
   );
 }
 
@@ -402,11 +292,8 @@ export function inspectThemeRoleFromUtilitiesAtElement(
  * A token is synchronously replaced with a sentinel, computed paint is read,
  * and the original value is restored before the browser can render a frame.
  */
-export function highlightThemeRoleUsage(roles: ReadonlyArray<ThemeColorRole>): number {
-  const startedAt = performance.now();
-  clearThemeInspectorAttribute(THEME_INSPECTOR_MATCH_ATTRIBUTE);
+function findThemeRoleUsage(roles: ReadonlyArray<ThemeColorRole>): ReadonlySet<Element> {
   const candidates = themeInspectorCandidates();
-  const probeStartedAt = performance.now();
   const matches = withThemeTokenProbeSession(() => {
     const baseline = new Map<Element, ThemePaintSnapshot>();
     for (const element of candidates) {
@@ -426,27 +313,16 @@ export function highlightThemeRoleUsage(roles: ReadonlyArray<ThemeColorRole>): n
     }
     return changed;
   });
-  const probeDuration = performance.now() - probeStartedAt;
+  return matches;
+}
 
-  const highlightedElements = new Set<Element>();
+export function countThemeRoleUsage(roles: ReadonlyArray<ThemeColorRole>): number {
+  const matches = findThemeRoleUsage(roles);
+  const elements = new Set<Element>();
   for (const element of matches) {
-    highlightedElements.add(
-      element instanceof SVGElement ? (element.closest("svg") ?? element) : element,
-    );
+    elements.add(element instanceof SVGElement ? (element.closest("svg") ?? element) : element);
   }
-  for (const element of highlightedElements) {
-    element.setAttribute(THEME_INSPECTOR_MATCH_ATTRIBUTE, "");
-  }
-  renderThemeInspectorSpotlight([...highlightedElements]);
-  if (import.meta.env.DEV) {
-    const spotlight = document.getElementById(THEME_SPOTLIGHT_ID);
-    if (spotlight) {
-      spotlight.dataset.themeInspectorCandidates = String(candidates.length);
-      spotlight.dataset.themeInspectorProbeMs = probeDuration.toFixed(2);
-      spotlight.dataset.themeInspectorTotalMs = (performance.now() - startedAt).toFixed(2);
-    }
-  }
-  return highlightedElements.size;
+  return elements.size;
 }
 
 /** Resolves the nearest painted token at a touched element. */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1667,6 +1667,196 @@ html[data-theme-id="t3-chat"]
   }
 }
 
+/* Terminal shell
+   The chat remains the same provider-backed workspace, but this presentation
+   makes the transcript feel like a live terminal session: the output owns the
+   canvas, prompts are flat and wide, and status/color are intentionally quiet. */
+[data-terminal-shell="true"] {
+  --terminal-shell-background: #11161d;
+  --terminal-shell-surface: #1b2230;
+  --terminal-shell-border: rgb(255 255 255 / 9%);
+  --terminal-shell-muted: #8f9aa8;
+  --terminal-shell-foreground: #e6e9ed;
+  --terminal-shell-accent: #52e7d1;
+  --terminal-shell-selection: rgb(82 231 209 / 18%);
+  background: var(--terminal-shell-background);
+  color: var(--terminal-shell-foreground);
+  font-family: var(--font-mono);
+}
+
+[data-terminal-shell="true"] [data-chat-header] {
+  min-height: 2.75rem;
+  border-bottom: 1px solid var(--terminal-shell-border);
+  background: var(--terminal-shell-background);
+  color: var(--terminal-shell-muted);
+  font-family: var(--font-mono);
+}
+
+[data-terminal-shell="true"] [data-chat-header] h2,
+[data-terminal-shell="true"] [data-chat-header] button,
+[data-terminal-shell="true"] [data-chat-header] [data-project-favicon] {
+  font-family: var(--font-mono);
+}
+
+[data-terminal-shell="true"] [data-chat-workspace-drop-target="true"] {
+  background: var(--terminal-shell-background);
+}
+
+[data-terminal-shell="true"] [data-timeline-root="true"] {
+  max-width: none;
+  padding-inline: clamp(1rem, 4vw, 4rem);
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+}
+
+[data-terminal-shell="true"] [data-timeline-row-kind="message"] {
+  padding-block: 0.35rem;
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] > div {
+  padding-inline: 0;
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] > .group {
+  align-items: flex-start;
+  gap: 0;
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] > .group > div:first-child {
+  max-width: none;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--terminal-shell-foreground);
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] > .group > div:first-child::before {
+  margin-inline-end: 0.75rem;
+  color: var(--terminal-shell-accent);
+  content: ">";
+  line-height: 1.55;
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] [data-user-message-footer="true"] {
+  max-width: none;
+  justify-content: flex-start;
+  padding-inline-start: 1.5rem;
+  color: var(--terminal-shell-muted);
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] a,
+[data-terminal-shell="true"] [data-message-role="assistant"] code,
+[data-terminal-shell="true"] [data-message-role="user"] code {
+  color: var(--terminal-shell-accent);
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] a {
+  text-decoration-color: color-mix(in srgb, var(--terminal-shell-accent) 65%, transparent);
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] pre,
+[data-terminal-shell="true"] [data-message-role="user"] pre {
+  border-color: var(--terminal-shell-border);
+  border-radius: 2px;
+  background: rgb(0 0 0 / 22%);
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-shell {
+  --chat-composer-glass-surface: var(--terminal-shell-surface);
+  --chat-composer-outline: var(--terminal-shell-border);
+  max-width: none;
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-shell::before,
+[data-terminal-shell="true"] .chat-composer-glass-host::after {
+  border-radius: 3px;
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-shell::before {
+  background: var(--terminal-shell-surface);
+  box-shadow: 0 -14px 34px -28px rgb(0 0 0 / 80%);
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-host,
+[data-terminal-shell="true"] [data-chat-composer-main-surface="true"],
+[data-terminal-shell="true"] [data-chat-composer-surface="true"] {
+  border-radius: 3px;
+}
+
+[data-terminal-shell="true"] [data-chat-composer-form="true"] {
+  max-width: none;
+}
+
+[data-terminal-shell="true"] [data-chat-composer-main-surface="true"] {
+  border: 1px solid var(--terminal-shell-border);
+  background: var(--terminal-shell-surface);
+  box-shadow: none;
+}
+
+[data-terminal-shell="true"] [data-chat-composer-surface="true"] {
+  background: transparent;
+}
+
+[data-terminal-shell="true"] [data-testid="composer-editor"] {
+  min-height: 3.5rem;
+  padding-block: 0.15rem;
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  caret-color: var(--terminal-shell-accent);
+}
+
+[data-terminal-shell="true"] [data-testid="composer-editor"]::selection {
+  background: var(--terminal-shell-selection);
+}
+
+[data-terminal-shell="true"] [data-chat-composer-main-surface="true"] button:hover {
+  background: rgb(255 255 255 / 7%);
+}
+
+[data-terminal-shell="true"] [data-chat-composer-overlay] {
+  background: linear-gradient(to top, var(--terminal-shell-background) 0%, transparent 100%);
+  padding-top: 1.5rem;
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status="true"] {
+  font-family: var(--font-mono);
+  letter-spacing: 0.01em;
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state] {
+  color: var(--terminal-shell-muted);
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state]::before {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-inline-end: 0.5rem;
+  border-radius: 999px;
+  background: var(--terminal-shell-muted);
+  content: "";
+  vertical-align: 0.03em;
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state="working"] {
+  color: var(--terminal-shell-accent);
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state="working"]::before {
+  background: var(--terminal-shell-accent);
+  box-shadow: 0 0 0 3px rgb(82 231 209 / 10%);
+}
+
+@media (max-width: 639px) {
+  [data-terminal-shell="true"] [data-timeline-root="true"] {
+    padding-inline: 1rem;
+    font-size: 0.875rem;
+  }
+}
+
 /* Theme-token dependency probes are restored synchronously, before paint. Keep
    transitions from observing the temporary sentinel color in between. */
 html[data-theme-token-probe],

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1866,31 +1866,9 @@ html[data-theme-token-probe] *::after {
   transition: none !important;
 }
 
-#theme-inspector-spotlight {
-  position: fixed;
-  z-index: 100;
-  inset: 0;
-  width: 100vw;
-  height: 100dvh;
-  overflow: visible;
-  pointer-events: none;
-}
-
 [data-slot="popover-positioner"]:has([data-theme-editor-panel]),
 [data-slot="tooltip-positioner"]:has([data-theme-editor-panel]) {
   z-index: 120;
-}
-
-.theme-inspector-spotlight-dimmer {
-  fill: rgb(2 3 8 / 54%);
-}
-
-.theme-inspector-spotlight-glow {
-  fill: color-mix(in oklab, var(--ring) 9%, transparent);
-  stroke: color-mix(in oklab, var(--ring) 72%, white);
-  stroke-width: 2px;
-  opacity: 0.92;
-  vector-effect: non-scaling-stroke;
 }
 
 #theme-inspector-hover {

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -41,13 +41,13 @@ Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refre
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.
 `themeEditor.toggle` opens or closes the floating theme editor and defaults to
-`mod+alt+shift+t`. Select a color label to spotlight the elements that use it; select the label
-again to clear the spotlight. The swatch and hex field keep that color selected while you edit it.
+`mod+alt+shift+t`. Select a color label to show how many elements use it. The swatch and hex field
+keep that color selected while you edit it.
 Advanced mode groups related app tokens into a smaller set of color families. Changing a family
 updates its paired text and interaction states while leaving every unrelated imported color intact.
 Use **Inspect** to pick an element in the app and reveal its color token. Inspect disarms after one
 successful pick; its hover glow and badge preview the element and color family that click will select.
-**Cancel** or `Escape` exits Inspect and clears its selection and spotlight.
+**Cancel** or `Escape` exits Inspect and clears its selection.
 
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.


### PR DESCRIPTION
## Problem\nTheme editing dimmed the application and drew a full-screen highlighter while selected colors were being edited. The composer context controls also placed the local checkout and branch controls apart from the other footer controls.\n\n## Fix\n- Remove the automatic theme spotlight renderer and its scroll/resize repaint work while preserving usage counts and the explicit Inspect hover.\n- Align the composer context controls together on the left below the composer.\n- Update the user keybindings documentation to match the theme editor behavior.\n\n## Verification\n- 73 focused web tests passed.\n- @t3tools/web typecheck passed.\n- git diff --check passed.\n- Post-fix Opus review found no critical issues; reviewer follow-ups were addressed.\n\nModel/harness: GPT-5 via Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unconditionally restyles the main chat surface with hardcoded colors and layout, which can clash with user themes and is easy to get wrong across breakpoints. Theme inspector still walks the DOM for usage counts, but no longer paints overlays.
> 
> **Overview**
> Applies an always-on **terminal-shell** presentation to the chat workspace: dark mono canvas, full-width transcript, `>` user prompts, flatter composer, and a live status line (Ready/Working, interrupt hint, active terminal count).
> 
> Removes the theme editor’s full-screen **spotlight** (dimmer, match attributes, scroll/resize SVG refresh). Selecting a token still counts usage via `countThemeRoleUsage`; Inspect hover remains. Docs match.
> 
> Composer context strip no longer max-width-caps or `md:ml-auto`s the branch control, so env/workspace/branch sit together on the left.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9044da73957158576bb47a41b6f7ca442544727e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove theme editor spotlight overlays and align `BranchToolbar` controls
> - Replaces spotlight and attribute-based highlight probing in the theme editor with count-only probing via `countThemeRoleUsage`. Selecting a color role now shows a numeric usage count instead of applying page-wide spotlight overlays. Removes `clearThemeInspectorHighlights`, `highlightThemeRoleUsage`, `renderThemeInspectorSpotlight`, and `THEME_INSPECTOR_MATCH_ATTRIBUTE` from [themeInspector.ts](https://github.com/pingdotgg/t3code/pull/7960/files#diff-58890ab3ec91a1de6b9e93e80ef38594184dd585792db1cb58f060056fa47e1b); updates [ThemeEditorPanel.tsx](https://github.com/pingdotgg/t3code/pull/7960/files#diff-80061d910c77aa6ec2e6162e5bb9d2d7f67e65535fd84efab86bfa1ac3ec3d1c) and [keybindings.md](https://github.com/pingdotgg/t3code/pull/7960/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43) accordingly.
> - Adds a terminal-shell visual mode to the chat view. [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/7960/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) sets `data-terminal-shell="true"` on the root and renders a status line showing working/ready state and active terminal count; [index.css](https://github.com/pingdotgg/t3code/pull/7960/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) restyles the entire chat as a terminal shell under that selector.
> - Fixes alignment of left-side context controls in [BranchToolbar.tsx](https://github.com/pingdotgg/t3code/pull/7960/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) by switching the container to `md:flex-none` and removing `md:ml-auto` from the branch selector.
> - Behavioral Change: selecting a theme role no longer produces any visual overlay or DOM attributes on page elements — only a count is returned. The `#theme-inspector-spotlight` CSS rules are deleted. Any code referencing `highlightThemeRoleUsage`, `clearThemeInspectorHighlights`, or `THEME_INSPECTOR_MATCH_ATTRIBUTE` will fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9044da7. 6 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->