### PR TITLE
fix(web): keep code block word wrap across virtualizer remounts

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -67,7 +67,7 @@ import { LRUCache } from "../lib/lruCache";
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { RenderErrorBoundary } from "./RenderErrorBoundary";
 import { useTheme } from "../hooks/useTheme";
-import { getClientSettings } from "../hooks/useSettings";
+import { getClientSettings, updateClientSettings, useClientSettings } from "../hooks/useSettings";
 import {
   chatMarkdownClipboardPayload,
   serializeTableElementToCsv,
@@ -427,14 +427,21 @@ function estimateHighlightedSize(html: string, code: string): number {
   return Math.max(html.length * 2, code.length * 3);
 }
 
-function readInitialWordWrapSetting(): boolean {
-  return getClientSettings().wordWrap;
+// Live word-wrap preference: survives virtualizer remounts, unlike component state.
+function useWordWrapPreference(): [boolean, (value: boolean) => void] {
+  const wordWrap = useClientSettings((settings) => settings.wordWrap);
+  return [
+    wordWrap,
+    useCallback((value: boolean) => {
+      updateClientSettings({ wordWrap: value });
+    }, []),
+  ];
 }
 
 function MarkdownTable({ children, ...props }: React.ComponentProps<"table">) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const tableRef = useRef<HTMLTableElement | null>(null);
-  const [expanded, setExpanded] = useState(readInitialWordWrapSetting);
+  const [expanded, setExpanded] = useWordWrapPreference();
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const expandLabel = expanded ? "Collapse table cells" : "Expand table cells";
@@ -461,7 +468,7 @@ function MarkdownTable({ children, ...props }: React.ComponentProps<"table">) {
       });
     }
 
-    setExpanded((value) => !value);
+    setExpanded(!expanded);
   }
 
   const handleCopy = useCallback((format: "markdown" | "csv") => {
@@ -664,7 +671,7 @@ function MarkdownCodeBlock({
   children: ReactNode;
 }) {
   const [copied, setCopied] = useState(false);
-  const [wrapped, setWrapped] = useState(readInitialWordWrapSetting);
+  const [wrapped, setWrapped] = useWordWrapPreference();
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wrapLabel = wrapped ? "Disable line wrap" : "Wrap lines";
   const copyLabel = copied ? "Copied" : "Copy code";
@@ -731,7 +738,7 @@ function MarkdownCodeBlock({
                   size="icon-xs"
                   className="chat-markdown-chrome-action"
                   aria-pressed={wrapped}
-                  onClick={() => setWrapped((value) => !value)}
+                  onClick={() => setWrapped(!wrapped)}
                   aria-label={wrapLabel}
                 />
               }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -185,6 +185,11 @@ export function getClientSettings(): ClientSettings {
   return getClientSettingsSnapshot();
 }
 
+/** Imperative word-wrap preference update that any component (hook or not) can call. */
+export function updateClientSettings(patch: ClientSettingsPatch): void {
+  persistClientSettings({ ...getClientSettingsSnapshot(), ...patch });
+}
+
 /**
  * Resolves once client settings have been read from disk.
  *


### PR DESCRIPTION
## What

Code block and table wrap toggles used local state seeded from the word wrap setting. The chat list is virtualized, so scrolling unmounts/remounts messages and the toggle reset to the default after a few seconds of scrolling.

## Fix

Toggles now read/write the persisted `wordWrap` client setting instead of local state, so the choice survives remounts.

- Verified: typecheck clean, `ChatMarkdown.test.tsx` 7/7 passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference wiring only. Toggles now persist the global `wordWrap` setting, which can affect other surfaces that read that key.
> 
> **Overview**
> Code-block and table wrap toggles in chat markdown no longer live in local component state. They subscribe to and persist the `wordWrap` client setting, so scrolling a virtualized thread no longer resets wrap after remount.
> 
> Toggling wrap now writes the shared client preference (same key used elsewhere, e.g. diffs) instead of a one-shot seed from `getClientSettings()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd943a931d380e375362c8b48b555ebcb772b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix code block word wrap persistence across virtualizer remounts
> Replaces the one-time `readInitialWordWrapSetting` snapshot with a new `useWordWrapPreference` hook that reads and writes the shared `settings.wordWrap` value via `updateClientSettings`.
> - `MarkdownCodeBlock` and `MarkdownTable` now bind their wrap/expand state to the live, persisted preference instead of a local snapshot, so toggles survive remounts and stay in sync.
> - Adds `updateClientSettings` in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/8004/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) to imperatively merge and persist a `ClientSettingsPatch`.
> - Risk: the wrap/expand toggle now writes through to client settings on every click, so any other reader of `settings.wordWrap` will observe the change immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fcd943a. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->