### PR TITLE
fix(web): restore right panel toggle clicks after closing on desktop

### DIFF
--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1502,6 +1502,13 @@ function PullRequestsRouteView() {
       !pullRequestsSupported || rightPanelState.isOpen ? null : (
         <span aria-hidden className="w-7 shrink-0 sm:w-5" />
       ),
+    titlebarControls:
+      // While the panel is closed the strip lives inside the header: a no-drag
+      // descendant beats the header's desktop drag-region, where a floating
+      // sibling loses (app-region hit-testing ignores z-index). Open, it moves
+      // back out to the route container, which spans the panel too, so the
+      // toggle keeps one fixed top-right anchor and never jumps sideways.
+      pullRequestsSupported && !rightPanelState.isOpen ? openPanelControls : null,
     rightPanelOpen: rightPanelState.isOpen,
     listBody,
   };
@@ -1543,7 +1550,7 @@ function PullRequestsRouteView() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="relative flex min-h-0 flex-1">
-        {pullRequestsSupported ? openPanelControls : null}
+        {pullRequestsSupported && rightPanelState.isOpen ? openPanelControls : null}
         <PullRequestsColumn {...columnProps} />
 
         {rightPanelState.isOpen && activePullRequestSurface && panelEnvironmentId !== null ? (
@@ -1759,6 +1766,7 @@ function PullRequestsColumn({
   searchInput,
   filtersMenu,
   rightPanelControl,
+  titlebarControls,
   rightPanelOpen,
   listBody,
 }: {
@@ -1775,6 +1783,7 @@ function PullRequestsColumn({
   searchInput: ReactNode;
   filtersMenu: ReactNode;
   rightPanelControl: ReactNode;
+  titlebarControls: ReactNode;
   rightPanelOpen: boolean;
   listBody: ReactNode;
 }) {
@@ -1838,9 +1847,18 @@ function PullRequestsColumn({
     // content surface that lets it show reads as a different background than every thread.
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
       {/* A closed right panel leaves this column full-width, so the shared header
-          reserves native window controls. While the panel is open, the column ends
-          at the panel and the absolute controls strip owns the top-right corner. */}
-      <WorkspacePageHeader electron={isElectron} reserveNativeControls={!rightPanelOpen}>
+          reserves native window controls and hosts the controls strip itself: on
+          desktop the header is a drag-region, and only a no-drag descendant wins
+          clicks from it - a floating sibling loses to app-region hit-testing no
+          matter its z-index. While the panel is open, the strip mounts back at
+          the route level, whose box spans the panel too, so the toggle keeps one
+          fixed top-right anchor. */}
+      <WorkspacePageHeader
+        electron={isElectron}
+        reserveNativeControls={!rightPanelOpen}
+        className="relative bg-background"
+      >
+        {titlebarControls}
         {condensed ? (
           <WorkspaceBreadcrumb ariaLabel="Pull request scope">
             {/* The page name remains the foreground anchor in both states; the live filters are


### PR DESCRIPTION
## What Changed

On the Pull Requests page, the floating controls strip that holds the right-panel toggle now mounts **inside `WorkspacePageHeader` while the panel is closed**, instead of hovering above it as a sibling overlay. While the panel is open, it stays mounted at the route container exactly as before, so the toggle keeps one fixed top-right anchor and never jumps sideways across states.

One file: `apps/web/src/routes/_chat.pull-requests.tsx` (+22/−4). Mirrors the pattern ChatView already uses for its identical strip.

## Why

On desktop, after closing the right panel on the Pull Requests page, clicking the toggle did nothing - the panel could never be reopened with the icon. Web was unaffected.

The header is a `-webkit-app-region: drag` region under Electron so the window can be dragged by its top bar. Chromium resolves app-region during native hit-testing **without honoring z-index**, so when the strip floated over the header as a sibling overlay, the drag-region swallowed every click on the toggle no matter its `z-50`. DevTools confirmed it: the button was enabled, `elementFromPoint` returned the button itself, yet closed-state clicks produced zero DOM events until every `drag` region was neutralized at runtime.

Mounting the strip inside the header makes it a no-drag *descendant*, which beats an ancestor drag-region. With the panel open the column shrinks, so the old route-level mount (whose box spans the panel) keeps the corner position stable.

## UI Changes

https://github.com/user-attachments/assets/1e3b888f-6789-47b1-8f57-19e8ee0ca491

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes _(not applicable: no pixels change, desktop-only click behavior - see UI Changes)_
- [x] I included a video for animation/interaction changes

Built with ox-alpha in opencode.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop-only layout remount of existing titlebar controls; no data, auth, or API changes.
> 
> **Overview**
> Fixes the Pull Requests page so the right-panel toggle can be clicked again after closing the panel in Electron.
> 
> The header is a native drag-region, and Chromium ignores z-index for app-region hit-testing, so a floating sibling overlay never received clicks. While the panel is closed, the controls strip now mounts **inside** `WorkspacePageHeader` as a no-drag descendant. While open, it still mounts on the route container so the toggle stays pinned to the same top-right corner. Matches the ChatView pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d2fac32bb4b820b3ff96404ca9dc5b1b205dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->