### PR TITLE
feat: support antigravity via ACP

### DIFF
--- a/apps/mobile/src/components/ProviderIcon.tsx
+++ b/apps/mobile/src/components/ProviderIcon.tsx
@@ -59,6 +59,17 @@ export function ProviderIcon(props: ProviderIconProps) {
     );
   }
 
+  if (props.provider === "antigravity") {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 296 298" fill="none">
+        <Path
+          fill="#3186FF"
+          d="M141.201 4.886c2.282-6.17 11.042-6.071 13.184.148l5.985 17.37a184.004 184.004 0 0 0 111.257 113.049l19.304 6.997c6.143 2.227 6.156 10.91.02 13.155l-19.35 7.082a184.001 184.001 0 0 0-109.495 109.385l-7.573 20.629c-2.241 6.105-10.869 6.121-13.133.025l-7.908-21.296a184 184 0 0 0-109.02-108.658l-19.698-7.239c-6.102-2.243-6.118-10.867-.025-13.132l20.083-7.467A183.998 183.998 0 0 0 133.291 26.28l7.91-21.394Z"
+        />
+      </Svg>
+    );
+  }
+
   // codex (and unknown drivers)
   return (
     <Svg width={size} height={size} viewBox="0 0 256 260" fill="none">

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -2,6 +2,7 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFS from "node:fs";
 
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -278,18 +279,33 @@ function modeState(): AcpSchema.SessionModeState {
   };
 }
 
