### PR TITLE
fix(swift-ios): prevent lost messages and stale account access

### DIFF
--- a/apps/swift-ios/.gitignore
+++ b/apps/swift-ios/.gitignore
@@ -2,4 +2,3 @@
 DerivedData/
 *.xcuserstate
 xcuserdata/
-T3Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/apps/swift-ios/App/Cloud/T3ConnectCapability.swift
+++ b/apps/swift-ios/App/Cloud/T3ConnectCapability.swift
@@ -62,7 +62,18 @@ public final class T3ConnectController: T3ConnectDeviceManaging {
     public private(set) var account: T3ConnectAccount? {
         didSet {
             guard oldValue != account else { return }
-            NotificationCenter.default.post(name: .t3ConnectSessionChanged, object: self)
+            var accountIDs: [String: String] = [:]
+            if let previousAccountID = oldValue?.id {
+                accountIDs["previousAccountID"] = previousAccountID
+            }
+            if let accountID = account?.id {
+                accountIDs["accountID"] = accountID
+            }
+            NotificationCenter.default.post(
+                name: .t3ConnectSessionChanged,
+                object: self,
+                userInfo: accountIDs
+            )
         }
     }
     public private(set) var environments: [T3ConnectCloudEnvironment] = []

--- a/apps/swift-ios/App/Cloud/T3ConnectManagedAuthorization.swift
+++ b/apps/swift-ios/App/Cloud/T3ConnectManagedAuthorization.swift
@@ -192,9 +192,11 @@ public actor T3ConnectManagedEnvironmentAuthorizer {
             let httpBaseURL = authorization.endpoint.httpBaseURL,
             let webSocketBaseURL = authorization.endpoint.webSocketBaseURL,
             httpBaseURL.scheme?.lowercased() == "https",
-            httpBaseURL.host?.isEmpty == false,
+            let httpHost = httpBaseURL.host,
             webSocketBaseURL.scheme?.lowercased() == "wss",
-            webSocketBaseURL.host?.isEmpty == false
+            let webSocketHost = webSocketBaseURL.host,
+            httpHost.caseInsensitiveCompare(webSocketHost) == .orderedSame,
+            (httpBaseURL.port ?? 443) == (webSocketBaseURL.port ?? 443)
         else {
             throw T3ConnectRelayError.invalidConfiguration(
                 "The managed environment endpoint is invalid."

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -400,6 +400,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     func removeEnvironment(id: String) async throws {
         let removesActiveEnvironment = activeEnvironment?.id == id
+        let environment = try await runtime.environments().first { $0.id == id }
+        if environment?.kind == .managedDPoP {
+            try await runtime.revokeCredential(id: id)
+        }
         try await runtime.remove(id: id)
         if removesActiveEnvironment {
             await clearActiveEnvironment(disconnectClient: false)

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -279,8 +279,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
               let webSocketBaseURL = credential.endpoint.webSocketBaseURL,
               httpBaseURL.scheme?.lowercased() == "https",
               webSocketBaseURL.scheme?.lowercased() == "wss",
-              httpBaseURL.host != nil,
-              webSocketBaseURL.host != nil else {
+              let httpHost = httpBaseURL.host,
+              let webSocketHost = webSocketBaseURL.host,
+              httpHost.caseInsensitiveCompare(webSocketHost) == .orderedSame,
+              (httpBaseURL.port ?? 443) == (webSocketBaseURL.port ?? 443) else {
             throw T3ConnectRelayError.invalidConfiguration(
                 "The managed environment endpoint is invalid."
             )
@@ -461,14 +463,39 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func pullRequestLists(_ input: PullRequestListInput) async throws
         -> [FeaturePullRequestEnvironmentList]
     {
-        let environments = try await runtime.environments().filter(\.isEnabled)
+        let environments = try await runtime.environments().filter {
+            $0.isEnabled && $0.descriptor?.capabilities.pullRequests == true
+        }
         let runtime = runtime
         return await withTaskGroup(of: FeaturePullRequestEnvironmentList.self) { group in
             for environment in environments {
                 group.addTask {
                     let probe = await runtime.ephemeralClient(for: environment)
                     do {
-                        let result = try await probe.pullRequests(input)
+                        var result = try await probe.pullRequests(input)
+                        var visitedCursors = Set<String>()
+                        while !result.nextCursors.isEmpty {
+                            try Task.checkCancellation()
+                            let cursorIdentity = result.nextCursors
+                                .sorted { $0.key < $1.key }
+                                .map { "\($0.key)=\($0.value)" }
+                                .joined(separator: "&")
+                            guard visitedCursors.insert(cursorIdentity).inserted else { break }
+                            let next = try await probe.pullRequests(
+                                PullRequestListInput(
+                                    state: input.state,
+                                    involvement: input.involvement,
+                                    filters: input.filters,
+                                    projectId: input.projectId,
+                                    projectIds: input.projectIds,
+                                    host: input.host,
+                                    limit: input.limit,
+                                    cursors: result.nextCursors,
+                                    query: input.query
+                                )
+                            )
+                            result = result.appending(next)
+                        }
                         await probe.disconnect()
                         return FeaturePullRequestEnvironmentList(
                             environmentID: environment.id,
@@ -1887,6 +1914,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         settingsStore.set(data, forKey: Self.settingsKey)
     }
 
+    var managesServerSessions: Bool {
+        !t3ConnectDeviceManager.hasActiveAccount
+    }
+
     func loadDeviceSessions() async throws -> [FeatureDeviceSession] {
         if t3ConnectDeviceManager.hasActiveAccount {
             let devices = try await t3ConnectDeviceManager.registeredDevices()
@@ -2273,6 +2304,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let mapped = NativeWorkspaceMapper.terminal(snapshot)
         var scoped = mapped
         scoped.threadID = route.uiID
+        scoped.buffer = Self.cappedTerminalBuffer(scoped.buffer)
         terminalSnapshots[TerminalKey(threadID: route.uiID, terminalID: terminalID)] = scoped
     }
 
@@ -2881,7 +2913,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         client: T3Client,
         refreshActiveThread: Bool
     ) async {
-        guard let currentClient = self.client, currentClient === client else { return }
+        guard let currentClient = self.client,
+              currentClient === client,
+              shell.snapshotSequence >= (latestShell?.snapshotSequence ?? .min) else {
+            return
+        }
         shellPublishTask?.cancel()
         shellPublishTask = nil
         latestShell = shell
@@ -2899,7 +2935,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         client: T3Client,
         generation: Int
     ) async {
-        guard isCurrentSession(client: client, generation: generation) else { return }
+        guard isCurrentSession(client: client, generation: generation),
+              shell.snapshotSequence >= (latestShell?.snapshotSequence ?? .min) else {
+            return
+        }
         shellPublishTask?.cancel()
         shellPublishTask = nil
         latestShell = shell
@@ -3390,7 +3429,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 }
             }
             if let shell = load.shell {
-                shellsByEnvironmentID[load.environment.id] = shell
+                if shell.snapshotSequence
+                    >= (shellsByEnvironmentID[load.environment.id]?.snapshotSequence ?? .min) {
+                    shellsByEnvironmentID[load.environment.id] = shell
+                }
                 environmentConnectionStates[load.environment.id] = .connected
                 environmentConnectionDetails[load.environment.id] = nil
             } else {
@@ -3495,6 +3537,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let shell = try await client.shellSnapshot()
         guard isKnownClient(client, environmentID: environment.id, generation: generation) else {
             throw CancellationError()
+        }
+        guard shell.snapshotSequence
+            >= (shellsByEnvironmentID[environment.id]?.snapshotSequence ?? .min) else {
+            return
         }
         shellsByEnvironmentID[environment.id] = shell
         if activeEnvironment?.id == environment.id {
@@ -3601,7 +3647,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let environments = (try? await runtime.environments()) ?? [environment]
         guard generation == environmentGeneration,
               expectedGeneration == nil || expectedGeneration == environmentGeneration,
-              activeEnvironment?.id == environment.id else {
+              activeEnvironment?.id == environment.id,
+              shell.snapshotSequence
+                  >= (shellsByEnvironmentID[sourceEnvironment.id]?.snapshotSequence ?? .min) else {
             return
         }
         shellsByEnvironmentID[sourceEnvironment.id] = shell
@@ -3725,6 +3773,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         previous.connection == next.connection
             && previous.environments == next.environments
             && previous.providers == next.providers
+            && previous.providersByEnvironment == next.providersByEnvironment
+            && previous.preferencesByEnvironment == next.preferencesByEnvironment
             && previous.settings == next.settings
             && projectsMatchIgnoringThreadCounts(previous.projects, next.projects)
     }
@@ -3741,6 +3791,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 && left.name == right.name
                 && left.path == right.path
                 && left.defaultSelection == right.defaultSelection
+                && left.repositoryIdentity == right.repositoryIdentity
+                && left.createdAt == right.createdAt
+                && left.updatedAt == right.updatedAt
         }
     }
 
@@ -4049,7 +4102,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             providerID: thread.modelSelection.instanceId,
             providerName: threadProviderName(
                 session: thread.session,
-                modelSelection: thread.modelSelection
+                modelSelection: thread.modelSelection,
+                environmentID: environment.id
             ),
             modelID: thread.modelSelection.model,
             modelOptions: mapOptionSelections(thread.modelSelection.options),
@@ -4118,7 +4172,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             providerID: thread.modelSelection.instanceId,
             providerName: threadProviderName(
                 session: thread.session,
-                modelSelection: thread.modelSelection
+                modelSelection: thread.modelSelection,
+                environmentID: environment.id
             ),
             modelID: thread.modelSelection.model,
             modelOptions: mapOptionSelections(thread.modelSelection.options),
@@ -5193,14 +5248,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func threadProviderName(
         session: OrchestrationSession?,
-        modelSelection: ModelSelection
+        modelSelection: ModelSelection,
+        environmentID: String
     ) -> String {
         if let name = session?.providerName?.trimmingCharacters(in: .whitespacesAndNewlines),
            !name.isEmpty {
             return name
         }
         let providerID = session?.providerInstanceId ?? modelSelection.instanceId
-        if let provider = latestServerConfig?.providers.first(where: {
+        if let provider = serverConfigsByEnvironmentID[environmentID]?.providers.first(where: {
             $0.instanceId == providerID
         }) {
             return provider.displayName ?? providerDisplayName(provider.driver)

--- a/apps/swift-ios/App/Platform/PlatformCloudDelivery.swift
+++ b/apps/swift-ios/App/Platform/PlatformCloudDelivery.swift
@@ -104,6 +104,7 @@ final class PlatformCloudDeliveryCoordinator {
     private var activityTokenTasks: [String: Task<Void, Never>] = [:]
     private var pendingActivityTokens: Set<String> = []
     private var retryTask: Task<Void, Never>?
+    private var observedAccountID: String?
 
     private let deviceFingerprintKey = "swift-ios.cloud-delivery-device.v1"
     private let deviceRegisteredAtKey = "swift-ios.cloud-delivery-device-date.v1"
@@ -131,6 +132,7 @@ final class PlatformCloudDeliveryCoordinator {
 
     func install(controller: T3ConnectController) {
         self.controller = controller
+        observedAccountID = controller.account?.id
         guard observerTasks.isEmpty else {
             requestRegistration()
             return
@@ -148,12 +150,14 @@ final class PlatformCloudDeliveryCoordinator {
         observerTasks.append(Task { @MainActor [weak self] in
             for await _ in NotificationCenter.default.notifications(named: .t3ConnectSessionChanged) {
                 guard !Task.isCancelled, let self else { return }
-                if controller.account == nil {
+                let accountID = controller.account?.id
+                if observedAccountID != accountID {
                     clearSuccessfulRegistrationCache()
                     pendingActivityTokens.removeAll()
                     PlatformAgentAwarenessCoordinator.shared
                         .resetAndResynchronizeLiveActivity()
                 }
+                observedAccountID = accountID
                 refreshActivityTokenObservers()
                 requestRegistration()
             }

--- a/apps/swift-ios/App/Platform/PlatformCloudDelivery.swift
+++ b/apps/swift-ios/App/Platform/PlatformCloudDelivery.swift
@@ -132,11 +132,12 @@ final class PlatformCloudDeliveryCoordinator {
 
     func install(controller: T3ConnectController) {
         self.controller = controller
-        observedAccountID = controller.account?.id
         guard observerTasks.isEmpty else {
+            handleAccountChange(to: controller.account?.id)
             requestRegistration()
             return
         }
+        observedAccountID = controller.account?.id
 
         for name in [Notification.Name.platformDeviceTokenChanged, .platformLiveActivityChanged] {
             observerTasks.append(Task { @MainActor [weak self] in
@@ -148,16 +149,14 @@ final class PlatformCloudDeliveryCoordinator {
             })
         }
         observerTasks.append(Task { @MainActor [weak self] in
-            for await _ in NotificationCenter.default.notifications(named: .t3ConnectSessionChanged) {
+            for await notification in NotificationCenter.default.notifications(
+                named: .t3ConnectSessionChanged
+            ) {
                 guard !Task.isCancelled, let self else { return }
-                let accountID = controller.account?.id
-                if observedAccountID != accountID {
-                    clearSuccessfulRegistrationCache()
-                    pendingActivityTokens.removeAll()
-                    PlatformAgentAwarenessCoordinator.shared
-                        .resetAndResynchronizeLiveActivity()
-                }
-                observedAccountID = accountID
+                guard let controller = self.controller,
+                      let notificationController = notification.object as? T3ConnectController,
+                      notificationController === controller else { continue }
+                handleAccountChange(to: controller.account?.id)
                 refreshActivityTokenObservers()
                 requestRegistration()
             }
@@ -327,6 +326,14 @@ final class PlatformCloudDeliveryCoordinator {
         defaults.removeObject(forKey: deviceFingerprintKey)
         defaults.removeObject(forKey: deviceRegisteredAtKey)
         defaults.removeObject(forKey: activityFingerprintKey)
+    }
+
+    private func handleAccountChange(to accountID: String?) {
+        guard observedAccountID != accountID else { return }
+        clearSuccessfulRegistrationCache()
+        pendingActivityTokens.removeAll()
+        PlatformAgentAwarenessCoordinator.shared.resetAndResynchronizeLiveActivity()
+        observedAccountID = accountID
     }
 
     private func currentRegistration(settings: FeatureSettings) -> T3ConnectDeviceRegistration {

--- a/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
+++ b/apps/swift-ios/App/Platform/PlatformIncomingShare.swift
@@ -114,12 +114,13 @@ struct PlatformIncomingSharePipeline: Sendable {
 
     func importEnvelope(
         _ envelope: T3IncomingShareEnvelope,
-        into project: FeatureProject
+        into project: FeatureProject,
+        draftKey: String? = nil
     ) async throws -> FeatureComposerDraft {
         guard UUID(uuidString: envelope.id) != nil else {
             throw PlatformIncomingShareError.invalidEnvelope
         }
-        let key = FeatureComposerDraftStore.newTaskKey(project: project)
+        let key = draftKey ?? FeatureComposerDraftStore.newTaskKey(project: project)
         var prepared: [FeatureDraftAttachment] = []
         prepared.reserveCapacity(envelope.images.count)
         for (offset, image) in envelope.images.enumerated() {
@@ -194,11 +195,15 @@ final class PlatformIncomingShareCoordinator {
         pendingEnvelope = nil
     }
 
-    func importPending(into project: FeatureProject) async throws {
+    func importPending(into project: FeatureProject, draftKey: String? = nil) async throws {
         guard let pendingEnvelope, !isImporting else { return }
         isImporting = true
         do {
-            _ = try await pipeline.importEnvelope(pendingEnvelope, into: project)
+            _ = try await pipeline.importEnvelope(
+                pendingEnvelope,
+                into: project,
+                draftKey: draftKey
+            )
             self.pendingEnvelope = nil
             lastNoProjectNoticeID = nil
             isImporting = false

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -48,6 +48,17 @@ struct PlatformRootView: View {
             _ = PlatformRouteMailbox.shared.take()
             handle(route)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .t3ConnectSessionChanged)) { note in
+            guard let capability = model.client as? any T3ConnectCapable,
+                  let controller = note.object as? T3ConnectController,
+                  controller === capability.t3ConnectController,
+                  let previousAccountID = note.userInfo?["previousAccountID"] as? String,
+                  let accountID = note.userInfo?["accountID"] as? String,
+                  previousAccountID != accountID else { return }
+            Task { @MainActor in
+                await model.removeManagedEnvironmentsAfterAccountChange()
+            }
+        }
         .onChange(of: model.isLoading, initial: true) { _, isLoading in
             guard !isLoading else { return }
             processThreadChanges()
@@ -215,7 +226,13 @@ struct PlatformRootView: View {
         importedShareProjectID = project.id
         Task { @MainActor in
             do {
-                try await incomingShareCoordinator.importPending(into: project)
+                try await incomingShareCoordinator.importPending(
+                    into: project,
+                    draftKey: FeatureComposerDraftStore.newTaskKey(
+                        project: project,
+                        in: model.snapshot
+                    )
+                )
             } catch {
                 importedShareProjectID = nil
                 model.errorMessage = error.localizedDescription

--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -51,11 +51,16 @@ struct PlatformRootView: View {
         .onReceive(NotificationCenter.default.publisher(for: .t3ConnectSessionChanged)) { note in
             guard let capability = model.client as? any T3ConnectCapable,
                   let controller = note.object as? T3ConnectController,
-                  controller === capability.t3ConnectController,
-                  let previousAccountID = note.userInfo?["previousAccountID"] as? String,
-                  let accountID = note.userInfo?["accountID"] as? String,
-                  previousAccountID != accountID else { return }
+                  controller === capability.t3ConnectController else { return }
+            let previousAccountID = note.userInfo?["previousAccountID"] as? String
+            let accountID = note.userInfo?["accountID"] as? String
+            guard Self.shouldRemoveManagedEnvironments(
+                previousAccountID: previousAccountID,
+                accountID: accountID,
+                isSigningOut: model.isSigningOutT3Connect
+            ) else { return }
             Task { @MainActor in
+                guard !model.isSigningOutT3Connect else { return }
                 await model.removeManagedEnvironmentsAfterAccountChange()
             }
         }
@@ -112,6 +117,15 @@ struct PlatformRootView: View {
         } message: {
             Text("Your share is saved. Connect an environment and create a project to finish importing it.")
         }
+    }
+
+    static func shouldRemoveManagedEnvironments(
+        previousAccountID: String?,
+        accountID: String?,
+        isSigningOut: Bool
+    ) -> Bool {
+        guard !isSigningOut, let previousAccountID else { return false }
+        return previousAccountID != accountID
     }
 
     private var incomingShareProjects: [FeatureProject] {

--- a/apps/swift-ios/Core/HTTP.swift
+++ b/apps/swift-ios/Core/HTTP.swift
@@ -394,7 +394,20 @@ public actor EnvironmentAPI {
               refreshed.proofKeyThumbprint?.isEmpty == false else {
             throw HTTPError.incompatibleCredential
         }
-        try await credentials.setCredential(refreshed, for: environment.id)
+        guard try await credentials.replaceCredential(
+            refreshed,
+            ifMatching: credential,
+            for: environment.id
+        ) else {
+            if let current = try await newestUsableManagedCredential(
+                replacing: credential,
+                environment: environment,
+                using: managedAuthorization
+            ) {
+                return current
+            }
+            throw HTTPError.missingCredential
+        }
         return refreshed
     }
 

--- a/apps/swift-ios/Core/Models.swift
+++ b/apps/swift-ios/Core/Models.swift
@@ -99,6 +99,7 @@ public struct EnvironmentDescriptor: Codable, Equatable, Sendable {
     public struct Capabilities: Codable, Equatable, Sendable {
         public let repositoryIdentity: Bool
         public let connectionProbe: Bool?
+        public let pullRequests: Bool?
         public let threadSettlement: Bool?
         public let threadSnooze: Bool?
         public let threadPinning: Bool?
@@ -109,6 +110,7 @@ public struct EnvironmentDescriptor: Codable, Equatable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case repositoryIdentity
             case connectionProbe
+            case pullRequests
             case threadSettlement
             case threadSnooze
             case threadPinning
@@ -122,6 +124,7 @@ public struct EnvironmentDescriptor: Codable, Equatable, Sendable {
             repositoryIdentity =
                 try container.decodeIfPresent(Bool.self, forKey: .repositoryIdentity) ?? false
             connectionProbe = try container.decodeIfPresent(Bool.self, forKey: .connectionProbe)
+            pullRequests = try container.decodeIfPresent(Bool.self, forKey: .pullRequests)
             threadSettlement = try container.decodeIfPresent(Bool.self, forKey: .threadSettlement)
             threadSnooze = try container.decodeIfPresent(Bool.self, forKey: .threadSnooze)
             threadPinning = try container.decodeIfPresent(Bool.self, forKey: .threadPinning)

--- a/apps/swift-ios/Core/PairingService.swift
+++ b/apps/swift-ios/Core/PairingService.swift
@@ -77,8 +77,10 @@ public actor PairingService {
             expiresAt: Date().addingTimeInterval(access.expiresIn),
             scopes: access.scope.split(separator: " ").map(String.init)
         )
+        let previousCredential = try await credentialStore.credential(for: environment.id)
         // Store the secret first. A catalog record must never point at a
-        // credential that failed to persist.
+        // credential that failed to persist. Restore an existing credential if
+        // updating that environment's catalog entry fails.
         try await credentialStore.setCredential(credential, for: environment.id)
         do {
             try await environmentStore.upsert(environment)
@@ -86,7 +88,14 @@ public actor PairingService {
                 try await environmentStore.setActiveEnvironment(id: environment.id)
             }
         } catch {
-            try? await credentialStore.removeCredential(for: environment.id)
+            if let previousCredential {
+                try? await credentialStore.setCredential(
+                    previousCredential,
+                    for: environment.id
+                )
+            } else {
+                try? await credentialStore.removeCredential(for: environment.id)
+            }
             throw error
         }
         return environment

--- a/apps/swift-ios/Core/PairingService.swift
+++ b/apps/swift-ios/Core/PairingService.swift
@@ -77,11 +77,13 @@ public actor PairingService {
             expiresAt: Date().addingTimeInterval(access.expiresIn),
             scopes: access.scope.split(separator: " ").map(String.init)
         )
-        let previousCredential = try await credentialStore.credential(for: environment.id)
         // Store the secret first. A catalog record must never point at a
-        // credential that failed to persist. Restore an existing credential if
-        // updating that environment's catalog entry fails.
-        try await credentialStore.setCredential(credential, for: environment.id)
+        // credential that failed to persist. Capture the previous credential in
+        // the same actor operation so a concurrent refresh cannot be lost.
+        let previousCredential = try await credentialStore.swapCredential(
+            credential,
+            for: environment.id
+        )
         do {
             try await environmentStore.upsert(environment)
             if try await environmentStore.activeEnvironmentID() == nil {
@@ -89,12 +91,16 @@ public actor PairingService {
             }
         } catch {
             if let previousCredential {
-                try? await credentialStore.setCredential(
+                _ = try? await credentialStore.replaceCredential(
                     previousCredential,
+                    ifMatching: credential,
                     for: environment.id
                 )
             } else {
-                try? await credentialStore.removeCredential(for: environment.id)
+                _ = try? await credentialStore.removeCredential(
+                    ifMatching: credential,
+                    for: environment.id
+                )
             }
             throw error
         }

--- a/apps/swift-ios/Core/Persistence.swift
+++ b/apps/swift-ios/Core/Persistence.swift
@@ -4,6 +4,11 @@ import Security
 public protocol CredentialStore: Sendable {
     func credential(for environmentID: String) async throws -> EnvironmentCredential?
     func setCredential(_ credential: EnvironmentCredential, for environmentID: String) async throws
+    func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) async throws -> Bool
     func removeCredential(for environmentID: String) async throws
 }
 
@@ -91,6 +96,16 @@ public actor KeychainCredentialStore: CredentialStore {
             throw CredentialStoreError.keychain(status)
         }
     }
+
+    public func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) throws -> Bool {
+        guard try self.credential(for: environmentID) == expected else { return false }
+        try setCredential(credential, for: environmentID)
+        return true
+    }
 }
 
 public actor InMemoryCredentialStore: CredentialStore {
@@ -113,6 +128,16 @@ public actor InMemoryCredentialStore: CredentialStore {
 
     public func removeCredential(for environmentID: String) {
         credentials.removeValue(forKey: environmentID)
+    }
+
+    public func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard credentials[environmentID] == expected else { return false }
+        credentials[environmentID] = credential
+        return true
     }
 }
 

--- a/apps/swift-ios/Core/Persistence.swift
+++ b/apps/swift-ios/Core/Persistence.swift
@@ -20,6 +20,12 @@ public protocol CredentialStore: Sendable {
     ) async throws -> Bool
 }
 
+protocol KeychainCredentialBackend: Sendable {
+    func credential(for environmentID: String) throws -> EnvironmentCredential?
+    func setCredential(_ credential: EnvironmentCredential, for environmentID: String) throws
+    func removeCredential(for environmentID: String) throws
+}
+
 public enum CredentialStoreError: LocalizedError, Sendable {
     case keychain(OSStatus)
     case invalidData
@@ -37,8 +43,10 @@ public enum CredentialStoreError: LocalizedError, Sendable {
 /// Access tokens are deliberately isolated from the environment catalog so
 /// catalog exports and backups never contain authentication material.
 public actor KeychainCredentialStore: CredentialStore {
+    private static let keychainLock = NSLock()
     private let service: String
     private let accessibility: CFString
+    private let backend: (any KeychainCredentialBackend)?
 
     public init(
         service: String = "codes.t3.swift-ios.environment-credentials",
@@ -46,9 +54,78 @@ public actor KeychainCredentialStore: CredentialStore {
     ) {
         self.service = service
         self.accessibility = accessibility
+        backend = nil
+    }
+
+    init(
+        service: String,
+        backend: any KeychainCredentialBackend,
+        accessibility: CFString = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+    ) {
+        self.service = service
+        self.accessibility = accessibility
+        self.backend = backend
     }
 
     public func credential(for environmentID: String) throws -> EnvironmentCredential? {
+        try Self.keychainLock.withLock {
+            try readCredential(for: environmentID)
+        }
+    }
+
+    public func setCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) throws {
+        try Self.keychainLock.withLock {
+            try writeCredential(credential, for: environmentID)
+        }
+    }
+
+    public func removeCredential(for environmentID: String) throws {
+        try Self.keychainLock.withLock {
+            try deleteCredential(for: environmentID)
+        }
+    }
+
+    public func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) throws -> EnvironmentCredential? {
+        try Self.keychainLock.withLock {
+            let previousCredential = try readCredential(for: environmentID)
+            try writeCredential(credential, for: environmentID)
+            return previousCredential
+        }
+    }
+
+    public func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) throws -> Bool {
+        try Self.keychainLock.withLock {
+            guard try readCredential(for: environmentID) == expected else { return false }
+            try writeCredential(credential, for: environmentID)
+            return true
+        }
+    }
+
+    public func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) throws -> Bool {
+        try Self.keychainLock.withLock {
+            guard try readCredential(for: environmentID) == expected else { return false }
+            try deleteCredential(for: environmentID)
+            return true
+        }
+    }
+
+    private func readCredential(for environmentID: String) throws -> EnvironmentCredential? {
+        if let backend {
+            return try backend.credential(for: environmentID)
+        }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -68,10 +145,14 @@ public actor KeychainCredentialStore: CredentialStore {
         }
     }
 
-    public func setCredential(
+    private func writeCredential(
         _ credential: EnvironmentCredential,
         for environmentID: String
     ) throws {
+        if let backend {
+            try backend.setCredential(credential, for: environmentID)
+            return
+        }
         let data = try JSONEncoder.t3.encode(credential)
         let lookup: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -93,7 +174,11 @@ public actor KeychainCredentialStore: CredentialStore {
         }
     }
 
-    public func removeCredential(for environmentID: String) throws {
+    private func deleteCredential(for environmentID: String) throws {
+        if let backend {
+            try backend.removeCredential(for: environmentID)
+            return
+        }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -103,34 +188,6 @@ public actor KeychainCredentialStore: CredentialStore {
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw CredentialStoreError.keychain(status)
         }
-    }
-
-    public func swapCredential(
-        _ credential: EnvironmentCredential,
-        for environmentID: String
-    ) throws -> EnvironmentCredential? {
-        let previousCredential = try self.credential(for: environmentID)
-        try setCredential(credential, for: environmentID)
-        return previousCredential
-    }
-
-    public func replaceCredential(
-        _ credential: EnvironmentCredential,
-        ifMatching expected: EnvironmentCredential,
-        for environmentID: String
-    ) throws -> Bool {
-        guard try self.credential(for: environmentID) == expected else { return false }
-        try setCredential(credential, for: environmentID)
-        return true
-    }
-
-    public func removeCredential(
-        ifMatching expected: EnvironmentCredential,
-        for environmentID: String
-    ) throws -> Bool {
-        guard try credential(for: environmentID) == expected else { return false }
-        try removeCredential(for: environmentID)
-        return true
     }
 }
 

--- a/apps/swift-ios/Core/Persistence.swift
+++ b/apps/swift-ios/Core/Persistence.swift
@@ -4,12 +4,20 @@ import Security
 public protocol CredentialStore: Sendable {
     func credential(for environmentID: String) async throws -> EnvironmentCredential?
     func setCredential(_ credential: EnvironmentCredential, for environmentID: String) async throws
+    func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) async throws -> EnvironmentCredential?
     func replaceCredential(
         _ credential: EnvironmentCredential,
         ifMatching expected: EnvironmentCredential,
         for environmentID: String
     ) async throws -> Bool
     func removeCredential(for environmentID: String) async throws
+    func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) async throws -> Bool
 }
 
 public enum CredentialStoreError: LocalizedError, Sendable {
@@ -97,6 +105,15 @@ public actor KeychainCredentialStore: CredentialStore {
         }
     }
 
+    public func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) throws -> EnvironmentCredential? {
+        let previousCredential = try self.credential(for: environmentID)
+        try setCredential(credential, for: environmentID)
+        return previousCredential
+    }
+
     public func replaceCredential(
         _ credential: EnvironmentCredential,
         ifMatching expected: EnvironmentCredential,
@@ -104,6 +121,15 @@ public actor KeychainCredentialStore: CredentialStore {
     ) throws -> Bool {
         guard try self.credential(for: environmentID) == expected else { return false }
         try setCredential(credential, for: environmentID)
+        return true
+    }
+
+    public func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) throws -> Bool {
+        guard try credential(for: environmentID) == expected else { return false }
+        try removeCredential(for: environmentID)
         return true
     }
 }
@@ -130,6 +156,13 @@ public actor InMemoryCredentialStore: CredentialStore {
         credentials.removeValue(forKey: environmentID)
     }
 
+    public func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) -> EnvironmentCredential? {
+        credentials.updateValue(credential, forKey: environmentID)
+    }
+
     public func replaceCredential(
         _ credential: EnvironmentCredential,
         ifMatching expected: EnvironmentCredential,
@@ -137,6 +170,15 @@ public actor InMemoryCredentialStore: CredentialStore {
     ) -> Bool {
         guard credentials[environmentID] == expected else { return false }
         credentials[environmentID] = credential
+        return true
+    }
+
+    public func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard credentials[environmentID] == expected else { return false }
+        credentials.removeValue(forKey: environmentID)
         return true
     }
 }

--- a/apps/swift-ios/Core/PullRequestWireModels.swift
+++ b/apps/swift-ios/Core/PullRequestWireModels.swift
@@ -326,6 +326,27 @@ public struct PullRequestListResult: Codable, Equatable, Sendable {
     public let errors: [PullRequestListProjectError]
     public let truncated: Bool
     public let nextCursors: [String: String]
+
+    func appending(_ page: Self) -> Self {
+        var entryIDs = Set(entries.map(\.id))
+        var providerHosts = Set(providers.map(\.host))
+        var errorProjectIDs = Set(errors.map(\.projectId))
+
+        return Self(
+            viewers: viewers.merging(page.viewers) { _, latest in latest },
+            providers: providers + page.providers.filter {
+                providerHosts.insert($0.host).inserted
+            },
+            entries: entries + page.entries.filter {
+                entryIDs.insert($0.id).inserted
+            },
+            errors: errors + page.errors.filter {
+                errorProjectIDs.insert($0.projectId).inserted
+            },
+            truncated: page.truncated,
+            nextCursors: page.nextCursors
+        )
+    }
 }
 
 public struct PullRequestRef: Codable, Equatable, Hashable, Sendable {

--- a/apps/swift-ios/Core/T3Client.swift
+++ b/apps/swift-ios/Core/T3Client.swift
@@ -1741,7 +1741,7 @@ public enum OrchestrationCommands {
                 "type": .string("thread.snooze"),
                 "commandId": .string(commandID),
                 "threadId": .string(threadID),
-                "snoozedUntil": .string(iso8601.string(from: until)),
+                "snoozedUntil": .string(iso8601.format(until)),
             ])
         }
         return .object([
@@ -1803,10 +1803,9 @@ public enum OrchestrationCommands {
     }
 
     public static func now() -> String {
-        iso8601.string(from: Date())
+        iso8601.format(Date())
     }
 
-    /// ISO8601DateFormatter is expensive to construct and thread-safe to use;
-    /// `now()` runs as the default argument of nearly every outbound command.
-    static let iso8601 = ISO8601DateFormatter()
+    /// Commands are built on several actors, so their shared formatter must be Sendable.
+    private static let iso8601 = Date.ISO8601FormatStyle()
 }

--- a/apps/swift-ios/Core/T3Client.swift
+++ b/apps/swift-ios/Core/T3Client.swift
@@ -1273,8 +1273,10 @@ public actor EnvironmentRuntime {
         let previousEnvironment = try await environmentStore.load()
             .first(where: { $0.id == environment.id })
         let previousActiveID = try await environmentStore.activeEnvironmentID()
-        let previousCredential = try await credentialStore.credential(for: environment.id)
-        try await credentialStore.setCredential(credential, for: environment.id)
+        let previousCredential = try await credentialStore.swapCredential(
+            credential,
+            for: environment.id
+        )
         do {
             try await environmentStore.upsert(environment)
             try await environmentStore.setActiveEnvironment(id: environment.id)
@@ -1283,12 +1285,16 @@ public actor EnvironmentRuntime {
             var rollbackErrors: [String] = []
             do {
                 if let previousCredential {
-                    try await credentialStore.setCredential(
+                    _ = try await credentialStore.replaceCredential(
                         previousCredential,
+                        ifMatching: credential,
                         for: environment.id
                     )
                 } else {
-                    try await credentialStore.removeCredential(for: environment.id)
+                    _ = try await credentialStore.removeCredential(
+                        ifMatching: credential,
+                        for: environment.id
+                    )
                 }
             } catch {
                 rollbackErrors.append("credential: \(error.localizedDescription)")

--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -175,7 +175,7 @@ public actor WebSocketRPCClient {
         /// The connection that assigned `requestID`. Request IDs are reissued
         /// after reconnects, so an Interrupt is only valid on this connection.
         var requestConnectionID: UUID?
-        let yield: @Sendable (JSONValue) -> Void
+        let yield: @Sendable (JSONValue) -> Bool
         let finish: @Sendable (Error?) -> Void
     }
 
@@ -247,6 +247,8 @@ public actor WebSocketRPCClient {
     private let endpointProvider: EndpointProvider
     private let connectionWaitTimeout: Duration
     private let responseTimeout: Duration
+    private let keepaliveInterval: Duration
+    private let subscriptionBufferLimit: Int
     private let reconnectBackoff: @Sendable (Int) -> Duration
     private var connection: (any WebSocketConnection)?
     private var connectionID: UUID?
@@ -258,11 +260,14 @@ public actor WebSocketRPCClient {
     private var unary: [Int: UnaryRequest] = [:]
     private var subscriptions: [UUID: Subscription] = [:]
     private var subscriptionByRequestID: [Int: UUID] = [:]
+    private var awaitingKeepaliveResponse = false
 
     public init(
         connector: any WebSocketConnecting = URLSessionWebSocketConnector(),
         connectionWaitTimeout: Duration = .seconds(4),
         responseTimeout: Duration = .seconds(30),
+        keepaliveInterval: Duration = .seconds(5),
+        subscriptionBufferLimit: Int = 128,
         reconnectBackoff: @escaping @Sendable (Int) -> Duration = { failureCount in
             // Jitter desynchronizes reconnects across environments so a
             // server restart doesn't trigger simultaneous ticket mints.
@@ -274,6 +279,8 @@ public actor WebSocketRPCClient {
         self.connector = connector
         self.connectionWaitTimeout = connectionWaitTimeout
         self.responseTimeout = responseTimeout
+        self.keepaliveInterval = keepaliveInterval
+        self.subscriptionBufferLimit = max(1, subscriptionBufferLimit)
         self.reconnectBackoff = reconnectBackoff
         self.endpointProvider = endpointProvider
     }
@@ -306,6 +313,7 @@ public actor WebSocketRPCClient {
         loopTask = nil
         keepaliveTask?.cancel()
         keepaliveTask = nil
+        awaitingKeepaliveResponse = false
         connection = nil
         connectionID = nil
         failUnary(RPCError.disconnected, includingUnsent: true)
@@ -341,7 +349,8 @@ public actor WebSocketRPCClient {
         as type: Value.Type
     ) -> AsyncThrowingStream<Value, Error> {
         let subscriptionID = UUID()
-        return AsyncThrowingStream { continuation in
+        return AsyncThrowingStream(bufferingPolicy: .bufferingOldest(subscriptionBufferLimit)) {
+            continuation in
             subscriptions[subscriptionID] = Subscription(
                 tag: tag,
                 payload: payload,
@@ -349,9 +358,17 @@ public actor WebSocketRPCClient {
                 requestID: nil,
                 yield: { value in
                     do {
-                        continuation.yield(try value.decode(type))
+                        switch continuation.yield(try value.decode(type)) {
+                        case .enqueued:
+                            return true
+                        case .dropped, .terminated:
+                            return false
+                        @unknown default:
+                            return false
+                        }
                     } catch {
                         continuation.finish(throwing: error)
+                        return false
                     }
                 },
                 finish: { error in
@@ -516,8 +533,9 @@ public actor WebSocketRPCClient {
         keepaliveTask?.cancel()
         if let connectionID {
             let owner = WeakOwner(self)
+            let interval = keepaliveInterval
             keepaliveTask = Task {
-                await Self.keepaliveLoop(owner: owner, connectionID: connectionID)
+                await Self.keepaliveLoop(owner: owner, connectionID: connectionID, interval: interval)
             }
         }
         // Snapshot the keys: the sends suspend, and reentrant completions or
@@ -539,6 +557,7 @@ public actor WebSocketRPCClient {
         let closingConnection = connection
         keepaliveTask?.cancel()
         keepaliveTask = nil
+        awaitingKeepaliveResponse = false
         connection = nil
         connectionID = nil
         Self.logger.info("WebSocket connection closed")
@@ -560,6 +579,7 @@ public actor WebSocketRPCClient {
     private func handle(_ data: Data, expectedConnectionID: UUID) async throws -> Bool {
         guard connectionID == expectedConnectionID else { return false }
         let response = try JSONDecoder.t3.decode(RPCResponseEnvelope.self, from: data)
+        awaitingKeepaliveResponse = false
         try await handle(response)
         return connectionID == expectedConnectionID
     }
@@ -573,7 +593,13 @@ public actor WebSocketRPCClient {
                   let subscriptionID = subscriptionByRequestID[requestID],
                   let subscription = subscriptions[subscriptionID]
             else { return }
-            response.values?.forEach(subscription.yield)
+            for value in response.values ?? [] {
+                guard subscription.yield(value) else {
+                    throw RPCError.protocolViolation(
+                        "The live stream exceeded its buffered event limit."
+                    )
+                }
+            }
             try await sendControl("Ack", requestID: requestID)
         case "Exit":
             guard let requestID = response.requestId, let exit = response.exit else { return }
@@ -660,9 +686,13 @@ public actor WebSocketRPCClient {
         }
     }
 
-    private static func keepaliveLoop(owner: WeakOwner, connectionID: UUID) async {
+    private static func keepaliveLoop(
+        owner: WeakOwner,
+        connectionID: UUID,
+        interval: Duration
+    ) async {
         while !Task.isCancelled {
-            try? await Task.sleep(for: .seconds(5))
+            try? await Task.sleep(for: interval)
             guard !Task.isCancelled,
                   await owner.sendKeepalive(connectionID: connectionID) else { return }
         }
@@ -672,7 +702,12 @@ public actor WebSocketRPCClient {
         guard desired, connectionID == expectedConnectionID, connection != nil else {
             return false
         }
+        if awaitingKeepaliveResponse {
+            await disconnected(expectedConnectionID: expectedConnectionID)
+            return false
+        }
         do {
+            awaitingKeepaliveResponse = true
             try await sendControl("Ping", requestID: nil)
             return connectionID == expectedConnectionID
         } catch {

--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -606,9 +606,13 @@ public actor WebSocketRPCClient {
                 case .enqueued:
                     continue
                 case .dropped:
-                    throw RPCError.protocolViolation(
+                    let error = RPCError.protocolViolation(
                         "The live stream exceeded its buffered event limit."
                     )
+                    subscriptionByRequestID.removeValue(forKey: requestID)
+                    subscriptions.removeValue(forKey: subscriptionID)
+                    subscription.finish(error)
+                    throw error
                 case .terminated:
                     await removeSubscription(subscriptionID)
                     return

--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -167,6 +167,12 @@ public actor WebSocketRPCClient {
         let resume: @Sendable (Result<JSONValue, Error>) -> Void
     }
 
+    private enum SubscriptionYieldResult: Sendable {
+        case enqueued
+        case dropped
+        case terminated
+    }
+
     private struct Subscription {
         let tag: String
         let payload: JSONValue
@@ -175,7 +181,7 @@ public actor WebSocketRPCClient {
         /// The connection that assigned `requestID`. Request IDs are reissued
         /// after reconnects, so an Interrupt is only valid on this connection.
         var requestConnectionID: UUID?
-        let yield: @Sendable (JSONValue) -> Bool
+        let yield: @Sendable (JSONValue) -> SubscriptionYieldResult
         let finish: @Sendable (Error?) -> Void
     }
 
@@ -279,7 +285,7 @@ public actor WebSocketRPCClient {
         self.connector = connector
         self.connectionWaitTimeout = connectionWaitTimeout
         self.responseTimeout = responseTimeout
-        self.keepaliveInterval = keepaliveInterval
+        self.keepaliveInterval = keepaliveInterval > .zero ? keepaliveInterval : .seconds(5)
         self.subscriptionBufferLimit = max(1, subscriptionBufferLimit)
         self.reconnectBackoff = reconnectBackoff
         self.endpointProvider = endpointProvider
@@ -360,15 +366,17 @@ public actor WebSocketRPCClient {
                     do {
                         switch continuation.yield(try value.decode(type)) {
                         case .enqueued:
-                            return true
-                        case .dropped, .terminated:
-                            return false
+                            return .enqueued
+                        case .dropped:
+                            return .dropped
+                        case .terminated:
+                            return .terminated
                         @unknown default:
-                            return false
+                            return .dropped
                         }
                     } catch {
                         continuation.finish(throwing: error)
-                        return false
+                        return .terminated
                     }
                 },
                 finish: { error in
@@ -594,10 +602,16 @@ public actor WebSocketRPCClient {
                   let subscription = subscriptions[subscriptionID]
             else { return }
             for value in response.values ?? [] {
-                guard subscription.yield(value) else {
+                switch subscription.yield(value) {
+                case .enqueued:
+                    continue
+                case .dropped:
                     throw RPCError.protocolViolation(
                         "The live stream exceeded its buffered event limit."
                     )
+                case .terminated:
+                    await removeSubscription(subscriptionID)
+                    return
                 }
             }
             try await sendControl("Ack", requestID: requestID)

--- a/apps/swift-ios/Extensions/Share/SharePayloadLoader.swift
+++ b/apps/swift-ios/Extensions/Share/SharePayloadLoader.swift
@@ -8,6 +8,7 @@ struct T3LoadedSharePayload: Sendable {
 }
 
 enum T3SharePayloadLoader {
+    @MainActor
     static func load(from inputItems: [Any]) async -> T3LoadedSharePayload {
         var textFragments: [String] = []
         var images: [T3PendingShareImage] = []
@@ -51,22 +52,22 @@ enum T3SharePayloadLoader {
                 }
 
                 if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier),
-                   let value = try? await loadItem(
+                   let urlText = try? await loadItemString(
                        from: provider,
-                       typeIdentifier: UTType.url.identifier
-                   ),
-                   let urlText = urlString(from: value)
+                       typeIdentifier: UTType.url.identifier,
+                       expectingURL: true
+                   )
                 {
                     textFragments.append(urlText)
                     continue
                 }
 
                 if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier),
-                   let value = try? await loadItem(
+                   let text = try? await loadItemString(
                        from: provider,
-                       typeIdentifier: UTType.plainText.identifier
-                   ),
-                   let text = textString(from: value)
+                       typeIdentifier: UTType.plainText.identifier,
+                       expectingURL: false
+                   )
                 {
                     textFragments.append(text)
                 }
@@ -89,6 +90,7 @@ enum T3SharePayloadLoader {
         )
     }
 
+    @MainActor
     private static func loadStagedImage(
         from provider: NSItemProvider,
         typeIdentifier: String
@@ -153,14 +155,17 @@ enum T3SharePayloadLoader {
         }
     }
 
-    private static func loadItem(
+    @MainActor
+    private static func loadItemString(
         from provider: NSItemProvider,
-        typeIdentifier: String
-    ) async throws -> NSSecureCoding {
+        typeIdentifier: String,
+        expectingURL: Bool
+    ) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             provider.loadItem(forTypeIdentifier: typeIdentifier) { value, error in
-                if let value {
-                    continuation.resume(returning: value)
+                if let value,
+                   let text = expectingURL ? urlString(from: value) : textString(from: value) {
+                    continuation.resume(returning: text)
                 } else {
                     continuation.resume(throwing: error ?? CocoaError(.fileReadUnknown))
                 }

--- a/apps/swift-ios/Extensions/Widgets/RecentTasksWidget.swift
+++ b/apps/swift-ios/Extensions/Widgets/RecentTasksWidget.swift
@@ -179,7 +179,7 @@ private struct T3TaskWidgetView: View {
 }
 
 private enum T3WidgetURLs {
-    static let newTask = URL(string: "t3code-swiftui://new-task")!
+    static let newTask = URL(string: "\(T3SharedContainer.urlScheme)://new-task")!
 }
 
 private extension T3AgentActivityPhase {

--- a/apps/swift-ios/Features/Chat/FeatureComposerPowerFeatures.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerPowerFeatures.swift
@@ -23,7 +23,7 @@ struct FeatureComposerPowerFeatures {
         self.searchPaths = searchPaths
     }
 
-    static let disabled = FeatureComposerPowerFeatures()
+    static var disabled: FeatureComposerPowerFeatures { FeatureComposerPowerFeatures() }
 }
 
 public struct FeatureProviderSlashCommand: Identifiable, Sendable, Equatable, Hashable, Codable {

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -5,6 +5,7 @@ import UIKit
 public struct ThreadDetailView: View {
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @SwiftUI.Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @SwiftUI.Environment(\.scenePhase) private var scenePhase
 
     @Bindable var model: FeatureRootModel
     let thread: FeatureThread
@@ -79,6 +80,11 @@ public struct ThreadDetailView: View {
         .onChange(of: draft) { scheduleDraftSave() }
         .onChange(of: attachments) { scheduleDraftSave() }
         .onChange(of: selection) { scheduleDraftSave() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase != .active {
+                persistDraftBeforeLeaving()
+            }
+        }
         .onDisappear {
             model.releaseThread(thread.id)
             persistDraftBeforeLeaving()
@@ -254,7 +260,7 @@ public struct ThreadDetailView: View {
                         )
                     }
                 }
-                if currentThread.canToggleSettlement, !currentThread.isArchived {
+                if currentThread.canSettleNow, !currentThread.isArchived {
                     let isSettled = currentThread.isEffectivelySettled(at: .now)
                     Button {
                         Task { await model.setSettled(thread.id, settled: !isSettled) }
@@ -1419,10 +1425,6 @@ private struct ThreadBackSwipeGestureView: UIViewRepresentable {
 
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
-        }
-
-        deinit {
-            uninstallGesture()
         }
 
         override func didMoveToWindow() {

--- a/apps/swift-ios/Features/Connection/ConnectionOnboardingView.swift
+++ b/apps/swift-ios/Features/Connection/ConnectionOnboardingView.swift
@@ -149,7 +149,7 @@ public struct ConnectionOnboardingView: View {
                    let capability = model.client as? any T3ConnectCapable,
                    capability.t3ConnectController.unavailableReason == nil {
                     NavigationLink {
-                        T3ConnectView(capability: capability) {
+                        T3ConnectView(capability: capability, model: model) {
                             await model.reloadAfterConnection()
                             onConnected()
                         }

--- a/apps/swift-ios/Features/Connection/T3ConnectView.swift
+++ b/apps/swift-ios/Features/Connection/T3ConnectView.swift
@@ -23,13 +23,18 @@ public struct T3ConnectView: View {
 
     public init(
         capability: any T3ConnectCapable,
+        model: FeatureRootModel? = nil,
         purpose: Purpose = .connect,
         onConnected: @escaping @MainActor () async -> Void = {},
         onUnlinked: @escaping @MainActor (String) async -> Void = { _ in }
     ) {
         controller = capability.t3ConnectController
         connectEnvironment = capability.connectT3Environment
-        signOut = capability.signOutT3Connect
+        signOut = if let model {
+            model.signOutT3Connect
+        } else {
+            capability.signOutT3Connect
+        }
         self.purpose = purpose
         self.onConnected = onConnected
         self.onUnlinked = onUnlinked

--- a/apps/swift-ios/Features/Devices/DevicesView.swift
+++ b/apps/swift-ios/Features/Devices/DevicesView.swift
@@ -76,12 +76,16 @@ public struct DevicesView: View {
             ),
             presenting: revokeTarget
         ) { device in
-            Button("Remove access", role: .destructive) {
+            Button(manager.managesServerSessions ? "Remove access" : "Remove device", role: .destructive) {
                 Task { await revoke(device) }
             }
             Button("Cancel", role: .cancel) {}
         } message: { device in
-            Text("\(device.displayName) will need a new pairing code to reconnect.")
+            Text(
+                manager.managesServerSessions
+                    ? "\(device.displayName) will need a new pairing code to reconnect."
+                    : "\(device.displayName) will stop receiving T3 Connect notifications."
+            )
         }
         .confirmationDialog(
             "Remove all other devices?",
@@ -93,7 +97,11 @@ public struct DevicesView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Every other phone, tablet, browser, and desktop will be signed out.")
+            Text(
+                manager.managesServerSessions
+                    ? "Every other phone, tablet, browser, and desktop will be signed out."
+                    : "Other registered devices will stop receiving T3 Connect notifications."
+            )
         }
     }
 

--- a/apps/swift-ios/Features/Devices/FeatureDeviceManagement.swift
+++ b/apps/swift-ios/Features/Devices/FeatureDeviceManagement.swift
@@ -107,9 +107,14 @@ public struct FeatureDeviceSession: Identifiable, Sendable, Equatable, Codable {
 /// for environments that do not grant the access:read/access:write scopes.
 @MainActor
 public protocol FeatureDeviceManaging: AnyObject {
+    var managesServerSessions: Bool { get }
     func loadDeviceSessions() async throws -> [FeatureDeviceSession]
     func revokeDeviceSession(id: String) async throws
     func revokeOtherDeviceSessions() async throws
+}
+
+extension FeatureDeviceManaging {
+    var managesServerSessions: Bool { true }
 }
 
 @MainActor

--- a/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
+++ b/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
@@ -39,14 +39,22 @@ private final class PullRequestsModel {
     var errorMessage: String?
 
     private let client: any FeatureClient
+    private var loadGeneration: UInt64 = 0
 
     init(client: any FeatureClient) {
         self.client = client
     }
 
     func load(invalidate: Bool = false) async {
+        loadGeneration &+= 1
+        let generation = loadGeneration
         isLoading = true
         errorMessage = nil
+        defer {
+            if loadGeneration == generation {
+                isLoading = false
+            }
+        }
         do {
             if invalidate { try await client.invalidatePullRequests(nil) }
             let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -63,7 +71,9 @@ private final class PullRequestsModel {
                     query: trimmedQuery.isEmpty ? nil : trimmedQuery
                 )
             )
+            guard !Task.isCancelled, loadGeneration == generation else { return }
             environments = result
+            var seenPullRequestIDs = Set<String>()
             allRows = result.flatMap { environment in
                 (environment.result?.entries ?? []).map {
                     FeaturePullRequestRow(
@@ -73,12 +83,13 @@ private final class PullRequestsModel {
                     )
                 }
             }
+            .filter { seenPullRequestIDs.insert($0.entry.id).inserted }
             .sorted { $0.entry.updatedAt > $1.entry.updatedAt }
             applyLocalFilters()
         } catch {
+            guard loadGeneration == generation, !(error is CancellationError) else { return }
             errorMessage = error.localizedDescription
         }
-        isLoading = false
     }
 
     func applyLocalFilters() {
@@ -375,6 +386,7 @@ private final class PullRequestDetailModel {
     var detail: PullRequestDetail?
     var activity: PullRequestActivity?
     var diffFiles: [PullRequestDiffFile] = []
+    var isDiffIncomplete = false
     var isLoading = true
     var isLoadingDiff = false
     var isActing = false
@@ -410,12 +422,16 @@ private final class PullRequestDetailModel {
         do {
             var cursor: String?
             var patch = ""
+            var omittedChanges = false
             repeat {
                 let page = try await client.pullRequestDiff(target, cursor: cursor)
                 patch += page.patch
+                omittedChanges = omittedChanges || page.truncated
+                    || !(page.omittedFileStats ?? []).isEmpty
                 cursor = page.nextCursor
             } while cursor != nil
             diffFiles = PullRequestDiffParser.parse(patch)
+            isDiffIncomplete = omittedChanges
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -526,6 +542,13 @@ private enum PullRequestDetailTab: String, CaseIterable {
 }
 
 private struct PullRequestDetailView: View {
+    private struct PendingAction: Identifiable {
+        let id = UUID()
+        let action: PullRequestAction
+        var mergeMethod: PullRequestMergeMethod?
+        var updateMethod: PullRequestUpdateMethod?
+    }
+
     @Bindable var rootModel: FeatureRootModel
     let row: FeaturePullRequestRow
     @State private var model: PullRequestDetailModel
@@ -534,6 +557,7 @@ private struct PullRequestDetailView: View {
     @State private var reviewSheet = false
     @State private var reviewerSheet = false
     @State private var notice: String?
+    @State private var pendingAction: PendingAction?
 
     init(rootModel: FeatureRootModel, row: FeaturePullRequestRow) {
         self.rootModel = rootModel
@@ -602,6 +626,28 @@ private struct PullRequestDetailView: View {
             get: { model.errorMessage != nil },
             set: { if !$0 { model.errorMessage = nil } }
         )) { Button("OK") {} } message: { Text(model.errorMessage ?? "") }
+        .alert(
+            "Confirm pull request action",
+            isPresented: Binding(
+                get: { pendingAction != nil },
+                set: { if !$0 { pendingAction = nil } }
+            ),
+            presenting: pendingAction
+        ) { pending in
+            Button(pending.action.label, role: .destructive) {
+                pendingAction = nil
+                Task {
+                    await model.run(
+                        pending.action,
+                        mergeMethod: pending.mergeMethod,
+                        updateMethod: pending.updateMethod
+                    )
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingAction = nil }
+        } message: { pending in
+            Text("This action will \(pending.action.label.lowercased()).")
+        }
     }
 
     private func detailHeader(_ detail: PullRequestDetail) -> some View {
@@ -628,13 +674,21 @@ private struct PullRequestDetailView: View {
     private func tabContent(_ detail: PullRequestDetail) -> some View {
         switch tab {
         case .summary:
-            PullRequestSummaryView(detail: detail, activity: model.activity, model: model)
+            PullRequestSummaryView(
+                detail: detail,
+                activity: model.activity,
+                model: model,
+                onUpdateBranch: { method in
+                    pendingAction = PendingAction(action: .updateBranch, updateMethod: method)
+                }
+            )
         case .conversation:
             PullRequestActivityView(activity: model.activity, model: model)
         case .files:
             PullRequestFilesView(
                 files: model.diffFiles,
                 isLoading: model.isLoadingDiff,
+                isIncomplete: model.isDiffIncomplete,
                 drafts: $model.reviewDrafts,
                 canComment: detail.capabilities.review.inlineComment
                     && detail.viewerPermissions.comment,
@@ -676,7 +730,11 @@ private struct PullRequestDetailView: View {
                        action != .merge,
                        action != .updateBranch {
                         Button(action.label, systemImage: action.systemImage) {
-                            Task { await model.run(action) }
+                            if action == .close || action == .enableAutoMerge {
+                                pendingAction = PendingAction(action: action)
+                            } else {
+                                Task { await model.run(action) }
+                            }
                         }
                     }
                 }
@@ -685,7 +743,7 @@ private struct PullRequestDetailView: View {
                     Menu("Merge pull request") {
                         ForEach(availableMergeMethods(detail), id: \.self) { method in
                             Button(method.label) {
-                                Task { await model.run(.merge, mergeMethod: method) }
+                                pendingAction = PendingAction(action: .merge, mergeMethod: method)
                             }
                         }
                     }
@@ -751,6 +809,7 @@ private struct PullRequestSummaryView: View {
     let detail: PullRequestDetail
     let activity: PullRequestActivity?
     @Bindable var model: PullRequestDetailModel
+    let onUpdateBranch: (PullRequestUpdateMethod) -> Void
 
     var body: some View {
         ScrollView {
@@ -769,7 +828,7 @@ private struct PullRequestSummaryView: View {
                         Menu("Update") {
                             ForEach(detail.viewerPermissions.updateMethods ?? [], id: \.self) { method in
                                 Button(method.rawValue.capitalized) {
-                                    Task { await model.run(.updateBranch, updateMethod: method) }
+                                    onUpdateBranch(method)
                                 }
                             }
                         }
@@ -987,6 +1046,7 @@ private struct PullRequestReactionsView: View {
 private struct PullRequestFilesView: View {
     let files: [PullRequestDiffFile]
     let isLoading: Bool
+    let isIncomplete: Bool
     @Binding var drafts: [PullRequestReviewCommentDraft]
     let canComment: Bool
     let sendToAgent: (PullRequestDiffLine, PullRequestDiffFile) -> Void
@@ -995,6 +1055,14 @@ private struct PullRequestFilesView: View {
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 18) {
+                if isIncomplete {
+                    Label(
+                        "Some changes are missing from this diff.",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .font(T3Typography.supportingStrong)
+                    .foregroundStyle(T3Colors.warning)
+                }
                 if isLoading {
                     ProgressView("Loading diff…")
                         .frame(maxWidth: .infinity)
@@ -1097,7 +1165,12 @@ private struct PullRequestReviewSheet: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Submit") {
-                        Task { await model.review(verdict: verdict, body: reviewBody); dismiss() }
+                        Task {
+                            await model.review(verdict: verdict, body: reviewBody)
+                            if model.errorMessage == nil {
+                                dismiss()
+                            }
+                        }
                     }
                 }
             }
@@ -1271,6 +1344,9 @@ enum PullRequestDiffParser {
         }
 
         for raw in patch.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            if raw == "\\ No newline at end of file" {
+                continue
+            }
             if raw.hasPrefix("diff --git ") {
                 finish()
                 let parts = raw.split(separator: " ")

--- a/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
+++ b/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
@@ -73,7 +73,7 @@ private final class PullRequestsModel {
             )
             guard !Task.isCancelled, loadGeneration == generation else { return }
             environments = result
-            var seenPullRequestIDs = Set<String>()
+            var seenRowIDs = Set<String>()
             allRows = result.flatMap { environment in
                 (environment.result?.entries ?? []).map {
                     FeaturePullRequestRow(
@@ -83,7 +83,7 @@ private final class PullRequestsModel {
                     )
                 }
             }
-            .filter { seenPullRequestIDs.insert($0.entry.id).inserted }
+            .filter { seenRowIDs.insert($0.id).inserted }
             .sorted { $0.entry.updatedAt > $1.entry.updatedAt }
             applyLocalFilters()
         } catch {
@@ -421,17 +421,13 @@ private final class PullRequestDetailModel {
         isLoadingDiff = true
         do {
             var cursor: String?
-            var patch = ""
-            var omittedChanges = false
+            var pagination = PullRequestDiffPagination()
             repeat {
                 let page = try await client.pullRequestDiff(target, cursor: cursor)
-                patch += page.patch
-                omittedChanges = omittedChanges || page.truncated
-                    || !(page.omittedFileStats ?? []).isEmpty
-                cursor = page.nextCursor
+                cursor = pagination.append(page)
             } while cursor != nil
-            diffFiles = PullRequestDiffParser.parse(patch)
-            isDiffIncomplete = omittedChanges
+            diffFiles = PullRequestDiffParser.parse(pagination.patch)
+            isDiffIncomplete = pagination.isIncomplete
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -461,7 +457,8 @@ private final class PullRequestDetailModel {
         await mutate { try await client.commentOnPullRequest(target, body: body) }
     }
 
-    func review(verdict: PullRequestReviewVerdict, body: String) async {
+    func review(verdict: PullRequestReviewVerdict, body: String) async -> Bool {
+        var submitted = false
         await mutate {
             try await client.submitPullRequestReview(
                 target,
@@ -470,7 +467,9 @@ private final class PullRequestDetailModel {
                 comments: reviewDrafts
             )
             reviewDrafts = []
+            submitted = true
         }
+        return submitted
     }
 
     func reply(threadID: String, body: String) async {
@@ -1166,12 +1165,12 @@ private struct PullRequestReviewSheet: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Submit") {
                         Task {
-                            await model.review(verdict: verdict, body: reviewBody)
-                            if model.errorMessage == nil {
+                            if await model.review(verdict: verdict, body: reviewBody) {
                                 dismiss()
                             }
                         }
                     }
+                    .disabled(model.isActing)
                 }
             }
             .onAppear {
@@ -1324,6 +1323,25 @@ private struct PullRequestDiffSelection: Identifiable {
     var id: String { "\(file.id):\(line.id)" }
     let file: PullRequestDiffFile
     let line: PullRequestDiffLine
+}
+
+struct PullRequestDiffPagination {
+    private(set) var patch = ""
+    private(set) var isIncomplete = false
+    private var seenCursors = Set<String>()
+
+    mutating func append(_ page: PullRequestDiffResult) -> String? {
+        patch += page.patch
+        isIncomplete = isIncomplete || page.truncated
+            || !(page.omittedFileStats ?? []).isEmpty
+
+        guard let cursor = page.nextCursor, !cursor.isEmpty else { return nil }
+        guard seenCursors.insert(cursor).inserted else {
+            isIncomplete = true
+            return nil
+        }
+        return cursor
+    }
 }
 
 enum PullRequestDiffParser {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -41,6 +41,7 @@ public final class FeatureRootModel {
 
     let client: any FeatureClient
     private let outboxStore: FeatureOutboxStore
+    private let draftStore: FeatureComposerDraftStore
     private var pendingSubmissionsByID: [String: FeatureQueuedSubmission] = [:]
     private var pendingThreadsByID: [String: FeatureThread] = [:]
     private var pendingCompletionSubmissionIDs: Set<String> = []
@@ -57,10 +58,12 @@ public final class FeatureRootModel {
 
     public init(
         client: any FeatureClient,
-        outboxStore: FeatureOutboxStore = .shared
+        outboxStore: FeatureOutboxStore = .shared,
+        draftStore: FeatureComposerDraftStore = .shared
     ) {
         self.client = client
         self.outboxStore = outboxStore
+        self.draftStore = draftStore
     }
 
     public func start() async {
@@ -122,20 +125,81 @@ public final class FeatureRootModel {
     }
 
     public func removeEnvironment(_ id: String) async {
+        var logicalProjectIDs = Set<String>(snapshot.projects.compactMap { project in
+            guard project.environmentID == id, project.repositoryIdentity != nil else {
+                return nil
+            }
+            return DailyUXCreationContext.logicalProjectID(for: project, in: snapshot)
+        })
+        let remainingLogicalProjectIDs = Set<String>(snapshot.projects.compactMap { project in
+            guard project.environmentID != id, project.repositoryIdentity != nil else {
+                return nil
+            }
+            return DailyUXCreationContext.logicalProjectID(for: project, in: snapshot)
+        })
+        logicalProjectIDs.subtract(remainingLogicalProjectIDs)
         await stopOutboxDrain()
         await perform {
             try await client.removeEnvironment(id: id)
             do {
                 try await outboxStore.removeAll(environmentID: id)
                 removePendingSubmissions(environmentID: id)
+                try await draftStore.removeDrafts(
+                    environmentID: id,
+                    logicalProjectIDs: logicalProjectIDs
+                )
             } catch {
                 markPendingSubmissionsForDiscard(environmentID: id)
-                errorMessage = "Environment removed, but its queued messages could not be cleared: \(error.localizedDescription)"
+                errorMessage = "Environment removed, but its queued messages or drafts could not be cleared: \(error.localizedDescription)"
             }
             install(try await client.initialSnapshot())
             clearDetails()
         }
         scheduleOutboxDrain()
+    }
+
+    public func signOutT3Connect() async {
+        guard let capability = client as? any T3ConnectCapable else { return }
+        let removedEnvironmentIDs = snapshot.environments
+            .filter { $0.source == .t3Connect }
+            .map(\.id)
+        let groupedProjects = Dictionary(
+            grouping: snapshot.projects.filter { $0.repositoryIdentity != nil },
+            by: \.environmentID
+        )
+        let logicalProjectIDs = removedEnvironmentIDs.reduce(into: [String: Set<String>]()) {
+            result, environmentID in
+            result[environmentID] = Set((groupedProjects[environmentID] ?? []).map {
+                DailyUXCreationContext.logicalProjectID(for: $0, in: snapshot)
+            })
+        }
+
+        await stopOutboxDrain()
+        await capability.signOutT3Connect()
+        for environmentID in removedEnvironmentIDs {
+            do {
+                try await outboxStore.removeAll(environmentID: environmentID)
+                removePendingSubmissions(environmentID: environmentID)
+                try await draftStore.removeDrafts(
+                    environmentID: environmentID,
+                    logicalProjectIDs: logicalProjectIDs[environmentID] ?? []
+                )
+            } catch {
+                errorMessage = "Could not clear saved T3 Connect data: \(error.localizedDescription)"
+            }
+        }
+        clearDetails()
+        await reload()
+        scheduleOutboxDrain()
+    }
+
+    func removeManagedEnvironmentsAfterAccountChange() async {
+        let managedIDs = snapshot.environments
+            .filter { $0.source == .t3Connect }
+            .map(\.id)
+        for id in managedIDs {
+            await removeEnvironment(id)
+        }
     }
 
     @discardableResult
@@ -302,6 +366,13 @@ public final class FeatureRootModel {
     }
 
     public func setArchived(_ id: String, archived: Bool) async {
+        if archived,
+           let thread = snapshot.threads.first(where: { $0.id == id }),
+           [.queued, .working, .monitoring, .waitingForApproval, .waitingForInput]
+               .contains(thread.state) {
+            errorMessage = "This thread is still active. Stop it before archiving."
+            return
+        }
         let environment = currentEnvironmentIdentity
         await perform {
             try await client.setThreadArchived(id: id, archived: archived)
@@ -311,6 +382,12 @@ public final class FeatureRootModel {
     }
 
     public func setSettled(_ id: String, settled: Bool) async {
+        if settled,
+           let thread = snapshot.threads.first(where: { $0.id == id }),
+           !thread.canSettleNow {
+            errorMessage = "This thread still needs attention. Resolve or stop it first."
+            return
+        }
         let environment = currentEnvironmentIdentity
         await perform {
             try await client.setThreadSettled(id: id, settled: settled)
@@ -542,6 +619,19 @@ public final class FeatureRootModel {
     }
 
     public func cancelTurn(threadID: String) async {
+        if pendingSubmissionsByID.values.contains(where: {
+            $0.threadID == threadID && $0.creation != nil
+        }) {
+            await stopOutboxDrain()
+            let queued = pendingSubmissionsByID.values.filter { $0.threadID == threadID }
+            for submission in queued {
+                if !(await discardQueuedSubmission(submission)) {
+                    scheduleOutboxRetry()
+                }
+            }
+            scheduleOutboxDrain()
+            return
+        }
         await perform {
             try await client.cancelTurn(threadID: threadID)
         }
@@ -670,7 +760,6 @@ public final class FeatureRootModel {
                 scheduleOutboxDrain()
             }
         case let .thread(value):
-            acknowledgeAuthoritativeThread(value.id)
             upsert(value)
         case let .threadRemoved(id):
             removeThread(id: id)
@@ -736,9 +825,6 @@ public final class FeatureRootModel {
     private func install(_ value: FeatureSnapshot) {
         var value = value
         let authoritativeThreadIDs = Set(value.threads.map(\.id))
-        for id in authoritativeThreadIDs {
-            acknowledgeAuthoritativeThread(id)
-        }
         for pending in pendingThreadsByID.values where !authoritativeThreadIDs.contains(pending.id) {
             value.threads.append(pending)
             if let index = value.projects.firstIndex(where: { $0.id == pending.projectID }) {
@@ -957,7 +1043,10 @@ public final class FeatureRootModel {
         for submission in submissions {
             if let creation = submission.creation {
                 if snapshot.threads.contains(where: { $0.id == submission.threadID }) {
-                    await discardRestoredSubmission(submission)
+                    pendingSubmissionsByID[submission.id] = submission
+                    if let detail = details[submission.threadID] {
+                        store(addingPendingMessages(to: detail))
+                    }
                     continue
                 }
                 guard let project = snapshot.projects.first(where: {
@@ -1121,14 +1210,6 @@ public final class FeatureRootModel {
         return result
     }
 
-    private func acknowledgeAuthoritativeThread(_ id: String) {
-        guard pendingThreadsByID[id] != nil,
-              let submission = pendingSubmissionsByID.values.first(where: {
-                  $0.threadID == id && $0.creation != nil
-              }) else { return }
-        scheduleQueuedSubmissionCompletion(submission)
-    }
-
     private func acknowledgeDeliveredMessages(_ messages: [FeatureMessage]) {
         // Runs on every detail publish; skip the full message-ID scan in the
         // common case where nothing is waiting in the outbox.
@@ -1140,7 +1221,7 @@ public final class FeatureRootModel {
             .filter { $0.state != .queued }
             .map(\.id))
         let delivered = pendingSubmissionsByID.values.filter {
-            $0.creation == nil && messageIDs.contains($0.identity.messageID)
+            messageIDs.contains($0.identity.messageID)
         }
         for submission in delivered {
             scheduleQueuedSubmissionCompletion(submission)
@@ -1299,7 +1380,11 @@ public final class FeatureRootModel {
             switch FeatureOutboxPolicy.decision(
                 for: submission,
                 snapshot: policySnapshot,
-                pendingCreationThreadIDs: Set(pendingThreadsByID.keys)
+                pendingCreationThreadIDs: Set(
+                    pendingSubmissionsByID.values.compactMap {
+                        $0.creation == nil ? nil : $0.threadID
+                    }
+                )
             ) {
             case .discard:
                 if !(await discardQueuedSubmission(submission)) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -37,6 +37,7 @@ public final class FeatureRootModel {
     public private(set) var isLoading = true
     public private(set) var isPerformingAction = false
     public private(set) var isManagingConnections = false
+    private(set) var isSigningOutT3Connect = false
     public var errorMessage: String?
 
     let client: any FeatureClient
@@ -141,16 +142,24 @@ public final class FeatureRootModel {
         await stopOutboxDrain()
         await perform {
             try await client.removeEnvironment(id: id)
+            var cleanupError: (any Error)?
             do {
                 try await outboxStore.removeAll(environmentID: id)
                 removePendingSubmissions(environmentID: id)
+            } catch {
+                markPendingSubmissionsForDiscard(environmentID: id)
+                cleanupError = error
+            }
+            do {
                 try await draftStore.removeDrafts(
                     environmentID: id,
                     logicalProjectIDs: logicalProjectIDs
                 )
             } catch {
-                markPendingSubmissionsForDiscard(environmentID: id)
-                errorMessage = "Environment removed, but its queued messages or drafts could not be cleared: \(error.localizedDescription)"
+                cleanupError = cleanupError ?? error
+            }
+            if let cleanupError {
+                errorMessage = "Environment removed, but its queued messages or drafts could not be cleared: \(cleanupError.localizedDescription)"
             }
             install(try await client.initialSnapshot())
             clearDetails()
@@ -160,32 +169,51 @@ public final class FeatureRootModel {
 
     public func signOutT3Connect() async {
         guard let capability = client as? any T3ConnectCapable else { return }
+        isSigningOutT3Connect = true
+        defer { isSigningOutT3Connect = false }
         let removedEnvironmentIDs = snapshot.environments
             .filter { $0.source == .t3Connect }
             .map(\.id)
+        let removedEnvironmentIDSet = Set(removedEnvironmentIDs)
         let groupedProjects = Dictionary(
             grouping: snapshot.projects.filter { $0.repositoryIdentity != nil },
             by: \.environmentID
         )
+        let retainedLogicalProjectIDs = Set<String>(snapshot.projects.compactMap { project in
+            guard project.repositoryIdentity != nil,
+                  !removedEnvironmentIDSet.contains(project.environmentID) else {
+                return nil
+            }
+            return DailyUXCreationContext.logicalProjectID(for: project, in: snapshot)
+        })
         let logicalProjectIDs = removedEnvironmentIDs.reduce(into: [String: Set<String>]()) {
             result, environmentID in
-            result[environmentID] = Set((groupedProjects[environmentID] ?? []).map {
+            let projectIDs = Set((groupedProjects[environmentID] ?? []).map {
                 DailyUXCreationContext.logicalProjectID(for: $0, in: snapshot)
             })
+            result[environmentID] = projectIDs.subtracting(retainedLogicalProjectIDs)
         }
 
         await stopOutboxDrain()
         await capability.signOutT3Connect()
         for environmentID in removedEnvironmentIDs {
+            var cleanupError: (any Error)?
             do {
                 try await outboxStore.removeAll(environmentID: environmentID)
-                removePendingSubmissions(environmentID: environmentID)
+            } catch {
+                cleanupError = error
+            }
+            removePendingSubmissions(environmentID: environmentID)
+            do {
                 try await draftStore.removeDrafts(
                     environmentID: environmentID,
                     logicalProjectIDs: logicalProjectIDs[environmentID] ?? []
                 )
             } catch {
-                errorMessage = "Could not clear saved T3 Connect data: \(error.localizedDescription)"
+                cleanupError = cleanupError ?? error
+            }
+            if let cleanupError {
+                errorMessage = "Could not clear saved T3 Connect data: \(cleanupError.localizedDescription)"
             }
         }
         clearDetails()
@@ -330,7 +358,8 @@ public final class FeatureRootModel {
                 if isEnvironmentConnected(project.environmentID) {
                     scheduleOutboxRetry()
                 }
-                return pendingThreadsByID[threadID]
+                return snapshot.threads.first { $0.id == threadID }
+                    ?? pendingThreadsByID[threadID]
             }
             let discarded = await discardQueuedSubmission(queued)
             if !discarded {
@@ -629,6 +658,12 @@ public final class FeatureRootModel {
                     scheduleOutboxRetry()
                 }
             }
+            if pendingThreadsByID[threadID] == nil,
+               snapshot.threads.contains(where: { $0.id == threadID }) {
+                await perform {
+                    try await client.cancelTurn(threadID: threadID)
+                }
+            }
             scheduleOutboxDrain()
             return
         }
@@ -760,14 +795,17 @@ public final class FeatureRootModel {
                 scheduleOutboxDrain()
             }
         case let .thread(value):
+            pendingThreadsByID.removeValue(forKey: value.id)
             upsert(value)
         case let .threadRemoved(id):
             removeThread(id: id)
             removeDetail(id: id)
         case let .detail(value):
+            pendingThreadsByID.removeValue(forKey: value.thread.id)
             store(value)
             upsert(value.thread)
         case let .detailDelta(value, delta):
+            pendingThreadsByID.removeValue(forKey: value.thread.id)
             store(value, delta: delta)
             upsert(value.thread)
         case let .failure(message):
@@ -825,6 +863,9 @@ public final class FeatureRootModel {
     private func install(_ value: FeatureSnapshot) {
         var value = value
         let authoritativeThreadIDs = Set(value.threads.map(\.id))
+        for id in authoritativeThreadIDs {
+            pendingThreadsByID.removeValue(forKey: id)
+        }
         for pending in pendingThreadsByID.values where !authoritativeThreadIDs.contains(pending.id) {
             value.threads.append(pending)
             if let index = value.projects.firstIndex(where: { $0.id == pending.projectID }) {

--- a/apps/swift-ios/Features/Settings/ConnectionsView.swift
+++ b/apps/swift-ios/Features/Settings/ConnectionsView.swift
@@ -60,6 +60,7 @@ struct ConnectionsView: View {
                 NavigationStack {
                     T3ConnectView(
                         capability: capability,
+                        model: model,
                         purpose: .manage,
                         onUnlinked: { id in
                             await model.removeEnvironment(id)

--- a/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureComposerDraftStore.swift
@@ -235,10 +235,16 @@ public actor FeatureComposerDraftStore {
         loadedDrafts = drafts
     }
 
-    public func removeDrafts(environmentID: String) throws {
+    public func removeDrafts(
+        environmentID: String,
+        logicalProjectIDs: Set<String> = []
+    ) throws {
         var drafts = try loadIfNeeded()
         let environmentPrefix = "environment:\(environmentID):"
-        drafts = drafts.filter { !$0.key.hasPrefix(environmentPrefix) }
+        let logicalKeys = Set(logicalProjectIDs.map(Self.newTaskKey(logicalProjectID:)))
+        drafts = drafts.filter {
+            !$0.key.hasPrefix(environmentPrefix) && !logicalKeys.contains($0.key)
+        }
         try persist(drafts)
         loadedDrafts = drafts
     }
@@ -252,6 +258,18 @@ public actor FeatureComposerDraftStore {
     public static func newTaskKey(project: FeatureProject) -> String {
         let projectID = project.wireID ?? project.id
         return "environment:\(project.environmentID):new-task:\(projectID)"
+    }
+
+    static func newTaskKey(project: FeatureProject, in snapshot: FeatureSnapshot) -> String {
+        guard project.repositoryIdentity != nil else {
+            return newTaskKey(project: project)
+        }
+        return newTaskKey(
+            logicalProjectID: DailyUXCreationContext.logicalProjectID(
+                for: project,
+                in: snapshot
+            )
+        )
     }
 
     public static func newTaskKey(logicalProjectID: String) -> String {

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -293,18 +293,29 @@ public struct FeatureThread: Identifiable, Sendable, Equatable, Hashable, Codabl
         self.interactionMode = interactionMode
     }
 
-    /// Older cached environment descriptors may omit the optional capability even
-    /// when their server supports pinning. Always keep an existing pin reversible.
+    /// Missing capabilities mean unsupported. Existing states remain reversible
+    /// so older cached snapshots cannot trap a thread in its current state.
     public var canTogglePin: Bool {
-        pinnedAt != nil || supportsPinning != false
+        pinnedAt != nil || supportsPinning == true
     }
 
     public var canToggleSettlement: Bool {
-        isSettled || supportsSettlement != false
+        isSettled || supportsSettlement == true
     }
 
     public var canToggleSnooze: Bool {
-        snoozedUntil != nil || supportsSnooze != false
+        snoozedUntil != nil || supportsSnooze == true
+    }
+
+    var canSettleNow: Bool {
+        guard canToggleSettlement else { return false }
+        if isSettled { return true }
+        switch state {
+        case .queued, .working, .monitoring, .waitingForApproval, .waitingForInput:
+            return false
+        case .idle, .failed, .completed:
+            return true
+        }
     }
 }
 

--- a/apps/swift-ios/Features/Shared/FeatureOutboxStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureOutboxStore.swift
@@ -121,8 +121,8 @@ public enum FeatureOutboxDeliveryDecision: Equatable {
 public enum FeatureOutboxPolicy {
     /// Delivery waits for the owning environment. Existing threads accept
     /// follow-up messages while a turn is running, matching the web queue.
-    /// A creation whose thread already exists was committed before a cleanup
-    /// interruption, so it is removed instead of sent twice.
+    /// A created thread does not prove that its first message was accepted.
+    /// Retry its stable command identity until the message itself is confirmed.
     public static func decision(
         for submission: FeatureQueuedSubmission,
         snapshot: FeatureSnapshot,
@@ -134,7 +134,7 @@ public enum FeatureOutboxPolicy {
         let thread = snapshot.threads.first { $0.id == submission.threadID }
 
         if submission.creation != nil {
-            if thread != nil { return .discard }
+            if thread != nil { return isConnected ? .send : .wait }
             let projectExists = snapshot.projects.contains {
                 $0.id == submission.creation?.projectID
                     && $0.environmentID == submission.environmentID

--- a/apps/swift-ios/Features/SourceControl/FeatureSourceControlView.swift
+++ b/apps/swift-ios/Features/SourceControl/FeatureSourceControlView.swift
@@ -60,6 +60,14 @@ public struct FeatureSourceControlView: View {
             }
             .disabled(commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
+        .alert("Source control failed", isPresented: Binding(
+            get: { status != nil && errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "The source control action could not be completed.")
+        }
         .task { await load() }
     }
 

--- a/apps/swift-ios/Features/Terminal/FeatureTerminalView.swift
+++ b/apps/swift-ios/Features/Terminal/FeatureTerminalView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 private enum TerminalFontSize {
     static let minimum = 6.0
-    static let maximum = 14.0
+    static let maximum = 32.0
     static let step = 0.5
     static let defaultValue = 10.5
 
@@ -89,13 +89,15 @@ public struct FeatureTerminalView: View {
                 isRunning: isRunning,
                 focusRequest: focusRequest,
                 onInput: { data in
-                    Task { await write(data) }
+                    let terminalID = activeTerminalID
+                    Task { await write(data, terminalID: terminalID) }
                 },
                 onResize: { nextColumns, nextRows in
                     updateGrid(columns: nextColumns, rows: nextRows)
                 },
                 onClear: {
-                    Task { await clear() }
+                    let terminalID = activeTerminalID
+                    Task { await clear(terminalID: terminalID) }
                 },
                 onFontSizeStep: { direction in
                     stepFontSize(direction)
@@ -267,7 +269,8 @@ public struct FeatureTerminalView: View {
                 }
 
                 Button {
-                    Task { await clear() }
+                    let terminalID = activeTerminalID
+                    Task { await clear(terminalID: terminalID) }
                 } label: {
                     Label("Clear", systemImage: "eraser")
                 }
@@ -372,16 +375,19 @@ public struct FeatureTerminalView: View {
         columns = nextColumns
         rows = nextRows
         guard isRunning else { return }
+        let terminalID = activeTerminalID
         Task {
             do {
                 try await client.resizeTerminal(
                     threadID: threadID,
-                    terminalID: activeTerminalID,
+                    terminalID: terminalID,
                     columns: nextColumns,
                     rows: nextRows
                 )
             } catch {
-                errorMessage = error.localizedDescription
+                if terminalID == activeTerminalID {
+                    errorMessage = error.localizedDescription
+                }
             }
         }
     }
@@ -455,36 +461,45 @@ public struct FeatureTerminalView: View {
         }
     }
 
-    private func clear() async {
+    private func clear(terminalID: String) async {
+        let wasRunning = isRunning
         do {
-            terminal?.buffer = ""
-            surfaceGeneration += 1
+            if terminalID == activeTerminalID {
+                terminal?.buffer = ""
+                surfaceGeneration += 1
+            }
             try await client.clearTerminal(
                 threadID: threadID,
-                terminalID: activeTerminalID
+                terminalID: terminalID
             )
-            if isRunning {
+            if wasRunning {
                 try await client.writeTerminal(
                     threadID: threadID,
-                    terminalID: activeTerminalID,
+                    terminalID: terminalID,
                     data: "\u{0C}"
                 )
             }
-            errorMessage = nil
+            if terminalID == activeTerminalID {
+                errorMessage = nil
+            }
         } catch {
-            errorMessage = error.localizedDescription
+            if terminalID == activeTerminalID {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
-    private func write(_ data: String) async {
+    private func write(_ data: String, terminalID: String) async {
         do {
             try await client.writeTerminal(
                 threadID: threadID,
-                terminalID: activeTerminalID,
+                terminalID: terminalID,
                 data: data
             )
         } catch {
-            errorMessage = error.localizedDescription
+            if terminalID == activeTerminalID {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 }

--- a/apps/swift-ios/Features/Terminal/TerminalSurfaceView.swift
+++ b/apps/swift-ios/Features/Terminal/TerminalSurfaceView.swift
@@ -25,6 +25,10 @@ struct GhosttyTerminalSurface: UIViewRepresentable {
         configure(view)
     }
 
+    static func dismantleUIView(_ view: GhosttyTerminalView, coordinator _: ()) {
+        view.tearDown()
+    }
+
     private func configure(_ view: GhosttyTerminalView) {
         view.isDarkMode = colorScheme == .dark
         view.onInput = onInput
@@ -78,7 +82,7 @@ enum TerminalText {
 
 private enum GhosttyRuntime {
     private static let lock = NSLock()
-    private static var initialized = false
+    nonisolated(unsafe) private static var initialized = false
 
     static func ensureInitialized() -> Bool {
         lock.lock()
@@ -90,6 +94,7 @@ private enum GhosttyRuntime {
     }
 }
 
+@MainActor
 private enum TerminalHardwareKeyEncoder {
     private static let controlInputs = "abcdefghijklmnopqrstuvwxyz@[\\]^_-? "
 
@@ -515,6 +520,11 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIContextMenuInter
         didSet {
             guard oldValue != buffer else { return }
             applyRemoteBuffer(buffer)
+            if UIAccessibility.isVoiceOverRunning {
+                terminalViewport.accessibilityValue = TerminalText.plainText(
+                    from: String(buffer.suffix(8_192))
+                )
+            }
         }
     }
 
@@ -580,6 +590,9 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIContextMenuInter
         terminalViewport.contentScaleFactor = contentScaleFactor
         terminalViewport.translatesAutoresizingMaskIntoConstraints = false
         terminalViewport.isUserInteractionEnabled = true
+        terminalViewport.isAccessibilityElement = true
+        terminalViewport.accessibilityLabel = "Terminal output"
+        terminalViewport.accessibilityTraits = .staticText
 
         inputField.delegate = self
         inputField.inputAccessoryView = accessoryView
@@ -649,8 +662,6 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIContextMenuInter
 
     @available(*, unavailable)
     required init?(coder _: NSCoder) { nil }
-
-    deinit { destroySurface() }
 
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -814,6 +825,14 @@ final class GhosttyTerminalView: UIView, UITextFieldDelegate, UIContextMenuInter
     private func refreshSurface() {
         resetSurface()
         createSurfaceIfPossible()
+    }
+
+    func tearDown() {
+        onInput = nil
+        onResize = nil
+        onClear = nil
+        onFontSizeStep = nil
+        destroySurface()
     }
 
     private func destroySurface() {

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -588,7 +588,10 @@ struct DailyUXSidebarIndex {
             .sorted(by: Self.creationOrder)
 
         active = available
-            .filter { $0.pinnedAt == nil && !$0.isEffectivelySettled(at: now) }
+            .filter {
+                $0.pinnedAt == nil
+                    && !($0.canToggleSettlement && $0.isEffectivelySettled(at: now))
+            }
             .sorted(by: Self.creationOrder)
 
         snoozed = visible
@@ -603,7 +606,11 @@ struct DailyUXSidebarIndex {
             }
 
         settled = available
-            .filter { $0.pinnedAt == nil && $0.isEffectivelySettled(at: now) }
+            .filter {
+                $0.pinnedAt == nil
+                    && $0.canToggleSettlement
+                    && $0.isEffectivelySettled(at: now)
+            }
             .sorted { lhs, rhs in
                 if lhs.settledSortDate != rhs.settledSortDate {
                     return lhs.settledSortDate > rhs.settledSortDate

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -377,7 +377,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     })
                 }
 
-                if thread.canToggleSettlement {
+                if thread.canSettleNow {
                     let isSettled = thread.isEffectivelySettled(at: .now)
                     actions.append(accessibilityAction(
                         isSettled ? "Reopen" : "Settle",
@@ -497,7 +497,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         }
                     )
                 }
-                if thread.canToggleSettlement {
+                if thread.canSettleNow {
                     let isSettled = thread.isEffectivelySettled(at: .now)
                     statusActions.append(
                         UIAction(
@@ -739,7 +739,7 @@ enum HomeThreadSwipeAction: Equatable {
     ) -> [HomeThreadSwipeAction] {
         guard !isArchived else { return [.restore, .delete] }
 
-        let settlement: HomeThreadSwipeAction? = thread.canToggleSettlement
+        let settlement: HomeThreadSwipeAction? = thread.canSettleNow
             ? (thread.isEffectivelySettled(at: now) ? .reopen : .settle)
             : nil
         let isPinned = thread.pinnedAt != nil && thread.canTogglePin

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct NewThreadView: View {
     @SwiftUI.Environment(\.dismiss) private var dismiss
+    @SwiftUI.Environment(\.scenePhase) private var scenePhase
     @Bindable var model: FeatureRootModel
     let submit: (NewTaskRequest) async -> FeatureThread?
     let onCreated: (FeatureThread) -> Void
@@ -153,6 +154,11 @@ public struct NewThreadView: View {
         .onChange(of: startFromOrigin) { scheduleDraftSave() }
         .onChange(of: submissionValidationMessage) { _, _ in
             submissionValidationError = nil
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase != .active, !submittedSuccessfully {
+                persistCurrentDraftImmediately()
+            }
         }
         .task(id: projectID) { await restoreDraftAndLoadBranches() }
         .onDisappear {
@@ -928,14 +934,7 @@ public struct NewThreadView: View {
     }
 
     private func draftKey(for project: FeatureProject) -> String {
-        guard project.repositoryIdentity != nil,
-              let group = DailyUXProjectGrouping.group(
-                  containing: project.id,
-                  in: creationProjectGroups
-              ) else {
-            return FeatureComposerDraftStore.newTaskKey(project: project)
-        }
-        return FeatureComposerDraftStore.newTaskKey(logicalProjectID: group.id)
+        FeatureComposerDraftStore.newTaskKey(project: project, in: model.snapshot)
     }
 
     private var composerDraft: FeatureComposerDraft {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -40,6 +40,7 @@ public struct WorkspaceView: View {
     @State private var showingEnvironments = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
+    @State private var deletingThread: FeatureThread?
     @State private var renameTitle = ""
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
@@ -173,6 +174,22 @@ public struct WorkspaceView: View {
             }
             .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
+        .alert(
+            "Delete thread?",
+            isPresented: Binding(
+                get: { deletingThread != nil },
+                set: { if !$0 { deletingThread = nil } }
+            ),
+            presenting: deletingThread
+        ) { thread in
+            Button("Delete", role: .destructive) {
+                deletingThread = nil
+                Task { await model.deleteThread(thread.id) }
+            }
+            Button("Cancel", role: .cancel) { deletingThread = nil }
+        } message: { thread in
+            Text("\"\(thread.title)\" and its terminal history will be permanently deleted.")
+        }
         .onChange(of: selectedThreadIsAvailable) { _, isAvailable in
             if !isAvailable { closeSelectedThread() }
         }
@@ -270,7 +287,7 @@ public struct WorkspaceView: View {
                     Task { await model.setPinned(thread.id, pinned: pinned) }
                 },
                 onDelete: { thread in
-                    Task { await model.deleteThread(thread.id) }
+                    deletingThread = thread
                 }
             )
         }

--- a/apps/swift-ios/Resources/Info.plist
+++ b/apps/swift-ios/Resources/Info.plist
@@ -47,5 +47,10 @@
         <string>fetch</string>
         <string>remote-notification</string>
     </array>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
 </dict>
 </plist>

--- a/apps/swift-ios/T3Code.xcodeproj/project.pbxproj
+++ b/apps/swift-ios/T3Code.xcodeproj/project.pbxproj
@@ -628,7 +628,7 @@
 				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Allow T3 Code to connect to T3 Code servers on your local network or tailnet.";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_NSSupportsLiveActivitiesFrequentUpdates = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = NO;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
@@ -684,7 +684,7 @@
 				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Allow T3 Code to connect to T3 Code servers on your local network or tailnet.";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_NSSupportsLiveActivitiesFrequentUpdates = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = NO;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;

--- a/apps/swift-ios/T3Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/swift-ios/T3Code.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "0da9fa23290c75a06cf2d88ffeab37061a648ea0656f8262ec633d415fa7466a",
+  "pins" : [
+    {
+      "identity" : "clerk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/clerk/clerk-ios.git",
+      "state" : {
+        "revision" : "d0a5f2231dcb4b66e091a514ce2d0bead9056404",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "30f7a7e72e0607d304fbf69c799474bd5fb6d1ce",
+        "version" : "13.2.0"
+      }
+    },
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/marmelroy/PhoneNumberKit",
+      "state" : {
+        "revision" : "169ab10234347fb19b37441f2867ace896a284b0",
+        "version" : "4.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
@@ -326,6 +326,16 @@ private actor RemovalOrderCredentialStore: CredentialStore {
         storedCredential = credential
     }
 
+    func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) -> EnvironmentCredential? {
+        guard environmentID == self.environmentID else { return nil }
+        let previousCredential = storedCredential
+        storedCredential = credential
+        return previousCredential
+    }
+
     func replaceCredential(
         _ credential: EnvironmentCredential,
         ifMatching expected: EnvironmentCredential,
@@ -342,5 +352,18 @@ private actor RemovalOrderCredentialStore: CredentialStore {
         catalogContainedEnvironmentOnRemoval = try await environmentStore.load()
             .contains(where: { $0.id == environmentID })
         storedCredential = nil
+    }
+
+    func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) async throws -> Bool {
+        guard environmentID == self.environmentID,
+              storedCredential == expected else { return false }
+        catalogContainedEnvironmentOnRemoval = try await environmentStore.load()
+            .contains(where: { $0.id == environmentID })
+        guard storedCredential == expected else { return false }
+        storedCredential = nil
+        return true
     }
 }

--- a/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
@@ -326,6 +326,17 @@ private actor RemovalOrderCredentialStore: CredentialStore {
         storedCredential = credential
     }
 
+    func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard environmentID == self.environmentID,
+              storedCredential == expected else { return false }
+        storedCredential = credential
+        return true
+    }
+
     func removeCredential(for environmentID: String) async throws {
         guard environmentID == self.environmentID else { return }
         catalogContainedEnvironmentOnRemoval = try await environmentStore.load()

--- a/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/CoreContractTests.swift
@@ -225,6 +225,41 @@ final class CoreContractTests: XCTestCase {
         XCTAssertEqual(fallback, first.id)
     }
 
+    func testKeychainCredentialUpdatesAreAtomicAcrossStoreInstances() async throws {
+        let service = "codes.t3.swift-ios.credential-tests.\(UUID().uuidString)"
+        let environmentID = "shared-environment"
+        let backend = InMemoryKeychainCredentialBackend()
+        let first = KeychainCredentialStore(service: service, backend: backend)
+        let second = KeychainCredentialStore(service: service, backend: backend)
+
+        do {
+            for index in 0..<12 {
+                let original = EnvironmentCredential(accessToken: "original-\(index)")
+                let replacement = EnvironmentCredential(accessToken: "replacement-\(index)")
+                try await first.setCredential(original, for: environmentID)
+
+                async let replaced = first.replaceCredential(
+                    replacement,
+                    ifMatching: original,
+                    for: environmentID
+                )
+                async let removed = second.removeCredential(
+                    ifMatching: original,
+                    for: environmentID
+                )
+                let (didReplace, didRemove) = try await (replaced, removed)
+
+                XCTAssertNotEqual(didReplace, didRemove)
+                let stored = try await first.credential(for: environmentID)
+                XCTAssertEqual(stored, didReplace ? replacement : nil)
+            }
+            try await first.removeCredential(for: environmentID)
+        } catch {
+            try? await first.removeCredential(for: environmentID)
+            throw error
+        }
+    }
+
     func testRuntimeReplacesCachedClientWhenSavedEndpointChanges() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-swift-runtime-\(UUID().uuidString)", isDirectory: true)
@@ -295,6 +330,24 @@ final class CoreContractTests: XCTestCase {
         XCTAssertTrue(remaining.isEmpty)
         let credential = await credentials.credential(for: environment.id)
         XCTAssertNil(credential)
+    }
+}
+
+private final class InMemoryKeychainCredentialBackend: @unchecked Sendable,
+    KeychainCredentialBackend
+{
+    private var credentials: [String: EnvironmentCredential] = [:]
+
+    func credential(for environmentID: String) -> EnvironmentCredential? {
+        credentials[environmentID]
+    }
+
+    func setCredential(_ credential: EnvironmentCredential, for environmentID: String) {
+        credentials[environmentID] = credential
+    }
+
+    func removeCredential(for environmentID: String) {
+        credentials.removeValue(forKey: environmentID)
     }
 }
 

--- a/apps/swift-ios/Tests/CoreTests/PairingServiceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/PairingServiceTests.swift
@@ -84,6 +84,146 @@ final class PairingServiceTests: XCTestCase {
             XCTAssertEqual(restored?.accessToken, "previous-access-token")
         }
     }
+
+    func testFailedRepairDoesNotOverwriteNewerCredential() async throws {
+        let credentials = InterleavedCredentialStore(
+            previousCredential: EnvironmentCredential(accessToken: "previous-access-token"),
+            newerCredential: EnvironmentCredential(accessToken: "newer-access-token")
+        )
+
+        try await assertFailedPairingPreservesNewerCredential(credentials)
+    }
+
+    func testFailedFirstPairingDoesNotDeleteNewerCredential() async throws {
+        let credentials = InterleavedCredentialStore(
+            previousCredential: nil,
+            newerCredential: EnvironmentCredential(accessToken: "newer-access-token")
+        )
+
+        try await assertFailedPairingPreservesNewerCredential(credentials)
+    }
+
+    func testFailedRepairRestoresCredentialRefreshedBeforeInstallation() async throws {
+        let credentials = InterleavedCredentialStore(
+            previousCredential: EnvironmentCredential(accessToken: "previous-access-token"),
+            newerCredential: EnvironmentCredential(accessToken: "newer-access-token"),
+            replacementTiming: .beforeInstallation
+        )
+
+        try await assertFailedPairingPreservesNewerCredential(credentials)
+    }
+
+    private func assertFailedPairingPreservesNewerCredential(
+        _ credentials: InterleavedCredentialStore
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-swift-pairing-race-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o700))],
+                ofItemAtPath: directory.path
+            )
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let service = PairingService(
+            transport: PairingHTTPTransport(),
+            environmentStore: EnvironmentStore(
+                fileURL: directory.appendingPathComponent("environments.json")
+            ),
+            credentialStore: credentials
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o500))],
+            ofItemAtPath: directory.path
+        )
+
+        do {
+            _ = try await service.pair(url: "https://studio.example/#token=pair-once")
+            XCTFail("Pairing unexpectedly updated a read-only environment catalog")
+        } catch {
+            let stored = await credentials.credential(for: "environment-1")
+            XCTAssertEqual(stored?.accessToken, "newer-access-token")
+        }
+    }
+}
+
+private actor InterleavedCredentialStore: CredentialStore {
+    enum ReplacementTiming {
+        case beforeInstallation
+        case afterInstallation
+    }
+
+    private var storedCredential: EnvironmentCredential?
+    private let newerCredential: EnvironmentCredential
+    private let replacementTiming: ReplacementTiming
+    private var hasInsertedNewerCredential = false
+
+    init(
+        previousCredential: EnvironmentCredential?,
+        newerCredential: EnvironmentCredential,
+        replacementTiming: ReplacementTiming = .afterInstallation
+    ) {
+        storedCredential = previousCredential
+        self.newerCredential = newerCredential
+        self.replacementTiming = replacementTiming
+    }
+
+    func credential(for environmentID: String) -> EnvironmentCredential? {
+        let currentCredential = storedCredential
+        if replacementTiming == .beforeInstallation, !hasInsertedNewerCredential {
+            hasInsertedNewerCredential = true
+            storedCredential = newerCredential
+        }
+        return currentCredential
+    }
+
+    func setCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) {
+        storedCredential = credential
+        if replacementTiming == .afterInstallation, !hasInsertedNewerCredential {
+            hasInsertedNewerCredential = true
+            storedCredential = newerCredential
+        }
+    }
+
+    func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) -> EnvironmentCredential? {
+        if replacementTiming == .beforeInstallation, !hasInsertedNewerCredential {
+            hasInsertedNewerCredential = true
+            storedCredential = newerCredential
+        }
+        let previousCredential = storedCredential
+        setCredential(credential, for: environmentID)
+        return previousCredential
+    }
+
+    func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard storedCredential == expected else { return false }
+        storedCredential = credential
+        return true
+    }
+
+    func removeCredential(for environmentID: String) {
+        storedCredential = nil
+    }
+
+    func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard storedCredential == expected else { return false }
+        storedCredential = nil
+        return true
+    }
 }
 
 private actor PairingHTTPTransport: HTTPTransport {

--- a/apps/swift-ios/Tests/CoreTests/PairingServiceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/PairingServiceTests.swift
@@ -45,6 +45,45 @@ final class PairingServiceTests: XCTestCase {
         // fails with scope_not_granted.
         XCTAssertFalse(form.contains("scope="))
     }
+
+    func testFailedRepairRestoresTheExistingCredential() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-swift-pairing-rollback-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o700))],
+                ofItemAtPath: directory.path
+            )
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let credentials = InMemoryCredentialStore(credentials: [
+            "environment-1": EnvironmentCredential(accessToken: "previous-access-token"),
+        ])
+        let environments = EnvironmentStore(
+            fileURL: directory.appendingPathComponent("environments.json")
+        )
+        let service = PairingService(
+            transport: PairingHTTPTransport(),
+            environmentStore: environments,
+            credentialStore: credentials
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o500))],
+            ofItemAtPath: directory.path
+        )
+
+        do {
+            _ = try await service.pair(
+                url: "https://studio.example/#token=pair-once",
+                label: "Theo's iPhone"
+            )
+            XCTFail("Pairing unexpectedly updated a read-only environment catalog")
+        } catch {
+            let restored = await credentials.credential(for: "environment-1")
+            XCTAssertEqual(restored?.accessToken, "previous-access-token")
+        }
+    }
 }
 
 private actor PairingHTTPTransport: HTTPTransport {

--- a/apps/swift-ios/Tests/CoreTests/PullRequestContractTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/PullRequestContractTests.swift
@@ -50,4 +50,30 @@ final class PullRequestContractTests: XCTestCase {
             ])
         )
     }
+
+    func testListPagesPreserveRowsAndAdvanceCursors() {
+        let first = PullRequestListResult(
+            viewers: ["github.com": "theo"],
+            providers: [],
+            entries: [],
+            errors: [],
+            truncated: true,
+            nextCursors: ["github.com t3/repo": "first"]
+        )
+        let second = PullRequestListResult(
+            viewers: ["gitlab.com": "maintainer"],
+            providers: [],
+            entries: [],
+            errors: [],
+            truncated: false,
+            nextCursors: [:]
+        )
+
+        let combined = first.appending(second)
+
+        XCTAssertEqual(combined.viewers["github.com"], "theo")
+        XCTAssertEqual(combined.viewers["gitlab.com"], "maintainer")
+        XCTAssertFalse(combined.truncated)
+        XCTAssertTrue(combined.nextCursors.isEmpty)
+    }
 }

--- a/apps/swift-ios/Tests/CoreTests/T3ConnectRuntimeTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/T3ConnectRuntimeTests.swift
@@ -256,6 +256,64 @@ final class T3ConnectRuntimeTests: XCTestCase {
         XCTAssertEqual(calls, 1)
     }
 
+    func testRevokedCredentialCannotBeRestoredByAnInFlightRefresh() async throws {
+        let signer = try testSigner()
+        let environment = managedEnvironment(descriptor: descriptor())
+        let expired = EnvironmentCredential.managedDPoP(
+            accessToken: "expired-token",
+            expiresAt: Date().addingTimeInterval(-1),
+            scopes: T3ConnectManagedEnvironmentAuthorizer.standardScopes,
+            environmentID: environment.id,
+            proofKeyThumbprint: try await signer.thumbprint()
+        )
+        let credentials = InMemoryCredentialStore(credentials: [environment.id: expired])
+        let bootstrap = BlockingT3ConnectBootstrapSource(
+            credential: try await bootstrapCredential(signer: signer)
+        )
+        let transport = T3ConnectScriptedHTTPTransport { request, _ in
+            switch request.url?.path {
+            case "/.well-known/t3/environment":
+                return (.descriptor, 200)
+            case "/oauth/token":
+                return (
+                    .token(
+                        scopes: T3ConnectManagedEnvironmentAuthorizer.standardScopes
+                            .joined(separator: " ")
+                    ),
+                    200
+                )
+            default:
+                throw T3ConnectTestError.unexpectedPath(request.url?.path)
+            }
+        }
+        let authorization = T3ConnectRuntimeAuthorization(
+            authorizer: T3ConnectManagedEnvironmentAuthorizer(
+                transport: transport,
+                signer: signer
+            ),
+            bootstrapProvider: { id in try await bootstrap.value(for: id) }
+        )
+        let api = EnvironmentAPI(
+            transport: transport,
+            credentials: credentials,
+            managedAuthorization: authorization
+        )
+
+        let request = Task { try await api.session(for: environment) }
+        await bootstrap.waitUntilCallCount(1)
+        await credentials.removeCredential(for: environment.id)
+        await bootstrap.release()
+
+        do {
+            _ = try await request.value
+            XCTFail("A revoked environment credential was restored by an in-flight refresh")
+        } catch HTTPError.missingCredential {
+            // Removing the saved credential permanently invalidates this refresh.
+        }
+        let restoredCredential = await credentials.credential(for: environment.id)
+        XCTAssertNil(restoredCredential)
+    }
+
     func testRotatedProofKeyRebindsFreshCredential() async throws {
         let fixture = try await refreshFixture(
             savedThumbprint: "stale-proof-key",
@@ -513,6 +571,41 @@ final class T3ConnectRuntimeTests: XCTestCase {
         do {
             _ = try await authorizer.webSocketURL(using: authorization)
             XCTFail("An unencrypted managed WebSocket endpoint was accepted")
+        } catch let error as T3ConnectRelayError {
+            guard case .invalidConfiguration = error else {
+                return XCTFail("Unexpected T3 Connect error: \(error)")
+            }
+        }
+        let requests = await transport.requests
+        XCTAssertTrue(requests.isEmpty)
+    }
+
+    func testManagedWebSocketRejectsDifferentHostBeforeMintingTicket() async throws {
+        let signer = try testSigner()
+        let transport = T3ConnectScriptedHTTPTransport { request, _ in
+            throw T3ConnectTestError.unexpectedPath(request.url?.path)
+        }
+        let authorizer = T3ConnectManagedEnvironmentAuthorizer(
+            transport: transport,
+            signer: signer
+        )
+        let authorization = T3ConnectEnvironmentAccessToken(
+            environmentID: "managed-1",
+            label: "Managed Studio",
+            endpoint: T3ConnectManagedEndpoint(
+                httpBaseUrl: "https://managed.example",
+                wsBaseUrl: "wss://different.example/ws",
+                providerKind: .t3Relay
+            ),
+            accessToken: "access-token",
+            expiresAt: Date().addingTimeInterval(300),
+            scopes: T3ConnectManagedEnvironmentAuthorizer.standardScopes,
+            proofKeyThumbprint: try await signer.thumbprint()
+        )
+
+        do {
+            _ = try await authorizer.webSocketURL(using: authorization)
+            XCTFail("A managed WebSocket ticket was sent to a different host")
         } catch let error as T3ConnectRelayError {
             guard case .invalidConfiguration = error else {
                 return XCTFail("Unexpected T3 Connect error: \(error)")

--- a/apps/swift-ios/Tests/CoreTests/T3ConnectRuntimeTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/T3ConnectRuntimeTests.swift
@@ -314,6 +314,27 @@ final class T3ConnectRuntimeTests: XCTestCase {
         XCTAssertNil(restoredCredential)
     }
 
+    func testFailedManagedSaveDoesNotOverwriteNewerCredential() async throws {
+        try await assertFailedManagedSavePreservesNewerCredential(
+            previousCredential: managedCredential(accessToken: "previous-managed-token"),
+            replacementTiming: .afterInstallation
+        )
+    }
+
+    func testFailedFirstManagedSaveDoesNotDeleteNewerCredential() async throws {
+        try await assertFailedManagedSavePreservesNewerCredential(
+            previousCredential: nil,
+            replacementTiming: .afterInstallation
+        )
+    }
+
+    func testFailedManagedSaveRestoresCredentialRefreshedBeforeInstallation() async throws {
+        try await assertFailedManagedSavePreservesNewerCredential(
+            previousCredential: managedCredential(accessToken: "previous-managed-token"),
+            replacementTiming: .beforeInstallation
+        )
+    }
+
     func testRotatedProofKeyRebindsFreshCredential() async throws {
         let fixture = try await refreshFixture(
             savedThumbprint: "stale-proof-key",
@@ -965,6 +986,60 @@ final class T3ConnectRuntimeTests: XCTestCase {
         )
     }
 
+    private func assertFailedManagedSavePreservesNewerCredential(
+        previousCredential: EnvironmentCredential?,
+        replacementTiming: ManagedPersistenceCredentialStore.ReplacementTiming
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-managed-credential-race-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o700))],
+                ofItemAtPath: directory.path
+            )
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let environment = managedEnvironment(descriptor: descriptor())
+        let newerCredential = managedCredential(accessToken: "newer-managed-token")
+        let credentials = ManagedPersistenceCredentialStore(
+            previousCredential: previousCredential,
+            newerCredential: newerCredential,
+            replacementTiming: replacementTiming
+        )
+        let runtime = EnvironmentRuntime(
+            environmentStore: EnvironmentStore(
+                fileURL: directory.appendingPathComponent("environments.json")
+            ),
+            credentialStore: credentials
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o500))],
+            ofItemAtPath: directory.path
+        )
+
+        do {
+            _ = try await runtime.saveManagedEnvironment(
+                environment,
+                credential: managedCredential(accessToken: "pairing-managed-token")
+            )
+            XCTFail("Managed pairing unexpectedly updated a read-only environment catalog")
+        } catch {
+            let saved = await credentials.credential(for: environment.id)
+            XCTAssertEqual(saved, newerCredential)
+        }
+    }
+
+    private func managedCredential(accessToken: String) -> EnvironmentCredential {
+        .managedDPoP(
+            accessToken: accessToken,
+            expiresAt: Date(timeIntervalSince1970: 2_000_000_000),
+            scopes: T3ConnectManagedEnvironmentAuthorizer.standardScopes,
+            environmentID: "managed-1",
+            proofKeyThumbprint: "proof-key"
+        )
+    }
+
     private func testSigner() throws -> T3ConnectDPoPSigner {
         var scalar = Data(repeating: 0, count: 32)
         scalar[31] = 7
@@ -1028,6 +1103,84 @@ private struct T3ConnectRefreshFixture {
 private enum T3ConnectTestError: Error {
     case unexpectedRefresh
     case unexpectedPath(String?)
+}
+
+private actor ManagedPersistenceCredentialStore: CredentialStore {
+    enum ReplacementTiming {
+        case beforeInstallation
+        case afterInstallation
+    }
+
+    private var storedCredential: EnvironmentCredential?
+    private let newerCredential: EnvironmentCredential
+    private let replacementTiming: ReplacementTiming
+    private var hasInsertedNewerCredential = false
+
+    init(
+        previousCredential: EnvironmentCredential?,
+        newerCredential: EnvironmentCredential,
+        replacementTiming: ReplacementTiming
+    ) {
+        storedCredential = previousCredential
+        self.newerCredential = newerCredential
+        self.replacementTiming = replacementTiming
+    }
+
+    func credential(for environmentID: String) -> EnvironmentCredential? {
+        let currentCredential = storedCredential
+        if replacementTiming == .beforeInstallation, !hasInsertedNewerCredential {
+            hasInsertedNewerCredential = true
+            storedCredential = newerCredential
+        }
+        return currentCredential
+    }
+
+    func setCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) {
+        storedCredential = credential
+        if replacementTiming == .afterInstallation, !hasInsertedNewerCredential {
+            hasInsertedNewerCredential = true
+            storedCredential = newerCredential
+        }
+    }
+
+    func swapCredential(
+        _ credential: EnvironmentCredential,
+        for environmentID: String
+    ) -> EnvironmentCredential? {
+        if replacementTiming == .beforeInstallation, !hasInsertedNewerCredential {
+            hasInsertedNewerCredential = true
+            storedCredential = newerCredential
+        }
+        let previousCredential = storedCredential
+        setCredential(credential, for: environmentID)
+        return previousCredential
+    }
+
+    func replaceCredential(
+        _ credential: EnvironmentCredential,
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard storedCredential == expected else { return false }
+        storedCredential = credential
+        return true
+    }
+
+    func removeCredential(for environmentID: String) {
+        storedCredential = nil
+    }
+
+    func removeCredential(
+        ifMatching expected: EnvironmentCredential,
+        for environmentID: String
+    ) -> Bool {
+        guard storedCredential == expected else { return false }
+        storedCredential = nil
+        return true
+    }
 }
 
 private actor T3ConnectBootstrapSource {

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -59,6 +59,46 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await client.stop()
     }
 
+    func testUnansweredKeepaliveReconnectsAHalfOpenSocket() async throws {
+        let silent = BlockingReceiveConnection()
+        let recovered = AutoReplyConnection()
+        let connector = SequencedConnector(connections: [silent, recovered])
+        let client = WebSocketRPCClient(
+            connector: connector,
+            connectionWaitTimeout: .seconds(1),
+            keepaliveInterval: .milliseconds(10),
+            reconnectBackoff: { _ in .zero },
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+
+        await client.start()
+        await connector.waitUntilConnectionCount(2)
+
+        let response = try await client.request("server.afterKeepalive", as: JSONValue.self)
+        XCTAssertEqual(response, .object([:]))
+        await client.stop()
+    }
+
+    func testSubscriptionOverflowReconnectsWithoutAcknowledgingDroppedEvents() async {
+        let overflowing = OverflowingSubscriptionConnection()
+        let recovered = BlockingReceiveConnection()
+        let connector = SequencedConnector(connections: [overflowing, recovered])
+        let client = WebSocketRPCClient(
+            connector: connector,
+            subscriptionBufferLimit: 2,
+            reconnectBackoff: { _ in .zero },
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+
+        let stream = await client.subscribe("thread.events", as: JSONValue.self)
+        await connector.waitUntilConnectionCount(2)
+
+        let acknowledgementCount = await overflowing.acknowledgementCount()
+        XCTAssertEqual(acknowledgementCount, 0)
+        _ = stream
+        await client.stop()
+    }
+
     func testHungSendTimesOutAndReconnectsWithAFreshResponseWindow() async throws {
         let hung = HungSendConnection()
         let recovered = AutoReplyConnection()
@@ -461,6 +501,54 @@ private actor BlockingReceiveConnection: WebSocketConnection {
     func close() {
         continuation?.resume(throwing: CancellationError())
         continuation = nil
+    }
+}
+
+private actor OverflowingSubscriptionConnection: WebSocketConnection {
+    private var queuedResponses: [Data] = []
+    private var receiver: CheckedContinuation<Data, Error>?
+    private var acknowledgements = 0
+
+    func send(_ data: Data) throws {
+        let envelope = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        if envelope["_tag"]?.stringValue == "Ack" {
+            acknowledgements += 1
+            return
+        }
+        guard envelope["_tag"]?.stringValue == "Request",
+              case let .number(requestID)? = envelope["id"] else { return }
+        let chunk = JSONValue.object([
+            "_tag": .string("Chunk"),
+            "requestId": .number(requestID),
+            "values": .array([
+                .string("first"),
+                .string("second"),
+                .string("overflow"),
+            ]),
+        ])
+        let response = try JSONEncoder.t3.encode(chunk)
+        if let receiver {
+            self.receiver = nil
+            receiver.resume(returning: response)
+        } else {
+            queuedResponses.append(response)
+        }
+    }
+
+    func receive() async throws -> Data {
+        if !queuedResponses.isEmpty {
+            return queuedResponses.removeFirst()
+        }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func close() {
+        receiver?.resume(throwing: CancellationError())
+        receiver = nil
+    }
+
+    func acknowledgementCount() -> Int {
+        acknowledgements
     }
 }
 

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -79,6 +79,23 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await client.stop()
     }
 
+    func testValidInboundTrafficSatisfiesKeepaliveWithoutPong() async {
+        let connection = SubscriptionTrafficConnection(respondsToPingsWithChunks: true)
+        let client = WebSocketRPCClient(
+            connector: SequencedConnector(connections: [connection]),
+            keepaliveInterval: .milliseconds(10),
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+
+        let stream = await client.subscribe("thread.events", as: JSONValue.self)
+        await connection.waitUntilPingCount(3)
+
+        let isConnected = await client.isConnected()
+        XCTAssertTrue(isConnected, "Valid stream traffic proves that the socket is still alive.")
+        _ = stream
+        await client.stop()
+    }
+
     func testSubscriptionOverflowReconnectsWithoutAcknowledgingDroppedEvents() async {
         let overflowing = OverflowingSubscriptionConnection()
         let recovered = BlockingReceiveConnection()
@@ -96,6 +113,28 @@ final class WebSocketRPCRaceTests: XCTestCase {
         let acknowledgementCount = await overflowing.acknowledgementCount()
         XCTAssertEqual(acknowledgementCount, 0)
         _ = stream
+        await client.stop()
+    }
+
+    func testTerminatedSubscriptionDoesNotDisconnectSharedSocket() async throws {
+        let connection = SubscriptionTrafficConnection(sendsInvalidSubscriptionValue: true)
+        let client = WebSocketRPCClient(
+            connector: SequencedConnector(connections: [connection]),
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+
+        let stream = await client.subscribe("thread.events", as: Int.self)
+        var iterator = stream.makeAsyncIterator()
+        do {
+            _ = try await iterator.next()
+            XCTFail("An invalid stream event must terminate its subscription.")
+        } catch is DecodingError {}
+
+        let wasInterrupted = await connection.waitUntilSubscriptionEnded()
+        XCTAssertTrue(wasInterrupted, "The subscription should end without closing the socket.")
+
+        let response = try await client.request("server.afterSubscriptionFailure", as: JSONValue.self)
+        XCTAssertEqual(response, .object(["ok": .bool(true)]))
         await client.stop()
     }
 
@@ -501,6 +540,122 @@ private actor BlockingReceiveConnection: WebSocketConnection {
     func close() {
         continuation?.resume(throwing: CancellationError())
         continuation = nil
+    }
+}
+
+private actor SubscriptionTrafficConnection: WebSocketConnection {
+    private let respondsToPingsWithChunks: Bool
+    private let sendsInvalidSubscriptionValue: Bool
+    private var subscriptionRequestID: Int?
+    private var queuedResponses: [Data] = []
+    private var receiver: CheckedContinuation<Data, Error>?
+    private var pingCount = 0
+    private var pingWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var subscriptionEnded: Bool?
+    private var subscriptionEndWaiters: [CheckedContinuation<Bool, Never>] = []
+
+    init(
+        respondsToPingsWithChunks: Bool = false,
+        sendsInvalidSubscriptionValue: Bool = false
+    ) {
+        self.respondsToPingsWithChunks = respondsToPingsWithChunks
+        self.sendsInvalidSubscriptionValue = sendsInvalidSubscriptionValue
+    }
+
+    func send(_ data: Data) throws {
+        let envelope = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        switch envelope["_tag"]?.stringValue {
+        case "Request":
+            guard case let .number(rawID)? = envelope["id"],
+                  let requestID = Int(exactly: rawID) else { return }
+            if envelope["tag"]?.stringValue == "thread.events" {
+                subscriptionRequestID = requestID
+                if sendsInvalidSubscriptionValue {
+                    enqueue(try chunk(requestID: requestID, value: .string("not an integer")))
+                }
+            } else {
+                enqueue(try success(requestID: requestID))
+            }
+        case "Ping":
+            pingCount += 1
+            if respondsToPingsWithChunks, let subscriptionRequestID {
+                enqueue(try chunk(requestID: subscriptionRequestID, value: .string("alive")))
+            }
+            let ready = pingWaiters.filter { pingCount >= $0.0 }
+            pingWaiters.removeAll { pingCount >= $0.0 }
+            ready.forEach { $0.1.resume() }
+        case "Interrupt":
+            finishSubscription(interrupted: true)
+        default:
+            break
+        }
+    }
+
+    func receive() async throws -> Data {
+        if !queuedResponses.isEmpty {
+            return queuedResponses.removeFirst()
+        }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func close() {
+        finishSubscription(interrupted: false)
+        receiver?.resume(throwing: CancellationError())
+        receiver = nil
+    }
+
+    func waitUntilPingCount(_ count: Int) async {
+        guard pingCount < count else { return }
+        await withCheckedContinuation { continuation in
+            pingWaiters.append((count, continuation))
+        }
+    }
+
+    func waitUntilSubscriptionEnded() async -> Bool {
+        if let subscriptionEnded { return subscriptionEnded }
+        return await withCheckedContinuation { continuation in
+            subscriptionEndWaiters.append(continuation)
+        }
+    }
+
+    private func finishSubscription(interrupted: Bool) {
+        guard subscriptionEnded == nil else { return }
+        subscriptionEnded = interrupted
+        let waiters = subscriptionEndWaiters
+        subscriptionEndWaiters.removeAll()
+        waiters.forEach { $0.resume(returning: interrupted) }
+    }
+
+    private func enqueue(_ data: Data) {
+        if let receiver {
+            self.receiver = nil
+            receiver.resume(returning: data)
+        } else {
+            queuedResponses.append(data)
+        }
+    }
+
+    private func chunk(requestID: Int, value: JSONValue) throws -> Data {
+        try JSONEncoder.t3.encode(
+            JSONValue.object([
+                "_tag": .string("Chunk"),
+                "requestId": .number(Double(requestID)),
+                "values": .array([value]),
+            ])
+        )
+    }
+
+    private func success(requestID: Int) throws -> Data {
+        try JSONEncoder.t3.encode(
+            JSONValue.object([
+                "_tag": .string("Exit"),
+                "requestId": .number(Double(requestID)),
+                "exit": .object([
+                    "_tag": .string("Success"),
+                    "value": .object(["ok": .bool(true)]),
+                ]),
+            ])
+        )
     }
 }
 

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -96,9 +96,9 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await client.stop()
     }
 
-    func testSubscriptionOverflowReconnectsWithoutAcknowledgingDroppedEvents() async {
+    func testSubscriptionOverflowReconnectsWithoutAcknowledgingOrReplayingDroppedEvents() async throws {
         let overflowing = OverflowingSubscriptionConnection()
-        let recovered = BlockingReceiveConnection()
+        let recovered = AutoReplyConnection()
         let connector = SequencedConnector(connections: [overflowing, recovered])
         let client = WebSocketRPCClient(
             connector: connector,
@@ -110,9 +110,28 @@ final class WebSocketRPCRaceTests: XCTestCase {
         let stream = await client.subscribe("thread.events", as: JSONValue.self)
         await connector.waitUntilConnectionCount(2)
 
+        var iterator = stream.makeAsyncIterator()
+        let firstValue = try await iterator.next()
+        let secondValue = try await iterator.next()
+        XCTAssertEqual(firstValue, .string("first"))
+        XCTAssertEqual(secondValue, .string("second"))
+        do {
+            _ = try await iterator.next()
+            XCTFail("An overflowing subscription must finish with its protocol error.")
+        } catch let error as RPCError {
+            guard case .protocolViolation = error else {
+                await client.stop()
+                return XCTFail("Unexpected RPC error: \(error)")
+            }
+        }
+
         let acknowledgementCount = await overflowing.acknowledgementCount()
         XCTAssertEqual(acknowledgementCount, 0)
-        _ = stream
+
+        let response = try await client.request("server.afterOverflow", as: JSONValue.self)
+        XCTAssertEqual(response, .object([:]))
+        let recoveredRequestCount = await recovered.sentRequestCount()
+        XCTAssertEqual(recoveredRequestCount, 1, "A failed stream must not resubscribe.")
         await client.stop()
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerDraftStoreTests.swift
@@ -99,6 +99,31 @@ struct ComposerDraftStoreTests {
         )
     }
 
+    @Test func environmentRemovalClearsItsGroupedProjectDrafts() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let removedKey = FeatureComposerDraftStore.newTaskKey(
+            logicalProjectID: "github.com/t3/removed"
+        )
+        let preservedKey = FeatureComposerDraftStore.newTaskKey(
+            logicalProjectID: "github.com/t3/preserved"
+        )
+        try await store.setDraft(FeatureComposerDraft(text: "remove"), for: removedKey)
+        try await store.setDraft(FeatureComposerDraft(text: "keep"), for: preservedKey)
+
+        try await store.removeDrafts(
+            environmentID: "first",
+            logicalProjectIDs: ["github.com/t3/removed"]
+        )
+
+        #expect(try await store.draft(for: removedKey) == nil)
+        #expect(try await store.draft(for: preservedKey)?.text == "keep")
+    }
+
     @Test func migratesResolvedVersionOneNewTaskDefaultsBackToImplicit() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -150,10 +150,10 @@ struct DailyUXSidebarTests {
     }
 
     @Test
-    func pinActionsTolerateMissingCapabilitiesAndKeepPinsReversible() {
+    func pinActionsRequireCapabilitiesAndKeepPinsReversible() {
         var legacyDescriptor = thread(id: "legacy", created: -20, updated: -10)
         legacyDescriptor.supportsPinning = nil
-        #expect(legacyDescriptor.canTogglePin)
+        #expect(!legacyDescriptor.canTogglePin)
 
         var explicitlyUnsupported = thread(id: "unsupported", created: -20, updated: -10)
         explicitlyUnsupported.supportsPinning = false
@@ -179,8 +179,8 @@ struct DailyUXSidebarTests {
         var legacy = thread(id: "legacy-capabilities", created: -20, updated: -10)
         legacy.supportsSettlement = nil
         legacy.supportsSnooze = nil
-        #expect(legacy.canToggleSettlement)
-        #expect(legacy.canToggleSnooze)
+        #expect(!legacy.canToggleSettlement)
+        #expect(!legacy.canToggleSnooze)
     }
 
     @Test
@@ -502,7 +502,10 @@ struct DailyUXSidebarTests {
             updatedAt: now.addingTimeInterval(updated),
             state: state,
             isSettled: isSettled,
-            lastActivityAt: now.addingTimeInterval(updated)
+            lastActivityAt: now.addingTimeInterval(updated),
+            supportsSettlement: true,
+            supportsSnooze: true,
+            supportsPinning: true
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureOutboxStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureOutboxStoreTests.swift
@@ -81,7 +81,7 @@ struct FeatureOutboxStoreTests {
     }
 
     @Test
-    func committedCreationAndDeletedThreadAreDiscarded() {
+    func existingThreadDoesNotProveItsFirstMessageWasDelivered() {
         let thread = FeatureThread(
             id: "thread-scoped",
             projectID: "project-1",
@@ -128,7 +128,11 @@ struct FeatureOutboxStoreTests {
             threads: [thread]
         )
 
-        #expect(FeatureOutboxPolicy.decision(for: creation, snapshot: snapshot) == .discard)
+        #expect(FeatureOutboxPolicy.decision(for: creation, snapshot: snapshot) == .send)
+
+        snapshot.environments[0].connectionState = .disconnected
+        #expect(FeatureOutboxPolicy.decision(for: creation, snapshot: snapshot) == .wait)
+        snapshot.environments[0].connectionState = .connected
 
         var followUp = creation
         followUp.creation = nil

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -188,6 +188,128 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func restoredCreationWaitsForItsFirstMessageEvenWhenTheThreadExists() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-partial-creation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let identity = FeatureSubmissionIdentity(
+            threadID: "created-thread",
+            commandID: "create-command",
+            messageID: "missing-message",
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let threadID = "environment-1::thread::created-thread"
+        let submission = FeatureQueuedSubmission(
+            environmentID: "environment-1",
+            identity: identity,
+            threadID: threadID,
+            text: "Do not lose the first message",
+            selection: nil,
+            runtimeMode: .fullAccess,
+            interactionMode: .standard,
+            attachments: [
+                .init(data: Data([0x01]), name: "reference.png", mimeType: "image/png"),
+            ],
+            creation: .init(
+                projectID: "project-1",
+                projectName: "Native",
+                workspaceMode: .local,
+                branch: nil,
+                worktreePath: nil,
+                startFromOrigin: false
+            )
+        )
+        try await store.enqueue(submission)
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .connected),
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .connected
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "project-1",
+                    environmentID: "environment-1",
+                    name: "Native",
+                    path: "/native"
+                ),
+            ],
+            threads: [
+                .init(
+                    id: threadID,
+                    wireID: identity.threadID,
+                    projectID: "project-1",
+                    environmentID: "environment-1",
+                    title: "Created without a message"
+                ),
+            ]
+        )
+        client.startTaskError = URLError(.timedOut)
+        client.finishEvents()
+        let model = FeatureRootModel(client: client, outboxStore: store)
+
+        await model.start()
+        await model.disconnect()
+
+        #expect(try await store.submissions() == [submission])
+    }
+
+    @Test
+    func cancellingAnOfflineTaskRemovesItsDurableSubmission() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-cancel-queued-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .disconnected),
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .disconnected
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "project-1",
+                    environmentID: "environment-1",
+                    name: "Native",
+                    path: "/native"
+                ),
+            ]
+        )
+        client.startTaskError = URLError(.notConnectedToInternet)
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        await model.reload()
+        let thread = try #require(await model.startTask(
+            NewTaskRequest(
+                projectID: "project-1",
+                prompt: "Cancel this task",
+                selection: nil,
+                runtimeMode: .fullAccess,
+                interactionMode: .standard
+            )
+        ))
+
+        await model.cancelTurn(threadID: thread.id)
+
+        #expect(try await store.submissions().isEmpty)
+        #expect(!model.snapshot.threads.contains(where: { $0.id == thread.id }))
+        #expect(client.cancelTurnCallCount == 0)
+    }
+
+    @Test
     func testPairReloadsConnectedSnapshot() async {
         let client = FeatureClientStub()
         client.snapshot = FeatureSnapshot(connection: .init(state: .disconnected))
@@ -249,6 +371,122 @@ struct FeatureRootModelTests {
         #expect(client.enabledEnvironmentID == "studio")
         #expect(client.environmentEnabledValue == false)
         #expect(model.snapshot.environments.first?.isEnabled == false)
+    }
+
+    @Test
+    func removingAnEnvironmentClearsItsPhysicalAndGroupedDrafts() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-draft-cleanup-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let drafts = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let outbox = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let project = FeatureProject(
+            id: "project-1",
+            environmentID: "environment-1",
+            name: "Native",
+            path: "/native",
+            repositoryIdentity: FeatureRepositoryIdentity(canonicalKey: "github.com/t3/native")
+        )
+        let physicalKey = "environment:environment-1:thread:one"
+        let logicalKey = FeatureComposerDraftStore.newTaskKey(
+            logicalProjectID: "github.com/t3/native"
+        )
+        let otherKey = "environment:environment-2:thread:two"
+        try await drafts.setDraft(FeatureComposerDraft(text: "remove physical"), for: physicalKey)
+        try await drafts.setDraft(FeatureComposerDraft(text: "remove logical"), for: logicalKey)
+        try await drafts.setDraft(FeatureComposerDraft(text: "keep"), for: otherKey)
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example"
+                ),
+            ],
+            projects: [project]
+        )
+        client.snapshotAfterEnvironmentRemoval = FeatureSnapshot()
+        let model = FeatureRootModel(
+            client: client,
+            outboxStore: outbox,
+            draftStore: drafts
+        )
+        await model.reload()
+
+        await model.removeEnvironment("environment-1")
+
+        #expect(try await drafts.draft(for: physicalKey) == nil)
+        #expect(try await drafts.draft(for: logicalKey) == nil)
+        #expect(try await drafts.draft(for: otherKey)?.text == "keep")
+    }
+
+    @Test
+    func signingOutClearsManagedOutboxEntriesAndGroupedDrafts() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-sign-out-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let drafts = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let outbox = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let project = FeatureProject(
+            id: "project-1",
+            environmentID: "managed-1",
+            name: "Native",
+            path: "/native",
+            repositoryIdentity: FeatureRepositoryIdentity(canonicalKey: "github.com/t3/native")
+        )
+        let groupedDraftKey = FeatureComposerDraftStore.newTaskKey(
+            logicalProjectID: "github.com/t3/native"
+        )
+        try await drafts.setDraft(FeatureComposerDraft(text: "Private prompt"), for: groupedDraftKey)
+        try await outbox.enqueue(
+            FeatureQueuedSubmission(
+                environmentID: "managed-1",
+                identity: FeatureSubmissionIdentity(),
+                threadID: "managed-1::thread::queued",
+                text: "Private queued message",
+                selection: nil,
+                runtimeMode: .fullAccess,
+                interactionMode: .standard,
+                attachments: []
+            )
+        )
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            environments: [
+                .init(
+                    id: "managed-1",
+                    name: "Managed",
+                    endpoint: "https://managed.example",
+                    source: .t3Connect
+                ),
+                .init(
+                    id: "manual-1",
+                    name: "Manual",
+                    endpoint: "https://manual.example"
+                ),
+            ],
+            projects: [project]
+        )
+        let model = FeatureRootModel(
+            client: client,
+            outboxStore: outbox,
+            draftStore: drafts
+        )
+        await model.reload()
+
+        await model.signOutT3Connect()
+
+        #expect(client.signOutCallCount == 1)
+        #expect(model.snapshot.environments.map(\.id) == ["manual-1"])
+        #expect(try await outbox.submissions().isEmpty)
+        #expect(try await drafts.draft(for: groupedDraftKey) == nil)
     }
 
     @Test
@@ -736,6 +974,32 @@ struct FeatureRootModelTests {
 
         await model.deleteThread(thread.id)
         #expect(model.snapshot.threads.isEmpty)
+    }
+
+    @Test
+    func activeThreadsCannotBeArchivedOrSettled() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(
+            id: "thread-1",
+            projectID: "project-1",
+            title: "Running task",
+            state: .working,
+            supportsSettlement: true
+        )
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        await model.setArchived(thread.id, archived: true)
+
+        #expect(model.snapshot.threads.first?.isArchived == false)
+        #expect(model.errorMessage?.contains("still active") == true)
+
+        model.errorMessage = nil
+        await model.setSettled(thread.id, settled: true)
+
+        #expect(model.snapshot.threads.first?.isSettled == false)
+        #expect(model.errorMessage?.contains("needs attention") == true)
     }
 
     @Test
@@ -1710,7 +1974,7 @@ private func orchestrationThread(
 }
 
 @MainActor
-private final class FeatureClientStub: FeatureClient {
+private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     private let eventStream: AsyncStream<FeatureEvent>
     private let eventContinuation: AsyncStream<FeatureEvent>.Continuation
     var snapshot = FeatureSnapshot()
@@ -1734,6 +1998,8 @@ private final class FeatureClientStub: FeatureClient {
     var startedFromOrigin = false
     var createThreadCallCount = 0
     var sendMessageCallCount = 0
+    var cancelTurnCallCount = 0
+    var signOutCallCount = 0
     var startTaskError: (any Error)?
     var sendMessageError: (any Error)?
     var enabledEnvironmentID: String?
@@ -1747,6 +2013,9 @@ private final class FeatureClientStub: FeatureClient {
     var resolvedInputID: String?
     var resolvedInputAnswers: [String: FeatureInputAnswer]?
     var savedSettings: [FeatureSettings] = []
+    lazy var t3ConnectController = T3ConnectController(
+        resolution: .unavailable(reason: "T3 Connect is disabled in feature tests.")
+    )
 
     init() {
         let pair = AsyncStream<FeatureEvent>.makeStream()
@@ -1797,6 +2066,20 @@ private final class FeatureClientStub: FeatureClient {
 
     func removeEnvironment(id: String) async throws {
         removedEnvironmentID = id
+    }
+
+    func connectT3Environment(
+        _ credential: T3ConnectManagedEnvironmentCredential
+    ) async throws {}
+
+    func signOutT3Connect() async {
+        signOutCallCount += 1
+        let removedIDs = Set(snapshot.environments.filter { $0.source == .t3Connect }.map(\.id))
+        snapshot.environments.removeAll { removedIDs.contains($0.id) }
+        snapshot.projects.removeAll { removedIDs.contains($0.environmentID) }
+        snapshot.threads.removeAll {
+            $0.environmentID.map(removedIDs.contains) ?? false
+        }
     }
 
     func createThread(
@@ -1874,7 +2157,9 @@ private final class FeatureClientStub: FeatureClient {
         sentText = text
     }
 
-    func cancelTurn(threadID: String) async throws {}
+    func cancelTurn(threadID: String) async throws {
+        cancelTurnCallCount += 1
+    }
     func resolveApproval(id: String, decision: FeatureApprovalDecision) async throws {}
     func resolveUserInput(
         id: String,

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -310,6 +310,216 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func cancellingARestoredServerThreadAlsoInterruptsItsTurn() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-cancel-restored-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let identity = FeatureSubmissionIdentity(threadID: "created-thread")
+        let threadID = "environment-1::thread::created-thread"
+        let submission = FeatureQueuedSubmission(
+            environmentID: "environment-1",
+            identity: identity,
+            threadID: threadID,
+            text: "Already running on the server",
+            selection: nil,
+            runtimeMode: .fullAccess,
+            interactionMode: .standard,
+            attachments: [],
+            creation: .init(
+                projectID: "project-1",
+                projectName: "Native",
+                workspaceMode: .local,
+                branch: nil,
+                worktreePath: nil,
+                startFromOrigin: false
+            )
+        )
+        try await store.enqueue(submission)
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .disconnected),
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .disconnected
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "project-1",
+                    environmentID: "environment-1",
+                    name: "Native",
+                    path: "/native"
+                ),
+            ],
+            threads: [
+                .init(
+                    id: threadID,
+                    wireID: identity.threadID,
+                    projectID: "project-1",
+                    environmentID: "environment-1",
+                    title: "Already running",
+                    state: .working
+                ),
+            ]
+        )
+        client.finishEvents()
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        await model.start()
+
+        await model.cancelTurn(threadID: threadID)
+
+        #expect(client.cancelTurnCallCount == 1)
+        #expect(try await store.submissions().isEmpty)
+        #expect(model.snapshot.threads.contains(where: { $0.id == threadID }))
+    }
+
+    @Test(arguments: [false, true])
+    func cancellingAnAcknowledgedQueuedThreadInterruptsItsTurn(
+        acknowledgedBySnapshot: Bool
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-cancel-acknowledged-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let identity = FeatureSubmissionIdentity(threadID: "acknowledged-thread")
+        let threadID = "environment-1::thread::acknowledged-thread"
+        try await store.enqueue(
+            FeatureQueuedSubmission(
+                environmentID: "environment-1",
+                identity: identity,
+                threadID: threadID,
+                text: "Accepted before the outbox cleared",
+                selection: nil,
+                runtimeMode: .fullAccess,
+                interactionMode: .standard,
+                attachments: [],
+                creation: .init(
+                    projectID: "project-1",
+                    projectName: "Native",
+                    workspaceMode: .local,
+                    branch: nil,
+                    worktreePath: nil,
+                    startFromOrigin: false
+                )
+            )
+        )
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .disconnected),
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .disconnected
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "project-1",
+                    environmentID: "environment-1",
+                    name: "Native",
+                    path: "/native"
+                ),
+            ]
+        )
+        let acknowledged = FeatureThread(
+            id: threadID,
+            wireID: identity.threadID,
+            projectID: "project-1",
+            environmentID: "environment-1",
+            title: "Accepted on the server",
+            state: .working
+        )
+        if acknowledgedBySnapshot {
+            var snapshot = client.snapshot
+            snapshot.threads = [acknowledged]
+            client.emit(.snapshot(snapshot))
+        } else {
+            client.emit(.thread(acknowledged))
+        }
+        client.finishEvents()
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        await model.start()
+
+        await model.cancelTurn(threadID: threadID)
+
+        #expect(client.cancelTurnCallCount == 1)
+        #expect(try await store.submissions().isEmpty)
+        #expect(model.snapshot.threads == [acknowledged])
+    }
+
+    @Test
+    func retryableCreationFailureReturnsTheAcknowledgedServerThread() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-acknowledged-creation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .disconnected),
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .disconnected
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "project-1",
+                    environmentID: "environment-1",
+                    name: "Native",
+                    path: "/native"
+                ),
+            ]
+        )
+        client.startTaskError = URLError(.notConnectedToInternet)
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        await model.reload()
+        client.beforeStartTask = {
+            var acknowledged = try #require(model.snapshot.threads.first)
+            acknowledged.title = "Accepted on the server"
+            acknowledged.state = .working
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.snapshot.threads.first(where: { $0.id == acknowledged.id })?.state
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.thread(acknowledged))
+            }
+        }
+        let run = Task { await model.start() }
+
+        let thread = await model.startTask(
+            NewTaskRequest(
+                projectID: "project-1",
+                prompt: "Create this task once",
+                selection: nil,
+                runtimeMode: .fullAccess,
+                interactionMode: .standard
+            )
+        )
+        client.finishEvents()
+        await run.value
+
+        #expect(thread?.title == "Accepted on the server")
+        #expect(thread?.state == .working)
+        #expect(try await store.submissions().count == 1)
+    }
+
+    @Test
     func testPairReloadsConnectedSnapshot() async {
         let client = FeatureClientStub()
         client.snapshot = FeatureSnapshot(connection: .init(state: .disconnected))
@@ -425,6 +635,38 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func removingAnEnvironmentClearsDraftsWhenOutboxCleanupFails() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-cleanup-failure-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let drafts = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let draftKey = "environment:environment-1:thread:one"
+        try await drafts.setDraft(FeatureComposerDraft(text: "Clear this draft"), for: draftKey)
+        let outbox = FeatureOutboxStore(fileURL: directory)
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example"
+                ),
+            ]
+        )
+        client.snapshotAfterEnvironmentRemoval = FeatureSnapshot()
+        let model = FeatureRootModel(client: client, outboxStore: outbox, draftStore: drafts)
+        await model.reload()
+
+        await model.removeEnvironment("environment-1")
+
+        #expect(try await drafts.draft(for: draftKey) == nil)
+        #expect(model.errorMessage?.contains("queued messages or drafts") == true)
+    }
+
+    @Test
     func signingOutClearsManagedOutboxEntriesAndGroupedDrafts() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-root-sign-out-\(UUID().uuidString)", isDirectory: true)
@@ -487,6 +729,139 @@ struct FeatureRootModelTests {
         #expect(model.snapshot.environments.map(\.id) == ["manual-1"])
         #expect(try await outbox.submissions().isEmpty)
         #expect(try await drafts.draft(for: groupedDraftKey) == nil)
+    }
+
+    @Test
+    func signingOutPreservesGroupedDraftsUsedByDirectEnvironments() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-shared-draft-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let drafts = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let outbox = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let identity = FeatureRepositoryIdentity(canonicalKey: "github.com/t3/native")
+        let groupedDraftKey = FeatureComposerDraftStore.newTaskKey(
+            logicalProjectID: identity.canonicalKey
+        )
+        let managedDraftKey = "environment:managed-1:thread:one"
+        try await drafts.setDraft(FeatureComposerDraft(text: "Keep shared prompt"), for: groupedDraftKey)
+        try await drafts.setDraft(FeatureComposerDraft(text: "Remove managed prompt"), for: managedDraftKey)
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            environments: [
+                .init(
+                    id: "managed-1",
+                    name: "Managed",
+                    endpoint: "https://managed.example",
+                    source: .t3Connect
+                ),
+                .init(
+                    id: "manual-1",
+                    name: "Manual",
+                    endpoint: "https://manual.example"
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "managed-project",
+                    environmentID: "managed-1",
+                    name: "Native",
+                    path: "/managed/native",
+                    repositoryIdentity: identity
+                ),
+                .init(
+                    id: "manual-project",
+                    environmentID: "manual-1",
+                    name: "Native",
+                    path: "/manual/native",
+                    repositoryIdentity: identity
+                ),
+            ]
+        )
+        let model = FeatureRootModel(client: client, outboxStore: outbox, draftStore: drafts)
+        await model.reload()
+
+        await model.signOutT3Connect()
+
+        #expect(try await drafts.draft(for: groupedDraftKey)?.text == "Keep shared prompt")
+        #expect(try await drafts.draft(for: managedDraftKey) == nil)
+        #expect(model.snapshot.projects.map(\.id) == ["manual-project"])
+    }
+
+    @Test
+    func signingOutClearsDraftsWhenOutboxCleanupFails() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-sign-out-failure-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let drafts = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let draftKey = "environment:managed-1:thread:one"
+        try await drafts.setDraft(FeatureComposerDraft(text: "Clear this draft"), for: draftKey)
+        let outboxURL = directory.appendingPathComponent("outbox.json")
+        let outbox = FeatureOutboxStore(fileURL: outboxURL)
+        let threadID = "managed-1::thread::queued"
+        try await outbox.enqueue(
+            FeatureQueuedSubmission(
+                environmentID: "managed-1",
+                identity: FeatureSubmissionIdentity(threadID: "queued"),
+                threadID: threadID,
+                text: "Private queued message",
+                selection: nil,
+                runtimeMode: .fullAccess,
+                interactionMode: .standard,
+                attachments: [],
+                creation: .init(
+                    projectID: "managed-project",
+                    projectName: "Native",
+                    workspaceMode: .local,
+                    branch: nil,
+                    worktreePath: nil,
+                    startFromOrigin: false
+                )
+            )
+        )
+
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .disconnected),
+            environments: [
+                .init(
+                    id: "managed-1",
+                    name: "Managed",
+                    endpoint: "https://managed.example",
+                    source: .t3Connect,
+                    connectionState: .disconnected
+                ),
+            ],
+            projects: [
+                .init(
+                    id: "managed-project",
+                    environmentID: "managed-1",
+                    name: "Native",
+                    path: "/native"
+                ),
+            ]
+        )
+        client.finishEvents()
+        let model = FeatureRootModel(client: client, outboxStore: outbox, draftStore: drafts)
+        await model.start()
+        #expect(model.snapshot.threads.contains(where: { $0.id == threadID }))
+        #expect(model.details[threadID] != nil)
+        try FileManager.default.removeItem(at: outboxURL)
+        try FileManager.default.createDirectory(
+            at: outboxURL,
+            withIntermediateDirectories: false
+        )
+
+        await model.signOutT3Connect()
+
+        #expect(try await drafts.draft(for: draftKey) == nil)
+        #expect(model.snapshot.threads.isEmpty)
+        #expect(model.details.isEmpty)
+        #expect(model.errorMessage?.contains("Could not clear saved T3 Connect data") == true)
     }
 
     @Test
@@ -2005,6 +2380,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var enabledEnvironmentID: String?
     var environmentEnabledValue: Bool?
     var removedEnvironmentID: String?
+    var beforeStartTask: (() async throws -> Void)?
     var beforeSendMessage: (() throws -> Void)?
     var loadThreadError: (any Error)?
     var loadThreadHandler: ((String) async throws -> FeatureThreadDetail)?
@@ -2117,6 +2493,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
         startFromOrigin: Bool,
         attachments: [FeatureUploadAttachment]
     ) async throws -> FeatureThread {
+        try await beforeStartTask?()
         if let startTaskError { throw startTaskError }
         startedPrompt = prompt
         startedAttachments = attachments

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -114,6 +114,29 @@ struct HomeThreadSwipeActionTests {
         #expect(!HomeThreadSwipeAction.performsFullSwipe(with: archivedActions))
     }
 
+    @Test
+    func workingRowsNeverOfferSettlementOrAFullSwipe() {
+        for state in [
+            FeatureThreadState.queued,
+            .working,
+            .monitoring,
+            .waitingForApproval,
+            .waitingForInput,
+        ] {
+            var active = thread(id: "active-\(state.rawValue)")
+            active.state = state
+
+            let actions = HomeThreadSwipeAction.trailingActions(
+                for: active,
+                isArchived: false,
+                at: now
+            )
+
+            #expect(actions == [.archive, .delete])
+            #expect(!HomeThreadSwipeAction.performsFullSwipe(with: actions))
+        }
+    }
+
     /// Delete must never reach the edge slot, because the edge slot is what a
     /// full swipe runs. This sweeps every pinned/settled/capability/archived
     /// combination rather than trusting the branch order.
@@ -264,7 +287,9 @@ struct HomeThreadSwipeActionTests {
             updatedAt: now.addingTimeInterval(-50),
             state: .idle,
             lastActivityAt: now.addingTimeInterval(-50),
-            pinnedAt: pinnedAt
+            pinnedAt: pinnedAt,
+            supportsSettlement: true,
+            supportsPinning: true
         )
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -200,6 +200,51 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testOlderHTTPSnapshotCannotReplaceNewerEnvironmentState() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+
+        let newer = multiEnvironmentShell(
+            projectID: "project-one",
+            threadID: "thread-one",
+            title: "Newer work"
+        )
+        await fixture.transport.setShell(
+            OrchestrationShellSnapshot(
+                snapshotSequence: 3,
+                projects: newer.projects,
+                threads: newer.threads,
+                updatedAt: newer.updatedAt
+            ),
+            host: "one.example"
+        )
+        _ = try await fixture.client.initialSnapshot()
+
+        let older = multiEnvironmentShell(
+            projectID: "project-one",
+            threadID: "thread-one",
+            title: "Stale work"
+        )
+        await fixture.transport.setShell(
+            OrchestrationShellSnapshot(
+                snapshotSequence: 2,
+                projects: older.projects,
+                threads: older.threads,
+                updatedAt: older.updatedAt
+            ),
+            host: "one.example"
+        )
+
+        let snapshot = try await fixture.client.initialSnapshot()
+
+        XCTAssertEqual(
+            snapshot.threads.first(where: { $0.environmentID == "one" })?.title,
+            "Newer work"
+        )
+        await fixture.client.disconnect()
+    }
+
     func testBackgroundSnapshotDoesNotStartAggregateRefreshLoops() async throws {
         let loader = CountingAggregateEnvironmentLoader()
         let fixture = try await makeFixture(

--- a/apps/swift-ios/Tests/FeatureTests/PullRequestDiffTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/PullRequestDiffTests.swift
@@ -66,4 +66,37 @@ struct PullRequestDiffTests {
         #expect(file.lines[3].oldLine == 2)
         #expect(file.lines[3].newLine == 2)
     }
+
+    @Test
+    func repeatedDiffCursorsStopPaginationAndMarkDiffIncomplete() {
+        var pagination = PullRequestDiffPagination()
+
+        #expect(pagination.append(
+            PullRequestDiffResult(
+                patch: "first",
+                truncated: false,
+                nextCursor: "first-cursor",
+                omittedFileStats: nil
+            )
+        ) == "first-cursor")
+        #expect(pagination.append(
+            PullRequestDiffResult(
+                patch: "second",
+                truncated: false,
+                nextCursor: "second-cursor",
+                omittedFileStats: nil
+            )
+        ) == "second-cursor")
+        #expect(pagination.append(
+            PullRequestDiffResult(
+                patch: "third",
+                truncated: false,
+                nextCursor: "first-cursor",
+                omittedFileStats: nil
+            )
+        ) == nil)
+
+        #expect(pagination.patch == "firstsecondthird")
+        #expect(pagination.isIncomplete)
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/PullRequestDiffTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/PullRequestDiffTests.swift
@@ -43,4 +43,27 @@ struct PullRequestDiffTests {
         #expect(file.oldPath == "Old.swift")
         #expect(file.path == "New.swift")
     }
+
+    @Test
+    func missingNewlineMarkersDoNotChangeReviewLineNumbers() throws {
+        let patch = """
+        diff --git a/App.swift b/App.swift
+        --- a/App.swift
+        +++ b/App.swift
+        @@ -1,2 +1,2 @@
+        -old
+        \\ No newline at end of file
+        +new
+        \\ No newline at end of file
+         context
+        """
+
+        let file = try #require(PullRequestDiffParser.parse(patch).first)
+
+        #expect(file.lines.count == 4)
+        #expect(file.lines[1].position == .deleted(1))
+        #expect(file.lines[2].position == .added(1))
+        #expect(file.lines[3].oldLine == 2)
+        #expect(file.lines[3].newLine == 2)
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/T3ConnectNativeCapabilityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/T3ConnectNativeCapabilityTests.swift
@@ -285,6 +285,80 @@ final class T3ConnectNativeCapabilityTests: XCTestCase {
         XCTAssertNotNil(controller.errorMessage)
     }
 
+    func testManagedEnvironmentRemovalRevokesCredentialWhenCatalogRemovalFails() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-connect-account-change-revoke-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let catalogURL = directory.appendingPathComponent("environments.json")
+        let managed = Environment(
+            id: "managed-1",
+            label: "Managed Studio",
+            httpBaseURL: URL(string: "https://managed.example")!,
+            webSocketBaseURL: URL(string: "wss://managed.example")!,
+            kind: .managedDPoP
+        )
+        let store = EnvironmentStore(fileURL: catalogURL)
+        try await store.save([managed])
+        let credentials = InMemoryCredentialStore(credentials: [
+            managed.id: .managedDPoP(
+                accessToken: "managed-secret",
+                expiresAt: Date().addingTimeInterval(300),
+                scopes: T3ConnectManagedEnvironmentAuthorizer.standardScopes,
+                environmentID: managed.id,
+                proofKeyThumbprint: "proof-key"
+            ),
+        ])
+        let runtime = EnvironmentRuntime(
+            environmentStore: store,
+            credentialStore: credentials
+        )
+        let client = NativeFeatureClient(runtime: runtime)
+
+        try FileManager.default.removeItem(at: catalogURL)
+        try FileManager.default.createDirectory(at: catalogURL, withIntermediateDirectories: true)
+
+        do {
+            try await client.removeEnvironment(id: managed.id)
+            XCTFail("Managed environment removal succeeded with an unwritable catalog")
+        } catch {
+            let remainingCredential = await credentials.credential(for: managed.id)
+            XCTAssertNil(remainingCredential)
+        }
+    }
+
+    func testManualEnvironmentRemovalKeepsCredentialWhenCatalogRemovalFails() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-connect-manual-removal-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let catalogURL = directory.appendingPathComponent("environments.json")
+        let manual = Environment(
+            id: "manual-1",
+            label: "Manual Studio",
+            httpBaseURL: URL(string: "https://manual.example")!,
+            webSocketBaseURL: URL(string: "wss://manual.example")!
+        )
+        let store = EnvironmentStore(fileURL: catalogURL)
+        try await store.save([manual])
+        let credential = EnvironmentCredential(accessToken: "manual-secret")
+        let credentials = InMemoryCredentialStore(credentials: [manual.id: credential])
+        let runtime = EnvironmentRuntime(
+            environmentStore: store,
+            credentialStore: credentials
+        )
+        let client = NativeFeatureClient(runtime: runtime)
+
+        try FileManager.default.removeItem(at: catalogURL)
+        try FileManager.default.createDirectory(at: catalogURL, withIntermediateDirectories: true)
+
+        do {
+            try await client.removeEnvironment(id: manual.id)
+            XCTFail("Manual environment removal succeeded with an unwritable catalog")
+        } catch {
+            let remainingCredential = await credentials.credential(for: manual.id)
+            XCTAssertEqual(remainingCredential, credential)
+        }
+    }
+
     func testInjectedManagedRuntimeRequiresItsMatchingController() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-connect-controller-mismatch-\(UUID().uuidString)")

--- a/apps/swift-ios/Tests/PlatformTests/PlatformCloudDeliveryTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformCloudDeliveryTests.swift
@@ -45,4 +45,40 @@ struct PlatformCloudDeliveryTests {
         #expect(registration.preferences.liveActivitiesEnabled)
     }
 
+    @Test
+    @MainActor
+    func installingNewControllerReleasesPreviousController() throws {
+        let suiteName = "cloud-delivery-controller-\(UUID())"
+        let suite = try #require(UserDefaults(suiteName: suiteName))
+        defer { suite.removePersistentDomain(forName: suiteName) }
+        suite.set("existing-registration", forKey: "swift-ios.cloud-delivery-device.v1")
+
+        let coordinator = PlatformCloudDeliveryCoordinator(
+            defaults: suite,
+            deviceID: "test-device"
+        )
+        let currentController = T3ConnectController(
+            resolution: .unavailable(reason: "Authentication is not needed for this test.")
+        )
+        weak var previousController: T3ConnectController?
+
+        do {
+            let controller = T3ConnectController(
+                resolution: .unavailable(reason: "Authentication is not needed for this test.")
+            )
+            previousController = controller
+            coordinator.install(controller: controller)
+            #expect(
+                suite.string(forKey: "swift-ios.cloud-delivery-device.v1")
+                    == "existing-registration"
+            )
+            coordinator.install(controller: currentController)
+        }
+
+        #expect(previousController == nil)
+        #expect(
+            suite.string(forKey: "swift-ios.cloud-delivery-device.v1")
+                == "existing-registration"
+        )
+    }
 }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformIncomingShareTests.swift
@@ -113,6 +113,49 @@ struct PlatformIncomingShareTests {
     }
 
     @Test
+    func groupedProjectImportUsesTheSameDraftKeyAsTheComposer() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureComposerDraftStore(
+            fileURL: directory.appendingPathComponent("drafts.json")
+        )
+        let project = Self.project(
+            repositoryIdentity: FeatureRepositoryIdentity(canonicalKey: "github.com/t3/example")
+        )
+        let snapshot = FeatureSnapshot(projects: [project])
+        let draftKey = FeatureComposerDraftStore.newTaskKey(project: project, in: snapshot)
+        let envelope = Self.envelope(text: "Keep shared context")
+        let pipeline = PlatformIncomingSharePipeline(
+            source: PlatformIncomingShareSource(
+                loadAll: { [envelope] },
+                data: { _ in Data() },
+                remove: { _ in }
+            ),
+            drafts: PlatformIncomingShareDraftRepository(
+                importContent: { shareID, text, attachments, key, maximumCount in
+                    try await store.importSharedContent(
+                        shareID: shareID,
+                        text: text,
+                        attachments: attachments,
+                        for: key,
+                        maximumAttachmentCount: maximumCount
+                    )
+                }
+            ),
+            prepareImage: { _, _ in Self.attachment(id: UUID(), value: 1) }
+        )
+
+        _ = try await pipeline.importEnvelope(envelope, into: project, draftKey: draftKey)
+
+        #expect(draftKey == "logical-project:github.com/t3/example:new-task")
+        #expect(try await store.draft(for: draftKey)?.text == "Keep shared context")
+        #expect(
+            try await store.draft(for: FeatureComposerDraftStore.newTaskKey(project: project)) == nil
+        )
+    }
+
+    @Test
     func imageFailureDoesNotPersistOrRemoveTheEnvelope() async {
         let recorder = IncomingShareTestRecorder()
         let envelope = Self.envelope(
@@ -290,13 +333,16 @@ struct PlatformIncomingShareTests {
         )
     }
 
-    private static func project() -> FeatureProject {
+    private static func project(
+        repositoryIdentity: FeatureRepositoryIdentity? = nil
+    ) -> FeatureProject {
         FeatureProject(
             id: "project:environment:project",
             wireID: "project",
             environmentID: "environment",
             name: "t3code",
-            path: "/repo"
+            path: "/repo",
+            repositoryIdentity: repositoryIdentity
         )
     }
 }

--- a/apps/swift-ios/Tests/PlatformTests/PlatformRootViewTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformRootViewTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import T3Code
+
+@MainActor
+@Suite("Platform account session transitions")
+struct PlatformRootViewTests {
+    @Test
+    func accountSignOutRemovesManagedEnvironments() {
+        #expect(PlatformRootView.shouldRemoveManagedEnvironments(
+            previousAccountID: "account-1",
+            accountID: nil,
+            isSigningOut: false
+        ))
+    }
+
+    @Test
+    func changingAccountsRemovesManagedEnvironments() {
+        #expect(PlatformRootView.shouldRemoveManagedEnvironments(
+            previousAccountID: "account-1",
+            accountID: "account-2",
+            isSigningOut: false
+        ))
+    }
+
+    @Test
+    func loadingAnExistingAccountKeepsManagedEnvironments() {
+        #expect(!PlatformRootView.shouldRemoveManagedEnvironments(
+            previousAccountID: nil,
+            accountID: "account-1",
+            isSigningOut: false
+        ))
+    }
+
+    @Test
+    func unchangedAccountsKeepManagedEnvironments() {
+        #expect(!PlatformRootView.shouldRemoveManagedEnvironments(
+            previousAccountID: "account-1",
+            accountID: "account-1",
+            isSigningOut: false
+        ))
+    }
+
+    @Test
+    func explicitSignOutOwnsItsManagedEnvironmentCleanup() {
+        #expect(!PlatformRootView.shouldRemoveManagedEnvironments(
+            previousAccountID: "account-1",
+            accountID: nil,
+            isSigningOut: true
+        ))
+    }
+}


### PR DESCRIPTION
The SwiftUI client could lose queued messages, keep stale account data after sign-out, and apply unsafe or outdated state.

This fixes durable message delivery, account cleanup, live connection recovery, terminal routing, pull request actions, server capability checks, development app isolation, accessibility, and Swift dependency locking.

Stacks on #5178.

Verification: 446 native tests passed, one existing optional test was skipped, 54 Thread Sanitizer tests passed, Debug and Release builds passed, and generated wire fixtures match.

Model: GPT-5.6 Sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches keychain credentials, DPoP refresh, account sign-out, and WebSocket recovery. A CAS or host-match mistake can drop tokens or disconnect managed environments.
> 
> **Overview**
> Hardens the Swift iOS client so queued first messages are not discarded, T3 Connect account switches/sign-out actually revoke credentials and purge local data, and concurrent credential writes cannot clobber a newer token.
> 
> **Auth and account cleanup:** credential stores gain compare-and-swap (`swap` / `replace` / `remove` if matching). Pairing, managed save, and DPoP refresh roll back only if the stored token still matches. Sign-out and account-change now remove managed environments, revoke DPoP credentials, and clear drafts/outbox. Managed HTTP/WS endpoints must share host and port.
> 
> **Delivery and live state:** outbox creations retry until the message itself is confirmed. WebSocket keepalive fails half-open sockets, bounds subscription buffers, and errors on overflow. Shell snapshots ignore older `snapshotSequence` values.
> 
> **Product behavior:** pin/settle/snooze require an explicit capability; settle is blocked while a thread still needs attention. PR lists paginate with duplicate/cursor guards, incomplete diffs are flagged, and merge/close/update-branch need confirmation. Drafts persist on background, terminal I/O is scoped to the active session, and thread delete is confirmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f22eac22e0b478095112d24c37c142f356bb407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent lost messages and stale account access across swift-ios
> - Makes credential store operations atomic via new `swapCredential`, `replaceCredential(ifMatching:)`, and `removeCredential(ifMatching:)` methods in [Persistence.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-8253ecd1929a2cd0b03a4254f703617c2b21b1e8ee3f425f694f69a4edce60b5); callers in [PairingService.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-607bfc75c90c94c03097d63224da402a1f933c927e28d88b286d5ed400b0a956), [T3Client.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-3b5ec6ff6b91ca4755fd1de9fc4d2d3d1692ed7f5f9e0c7a44a611f602d7ed72), and [HTTP.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-e184681de61fafab1aa0bfb24ac8290bcd1c5179af1723745729f3ea6cd9b2f9) use compare-and-swap semantics to avoid overwriting concurrently updated credentials.
> - `FeatureOutboxPolicy.decision` in [FeatureOutboxStore.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-f8d2272938398df59e03d96adefd0e37a683b2de4c3a5471e76e284e71e5228c) now retries creation messages even when the thread already exists, and [FeatureRootModel.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-f6b20b6d256ebc9824a930a08027bd7196d59c162edd8918fcaba018a505bcc2) re-queues restored submissions instead of discarding them.
> - [PlatformCloudDelivery.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-7bf7ab91d393981ac51b209e64d68b5a7081c20433fc7134bf4274d78beddae4) tracks `observedAccountID` and only resets caches, live activity tokens, and registration on actual T3 Connect account changes, not on re-install calls.
> - [WebSocketRPC.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-8083d45e5b8c124fd6e674375591682e18e12f02e7b36c312f2d4e4fbab23310) adds keepalive half-open detection (disconnects if no pong before next interval) and bounded subscription buffers that terminate streams on overflow instead of growing unbounded.
> - [FeatureRootModel.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-f6b20b6d256ebc9824a930a08027bd7196d59c162edd8918fcaba018a505bcc2) adds a full `signOutT3Connect()` flow, clears drafts on environment removal, blocks archiving/settling active threads, and cancels queued creations when stopping a thread.
> - Risk: `FeatureThread.canTogglePin`, `canToggleSettlement`, and `canToggleSnooze` in [FeatureModels.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-4ae6723d64bd8c9dbdac2f7091b357caf6669336a15a774435576c1b07f71c70) now require explicit `true` capability flags; threads with `nil` capabilities lose those toggles unless already toggled. Monotonicity guards in [NativeFeatureClient.swift](https://github.com/pingdotgg/t3code/pull/7974/files#diff-8279266d99011132202ed170e0094211bf4d68743088364655f75a2c4a70adac) drop shell/snapshot updates with lower `snapshotSequence`, which could lose data if sequences are not strictly increasing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f22eac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now support safer actions with confirmations, improved pagination, duplicate removal, and warnings for incomplete diffs.
  * Added clearer handling for server-managed sessions and account changes.
  * Terminal text supports larger font sizes and improved VoiceOver accessibility.
  * Incoming shared content preserves project-aware task drafts.

* **Bug Fixes**
  * Prevented stale updates, credential overwrites, and lost drafts during app transitions.
  * Added confirmation before permanently deleting threads and terminal history.
  * Improved WebSocket reliability and recovery from connection interruptions.
  * Active threads can no longer be archived or settled prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->