### PR TITLE
feat(web): redesign skills in `$` menu and in `/` menu

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -36,6 +36,7 @@ const clientSettings: ClientSettings = {
   fontSmoothing: true,
   glassOpacity: 80,
   planModeEnabled: false,
+  showSkillsInSlashMenu: false,
   providerModelPreferences: {},
   sidebarAutoSettleAfterDays: 3,
   sidebarAutoSettleOnMerge: true,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -252,7 +252,11 @@ import type { SessionPhase, Thread } from "../../types";
 import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
 import type { PendingApproval, PendingUserInput } from "../../session-logic";
 import { deriveLatestContextWindowSnapshot } from "../../lib/contextWindow";
-import { formatProviderSkillDisplayName } from "@t3tools/client-runtime/providerSkills";
+import {
+  formatProviderSkillDisplayName,
+  getProviderSlashCommandsForSlashMenu,
+  getProviderSkillsForSlashMenu,
+} from "@t3tools/client-runtime/providerSkills";
 import { searchProviderSkills } from "../../providerSkillSearch";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import type { ReviewCommentContext } from "../../reviewCommentContext";
@@ -1107,30 +1111,32 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             ] as const)
           : []),
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
-      const providerSlashCommandItems = (selectedProviderStatus?.slashCommands ?? []).map(
-        (command) => ({
-          id: `provider-slash-command:${selectedProvider}:${command.name}`,
-          type: "provider-slash-command" as const,
-          provider: selectedProvider,
-          command,
-          label: `/${command.name}`,
-          description: command.description ?? command.input?.hint ?? "Run provider command",
-        }),
-      );
+      const providerSlashCommandItems = getProviderSlashCommandsForSlashMenu(
+        selectedProviderStatus?.slashCommands ?? [],
+        selectedProviderStatus?.skills ?? [],
+      ).map((command) => ({
+        id: `provider-slash-command:${selectedProvider}:${command.name}`,
+        type: "provider-slash-command" as const,
+        provider: selectedProvider,
+        command,
+        label: `/${command.name}`,
+        description: command.description ?? command.input?.hint ?? "Run provider command",
+      }));
       const query = composerTrigger.query.trim().toLowerCase();
-      const skillItems = (selectedProviderStatus?.skills ?? [])
-        .filter((skill) => skill.enabled)
-        .map((skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: `skill:${skill.name}`,
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : ""),
-        }));
+      const skillItems = getProviderSkillsForSlashMenu(
+        selectedProviderStatus?.skills ?? [],
+        settings.showSkillsInSlashMenu,
+      ).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: `/skill:${skill.name}`,
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : ""),
+      }));
       const slashCommandItems = [
         ...builtInSlashCommandItems,
         ...providerSlashCommandItems,
@@ -1159,6 +1165,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     planModeUiEnabled,
     selectedProvider,
     selectedProviderStatus,
+    settings.showSkillsInSlashMenu,
     workspaceEntries.entries,
   ]);
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1111,9 +1111,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             ] as const)
           : []),
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
+      const slashMenuSkills = getProviderSkillsForSlashMenu(
+        selectedProviderStatus?.skills ?? [],
+        settings.showSkillsInSlashMenu,
+      );
       const providerSlashCommandItems = getProviderSlashCommandsForSlashMenu(
         selectedProviderStatus?.slashCommands ?? [],
-        selectedProviderStatus?.skills ?? [],
+        slashMenuSkills,
       ).map((command) => ({
         id: `provider-slash-command:${selectedProvider}:${command.name}`,
         type: "provider-slash-command" as const,
@@ -1123,10 +1127,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         description: command.description ?? command.input?.hint ?? "Run provider command",
       }));
       const query = composerTrigger.query.trim().toLowerCase();