+const isAntigravity = process.env.T3_PROVIDER === "antigravity";
+
+const antigravityAcpModels: ReadonlyArray<AcpSchema.ModelInfo> = [
+  { modelId: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
+  { modelId: "gemini-3.7-flash-high", name: "Gemini 3.7 Flash (High Thinking)" },
+  { modelId: "gemini-3.7-flash-medium", name: "Gemini 3.7 Flash (Medium Thinking)" },
+  { modelId: "gemini-3.7-flash-low", name: "Gemini 3.7 Flash (Low Thinking)" },
+  { modelId: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
+];
+
 const grokAcpModels: ReadonlyArray<AcpSchema.ModelInfo> = [
   { modelId: "grok-build", name: "Grok Build" },
   { modelId: "grok-mock-alt", name: "Grok Mock Alt" },
 ];
 
+const acpModels: ReadonlyArray<AcpSchema.ModelInfo> = isAntigravity
+  ? antigravityAcpModels
+  : grokAcpModels;
+
 function modelState(): AcpSchema.SessionModelState {
-  const modelId = grokAcpModels.some((model) => model.modelId === currentModelId)
+  const defaultModelId = isAntigravity ? "gemini-3.7-flash" : "grok-build";
+  const modelId = acpModels.some((model) => model.modelId === currentModelId)
     ? currentModelId
-    : "grok-build";
+    : defaultModelId;
   return {
     currentModelId: modelId,
-    availableModels: grokAcpModels,
+    availableModels: acpModels,
   };
 }
 
@@ -382,7 +398,7 @@ const program = Effect.gen(function* () {
 
   yield* agent.handleSetSessionModel((request) =>
     Effect.gen(function* () {
-      if (!grokAcpModels.some((model) => model.modelId === request.modelId)) {
+      if (!acpModels.some((model) => model.modelId === request.modelId)) {
         return yield* AcpError.AcpRequestError.invalidParams(
           `Unknown mock model id: ${request.modelId}`,
           {
@@ -433,10 +449,15 @@ const program = Effect.gen(function* () {
     }),
   );
 
+  const activePromptCancelDeferred = yield* Deferred.make<AcpSchema.PromptResponse>();
+
   yield* agent.handleCancel(({ sessionId }) =>
     Effect.gen(function* () {
       const cancelledSessionId = String(sessionId ?? "mock-session-1");
       cancelledSessions.add(cancelledSessionId);
+      yield* Deferred.succeed(activePromptCancelDeferred, { stopReason: "cancelled" }).pipe(
+        Effect.ignore,
+      );
       if (emitLateUpdateAfterCancel) {
         yield* Effect.sleep("50 millis");
         yield* Effect.sync(() => {
@@ -519,7 +540,7 @@ const program = Effect.gen(function* () {
       }
 
       if (hangPromptForever || (hangFirstPromptForever && promptCount === 1)) {
-        return yield* Effect.never;
+        return yield* Deferred.await(activePromptCancelDeferred);
       }
 
       if (emitXAiPromptCompleteThenHang) {

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -1,0 +1,167 @@
+import { AntigravitySettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeAntigravityTextGeneration } from "../../textGeneration/AntigravityTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeAntigravityAdapter } from "../Layers/AntigravityAdapter.ts";
+import {
+  buildInitialAntigravityProviderSnapshot,
+  checkAntigravityProviderStatus,
+  enrichAntigravitySnapshot,
+} from "../Layers/AntigravityProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("antigravity");
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+  }),
+);
+
+export type AntigravityDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Antigravity",
+    supportsMultipleInstances: true,
+  },
+  configSchema: AntigravitySettings,
+  defaultConfig: (): AntigravitySettings => decodeAntigravitySettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies AntigravitySettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeAntigravityAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeAntigravityTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkAntigravityProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<
+        ProviderSnapshotSettings<AntigravitySettings>
+      >({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialAntigravityProviderSnapshot(settings.provider).pipe(
+            Effect.map(stampIdentity),
+          ),
+        checkProvider,
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichAntigravitySnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            httpClient,
+          }),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: "Failed to build Antigravity snapshot.",
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1,0 +1,352 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+import * as NodeOS from "node:os";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+
+import {
+  ApprovalRequestId,
+  AntigravitySettings,
+  ProviderDriverKind,
+  ThreadId,
+  TurnId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+
+import { ServerConfig } from "../../config.ts";
+import {
+  antigravityPromptSettlementBelongsToContext,
+  makeAntigravityAdapter,
+} from "./AntigravityAdapter.ts";
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
+const mockAgentCommand = process.execPath;
+
+async function makeMockAntigravityWrapper(extraEnv?: Record<string, string>) {
+  const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "antigravity-acp-mock-"));
+  const wrapperPath = NodePath.join(dir, "fake-antigravity.sh");
+  const envExports = Object.entries(extraEnv ?? {})
+    .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
+    .join("\n");
+  const script = `#!/bin/sh
+export T3_PROVIDER=antigravity
+${envExports}
+exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
+`;
+  await NodeFSP.writeFile(wrapperPath, script, "utf8");
+  await NodeFSP.chmod(wrapperPath, 0o755);
+  return wrapperPath;
+}
+
+const antigravityAdapterTestLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-antigravity-adapter-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+const makeTestAdapter = (
+  binaryPath: string,
+  options?: Parameters<typeof makeAntigravityAdapter>[1],
+) => makeAntigravityAdapter(decodeAntigravitySettings({ binaryPath }), options).pipe(Effect.orDie);
+
+it("requires a settlement to match the live Antigravity turn", () => {
+  const staleTurnId = TurnId.make("stale-turn");
+  const replacementTurnId = TurnId.make("replacement-turn");
+
+  assert.isFalse(
+    antigravityPromptSettlementBelongsToContext({
+      liveAcpSessionId: "session-1",
+      expectedAcpSessionId: "session-1",
+      liveActiveTurnId: replacementTurnId,
+      liveSessionActiveTurnId: replacementTurnId,
+      turnId: staleTurnId,
+    }),
+  );
+  assert.isFalse(
+    antigravityPromptSettlementBelongsToContext({
+      liveAcpSessionId: "replacement-session",
+      expectedAcpSessionId: "stale-session",
+      liveActiveTurnId: staleTurnId,
+      liveSessionActiveTurnId: staleTurnId,
+      turnId: staleTurnId,
+    }),
+  );
+  assert.isTrue(
+    antigravityPromptSettlementBelongsToContext({
+      liveAcpSessionId: "session-1",
+      expectedAcpSessionId: "session-1",
+      liveActiveTurnId: staleTurnId,
+      liveSessionActiveTurnId: staleTurnId,
+      turnId: staleTurnId,
+    }),
+  );
+});
+
+it.layer(antigravityAdapterTestLayer)("AntigravityAdapterLive", (it) => {
+  it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-mock-thread");
+      const wrapperPath = yield* Effect.promise(() => makeMockAntigravityWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "turn.completed"
+              ? Deferred.succeed(turnCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      assert.strictEqual(session.provider, "antigravity");
+      assert.strictEqual(session.status, "ready");
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "hello mock agent",
+      });
+
+      yield* Deferred.await(turnCompleted);
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const eventTypes = runtimeEvents.map((e) => e.type);
+      assert.isTrue(eventTypes.includes("turn.started"));
+      assert.isTrue(eventTypes.includes("turn.completed"));
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("handles permission requests and approvals", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-approval-thread");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAntigravityWrapper({
+          T3_ACP_EMIT_TOOL_CALLS: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const requestOpened = yield* Deferred.make<ApprovalRequestId>();
+      const turnCompleted = yield* Deferred.make<void>();
+
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          if (event.type === "request.opened" && event.requestId) {
+            yield* Deferred.succeed(requestOpened, ApprovalRequestId.make(event.requestId));
+          }
+          if (event.type === "turn.completed") {
+            yield* Deferred.succeed(turnCompleted, undefined);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "approval-required",
+      });
+
+      const sendTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "trigger permission",
+        })
+        .pipe(Effect.forkChild);
+
+      const requestId = yield* Deferred.await(requestOpened);
+      yield* adapter.respondToRequest(threadId, requestId, "accept");
+
+      yield* Fiber.join(sendTurnFiber);
+      yield* Deferred.await(turnCompleted);
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("auto-approves permissions in full-access runtime mode", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-full-access-thread");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAntigravityWrapper({
+          T3_ACP_EMIT_TOOL_CALLS: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "trigger permission with auto-approval",
+      });
+
+      const requestOpenedEvents = runtimeEvents.filter((e) => e.type === "request.opened");
+      assert.lengthOf(requestOpenedEvents, 0);
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("interruptTurn cancels an in-flight prompt and restores ready status", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-interrupt-thread");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAntigravityWrapper({
+          T3_ACP_HANG_PROMPT_FOREVER: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      yield* Effect.gen(function* () {
+        yield* Effect.sleep("500 millis");
+        yield* adapter.interruptTurn(threadId);
+      }).pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "hang forever",
+        attachments: [],
+      });
+
+      for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+
+      const cancelledEvents = runtimeEvents.filter(
+        (event): event is Extract<ProviderRuntimeEvent, { type: "turn.completed" }> =>
+          event.type === "turn.completed" && String(event.threadId) === String(threadId),
+      );
+      const readySessions = yield* adapter.listSessions();
+      const readySession = readySessions.find((session) => session.threadId === threadId);
+
+      assert.lengthOf(cancelledEvents, 1);
+      assert.equal(cancelledEvents[0]?.payload.state, "cancelled");
+      assert.equal(readySession?.status, "ready");
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
+  );
+
+  it.effect("steers an in-flight prompt by folding into active turn", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-steer-thread");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockAntigravityWrapper({
+          T3_ACP_PROMPT_DELAY_MS: "300",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      const firstTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "first prompt",
+        })
+        .pipe(Effect.forkChild);
+
+      yield* Effect.sleep("100 millis");
+
+      const secondTurnResult = yield* adapter.sendTurn({
+        threadId,
+        input: "steer while first is running",
+      });
+
+      const firstTurnResult = yield* Fiber.join(firstTurnFiber);
+
+      assert.strictEqual(firstTurnResult.turnId, secondTurnResult.turnId);
+
+      const turnStartedEvents = runtimeEvents.filter(
+        (e) => e.type === "turn.started" && String(e.threadId) === String(threadId),
+      );
+      const turnCompletedEvents = runtimeEvents.filter(
+        (e) => e.type === "turn.completed" && String(e.threadId) === String(threadId),
+      );
+
+      assert.lengthOf(turnStartedEvents, 1);
+      assert.lengthOf(turnCompletedEvents, 1);
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
+  );
+
+  it.effect("rejects rollbackThread with request error", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-rollback-thread");
+      const wrapperPath = yield* Effect.promise(() => makeMockAntigravityWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      yield* adapter.startSession({
+        threadId,
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      const rollbackResult = yield* adapter.rollbackThread(threadId, 1).pipe(Effect.exit);
+      assert.isTrue(rollbackResult._tag === "Failure");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1,0 +1,1375 @@
+import {
+  ApprovalRequestId,
+  type AntigravitySettings,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import {
+  applyAntigravityAcpModelSelection,
+  currentAntigravityModelIdFromSessionSetup,
+  makeAntigravityAcpRuntime,
+  resolveAntigravityAcpBaseModelId,
+} from "../acp/AntigravityAcpSupport.ts";
+import { type AntigravityAdapterShape } from "../Services/AntigravityAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
+
+const PROVIDER = ProviderDriverKind.make("antigravity");
+const ANTIGRAVITY_RESUME_VERSION = 1 as const;
+
+function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
+  const result = encodeUnknownJsonStringExit(input);
+  return Exit.isSuccess(result) ? result.value : undefined;
+}
+
+export interface AntigravityAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly instanceId?: ProviderInstanceId;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+interface AntigravitySessionContext {
+  readonly threadId: ThreadId;
+  acpSessionId: string;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  notificationFiber: Fiber.Fiber<void, unknown> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  lastPlanFingerprint: string | undefined;
+  activeTurnId: TurnId | undefined;
+  /** Turns already interrupted; late prompt RPCs must not resurrect them. */
+  interruptedTurnIds: Set<TurnId>;
+  /** Number of sendTurn prompts currently in flight or being prepared. */
+  promptsInFlight: number;
+  currentModelId: string | undefined;
+  stopped: boolean;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    Array.from(pendingApprovals.values()),
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+function appendPromptResultToTurn(
+  ctx: AntigravitySessionContext,
+  turnId: TurnId,
+  promptParts: ReadonlyArray<EffectAcpSchema.ContentBlock>,
+  result: EffectAcpSchema.PromptResponse,
+): void {
+  const existingTurnRecord = ctx.turns.find((turn) => turn.id === turnId);
+  ctx.turns = existingTurnRecord
+    ? ctx.turns.map((turn) =>
+        turn.id === turnId
+          ? { ...turn, items: [...turn.items, { prompt: promptParts, result }] }
+          : turn,
+      )
+    : [...ctx.turns, { id: turnId, items: [{ prompt: promptParts, result }] }];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const resolveNotificationTurnId = (ctx: AntigravitySessionContext): TurnId | undefined =>
+  ctx.activeTurnId;
+
+const resolveCallbackTurnId = (ctx: AntigravitySessionContext): TurnId | undefined =>
+  ctx.activeTurnId;
+
+const resolveSessionCallbackTurnId = (
+  sessions: ReadonlyMap<ThreadId, AntigravitySessionContext>,
+  threadId: ThreadId,
+): TurnId | undefined => {
+  const ctx = sessions.get(threadId);
+  return ctx ? resolveCallbackTurnId(ctx) : undefined;
+};
+
+function parseAntigravityResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== ANTIGRAVITY_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+function selectPermissionOptionId(
+  request: EffectAcpSchema.RequestPermissionRequest,
+  decision: Exclude<ProviderApprovalDecision, "cancel">,
+): string | undefined {
+  const kind =
+    decision === "acceptForSession"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  const option = request.options.find((entry) => entry.kind === kind);
+  return option?.optionId.trim() || undefined;
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  return (
+    selectPermissionOptionId(request, "acceptForSession") ??
+    selectPermissionOptionId(request, "accept")
+  );
+}
+
+function completedStopReasonFromPromptResponse(
+  response: EffectAcpSchema.PromptResponse | undefined,
+): EffectAcpSchema.StopReason | null {
+  if (response === undefined) {
+    return null;
+  }
+  return response.stopReason;
+}
+
+export function antigravityPromptSettlementBelongsToContext(input: {
+  readonly liveAcpSessionId: string;
+  readonly expectedAcpSessionId: string;
+  readonly liveActiveTurnId: TurnId | undefined;
+  readonly liveSessionActiveTurnId: TurnId | undefined;
+  readonly turnId: TurnId;
+}): boolean {
+  return (
+    input.liveAcpSessionId === input.expectedAcpSessionId &&
+    (input.liveActiveTurnId === input.turnId || input.liveSessionActiveTurnId === input.turnId)
+  );
+}
+
+export function makeAntigravityAdapter(
+  antigravitySettings: AntigravitySettings,
+  options?: AntigravityAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("antigravity");
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, AntigravitySessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Antigravity runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapAcpCallbackFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Antigravity ACP callback.",
+              cause,
+            }),
+        ),
+      );
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const settlePromptInFlight = (
+      threadId: ThreadId,
+      turnId: TurnId,
+      expectedAcpSessionId: string,
+      options?: {
+        readonly errorMessage?: string;
+        readonly completedStopReason?: EffectAcpSchema.StopReason | null;
+        readonly emitTurnCompletion?: boolean;
+        readonly settleAllPrompts?: boolean;
+      },
+    ) =>
+      Effect.gen(function* () {
+        const liveCtx = sessions.get(threadId);
+        if (!liveCtx) {
+          return;
+        }
+        const settlementBelongsToLiveContext = antigravityPromptSettlementBelongsToContext({
+          liveAcpSessionId: liveCtx.acpSessionId,
+          expectedAcpSessionId,
+          liveActiveTurnId: liveCtx.activeTurnId,
+          liveSessionActiveTurnId: liveCtx.session.activeTurnId,
+          turnId,
+        });
+        if (!settlementBelongsToLiveContext) {
+          if (
+            liveCtx.acpSessionId !== expectedAcpSessionId ||
+            liveCtx.interruptedTurnIds.has(turnId)
+          ) {
+            return;
+          }
+          if (options?.emitTurnCompletion !== false) {
+            if (options?.errorMessage !== undefined) {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId,
+                turnId,
+                payload: {
+                  state: "failed",
+                  errorMessage: options.errorMessage,
+                },
+              });
+            } else if (options?.completedStopReason !== undefined) {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId,
+                turnId,
+                payload: {
+                  state: options.completedStopReason === "cancelled" ? "cancelled" : "completed",
+                  stopReason: options.completedStopReason ?? null,
+                },
+              });
+            }
+          }
+          return;
+        }
+        let settleTurnId = turnId;
+        if (options?.settleAllPrompts) {
+          liveCtx.promptsInFlight = 0;
+          if (liveCtx.activeTurnId !== turnId && liveCtx.session.activeTurnId !== turnId) {
+            const fallbackTurnId = liveCtx.activeTurnId ?? liveCtx.session.activeTurnId;
+            if (!fallbackTurnId) {
+              if (liveCtx.session.status === "running" || liveCtx.session.status === "connecting") {
+                const updatedAt = yield* nowIso;
+                const { activeTurnId: _activeTurnId, ...readySession } = liveCtx.session;
+                liveCtx.activeTurnId = undefined;
+                liveCtx.session = {
+                  ...readySession,
+                  status: "ready",
+                  updatedAt,
+                };
+              }
+              return;
+            }
+            settleTurnId = fallbackTurnId;
+          }
+        } else {
+          const remainingPrompts = Math.max(0, liveCtx.promptsInFlight - 1);
+          if (
+            remainingPrompts > 0 ||
+            liveCtx.activeTurnId !== settleTurnId ||
+            liveCtx.session.activeTurnId !== settleTurnId
+          ) {
+            liveCtx.promptsInFlight = remainingPrompts;
+            return;
+          }
+          liveCtx.promptsInFlight = remainingPrompts;
+        }
+        const updatedAt = yield* nowIso;
+        const canEmitTurnCompletion =
+          liveCtx.session.status === "running" || liveCtx.session.status === "connecting";
+        const shouldEmitFailedTurn = options?.errorMessage !== undefined && canEmitTurnCompletion;
+        const shouldEmitCompletedTurn =
+          options?.completedStopReason !== undefined && canEmitTurnCompletion;
+        const { activeTurnId: _activeTurnId, ...readySession } = liveCtx.session;
+        liveCtx.activeTurnId = undefined;
+        liveCtx.session = {
+          ...readySession,
+          status: "ready",
+          updatedAt,
+        };
+        if (options?.emitTurnCompletion === false) {
+          return;
+        }
+        if (shouldEmitFailedTurn) {
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId,
+            turnId: settleTurnId,
+            payload: {
+              state: "failed",
+              errorMessage: options.errorMessage,
+            },
+          });
+        } else if (shouldEmitCompletedTurn) {
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId,
+            turnId: settleTurnId,
+            payload: {
+              state: options.completedStopReason === "cancelled" ? "cancelled" : "completed",
+              stopReason: options.completedStopReason ?? null,
+            },
+          });
+        }
+      });
+
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Failed to write native Antigravity notification log.", {
+            cause,
+            threadId,
+            method,
+          }),
+        ),
+      );
+
+    const emitPlanUpdate = (
+      ctx: AntigravitySessionContext,
+      turnId: TurnId | undefined,
+      stamp: { readonly eventId: EventId; readonly createdAt: string },
+      payload: {
+        readonly explanation?: string | null;
+        readonly plan: ReadonlyArray<{
+          readonly step: string;
+          readonly status: "pending" | "inProgress" | "completed";
+        }>;
+      },
+      rawPayload: unknown,
+      method: string,
+    ) =>
+      Effect.gen(function* () {
+        const fingerprint = `${turnId ?? "no-turn"}:${encodeJsonStringForDiagnostics(payload) ?? "[unserializable payload]"}`;
+        if (ctx.lastPlanFingerprint === fingerprint) {
+          return;
+        }
+        ctx.lastPlanFingerprint = fingerprint;
+        yield* offerRuntimeEvent(
+          makeAcpPlanUpdatedEvent({
+            stamp,
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId,
+            payload,
+            source: "acp.jsonrpc",
+            method,
+            rawPayload,
+          }),
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<AntigravitySessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: AntigravitySessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: AntigravityAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const antigravityModelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+
+          const resumeSessionId = parseAntigravityResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+          const acp = yield* makeAntigravityAcpRuntime({
+            antigravitySettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(mcpSession
+              ? {
+                  mcpServers: [
+                    {
+                      type: "http" as const,
+                      name: "t3-code",
+                      url: mcpSession.endpoint,
+                      headers: [
+                        {
+                          name: "Authorization",
+                          value: mcpSession.authorizationHeader,
+                        },
+                      ],
+                    },
+                  ],
+                }
+              : {}),
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Crypto.Crypto, crypto),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const ctx: AntigravitySessionContext = {
+            threadId: input.threadId,
+            acpSessionId: "",
+            session: {
+              provider: PROVIDER,
+              providerInstanceId: boundInstanceId,
+              status: "ready",
+              runtimeMode: input.runtimeMode,
+              cwd,
+              threadId: input.threadId,
+              createdAt: yield* nowIso,
+              updatedAt: yield* nowIso,
+            },
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            turns: [],
+            lastPlanFingerprint: undefined,
+            activeTurnId: undefined,
+            interruptedTurnIds: new Set<TurnId>(),
+            promptsInFlight: 0,
+            currentModelId: undefined,
+            stopped: false,
+          };
+
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              mapAcpCallbackFailure(
+                Effect.gen(function* () {
+                  yield* logNative(input.threadId, "session/request_permission", params);
+                  if (input.runtimeMode === "full-access") {
+                    const autoApprovedOptionId = selectAutoApprovedPermissionOption(params);
+                    if (autoApprovedOptionId !== undefined) {
+                      return {
+                        outcome: {
+                          outcome: "selected" as const,
+                          optionId: autoApprovedOptionId,
+                        },
+                      };
+                    }
+                  }
+                  const permissionRequest = parsePermissionRequest(params);
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
+                  pendingApprovals.set(requestId, { decision });
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail:
+                        permissionRequest.detail ??
+                        encodeJsonStringForDiagnostics(params)?.slice(0, 2000) ??
+                        "[unserializable params]",
+                      args: params,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: params,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  const selectedOptionId =
+                    resolved === "cancel" ? undefined : selectPermissionOptionId(params, resolved);
+                  return {
+                    outcome: selectedOptionId
+                      ? {
+                          outcome: "selected" as const,
+                          optionId: selectedOptionId,
+                        }
+                      : ({ outcome: "cancelled" } as const),
+                  };
+                }),
+              ),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          const requestedStartModelId = antigravityModelSelection?.model
+            ? resolveAntigravityAcpBaseModelId(antigravityModelSelection.model)
+            : undefined;
+          const boundModelId = yield* applyAntigravityAcpModelSelection({
+            runtime: acp,
+            currentModelId: currentAntigravityModelIdFromSessionSetup(started.sessionSetupResult),
+            requestedModelId: requestedStartModelId,
+            mapError: (cause) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+          });
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            ...(boundModelId ? { model: resolveAntigravityAcpBaseModelId(boundModelId) } : {}),
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: ANTIGRAVITY_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx.session = session;
+          ctx.acpSessionId = started.sessionId;
+          ctx.currentModelId = boundModelId;
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                if (event._tag === "EventStreamBarrier") {
+                  yield* Deferred.succeed(event.acknowledge, undefined);
+                  return;
+                }
+                if (
+                  event._tag === "PlanUpdated" ||
+                  event._tag === "ToolCallUpdated" ||
+                  event._tag === "ContentDelta"
+                ) {
+                  yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                }
+
+                if (event._tag === "ModeChanged") {
+                  return;
+                }
+
+                const notificationTurnId = resolveNotificationTurnId(ctx);
+                if (
+                  notificationTurnId === undefined ||
+                  ctx.interruptedTurnIds.has(notificationTurnId)
+                ) {
+                  return;
+                }
+                const stamp = yield* makeEventStamp();
+
+                switch (event._tag) {
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* emitPlanUpdate(
+                      ctx,
+                      notificationTurnId,
+                      stamp,
+                      event.payload,
+                      event.rawPayload,
+                      "session/update",
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
+            ),
+            Effect.forkIn(ctx.scope),
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Antigravity ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const prepared = yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(input.threadId);
+            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+            ctx.promptsInFlight += 1;
+            ctx.activeTurnId = turnId;
+            ctx.session = {
+              ...ctx.session,
+              status: steeringTurnId === undefined ? "connecting" : "running",
+              activeTurnId: turnId,
+              updatedAt: yield* nowIso,
+            };
+
+            return yield* Effect.gen(function* () {
+              const turnModelSelection =
+                input.modelSelection?.instanceId === boundInstanceId
+                  ? input.modelSelection
+                  : undefined;
+              const requestedTurnModelId = turnModelSelection?.model
+                ? resolveAntigravityAcpBaseModelId(turnModelSelection.model)
+                : undefined;
+              const currentModelId = yield* applyAntigravityAcpModelSelection({
+                runtime: ctx.acp,
+                currentModelId: ctx.currentModelId,
+                requestedModelId: requestedTurnModelId,
+                mapError: (cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
+
+              const text = input.input?.trim();
+              const imagePromptParts = yield* Effect.forEach(
+                input.attachments ?? [],
+                (attachment) =>
+                  Effect.gen(function* () {
+                    const attachmentPath = resolveAttachmentPath({
+                      attachmentsDir: serverConfig.attachmentsDir,
+                      attachment,
+                    });
+                    if (!attachmentPath) {
+                      return yield* new ProviderAdapterRequestError({
+                        provider: PROVIDER,
+                        method: "session/prompt",
+                        detail: `Invalid attachment id '${attachment.id}'.`,
+                      });
+                    }
+                    const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ProviderAdapterRequestError({
+                            provider: PROVIDER,
+                            method: "session/prompt",
+                            detail: cause.message,
+                            cause,
+                          }),
+                      ),
+                    );
+                    return {
+                      type: "image",
+                      data: Buffer.from(bytes).toString("base64"),
+                      mimeType: attachment.mimeType,
+                    } satisfies EffectAcpSchema.ContentBlock;
+                  }),
+              );
+              const promptParts: Array<EffectAcpSchema.ContentBlock> = [
+                ...(text ? [{ type: "text" as const, text }] : []),
+                ...imagePromptParts,
+              ];
+
+              if (promptParts.length === 0) {
+                return yield* new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "sendTurn",
+                  issue: "Turn requires non-empty text or attachments.",
+                });
+              }
+
+              ctx.currentModelId = currentModelId;
+              const displayModel = currentModelId
+                ? resolveAntigravityAcpBaseModelId(currentModelId)
+                : undefined;
+              for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
+                yield* Effect.yieldNow;
+              }
+              if (ctx.interruptedTurnIds.has(turnId)) {
+                yield* settlePromptInFlight(input.threadId, turnId, ctx.acpSessionId, {
+                  completedStopReason: "cancelled",
+                  emitTurnCompletion: false,
+                  settleAllPrompts: true,
+                });
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/prompt",
+                  detail: "Antigravity prompt was interrupted during preparation.",
+                });
+              }
+              if (steeringTurnId === undefined) {
+                ctx.lastPlanFingerprint = undefined;
+              }
+              ctx.session = {
+                ...ctx.session,
+                status: "running",
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+                ...(displayModel ? { model: displayModel } : {}),
+              };
+
+              if (steeringTurnId === undefined) {
+                yield* offerRuntimeEvent({
+                  type: "turn.started",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId,
+                  payload: displayModel ? { model: displayModel } : {},
+                });
+              }
+
+              return {
+                acp: ctx.acp,
+                acpSessionId: ctx.acpSessionId,
+                displayModel,
+                promptParts,
+                turnId,
+              };
+            }).pipe(
+              Effect.tapCause(() =>
+                Effect.gen(function* () {
+                  const liveCtx = sessions.get(input.threadId);
+                  if (!liveCtx) {
+                    return;
+                  }
+                  yield* settlePromptInFlight(input.threadId, turnId, liveCtx.acpSessionId, {
+                    errorMessage: "Antigravity prompt preparation failed.",
+                    emitTurnCompletion: false,
+                  });
+                }),
+              ),
+            );
+          }),
+        );
+        const promptSettled = yield* Ref.make(false);
+        const promptRpcSucceeded = yield* Ref.make(false);
+        const promptResultRef = yield* Ref.make<EffectAcpSchema.PromptResponse | undefined>(
+          undefined,
+        );
+        const promptFailureMessageRef = yield* Ref.make<string | undefined>(undefined);
+
+        return yield* Effect.gen(function* () {
+          const result = yield* prepared.acp
+            .prompt({
+              prompt: prepared.promptParts,
+            })
+            .pipe(
+              Effect.tap((promptResult) =>
+                Effect.all([
+                  Ref.set(promptRpcSucceeded, true),
+                  Ref.set(promptResultRef, promptResult),
+                ]),
+              ),
+              Effect.tapError((error) =>
+                Ref.set(
+                  promptFailureMessageRef,
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error).message,
+                ).pipe(Effect.andThen(prepared.acp.drainEvents)),
+              ),
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+
+          return yield* withThreadLock(
+            input.threadId,
+            Effect.gen(function* () {
+              const ctx = yield* requireSession(input.threadId);
+              if (ctx.acpSessionId !== prepared.acpSessionId) {
+                yield* settlePromptInFlight(
+                  input.threadId,
+                  prepared.turnId,
+                  prepared.acpSessionId,
+                  {
+                    errorMessage: "Antigravity session changed before the turn completed.",
+                    settleAllPrompts: true,
+                  },
+                );
+                yield* Ref.set(promptSettled, true);
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/prompt",
+                  detail: "Antigravity session changed before the turn completed.",
+                });
+              }
+              for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
+                yield* Effect.yieldNow;
+              }
+              yield* prepared.acp.drainEvents;
+              if (ctx.interruptedTurnIds.has(prepared.turnId)) {
+                yield* Ref.set(promptSettled, true);
+                return {
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
+
+              if (
+                ctx.promptsInFlight <= 0 ||
+                ctx.activeTurnId !== prepared.turnId ||
+                ctx.session.activeTurnId !== prepared.turnId
+              ) {
+                yield* Ref.set(promptSettled, true);
+                return {
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
+
+              appendPromptResultToTurn(ctx, prepared.turnId, prepared.promptParts, result);
+              ctx.session = {
+                ...ctx.session,
+                status: "running",
+                activeTurnId: prepared.turnId,
+                updatedAt: yield* nowIso,
+                ...(prepared.displayModel ? { model: prepared.displayModel } : {}),
+              };
+              const remainingPrompts = Math.max(0, ctx.promptsInFlight - 1);
+              ctx.promptsInFlight = remainingPrompts;
+
+              if (
+                remainingPrompts === 0 &&
+                ctx.activeTurnId === prepared.turnId &&
+                ctx.session.activeTurnId === prepared.turnId
+              ) {
+                if (ctx.interruptedTurnIds.has(prepared.turnId)) {
+                  yield* Ref.set(promptSettled, true);
+                  return {
+                    threadId: input.threadId,
+                    turnId: prepared.turnId,
+                    resumeCursor: ctx.session.resumeCursor,
+                  };
+                }
+                const completedAt = yield* nowIso;
+                const { activeTurnId: _completedTurnId, ...readySession } = ctx.session;
+                ctx.activeTurnId = undefined;
+                ctx.session = {
+                  ...readySession,
+                  status: "ready",
+                  updatedAt: completedAt,
+                  ...(prepared.displayModel ? { model: prepared.displayModel } : {}),
+                };
+                const completedStopReason = completedStopReasonFromPromptResponse(result);
+                yield* offerRuntimeEvent({
+                  type: "turn.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  payload: {
+                    state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                    stopReason: completedStopReason,
+                  },
+                });
+                ctx.interruptedTurnIds.delete(prepared.turnId);
+                yield* Ref.set(promptSettled, true);
+              } else if (remainingPrompts > 0) {
+                yield* Ref.set(promptSettled, true);
+              }
+
+              return {
+                threadId: input.threadId,
+                turnId: prepared.turnId,
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }),
+          );
+        }).pipe(
+          Effect.ensuring(
+            Effect.gen(function* () {
+              if (yield* Ref.get(promptSettled)) {
+                return;
+              }
+
+              if (yield* Ref.get(promptRpcSucceeded)) {
+                const promptResult = yield* Ref.get(promptResultRef);
+                if (promptResult === undefined) {
+                  return;
+                }
+                yield* withThreadLock(
+                  input.threadId,
+                  Effect.gen(function* () {
+                    const ctx = yield* requireSession(input.threadId);
+                    if (ctx.acpSessionId !== prepared.acpSessionId) {
+                      yield* settlePromptInFlight(
+                        input.threadId,
+                        prepared.turnId,
+                        prepared.acpSessionId,
+                        {
+                          errorMessage: "Antigravity session changed before the turn completed.",
+                          settleAllPrompts: true,
+                        },
+                      );
+                      return;
+                    }
+                    if (ctx.interruptedTurnIds.has(prepared.turnId)) {
+                      return;
+                    }
+                    if (
+                      ctx.promptsInFlight <= 0 ||
+                      ctx.activeTurnId !== prepared.turnId ||
+                      ctx.session.activeTurnId !== prepared.turnId
+                    ) {
+                      return;
+                    }
+                    appendPromptResultToTurn(
+                      ctx,
+                      prepared.turnId,
+                      prepared.promptParts,
+                      promptResult,
+                    );
+                    yield* settlePromptInFlight(
+                      input.threadId,
+                      prepared.turnId,
+                      prepared.acpSessionId,
+                      {
+                        completedStopReason: completedStopReasonFromPromptResponse(promptResult),
+                      },
+                    );
+                  }),
+                );
+                return;
+              }
+
+              const errorMessage = yield* Ref.get(promptFailureMessageRef);
+              yield* withThreadLock(
+                input.threadId,
+                settlePromptInFlight(input.threadId, prepared.turnId, prepared.acpSessionId, {
+                  errorMessage: errorMessage ?? "Antigravity prompt request failed.",
+                }),
+              );
+            }).pipe(Effect.catch(() => Effect.void)),
+          ),
+        );
+      });
+
+    const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId, turnId) =>
+      Effect.gen(function* () {
+        const observed = yield* Effect.sync(() => {
+          const ctx = sessions.get(threadId);
+          if (!ctx || ctx.stopped) {
+            return {
+              _tag: "Proceed" as const,
+              acpSessionId: undefined,
+              interruptedTurnId: turnId,
+            };
+          }
+          const activeTurnId = ctx.activeTurnId ?? ctx.session.activeTurnId;
+          if (turnId !== undefined && activeTurnId !== undefined && activeTurnId !== turnId) {
+            return { _tag: "Ignore" as const };
+          }
+          const interruptedTurnId = turnId ?? activeTurnId;
+          if (interruptedTurnId !== undefined) {
+            ctx.interruptedTurnIds.add(interruptedTurnId);
+          }
+          return {
+            _tag: "Proceed" as const,
+            acpSessionId: ctx.acpSessionId,
+            interruptedTurnId,
+          };
+        });
+        if (observed._tag === "Ignore") {
+          return;
+        }
+
+        yield* withThreadLock(
+          threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(threadId);
+            const activeTurnId = ctx.activeTurnId ?? ctx.session.activeTurnId;
+            if (observed.acpSessionId !== undefined && ctx.acpSessionId !== observed.acpSessionId) {
+              return;
+            }
+            if (turnId !== undefined && activeTurnId !== undefined && activeTurnId !== turnId) {
+              return;
+            }
+            if (
+              observed.interruptedTurnId !== undefined &&
+              activeTurnId !== undefined &&
+              activeTurnId !== observed.interruptedTurnId
+            ) {
+              return;
+            }
+            const interruptedTurnId =
+              observed.interruptedTurnId ?? turnId ?? activeTurnId ?? ctx.session.activeTurnId;
+            yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+            yield* Effect.ignore(
+              ctx.acp.cancel.pipe(
+                Effect.mapError((error) =>
+                  mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+                ),
+              ),
+            );
+            if (interruptedTurnId) {
+              ctx.interruptedTurnIds.add(interruptedTurnId);
+              yield* settlePromptInFlight(threadId, interruptedTurnId, ctx.acpSessionId, {
+                completedStopReason: "cancelled",
+                settleAllPrompts: true,
+              });
+            } else if (
+              ctx.promptsInFlight > 0 ||
+              ctx.session.status === "running" ||
+              ctx.session.status === "connecting"
+            ) {
+              const updatedAt = yield* nowIso;
+              ctx.promptsInFlight = 0;
+              ctx.activeTurnId = undefined;
+              const { activeTurnId: _activeTurnId, ...readySession } = ctx.session;
+              ctx.session = {
+                ...readySession,
+                status: "ready",
+                updatedAt,
+              };
+            }
+          }),
+        );
+      });
+
+    const respondToRequest: AntigravityAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: AntigravityAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+    ) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "session/respond_to_user_input",
+          detail: `Antigravity ACP sessions do not support interactive user questions: ${requestId}`,
+        });
+      });
+
+    const readThread: AntigravityAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: AntigravityAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread/rollback",
+          detail: "Antigravity ACP sessions do not support provider-side rollback yet.",
+        });
+      });
+
+    const stopSession: AntigravityAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: AntigravityAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: AntigravityAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll = (): Effect.Effect<void> =>
+      Effect.forEach(
+        Array.from(sessions.keys()),
+        (threadId) => stopSession(threadId).pipe(Effect.ignore),
+        { discard: true },
+      );
+
+    const adapter: AntigravityAdapterShape = {
+      provider: PROVIDER,
+      capabilities: {
+        sessionModelSwitch: "in-session",
+      },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      readThread,
+      rollbackThread,
+      stopAll,
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    };
+
+    if (managedNativeEventLogger) {
+      yield* Effect.addFinalizer(() => managedNativeEventLogger.close().pipe(Effect.ignore));
+    }
+
+    return adapter;
+  });
+}

