### PR TITLE
fix(server): cancel pending questions on stop

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2451,53 +2451,140 @@ describe("ProviderCommandReactor", () => {
 
   it("interrupts the provider and cancels pending user input", async () => {
     const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+    // The interrupt command's timestamp predates every request below, so a
+    // synthetic cancellation carrying it would fold closed before the request
+    // it closes. The reactor must stamp cancellations with server time.
+    const now = "2025-12-31T00:00:00.000Z";
+
+    const appendUserInputActivity = (input: {
+      readonly commandId: string;
+      readonly activityId: string;
+      readonly kind:
+        | "user-input.requested"
+        | "user-input.resolved"
+        | "provider.user-input.respond.failed";
+      readonly payload: Record<string, unknown>;
+      readonly createdAt: string;
+    }) =>
+      harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make(input.commandId),
+        threadId: ThreadId.make("thread-1"),
+        activity: {
+          id: EventId.make(input.activityId),
+          tone: "info",
+          kind: input.kind,
+          summary:
+            input.kind === "user-input.requested"
+              ? "User input requested"
+              : input.kind === "user-input.resolved"
+                ? "User input resolved"
+                : "Provider user input response failed",
+          payload: input.payload,
+          turnId: asTurnId("turn-1"),
+          createdAt: input.createdAt,
+        },
+        createdAt: input.createdAt,
+      });
+
+    const questions = [
+      {
+        id: "continue",
+        header: "Continue",
+        question: "Continue?",
+        options: [{ label: "Yes", description: "Continue the turn." }],
+        multiSelect: false,
+      },
+    ];
 
     await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.make("cmd-session-set"),
-        threadId: ThreadId.make("thread-1"),
-        session: {
+      Effect.gen(function* () {
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-session-set"),
           threadId: ThreadId.make("thread-1"),
-          status: "running",
-          providerName: "codex",
-          runtimeMode: "approval-required",
-          activeTurnId: asTurnId("turn-1"),
-          lastError: null,
-          updatedAt: now,
-        },
-        createdAt: now,
+          session: {
+            threadId: ThreadId.make("thread-1"),
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: asTurnId("turn-1"),
+            lastError: null,
+            updatedAt: now,
+          },
+          createdAt: now,
+        });
+
+        // Answered before the interrupt, so it must not be cancelled again.
+        yield* appendUserInputActivity({
+          commandId: "cmd-user-input-requested-1",
+          activityId: "activity-user-input-requested-1",
+          kind: "user-input.requested",
+          payload: { requestId: "user-input-request-1", questions },
+          createdAt: "2025-12-31T23:59:57.000Z",
+        });
+        yield* appendUserInputActivity({
+          commandId: "cmd-user-input-resolved-1",
+          activityId: "activity-user-input-resolved-1",
+          kind: "user-input.resolved",
+          payload: { requestId: "user-input-request-1", answers: { continue: "Yes" } },
+          createdAt: "2025-12-31T23:59:58.000Z",
+        });
+
+        // Response already failed as stale, so it is dead and must not be cancelled.
+        yield* appendUserInputActivity({
+          commandId: "cmd-user-input-requested-stale",
+          activityId: "activity-user-input-requested-stale",
+          kind: "user-input.requested",
+          payload: { requestId: "user-input-request-stale", questions },
+          createdAt: "2025-12-31T23:59:58.500Z",
+        });
+        yield* appendUserInputActivity({
+          commandId: "cmd-user-input-respond-failed-stale",
+          activityId: "activity-user-input-respond-failed-stale",
+          kind: "provider.user-input.respond.failed",
+          payload: {
+            requestId: "user-input-request-stale",
+            detail: `Stale pending user-input request: user-input-request-stale. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`,
+          },
+          createdAt: "2025-12-31T23:59:58.750Z",
+        });
+
+        // Still open when the interrupt lands; the provider resolves it for
+        // real while handling the interrupt, so no cancelled duplicate may be
+        // appended on top of the real resolution.
+        yield* appendUserInputActivity({
+          commandId: "cmd-user-input-requested-2",
+          activityId: "activity-user-input-requested-2",
+          kind: "user-input.requested",
+          payload: { requestId: "user-input-request-2", questions },
+          createdAt: "2025-12-31T23:59:59.000Z",
+        });
+
+        // Still open when the interrupt lands and untouched by the provider,
+        // so the reactor must cancel it.
+        yield* appendUserInputActivity({
+          commandId: "cmd-user-input-requested-3",
+          activityId: "activity-user-input-requested-3",
+          kind: "user-input.requested",
+          payload: { requestId: "user-input-request-3", questions },
+          createdAt: "2025-12-31T23:59:59.500Z",
+        });
       }),
     );
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.activity.append",
-        commandId: CommandId.make("cmd-user-input-requested"),
-        threadId: ThreadId.make("thread-1"),
-        activity: {
-          id: EventId.make("activity-user-input-requested-before-interrupt"),
-          tone: "info",
-          kind: "user-input.requested",
-          summary: "User input requested",
-          payload: {
-            requestId: "user-input-request-1",
-            questions: [
-              {
-                id: "continue",
-                header: "Continue",
-                question: "Continue?",
-                options: [{ label: "Yes", description: "Continue the turn." }],
-                multiSelect: false,
-              },
-            ],
-          },
-          turnId: asTurnId("turn-1"),
-          createdAt: "2025-12-31T23:59:59.000Z",
-        },
-        createdAt: "2025-12-31T23:59:59.000Z",
-      }),
+    harness.interruptTurn.mockImplementation(() =>
+      Effect.asVoid(
+        Effect.orDie(
+          appendUserInputActivity({
+            commandId: "cmd-user-input-resolved-2-during-interrupt",
+            activityId: "activity-user-input-resolved-2",
+            kind: "user-input.resolved",
+            payload: { requestId: "user-input-request-2", answers: { continue: "Yes" } },
+            createdAt: "2026-01-01T00:00:01.000Z",
+          }),
+        ),
+      ),
     );
 
     await Effect.runPromise(
@@ -2521,23 +2608,67 @@ describe("ProviderCommandReactor", () => {
         thread?.activities.some(
           (activity) =>
             activity.kind === "user-input.resolved" &&
-            (activity.payload as { requestId?: unknown }).requestId === "user-input-request-1",
+            (activity.payload as { requestId?: unknown }).requestId === "user-input-request-3" &&
+            (activity.payload as { cancelled?: unknown }).cancelled === true,
         ) ?? false
       );
     });
 
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    const activities = thread?.activities ?? [];
+
+    // The real mid-interrupt resolution stands alone; appending a cancelled
+    // duplicate here would re-close a question the user actually answered.
     expect(
-      thread?.activities.find((activity) => activity.kind === "user-input.resolved"),
-    ).toMatchObject({
+      activities.filter(
+        (activity) =>
+          activity.kind === "user-input.resolved" &&
+          (activity.payload as { requestId?: unknown }).requestId === "user-input-request-2",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        summary: "User input resolved",
+        payload: { requestId: "user-input-request-2", answers: { continue: "Yes" } },
+      }),
+    ]);
+
+    // Only the still-open request folds closed, exactly once.
+    const cancelledRequestIds = activities
+      .filter(
+        (activity) =>
+          activity.kind === "user-input.resolved" &&
+          (activity.payload as { cancelled?: unknown }).cancelled === true,
+      )
+      .map((activity) => (activity.payload as { requestId?: unknown }).requestId)
+      .toSorted();
+    expect(cancelledRequestIds).toEqual(["user-input-request-3"]);
+
+    // Its cancellation carries server time, so it orders after the request
+    // despite the earlier interrupt command timestamp.
+    const request3Activity = activities.find(
+      (activity) =>
+        activity.kind === "user-input.requested" &&
+        (activity.payload as { requestId?: unknown }).requestId === "user-input-request-3",
+    );
+    const cancelledActivity = activities.find(
+      (activity) =>
+        activity.kind === "user-input.resolved" &&
+        (activity.payload as { requestId?: unknown }).requestId === "user-input-request-3" &&
+        (activity.payload as { cancelled?: unknown }).cancelled === true,
+    );
+    expect(request3Activity).toBeDefined();
+    expect(cancelledActivity).toMatchObject({
       summary: "User input cancelled",
       payload: {
-        requestId: "user-input-request-1",
+        requestId: "user-input-request-3",
         cancelled: true,
       },
       turnId: "turn-1",
     });
