### PR TITLE
fix(server): automatic activity unsettle no longer clears a user's "active" pin

### DIFF
--- a/apps/server/src/orchestration/decider.settled.test.ts
+++ b/apps/server/src/orchestration/decider.settled.test.ts
@@ -428,7 +428,7 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
     }),
   );
 
-  it.effect("prepends activity unsets for turn starts and live session updates", () =>
+  it.effect("prepends activity unsets for settled threads and leaves active pins alone", () =>
     Effect.gen(function* () {
       const turnResult = yield* decideOrchestrationCommand({
         command: {
@@ -462,19 +462,16 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
           session: makeSession("running"),
           createdAt: NOW,
         },
-        // A keep-active pin is also an override: real activity clears it
-        // back to neutral so auto-settle can apply again later.
+        // A keep-active pin is a user pin, not an auto-settle guard: real
+        // activity must not clear it back to neutral.
         readModel: makeReadModel("active"),
       });
       const sessionEvents = Array.isArray(sessionResult) ? sessionResult : [sessionResult];
-      expect(sessionEvents.map((event) => event.type)).toEqual([
-        "thread.unsettled",
-        "thread.session-set",
-      ]);
+      expect(sessionEvents.map((event) => event.type)).toEqual(["thread.session-set"]);
     }),
   );
 
-  it.effect("clears a keep-active pin on real activity", () =>
+  it.effect("does not clear a keep-active pin on real activity", () =>
     Effect.gen(function* () {
       const turnResult = yield* decideOrchestrationCommand({
         command: {
@@ -494,10 +491,9 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
         readModel: makeReadModel("active"),
       });
       const turnEvents = Array.isArray(turnResult) ? turnResult : [turnResult];
-      // The pin exists to suppress AUTO-settle, not to survive real work:
-      // activity resets it to neutral, restoring the default lifecycle.
+      // The pin is the user asking to keep this thread active: real work
+      // must not silently clear it back to neutral.
       expect(turnEvents.map((event) => event.type)).toEqual([
-        "thread.unsettled",
         "thread.message-sent",
         "thread.turn-start-requested",
       ]);
@@ -521,10 +517,7 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
         readModel: makeReadModel("active"),
       });
       const activityEvents = Array.isArray(activityResult) ? activityResult : [activityResult];
-      expect(activityEvents.map((event) => event.type)).toEqual([
-        "thread.unsettled",
-        "thread.activity-appended",
-      ]);
+      expect(activityEvents.map((event) => event.type)).toEqual(["thread.activity-appended"]);
     }),
   );
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -995,13 +995,15 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           createdAt: command.createdAt,
         },
       };
-      // Real activity resets ANY override: it wakes an explicitly settled
-      // thread, and it clears a keep-active pin back to neutral so the
-      // thread can auto-settle again after this burst of work goes stale.
+      // Real activity wakes an explicitly settled thread, but it must not
+      // clear a keep-active pin: the user asked for that thread to stay
+      // active, and an automatic "activity" unsettle is a no-op against a
+      // state that is already unsettled in spirit. Only a settled override
+      // is cleared here; an active override is left alone.
       // A snooze clears the same way — sending a message to a snoozed
       // thread is the user re-engaging, so the return ticket is spent.
       const lifecycleResetEvents: Array<Omit<OrchestrationEvent, "sequence">> = [];
