### PR TITLE
fix(opencode): show bash commands instead of repeating their output

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1150,6 +1150,87 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("projects bash tool parts as command plus raw output instead of output-as-detail", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-bash-projection");
+      const part = {
+        id: "part-bash",
+        callID: "call-bash",
+        sessionID: "http://127.0.0.1:9999/session",
+        messageID: "msg-bash",
+        type: "tool" as const,
+        tool: "bash",
+        state: {
+          status: "running" as const,
+          input: { command: "git status" },
+          title: "git status",
+          time: { start: 1 },
+        },
+      };
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.part.updated",
+          properties: { sessionID: part.sessionID, part, time: 1 },
+        },
+        {
+          type: "message.part.updated",
+          properties: {
+            sessionID: part.sessionID,
+            part: {
+              ...part,
+              state: {
+                status: "completed" as const,
+                input: { command: "git status" },
+                title: "git status",
+                output: "On branch main\nnothing to commit\n",
+                time: { start: 1, end: 2 },
+              },
+            },
+            time: 2,
+          },
+        },
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "item.updated" || event.type === "item.completed"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.equal(events.length, 2);
+      const updated = events[0];
+      const completed = events[1];
+      if (updated?.type !== "item.updated" || completed?.type !== "item.completed") {
+        NodeAssert.fail(`unexpected events: ${events.map((event) => event.type).join(", ")}`);
+      }
+      // The command itself is the detail/preview; the output rides in
+      // data.rawOutput so clients render it once in the expanded body.
+      NodeAssert.equal(updated.payload.detail, "git status");
+      NodeAssert.deepEqual(
+        (updated.payload.data as Record<string, unknown>).command,
+        "git status",
+      );
+      NodeAssert.equal(completed.payload.detail, "git status");
+      NodeAssert.deepEqual(completed.payload.data, {
+        tool: "bash",
+        command: "git status",
+        rawOutput: { content: "On branch main\nnothing to commit\n" },
+      });
+    }),
+  );
+
   it.effect("lets OpenCode own session title generation and emits title metadata updates", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1231,6 +1231,63 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("keeps the failure reason on failed bash parts while preserving the command", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-bash-failure");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            part: {
+              id: "part-bash-fail",
+              callID: "call-bash-fail",
+              sessionID: "http://127.0.0.1:9999/session",
+              messageID: "msg-bash-fail",
+              type: "tool" as const,
+              tool: "bash",
+              state: {
+                status: "error" as const,
+                input: { command: "exit 3" },
+                title: "exit 3",
+                error: "Command failed with exit code 3",
+                time: { start: 1, end: 2 },
+              },
+            },
+            time: 2,
+          },
+        },
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) => event.threadId === threadId && event.type === "item.completed",
+        ),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      const completed = events[0];
+      if (completed?.type !== "item.completed") {
+        NodeAssert.fail(`unexpected events: ${events.map((event) => event.type).join(", ")}`);
+      }
+      NodeAssert.equal(completed.payload.status, "failed");
+      NodeAssert.equal(completed.payload.detail, "Command failed with exit code 3");
+      NodeAssert.deepEqual(
+        (completed.payload.data as Record<string, unknown>).command,
+        "exit 3",
+      );
+    }),
+  );
+
   it.effect("lets OpenCode own session title generation and emits title metadata updates", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -492,6 +492,16 @@ function messageRoleForPart(
   return part.type === "tool" ? "assistant" : undefined;
 }
 
+// OpenCode carries a bash invocation at `state.input.command`; project it
+// into the command/rawOutput shape every client already renders (mirrors
+// Claude/Codex adapters). Without this, clients fall back to reading the
+// output in `detail` as the command (#7307).
+function commandFromToolInput(part: Extract<Part, { type: "tool" }>): string | undefined {
+  const input = (part.state as { input?: Record<string, unknown> }).input;
+  const command = typeof input?.command === "string" ? input.command.trim() : "";
+  return command || undefined;
+}
+
 function detailFromToolPart(part: Extract<Part, { type: "tool" }>): string | undefined {
   switch (part.state.status) {
     case "completed":
@@ -918,7 +928,9 @@ export function makeOpenCodeAdapter(
             const itemType = toToolLifecycleItemType(part.tool);
             const title =
               part.state.status === "running" ? (part.state.title ?? part.tool) : part.tool;
-            const detail = detailFromToolPart(part);
+            const command =
+              itemType === "command_execution" ? commandFromToolInput(part) : undefined;
+            const detail = command ?? detailFromToolPart(part);
             const payload = {
               itemType,
               ...(part.state.status === "error"
@@ -930,7 +942,14 @@ export function makeOpenCodeAdapter(
               ...(detail ? { detail } : {}),
               data: {
                 tool: part.tool,
-                state: part.state,
+                ...(command
+                  ? {
+                      command,
+                      ...(part.state.status === "completed"
+                        ? { rawOutput: { content: part.state.output } }
+                        : {}),
+                    }
+                  : {}),
               },
             };
             const runtimeEvent: ProviderRuntimeEvent = {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -930,7 +930,12 @@ export function makeOpenCodeAdapter(
               part.state.status === "running" ? (part.state.title ?? part.tool) : part.tool;
             const command =
               itemType === "command_execution" ? commandFromToolInput(part) : undefined;
-            const detail = command ?? detailFromToolPart(part);
+            // Failed commands surface the failure reason; the invocation
+            // itself stays in data.command for the row preview.
+            const detail =
+              part.state.status === "error"
+                ? (detailFromToolPart(part) ?? command)
+                : (command ?? detailFromToolPart(part));
             const payload = {
               itemType,
               ...(part.state.status === "error"

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -82,4 +82,24 @@ describe("deriveWorkLogEntries command output", () => {
     expect(entry?.command).toBe("true");
     expect(entry?.detail).toBeUndefined();
   });
+
+  it("renders the OpenCode bash command as the preview and its output once", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("opencode-command", {
+        itemType: "command_execution",
+        title: "bash",
+        detail: "git status",
+        data: {
+          tool: "bash",
+          command: "git status",
+          rawOutput: { content: "On branch main\nnothing to commit" },
+        },
+      }),
+    ]);
+
+    expect(entry).toMatchObject({
+      command: "git status",
+      detail: "On branch main\nnothing to commit",
+    });
+  });
 });


### PR DESCRIPTION
Fixes #7307

## Problem

With the OpenCode provider, bash tool calls showed the command **output** as the collapsed row title and the same output again inside the expanded body — the actual command being run was never visible (see screenshot in #7307). Claude and Codex users were not affected.

## Root cause

The OpenCode adapter emitted `item.completed` with `detail` set to the command's **output** (`part.state.output`) while never reading the real invocation at `part.state.input.command`. For `command_execution` items, clients fall back to treating `detail` as the command when no structured command field is present, so:

- collapsed title := `command` fallback = output
- expanded body := command block + detail block = output twice
- the actual command was dropped entirely

## Fix

Adapter-side, one place fixes web/desktop/mobile. The `message.part.updated` handler now projects command tools into the payload shape clients already render for Claude/Codex:

- `detail` / `data.command` carry the command (`state.input.command`)
- on completion the output moves to `data.rawOutput.content`, which clients render once in the expanded view
- the unread raw `data.state` blob is no longer sent (nothing consumed it; it duplicated the whole output over the websocket)

Error states keep surfacing `state.error`; non-command tools are unchanged.

## Testing

- Added an adapter test asserting running/completed projections (`OpenCodeAdapter.test.ts`)
- Added a client-shape test asserting the OpenCode payload renders as `command` + single output (`session-logic.command-output.test.ts`)

Worked on by ox-alpha via opencode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider event payloads for command tools, including dropping `data.state`. Low blast radius but it is a wire-format change for OpenCode tool items.
> 
> **Overview**
> Fixes OpenCode bash rows showing stdout as the collapsed title (and again in the expanded body) instead of the actual command (#7307).
> 
> `OpenCodeAdapter` now reads `state.input.command` for `command_execution` items. `detail`/`data.command` carry the invocation; completed output moves to `data.rawOutput.content`. Failures still use `state.error` as `detail` while keeping `data.command`. The unused `data.state` blob is no longer sent.
> 
> A client work-log test confirms the new payload renders as command + a single output block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e343705e311b1de55ac9db72dc6df5d22d9e63bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OpenCodeAdapter` to show bash commands instead of repeating output
> - Modifies tool-part event projection in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7989/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to set `payload.detail` to the command string for command_execution items, and to `payload.data.rawOutput` for the tool output on completion
> - Adds `commandFromToolInput` helper to extract a trimmed command from a tool part's `state.input.command`
> - For error states, `payload.detail` shows the failure reason while `payload.data.command` preserves the original command
> - Behavioral Change: removes the entire `state` object from `payload.data`; consumers expecting `data.state` must use `data.command` and `data.rawOutput` instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e343705.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->