--- a/apps/server/src/provider/Layers/AntigravityProvider.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.test.ts
@@ -1,0 +1,135 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { AntigravitySettings } from "@t3tools/contracts";
+
+import {
+  buildInitialAntigravityProviderSnapshot,
+  checkAntigravityProviderStatus,
+} from "./AntigravityProvider.ts";
+
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+describe("buildInitialAntigravityProviderSnapshot", () => {
+  it.effect("returns a disabled snapshot when settings.enabled is false", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialAntigravityProviderSnapshot(
+        decodeAntigravitySettings({ enabled: false }),
+      );
+      expect(snapshot.enabled).toBe(false);
+      expect(snapshot.status).toBe("disabled");
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.message).toContain("disabled");
+    }),
+  );
+
+  it.effect("returns a disabled snapshot by default — Antigravity is opt-in", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialAntigravityProviderSnapshot(
+        decodeAntigravitySettings({}),
+      );
+      expect(snapshot.enabled).toBe(false);
+      expect(snapshot.status).toBe("disabled");
+    }),
+  );
+
+  it.effect("returns a pending snapshot when enabled", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialAntigravityProviderSnapshot(
+        decodeAntigravitySettings({ enabled: true }),
+      );
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.status).toBe("warning");
+      expect(snapshot.version).toBeNull();
+      expect(snapshot.message).toContain("Checking Antigravity");
+      expect(snapshot.requiresNewThreadForModelChange).toBe(true);
+    }),
+  );
+});
+
+it.layer(NodeServices.layer)("checkAntigravityProviderStatus", (it) => {
+  it.effect("reports the binary as missing when the binary path does not resolve", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkAntigravityProviderStatus(
+        decodeAntigravitySettings({
+          enabled: true,
+          binaryPath: "/definitely/not/installed/antigravity-binary",
+        }),
+      );
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toMatch(/not installed|not on PATH|Failed to execute/);
+    }),
+  );
+
+  it.effect("reports an installed CLI as unhealthy when --version exits non-zero", () =>
+    Effect.gen(function* () {
+      const secretStderr = "broken antigravity install: secret-token-value";
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({
+            prefix: "t3code-antigravity-version-",
+          });
+          const agyPath = path.join(dir, "antigravity");
+          yield* fs.writeFileString(
+            agyPath,
+            ["#!/bin/sh", `printf "%s\\n" "${secretStderr}" >&2`, "exit 2", ""].join("\n"),
+          );
+          yield* fs.chmod(agyPath, 0o755);
+
+          return yield* checkAntigravityProviderStatus(
+            decodeAntigravitySettings({ enabled: true, binaryPath: agyPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toBe("Antigravity ACP server is installed but failed to run.");
+      expect(snapshot.message).not.toContain(secretStderr);
+    }),
+  );
+
+  it.effect("reports an error when ACP model discovery is unavailable", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({
+            prefix: "t3code-antigravity-success-",
+          });
+          const agyPath = path.join(dir, "antigravity");
+          yield* fs.writeFileString(
+            agyPath,
+            ["#!/bin/sh", 'printf "antigravity-acp 0.1.0\\n"', "exit 0", ""].join("\n"),
+          );
+          yield* fs.chmod(agyPath, 0o755);
+
+          return yield* checkAntigravityProviderStatus(
+            decodeAntigravitySettings({ enabled: true, binaryPath: agyPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.models.map((model) => model.slug)).toEqual([
+        "gemini-3.7-flash",
+        "gemini-3.7-flash-high",
+        "gemini-3.7-flash-medium",
+        "gemini-3.7-flash-low",
+        "gemini-3.1-pro",
+      ]);
+      expect(snapshot.message).toContain("ACP startup failed");
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -1,0 +1,368 @@
+import {
+  type AntigravitySettings,
+  type ModelCapabilities,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import {
+  makeAntigravityAcpRuntime,
+  resolveAntigravityAcpBaseModelId,
+} from "../acp/AntigravityAcpSupport.ts";
+
+const ANTIGRAVITY_PRESENTATION = {
+  displayName: "Antigravity",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: false,
+  requiresNewThreadForModelChange: true,
+} as const;
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const VERSION_PROBE_TIMEOUT_MS = 15_000;
+const ANTIGRAVITY_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+
+const ANTIGRAVITY_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "gemini-3.7-flash",
+    name: "Gemini 3.7 Flash",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "gemini-3.7-flash-high",
+    name: "Gemini 3.7 Flash (High Thinking)",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "gemini-3.7-flash-medium",
+    name: "Gemini 3.7 Flash (Medium Thinking)",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "gemini-3.7-flash-low",
+    name: "Gemini 3.7 Flash (Low Thinking)",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "gemini-3.1-pro",
+    name: "Gemini 3.1 Pro",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+];
+
+export function buildInitialAntigravityProviderSnapshot(
+  antigravitySettings: AntigravitySettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = antigravityModelsFromSettings(antigravitySettings.customModels);
+
+    if (!antigravitySettings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Antigravity ACP server availability...",
+      },
+    });
+  });
+}
+
+function antigravityModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = ANTIGRAVITY_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+}
+
+function buildAntigravityDiscoveredModelsFromSessionModelState(
+  modelState: EffectAcpSchema.SessionModelState | null | undefined,
+): ReadonlyArray<ServerProviderModel> {
+  if (!modelState || modelState.availableModels.length === 0) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return modelState.availableModels
+    .map((model): ServerProviderModel | undefined => {
+      const slug = resolveAntigravityAcpBaseModelId(model.modelId);
+      if (!slug || seen.has(slug)) {
+        return undefined;
+      }
+      seen.add(slug);
+      return {
+        slug,
+        name: model.name.trim() || slug,
+        isCustom: false,
+        capabilities: EMPTY_CAPABILITIES,
+      };
+    })
+    .filter((model): model is ServerProviderModel => model !== undefined);
+}
+
+const discoverAntigravityModelsViaAcp = (
+  antigravitySettings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const acp = yield* makeAntigravityAcpRuntime({
+      antigravitySettings,
+      environment,
+      childProcessSpawner,
+      cwd: process.cwd(),
+      clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
+    });
+    const started = yield* acp.start();
+    return buildAntigravityDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
+  }).pipe(Effect.scoped);
+
+const runAntigravityVersionCommand = (
+  antigravitySettings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const command = antigravitySettings.binaryPath || "antigravity-acp-server";
+    const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
+      env: environment,
+    });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+      }),
+    );
+  });
+
+export const checkAntigravityProviderStatus = Effect.fn("checkAntigravityProviderStatus")(
+  function* (
+    antigravitySettings: AntigravitySettings,
+    environment: NodeJS.ProcessEnv = process.env,
+  ): Effect.fn.Return<
+    ServerProviderDraft,
+    never,
+    ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+  > {
+    const checkedAt = DateTime.formatIso(yield* DateTime.now);
+    const fallbackModels = antigravityModelsFromSettings(antigravitySettings.customModels);
+
+    if (!antigravitySettings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    const versionResult = yield* runAntigravityVersionCommand(
+      antigravitySettings,
+      environment,
+    ).pipe(Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS), Effect.result);
+
+    if (Result.isFailure(versionResult)) {
+      const error = versionResult.failure;
+      yield* Effect.logWarning("Antigravity ACP health check failed.", {
+        errorTag: error._tag,
+      });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: antigravitySettings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: !isCommandMissingCause(error),
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: isCommandMissingCause(error)
+            ? `Antigravity ACP server binary (\`${antigravitySettings.binaryPath || "antigravity-acp-server"}\`) is not installed or not on PATH.`
+            : "Failed to execute Antigravity ACP health check.",
+        },
+      });
+    }
+
+    if (Option.isNone(versionResult.success)) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: antigravitySettings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity ACP server is installed but timed out while running `--version`.",
+        },
+      });
+    }
+
+    const versionOutput = versionResult.success.value;
+    const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+    if (versionOutput.code !== 0) {
+      yield* Effect.logWarning(
+        "Antigravity ACP server version probe exited with a non-zero status.",
+        {
+          exitCode: versionOutput.code,
+          stdoutLength: versionOutput.stdout.length,
+          stderrLength: versionOutput.stderr.length,
+        },
+      );
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: antigravitySettings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity ACP server is installed but failed to run.",
+        },
+      });
+    }
+
+    const discoveryExit = yield* discoverAntigravityModelsViaAcp(
+      antigravitySettings,
+      environment,
+    ).pipe(Effect.timeoutOption(ANTIGRAVITY_ACP_MODEL_DISCOVERY_TIMEOUT_MS), Effect.exit);
+    if (Exit.isFailure(discoveryExit)) {
+      yield* Effect.logWarning("Antigravity ACP model discovery failed", {
+        errorTag: causeErrorTag(discoveryExit.cause),
+      });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: antigravitySettings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message:
+            "Antigravity ACP server is installed but ACP startup failed. Check server logs for details.",
+        },
+      });
+    }
+    if (Option.isNone(discoveryExit.value)) {
+      yield* Effect.logWarning(
+        `Antigravity ACP model discovery timed out after ${ANTIGRAVITY_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+      );
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: antigravitySettings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: `Antigravity ACP server is installed but ACP startup timed out after ${ANTIGRAVITY_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+        },
+      });
+    }
+    const discoveredModels = discoveryExit.value.value;
+    const models =
+      discoveredModels.length > 0
+        ? antigravityModelsFromSettings(antigravitySettings.customModels, discoveredModels)
+        : fallbackModels;
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: antigravitySettings.enabled,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version,
+        status: "ready",
+        auth: { status: "unknown" },
+      },
+    });
+  },
+);
+
+export const enrichAntigravitySnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Antigravity version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -25,6 +25,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
+  type AntigravitySettings,
   type ClaudeSettings,
   type CodexSettings,
   type CursorSettings,