-      if (targetThread.settledOverride !== null) {
+      if (targetThread.settledOverride === "settled") {
         lifecycleResetEvents.push({
           ...(yield* withEventBase({
             aggregateKind: "thread",
@@ -1204,8 +1206,10 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       // as snoozed, without spending the return ticket.
       const isSessionActivity =
         command.session.status === "starting" || command.session.status === "running";
-      // Real activity resets ANY override (settled wakes, active unpins).
-      if (thread.settledOverride === null || !isSessionActivity) {
+      // Real activity wakes a settled thread, but never clears an active
+      // pin: that override is the user asking to keep this thread active,
+      // and an automatic "activity" unsettle must not undo it.
+      if (thread.settledOverride !== "settled" || !isSessionActivity) {
         return sessionSetEvent;
       }
       const unsettledEvent: Omit<OrchestrationEvent, "sequence"> = {
@@ -1381,8 +1385,10 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       const wakesSettledThread =
         command.activity.kind === "approval.requested" ||
         command.activity.kind === "user-input.requested";
-      // Real activity resets ANY override (settled wakes, active unpins).
-      if (thread.settledOverride === null || !wakesSettledThread) {
+      // Real activity wakes a settled thread, but never clears an active
+      // pin: that override is the user asking to keep this thread active,
+      // and an automatic "activity" unsettle must not undo it.
+      if (thread.settledOverride !== "settled" || !wakesSettledThread) {
         return activityAppendedEvent;
       }
       const unsettledEvent: Omit<OrchestrationEvent, "sequence"> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5148,10 +5148,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}


### PR DESCRIPTION
## What Changed

The decider now emits the automatic activity unsettle only when the override is `"settled"`. Same guard at all three emit sites in `decider.ts` (turn start, session set, activity append). Two tests asserted the old behavior and now assert the pin survives.

Full `apps/server` test suite passes with the change: 2642 passed, 0 failed (pnpm 11.10.0, vitest via vite-plus). The change is unit-tested only; I have not run a patched build of the app.

## Why

Refs #6417. This addresses the part where an explicit Un-settle doesn't stick. It does not change merged-PR auto-settle itself, so the issue should stay open for a maintainer to judge.

Clicking Un-settle stores `settledOverride: "active"`. At the start of the next turn, the decider emits an automatic `thread.unsettled` with reason `"activity"` whenever any override is set, and the reducer maps every non-user reason to `null`. The pin is erased one turn after it was set, and on a thread with a merged/closed PR settles again right away.

The comments at these emit sites say real activity resets any override, active pins included. I disagree: The pin only matters on a thread that keeps re-settling on its own, and those threads always have activity, so the pin is removed before it can do anything.

Alternative considered: keep `"active"` in the reducer on non-user reasons. I chose the decider guard instead because 1. It touches one file, while the reducer is copied in three files across client and server. 2. It only affects new events, while a reducer change alters what already-recorded events mean on replay. 3. If #5462 lands, settled state becomes server-authored, so the decider seemed like the right place for the policy either way.

Repro and event-log trace are in my comment on #6417.

## Checklist

- [x] Small and focused
- [x] Explained what and why
- [ ] UI changes: none (no screenshots needed)
- [ ] Animation/timing changes: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration lifecycle policy for thread settle/unsettle. Wrong guards would hide settled threads or drop user pins, but the change is small, localized, and unit-tested.
> 
> **Overview**
> Stops automatic `thread.unsettled` (reason `"activity"`) from wiping a user’s keep-active pin (`settledOverride: "active"`). Un-settle now survives the next turn, live session, or blocking activity instead of being reset to neutral and immediately auto-settling again.
> 
> The decider only prepends that unsettle when the override is `"settled"`, at turn start, session set, and activity append. Tests now assert the pin is left alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit defb1553451e76ebe7ab769c144ada87e608e2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix automatic activity unsettle to preserve user's `active` pin in `decideOrchestrationCommand`
> Previously, any non-null `settledOverride` triggered a `thread.unsettled` event, which cleared a user's `active` pin. The decider now only emits `thread.unsettled` when `settledOverride === 'settled'`, leaving active-pinned threads intact.
>
> - Updated unsettle gating in three handlers in [decider.ts](https://github.com/pingdotgg/t3code/pull/8015/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6): `thread.turn.start`, `thread.session.set`, and `thread.activity.append` — all now check for an explicitly settled thread rather than a non-null override.
> - Adjusted test expectations in [decider.settled.test.ts](https://github.com/pingdotgg/t3code/pull/8015/files#diff-e33d5b7dc652f03d2225af699b29583bc02c97552845084e1bbb81d0b0dcf583) to no longer expect `thread.unsettled` events when a thread has an active pin.
> - Risk: threads pinned `active` will no longer auto-unsettle on activity, turn start, or session set — callers relying on automatic unsettle for active-pinned threads will see different lifecycle event sequences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized defb155.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->