### PR TITLE
fix(web): keep selected code blocks plain

### DIFF
--- a/apps/web/src/markdown-clipboard.test.ts
+++ b/apps/web/src/markdown-clipboard.test.ts
@@ -15,6 +15,7 @@ class FakeText {
 class FakeElement {
   readonly nodeType = ELEMENT_NODE;
   readonly childNodes: Array<FakeElement | FakeText> = [];
+  parentElement: FakeElement | null = null;
   readonly classList = {
     contains: (name: string) => this.classNames.includes(name),
   };
@@ -33,8 +34,22 @@ class FakeElement {
   }
 
   append(...children: Array<FakeElement | FakeText>): this {
+    for (const child of children) {
+      if (child instanceof FakeElement) child.parentElement = this;
+    }
     this.childNodes.push(...children);
     return this;
+  }
+
+  hasChildNodes(): boolean {
+    return this.childNodes.length > 0;
+  }
+
+  remove(): void {
+    if (!this.parentElement) return;
+    const index = this.parentElement.childNodes.indexOf(this);
+    if (index >= 0) this.parentElement.childNodes.splice(index, 1);
+    this.parentElement = null;
   }
 
   getAttribute(): string | null {
@@ -44,10 +59,28 @@ class FakeElement {
   hasAttribute(): boolean {
     return false;
   }
+
+  closest(): FakeElement | null {
+    return null;
+  }
+
+  querySelector(): FakeElement | null {
+    return null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const matches: FakeElement[] = [];
+    for (const child of this.childNodes) {
+      if (!(child instanceof FakeElement)) continue;
+      if (child.tagName === selector.toUpperCase()) matches.push(child);
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
 }
 
-function asNode(element: FakeElement): Node {
-  return element as unknown as Node;
+function asElement(element: FakeElement): Element {
+  return element as unknown as Element;
 }
 
 function shikiCodeLine(text: string): FakeElement {
@@ -72,7 +105,7 @@ describe("serializeRenderedMarkdownFragment", () => {
     );
     const container = new FakeElement("DIV").append(paragraph);
 
-    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("run `git status` first");
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe("run `git status` first");
   });
 
   it("keeps a highlighted block code selection plain when its pre wrapper is outside the range", () => {
@@ -81,7 +114,7 @@ describe("serializeRenderedMarkdownFragment", () => {
     );
     const container = new FakeElement("DIV").append(code);
 
-    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe(
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe(
       "git show-ref --verify refs/remotes/origin/opt/deploy/dev",
     );
   });
@@ -90,6 +123,45 @@ describe("serializeRenderedMarkdownFragment", () => {
     const code = new FakeElement("CODE").append(new FakeText("first line\nsecond line"));
     const container = new FakeElement("DIV").append(code);
 
-    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("first line\nsecond line");
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe("first line\nsecond line");
+  });
+
+  it("keeps a code-only selection plain when its cloned range contains pre wrappers", () => {
+    const container = new FakeElement("DIV").append(
+      new FakeElement("PRE").append(new FakeText("npx vp pack --watch")),
+      new FakeElement("PRE"),
+    );
+
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe("npx vp pack --watch");
+  });
+
+  it("preserves an empty rendered code block", () => {
+    const container = new FakeElement("DIV").append(
+      new FakeElement("PRE").append(new FakeElement("CODE")),
+    );
+
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe("```\n\n```");
+  });
+
+  it("preserves fences when a selection includes prose and a code block", () => {
+    const container = new FakeElement("DIV").append(
+      new FakeElement("P").append(new FakeText("Run this:")),
+      new FakeElement("PRE").append(new FakeText("npx vp pack --watch")),
+    );
+
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe(
+      "Run this:\n\n```\nnpx vp pack --watch\n```",
+    );
+  });
+
+  it("preserves non-text content selected with a code block", () => {
+    const container = new FakeElement("DIV").append(
+      new FakeElement("PRE").append(new FakeText("npx vp pack --watch")),
+      new FakeElement("HR"),
+    );
+
+    expect(serializeRenderedMarkdownFragment(asElement(container))).toBe(
+      "```\nnpx vp pack --watch\n```\n\n---",
+    );
   });
 });

--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -267,8 +267,17 @@ function tidyMarkdown(markdown: string): string {
     .trim();
 }
 
-export function serializeRenderedMarkdownFragment(container: Node): string {
-  return tidyMarkdown(serializeChildren(container));
+export function serializeRenderedMarkdownFragment(container: Element): string {
+  for (const pre of container.querySelectorAll("pre")) {
+    if (!pre.hasChildNodes()) pre.remove();
+  }
+  const markdown = tidyMarkdown(serializeChildren(container));
+  const codeBlocks = [...container.querySelectorAll("pre")].filter((pre) =>
+    pre.textContent?.trim(),
+  );
+  const codeBlock = codeBlocks.length === 1 ? codeBlocks[0] : null;
+  if (!codeBlock || markdown !== serializeCodeBlock(codeBlock).trim()) return markdown;
+  return (codeBlock.textContent ?? "").replace(/\n$/, "");
 }
 
 export function serializeTableElementToMarkdown(table: Element): string {


### PR DESCRIPTION
Selecting a command by double-clicking can clone `<pre>` wrappers around the browser range. The Markdown clipboard serializer then copies fences, sometimes including an extra empty fenced block, instead of the selected command.

This change removes childless boundary wrappers from the cloned fragment, serializes the complete selection, and returns plain text only when that serialization contains exactly one code block and nothing else. Genuine rendered empty code blocks retain their `<code>` child and their Markdown fences. Selections containing prose or non-text Markdown content still preserve their full Markdown representation.

Testing:
- `vp test run apps/web/src/markdown-clipboard.test.ts`
- `vp lint apps/web/src/markdown-clipboard.ts apps/web/src/markdown-clipboard.test.ts`
- `vp run typecheck` in `apps/web`

No visual UI change. Seven focused tests cover the exact fenced clipboard output, genuine empty blocks, and preservation of mixed content.

Implemented with GPT-5.6 Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Clipboard serialization only; no auth, data, or security-sensitive paths. Worst case is incorrect copy formatting.
> 
> **Overview**
> Copying a selected command no longer pastes extra markdown fences when the browser clones empty `<pre>` wrappers around the range.
> 
> `serializeRenderedMarkdownFragment` now takes an `Element`, strips empty `pre` nodes, then returns raw code text only if the selection serializes to exactly one non-empty code block. Mixed selections (prose, rules, etc.) still keep full markdown, including empty fenced blocks that were actually rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00a2c2d9372e2fc67cf56b60f6855e25002c0ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `serializeRenderedMarkdownFragment` to keep single code blocks plain
> - Changes the parameter type of `serializeRenderedMarkdownFragment` from `Node` to `Element` and removes empty `<pre>` elements before serializing.
> - When the selection is exactly one non-empty code block, returns the block's raw text content with trailing newline stripped; otherwise returns fenced/normal markdown as before.
> - Updates test helpers in [markdown-clipboard.test.ts](https://github.com/pingdotgg/t3code/pull/7973/files#diff-46aebed13cb3cb88806c272e3cf1f807fddfa5f79cef57fff01a784e0c361dd6): `FakeElement` gains `parentElement`, `remove`, `hasChildNodes`, and `querySelectorAll`; the cast helper is renamed to `asElement` and returns `Element`.
> - Risk: callers of `serializeRenderedMarkdownFragment` must now pass an `Element` instead of a `Node`; in-tree call sites are updated but out-of-tree callers will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f00a2c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->