+    expect(Date.parse(cancelledActivity!.createdAt)).toBeGreaterThan(
+      Date.parse(request3Activity!.createdAt),
+    );
   });
 
   it("starts a fresh session when only projected session state exists", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2449,7 +2449,7 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("reacts to thread.turn.interrupt-requested by calling provider interrupt", async () => {
+  it("interrupts the provider and cancels pending user input", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2473,6 +2473,35 @@ describe("ProviderCommandReactor", () => {
 
     await Effect.runPromise(
       harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.make("cmd-user-input-requested"),
+        threadId: ThreadId.make("thread-1"),
+        activity: {
+          id: EventId.make("activity-user-input-requested-before-interrupt"),
+          tone: "info",
+          kind: "user-input.requested",
+          summary: "User input requested",
+          payload: {
+            requestId: "user-input-request-1",
+            questions: [
+              {
+                id: "continue",
+                header: "Continue",
+                question: "Continue?",
+                options: [{ label: "Yes", description: "Continue the turn." }],
+                multiSelect: false,
+              },
+            ],
+          },
+          turnId: asTurnId("turn-1"),
+          createdAt: "2025-12-31T23:59:59.000Z",
+        },
+        createdAt: "2025-12-31T23:59:59.000Z",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
         type: "thread.turn.interrupt",
         commandId: CommandId.make("cmd-turn-interrupt"),
         threadId: ThreadId.make("thread-1"),
@@ -2484,6 +2513,30 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.interruptTurn.mock.calls.length === 1);
     expect(harness.interruptTurn.mock.calls[0]?.[0]).toEqual({
       threadId: "thread-1",
+    });
+    await waitFor(async () => {
+      const readModel = await harness.readModel();
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return (
+        thread?.activities.some(
+          (activity) =>
+            activity.kind === "user-input.resolved" &&
+            (activity.payload as { requestId?: unknown }).requestId === "user-input-request-1",
+        ) ?? false
+      );
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(
+      thread?.activities.find((activity) => activity.kind === "user-input.resolved"),
+    ).toMatchObject({
+      summary: "User input cancelled",
+      payload: {
+        requestId: "user-input-request-1",
+        cancelled: true,
+      },
+      turnId: "turn-1",
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  type OrchestrationThread,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -16,6 +17,7 @@ import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shar
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
@@ -48,6 +50,10 @@ import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
+
+// Server-side timestamps for reactor-appended activities. Client-supplied
+// command timestamps can predate the thread activity they must follow.
+const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 
 type ProviderIntentEvent = Extract<
   OrchestrationEvent,
@@ -275,6 +281,43 @@ function stalePendingRequestDetail(
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
 }
 
+function pendingUserInputRequests(
+  activities: OrchestrationThread["activities"],
+): ReadonlyArray<{ readonly requestId: string; readonly turnId: TurnId | null }> {
+  const openRequests = new Map<string, TurnId | null>();
+  const ordered = [...activities].toSorted(
+    (left, right) =>
+      left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+  );
+
+  for (const activity of ordered) {
+    const payload =
+      typeof activity.payload === "object" && activity.payload !== null
+        ? (activity.payload as Record<string, unknown>)
+        : null;
+    const requestId = typeof payload?.requestId === "string" ? payload.requestId : null;
+    if (requestId === null) continue;
+
+    if (activity.kind === "user-input.requested") {
+      openRequests.set(requestId, activity.turnId);
+    } else if (activity.kind === "user-input.resolved") {
+      openRequests.delete(requestId);
+    } else if (activity.kind === "provider.user-input.respond.failed") {
+      const detail = typeof payload?.detail === "string" ? payload.detail.toLowerCase() : "";
+      if (
+        detail.includes("stale pending user-input request") ||
+        detail.includes("unknown pending user-input request") ||
+        detail.includes("unknown pending user input request") ||
+        detail.includes("unknown pending codex user input request")
+      ) {
+        openRequests.delete(requestId);
+      }
+    }
+  }
+
+  return [...openRequests].map(([requestId, turnId]) => ({ requestId, turnId }));
+}
+
 function buildGeneratedWorktreeBranchName(raw: string): string {
   const normalized = raw
     .trim()
@@ -365,6 +408,36 @@ const make = Effect.gen(function* () {
         }),
       ),
     );
+
+  const appendCancelledUserInputActivity = Effect.fn(
+    "ProviderCommandReactor.appendCancelledUserInputActivity",
+  )(function* (input: {
+    readonly threadId: ThreadId;
+    readonly requestId: string;
+    readonly turnId: TurnId | null;
+    readonly createdAt: string;
+  }) {
+    const commandId = yield* serverCommandId("user-input-cancelled");
+    const eventId = yield* serverEventId();
+    yield* orchestrationEngine.dispatch({
+      type: "thread.activity.append",
+      commandId,
+      threadId: input.threadId,
+      activity: {
+        id: eventId,
+        tone: "info",
+        kind: "user-input.resolved",
+        summary: "User input cancelled",
+        payload: {
+          requestId: input.requestId,
+          cancelled: true,
+        },
+        turnId: input.turnId,
+        createdAt: input.createdAt,
+      },
+      createdAt: input.createdAt,
+    });
+  });
 
   const formatFailureDetail = (cause: Cause.Cause<unknown>): string => {
     const failReason = cause.reasons.find(Cause.isFailReason);
@@ -1194,6 +1267,28 @@ const make = Effect.gen(function* () {
 
     // Orchestration turn ids are not provider turn ids, so interrupt by session.
     yield* providerService.interruptTurn({ threadId: event.payload.threadId });
+    // Some providers discard their callbacks without emitting a matching
+    // resolution event. Close those requests once the interrupt succeeds,
+    // deriving from a fresh read: the provider can append real resolutions
+    // while handling the interrupt. Cancellations get server-side timestamps
+    // so they order after the request activity even when the interrupt
+    // command predates it.
+    const postInterruptThread = yield* resolveThread(event.payload.threadId);
+    if (!postInterruptThread) {
+      return;
+    }
+    yield* Effect.forEach(
+      pendingUserInputRequests(postInterruptThread.activities),
+      ({ requestId, turnId }) =>
+        Effect.flatMap(nowIso, (cancelledAt) =>
+          appendCancelledUserInputActivity({
+            threadId: event.payload.threadId,
+            requestId,
+            turnId,
+            createdAt: cancelledAt,
+          }),
+        ),
+    );
   });
 
   const processApprovalResponseRequested = Effect.fn("processApprovalResponseRequested")(function* (


### PR DESCRIPTION
## Problem

Stopping a turn that is blocked on a user question left the question prompt stuck on screen. The UI cleared it optimistically, but nothing durable recorded the resolution, so a reload or another client brought the dead prompt back and any answer to it failed as stale.

## Fix

After a successful provider interrupt, the ProviderCommandReactor re-reads the thread's activity log and derives the still-open user-input requests from that fresh snapshot (honoring prior resolutions and stale-response failures), so a resolution the provider appends while handling the interrupt is never followed by a false cancelled duplicate. Each durable `user-input.resolved` activity marked `cancelled: true` is stamped with server-side time rather than the stop command's timestamp, so it orders after the request activity even when the stop command carries an older one. The pending-UI derivation in every client then clears the prompt from the event stream itself, with no client-side special casing.

The reactor test covers an open request being cancelled despite an interrupt timestamp older than the request, a question the provider resolved during the interrupt keeping its real resolution untouched, and already-answered or stale-failed requests staying that way.

- bb49562b1 cancels pending questions after interrupt
- de3647d8f extends the test coverage

<!-- CURSOR_SUMMARY -->
---
> [!NOTE]
> **Medium Risk**
> Touches the turn-interrupt path and writes new orchestration activities. Wrong pending-request derivation could cancel live questions or leave dead prompts in the log.
>
> **Overview**
> Stopping a turn that is waiting on a user question now records a durable cancellation so the prompt does not come back after reload or on another client.
>
> After a successful provider interrupt, `ProviderCommandReactor` walks the thread activity log, finds still-open user-input requests (skipping already-resolved ones and stale-response failures), and appends `user-input.resolved` activities with `cancelled: true`. Clients already treat that kind as closed, so the prompt clears from the event stream without extra UI logic.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e1edf3301754edd93cf70b2ac2c8565b019a3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel pending user-input requests on `thread.turn.interrupt` in `ProviderCommandReactor`
> - On `thread.turn.interrupt-requested`, after calling `providerService.interruptTurn`, the reactor now appends `user-input.resolved` activities with `{cancelled: true}` for any still-open user-input requests inferred from the activity log.
> - Adds `pendingUserInputRequests` to scan sorted thread activities and compute open request IDs, closing them on resolution or when `provider.user-input.respond.failed` marks the request as stale or unknown.
> - Adds `appendCancelledUserInputActivity` to append the cancellation activity with summary "User input cancelled", preserving the original `turnId` and using the interrupt event's `createdAt`.
> - Behavioral Change: previously-open user-input requests are now resolved as cancelled on interrupt; consumers reading `user-input.resolved` activities in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/7987/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) should handle the new `{cancelled: true}` payload.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized de3647d. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
