### PR TITLE
fix(web): stop recovered tool failures from marking work logs red

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1470,57 +1470,54 @@ describe("deriveMessagesTimelineRows", () => {
     });
   });
 
-  it("keeps a failure visible when other hidden entries succeeded", () => {
-    const rows = deriveMessagesTimelineRows({
-      timelineEntries: [
-        {
-          id: "failed-work-entry",
-          kind: "work",
-          createdAt: "2026-01-01T00:00:01Z",
-          entry: {
-            id: "failed-work",
-            createdAt: "2026-01-01T00:00:01Z",
-            label: "Ran command",
-            tone: "tool",
-            toolLifecycleStatus: "failed",
-          },
-        },
-        {
-          id: "completed-work-entry",
-          kind: "work",
-          createdAt: "2026-01-01T00:00:02Z",
-          entry: {
-            id: "completed-work",
-            createdAt: "2026-01-01T00:00:02Z",
-            label: "Ran command",
-            tone: "tool",
-            toolLifecycleStatus: "completed",
-          },
-        },
-        {
-          id: "visible-info-entry",
-          kind: "work",
-          createdAt: "2026-01-01T00:00:03Z",
-          entry: {
-            id: "visible-info",
-            createdAt: "2026-01-01T00:00:03Z",
-            label: "Status updated",
-            tone: "info",
-          },
-        },
-      ],
-      isWorking: false,
-      activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
-      revertTurnCountByUserMessageId: new Map(),
-    });
+  it.each([
+    ["the later success is hidden", ["failed", "completed", "info"], false],
+    ["the later success is visible", ["failed", "info", "completed"], false],
+    ["an error-toned entry recovers", ["error", "info", "completed"], false],
+    ["the final failure is hidden", ["completed", "failed", "info"], true],
+    ["the final failure is visible", ["failed", "info", "failed"], true],
+    ["the only failure is visible", ["completed", "info", "failed"], false],
+  ] as const)(
+    "uses the final tool call for mixed work groups when %s",
+    (_, statuses, hasFailure) => {
+      const timelineEntries = statuses.map((status, index) => {
+        const id = `work-${index}`;
+        const createdAt = `2026-01-01T00:00:0${index}Z`;
 
-    expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
-      hiddenCount: 2,
-      summary: null,
-      hasFailure: true,
-    });
-  });
+        return {
+          id: `work-entry-${index}`,
+          kind: "work" as const,
+          createdAt,
+          entry:
+            status === "info"
+              ? { id, createdAt, label: "Status updated", tone: "info" as const }
+              : status === "error"
+                ? { id, createdAt, label: "Command failed", tone: "error" as const }
+                : {
+                    id,
+                    createdAt,
+                    label: "Ran command",
+                    tone: "tool" as const,
+                    toolLifecycleStatus: status,
+                  },
+        };
+      });
+
+      const rows = deriveMessagesTimelineRows({
+        timelineEntries,
+        isWorking: false,
+        activeTurnStartedAt: null,
+        turnDiffSummaryByAssistantMessageId: new Map(),
+        revertTurnCountByUserMessageId: new Map(),
+      });
+
+      expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
+        hiddenCount: 2,
+        summary: null,
+        hasFailure,
+      });
+    },
+  );
 });
 
 describe("computeStableMessagesTimelineRows", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -953,6 +953,8 @@ export function deriveMessagesTimelineRows(input: {
           }
 
           if (hiddenEntries.length > 0) {
+            const latestToolEntry = visibleGroupedEntries.findLast(workLogEntryIsToolLike);
+
             nextRows.push({
               kind: "work-toggle",
               id: `work-toggle:${timelineEntry.id}`,
@@ -963,9 +965,10 @@ export function deriveMessagesTimelineRows(input: {
               onlyToolEntries: hiddenEntries.every(workLogEntryIsToolLike),
               summary: null,
               summaryKind: null,
-              hasFailure: hiddenEntries.some((entry) =>
-                workEntryDisplayIndicatesToolFailure(entry),
-              ),
+              hasFailure:
+                latestToolEntry !== undefined &&
+                workEntryDisplayIndicatesToolFailure(latestToolEntry) &&
+                hiddenEntries.some(workEntryDisplayIndicatesToolFailure),
             });
           }
         }

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -973,6 +973,56 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain('aria-label="Tool call failed"');
   });
 
+  it("keeps mixed work logs neutral after a later tool call succeeds", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-failed",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-failed",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Run search",
+              tone: "tool",
+              itemType: "command_execution",
+              toolLifecycleStatus: "failed",
+            },
+          },
+          {
+            id: "entry-info",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:29.000Z",
+            entry: {
+              id: "work-info",
+              createdAt: "2026-03-17T19:12:29.000Z",
+              label: "Status updated",
+              tone: "info",
+            },
+          },
+          {
+            id: "entry-completed",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:30.000Z",
+            entry: {
+              id: "work-completed",
+              createdAt: "2026-03-17T19:12:30.000Z",
+              label: "Run tests",
+              tone: "tool",
+              itemType: "command_execution",
+              toolLifecycleStatus: "completed",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("+2 previous log entries");
+    expect(markup).not.toContain('aria-label="Hidden work includes a failure"');
+  });
+
   it("shows the animated one-line label for a live tool group", () => {
     const turnId = TurnId.make("turn-live");
     const markup = renderToStaticMarkup(


### PR DESCRIPTION
A failed tool call could leave a collapsed work log red even after a later tool call succeeded. The earlier fix covered tool-only groups but missed mixed work logs.

Mixed work logs now use the latest tool result, while real final failures remain visible. Tests cover hidden recoveries, visible recoveries, and error-toned entries.

Verified with 77 timeline tests, targeted lint and formatting, and the web typecheck.

Made with GPT-5.6 Sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timeline display logic for work-log failure styling; no auth, data, or backend changes.
> 
> **Overview**
> Collapsed mixed work logs no longer stay red after a later tool call succeeds. `hasFailure` now follows the **latest tool-like entry** in the group, and only if a hidden entry actually failed.
> 
> Final failures still mark the toggle. Tests cover hidden vs visible recoveries, error-toned entries, and a render check that the failure aria-label is gone after a later success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0bea8656bc0e0b4e120ad8ea3a02c170f6c167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `deriveMessagesTimelineRows` work-toggle `hasFailure` to require latest visible tool entry failure
> Previously, any hidden failing entry in a work group set `hasFailure` on the collapsed work-toggle row, so a recovered tool failure (failed tool followed by a successful one) still showed the group as red. Now `hasFailure` is true only when the latest visible tool-like grouped entry indicates failure and at least one hidden entry also indicates failure. Adds parameterized tests in [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/7999/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72) and a rendering test in [MessagesTimeline.test.tsx](https://github.com/pingdotgg/t3code/pull/7999/files#diff-ed3eb7f66cdae04c2cff32c0f2feb550aea5dddf9fe3af32adc68f50c0832a61) covering mixed work groups with varying entry orderings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f0bea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->