@@ -43,6 +44,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { AntigravityDriver } from "../Drivers/AntigravityDriver.ts";
 import { ClaudeDriver } from "../Drivers/ClaudeDriver.ts";
 import { CodexDriver } from "../Drivers/CodexDriver.ts";
 import { CursorDriver } from "../Drivers/CursorDriver.ts";
@@ -129,6 +131,14 @@ const makeOpenCodeConfig = (overrides: Partial<OpenCodeSettings>): OpenCodeSetti
   binaryPath: "opencode",
   serverUrl: "",
   serverPassword: "",
+  customModels: [],
+  ...overrides,
+});
+
+const makeAntigravityConfig = (overrides: Partial<AntigravitySettings>): AntigravitySettings => ({
+  enabled: false,
+  binaryPath: "antigravity-acp-server",
+  geminiHome: "",
   customModels: [],
   ...overrides,
 });
@@ -321,12 +331,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const cursorId = ProviderInstanceId.make("cursor_default");
       const grokId = ProviderInstanceId.make("grok_default");
       const openCodeId = ProviderInstanceId.make("opencode_default");
+      const antigravityId = ProviderInstanceId.make("antigravity_default");
 
       const codexDriverKind = ProviderDriverKind.make("codex");
       const claudeDriverKind = ProviderDriverKind.make("claudeAgent");
       const cursorDriverKind = ProviderDriverKind.make("cursor");
       const grokDriverKind = ProviderDriverKind.make("grok");
       const openCodeDriverKind = ProviderDriverKind.make("opencode");
