### PR TITLE
fix(ci): let Macroscope approve pull requests again

### DIFF
--- a/.macroscope/approvability.md
+++ b/.macroscope/approvability.md
@@ -1,0 +1,1 @@
+Use Macroscope's default approvability criteria.


### PR DESCRIPTION
Macroscope skips approval on every PR because the repository has no approvability policy to compare.

Add the supported policy file and preserve the default approval criteria.

Model: GPT-5.6 Sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change for review tooling; no application, auth, or data-handling code is modified.
> 
> **Overview**
> Adds `.macroscope/approvability.md` so Macroscope can evaluate PRs again. The file opts into Macroscope’s default approval criteria, which this repo previously lacked (causing approvals to be skipped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb847ade87a5a7427aee439b8e091a9100a36f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.macroscope/approvability.md` to restore Macroscope PR approvals
> Adds a new markdown file that tells Macroscope to use its default approvability criteria. This restores Macroscope's ability to approve pull requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebb847a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->