### PR TITLE
fix(web): clarify terminal sidebar grouping

### DIFF
--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -10,7 +10,6 @@ import {
   TerminalSquare,
   Volume2,
   VolumeOff,
-  X,
 } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
@@ -33,6 +32,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { Kbd } from "~/components/ui/kbd";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "~/components/ui/menu";
 import { ScrollArea } from "~/components/ui/scroll-area";
+import { PanelTabCloseButton } from "~/components/ui/panel-tab-close-button";
 import { faviconUrlForOrigin } from "~/lib/favicon";
 import { useTheme } from "~/hooks/useTheme";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
@@ -823,29 +823,24 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                       : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
                   )}
                 >
-                  <button
-                    type="button"
-                    className="cursor-pointer group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted"
-                    aria-label={`Close ${title}`}
+                  <PanelTabCloseButton
+                    label={`Close ${title}`}
                     onClick={() => props.onCloseSurface(surface)}
                   >
-                    <span className="relative flex size-3 items-center justify-center group-hover/tab:hidden group-focus-visible/close:hidden">
-                      <SurfaceIcon
-                        surface={surface}
-                        sessions={props.previewSessions}
-                        desktopByTabId={props.desktopByTabId}
-                        theme={resolvedTheme}
-                        pullRequestStatuses={props.pullRequestStatuses}
+                    <SurfaceIcon
+                      surface={surface}
+                      sessions={props.previewSessions}
+                      desktopByTabId={props.desktopByTabId}
+                      theme={resolvedTheme}
+                      pullRequestStatuses={props.pullRequestStatuses}
+                    />
+                    {pending ? (
+                      <span
+                        className="absolute -right-0.5 -bottom-0.5 size-1.5 rounded-full bg-current"
+                        aria-hidden
                       />
-                      {pending ? (
-                        <span
-                          className="absolute -right-0.5 -bottom-0.5 size-1.5 rounded-full bg-current"
-                          aria-hidden
-                        />
-                      ) : null}
-                    </span>
-                    <X className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
-                  </button>
+                    ) : null}
+                  </PanelTabCloseButton>
                   {audio === "none" || !audioRuntimeTabId ? null : (
                     <Tooltip>
                       <TooltipTrigger

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1645,65 +1645,39 @@ export default function ThreadTerminalDrawer({
                         </button>
                       )}
 
-                      <div
-                        className={cn(
-                          "flex flex-col gap-0.5",
-                          showGroupHeaders && "ml-1 border-l border-border/60 pl-1.5",
-                        )}
-                      >
+                      <div className="flex flex-col gap-0.5">
                         {terminalGroup.terminalIds.map((terminalId) => {
                           const isActive = terminalId === resolvedActiveTerminalId;
-                          const closeTerminalLabel = `Close ${
-                            terminalLabelById.get(terminalId) ?? "terminal"
-                          }${isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""}`;
+                          const terminalLabel = terminalLabelById.get(terminalId) ?? "Terminal";
+                          const closeTerminalLabel = `Close ${terminalLabel}${
+                            isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""
+                          }`;
                           return (
                             <div
                               key={terminalId}
-                              className={`group flex items-center gap-1 rounded px-1 py-0.5 text-[11px] ${
+                              className={cn(
+                                "group/tab flex h-6 w-full items-center gap-0.5 rounded-md pr-2 pl-1.5 text-xs",
                                 isActive
                                   ? "bg-accent text-foreground"
-                                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                              }`}
-                            >
-                              {showGroupHeaders && (
-                                <span className="text-[10px] text-muted-foreground/80">└</span>
+                                  : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
                               )}
+                            >
                               <button
                                 type="button"
-                                className="flex min-w-0 flex-1 items-center gap-1 text-left"
+                                className="group/close relative flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm hover:bg-muted"
+                                aria-label={closeTerminalLabel}
+                                onClick={() => confirmCloseTerminal(terminalId)}
+                              >
+                                <TerminalSquare className="size-3 shrink-0 group-hover/tab:hidden group-focus-visible/close:hidden" />
+                                <XIcon className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
+                              </button>
+                              <button
+                                type="button"
+                                className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-left"
                                 onClick={() => onActiveTerminalChange(terminalId)}
                               >
-                                <TerminalSquare className="size-3 shrink-0" />
-                                <span className="truncate">
-                                  {terminalLabelById.get(terminalId) ?? "Terminal"}
-                                </span>
+                                <span className="truncate">{terminalLabel}</span>
                               </button>
-                              {normalizedTerminalIds.length > 1 && (
-                                <Popover>
-                                  <PopoverTrigger
-                                    openOnHover
-                                    render={
-                                      <button
-                                        type="button"
-                                        className="inline-flex size-3.5 items-center justify-center rounded text-xs font-medium leading-none text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
-                                        onClick={() => confirmCloseTerminal(terminalId)}
-                                        aria-label={closeTerminalLabel}
-                                      />
-                                    }
-                                  >
-                                    <XIcon className="size-2.5" />
-                                  </PopoverTrigger>
-                                  <PopoverPopup
-                                    tooltipStyle
-                                    side="bottom"
-                                    sideOffset={6}
-                                    align="center"
-                                    className="pointer-events-none select-none"
-                                  >
-                                    {closeTerminalLabel}
-                                  </PopoverPopup>
-                                </Popover>
-                              )}
                             </div>
                           );
                         })}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -11,7 +11,6 @@ import {
   SquareSplitVertical,
   TerminalSquare,
   Trash2,
-  XIcon,
 } from "lucide-react";
 import {
   type ContextMenuItem,
@@ -34,6 +33,7 @@ import {
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { Button } from "~/components/ui/button";
+import { PanelTabCloseButton } from "~/components/ui/panel-tab-close-button";
 import { readTextFromClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { cn } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
@@ -1679,15 +1679,12 @@ export default function ThreadTerminalDrawer({
                                   : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
                               )}
                             >
-                              <button
-                                type="button"
-                                className="group/close relative flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm hover:bg-muted"
-                                aria-label={closeTerminalLabel}
+                              <PanelTabCloseButton
+                                label={closeTerminalLabel}
                                 onClick={() => confirmCloseTerminal(terminalId)}
                               >
-                                <TerminalSquare className="size-3 shrink-0 group-hover/tab:hidden group-focus-visible/close:hidden" />
-                                <XIcon className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
-                              </button>
+                                <TerminalSquare className="size-3 shrink-0" />
+                              </PanelTabCloseButton>
                               <button
                                 type="button"
                                 className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-left"

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -6,6 +6,7 @@ import {
 import { type TerminalSessionState } from "@t3tools/client-runtime/state/terminal";
 import {
   Plus,
+  Square,
   SquareSplitHorizontal,
   SquareSplitVertical,
   TerminalSquare,
@@ -1622,26 +1623,42 @@ export default function ThreadTerminalDrawer({
               </div>
 
               <div className="min-h-0 flex-1 overflow-y-auto px-1 py-1">
-                {resolvedTerminalGroups.map((terminalGroup, groupIndex) => {
+                {resolvedTerminalGroups.map((terminalGroup) => {
                   const isGroupActive =
                     terminalGroup.terminalIds.includes(resolvedActiveTerminalId);
                   const groupActiveTerminalId = isGroupActive
                     ? resolvedActiveTerminalId
                     : (terminalGroup.terminalIds[0] ?? resolvedActiveTerminalId);
+                  const terminalCount = terminalGroup.terminalIds.length;
+                  const isSplitGroup = terminalCount > 1;
+                  const groupLabel = !isSplitGroup
+                    ? "Single"
+                    : terminalGroup.splitDirection === "vertical"
+                      ? "Stacked"
+                      : "Side by side";
+                  const GroupIcon = !isSplitGroup
+                    ? Square
+                    : terminalGroup.splitDirection === "vertical"
+                      ? SquareSplitVertical
+                      : SquareSplitHorizontal;
 
                   return (
                     <div key={terminalGroup.id} className="pb-0.5">
                       {showGroupHeaders && (
                         <button
                           type="button"
-                          className={`flex w-full items-center rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${
+                          className={`flex h-[22px] w-full items-center gap-1 rounded px-1.5 text-[11px] ${
                             isGroupActive
-                              ? "bg-accent/70 text-foreground"
-                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                              ? "bg-accent/50 text-foreground"
+                              : "text-muted-foreground hover:bg-accent/40 hover:text-foreground"
                           }`}
                           onClick={() => onActiveTerminalChange(groupActiveTerminalId)}
                         >
-                          Group {groupIndex + 1}
+                          <GroupIcon className="size-3 shrink-0" />
+                          <span className="min-w-0 flex-1 truncate text-left">{groupLabel}</span>
+                          <span className="text-muted-foreground/70 text-[10px] tabular-nums">
+                            {terminalCount}
+                          </span>
                         </button>
                       )}
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1647,7 +1647,7 @@ export default function ThreadTerminalDrawer({
                       {showGroupHeaders && (
                         <button
                           type="button"
-                          className={`flex h-[22px] w-full items-center gap-1 rounded px-1.5 text-[11px] ${
+                          className={`flex h-[22px] w-full cursor-pointer items-center gap-1 rounded px-1.5 text-[11px] ${
                             isGroupActive
                               ? "bg-accent/50 text-foreground"
                               : "text-muted-foreground hover:bg-accent/40 hover:text-foreground"
@@ -1682,6 +1682,7 @@ export default function ThreadTerminalDrawer({
                               <PanelTabCloseButton
                                 label={closeTerminalLabel}
                                 onClick={() => confirmCloseTerminal(terminalId)}
+                                tooltip={closeTerminalLabel}
                               >
                                 <TerminalSquare className="size-3 shrink-0" />
                               </PanelTabCloseButton>

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1646,7 +1646,10 @@ export default function ThreadTerminalDrawer({
                       )}
 
                       <div
-                        className={showGroupHeaders ? "ml-1 border-l border-border/60 pl-1.5" : ""}
+                        className={cn(
+                          "flex flex-col gap-0.5",
+                          showGroupHeaders && "ml-1 border-l border-border/60 pl-1.5",
+                        )}
                       >
                         {terminalGroup.terminalIds.map((terminalId) => {
                           const isActive = terminalId === resolvedActiveTerminalId;

--- a/apps/web/src/components/ui/panel-tab-close-button.tsx
+++ b/apps/web/src/components/ui/panel-tab-close-button.tsx
@@ -1,15 +1,22 @@
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 
 interface PanelTabCloseButtonProps {
   children: ReactNode;
   label: string;
   onClick: () => void;
+  tooltip?: string;
 }
 
 /** Inside a `group/tab` row, swaps the tab identity for its close action on hover or focus. */
-export function PanelTabCloseButton({ children, label, onClick }: PanelTabCloseButtonProps) {
-  return (
+export function PanelTabCloseButton({
+  children,
+  label,
+  onClick,
+  tooltip,
+}: PanelTabCloseButtonProps) {
+  const button = (
     <button
       type="button"
       className="cursor-pointer group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted"
@@ -21,5 +28,14 @@ export function PanelTabCloseButton({ children, label, onClick }: PanelTabCloseB
       </span>
       <X className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
     </button>
+  );
+
+  if (!tooltip) return button;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipPopup>{tooltip}</TooltipPopup>
+    </Tooltip>
   );
 }

--- a/apps/web/src/components/ui/panel-tab-close-button.tsx
+++ b/apps/web/src/components/ui/panel-tab-close-button.tsx
@@ -1,0 +1,25 @@
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface PanelTabCloseButtonProps {
+  children: ReactNode;
+  label: string;
+  onClick: () => void;
+}
+
+/** Inside a `group/tab` row, swaps the tab identity for its close action on hover or focus. */
+export function PanelTabCloseButton({ children, label, onClick }: PanelTabCloseButtonProps) {
+  return (
+    <button
+      type="button"
+      className="cursor-pointer group/close relative flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted"
+      aria-label={label}
+      onClick={onClick}
+    >
+      <span className="relative flex size-3 items-center justify-center group-hover/tab:hidden group-focus-visible/close:hidden">
+        {children}
+      </span>
+      <X className="hidden size-3 group-hover/tab:block group-focus-visible/close:block" />
+    </button>
+  );
+}


### PR DESCRIPTION
The terminal sidebar did not read like the rest of the panel navigation. Terminal rows used a separate tree treatment, and uppercase `GROUP 1` labels did not explain what each section represented.

This aligns terminal rows with the right-panel tabs and names each section after its layout: `Single`, `Side by side`, or `Stacked`. Matching layout icons and terminal counts make the structure visible without exposing the internal group name. Both tab strips share the same identity-to-close control, and the 2px gap within each section remains unchanged.

## Before

![Terminal sidebar before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/bfdfa1de-13bb-47c0-a0a6-bce8ab26d5bc/terminal-sidebar-before.png)

## After

![Terminal sidebar with layout-aware section labels and Terminal 1 hovered](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/bac3f203-96f3-4e6f-9054-0079c7a3f3b1/terminal-sidebar-layout-labels-after.png)

## Verification

- `pnpm exec vp fmt --check apps/web/src/components/ui/panel-tab-close-button.tsx apps/web/src/components/RightPanelTabs.tsx apps/web/src/components/ThreadTerminalDrawer.tsx`
- `pnpm exec vp lint apps/web/src/components/ui/panel-tab-close-button.tsx apps/web/src/components/RightPanelTabs.tsx apps/web/src/components/ThreadTerminalDrawer.tsx`
- `pnpm --filter @t3tools/web typecheck`
- `pnpm exec vp test run apps/web/src/components/RightPanelTabs.test.tsx apps/web/src/components/ThreadTerminalDrawer.test.ts`
- Playwright: verified `Single`, `Side by side`, and `Stacked` states; pointer cursors; both tab strips' identity-to-close swap; the terminal close tooltip; inactive-row hover background; 24px rows; and no horizontal overflow

Made with gpt-5.6-sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify terminal sidebar grouping with shared `PanelTabCloseButton` and group header labels
> - Adds a reusable `PanelTabCloseButton` component that shows an identity icon by default and swaps to an X on hover/focus, with optional tooltip support
> - Replaces inline close buttons in `RightPanelTabs` with the shared component, rendering `SurfaceIcon` as tab identity
> - Reworks terminal rows in `ThreadTerminalDrawer` to use `PanelTabCloseButton` with `TerminalSquare` identity and a close tooltip, removing the prior Popover-based close affordance
> - Updates terminal group headers to show an icon (`Square`, `SquareSplitVertical`, or `SquareSplitHorizontal`), a semantic label (Single/Stacked/Side by side), and a terminal count badge instead of a numeric index
> - Behavioral Change: terminal rows drop the previous left-border indentation in favor of a uniform flex column layout; the close control is now always present rather than revealed via Popover
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 269eba5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar/tab styling with no auth, data, or terminal session logic changes. Close is still gated by the existing confirm dialog.
> 
> **Overview**
> Makes the terminal sidebar read like the rest of the panel tabs: groups are labeled by layout (`Single`, `Side by side`, `Stacked`) with matching icons and a count, instead of numbered `GROUP N` headers and tree-branch indentation.
> 
> Extracts the hover/focus identity-to-X close control into `PanelTabCloseButton` and uses it on both right-panel tabs and terminal rows. Terminal close is always available (not only when multiple terminals exist).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269eba50b654354ac759127434101efa3e201f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->