### PR TITLE
fix(web): scale Files tree with interface font size

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -41,7 +41,7 @@ const TREE_UNSAFE_CSS = `
     --trees-hover-bg-override: color-mix(in srgb, currentColor 7%, transparent);
     --trees-border-color-override: color-mix(in srgb, currentColor 14%, transparent);
     --trees-font-family-override: var(--font-sans);
-    --trees-font-size-override: 12px;
+    --trees-font-size-override: 0.75rem;
   }
   button[data-type='item'] { border-radius: 5px; }
 `;


### PR DESCRIPTION
## What changed

The Files tree was overriding its font size with a fixed `12px`, so it ignored Settings → Appearance → Interface font size. This changes the override to `0.75rem`, preserving the existing 12px default at the 16px interface setting while allowing the tree to scale with the interface.

## Why

Fixes the Files-tree typography bug reported in #7957 without adding another setting or changing the compact default.

## Verification

- `vp fmt --check apps/web/src/components/files/FileBrowserPanel.tsx`
- `vp lint --report-unused-disable-directives apps/web/src/components/files/FileBrowserPanel.tsx`
- `vp run --filter @t3tools/web typecheck`
- Manual local web verification with a disposable T3 home: the tree measured 12px at Interface 16px and 15px at Interface 20px.
- The change is limited to one CSS custom-property value in `FileBrowserPanel.tsx`.

## UI evidence

Before/after screenshots were captured at the same 20px interface setting: the old tree remains 12px, while the patched tree scales to 15px.

### Before

![Before: Files tree remains at 12px](https://github.com/Umais-Adeed/t3code/releases/download/pr-8011-evidence/t3-files-before.png)

### After

![After: Files tree scales to 15px](https://github.com/Umais-Adeed/t3code/releases/download/pr-8011-evidence/t3-files-after.png)

Fixes #7957

Generated with GPT-5.6-Luna in T3 Code using the Codex harness.
