### PR TITLE
fix(grok): skip set_model when effort is unchanged or a prompt is in flight

### DIFF
--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -1264,4 +1264,75 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       // hang until the suite timeout instead of failing here.
     }).pipe(TestClock.withLive),
   );
+
+  it.effect("does not call session/set_model while a prior Grok prompt is in flight", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-steer-skips-set-model");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-steer-set-model-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_PROMPT_DELAY_MS: "400",
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const instanceId = ProviderInstanceId.make("grok");
+      const startSelection = {
+        instanceId,
+        model: "grok-build",
+        options: [{ id: "reasoningEffort", value: "high" }],
+      };
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: startSelection,
+      });
+
+      const firstSendTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "first prompt",
+          attachments: [],
+          modelSelection: startSelection,
+        })
+        .pipe(Effect.forkChild);
+      yield* waitForFileContent(requestLogPath, 80, '"method":"session/prompt"');
+
+      const runningSessions = yield* adapter.listSessions();
+      const runningSession = runningSessions.find((session) => session.threadId === threadId);
+      const steered = yield* adapter.sendTurn({
+        threadId,
+        input: "steer with a different effort",
+        attachments: [],
+        modelSelection: {
+          instanceId,
+          model: "grok-build",
+          options: [{ id: "reasoningEffort", value: "low" }],
+        },
+      });
+      const firstTurn = yield* Fiber.join(firstSendTurnFiber);
+
+      assert.equal(String(steered.turnId), String(firstTurn.turnId));
+      assert.equal(String(steered.turnId), String(runningSession?.activeTurnId));
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const methods = requests.flatMap((entry) =>
+        typeof entry.method === "string" ? [entry.method] : [],
+      );
+      const firstPromptIndex = methods.indexOf("session/prompt");
+      assert.isAtLeast(firstPromptIndex, 0);
+      assert.isFalse(
+        methods.slice(firstPromptIndex + 1).includes("session/set_model"),
+        `set_model after in-flight prompt: ${methods.join(", ")}`,
+      );
+
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
+  );
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -58,6 +58,7 @@ import {
   currentGrokModelIdFromSessionSetup,
   makeGrokAcpRuntime,
   resolveGrokAcpBaseModelId,
+  resolveGrokReasoningEffortSelection,
 } from "../acp/GrokAcpSupport.ts";
 import {
   extractXAiAskUserQuestions,
@@ -117,6 +118,8 @@ interface GrokSessionContext {
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
   currentModelId: string | undefined;
+  /** Last effort successfully applied via `session/set_model` `_meta`. */
+  currentReasoningEffort: string | undefined;
   stopped: boolean;
 }
 
@@ -738,6 +741,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           const requestedStartModelId = grokModelSelection?.model
             ? resolveGrokAcpBaseModelId(grokModelSelection.model)
             : undefined;
+          const requestedStartReasoningEffort = resolveGrokReasoningEffortSelection(
+            grokModelSelection?.options,
+          );
           const boundModelId = yield* applyGrokAcpModelSelection({
             runtime: acp,
             currentModelId: currentGrokModelIdFromSessionSetup(started.sessionSetupResult),
@@ -779,6 +785,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
             currentModelId: boundModelId,
+            currentReasoningEffort: requestedStartReasoningEffort,
             stopped: false,
           };
 
@@ -949,14 +956,24 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               const requestedTurnModelId = turnModelSelection?.model
                 ? resolveGrokAcpBaseModelId(turnModelSelection.model)
                 : undefined;
-              const currentModelId = yield* applyGrokAcpModelSelection({
-                runtime: ctx.acp,
-                currentModelId: ctx.currentModelId,
-                requestedModelId: requestedTurnModelId,
-                selections: turnModelSelection?.options,
-                mapError: (cause) =>
-                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
-              });
+              const requestedTurnReasoningEffort = resolveGrokReasoningEffortSelection(
+                turnModelSelection?.options,
+              );
+              const previousModelId = ctx.currentModelId;
+              // Steers must not call session/set_model: prep holds the thread
+              // lock while the prior prompt is still in flight outside it.
+              const currentModelId =
+                steeringTurnId === undefined
+                  ? yield* applyGrokAcpModelSelection({
+                      runtime: ctx.acp,
+                      currentModelId: ctx.currentModelId,
+                      requestedModelId: requestedTurnModelId,
+                      currentReasoningEffort: ctx.currentReasoningEffort,
+                      selections: turnModelSelection?.options,
+                      mapError: (cause) =>
+                        mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+                    })
+                  : ctx.currentModelId;
 
               const text = input.input?.trim();
               const imagePromptParts = yield* Effect.forEach(
@@ -1006,6 +1023,16 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               }
 
               ctx.currentModelId = currentModelId;
+              if (steeringTurnId === undefined) {
+                if (requestedTurnReasoningEffort !== undefined) {
+                  ctx.currentReasoningEffort = requestedTurnReasoningEffort;
+                } else if (
+                  requestedTurnModelId !== undefined &&
+                  requestedTurnModelId !== previousModelId
+                ) {
+                  ctx.currentReasoningEffort = undefined;
+                }
+              }
               const displayModel = currentModelId
                 ? resolveGrokAcpBaseModelId(currentModelId)
                 : undefined;

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -117,6 +117,43 @@ describe("applyGrokAcpModelSelection", () => {
     }),
   );
 
+  it.effect("skips set_model when the composer restates the already-applied effort", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "model-a",
+        requestedModelId: "model-a",
+        currentReasoningEffort: "effort-c",
+        selections: [{ id: "reasoningEffort", value: "effort-c" }],
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([]);
+      expect(result).toBe("model-a");
+    }),
+  );
+
+  it.effect("calls set_model when only the reasoning effort changes", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "model-a",
+        requestedModelId: "model-a",
+        currentReasoningEffort: "effort-c",
+        selections: [{ id: "reasoningEffort", value: "effort-d" }],
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([
+        {
+          modelId: "model-a",
+          options: { _meta: { reasoningEffort: "effort-d" } },
+        },
+      ]);
+      expect(result).toBe("model-a");
+    }),
+  );
+
   it.effect("applies model switch and effort together", () =>
     Effect.gen(function* () {
       const { runtime, modelCalls } = makeRecordingRuntime();

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -109,21 +109,25 @@ export function resolveGrokReasoningEffortSelection(
 /**
  * Apply model and/or reasoning effort via Grok ACP `session/set_model`.
  * Effort is sent as `_meta.reasoningEffort` (Grok private extension).
- * Calls set_model when the model changes or when an effort selection is present
- * (effort can change without a model id change).
+ * Calls set_model only when the model id or the applied effort actually
+ * changes. A present-but-unchanged `reasoningEffort` selection is a no-op —
+ * the composer always includes that option once Grok capabilities are
+ * discovered, and `session/set_model` is unsafe while a prompt is in flight.
  */
 export function applyGrokAcpModelSelection<E>(input: {
   readonly runtime: Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "setSessionModel">;
   readonly currentModelId: string | undefined;
   readonly requestedModelId: string | undefined;
-  readonly selections?: ReadonlyArray<ProviderOptionSelection> | null;
+  readonly currentReasoningEffort?: string | undefined;
+  readonly selections?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
   readonly mapError: (cause: EffectAcpErrors.AcpError) => E;
 }): Effect.Effect<string | undefined, E> {
   const targetModelId = input.requestedModelId ?? input.currentModelId;
   const reasoningEffort = resolveGrokReasoningEffortSelection(input.selections);
   const shouldSwitchModel =
     input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
-  const shouldApplyEffort = reasoningEffort !== undefined;
+  const shouldApplyEffort =
+    reasoningEffort !== undefined && reasoningEffort !== input.currentReasoningEffort;
 
   if (!targetModelId || (!shouldSwitchModel && !shouldApplyEffort)) {
     return Effect.succeed(input.currentModelId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

`applyGrokAcpModelSelection` no longer treats a present `reasoningEffort` selection as enough reason to call `session/set_model`. It compares against the effort last applied on the session and only sends the RPC when the model id or effort actually changed.

`sendTurn` also skips the apply entirely on a steer (`promptsInFlight > 0`). Prep runs under the thread lock while `prompt` runs outside it, so a steer must not issue `set_model` while a prior prompt is still in flight.

## Why

The composer always restates `reasoningEffort` once Grok capabilities are discovered. Before the reasoning-effort change, same-model turns skipped `set_model` entirely, so steers never hit that path. After it, every turn — including steers — called `set_model`.

## UI Changes

None. This is a server-only apply/skip change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Made by Cursor Grok 4.6 via the Cursor Cloud harness while working on T3 Code.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc410118-d74a-4467-acdf-9f3339d8f90e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc410118-d74a-4467-acdf-9f3339d8f90e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip `session/set_model` in `GrokAdapter` when effort is unchanged or a prompt is in flight
> - Tracks the last applied reasoning effort via `ctx.currentReasoningEffort` in `GrokSessionContext`, set during `startSession` and updated after each model selection.
> - `sendTurn` now skips `session/set_model` entirely on steer turns (when a prior prompt is still in flight) and only calls it when the model id or `reasoningEffort` actually changes.
> - `applyGrokAcpModelSelection` accepts a `currentReasoningEffort` parameter and treats a present-but-unchanged effort as a no-op.
> - Risk: changing the model id without an explicit `reasoningEffort` selection now clears `ctx.currentReasoningEffort` (see [GrokAdapter.ts](https://github.com/pingdotgg/t3code/pull/7980/files#diff-1a00c5b795ace1b6633f05c6d3b900dc8d4778afd1879ebdbdf3fb41d04ed521)); a subsequent turn that restates the cleared effort will issue `set_model` again.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7db5f22. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->