### PR TITLE
fix(clients): sort project menus alphabetically

### DIFF
--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -85,10 +85,12 @@ export function HomeRouteScreen() {
         projects,
         environmentId: selectedEnvironmentId,
         projectGroupingMode: listOptions.projectGroupingMode,
-      }).map((scope) => ({
-        key: scope.key,
-        label: scope.title,
-      })),
+      })
+        .map((scope) => ({
+          key: scope.key,
+          label: scope.title,
+        }))
+        .toSorted((left, right) => left.label.localeCompare(right.label)),
     [listOptions.projectGroupingMode, projects, selectedEnvironmentId],
   );
   useEffect(() => {

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -281,10 +281,12 @@ function ThreadNavigationSidebarPane(
   );
   const projectFilterOptions = useMemo(
     () =>
-      projectScopes.map((scope) => ({
-        key: scope.key,
-        label: scope.title,
-      })),
+      projectScopes
+        .map((scope) => ({
+          key: scope.key,
+          label: scope.title,
+        }))
+        .toSorted((left, right) => left.label.localeCompare(right.label)),
     [projectScopes],
   );
   const projectTitleByProjectKey = useMemo(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1864,6 +1864,11 @@ export default function Sidebar() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
+  const projectScopeMenuGroups = useMemo(
+    () =>
+      projectGroups.toSorted((left, right) => left.displayName.localeCompare(right.displayName)),
+    [projectGroups],
+  );
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   // Threads on non-primary environments (T3 Connect, hosted) resolve their
   // provider entry from their own environment's config: default instance ids
@@ -3513,7 +3518,7 @@ export default function Sidebar() {
                         <FolderIcon className="size-4 shrink-0" />
                         <span className="min-w-0 truncate text-sm">All projects</span>
                       </MenuRadioItem>
-                      {projectGroups.map((project) => {
+                      {projectScopeMenuGroups.map((project) => {
                         const scopeKey = project.projectKey;
                         return (
                           <MenuRadioItem


### PR DESCRIPTION
Project filter menus inherited activity or manual project ordering, making projects harder to scan when choosing a scope.

Sort filter-menu options alphabetically by display label across web, desktop, and mobile while preserving the configured ordering of the main project lists. The web sidebar memoizes its derived menu order because the sidebar rerenders frequently as thread state changes.

<img width="278" height="250" alt="Screenshot 2026-08-23 at 1 01 33 PM" src="https://github.com/user-attachments/assets/fd0cef6d-70fa-4d56-b8bc-55ba3a982d81" />


## Testing

- Mobile typecheck
- Focused lint and formatting checks
- Manually verified the web menu with an isolated fixture: Alpha Studio, Metro Docs, Zulu Analytics

Generated with GPT-5.6-Sol via the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort project menus alphabetically in mobile and web sidebars
> - Sorts `projectFilterOptions` by label in `HomeRouteScreen` and `ThreadNavigationSidebarPane` using `toSorted` with `localeCompare`
> - Introduces a memoized `projectScopeMenuGroups` in web `Sidebar` that sorts `projectGroups` by `displayName` and renders `MenuRadioItem`s from it
> - Behavioral Change: project scope options now appear in alphabetical order in all three menus; sorting relies on `localeCompare` defaults
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dbb967.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->