### PR TITLE
fix(web): refine terminal chat layout

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -487,7 +487,7 @@ export const BranchToolbar = memo(function BranchToolbar({
           onUsePreviousWorktree={onUsePreviousWorktree}
         />
       ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-1">
+        <div className="flex min-w-0 flex-none items-center gap-1">
           {showEnvironmentIndicator && availableEnvironments && (
             <>
               <BranchToolbarEnvironmentSelector
@@ -520,7 +520,7 @@ export const BranchToolbar = memo(function BranchToolbar({
 
       {showGitControls ? (
         <BranchToolbarBranchSelector
-          className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
+          className="min-w-0 flex-none justify-start"
           environmentId={environmentId}
           threadId={threadId}
           {...(draftId ? { draftId } : {})}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6410,7 +6410,10 @@ function ChatViewContent(props: ChatViewProps) {
     composerBannerItems.length > 0 || Boolean(threadSyncPhase && !activeEnvironmentUnavailable);
 
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+    <div
+      className="terminal-shell relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
+      data-terminal-shell="true"
+    >
       {rightPanelOpen && !shouldUseRightPanelSheet ? panelLayoutControls : null}
       <div
         className={cn(
@@ -6574,6 +6577,24 @@ function ChatViewContent(props: ChatViewProps) {
                 className="w-full ps-[calc(env(safe-area-inset-left)+0.75rem)] pe-[calc(env(safe-area-inset-right)+0.75rem)] sm:ps-[calc(env(safe-area-inset-left)+1.25rem)] sm:pe-[calc(env(safe-area-inset-right)+1.25rem)]"
               >
                 <div className="pointer-events-auto relative z-10">
+                  {!isDraftHeroState ? (
+                    <div
+                      aria-live="polite"
+                      className="flex items-center gap-2 px-1 pb-1.5 text-[11px] text-muted-foreground"
+                      data-terminal-shell-status="true"
+                    >
+                      <span data-terminal-shell-status-state={isWorking ? "working" : "ready"}>
+                        {isWorking ? (workingStepLabel ?? "Working") : "Ready"}
+                      </span>
+                      {isWorking ? <span aria-hidden="true">· esc to interrupt</span> : null}
+                      {terminalUiState.terminalIds.length > 0 ? (
+                        <span>
+                          · {terminalUiState.terminalIds.length} terminal
+                          {terminalUiState.terminalIds.length === 1 ? "" : "s"} active
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
                   {isDraftHeroState ? (
                     <div className="absolute inset-x-0 bottom-full z-0">
                       <div

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6574,7 +6574,7 @@ function ChatViewContent(props: ChatViewProps) {
             >
               <div
                 ref={attachDraftHeroTransitionGroupRef}
-                className="w-full ps-[calc(env(safe-area-inset-left)+0.75rem)] pe-[calc(env(safe-area-inset-right)+0.75rem)] sm:ps-[calc(env(safe-area-inset-left)+1.25rem)] sm:pe-[calc(env(safe-area-inset-right)+1.25rem)]"
+                className="w-full ps-[calc(env(safe-area-inset-left)+0.75rem+clamp(1rem,4vw,4rem))] pe-[calc(env(safe-area-inset-right)+0.75rem+clamp(1rem,4vw,4rem))] sm:ps-[calc(env(safe-area-inset-left)+1.25rem+clamp(1rem,4vw,4rem)+0.375rem)] sm:pe-[calc(env(safe-area-inset-right)+1.25rem+clamp(1rem,4vw,4rem)+0.375rem)]"
               >
                 <div className="pointer-events-auto relative z-10">
                   {!isDraftHeroState ? (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4791,6 +4791,21 @@ function ChatViewContent(props: ChatViewProps) {
     );
   }, [activeThreadId, terminalUiState.terminalOpen]);
 
+  const interruptActiveTurn = useCallback(async () => {
+    if (!activeThread) return;
+    const result = await interruptThreadTurn({
+      environmentId,
+      input: buildThreadTurnInterruptInput(activeThread),
+    });
+    if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+      const error = squashAtomCommandFailure(result);
+      setThreadError(
+        activeThread.id,
+        error instanceof Error ? error.message : "Failed to interrupt the current turn.",
+      );
+    }
+  }, [activeThread, environmentId, interruptThreadTurn, setThreadError]);
+
   useEffect(() => {
     if (!activeThreadKey) return;
     const previous = terminalUiOpenByThreadRef.current[activeThreadKey] ?? false;
@@ -4838,6 +4853,19 @@ function ChatViewContent(props: ChatViewProps) {
         terminalOpen: Boolean(terminalUiState.terminalOpen),
         modelPickerOpen: composerRef.current?.isModelPickerOpen() ?? false,
       };
+
+      if (
+        event.ctrlKey &&
+        event.key.toLowerCase() === "c" &&
+        isWorking &&
+        !shortcutContext.terminalFocus &&
+        !shortcutContext.modelPickerOpen
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        void interruptActiveTurn();
+        return;
+      }
 
       if (
         !shortcutContext.terminalFocus &&
@@ -4959,6 +4987,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeProject,
     activeRightPanelSurface,
     addTerminalSurface,
+    isWorking,
     terminalUiState.terminalOpen,
     terminalUiState.activeTerminalId,
     activeThreadId,
@@ -4970,6 +4999,7 @@ function ChatViewContent(props: ChatViewProps) {
     splitTerminal,
     splitPanelTerminal,
     keybindings,
+    interruptActiveTurn,
     onToggleDiff,
     toggleRightPanel,
     toggleRightPanelMaximized,

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -581,7 +581,7 @@ describe("MessagesTimeline", () => {
 
     expect(markup).not.toContain("Show full message");
     expect(markup).toContain('data-user-message-collapsible="false"');
-    expect(markup).toContain("rounded-2xl bg-message p-3");
+    expect(markup).toContain("rounded-xl border border-border/35 bg-message/45");
   });
 
   it("preserves arbitrary XML-like tags and comparisons in rendered user messages", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -288,6 +288,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const disclosureAnchorKeyRef = useRef<string | null>(null);
   const disclosureSettleFrameRef = useRef<number | null>(null);
   const disclosureSettleSecondFrameRef = useRef<number | null>(null);
+  const minimapScrollFrameRef = useRef<number | null>(null);
   const previousContentInsetEndAdjustmentRef = useRef(contentInsetEndAdjustment);
 
   useLayoutEffect(() => {
@@ -307,6 +308,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       }
       if (disclosureSettleSecondFrameRef.current !== null) {
         cancelAnimationFrame(disclosureSettleSecondFrameRef.current);
+      }
+      if (minimapScrollFrameRef.current !== null) {
+        cancelAnimationFrame(minimapScrollFrameRef.current);
       }
     };
   }, []);
@@ -451,7 +455,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     return config ? { ...config, onReady: handleAnchorReady } : undefined;
   }, [anchorMessageId, handleAnchorReady, rows]);
 
-  const handleScroll = useCallback(() => {
+  const updateScrollState = useCallback(() => {
+    minimapScrollFrameRef.current = null;
     const state = listRef.current?.getState?.();
     const isAtEnd = resolveTimelineIsAtEnd(state, contentInsetEndAdjustment);
     if (isAtEnd !== undefined) {
@@ -476,15 +481,24 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         rowTop !== null &&
         rowTop < scrollBottom &&
         rowTop + Math.max(1, rowHeight ?? 1) > scrollTop;
-
-      strip.dataset.inView = inView ? "true" : "false";
+      const nextValue = inView ? "true" : "false";
+      if (strip.dataset.inView !== nextValue) {
+        strip.dataset.inView = nextValue;
+      }
     }
   }, [contentInsetEndAdjustment, listRef, minimapItems, minimapStripMap, onIsAtEndChange]);
 
+  const handleScroll = useCallback(() => {
+    if (minimapScrollFrameRef.current !== null) {
+      return;
+    }
+    minimapScrollFrameRef.current = requestAnimationFrame(updateScrollState);
+  }, [updateScrollState]);
+
   useEffect(() => {
-    const frame = requestAnimationFrame(handleScroll);
+    const frame = requestAnimationFrame(updateScrollState);
     return () => cancelAnimationFrame(frame);
-  }, [handleScroll, rows.length]);
+  }, [rows.length, updateScrollState]);
 
   useEffect(() => {
     if (!timelineViewportElement) {
@@ -1008,66 +1022,68 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
 
   return (
-    <div className="group flex flex-col items-end gap-1">
-      <div className="relative max-w-[80%] rounded-2xl bg-message p-3 text-message-foreground">
-        {regularImages.length > 0 && (
-          <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-            {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-              <div
-                key={image.id}
-                className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-              >
-                {image.previewUrl ? (
-                  <button
-                    type="button"
-                    className="h-full w-full cursor-zoom-in"
-                    aria-label={`Preview ${image.name}`}
-                    onClick={() => {
-                      const preview = buildExpandedImagePreview(regularImages, image.id);
-                      if (!preview) return;
-                      ctx.onImageExpand(preview);
-                    }}
-                  >
-                    <img
-                      src={image.previewUrl}
-                      alt={image.name}
-                      className="block h-auto max-h-[220px] w-full object-cover"
-                    />
-                  </button>
-                ) : (
-                  <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-secondary-label text-[11px]">
-                    {image.name}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-        {previewAnnotations.map((annotation, index) => (
-          <UserMessagePreviewAnnotationCard
-            key={annotation.id}
-            annotation={annotation}
-            image={previewImages[index] ?? null}
+    <div className="group flex flex-col items-start gap-1">
+      <div className="flex min-w-0 w-full items-start gap-2">
+        <div className="relative min-w-0 w-full rounded-xl border border-border/35 bg-message/45 px-2.5 py-2 text-message-foreground">
+          {regularImages.length > 0 && (
+            <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
+              {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                <div
+                  key={image.id}
+                  className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                >
+                  {image.previewUrl ? (
+                    <button
+                      type="button"
+                      className="h-full w-full cursor-zoom-in"
+                      aria-label={`Preview ${image.name}`}
+                      onClick={() => {
+                        const preview = buildExpandedImagePreview(regularImages, image.id);
+                        if (!preview) return;
+                        ctx.onImageExpand(preview);
+                      }}
+                    >
+                      <img
+                        src={image.previewUrl}
+                        alt={image.name}
+                        className="block h-auto max-h-[220px] w-full object-cover"
+                      />
+                    </button>
+                  ) : (
+                    <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-secondary-label text-[11px]">
+                      {image.name}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {previewAnnotations.map((annotation, index) => (
+            <UserMessagePreviewAnnotationCard
+              key={annotation.id}
+              annotation={annotation}
+              image={previewImages[index] ?? null}
+            />
+          ))}
+          {elementContexts.length > 0 ? (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {elementContexts.map((context) => (
+                <UserMessageElementContextChip
+                  key={`${context.header}:${context.body}`}
+                  context={context}
+                />
+              ))}
+            </div>
+          ) : null}
+          <CollapsibleUserMessageBody
+            text={elementContextState.promptText}
+            terminalContexts={terminalContexts}
+            skills={ctx.skills}
+            markdownCwd={ctx.markdownCwd}
           />
-        ))}
-        {elementContexts.length > 0 ? (
-          <div className="mb-2 flex flex-wrap gap-1.5">
-            {elementContexts.map((context) => (
-              <UserMessageElementContextChip
-                key={`${context.header}:${context.body}`}
-                context={context}
-              />
-            ))}
-          </div>
-        ) : null}
-        <CollapsibleUserMessageBody
-          text={elementContextState.promptText}
-          terminalContexts={terminalContexts}
-          skills={ctx.skills}
-          markdownCwd={ctx.markdownCwd}
-        />
+        </div>
       </div>
-      <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+      <div className="flex w-full items-center justify-start text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip>
             <TooltipTrigger render={<p className="text-muted-foreground text-xs tabular-nums" />}>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1829,7 +1829,7 @@ html[data-theme-id="t3-chat"]
 
 [data-terminal-shell="true"] [data-chat-composer-overlay] {
   background: linear-gradient(to top, var(--terminal-shell-background) 0%, transparent 100%);
-  padding-top: 0;
+  padding-top: 1.5rem;
 }
 
 [data-terminal-shell="true"] [data-terminal-shell-status="true"] {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1727,16 +1727,27 @@ html[data-theme-id="t3-chat"]
   max-width: none;
   border: 0;
   border-radius: 0;
-  background: transparent;
-  padding: 0;
+  background: var(--terminal-shell-surface);
+  padding: 0.5rem 0.625rem;
   color: var(--terminal-shell-foreground);
 }
 
 [data-terminal-shell="true"] [data-message-role="user"] > .group > div:first-child::before {
-  margin-inline-end: 0.75rem;
+  margin-inline-end: 0.375rem;
   color: var(--terminal-shell-accent);
   content: ">";
   line-height: 1.55;
+}
+
+[data-terminal-shell="true"]
+  [data-message-role="user"]
+  > .group
+  > div:first-child
+  > div:first-child {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }
 
 [data-terminal-shell="true"] [data-message-role="user"] [data-user-message-footer="true"] {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1829,7 +1829,7 @@ html[data-theme-id="t3-chat"]
 
 [data-terminal-shell="true"] [data-chat-composer-overlay] {
   background: linear-gradient(to top, var(--terminal-shell-background) 0%, transparent 100%);
-  padding-top: 0.5rem;
+  padding-top: 0;
 }
 
 [data-terminal-shell="true"] [data-terminal-shell-status="true"] {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1667,6 +1667,196 @@ html[data-theme-id="t3-chat"]
   }
 }
 
+/* Terminal shell
+   The chat remains the same provider-backed workspace, but this presentation
+   makes the transcript feel like a live terminal session: the output owns the
+   canvas, prompts are flat and wide, and status/color are intentionally quiet. */
+[data-terminal-shell="true"] {
+  --terminal-shell-background: #11161d;
+  --terminal-shell-surface: #1b2230;
+  --terminal-shell-border: rgb(255 255 255 / 9%);
+  --terminal-shell-muted: #8f9aa8;
+  --terminal-shell-foreground: #e6e9ed;
+  --terminal-shell-accent: #52e7d1;
+  --terminal-shell-selection: rgb(82 231 209 / 18%);
+  background: var(--terminal-shell-background);
+  color: var(--terminal-shell-foreground);
+  font-family: var(--font-mono);
+}
+
+[data-terminal-shell="true"] [data-chat-header] {
+  min-height: 2.75rem;
+  border-bottom: 1px solid var(--terminal-shell-border);
+  background: var(--terminal-shell-background);
+  color: var(--terminal-shell-muted);
+  font-family: var(--font-mono);
+}
+
+[data-terminal-shell="true"] [data-chat-header] h2,
+[data-terminal-shell="true"] [data-chat-header] button,
+[data-terminal-shell="true"] [data-chat-header] [data-project-favicon] {
+  font-family: var(--font-mono);
+}
+
+[data-terminal-shell="true"] [data-chat-workspace-drop-target="true"] {
+  background: var(--terminal-shell-background);
+}
+
+[data-terminal-shell="true"] [data-timeline-root="true"] {
+  max-width: none;
+  padding-inline: clamp(1rem, 4vw, 4rem);
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+}
+
+[data-terminal-shell="true"] [data-timeline-row-kind="message"] {
+  padding-block: 0.35rem;
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] > div {
+  padding-inline: 0;
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] > .group {
+  align-items: flex-start;
+  gap: 0;
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] > .group > div:first-child {
+  max-width: none;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--terminal-shell-foreground);
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] > .group > div:first-child::before {
+  margin-inline-end: 0.75rem;
+  color: var(--terminal-shell-accent);
+  content: ">";
+  line-height: 1.55;
+}
+
+[data-terminal-shell="true"] [data-message-role="user"] [data-user-message-footer="true"] {
+  max-width: none;
+  justify-content: flex-start;
+  padding-inline-start: 1.5rem;
+  color: var(--terminal-shell-muted);
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] a,
+[data-terminal-shell="true"] [data-message-role="assistant"] code,
+[data-terminal-shell="true"] [data-message-role="user"] code {
+  color: var(--terminal-shell-accent);
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] a {
+  text-decoration-color: color-mix(in srgb, var(--terminal-shell-accent) 65%, transparent);
+}
+
+[data-terminal-shell="true"] [data-message-role="assistant"] pre,
+[data-terminal-shell="true"] [data-message-role="user"] pre {
+  border-color: var(--terminal-shell-border);
+  border-radius: 2px;
+  background: rgb(0 0 0 / 22%);
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-shell {
+  --chat-composer-glass-surface: var(--terminal-shell-surface);
+  --chat-composer-outline: var(--terminal-shell-border);
+  max-width: none;
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-shell::before,
+[data-terminal-shell="true"] .chat-composer-glass-host::after {
+  border-radius: 3px;
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-shell::before {
+  background: var(--terminal-shell-surface);
+  box-shadow: 0 -14px 34px -28px rgb(0 0 0 / 80%);
+}
+
+[data-terminal-shell="true"] .chat-composer-glass-host,
+[data-terminal-shell="true"] [data-chat-composer-main-surface="true"],
+[data-terminal-shell="true"] [data-chat-composer-surface="true"] {
+  border-radius: 3px;
+}
+
+[data-terminal-shell="true"] [data-chat-composer-form="true"] {
+  max-width: none;
+}
+
+[data-terminal-shell="true"] [data-chat-composer-main-surface="true"] {
+  border: 1px solid var(--terminal-shell-border);
+  background: var(--terminal-shell-surface);
+  box-shadow: none;
+}
+
+[data-terminal-shell="true"] [data-chat-composer-surface="true"] {
+  background: transparent;
+}
+
+[data-terminal-shell="true"] [data-testid="composer-editor"] {
+  min-height: 3.5rem;
+  padding-block: 0.15rem;
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  caret-color: var(--terminal-shell-accent);
+}
+
+[data-terminal-shell="true"] [data-testid="composer-editor"]::selection {
+  background: var(--terminal-shell-selection);
+}
+
+[data-terminal-shell="true"] [data-chat-composer-main-surface="true"] button:hover {
+  background: rgb(255 255 255 / 7%);
+}
+
+[data-terminal-shell="true"] [data-chat-composer-overlay] {
+  background: linear-gradient(to top, var(--terminal-shell-background) 0%, transparent 100%);
+  padding-top: 1.5rem;
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status="true"] {
+  font-family: var(--font-mono);
+  letter-spacing: 0.01em;
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state] {
+  color: var(--terminal-shell-muted);
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state]::before {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-inline-end: 0.5rem;
+  border-radius: 999px;
+  background: var(--terminal-shell-muted);
+  content: "";
+  vertical-align: 0.03em;
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state="working"] {
+  color: var(--terminal-shell-accent);
+}
+
+[data-terminal-shell="true"] [data-terminal-shell-status-state="working"]::before {
+  background: var(--terminal-shell-accent);
+  box-shadow: 0 0 0 3px rgb(82 231 209 / 10%);
+}
+
+@media (max-width: 639px) {
+  [data-terminal-shell="true"] [data-timeline-root="true"] {
+    padding-inline: 1rem;
+    font-size: 0.875rem;
+  }
+}
+
 /* Theme-token dependency probes are restored synchronously, before paint. Keep
    transitions from observing the temporary sentinel color in between. */
 html[data-theme-token-probe],

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1829,7 +1829,7 @@ html[data-theme-id="t3-chat"]
 
 [data-terminal-shell="true"] [data-chat-composer-overlay] {
   background: linear-gradient(to top, var(--terminal-shell-background) 0%, transparent 100%);
-  padding-top: 1.5rem;
+  padding-top: 0.5rem;
 }
 
 [data-terminal-shell="true"] [data-terminal-shell-status="true"] {


### PR DESCRIPTION
What changed: refined terminal chat layout, sent-prompt surfaces, composer alignment, grouped centered checkout controls, and coalesced minimap scroll updates. Verification: MessagesTimeline 28 passed; BranchToolbar logic 69 passed; web typecheck and git diff --check passed. The configured external opus-review command was unavailable because its command module is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly presentation, but a capture-phase Ctrl+C handler now interrupts the active turn whenever the agent is working (unless the terminal or model picker has focus), which can override copy. Terminal-shell CSS is always applied on ChatView.
> 
> **Overview**
> Presents the chat workspace as a live terminal session: `ChatView` always sets `data-terminal-shell`, and new CSS in `index.css` applies a dark mono canvas, wide transcript, prompt `>` prefix, and quieter composer chrome.
> 
> User messages are left-aligned and full-width with flatter bordered surfaces instead of right-aligned bubbles. A polite live status line above the composer shows Ready/Working, interrupt hint, and active terminal count. Composer overlay padding is widened to match the timeline gutter.
> 
> Ctrl+C (when working, and not in the terminal or model picker) interrupts the current turn. Minimap/end-of-list scroll updates are coalesced with `requestAnimationFrame`. Branch toolbar env/branch controls no longer grow and sit left-justified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6315dba9486691e20645426a886c59957c633148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine terminal chat layout with new shell theme, `Ctrl+C` interrupt, and restyled user messages
> - Adds a terminal-shell visual theme keyed off `data-terminal-shell="true"` in [index.css](https://github.com/pingdotgg/t3code/pull/7962/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd), giving the chat mono font, dark surfaces, and flat user prompts with a leading chevron
> - Wires `Ctrl+C` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/7962/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to interrupt the active assistant turn when the terminal is not focused and the model picker is closed; adds an aria-live status line showing working state and active terminal count
> - Reworks user message markup in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/7962/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) to left-aligned, flat bordered blocks (`rounded-xl`, `border border-border/35`)
> - Throttles timeline scroll-state updates with `requestAnimationFrame` and skips redundant DOM writes to the minimap in-view markers
> - Adjusts flex/alignment in [BranchToolbar.tsx](https://github.com/pingdotgg/t3code/pull/7962/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) so the controls container no longer grows and the branch selector is left-aligned
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6315dba. 2 files reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 4858](https://github.com/pingdotgg/t3code/blob/6315dba9486691e20645426a886c59957c633148/apps/web/src/components/ChatView.tsx#L4858): The capture-phase `Ctrl+C` branch interrupts whenever `isWorking` is true without checking whether the event target is an editable field or whether the user has a text selection. While a turn is running, pressing Ctrl+C to copy selected transcript or composer text calls `preventDefault()` and `interruptActiveTurn()`, so copying fails and the active turn is stopped unexpectedly. <b>[ Already posted ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/index.css — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1682](https://github.com/pingdotgg/t3code/blob/6315dba9486691e20645426a886c59957c633148/apps/web/src/index.css#L1682): The terminal shell always applies a dark background, but it does not override the theme semantic foreground tokens used by descendants. In light mode, `ChatMarkdown` explicitly uses `text-foreground/80` (and metadata/work rows use similar semantic text utilities), so those declarations override the inherited `color` here and render dark text on `#11161d`, making assistant output and controls difficult or impossible to read. Scope the foreground/muted tokens to the terminal shell or explicitly style those descendants. <b>[ Already posted ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->