### PR TITLE
fix(web): keep server update banners flush with the composer

### DIFF
--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -53,6 +53,7 @@ describe("ComposerBannerStack", () => {
     expect(markup).not.toContain("data-composer-banner-stack-expanded-items");
     expect(markup).toContain("chat-composer-drawer-surface");
     expect(markup).toContain("chat-composer-drawer-attached");
+    expect(markup).toContain("before:mask-none");
     expect(markup).toContain("text-xs");
     expect(markup).toContain('data-composer-banner-drawer="true"');
     expect(markup).toContain('data-variant="warning"');

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -199,7 +199,7 @@ function ComposerBannerStackAlert({
       variant={item.variant}
       className={cn(
         attached
-          ? "chat-composer-drawer-surface chat-composer-drawer-attached px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)_+_0.375rem)] text-xs sm:px-4"
+          ? "chat-composer-drawer-surface chat-composer-drawer-attached px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)_+_0.375rem)] text-xs before:mask-none sm:px-4"
           : "alert-glass rounded-[22px]",
         item.className,
       )}


### PR DESCRIPTION
Conversation text showed through between the server update banner and the composer.

Attached composer banners now keep their background visible across the full composer overlap.

Verified with a real server update banner and a synthetic conversation. The previous 17px transparent mask now computes to `none`.

`vp test run apps/web/src/components/chat/ComposerBannerStack.test.tsx`

### Before

![Server update banner before the fix](https://files.tslop.org/2026/08/server-update-banner-before-7bad6462.png)

### After

![Server update banner after the fix](https://files.tslop.org/2026/08/server-update-banner-after-67b51107.png)

Made by GPT-5.6 Sol with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny CSS class tweak on composer banner styling with a matching unit test; no logic or security changes.
> 
> **Overview**
> Stops conversation text from showing through the gap where attached composer banners overlap the composer.
> 
> Attached banners now apply `before:mask-none` so the drawer surface stays opaque across the overlap instead of using the previous transparent mask. The single-banner stack test asserts the class is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceeec6b321ca5a29addb8e1f919c3931f6a542de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `before:mask-none` to `ComposerBannerStackAlert` for flush banners
> Adds the `before:mask-none` CSS utility class to `ComposerBannerStackAlert` when rendering in the attached state. This removes the mask on the `before` pseudo-element so the banner sits flush with the composer. Updates tests to assert the class is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ceeec6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->