### PR TITLE
fix(web): choose a server for grouped projects

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -126,7 +126,13 @@ export interface CommandPaletteView {
 
 export function enumerateCommandPaletteItems(
   items: ReadonlyArray<CommandPaletteActionItem>,
-): CommandPaletteActionItem[] {
+): CommandPaletteActionItem[];
+export function enumerateCommandPaletteItems(
+  items: ReadonlyArray<CommandPaletteActionItem | CommandPaletteSubmenuItem>,
+): Array<CommandPaletteActionItem | CommandPaletteSubmenuItem>;
+export function enumerateCommandPaletteItems(
+  items: ReadonlyArray<CommandPaletteActionItem | CommandPaletteSubmenuItem>,
+): Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> {
   return items.map((item, index) => {
     const shortcutCommand = THREAD_JUMP_KEYBINDING_COMMANDS[index];
     if (shortcutCommand) return { ...item, shortcutCommand };

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -42,7 +42,6 @@ import {
   FolderPlusIcon,
   LinkIcon,
   MessageSquareIcon,
-  MonitorIcon,
   PaletteIcon,
   ServerIcon,
   SettingsIcon,
@@ -166,7 +165,7 @@ import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore"
 import {
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
-  type SidebarProjectGroupMember,
+  listNewThreadProjectDestinations,
 } from "../sidebarProjectGrouping";
 import type { Project } from "../types";
 
@@ -667,7 +666,11 @@ function OpenCommandPaletteDialog(props: {
             {
               kind: isLocal ? "local" : "remote",
               label: isPrimary
-                ? environment.label
+                ? resolveEnvironmentOptionLabel({
+                    isPrimary,
+                    environmentId: environment.environmentId,
+                    runtimeLabel: environment.label,
+                  })
                 : isLocal
                   ? `${environment.label} (Local)`
                   : environment.label,
@@ -1028,23 +1031,15 @@ function OpenCommandPaletteDialog(props: {
       enumerateCommandPaletteItems(
         projectPickerEntries.map(
           ({ group, targetProject }): CommandPaletteActionItem | CommandPaletteSubmenuItem => {
-            const projectByEnvironmentId = new Map<EnvironmentId, SidebarProjectGroupMember>();
-            for (const member of group.memberProjects) {
-              if (
-                !projectByEnvironmentId.has(member.environmentId) ||
-                (member.environmentId === targetProject.environmentId &&
-                  member.id === targetProject.id)
-              ) {
-                projectByEnvironmentId.set(member.environmentId, member);
-              }
-            }
-            const locations = [...projectByEnvironmentId.values()].map((member) => {
-              const location = projectEnvironmentLocationById.get(member.environmentId) ?? {
-                kind: "remote" as const,
-                label: member.environmentLabel ?? member.environmentId,
-              };
-              return { location, member };
-            });
+            const locations = listNewThreadProjectDestinations(group, targetProject).map(
+              (member) => {
+                const location = projectEnvironmentLocationById.get(member.environmentId) ?? {
+                  kind: "remote" as const,
+                  label: member.environmentLabel ?? member.environmentId,
+                };
+                return { location, member };
+              },
+            );
             const searchTerms = group.memberProjects.flatMap((member) => [
               member.title,
               member.workspaceRoot,
@@ -1066,14 +1061,13 @@ function OpenCommandPaletteDialog(props: {
                     value: `new-thread-in-servers:${group.projectKey}`,
                     label: "Run on",
                     items: locations.map(({ location, member }) => {
-                      const LocationIcon = location.kind === "local" ? MonitorIcon : ServerIcon;
                       return {
                         kind: "action" as const,
                         value: `new-thread-in-server:${member.environmentId}:${member.id}`,
                         searchTerms: [location.label, member.workspaceRoot, member.title],
                         title: location.label,
                         description: member.workspaceRoot,
-                        icon: <LocationIcon className={ITEM_ICON_CLASS} />,
+                        icon: <ServerIcon className={ITEM_ICON_CLASS} />,
                         run: async () => {
                           await handleNewThread(scopeProjectRef(member.environmentId, member.id));
                         },
@@ -1095,7 +1089,6 @@ function OpenCommandPaletteDialog(props: {
                   projectRef.environmentId === contextualProjectRef.environmentId &&
                   projectRef.projectId === contextualProjectRef.projectId,
               );
-            const LocationIcon = activeLocation.kind === "local" ? MonitorIcon : ServerIcon;
             return {
               kind: "action",
               value: `new-thread-in:${targetProject.environmentId}:${targetProject.id}`,
@@ -1103,7 +1096,7 @@ function OpenCommandPaletteDialog(props: {
               title: group.displayName,
               description: (
                 <span className="flex min-w-0 items-center gap-1">
-                  <LocationIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
+                  <ServerIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
                   <span className="truncate">{activeLocation.label}</span>
                   <CommandPaletteMetaDot />
                   <span className="truncate">{targetProject.workspaceRoot}</span>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -42,6 +42,7 @@ import {
   FolderPlusIcon,
   LinkIcon,
   MessageSquareIcon,
+  MonitorIcon,
   PaletteIcon,
   ServerIcon,
   SettingsIcon,
@@ -165,6 +166,7 @@ import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore"
 import {
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  type SidebarProjectGroupMember,
 } from "../sidebarProjectGrouping";
 import type { Project } from "../types";
 
@@ -665,7 +667,7 @@ function OpenCommandPaletteDialog(props: {
             {
               kind: isLocal ? "local" : "remote",
               label: isPrimary
-                ? "Local"
+                ? environment.label
                 : isLocal
                   ? `${environment.label} (Local)`
                   : environment.label,
@@ -1024,61 +1026,102 @@ function OpenCommandPaletteDialog(props: {
   const projectThreadItems = useMemo(
     () =>
       enumerateCommandPaletteItems(
-        buildProjectActionItems({
-          projects: pickerProjects,
-          valuePrefix: "new-thread-in",
-          searchTerms: (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            const location = projectEnvironmentLocationById.get(project.environmentId);
-            return [
-              ...(group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ??
-                []),
-              ...(location ? [location.label] : []),
-            ];
-          },
-          renderDescription: (project) => {
-            const location = projectEnvironmentLocationById.get(project.environmentId) ?? {
-              kind: "remote",
+        projectPickerEntries.map(
+          ({ group, targetProject }): CommandPaletteActionItem | CommandPaletteSubmenuItem => {
+            const projectByEnvironmentId = new Map<EnvironmentId, SidebarProjectGroupMember>();
+            for (const member of group.memberProjects) {
+              if (
+                !projectByEnvironmentId.has(member.environmentId) ||
+                (member.environmentId === targetProject.environmentId &&
+                  member.id === targetProject.id)
+              ) {
+                projectByEnvironmentId.set(member.environmentId, member);
+              }
+            }
+            const locations = [...projectByEnvironmentId.values()].map((member) => {
+              const location = projectEnvironmentLocationById.get(member.environmentId) ?? {
+                kind: "remote" as const,
+                label: member.environmentLabel ?? member.environmentId,
+              };
+              return { location, member };
+            });
+            const searchTerms = group.memberProjects.flatMap((member) => [
+              member.title,
+              member.workspaceRoot,
+              member.environmentLabel ?? member.environmentId,
+            ]);
+            const icon = projectFavicon(targetProject);
+
+            if (locations.length > 1) {
+              return {
+                kind: "submenu",
+                value: `new-thread-in:${targetProject.environmentId}:${targetProject.id}`,
+                searchTerms,
+                title: group.displayName,
+                description: `${locations.length} servers`,
+                icon,
+                addonIcon: <ServerIcon className={ADDON_ICON_CLASS} />,
+                groups: [
+                  {
+                    value: `new-thread-in-servers:${group.projectKey}`,
+                    label: "Run on",
+                    items: locations.map(({ location, member }) => {
+                      const LocationIcon = location.kind === "local" ? MonitorIcon : ServerIcon;
+                      return {
+                        kind: "action" as const,
+                        value: `new-thread-in-server:${member.environmentId}:${member.id}`,
+                        searchTerms: [location.label, member.workspaceRoot, member.title],
+                        title: location.label,
+                        description: member.workspaceRoot,
+                        icon: <LocationIcon className={ITEM_ICON_CLASS} />,
+                        run: async () => {
+                          await handleNewThread(scopeProjectRef(member.environmentId, member.id));
+                        },
+                      };
+                    }),
+                  },
+                ],
+              };
+            }
+
+            const activeLocation = locations[0]?.location ?? {
+              kind: "remote" as const,
               label: "Remote",
             };
-            return (
-              <span className="flex min-w-0 items-center gap-1">
-                <span className="inline-flex min-w-0 items-center gap-1">
-                  {location.kind === "remote" ? (
-                    <ServerIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
-                  ) : null}
-                  <span className="truncate">{location.label}</span>
-                </span>
-                <CommandPaletteMetaDot />
-                <span className="truncate">{project.workspaceRoot}</span>
-              </span>
-            );
-          },
-          icon: projectFavicon,
-          runProject: async (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
             const contextualRefBelongsToGroup =
               contextualProjectRef !== null &&
-              group?.memberProjectRefs.some(
+              group.memberProjectRefs.some(
                 (projectRef) =>
                   projectRef.environmentId === contextualProjectRef.environmentId &&
                   projectRef.projectId === contextualProjectRef.projectId,
               );
-            await handleNewThread(
-              contextualRefBelongsToGroup
-                ? contextualProjectRef
-                : scopeProjectRef(project.environmentId, project.id),
-            );
+            const LocationIcon = activeLocation.kind === "local" ? MonitorIcon : ServerIcon;
+            return {
+              kind: "action",
+              value: `new-thread-in:${targetProject.environmentId}:${targetProject.id}`,
+              searchTerms,
+              title: group.displayName,
+              description: (
+                <span className="flex min-w-0 items-center gap-1">
+                  <LocationIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
+                  <span className="truncate">{activeLocation.label}</span>
+                  <CommandPaletteMetaDot />
+                  <span className="truncate">{targetProject.workspaceRoot}</span>
+                </span>
+              ),
+              icon,
+              run: async () => {
+                await handleNewThread(
+                  contextualRefBelongsToGroup
+                    ? contextualProjectRef
+                    : scopeProjectRef(targetProject.environmentId, targetProject.id),
+                );
+              },
+            };
           },
-        }),
+        ),
       ),
-    [
-      contextualProjectRef,
-      handleNewThread,
-      pickerProjects,
-      projectEnvironmentLocationById,
-      projectGroupByTargetKey,
-    ],
+    [contextualProjectRef, handleNewThread, projectEnvironmentLocationById, projectPickerEntries],
   );
 
   const allThreadItems = useMemo(

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -42,6 +42,7 @@ import {
   FolderPlusIcon,
   LinkIcon,
   MessageSquareIcon,
+  MonitorIcon,
   PaletteIcon,
   ServerIcon,
   SettingsIcon,
@@ -1061,13 +1062,14 @@ function OpenCommandPaletteDialog(props: {
                     value: `new-thread-in-servers:${group.projectKey}`,
                     label: "Run on",
                     items: locations.map(({ location, member }) => {
+                      const LocationIcon = location.kind === "local" ? MonitorIcon : ServerIcon;
                       return {
                         kind: "action" as const,
                         value: `new-thread-in-server:${member.environmentId}:${member.id}`,
                         searchTerms: [location.label, member.workspaceRoot, member.title],
                         title: location.label,
                         description: member.workspaceRoot,
-                        icon: <ServerIcon className={ITEM_ICON_CLASS} />,
+                        icon: <LocationIcon className={ITEM_ICON_CLASS} />,
                         run: async () => {
                           await handleNewThread(scopeProjectRef(member.environmentId, member.id));
                         },
@@ -1082,6 +1084,7 @@ function OpenCommandPaletteDialog(props: {
               kind: "remote" as const,
               label: "Remote",
             };
+            const ActiveLocationIcon = activeLocation.kind === "local" ? MonitorIcon : ServerIcon;
             const contextualRefBelongsToGroup =
               contextualProjectRef !== null &&
               group.memberProjectRefs.some(
@@ -1096,7 +1099,7 @@ function OpenCommandPaletteDialog(props: {
               title: group.displayName,
               description: (
                 <span className="flex min-w-0 items-center gap-1">
-                  <ServerIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
+                  <ActiveLocationIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
                   <span className="truncate">{activeLocation.label}</span>
                   <CommandPaletteMetaDot />
                   <span className="truncate">{targetProject.workspaceRoot}</span>

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -462,15 +462,15 @@ describe("isSidebarNestedLinkClick", () => {
 });
 
 describe("shouldCreateNewThreadInCurrentProject", () => {
-  it("creates directly on shift+click in a multi-project setup", () => {
+  it("creates directly on shift+click with multiple destinations", () => {
     expect(shouldCreateNewThreadInCurrentProject(true, 2)).toBe(true);
   });
 
-  it("opens the picker on a plain click in a multi-project setup", () => {
+  it("opens the picker on a plain click with multiple destinations", () => {
     expect(shouldCreateNewThreadInCurrentProject(false, 2)).toBe(false);
   });
 
-  it("creates directly on any click with a single project", () => {
+  it("creates directly on any click with a single destination", () => {
     expect(shouldCreateNewThreadInCurrentProject(false, 1)).toBe(true);
     expect(shouldCreateNewThreadInCurrentProject(true, 1)).toBe(true);
   });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -300,14 +300,14 @@ export function isSidebarNestedLinkClick(target: EventTarget | null): boolean {
 }
 
 // Shift+click on the new thread button creates directly in the current
-// project, skipping the command palette's project picker. With a single
-// project there is nothing to pick, so a plain click already creates
+// project, skipping the command palette's destination picker. With a single
+// destination there is nothing to pick, so a plain click already creates
 // immediately and the modifier changes nothing.
 export function shouldCreateNewThreadInCurrentProject(
   shiftKey: boolean,
-  projectGroupCount: number,
+  destinationCount: number,
 ): boolean {
-  return shiftKey || projectGroupCount <= 1;
+  return shiftKey || destinationCount <= 1;
 }
 
 export function orderItemsByPreferredIds<TItem, TId>(input: {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -93,6 +93,7 @@ import { readLocalApi } from "../localApi";
 import { getProjectOrderKey, selectProjectGroupingSettings } from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
+  countNewThreadDestinations,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
@@ -1868,6 +1869,10 @@ export default function Sidebar() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
+  const newThreadDestinationCount = useMemo(
+    () => countNewThreadDestinations(projectGroups),
+    [projectGroups],
+  );
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   // Threads on non-primary environments (T3 Connect, hosted) resolve their
   // provider entry from their own environment's config: default instance ids
@@ -3332,14 +3337,16 @@ export default function Sidebar() {
 
   // New thread defaults to the project you're in (active thread's project,
   // falling back to the top project) — same resolution the command palette
-  // uses. The command palette already offers a "New thread in..." submenu
-  // for multi-project setups.
+  // uses. A grouped project that exists on multiple environments still has
+  // multiple destinations, so route it through the picker too.
   const handleNewThreadClick = useCallback(
     (event?: ReactMouseEvent) => {
-      // One project: nothing to pick, create immediately. Shift+click creates
-      // directly in the current project even with several projects, skipping
-      // the palette picker.
-      if (shouldCreateNewThreadInCurrentProject(event?.shiftKey ?? false, projectGroups.length)) {
+      // One destination: nothing to pick, create immediately. Shift+click
+      // creates directly in the current project even with several destinations,
+      // skipping the palette picker.
+      if (
+        shouldCreateNewThreadInCurrentProject(event?.shiftKey ?? false, newThreadDestinationCount)
+      ) {
         if (isMobile) setOpenMobile(false);
         void startNewThreadFromContext({
           activeDraftThread: newThreadContext.activeDraftThread,
@@ -3352,20 +3359,18 @@ export default function Sidebar() {
       if (isMobile) setOpenMobile(false);
       openCommandPalette({ open: "new-thread-in" });
     },
-    [isMobile, newThreadContext, projectGroups.length, setOpenMobile],
+    [isMobile, newThreadContext, newThreadDestinationCount, setOpenMobile],
   );
 
-  // The button mirrors chat.new: in multi-project setups both route through
-  // the command palette's "New thread in..." picker, and in single-project
-  // setups both create immediately. In multi-project setups the label is only
-  // the picker's shortcut: falling back to chat.newLocal would advertise the
-  // same shortcut for both the picker and direct create. In single-project
-  // setups both commands create directly, so chat.newLocal is a valid
-  // fallback. The second tooltip line (multi-project only) advertises
-  // shift+click and its keyboard twin chat.newLocal for direct create.
+  // The button mirrors chat.new: with multiple destinations both route through
+  // the command palette picker, and with one destination both create
+  // immediately. The second tooltip line advertises shift+click and its
+  // keyboard twin chat.newLocal for direct create.
   const newThreadShortcutLabel =
     shortcutLabelForCommand(keybindings, "chat.new") ??
-    (projectGroups.length <= 1 ? shortcutLabelForCommand(keybindings, "chat.newLocal") : undefined);
+    (newThreadDestinationCount <= 1
+      ? shortcutLabelForCommand(keybindings, "chat.newLocal")
+      : undefined);
   const newThreadInProjectShortcutLabel = shortcutLabelForCommand(keybindings, "chat.newLocal");
   return (
     <>
@@ -3444,7 +3449,7 @@ export default function Sidebar() {
                     />
                   </TooltipTrigger>
                   <TooltipPopup side="right">
-                    {projectGroups.length > 1 ? (
+                    {newThreadDestinationCount > 1 ? (
                       <span className="flex flex-col gap-0.5">
                         <span>
                           {newThreadShortcutLabel

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -12,6 +12,7 @@ import {
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  countNewThreadDestinations,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
 import { legacyProjectCwdPreferenceKey } from "./uiStateStore";
@@ -63,7 +64,7 @@ describe("environment grouping", () => {
     expect(deriveLogicalProjectKey(remote)).toBe(repositoryIdentity.canonicalKey);
   });
 
-  it("counts cross-environment copies as one new-thread project choice", () => {
+  it("counts each server copy as a new-thread destination", () => {
     const primary = makeProject({ repositoryIdentity });
     const remote = makeProject({
       id: ProjectId.make("project-remote"),
@@ -71,14 +72,15 @@ describe("environment grouping", () => {
       repositoryIdentity,
     });
 
-    const projectGroupCount = buildSidebarProjectSnapshots({
+    const groups = buildSidebarProjectSnapshots({
       projects: [primary, remote],
       settings: defaultGroupingSettings,
       primaryEnvironmentId,
       resolveEnvironmentLabel: () => null,
-    }).length;
+    });
 
-    expect(projectGroupCount).toBe(1);
+    expect(groups).toHaveLength(1);
+    expect(countNewThreadDestinations(groups)).toBe(2);
   });
 
   it("keeps projects without repository identity physically scoped", () => {

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -13,6 +13,7 @@ import {
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
   countNewThreadDestinations,
+  listNewThreadProjectDestinations,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
 import { legacyProjectCwdPreferenceKey } from "./uiStateStore";
@@ -81,6 +82,9 @@ describe("environment grouping", () => {
 
     expect(groups).toHaveLength(1);
     expect(countNewThreadDestinations(groups)).toBe(2);
+    expect(
+      listNewThreadProjectDestinations(groups[0]!, remote).map((project) => project.id),
+    ).toEqual([remote.id, primary.id]);
   });
 
   it("keeps projects without repository identity physically scoped", () => {

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -8,7 +8,10 @@ import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
-import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
+import {
+  buildSidebarProjectSnapshots,
+  countNewThreadDestinations,
+} from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
@@ -32,14 +35,16 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const projectGroupCount = useMemo(
+  const newThreadDestinationCount = useMemo(
     () =>
-      buildSidebarProjectSnapshots({
-        projects,
-        settings: projectGroupingSettings,
-        primaryEnvironmentId,
-        resolveEnvironmentLabel: () => null,
-      }).length,
+      countNewThreadDestinations(
+        buildSidebarProjectSnapshots({
+          projects,
+          settings: projectGroupingSettings,
+          primaryEnvironmentId,
+          resolveEnvironmentLabel: () => null,
+        }),
+      ),
     [primaryEnvironmentId, projectGroupingSettings, projects],
   );
   const terminalOpen = useTerminalUiStateStore((state) =>
@@ -94,8 +99,8 @@ function ChatRouteGlobalShortcuts() {
         event.stopPropagation();
         // The default sidebar routes creation through the command palette
         // whenever there is a real choice to make; the legacy sidebar (and
-        // single-project setups) keep the immediate contextual create.
-        if (!legacySidebarEnabled && projectGroupCount > 1) {
+        // single-destination setups) keep the immediate contextual create.
+        if (!legacySidebarEnabled && newThreadDestinationCount > 1) {
           openCommandPalette({ open: "new-thread-in" });
           return;
         }
@@ -164,7 +169,7 @@ function ChatRouteGlobalShortcuts() {
     keybindings,
     defaultProjectRef,
     previewOpen,
-    projectGroupCount,
+    newThreadDestinationCount,
     routeThreadRef,
     selectedThreadKeysSize,
     legacySidebarEnabled,

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -31,6 +31,16 @@ export interface SidebarProjectPickerEntry {
   isPreferred: boolean;
 }
 
+export function countNewThreadDestinations(
+  groups: ReadonlyArray<Pick<SidebarProjectSnapshot, "memberProjects">>,
+): number {
+  return groups.reduce(
+    (count, group) =>
+      count + new Set(group.memberProjects.map((project) => project.environmentId)).size,
+    0,
+  );
+}
+
 export function buildPhysicalToLogicalProjectKeyMap(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -41,6 +41,33 @@ export function countNewThreadDestinations(
   );
 }
 
+export function listNewThreadProjectDestinations(
+  group: Pick<SidebarProjectSnapshot, "memberProjects">,
+  targetProject: Pick<Project, "environmentId" | "id">,
+): SidebarProjectGroupMember[] {
+  const projectByEnvironmentId = new Map<EnvironmentId, SidebarProjectGroupMember>();
+  for (const member of group.memberProjects) {
+    if (
+      !projectByEnvironmentId.has(member.environmentId) ||
+      (member.environmentId === targetProject.environmentId && member.id === targetProject.id)
+    ) {
+      projectByEnvironmentId.set(member.environmentId, member);
+    }
+  }
+
+  const destinations = [...projectByEnvironmentId.values()];
+  const targetIndex = destinations.findIndex(
+    (project) => project.environmentId === targetProject.environmentId,
+  );
+  if (targetIndex <= 0) return destinations;
+
+  return [
+    destinations[targetIndex]!,
+    ...destinations.slice(0, targetIndex),
+    ...destinations.slice(targetIndex + 1),
+  ];
+}
+
 export function buildPhysicalToLogicalProjectKeyMap(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;


### PR DESCRIPTION
Grouped projects can exist on more than one T3 environment, but the new-thread picker only showed the representative server. The sidebar also treated that group as a single choice, so it skipped the picker even though the user still had to choose where the thread should run.

This shows the server count on grouped project rows and opens a `Run on` list with every server and workspace path. The sidebar button and `chat.new` shortcut now count server destinations, while single-server projects and the direct-create shortcut keep their existing behavior.

## Proof

### Before

The grouped project row showed one server with no indication that another copy existed.

![Before: grouped project row showed only one server](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/31d08953-4a42-4e85-9691-98d70d74143c/t3code-project-server-before.png)

### After

The row shows `2 servers`.

![After: grouped project row shows 2 servers](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/1308f973-56f5-4aff-8c28-2ee5dc67df0d/t3code-project-server-count-v2.png)

Opening the row shows the full server list. Playwright also selected `workbench-01` and confirmed the composer changed its `Run on` value.

![After: Run on list shows every server and workspace](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c0a79fe4-1ba0-4871-8a27-9a12e9038606/t3code-project-server-list-v3.png)

## Verification

- Web TypeScript check
- Command palette logic, 17 tests
- Environment grouping, 13 tests
- Sidebar logic, 105 tests
- Playwright pass against two disposable connected environments

Created by GPT-5.6-Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when new threads are created vs routed through the picker, so a destination-count bug could skip the picker or create threads on the wrong environment.
> 
> **Overview**
> New threads for a grouped project now treat each unique environment as a destination, not the group as a single choice.
> 
> The command palette “New thread in…” row shows a server count and opens a **Run on** submenu with every server and workspace path. The sidebar new-thread button and `chat.new` use the same destination count, so a single grouped project on two servers still opens the picker. Shift-click / `chat.newLocal` still create in the current project.
> 
> Primary environment labels in the palette use `resolveEnvironmentOptionLabel` instead of a hardcoded “Local”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5c47c9839a3fe4dc906205e592ffa8ec685abb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show server destination picker for grouped projects in Command Palette
> - Adds `countNewThreadDestinations` and `listNewThreadProjectDestinations` to count and list distinct environment destinations across grouped projects
> - Command Palette 'New thread in…' section now shows a submenu when a project has multiple server destinations, letting users pick the environment; single-destination projects remain a direct action with an icon and label
> - Sidebar 'New thread' button and `chat.new` shortcut now open the picker based on destination count instead of project group count
> - `enumerateCommandPaletteItems` accepts `CommandPaletteSubmenuItem` alongside action items
> - Primary environment label resolves via `resolveEnvironmentOptionLabel` instead of a hardcoded 'Local' string
> - Behavioral Change: `shouldCreateNewThreadInCurrentProject` parameter renamed from `projectGroupCount` to `destinationCount`; callers in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/8012/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [_chat.tsx](https://github.com/pingdotgg/t3code/pull/8012/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691) now pass distinct environment counts
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db5c47c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->