-      const skillItems = getProviderSkillsForSlashMenu(
-        selectedProviderStatus?.skills ?? [],
-        settings.showSkillsInSlashMenu,
-      ).map((skill) => ({
+      const skillItems = slashMenuSkills.map((skill) => ({
         id: `skill:${selectedProvider}:${skill.name}`,
         type: "skill" as const,
         provider: selectedProvider,

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -51,10 +51,12 @@ describe("ComposerCommandMenu", () => {
     expect(markup).not.toContain("<svg");
     expect(markup).toContain("font-sans text-xs font-medium");
     expect(markup).not.toContain("font-mono");
-    expect(markup).toContain("text-right");
+    expect(markup).not.toContain("grid-cols-");
+    expect(markup).toContain("max-w-[45%]");
+    expect(markup).toContain("text-left");
   });
 
-  it("renders a skill source icon with an accessible source label", () => {
+  it("renders the skill source icon inside its badge", () => {
     const markup = renderToStaticMarkup(
       <ComposerCommandMenu
         items={[
@@ -82,40 +84,56 @@ describe("ComposerCommandMenu", () => {
     );
 
     expect(markup).toContain("Browser");
-    expect(markup).toContain('<span class="sr-only">App skill</span>');
+    expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain(">App Skill</span>");
+    expect(markup).toContain("Open and control the in-app browser");
+    expect(markup).toContain("max-w-[48ch]");
+    expect(markup).toContain("text-muted-foreground! text-xs opacity-60");
+    expect(markup).toContain("ms-auto");
+    expect(markup).toContain('data-icon="inline-start"');
+    expect(markup.indexOf("Open and control the in-app browser")).toBeLessThan(
+      markup.indexOf(">App Skill</span>"),
+    );
     expect(markup).toContain("<svg");
-    expect(markup).toContain("text-icon-muted");
+    expect(markup.indexOf('data-slot="badge"')).toBeLessThan(markup.indexOf("<svg"));
   });
 
-  it("renders slash skill results with only the skill prefix dimmed", () => {
+  it("keeps slash skills aligned with the source icon inside the badge", () => {
     const markup = renderToStaticMarkup(
       <ComposerCommandMenu
         items={[
           {
-            id: "skill:codex:browser",
+            id: "skill:codex:ask-matt",
             type: "skill",
             provider: ProviderDriverKind.make("codex"),
             skill: {
-              name: "browser",
-              path: "/skills/browser/SKILL.md",
+              name: "ask-matt",
+              displayName: "Ask Matt",
+              path: "/skills/ask-matt/SKILL.md",
+              scope: "repo",
               enabled: true,
             },
-            label: "skill:browser",
-            description: "Open and control the in-app browser",
+            label: "/skill:ask-matt",
+            description: "Find the right skill or workflow",
           },
         ]}
         resolvedTheme="dark"
         isLoading={false}
         triggerKind="slash-command"
-        activeItemId="skill:codex:browser"
+        activeItemId="skill:codex:ask-matt"
         onHighlightedItemChange={() => {}}
         onSelect={() => {}}
       />,
     );
 
-    expect(markup).toContain('<span class="text-secondary-label">skill:</span>browser');
-    expect(markup).toContain("Open and control the in-app browser");
+    expect(markup).toContain(
+      '/<span class="text-muted-foreground! opacity-60">skill:</span>Ask Matt',
+    );
+    expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain("lucide-git-branch");
+    expect(markup).toContain(">Repo</span>");
+    expect(markup).toContain("Find the right skill or workflow");
     expect(markup).not.toContain("font-medium text-secondary-label");
-    expect(markup).not.toContain("<svg");
+    expect(markup).toContain('data-icon="inline-start"');
   });
 });

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -130,7 +130,7 @@ describe("ComposerCommandMenu", () => {
       '/<span class="text-muted-foreground! opacity-60">skill:</span>Ask Matt',
     );
     expect(markup).toContain('data-slot="badge"');
-    expect(markup).toContain("lucide-git-branch");
+    expect(markup).toContain("lucide-folder");
     expect(markup).toContain(">Repo</span>");
     expect(markup).toContain("Find the right skill or workflow");
     expect(markup).not.toContain("font-medium text-secondary-label");

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -126,7 +126,7 @@ describe("ComposerCommandMenu", () => {
       />,
     );
 
-    expect(markup).toContain('/<span class="text-secondary-label">skill:</span>Ask Matt');
+    expect(markup).toContain('<span class="text-secondary-label">/skill:</span>Ask Matt');
     expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain("lucide-folder");
     expect(markup).toContain(">Repo</span>");

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -88,9 +88,9 @@ describe("ComposerCommandMenu", () => {
     expect(markup).toContain(">App Skill</span>");
     expect(markup).toContain("Open and control the in-app browser");
     expect(markup).toContain("max-w-[48ch]");
-    expect(markup).toContain("text-muted-foreground! text-xs opacity-60");
+    expect(markup).toContain("text-secondary-label text-xs");
     expect(markup).toContain("ms-auto");
-    expect(markup).toContain('data-icon="inline-start"');
+    expect(markup).toContain("text-current");
     expect(markup.indexOf("Open and control the in-app browser")).toBeLessThan(
       markup.indexOf(">App Skill</span>"),
     );
@@ -126,14 +126,11 @@ describe("ComposerCommandMenu", () => {
       />,
     );
 
-    expect(markup).toContain(
-      '/<span class="text-muted-foreground! opacity-60">skill:</span>Ask Matt',
-    );
+    expect(markup).toContain('/<span class="text-secondary-label">skill:</span>Ask Matt');
     expect(markup).toContain('data-slot="badge"');
     expect(markup).toContain("lucide-folder");
     expect(markup).toContain(">Repo</span>");
     expect(markup).toContain("Find the right skill or workflow");
     expect(markup).not.toContain("font-medium text-secondary-label");
-    expect(markup).toContain('data-icon="inline-start"');
   });
 });

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -12,7 +12,6 @@ import {
 import {
   BlocksIcon,
   FolderIcon,
-  GitBranchIcon,
   PackageIcon,
   SettingsIcon,
   UserRoundIcon,
@@ -196,7 +195,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
 
 const SKILL_SOURCE_ICON_BY_KIND: Record<ProviderSkillSourceKind, LucideIcon> = {
   app: BlocksIcon,
-  repo: GitBranchIcon,
+  repo: FolderIcon,
   project: FolderIcon,
   personal: UserRoundIcon,
   system: SettingsIcon,

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -172,14 +172,14 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <span className="min-w-0 max-w-[45%] shrink-0 truncate font-sans text-xs font-medium">
           {isSlashSkill ? (
             <>
-              /<span className="text-muted-foreground! opacity-60">skill:</span>
+              /<span className="text-secondary-label">skill:</span>
               {formatProviderSkillDisplayName(isSlashSkill)}
             </>
           ) : (
             props.item.label
           )}
         </span>
-        <span className="min-w-0 max-w-[48ch] flex-1 truncate text-left text-muted-foreground! text-xs opacity-60">
+        <span className="min-w-0 max-w-[48ch] flex-1 truncate text-left text-secondary-label text-xs">
           {props.item.description}
         </span>
         {skillSourceKind ? (
@@ -215,7 +215,7 @@ function SkillSourceBadge(props: { kind: ProviderSkillSourceKind; showSkillSuffi
   const Icon = SKILL_SOURCE_ICON_BY_KIND[props.kind];
   return (
     <Badge className="ms-auto" variant="secondary">
-      <Icon aria-hidden="true" data-icon="inline-start" />
+      <Icon aria-hidden="true" className="text-current" />
       {SKILL_SOURCE_LABEL_BY_KIND[props.kind]}
       {props.showSkillSuffix ? " Skill" : null}
     </Badge>

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -172,7 +172,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <span className="min-w-0 max-w-[45%] shrink-0 truncate font-sans text-xs font-medium">
           {isSlashSkill ? (
             <>
-              /<span className="text-secondary-label">skill:</span>
+              <span className="text-secondary-label">/skill:</span>
               {formatProviderSkillDisplayName(isSlashSkill)}
             </>
           ) : (

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  formatProviderSkillDisplayName,
   resolveProviderSkillSourceKind,
   type ProviderSkillSourceKind,
 } from "@t3tools/client-runtime/providerSkills";
@@ -10,8 +11,8 @@ import {
 } from "@t3tools/contracts";
 import {
   BlocksIcon,
-  FolderGit2Icon,
   FolderIcon,
+  GitBranchIcon,
   PackageIcon,
   SettingsIcon,
   UserRoundIcon,
@@ -21,6 +22,7 @@ import { memo, useLayoutEffect, useRef } from "react";
 
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
 import { cn } from "~/lib/utils";
+import { Badge } from "../ui/badge";
 import { Command, CommandGroup, CommandItem, CommandList } from "../ui/command";
 import { PierreEntryIcon } from "./PierreEntryIcon";
 
@@ -139,7 +141,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
 }) {
   const skillSourceKind =
     props.item.type === "skill" ? resolveProviderSkillSourceKind(props.item.skill) : null;
-  const slashSkill =
+  const isSlashSkill =
     props.triggerKind === "slash-command" && props.item.type === "skill" ? props.item.skill : null;
 
   return (
@@ -166,23 +168,27 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
           kind={props.item.pathKind}
           theme={props.resolvedTheme}
         />
-      ) : skillSourceKind && !slashSkill ? (
-        <SkillSourceIcon kind={skillSourceKind} />
       ) : null}
-      <span className="flex min-w-0 flex-1 items-baseline gap-3">
-        <span className="shrink-0 font-sans text-xs font-medium">
-          {slashSkill ? (
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="min-w-0 max-w-[45%] shrink-0 truncate font-sans text-xs font-medium">
+          {isSlashSkill ? (
             <>
-              <span className="text-secondary-label">skill:</span>
-              {slashSkill.name}
+              /<span className="text-muted-foreground! opacity-60">skill:</span>
+              {formatProviderSkillDisplayName(isSlashSkill)}
             </>
           ) : (
             props.item.label
           )}
         </span>
-        <span className="min-w-0 flex-1 truncate text-right text-secondary-label text-xs">
+        <span className="min-w-0 max-w-[48ch] flex-1 truncate text-left text-muted-foreground! text-xs opacity-60">
           {props.item.description}
         </span>
+        {skillSourceKind ? (
+          <SkillSourceBadge
+            kind={skillSourceKind}
+            showSkillSuffix={props.triggerKind === "skill"}
+          />
+        ) : null}
       </span>
     </CommandItem>
   );
@@ -190,7 +196,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
 
 const SKILL_SOURCE_ICON_BY_KIND: Record<ProviderSkillSourceKind, LucideIcon> = {
   app: BlocksIcon,
-  repo: FolderGit2Icon,
+  repo: GitBranchIcon,
   project: FolderIcon,
   personal: UserRoundIcon,
   system: SettingsIcon,
@@ -203,15 +209,16 @@ const SKILL_SOURCE_LABEL_BY_KIND: Record<ProviderSkillSourceKind, string> = {
   project: "Project",
   personal: "Personal",
   system: "System",
-  other: "Other",
+  other: "Provider",
 };
 
-function SkillSourceIcon(props: { kind: ProviderSkillSourceKind }) {
+function SkillSourceBadge(props: { kind: ProviderSkillSourceKind; showSkillSuffix: boolean }) {
   const Icon = SKILL_SOURCE_ICON_BY_KIND[props.kind];
   return (
-    <>
-      <Icon aria-hidden="true" className="size-4 shrink-0 text-icon-muted" />
-      <span className="sr-only">{SKILL_SOURCE_LABEL_BY_KIND[props.kind]} skill</span>
-    </>
+    <Badge className="ms-auto" variant="secondary">
+      <Icon aria-hidden="true" data-icon="inline-start" />
+      {SKILL_SOURCE_LABEL_BY_KIND[props.kind]}
+      {props.showSkillSuffix ? " Skill" : null}
+    </Badge>
   );
 }

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -81,7 +81,7 @@ describe("searchSlashCommandItems", () => {
           enabled: true,
           shortDescription: "Open and control the in-app browser",
         },
-        label: "skill:browser",
+        label: "/skill:browser",
         description: "Open and control the in-app browser",
       },
     ] satisfies Array<Extract<ComposerCommandItem, { type: "skill" }>>;
@@ -97,23 +97,26 @@ describe("searchSlashCommandItems", () => {
   it("matches skills by display name", () => {
     const items = [
       {
-        id: "skill:claudeAgent:browser",
+        id: "skill:claudeAgent:ask-matt",
         type: "skill",
         provider: claudeDriver,
         skill: {
-          name: "browser",
-          displayName: "Web Navigator",
-          path: "/skills/browser/SKILL.md",
+          name: "ask-matt",
+          displayName: "Ask Matt",
+          path: "/skills/ask-matt/SKILL.md",
           enabled: true,
-          shortDescription: "Open and control the in-app browser",
+          shortDescription: "Find the right skill or workflow",
         },
-        label: "skill:browser",
-        description: "Open and control the in-app browser",
+        label: "/skill:ask-matt",
+        description: "Find the right skill or workflow",
       },
     ] satisfies Array<Extract<ComposerCommandItem, { type: "skill" }>>;
 
-    expect(searchSlashCommandItems(items, "navigator").map((item) => item.id)).toEqual([
-      "skill:claudeAgent:browser",
+    expect(searchSlashCommandItems(items, "ask matt").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:ask-matt",
+    ]);
+    expect(searchSlashCommandItems(items, "/skill:ask-matt").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:ask-matt",
     ]);
   });
 
@@ -128,7 +131,7 @@ describe("searchSlashCommandItems", () => {
           path: "/skills/browser/SKILL.md",
           enabled: true,
         },
-        label: "skill:browser",
+        label: "/skill:browser",
         description: "Open and control the in-app browser",
       },
     ] satisfies Array<Extract<ComposerCommandItem, { type: "skill" }>>;
@@ -136,7 +139,9 @@ describe("searchSlashCommandItems", () => {
     expect(searchSlashCommandItems(items, "/skill:brow").map((item) => item.id)).toEqual([
       "skill:claudeAgent:browser",
     ]);
-    expect(searchSlashCommandItems(items, "/sk")).toEqual([]);
+    expect(searchSlashCommandItems(items, "/sk").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:browser",
+    ]);
     expect(searchSlashCommandItems(items, "/ill")).toEqual([]);
   });
 
@@ -158,7 +163,7 @@ describe("searchSlashCommandItems", () => {
           path: "/skills/unslop/SKILL.md",
           enabled: true,
         },
-        label: "skill:unslop",
+        label: "/skill:unslop",
         description: "Cut AI tells from writing",
       },
     ] satisfies Array<Extract<ComposerCommandItem, { type: "slash-command" | "skill" }>>;

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -145,36 +145,6 @@ describe("searchSlashCommandItems", () => {
     expect(searchSlashCommandItems(items, "/ill")).toEqual([]);
   });
 
-  it("keeps command prefix matches ahead of the skill prefix alias", () => {
-    const items = [
-      {
-        id: "provider-slash-command:claudeAgent:sketch",
-        type: "provider-slash-command",
-        provider: claudeDriver,
-        command: { name: "sketch" },
-        label: "/sketch",
-        description: "Sketch an implementation",
-      },
-      {
-        id: "skill:claudeAgent:browser",
-        type: "skill",
-        provider: claudeDriver,
-        skill: {
-          name: "browser",
-          path: "/skills/browser/SKILL.md",
-          enabled: true,
-        },
-        label: "/skill:browser",
-        description: "Open and control the in-app browser",
-      },
-    ] satisfies Array<Extract<ComposerCommandItem, { type: "provider-slash-command" | "skill" }>>;
-
-    expect(searchSlashCommandItems(items, "/sk").map((item) => item.id)).toEqual([
-      "provider-slash-command:claudeAgent:sketch",
-      "skill:claudeAgent:browser",
-    ]);
-  });
-
   it("keeps skills alongside commands for an empty slash query", () => {
     const items = [
       {

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -145,6 +145,36 @@ describe("searchSlashCommandItems", () => {
     expect(searchSlashCommandItems(items, "/ill")).toEqual([]);
   });
 
+  it("keeps command prefix matches ahead of the skill prefix alias", () => {
+    const items = [
+      {
+        id: "provider-slash-command:claudeAgent:sketch",
+        type: "provider-slash-command",
+        provider: claudeDriver,
+        command: { name: "sketch" },
+        label: "/sketch",
+        description: "Sketch an implementation",
+      },
+      {
+        id: "skill:claudeAgent:browser",
+        type: "skill",
+        provider: claudeDriver,
+        skill: {
+          name: "browser",
+          path: "/skills/browser/SKILL.md",
+          enabled: true,
+        },
+        label: "/skill:browser",
+        description: "Open and control the in-app browser",
+      },
+    ] satisfies Array<Extract<ComposerCommandItem, { type: "provider-slash-command" | "skill" }>>;
+
+    expect(searchSlashCommandItems(items, "/sk").map((item) => item.id)).toEqual([
+      "provider-slash-command:claudeAgent:sketch",
+      "skill:claudeAgent:browser",
+    ]);
+  });
+
   it("keeps skills alongside commands for an empty slash query", () => {
     const items = [
       {

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -14,11 +14,15 @@ type SlashSearchItem = Extract<
 
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
   if (item.type === "skill") {
-    if ("skill".startsWith(query)) {
+    if (query === "skill") {
       return 0;
     }
     const skillQuery = query.startsWith("skill:") ? query.slice("skill:".length) : query;
-    return skillQuery ? scoreProviderSkill(item.skill, skillQuery) : 0;
+    const skillScore = skillQuery ? scoreProviderSkill(item.skill, skillQuery) : 0;
+    if (skillScore !== null) {
+      return skillScore;
+    }
+    return "skill".startsWith(query) ? Number.MAX_SAFE_INTEGER : null;
   }
 
   const primaryValue =

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -14,8 +14,10 @@ type SlashSearchItem = Extract<
 
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
   if (item.type === "skill") {
-    const skillQuery =
-      query === "skill" ? "" : query.startsWith("skill:") ? query.slice("skill:".length) : query;
+    if ("skill".startsWith(query)) {
+      return 0;
+    }
+    const skillQuery = query.startsWith("skill:") ? query.slice("skill:".length) : query;
     return skillQuery ? scoreProviderSkill(item.skill, skillQuery) : 0;
   }
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -507,6 +507,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
         ? ["Diff whitespace changes"]
         : []),
+      ...(settings.showSkillsInSlashMenu !== DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu
+        ? ["Show skills in slash menu"]
+        : []),
       ...(settings.enableLegacyTokenStreaming !==
       DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming
         ? ["Stream token by token"]
@@ -573,6 +576,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarAutoSettleOnMerge,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
+      settings.showSkillsInSlashMenu,
       settings.timestampFormat,
       settings.wordWrap,
       followSystem,
@@ -648,6 +652,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+      showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
@@ -2072,6 +2077,32 @@ export function GeneralSettingsPanel() {
                 updateSettings({ diffIgnoreWhitespace: Boolean(checked) })
               }
               aria-label="Hide whitespace changes by default"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("skills-in-slash-menu")}
+          description="Also include skills in the / command menu. Skills always appear when you type $."
+          resetAction={
+            settings.showSkillsInSlashMenu !== DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu ? (
+              <SettingResetButton
+                label="skills in slash menu"
+                onClick={() =>
+                  updateSettings({
+                    showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.showSkillsInSlashMenu}
+              onCheckedChange={(checked) =>
+                updateSettings({ showSkillsInSlashMenu: Boolean(checked) })
+              }
+              aria-label="Show skills in slash menu"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -132,6 +132,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "skills-in-slash-menu",
+    title: "Show skills in slash menu",
+    to: "/settings/general",
+  },
+  {
     id: "provider-update-checks",
     title: "Provider update checks",
     to: "/settings/general",

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -4,6 +4,17 @@ Messages can contain up to 120,000 characters. If a draft is longer, T3 Code kee
 composer and shows how many characters need to be removed. Shorten the draft or split it into
 multiple messages, then send again in the same thread.
 
+## Commands and skills
+
+Type `/` to open the command menu. Type `$` to find and add a skill. Skill rows show their source,
+such as System, Personal, Project, or App.
+
+By default, the `/` menu contains commands only. To include skills in this menu, turn on **Show
+skills in slash menu** in **Settings → General**. These results use the `/skill:Skill Name` label and
+add the same `$name` skill token to your message. The original skill name remains searchable. If the
+provider also reports that skill as a native slash command, T3 Code hides the duplicate native entry
+and keeps the `/skill:Skill Name` label.
+
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -9,11 +9,11 @@ multiple messages, then send again in the same thread.
 Type `/` to open the command menu. Type `$` to find and add a skill. Skill rows show their source,
 such as System, Personal, Project, or App.
 
-By default, the `/` menu contains commands only. To include skills in this menu, turn on **Show
-skills in slash menu** in **Settings → General**. These results use the `/skill:Skill Name` label and
-add the same `$name` skill token to your message. The original skill name remains searchable. If the
-provider also reports that skill as a native slash command, T3 Code hides the duplicate native entry
-and keeps the `/skill:Skill Name` label.
+By default, the `/` menu includes skills. To keep this menu command-only, turn off **Show skills in
+slash menu** in **Settings → General**. Skill results use the `/skill:Skill Name` label and add the
+same `$name` skill token to your message. The original skill name remains searchable. If the provider
+also reports that skill as a native slash command, T3 Code hides the duplicate native entry and keeps
+the `/skill:Skill Name` label.
 
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -55,22 +55,30 @@ describe("getProviderSkillsForSlashMenu", () => {
 });
 
 describe("getProviderSlashCommandsForSlashMenu", () => {
-  it("lets the skill alias win when a provider command has the same name", () => {
-    const commands = [
-      { name: "ask-matt", description: "Ask which skill fits your situation." },
-      { name: "compact", description: "Compact the conversation." },
-    ];
-    const skills = [
-      {
-        name: "ask-matt",
-        path: "/Users/matt/.agents/skills/ask-matt/SKILL.md",
-        enabled: true,
-      },
-    ];
+  const commands = [
+    { name: "ask-matt", description: "Ask which skill fits your situation." },
+    { name: "compact", description: "Compact the conversation." },
+  ];
+  const skills = [
+    {
+      name: "ask-matt",
+      path: "/Users/matt/.agents/skills/ask-matt/SKILL.md",
+      enabled: true,
+    },
+  ];
 
+  it("lets the skill alias win when a provider command has the same name", () => {
     expect(
       getProviderSlashCommandsForSlashMenu(commands, skills).map((command) => command.name),
     ).toEqual(["compact"]);
+  });
+
+  it("keeps the provider command when the matching skill alias is hidden", () => {
+    const visibleSkills = getProviderSkillsForSlashMenu(skills, false);
+
+    expect(
+      getProviderSlashCommandsForSlashMenu(commands, visibleSkills).map((command) => command.name),
+    ).toEqual(["ask-matt", "compact"]);
   });
 });
 

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   formatProviderSkillDisplayName,
+  getProviderSlashCommandsForSlashMenu,
+  getProviderSkillsForSlashMenu,
   resolveProviderSkillSourceKind,
 } from "./providerSkills.ts";
 
@@ -21,6 +23,54 @@ describe("formatProviderSkillDisplayName", () => {
         name: "review-follow-up",
       }),
     ).toBe("Review Follow Up");
+  });
+});
+
+describe("getProviderSkillsForSlashMenu", () => {
+  const skills = [
+    { name: "browser", path: "/skills/browser/SKILL.md", enabled: true },
+    { name: "retired", path: "/skills/retired/SKILL.md", enabled: false },
+  ];
+
+  it("keeps skills out of the slash menu by default", () => {
+    expect(getProviderSkillsForSlashMenu(skills, false)).toEqual([]);
+  });
+
+  it("includes enabled skills after the user opts in", () => {
+    expect(getProviderSkillsForSlashMenu(skills, true).map((skill) => skill.name)).toEqual([
+      "browser",
+    ]);
+  });
+
+  it("keeps the skill alias when the provider also exposes it as a slash command", () => {
+    const askMatt = {
+      name: "ask-matt",
+      path: "/Users/matt/.agents/skills/ask-matt/SKILL.md",
+      enabled: true,
+    };
+    expect(getProviderSkillsForSlashMenu([askMatt], true).map((skill) => skill.name)).toEqual([
+      "ask-matt",
+    ]);
+  });
+});
+
+describe("getProviderSlashCommandsForSlashMenu", () => {
+  it("lets the skill alias win when a provider command has the same name", () => {
+    const commands = [
+      { name: "ask-matt", description: "Ask which skill fits your situation." },
+      { name: "compact", description: "Compact the conversation." },
+    ];
+    const skills = [
+      {
+        name: "ask-matt",
+        path: "/Users/matt/.agents/skills/ask-matt/SKILL.md",
+        enabled: true,
+      },
+    ];
+
+    expect(
+      getProviderSlashCommandsForSlashMenu(commands, skills).map((command) => command.name),
+    ).toEqual(["compact"]);
   });
 });
 

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -27,21 +27,6 @@ describe("formatProviderSkillDisplayName", () => {
 });
 
 describe("getProviderSkillsForSlashMenu", () => {
-  const skills = [
-    { name: "browser", path: "/skills/browser/SKILL.md", enabled: true },
-    { name: "retired", path: "/skills/retired/SKILL.md", enabled: false },
-  ];
-
-  it("keeps skills out of the slash menu by default", () => {
-    expect(getProviderSkillsForSlashMenu(skills, false)).toEqual([]);
-  });
-
-  it("includes enabled skills after the user opts in", () => {
-    expect(getProviderSkillsForSlashMenu(skills, true).map((skill) => skill.name)).toEqual([
-      "browser",
-    ]);
-  });
-
   it("keeps the skill alias when the provider also exposes it as a slash command", () => {
     const askMatt = {
       name: "ask-matt",

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -34,11 +34,9 @@ export function getProviderSkillsForSlashMenu(
 
 export function getProviderSlashCommandsForSlashMenu(
   slashCommands: ReadonlyArray<ServerProviderSlashCommand>,
-  skills: ReadonlyArray<ServerProviderSkill>,
+  visibleSkills: ReadonlyArray<ServerProviderSkill>,
 ): ServerProviderSlashCommand[] {
-  const skillNames = new Set(
-    skills.filter((skill) => skill.enabled).map((skill) => skill.name.trim().toLowerCase()),
-  );
+  const skillNames = new Set(visibleSkills.map((skill) => skill.name.trim().toLowerCase()));
   return slashCommands.filter((command) => !skillNames.has(command.name.trim().toLowerCase()));
 }
 

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -1,4 +1,4 @@
-import type { ServerProviderSkill } from "@t3tools/contracts";
+import type { ServerProviderSkill, ServerProviderSlashCommand } from "@t3tools/contracts";
 
 export type ProviderSkillSourceKind = "app" | "repo" | "project" | "personal" | "system" | "other";
 
@@ -23,6 +23,23 @@ export function formatProviderSkillDisplayName(
     return displayName;
   }
   return titleCaseWords(skill.name);
+}
+
+export function getProviderSkillsForSlashMenu(
+  skills: ReadonlyArray<ServerProviderSkill>,
+  showSkillsInSlashMenu: boolean,
+): ServerProviderSkill[] {
+  return showSkillsInSlashMenu ? skills.filter((skill) => skill.enabled) : [];
+}
+
+export function getProviderSlashCommandsForSlashMenu(
+  slashCommands: ReadonlyArray<ServerProviderSlashCommand>,
+  skills: ReadonlyArray<ServerProviderSkill>,
+): ServerProviderSlashCommand[] {
+  const skillNames = new Set(
+    skills.filter((skill) => skill.enabled).map((skill) => skill.name.trim().toLowerCase()),
+  );
+  return slashCommands.filter((command) => !skillNames.has(command.name.trim().toLowerCase()));
 }
 
 export function resolveProviderSkillSourceKind(

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -35,6 +35,15 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings composer menus", () => {
+  it("keeps skills in the dollar menu unless the slash-menu option is enabled", () => {
+    expect(decodeClientSettings({}).showSkillsInSlashMenu).toBe(false);
+    expect(decodeClientSettingsPatch({ showSkillsInSlashMenu: true }).showSkillsInSlashMenu).toBe(
+      true,
+    );
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -35,15 +35,6 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
-describe("ClientSettings composer menus", () => {
-  it("keeps skills in the dollar menu unless the slash-menu option is enabled", () => {
-    expect(decodeClientSettings({}).showSkillsInSlashMenu).toBe(false);
-    expect(decodeClientSettingsPatch({ showSkillsInSlashMenu: true }).showSkillsInSlashMenu).toBe(
-      true,
-    );
-  });
-});
-
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -225,7 +225,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // default UI; this beta flag restores it (plus the /plan and /default slash
   // commands) for users who still rely on the old workflow.
   planModeEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
   // (was `sidebarV2Enabled` + `sidebarV2ConfiguredByUser`): decoding drops the
   // old keys, so everyone, including prior beta opt-outs, resets to the new

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -225,6 +225,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // default UI; this beta flag restores it (plus the /plan and /default slash
   // commands) for users who still rely on the old workflow.
   planModeEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
   // (was `sidebarV2Enabled` + `sidebarV2ConfiguredByUser`): decoding drops the
   // old keys, so everyone, including prior beta opt-outs, resets to the new
@@ -913,6 +914,7 @@ export const ClientSettingsPatch = Schema.Struct({
     ),
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
+  showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarAutoSettleOnMerge: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
## What Changed

- Made `$` the primary skill menu.
- Added an opt-in **Show skills in slash menu** setting.
- Rendered slash-menu skills as `/skill:Skill Name` while keeping their original names searchable.
- Muted skill prefixes and descriptions, shortened long descriptions, and moved source icons into right-aligned badges.
- Removed duplicate provider slash commands when a matching skill exists.

## Why

Styling in both the $ and / menus was inconsistent. Skills didn't fit in the / menu and icons in the $ menu weren't clearly explaining their meaning.

## UI Changes

Before:

<img width="798" height="458" alt="image" src="https://github.com/user-attachments/assets/8a28ed49-fbc5-45f4-8957-cf8751d5d87e" />

<img width="827" height="514" alt="image" src="https://github.com/user-attachments/assets/501e70d0-0e7d-4410-9c40-fb6da903f419" />

After:

<img width="838" height="523" alt="image" src="https://github.com/user-attachments/assets/adc62588-0376-4144-83ac-eddb22c433d3" />

<img width="866" height="560" alt="image" src="https://github.com/user-attachments/assets/9fcaf8ae-9c36-454b-bafc-c9c9a8808009" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

Built with GPT-5.6 Sol in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign skill display in `/` menu and add `showSkillsInSlashMenu` setting
> - Adds `showSkillsInSlashMenu` setting (default `true`) to persist user preference for showing provider skills in the `/` menu, with a toggle in Settings → General.
> - Skills in the `/` menu use the `/skill:<name>` label format, and provider slash commands that duplicate a visible skill name are filtered out via `getProviderSlashCommandsForSlashMenu`.
> - Redesigns `ComposerCommandMenu` items to use left-aligned labels and a right-aligned `SkillSourceBadge` showing the skill source icon and label.
> - Updates slash search logic to support `/skill:` prefixes and retain skills for partial `sk` queries.
> - Behavioral Change: the `other` skill source label is now "Provider" and the `repo` source icon changes from `FolderGit2Icon` to `FolderIcon`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c4771b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer UI and a client-local boolean setting only; no auth, data, or server-side behavior changes.
> 
> **Overview**
> Redesigns how skills appear in the composer `/` and `$` menus, and adds a **Show skills in slash menu** setting (default on) so users can keep `/` command-only. Skills still always show when typing `$`.
> 
> Slash-menu skills now render as `/skill:Display Name` (original names stay searchable). Provider slash commands that share a visible skill name are dropped so the skill alias wins. Menu rows use left-aligned labels/descriptions and a right-aligned source **badge** (App, Repo, Personal, etc.; `other` is labeled Provider).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c4771bd7ce3c0465bef23e3cf79e252cc71a956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->