### PR TITLE
fix(web): tolerate external project script ids in keybinding commands

### DIFF
--- a/apps/web/src/projectScripts.test.ts
+++ b/apps/web/src/projectScripts.test.ts
@@ -58,6 +58,12 @@ describe("projectScripts helpers", () => {
     const command = commandForProjectScript("lint");
     expect(command).toBe("script.lint.run");
     expect(projectScriptIdFromCommand(command)).toBe("lint");
+
+    const externalId = "123e4567-e89b-42d3-a456-426614174000";
+    const externalCommand = commandForProjectScript(externalId);
+    expect(externalCommand).toBe(`script.${externalId}.run`);
+    expect(projectScriptIdFromCommand(externalCommand)).toBe(externalId);
+
     expect(projectScriptIdFromCommand("terminal.toggle")).toBeNull();
   });
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -115,7 +115,7 @@ it.effect("rejects invalid command values", () =>
     const result = yield* Effect.exit(
       decode(KeybindingRule, {
         key: "mod+j",
-        command: "script.Test.run",
+        command: "script..run",
       }),
     );
     assert.strictEqual(result._tag, "Failure");
@@ -129,6 +129,12 @@ it.effect("accepts dynamic script run commands", () =>
       command: "script.setup.run",
     });
     assert.strictEqual(parsed.command, "script.setup.run");
+
+    const parsedExternalId = yield* decode(KeybindingRule, {
+      key: "mod+r",
+      command: "script.123e4567-e89b-42d3-a456-426614174000.run",
+    });
+    assert.strictEqual(parsedExternalId.command, "script.123e4567-e89b-42d3-a456-426614174000.run");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { ForwardCompatibleArray, TrimmedString } from "./baseSchemas.ts";
+import { ForwardCompatibleArray, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 
 export const MAX_KEYBINDING_VALUE_LENGTH = 64;
 export const MAX_KEYBINDING_WHEN_LENGTH = 256;
@@ -77,10 +77,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
 
 export const SCRIPT_RUN_COMMAND_PATTERN = Schema.TemplateLiteral([
   Schema.Literal("script."),
-  Schema.NonEmptyString.check(
-    Schema.isMaxLength(MAX_SCRIPT_ID_LENGTH),
-    Schema.isPattern(/^[a-z0-9][a-z0-9-]*$/),
-  ),
+  TrimmedNonEmptyString,
   Schema.Literal(".run"),
 ]);
 


### PR DESCRIPTION
## Problem

The server accepts any non-empty trimmed string as a `ProjectScript.id`, but the client's `SCRIPT_RUN_COMMAND_PATTERN` only allowed lowercase slugs of up to 24 characters. An id dispatched over the API (e.g. a UUID) made `commandForProjectScript` throw during render, crashing every thread view and the project settings panel with no way to repair from the UI.

## Fix

Relax the pattern's middle segment to `TrimmedNonEmptyString`, matching the server-side constraint. UI-generated ids are still slugs via `nextProjectScriptId`, so nothing changes for normal usage; existing keybinding rules keep decoding.

Fixes #7851

## Validation

- `vp test run packages/contracts/src/keybindings.test.ts apps/web/src/projectScripts.test.ts` — 19 tests passed (includes new UUID round-trip cases)
- `pnpm --filter @t3tools/contracts typecheck`
- `pnpm --filter @t3tools/web typecheck`
- `vp fmt --check`, `vp lint`, `git diff --check`

Worked on by ox-alpha via the pi coding agent harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept external script IDs in `script.<id>.run` keybinding commands
> Replaces the constrained `NonEmptyString` schema for the middle segment of `keybindings.SCRIPT_RUN_COMMAND_PATTERN` with `TrimmedNonEmptyString`, so external IDs like UUIDs are accepted. Tests in [keybindings.test.ts](https://github.com/pingdotgg/t3code/pull/7961/files#diff-a6208b09d36f773ab88d431329aae0d1bea2baf9b85be89fad3817443c59ac81) and [projectScripts.test.ts](https://github.com/pingdotgg/t3code/pull/7961/files#diff-cea5eafa5d5e180b1582a180f2cc81f1f0fe8f370e9df8a3b8e811f2ec6cc4f1) are updated to cover UUID-style IDs and confirm that empty IDs remain invalid.
> - Risk: removes the previous `/^[a-z0-9][a-z0-9-]*$/` pattern and max-length checks on the script ID segment; any trimmed non-empty string is now valid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6be823d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->