### PR TITLE
fix(mobile): show project favicons in filters

### DIFF
--- a/apps/mobile/src/components/AndroidAnchoredMenu.tsx
+++ b/apps/mobile/src/components/AndroidAnchoredMenu.tsx
@@ -42,6 +42,8 @@ export type AndroidAnchoredMenuProps = {
   readonly actions: readonly MenuAction[];
   readonly title?: string;
   readonly onPressAction?: MenuComponentProps["onPressAction"];
+  /** Optional Android-only content rendered before the standard trailing state glyph. */
+  readonly renderActionTrailing?: (action: MenuAction) => ReactNode;
   /** Applied to the anchor wrapper — call sites flex these to fill toolbars. */
   readonly className?: string;
   readonly style?: StyleProp<ViewStyle>;
@@ -276,6 +278,7 @@ export function AndroidAnchoredMenu(props: AndroidAnchoredMenuProps) {
                     const destructive = action.attributes?.destructive ?? false;
                     const disabled = action.attributes?.disabled ?? false;
                     const hasSubmenu = (action.subactions?.length ?? 0) > 0;
+                    const customTrailing = props.renderActionTrailing?.(action);
                     return (
                       <Pressable
                         key={action.id ?? `${index}-${action.title}`}
@@ -303,6 +306,7 @@ export function AndroidAnchoredMenu(props: AndroidAnchoredMenuProps) {
                             </Text>
                           ) : null}
                         </View>
+                        {customTrailing}
                         {hasSubmenu ? (
                           <SymbolView
                             name="chevron.right"

--- a/apps/mobile/src/components/ControlPill.tsx
+++ b/apps/mobile/src/components/ControlPill.tsx
@@ -13,7 +13,7 @@ import { useThemeColor } from "../lib/useThemeColor";
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
 
 import { cn } from "../lib/cn";
-import { AndroidAnchoredMenu } from "./AndroidAnchoredMenu";
+import { AndroidAnchoredMenu, type AndroidAnchoredMenuProps } from "./AndroidAnchoredMenu";
 import { SymbolView } from "./AppSymbol";
 import { AppText as Text } from "./AppText";
 
@@ -116,6 +116,7 @@ export function ControlPillMenu(
   props: Omit<ComponentProps<typeof MenuView>, "children" | "themeVariant"> & {
     readonly children: ReactNode;
     readonly className?: string;
+    readonly renderActionTrailing?: AndroidAnchoredMenuProps["renderActionTrailing"];
   },
 ) {
   const { themeAppearance } = useAppearancePreferences();
@@ -134,6 +135,7 @@ export function ControlPillMenu(
           title={props.title}
           style={props.style}
           onPressAction={props.onPressAction}
+          renderActionTrailing={props.renderActionTrailing}
         >
           {(open) =>
             cloneElement(child, {
@@ -153,13 +155,18 @@ export function ControlPillMenu(
         title={props.title}
         style={props.style}
         onPressAction={props.onPressAction}
+        renderActionTrailing={props.renderActionTrailing}
       >
         {props.children}
       </AndroidAnchoredMenu>
     );
   }
 
-  const { className: _className, ...menuProps } = props;
+  const {
+    className: _className,
+    renderActionTrailing: _renderActionTrailing,
+    ...menuProps
+  } = props;
   let children = menuProps.children;
   // In long-press mode the wrapped pressable still receives the touch (the
   // patched MenuView button is touch-transparent) and RN's Fabric touch

--- a/apps/mobile/src/features/home/AndroidProjectFilterIcon.tsx
+++ b/apps/mobile/src/features/home/AndroidProjectFilterIcon.tsx
@@ -1,0 +1,31 @@
+import type { MenuAction } from "@react-native-menu/menu";
+import type { ReactNode } from "react";
+
+import { ProjectFavicon } from "../../components/ProjectFavicon";
+import { SymbolView } from "../../components/AppSymbol";
+import { useThemeColor } from "../../lib/useThemeColor";
+import { resolveAndroidProjectFilterProject } from "./android-home-list-filter-menu";
+import type { HomeListFilterMenuProject } from "./home-list-filter-menu";
+
+export function AndroidProjectFilterIcon(props: {
+  readonly action: MenuAction;
+  readonly projects: ReadonlyArray<HomeListFilterMenuProject>;
+}): ReactNode {
+  const iconColor = useThemeColor("--color-icon");
+  if (props.action.id === "project:all") {
+    return <SymbolView name="folder" size={18} tintColor={iconColor} type="monochrome" />;
+  }
+
+  const project = resolveAndroidProjectFilterProject(props.action.id, props.projects);
+  if (project === null) return null;
+
+  return (
+    <ProjectFavicon
+      environmentId={project.environmentId}
+      faviconPath={project.faviconPath}
+      projectTitle={project.label}
+      size={18}
+      workspaceRoot={project.workspaceRoot}
+    />
+  );
+}

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -21,6 +21,8 @@ import {
   NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED,
 } from "../layout/native-mail-search-toolbar";
 import type { HomeProjectSortOrder } from "./homeThreadList";
+import { buildAndroidProjectFilterActions } from "./android-home-list-filter-menu";
+import { AndroidProjectFilterIcon } from "./AndroidProjectFilterIcon";
 import { WorkspaceConnectionTitle } from "./WorkspaceConnectionTitle";
 import {
   buildHomeListFilterMenu,
@@ -101,18 +103,10 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
             {
               id: "project",
               title: "Project",
-              subactions: [
-                {
-                  id: "project:all",
-                  title: "All projects",
-                  state: checkedMenuState(props.selectedProjectKey === null),
-                },
-                ...props.projects.map((project) => ({
-                  id: `project:${project.key}`,
-                  title: project.label,
-                  state: checkedMenuState(props.selectedProjectKey === project.key),
-                })),
-              ],
+              subactions: buildAndroidProjectFilterActions(
+                props.projects,
+                props.selectedProjectKey,
+              ),
             },
           ] satisfies MenuAction[])),
       ...(threadListV2Enabled
@@ -235,6 +229,9 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
               actions={menuActions}
               isAnchoredToRight
               onPressAction={handleMenuAction}
+              renderActionTrailing={(action) => (
+                <AndroidProjectFilterIcon action={action} projects={props.projects} />
+              )}
             >
               <Pressable
                 accessibilityLabel="Filter and sort threads"

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -88,6 +88,9 @@ export function HomeRouteScreen() {
       }).map((scope) => ({
         key: scope.key,
         label: scope.title,
+        environmentId: scope.representative.environmentId,
+        workspaceRoot: scope.representative.workspaceRoot,
+        faviconPath: scope.representative.faviconPath ?? null,
       })),
     [listOptions.projectGroupingMode, projects, selectedEnvironmentId],
   );

--- a/apps/mobile/src/features/home/android-home-list-filter-menu.test.ts
+++ b/apps/mobile/src/features/home/android-home-list-filter-menu.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { EnvironmentId } from "@t3tools/contracts";
+
+import {
+  buildAndroidProjectFilterActions,
+  resolveAndroidProjectFilterProject,
+} from "./android-home-list-filter-menu";
+
+const projects = [
+  {
+    key: "environment-1:project-1",
+    label: "Codething",
+    environmentId: EnvironmentId.make("environment-1"),
+    workspaceRoot: "/workspace/codething",
+    faviconPath: "brand/icon.svg",
+  },
+  {
+    key: "environment-1:project-2",
+    label: "Website",
+    environmentId: EnvironmentId.make("environment-1"),
+    workspaceRoot: "/workspace/website",
+    faviconPath: null,
+  },
+] as const;
+
+describe("buildAndroidProjectFilterActions", () => {
+  it("keeps project action identity separate from the selected state", () => {
+    const actions = buildAndroidProjectFilterActions(projects, "environment-1:project-1");
+
+    expect(actions).toMatchObject([
+      { id: "project:all" },
+      { id: "project:environment-1:project-1", state: "on" },
+      { id: "project:environment-1:project-2" },
+    ]);
+  });
+
+  it("resolves the matching project data for its recognized favicon", () => {
+    expect(resolveAndroidProjectFilterProject("project:environment-1:project-1", projects)).toEqual(
+      projects[0],
+    );
+    expect(resolveAndroidProjectFilterProject("project:all", projects)).toBeNull();
+    expect(resolveAndroidProjectFilterProject("environment:all", projects)).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/home/android-home-list-filter-menu.ts
+++ b/apps/mobile/src/features/home/android-home-list-filter-menu.ts
@@ -1,0 +1,34 @@
+import type { MenuAction } from "@react-native-menu/menu";
+
+import type { HomeListFilterMenuProject } from "./home-list-filter-menu";
+
+function checkedMenuState(checked: boolean) {
+  return checked ? ("on" as const) : undefined;
+}
+
+export function buildAndroidProjectFilterActions(
+  projects: ReadonlyArray<HomeListFilterMenuProject>,
+  selectedProjectKey: string | null,
+): MenuAction[] {
+  return [
+    {
+      id: "project:all",
+      title: "All projects",
+      state: checkedMenuState(selectedProjectKey === null),
+    },
+    ...projects.map((project) => ({
+      id: `project:${project.key}`,
+      title: project.label,
+      state: checkedMenuState(selectedProjectKey === project.key),
+    })),
+  ];
+}
+
+export function resolveAndroidProjectFilterProject(
+  actionId: string | undefined,
+  projects: ReadonlyArray<HomeListFilterMenuProject>,
+): HomeListFilterMenuProject | null {
+  if (!actionId?.startsWith("project:") || actionId === "project:all") return null;
+  const projectKey = actionId.slice("project:".length);
+  return projects.find((project) => project.key === projectKey) ?? null;
+}

--- a/apps/mobile/src/features/home/home-list-filter-menu.test.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import { EnvironmentId } from "@t3tools/contracts";
 
 import { buildHomeListFilterMenu } from "./home-list-filter-menu";
 
@@ -8,8 +9,20 @@ describe("buildHomeListFilterMenu", () => {
     const menu = buildHomeListFilterMenu({
       environments: [],
       projects: [
-        { key: "environment-1:project-1", label: "Codething" },
-        { key: "environment-1:project-2", label: "Website" },
+        {
+          key: "environment-1:project-1",
+          label: "Codething",
+          environmentId: EnvironmentId.make("environment-1"),
+          workspaceRoot: "/workspace/codething",
+          faviconPath: null,
+        },
+        {
+          key: "environment-1:project-2",
+          label: "Website",
+          environmentId: EnvironmentId.make("environment-1"),
+          workspaceRoot: "/workspace/website",
+          faviconPath: null,
+        },
       ],
       selectedEnvironmentId: null,
       selectedProjectKey: "environment-1:project-1",

--- a/apps/mobile/src/features/home/home-list-filter-menu.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.ts
@@ -11,6 +11,9 @@ export interface HomeListFilterMenuEnvironment {
 export interface HomeListFilterMenuProject {
   readonly key: string;
   readonly label: string;
+  readonly environmentId: EnvironmentId;
+  readonly workspaceRoot: string;
+  readonly faviconPath: string | null;
 }
 
 type HomeListFilterMenuAction = {

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -47,6 +47,7 @@ import {
   useHomeListOptions,
 } from "../home/home-list-options";
 import { buildHomeListFilterMenu } from "../home/home-list-filter-menu";
+import { AndroidProjectFilterIcon } from "../home/AndroidProjectFilterIcon";
 import {
   buildHomeListLayout,
   DEFAULT_GROUP_DISPLAY_STATE,
@@ -284,6 +285,9 @@ function ThreadNavigationSidebarPane(
       projectScopes.map((scope) => ({
         key: scope.key,
         label: scope.title,
+        environmentId: scope.representative.environmentId,
+        workspaceRoot: scope.representative.workspaceRoot,
+        faviconPath: scope.representative.faviconPath ?? null,
       })),
     [projectScopes],
   );
@@ -1383,7 +1387,13 @@ function ThreadNavigationSidebarPane(
             }
           />
           <SidebarHeaderButtonGroup colorScheme={colorScheme}>
-            <ControlPillMenu actions={listMenuActions} onPressAction={handleListMenuAction}>
+            <ControlPillMenu
+              actions={listMenuActions}
+              onPressAction={handleListMenuAction}
+              renderActionTrailing={(action) => (
+                <AndroidProjectFilterIcon action={action} projects={projectFilterOptions} />
+              )}
+            >
               <SidebarFilterButton
                 grouped
                 accessibilityLabel="Filter and sort threads"


### PR DESCRIPTION
Closes #7981

## UI Changes

| Before | After |
| --- | --- |
| ![Android project filter without favicons](https://github.com/user-attachments/assets/1ff51940-04f2-45e9-8fcb-a6bd978b3256) | ![Android project filter with recognized favicons](https://github.com/user-attachments/assets/7ed9018a-dcbb-4e0a-8511-0a17543ec6cb) |

## What Changed

The Android project filter now renders each project's resolved favicon on the right in the custom Android menu. `All projects` keeps its folder icon, and the selected check remains visible.

This applies to the Home header and persistent sidebar filter. iOS keeps using the native menu unchanged.

## Why

T3 already resolves and displays these icons elsewhere, but Android's project filter only showed labels. That made projects harder to distinguish at a glance and inconsistent with desktop.

<details><summary>Verification</summary>

- `vp test run apps/mobile/src/features/home/android-home-list-filter-menu.test.ts apps/mobile/src/features/home/home-list-filter-menu.test.ts`: 2 test files and 3 tests passed.
- `vp run --filter @t3tools/mobile typecheck`: passed.
- Targeted format and lint checks on the changed files: passed.
- Verified the Android project filter at 1080 x 1920 in dark mode. The before and after images above show the exact changed state.

</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] A video is not required because no animation or interaction changed

GPT-5 in Codex Desktop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Android-only UI in the custom anchored menu; iOS native menus are unchanged and filter action IDs stay the same.
> 
> **Overview**
> Android project filter menus now show resolved project favicons next to each row, with a folder icon for **All projects**, while keeping the selected checkmark.
> 
> `AndroidAnchoredMenu` / `ControlPillMenu` gain an optional `renderActionTrailing` slot (ignored on iOS). Home header and the persistent sidebar pass `AndroidProjectFilterIcon`, and project filter options now include `environmentId`, `workspaceRoot`, and `faviconPath` so those icons can load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fddde927837a22e1c10fcf05001c7d096cd01a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show project favicons in Android filter menus
> - Adds a `renderActionTrailing` prop to `AndroidAnchoredMenu` and `ControlPillMenu`, allowing custom trailing content per menu action on Android (no effect on iOS)
> - Introduces `AndroidProjectFilterIcon` which renders a folder icon for the 'All projects' action and a `ProjectFavicon` for specific project actions
> - Extends `HomeListFilterMenuProject` with `environmentId`, `workspaceRoot`, and `faviconPath` fields so project data is available to the icon renderer
> - Wires the icon renderer into the home header filter menu ([HomeHeader.tsx](https://github.com/pingdotgg/t3code/pull/7984/files#diff-1ba9649b1bf1262669a23a80f40994038467f6ae019d2ce77f1bbc7e0f65e198)) and the thread navigation sidebar ([ThreadNavigationSidebar.tsx](https://github.com/pingdotgg/t3code/pull/7984/files#diff-4431208d7dda139d19919302f332d6a63788b9d114b4b7a410d89a727b9ed455))
> - Adds `buildAndroidProjectFilterActions` and `resolveAndroidProjectFilterProject` utils to construct project menu actions with stable ids and resolve the matching project for icon rendering
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fddde9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