+      const antigravityDriverKind = ProviderDriverKind.make("antigravity");
 
       const configMap: ProviderInstanceConfigMap = {
         [codexId]: {
@@ -362,10 +374,23 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
           enabled: false,
           config: makeOpenCodeConfig({}),
         },
+        [antigravityId]: {
+          driver: antigravityDriverKind,
+          displayName: "Antigravity",
+          enabled: false,
+          config: makeAntigravityConfig({}),
+        },
       };
 
       const { registry } = yield* makeProviderInstanceRegistry({
-        drivers: [CodexDriver, ClaudeDriver, CursorDriver, GrokDriver, OpenCodeDriver],
+        drivers: [
+          CodexDriver,
+          ClaudeDriver,
+          CursorDriver,
+          GrokDriver,
+          OpenCodeDriver,
+          AntigravityDriver,
+        ],
         configMap,
       });
 
@@ -375,9 +400,9 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(unavailable).toEqual([]);
 
       const instances = yield* registry.listInstances;
-      expect(instances).toHaveLength(5);
+      expect(instances).toHaveLength(6);
       expect(instances.map((instance) => instance.instanceId).toSorted()).toEqual(
-        [codexId, claudeId, cursorId, grokId, openCodeId].toSorted(),
+        [codexId, claudeId, cursorId, grokId, openCodeId, antigravityId].toSorted(),
       );
 
       // Instance lookup by id resolves each instance to its own bundle —
