### PR TITLE
fix(web): treat configured urls with uppercase schemes as secure

### DIFF
--- a/apps/web/src/environments/primary/bootstrap.test.ts
+++ b/apps/web/src/environments/primary/bootstrap.test.ts
@@ -155,6 +155,24 @@ describe("environmentBootstrap", () => {
     });
   });
 
+  it("keeps an uppercase wss scheme secure when deriving the http url", () => {
+    vi.stubEnv("VITE_WS_URL", "WSS://remote.example.com");
+
+    expect(readPrimaryEnvironmentTarget().target).toEqual({
+      httpBaseUrl: "https://remote.example.com/",
+      wsBaseUrl: "wss://remote.example.com/",
+    });
+  });
+
+  it("keeps an uppercase https scheme secure when deriving the websocket url", () => {
+    vi.stubEnv("VITE_HTTP_URL", "HTTPS://remote.example.com");
+
+    expect(readPrimaryEnvironmentTarget().target).toEqual({
+      httpBaseUrl: "https://remote.example.com/",
+      wsBaseUrl: "wss://remote.example.com/",
+    });
+  });
+
   it("uses the current origin as the descriptor base for local dev environments", async () => {
     installTestBrowser("http://localhost:5735/");
     await installDescriptorApi();

--- a/apps/web/src/environments/primary/target.ts
+++ b/apps/web/src/environments/primary/target.ts
@@ -189,14 +189,18 @@ function resolveConfiguredPrimaryTarget(): PrimaryEnvironmentTarget | null {
     return null;
   }
 
+  // Scheme checks run on the raw configured string, while the URL parser
+  // folds schemes to lowercase ("WSS://host" parses fine). Without the
+  // case folding an uppercase scheme would be classified as plaintext and
+  // swapped to http/ws, silently downgrading TLS.
   const resolvedHttpBaseUrl =
     configuredHttpBaseUrl ??
-    (configuredWsBaseUrl?.startsWith("wss:")
+    (configuredWsBaseUrl?.toLowerCase().startsWith("wss:")
       ? swapBaseUrlProtocol(configuredWsBaseUrl, "https:", "websocket-base-url")
       : swapBaseUrlProtocol(configuredWsBaseUrl!, "http:", "websocket-base-url"));
   const resolvedWsBaseUrl =
     configuredWsBaseUrl ??
-    (configuredHttpBaseUrl?.startsWith("https:")
+    (configuredHttpBaseUrl?.toLowerCase().startsWith("https:")
       ? swapBaseUrlProtocol(configuredHttpBaseUrl, "wss:", "http-base-url")
       : swapBaseUrlProtocol(configuredHttpBaseUrl!, "ws:", "http-base-url"));
 


### PR DESCRIPTION
## Problem

`resolveConfiguredPrimaryTarget` classifies `VITE_WS_URL` / `VITE_HTTP_URL` with case-sensitive `startsWith("wss:")` / `startsWith("https:")` checks, while the URL parser folds any scheme casing (`new URL("WSS://host")` is valid). A configured `WSS://host` therefore falls into the plaintext branch and the derived HTTP base URL becomes `http://host` — silently downgrading TLS for that deployment (same for `HTTPS://host` → plain `ws://`).

## Fix

Both raw-string scheme checks are case-folded before classification, so uppercase variants land in the secure branch like their lowercase equivalents.

## Verification

- Two new regression tests in `bootstrap.test.ts` (`WSS://` and `HTTPS://` configured URLs must resolve to https/wss targets); both fail against the old code and pass now.
- Full `environments/primary` suite green, `tsgo --noEmit` clean.

ox-alpha via opencode

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveConfiguredPrimaryTarget` to treat uppercase `HTTPS`/`WSS` schemes as secure
> When only one of `VITE_HTTP_URL` or `VITE_WS_URL` is set, the other is derived from it. Previously, uppercase secure schemes like `HTTPS:` or `WSS:` were not recognized as secure, causing the derived URL to downgrade to `http` or `ws`. The fix in [target.ts](https://github.com/pingdotgg/t3code/pull/8005/files#diff-99ce0255891a2cca2741f0ba0d790a84c1dbe11a91a7b89eeec108bf16864075) normalizes the scheme via `toLowerCase()` before the security check. Tests in [bootstrap.test.ts](https://github.com/pingdotgg/t3code/pull/8005/files#diff-a75892ef0efd0cd9dd2ededd2c01b4274e6c425ca4ef6eba6c701bab817cbde1) cover uppercase `HTTPS` and `WSS` env values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83fe887.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how configured environment URLs are classified as TLS vs plaintext, which previously could silently downgrade derived http/ws bases. The change itself is a small, well-tested case-fold.
> 
> **Overview**
> Stops a silent TLS downgrade when only one of `VITE_HTTP_URL` or `VITE_WS_URL` is set with an uppercase scheme (`HTTPS://` / `WSS://`).
> 
> `resolveConfiguredPrimaryTarget` now case-folds the raw scheme before deciding whether to derive `https`/`wss` vs `http`/`ws`. Regression tests cover both uppercase env values resolving to secure targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fe88759141cf21c8326832ab3acfcf44d5e4cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of uppercase `HTTPS` and `WSS` URL schemes.
  * Secure connections now consistently remain on `https` and `wss` targets instead of being downgraded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->