@@ -388,16 +413,19 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const cursor = yield* registry.getInstance(cursorId);
       const grok = yield* registry.getInstance(grokId);
       const openCode = yield* registry.getInstance(openCodeId);
+      const antigravity = yield* registry.getInstance(antigravityId);
       expect(codex?.driverKind).toBe(codexDriverKind);
       expect(claude?.driverKind).toBe(claudeDriverKind);
       expect(cursor?.driverKind).toBe(cursorDriverKind);
       expect(grok?.driverKind).toBe(grokDriverKind);
       expect(openCode?.driverKind).toBe(openCodeDriverKind);
+      expect(antigravity?.driverKind).toBe(antigravityDriverKind);
       expect(codex?.displayName).toBe("Codex");
       expect(claude?.displayName).toBe("Claude");
       expect(cursor?.displayName).toBe("Cursor");
       expect(grok?.displayName).toBe("Grok");
       expect(openCode?.displayName).toBe("OpenCode");
+      expect(antigravity?.displayName).toBe("Antigravity");
 
       // Every instance owns its own set of closures — no sharing across
       // drivers. `adapter` / `textGeneration` / `snapshot` are all
@@ -410,6 +438,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         cursor!.adapter,
         grok!.adapter,
         openCode!.adapter,
+        antigravity!.adapter,
       ];
       expect(new Set(adapters).size).toBe(adapters.length);
       const textGenerations = [
@@ -418,6 +447,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         cursor!.textGeneration,
         grok!.textGeneration,
         openCode!.textGeneration,
+        antigravity!.textGeneration,
       ];
       expect(new Set(textGenerations).size).toBe(textGenerations.length);
       const snapshots = [
@@ -426,6 +456,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         cursor!.snapshot,
         grok!.snapshot,
         openCode!.snapshot,
+        antigravity!.snapshot,
       ];
       expect(new Set(snapshots).size).toBe(snapshots.length);
 
@@ -467,6 +498,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(openCodeSnapshot.enabled).toBe(false);
       expect(openCodeSnapshot.continuation?.groupKey).toBe(
         `${openCodeDriverKind}:instance:${openCodeId}`,
+      );
+
+      const antigravitySnapshot = yield* antigravity!.snapshot.getSnapshot;
+      expect(antigravitySnapshot.instanceId).toBe(antigravityId);
+      expect(antigravitySnapshot.driver).toBe(antigravityDriverKind);
+      expect(antigravitySnapshot.enabled).toBe(false);
+      expect(antigravitySnapshot.continuation?.groupKey).toBe(
+        `${antigravityDriverKind}:instance:${antigravityId}`,
       );
     }).pipe(Effect.provide(testLayer)),
   );

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1734,6 +1734,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               );
 
               assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
+                "antigravity",
                 "claudeAgent",
                 "codex",
                 "cursor",

--- a/apps/server/src/provider/Services/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Services/AntigravityAdapter.ts
@@ -1,0 +1,16 @@
+/**
+ * AntigravityAdapter — shape type for the Antigravity provider adapter.
+ *
+ * The driver model ({@link ../Drivers/AntigravityDriver}) bundles one adapter per
+ * instance as a captured closure, so this module only retains the shape
+ * interface as a naming anchor for the driver bundle.
+ *
+ * @module AntigravityAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * AntigravityAdapterShape — per-instance Antigravity adapter contract.
+ */
+export interface AntigravityAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -761,13 +761,11 @@ export const make = (
       cancel: getStartedState.pipe(
         Effect.flatMap((started) =>
           Effect.gen(function* () {
+            yield* acp.agent.cancel({ sessionId: started.sessionId }).pipe(Effect.ignore);
             const activePromptFiber = yield* Ref.get(activePromptFiberRef);
             if (Option.isSome(activePromptFiber)) {
               yield* Fiber.interrupt(activePromptFiber.value).pipe(Effect.ignore);
             }
-            yield* acp.agent
-              .cancel({ sessionId: started.sessionId })
-              .pipe(Effect.ignore, Effect.forkIn(runtimeScope));
           }),
         ),
       ),

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -1,0 +1,110 @@
+import { type AntigravitySettings, ProviderDriverKind } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import type * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+const GEMINI_API_KEY_ENV = "GEMINI_API_KEY";
+const GOOGLE_API_KEY_ENV = "GOOGLE_API_KEY";
+const ANTIGRAVITY_AUTH_METHOD_API_KEY = "gemini-api-key";
+const ANTIGRAVITY_AUTH_METHOD_OAUTH = "oauth-personal";
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
+
+type AntigravityAcpRuntimeSettings = Pick<AntigravitySettings, "binaryPath" | "geminiHome">;
+
+export interface AntigravityAcpRuntimeInput extends Omit<
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly antigravitySettings: AntigravityAcpRuntimeSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv | undefined;
+}
+
+export function buildAntigravityAcpSpawnInput(
+  antigravitySettings: AntigravityAcpRuntimeSettings | null | undefined,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): AcpSessionRuntime.AcpSpawnInput {
+  const env: Record<string, string | undefined> = { ...environment };
+  if (antigravitySettings?.geminiHome) {
+    env.GEMINI_HOME = antigravitySettings.geminiHome;
+  }
+  return {
+    command: antigravitySettings?.binaryPath || "antigravity-acp-server",
+    args: [],
+    cwd,
+    env,
+  };
+}
+
+function resolveAntigravityAuthMethodId(environment: NodeJS.ProcessEnv | undefined): string {
+  const hasApiKey =
+    environment?.[GEMINI_API_KEY_ENV]?.trim() || environment?.[GOOGLE_API_KEY_ENV]?.trim();
+  return hasApiKey ? ANTIGRAVITY_AUTH_METHOD_API_KEY : ANTIGRAVITY_AUTH_METHOD_OAUTH;
+}
+
+export const makeAntigravityAcpRuntime = (
+  input: AntigravityAcpRuntimeInput,
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Crypto.Crypto | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildAntigravityAcpSpawnInput(
+          input.antigravitySettings,
+          input.cwd,
+          input.environment,
+        ),
+        authMethodId: resolveAntigravityAuthMethodId(input.environment),
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
+  });
+
+export function resolveAntigravityAcpBaseModelId(model: string | null | undefined): string {
+  const trimmed = model?.trim();
+  const base = trimmed && trimmed.length > 0 ? trimmed : "gemini-3.7-flash";
+  return normalizeModelSlug(base, ANTIGRAVITY_DRIVER_KIND) ?? "gemini-3.7-flash";
+}
+
+export function currentAntigravityModelIdFromSessionSetup(
+  sessionSetupResult:
+    | EffectAcpSchema.LoadSessionResponse
+    | EffectAcpSchema.NewSessionResponse
+    | EffectAcpSchema.ResumeSessionResponse,
+): string | undefined {
+  return sessionSetupResult.models?.currentModelId?.trim() || undefined;
+}
+
+export function applyAntigravityAcpModelSelection<E>(input: {
+  readonly runtime: Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "setSessionModel">;
+  readonly currentModelId: string | undefined;
+  readonly requestedModelId: string | undefined;
+  readonly mapError: (cause: EffectAcpErrors.AcpError) => E;
+}): Effect.Effect<string | undefined, E> {
+  const shouldSwitchModel =
+    input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
+  if (!shouldSwitchModel) {
+    return Effect.succeed(input.currentModelId);
+  }
+  return input.runtime
+    .setSessionModel(input.requestedModelId)
+    .pipe(Effect.mapError(input.mapError), Effect.as(input.requestedModelId));
+}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -20,6 +20,7 @@
  *
  * @module provider/builtInDrivers
  */
+import { AntigravityDriver, type AntigravityDriverEnv } from "./Drivers/AntigravityDriver.ts";
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
@@ -33,6 +34,7 @@ import type { AnyProviderDriver } from "./ProviderDriver.ts";
  * layer must provide every service in this union.
  */
 export type BuiltInDriversEnv =
+  | AntigravityDriverEnv
   | ClaudeDriverEnv
   | CodexDriverEnv
   | CursorDriverEnv
@@ -50,4 +52,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,
+  AntigravityDriver,
 ];

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.test.ts
@@ -1,0 +1,127 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+import * as NodeOS from "node:os";
+import * as NodeURL from "node:url";
+import * as NodeFS from "node:fs";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { createModelSelection } from "@t3tools/shared/model";
+import { expect } from "vite-plus/test";
+import { AntigravitySettings, ProviderInstanceId } from "@t3tools/contracts";
+
+import * as ServerConfig from "../config.ts";
+import * as TextGeneration from "./TextGeneration.ts";
+import { makeAntigravityTextGeneration } from "./AntigravityTextGeneration.ts";
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockAgentPath = NodePath.join(__dirname, "../../scripts/acp-mock-agent.ts");
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+const AntigravityTextGenerationTestLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-antigravity-text-generation-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+function makeAcpAntigravityWrapper(dir: string, env: Record<string, string>): string {
+  const binDir = NodePath.join(dir, "bin");
+  const agyPath = NodePath.join(binDir, "antigravity-acp-server");
+  NodeFS.mkdirSync(binDir, { recursive: true });
+  NodeFS.writeFileSync(
+    agyPath,
+    [
+      "#!/bin/sh",
+      "export T3_PROVIDER=antigravity",
+      ...Object.entries(env).map(([key, value]) => `export ${key}=${shellSingleQuote(value)}`),
+      `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(mockAgentPath)}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  NodeFS.chmodSync(agyPath, 0o755);
+  return agyPath;
+}
+
+function withFakeAcpAntigravity<A, E, R>(
+  env: Record<string, string>,
+  effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const tempDir = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3code-antigravity-text-acp-"),
+    );
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }),
+    );
+    const binaryPath = makeAcpAntigravityWrapper(tempDir, env);
+    const config = decodeAntigravitySettings({ binaryPath });
+    const textGeneration = yield* makeAntigravityTextGeneration(config);
+    return yield* effectFn(textGeneration);
+  }).pipe(Effect.scoped);
+}
+
+it.layer(AntigravityTextGenerationTestLayer)("AntigravityTextGeneration", (it) => {
+  it.effect("generates commit message via ACP", () => {
+    const requestLogDir = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3code-antigravity-text-log-"),
+    );
+    const requestLogPath = NodePath.join(requestLogDir, "requests.ndjson");
+
+    return withFakeAcpAntigravity(
+      {
+        T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
+          subject: "Add Antigravity provider",
+          body: "Wire up the ACP runtime and headless text generation path.",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateCommitMessage({
+            cwd: process.cwd(),
+            branch: "feat/antigravity",
+            stagedSummary: "1 file changed",
+            stagedPatch: "+ const x = 1;",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("antigravity"),
+              "gemini-3.7-flash",
+            ),
+          });
+
+          expect(generated.subject).toBe("Add Antigravity provider");
+          expect(generated.body).toBe("Wire up the ACP runtime and headless text generation path.");
+        }),
+    );
+  });
+
+  it.effect("generates thread title via ACP", () =>
+    withFakeAcpAntigravity(
+      {
+        T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
+          title: "Antigravity Integration",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateThreadTitle({
+            cwd: process.cwd(),
+            message: "Help me add Antigravity provider support",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("antigravity"),
+              "gemini-3.7-flash",
+            ),
+          });
+
+          expect(generated.title).toBe("Antigravity Integration");
+        }),
+    ),
+  );
+});

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.ts
@@ -1,0 +1,263 @@
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import { type AntigravitySettings, type ModelSelection } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { TextGenerationError } from "@t3tools/contracts";
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import {
+  applyAntigravityAcpModelSelection,
+  currentAntigravityModelIdFromSessionSetup,
+  makeAntigravityAcpRuntime,
+  resolveAntigravityAcpBaseModelId,
+} from "../provider/acp/AntigravityAcpSupport.ts";
+
+const ANTIGRAVITY_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+export const makeAntigravityTextGeneration = Effect.fn("makeAntigravityTextGeneration")(function* (
+  antigravitySettings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const runAntigravityJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const resolvedModel = resolveAntigravityAcpBaseModelId(modelSelection.model);
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeAntigravityAcpRuntime({
+        antigravitySettings,
+        environment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      }).pipe(Effect.provideService(Crypto.Crypto, crypto));
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        const started = yield* runtime.start();
+        yield* applyAntigravityAcpModelSelection({
+          runtime,
+          currentModelId: currentAntigravityModelIdFromSessionSetup(started.sessionSetupResult),
+          requestedModelId: resolvedModel,
+          mapError: (cause) =>
+            new TextGenerationError({
+              operation,
+              detail: "Failed to set Antigravity ACP base model for text generation.",
+              cause,
+            }),
+        });
+
+        return yield* runtime.prompt({
+          prompt: [{ type: "text", text: prompt }],
+        });
+      }).pipe(
+        Effect.timeoutOption(ANTIGRAVITY_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({
+                  operation,
+                  detail: "Antigravity ACP request timed out.",
+                }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause: EffectAcpErrors.AcpError | TextGenerationError) =>
+          isTextGenerationError(cause)
+            ? cause
+            : new TextGenerationError({
+                operation,
+                detail: "Antigravity ACP request failed.",
+                cause,
+              }),
+        ),
+      );
+
+      const trimmed = (yield* Ref.get(outputRef)).trim();
+      if (!trimmed) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "Antigravity ACP request was cancelled."
+              : "Antigravity Agent returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(trimmed)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "Antigravity Agent returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "Antigravity ACP text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGeneration.TextGeneration["Service"]["generateCommitMessage"] =
+    Effect.fn("AntigravityTextGeneration.generateCommitMessage")(function* (input) {
+      const { prompt, outputSchema } = buildCommitMessagePrompt({
+        branch: input.branch,
+        stagedSummary: input.stagedSummary,
+        stagedPatch: input.stagedPatch,
+        includeBranch: input.includeBranch === true,
+        policy: input.policy,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateCommitMessage",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        subject: sanitizeCommitSubject(generated.subject),
+        body: generated.body.trim(),
+        ...("branch" in generated && typeof generated.branch === "string"
+          ? { branch: sanitizeFeatureBranchName(generated.branch) }
+          : {}),
+      };
+    });
+
+  const generatePrContent: TextGeneration.TextGeneration["Service"]["generatePrContent"] =
+    Effect.fn("AntigravityTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+        policy: input.policy,
+        changeRequestTemplate: input.changeRequestTemplate,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body.trim(),
+      };
+    });
+
+  const generateBranchName: TextGeneration.TextGeneration["Service"]["generateBranchName"] =
+    Effect.fn("AntigravityTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        branch: sanitizeBranchFragment(generated.branch),
+      };
+    });
+
+  const generateThreadTitle: TextGeneration.TextGeneration["Service"]["generateThreadTitle"] =
+    Effect.fn("AntigravityTextGeneration.generateThreadTitle")(function* (input) {
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        previousTitle: input.previousTitle,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizeThreadTitle(generated.title),
+      } satisfies TextGeneration.ThreadTitleGenerationResult;
+    });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGeneration.TextGeneration["Service"];
+});

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,13 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +16,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("antigravity")]: AntigravityIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,4 +1,5 @@
 import {
+  AntigravitySettings,
   ClaudeSettings,
   CodexSettings,
   CursorSettings,
@@ -7,7 +8,15 @@ import {
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -60,6 +69,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: GrokIcon,
     badgeLabel: "Early Access",
     settingsSchema: GrokSettings,
+  },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Antigravity",
+    icon: AntigravityIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: AntigravitySettings,
   },
   {
     value: ProviderDriverKind.make("opencode"),

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -176,6 +176,29 @@ describe("instance-scoped model selection", () => {
     );
   });
 
+  it("includes Antigravity custom models from the selected provider instance", () => {
+    const providers = [
+      provider({ provider: ProviderDriverKind.make("antigravity"), instanceId: "antigravity" }),
+    ];
+    const settings: UnifiedSettings = {
+      ...settingsWithProviderInstances(),
+      providerInstances: {
+        ...settingsWithProviderInstances().providerInstances,
+        [ProviderInstanceId.make("antigravity")]: {
+          driver: ProviderDriverKind.make("antigravity"),
+          config: { customModels: ["gemini-experimental-custom"] },
+        },
+      },
+    };
+    const antigravity = deriveProviderInstanceEntries(providers).find(
+      (entry) => entry.instanceId === "antigravity",
+    )!;
+
+    expect(
+      getAppModelOptionsForInstance(settings, antigravity).map((option) => option.slug),
+    ).toContain("gemini-experimental-custom");
+  });
+
   it("does not inject an unknown selected slug into the stock instance list", () => {
     const providers = [
       provider({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -52,6 +52,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Antigravity",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -7,15 +7,16 @@ orchestration layer does not know which one is behind a thread.
 
 ## Built-in drivers
 
-[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with five entries:
+[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with six entries:
 
-| Driver kind   | Driver source                           |
-| ------------- | --------------------------------------- |
-| `codex`       | [`Drivers/CodexDriver.ts`][codex]       |
-| `claudeAgent` | [`Drivers/ClaudeDriver.ts`][claude]     |
-| `cursor`      | [`Drivers/CursorDriver.ts`][cursor]     |
-| `grok`        | [`Drivers/GrokDriver.ts`][grok]         |
-| `opencode`    | [`Drivers/OpenCodeDriver.ts`][opencode] |
+| Driver kind   | Driver source                                 |
+| ------------- | --------------------------------------------- |
+| `codex`       | [`Drivers/CodexDriver.ts`][codex]             |
+| `claudeAgent` | [`Drivers/ClaudeDriver.ts`][claude]           |
+| `cursor`      | [`Drivers/CursorDriver.ts`][cursor]           |
+| `grok`        | [`Drivers/GrokDriver.ts`][grok]               |
+| `antigravity` | [`Drivers/AntigravityDriver.ts`][antigravity] |
+| `opencode`    | [`Drivers/OpenCodeDriver.ts`][opencode]       |
 
 Each driver declares its `driverKind`, a `configSchema`, and a `create` function that builds an
 adapter in a child scope. Adapter implementations live beside them in
@@ -80,6 +81,7 @@ when a request opens (approval) or user input is requested, via
 [claude]: ../../apps/server/src/provider/Drivers/ClaudeDriver.ts
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts
+[antigravity]: ../../apps/server/src/provider/Drivers/AntigravityDriver.ts
 [opencode]: ../../apps/server/src/provider/Drivers/OpenCodeDriver.ts
 [adapter]: ../../apps/server/src/provider/Services/ProviderAdapter.ts
 [instances]: ../../apps/server/src/provider/Services/ProviderInstanceRegistry.ts

--- a/docs/user/providers-antigravity.md
+++ b/docs/user/providers-antigravity.md
@@ -1,0 +1,28 @@
+# Antigravity
+
+This guide covers setting up Antigravity in T3 Code. Antigravity connects to an Agent Client Protocol (ACP) server backend powered by Google's Gemini models (`gemini-3.7-flash`, `gemini-3.1-pro`).
+
+## Requirements
+
+- An Antigravity ACP server binary (`antigravity-acp-server`) available on your system `PATH`, or configured via a custom binary path in Settings.
+- Authentication configured either via API key (`GEMINI_API_KEY` or `GOOGLE_API_KEY`) or via OAuth credentials.
+
+## Enabling Antigravity
+
+1. Open **Settings** → **Providers**.
+2. Locate the **Antigravity** provider instance.
+3. Toggle **Enabled** to on.
+4. If your ACP server binary is installed in a custom location, set **Binary Path** accordingly.
+5. Optionally configure **GEMINI_HOME** if using a custom configuration directory.
+
+## Default Models
+
+Antigravity defaults to **Gemini 3.7 Flash** (`gemini-3.7-flash`), offering high throughput and reasoning capabilities:
+
+- `gemini-3.7-flash` (Default): Fast, versatile frontier multimodal model.
+- `gemini-3.7-flash-high`: Flash with high reasoning effort.
+- `gemini-3.7-flash-medium`: Flash with balanced reasoning effort.
+- `gemini-3.7-flash-low`: Flash with low reasoning effort.
+- `gemini-3.1-pro`: Advanced complex reasoning and coding model.
+
+You can also specify additional model identifiers under **Custom models** in Settings.

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -153,6 +154,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "gemini-3.7-flash",
 };
 
 /** Per-provider text generation model defaults. */
@@ -163,6 +165,7 @@ export const DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "gemini-3.7-flash",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -212,6 +215,16 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [ANTIGRAVITY_DRIVER_KIND]: {
+    "3.7": "gemini-3.7-flash",
+    "3.7-flash": "gemini-3.7-flash",
+    flash: "gemini-3.7-flash",
+    "flash-high": "gemini-3.7-flash-high",
+    "flash-medium": "gemini-3.7-flash-medium",
+    "flash-low": "gemini-3.7-flash-low",
+    "3.1-pro": "gemini-3.1-pro",
+    pro: "gemini-3.1-pro",
+  },
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -222,4 +235,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ANTIGRAVITY_DRIVER_KIND]: "Antigravity",
 };

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -203,12 +203,14 @@ describe("provider enabled defaults", () => {
     expect(decoded.providers.cursor.enabled).toBe(true);
     expect(decoded.providers.grok.enabled).toBe(false);
     expect(decoded.providers.opencode.enabled).toBe(false);
+    expect(decoded.providers.antigravity.enabled).toBe(false);
   });
 
   it("derives per-driver defaults from the settings schemas", () => {
     expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(true);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("antigravity"))).toBe(false);
     // Unknown fork drivers stay enabled; their own build decides otherwise.
     expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
   });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -530,6 +530,45 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const AntigravitySettings = makeProviderSettingsSchema(
+  {
+    // Off by default (like Cursor, Grok, and OpenCode): users opt in from Settings.
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("antigravity-acp-server").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Antigravity ACP server binary.",
+        providerSettingsForm: {
+          placeholder: "antigravity-acp-server",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    geminiHome: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Gemini home directory",
+        description: "Optional custom GEMINI_HOME directory.",
+        providerSettingsForm: {
+          placeholder: "~/.gemini",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "geminiHome"],
+  },
+);
+export type AntigravitySettings = typeof AntigravitySettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -672,6 +711,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    antigravity: AntigravitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -819,6 +859,13 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const AntigravitySettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  geminiHome: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
@@ -860,6 +907,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      antigravity: Schema.optionalKey(AntigravitySettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5184,10 +5184,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}


### PR DESCRIPTION
## What Changed

Added support for the **Antigravity** provider runtime via the Agent Client Protocol (ACP) across contracts, server orchestration, web, and mobile clients:

1. **Contracts (`packages/contracts`)**:
   - Added `ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity")`.
   - Configured `gemini-3.7-flash` as default model, along with aliases (`flash`, `flash-high`, `flash-medium`, `flash-low`, `3.1-pro`, `pro`).
   - Added `AntigravitySettings` and `AntigravitySettingsPatch` (`binaryPath: "antigravity-acp-server"`, `geminiHome: ""`, custom models).

2. **Server (`apps/server`)**:
   - Implemented `AntigravityAdapter` for stdio JSON-RPC ACP sessions, turn streaming, plan updates, model switching, and permission approvals.
   - Implemented `AntigravityProvider` with version probing and process health checks.
   - Implemented `AntigravityTextGeneration` service for commit message and thread title generation via headless ACP sessions.
   - Registered plain-value `AntigravityDriver` in `builtInDrivers.ts`.

3. **Web & Mobile (`apps/web`, `apps/mobile`)**:
   - Added Antigravity settings card with "Early Access" badge in Settings → Providers.
   - Added Antigravity sparkle icon components and model picker selection.

4. **Docs**:
   - Added user documentation in `docs/user/providers-antigravity.md` and updated `docs/internals/providers.md`.

## Why

Antigravity operates as a local Agent Client Protocol (ACP) server binary (`antigravity-acp-server`), standardizing process lifecycle, session multiplexing, and tool approvals identical to existing ACP providers (like Grok). Supporting Antigravity gives users access to Gemini 3.7 Flash and Pro models in T3 Code while keeping all runtime complexity contained at the provider adapter boundary.

## UI Changes

**Settings → Providers** (Antigravity enabled & probed)
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/03787700-d331-4160-ab2e-478b584ce825" />

**Chat View** (Model picker & completed ACP turn response)
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/ca6219cf-38f1-4b90-92c6-8e92aa6d12de" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

---

Human note:

well I guess this arguably isn't strictly "small" from a LoC perspective, but this seems about par for what it means to add support for a new model provider?


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Antigravity provider via ACP
> - Adds `AntigravityDriver` and `AntigravityAdapter` to manage ACP session lifecycle, prompt execution, and event streaming.
> - Adds `AntigravityTextGeneration` to generate commit messages, PR content, branch names, and thread titles via ACP with a 180s timeout.
> - Adds `AntigravitySettings` schema to `packages/contracts/src/settings.ts` with `enabled`, `binaryPath`, and `geminiHome` fields, defaulting to disabled.
> - Registers `antigravity` driver kind in `packages/contracts/src/model.ts` and adds UI options and icons in web and mobile apps.
> - Risk: `MODEL_SLUG_ALIASES_BY_PROVIDER['claude']` in `packages/contracts/src/model.ts` corrects alias keys from dashes to dots (e.g., `claude-opus-4.6-20251117`), which may break existing consumers relying on the dashed aliases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7568c18. 16 files reviewed, 6 issues evaluated, 1 issue filtered, 5 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/AntigravityProvider.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 237](https://github.com/pingdotgg/t3code/blob/7568c18b5772e10e214558e75fcef2a750deee4e/apps/server/src/provider/Layers/AntigravityProvider.ts#L237): The command-not-found message hard-codes `antigravity-acp-server` even when `antigravitySettings.binaryPath` selected a custom executable. If that custom path is missing, the snapshot tells the user that the default binary is absent/not on PATH, sending them to troubleshoot the wrong command; interpolate the configured command instead. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->