### PR TITLE
feat(web): add opt-in panel collapse animations

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -35,6 +35,7 @@ const clientSettings: ClientSettings = {
   fontSizeTerminal: 12,
   fontSmoothing: true,
   glassOpacity: 80,
+  panelAnimations: false,
   planModeEnabled: false,
   showSkillsInSlashMenu: false,
   providerModelPreferences: {},

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2949,8 +2949,9 @@ function ChatViewContent(props: ChatViewProps) {
     enabled: panelAnimationsEnabled,
     dimension: "height",
     identity: routeThreadKey,
-    // Opening/closing sessions mid-collapse supersedes a pending hide.
-    supersedeKey: terminalUiState.terminalIds.join("|"),
+    // Opening, closing, or focusing sessions mid-collapse supersedes a
+    // pending hide.
+    supersedeKey: `${terminalUiState.terminalIds.join("|")}:${terminalUiState.activeTerminalId ?? ""}`,
     onClose: () => setTerminalOpen(false),
   });
   const toggleTerminalVisibility = useCallback(() => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -201,7 +201,9 @@ import {
   useClientSettings,
   useClientSettingsHydrated,
   useEnvironmentSettings,
+  usePanelAnimations,
 } from "../hooks/useSettings";
+import { type PanelCollapseFlight, PanelCollapseFrame, usePanelCollapse } from "./PanelCollapse";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
@@ -691,6 +693,9 @@ interface PersistentThreadTerminalDrawerProps {
   visible: boolean;
   launchContext: PersistentTerminalLaunchContext | null;
   focusRequestId: number;
+  /** Collapse flight for the active drawer only; background drawers pass no-ops. */
+  collapseRef: (node: HTMLElement | null) => void;
+  collapseFlight: PanelCollapseFlight | null;
   splitShortcutLabel: string | undefined;
   splitVerticalShortcutLabel: string | undefined;
   newShortcutLabel: string | undefined;
@@ -699,12 +704,16 @@ interface PersistentThreadTerminalDrawerProps {
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
 }
 
+const noopRef = () => {};
+
 const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDrawer({
   threadRef,
   threadId,
   visible,
   launchContext,
   focusRequestId,
+  collapseRef,
+  collapseFlight,
   splitShortcutLabel,
   splitVerticalShortcutLabel,
   newShortcutLabel,
@@ -1015,7 +1024,11 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   }
 
   return (
-    <div className={visible ? undefined : "hidden"}>
+    <PanelCollapseFrame
+      state={{ ref: collapseRef, flight: collapseFlight }}
+      dimension="height"
+      className={visible ? undefined : "hidden"}
+    >
       <ThreadTerminalDrawer
         threadRef={threadRef}
         threadId={threadId}
@@ -1045,7 +1058,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         terminalLabelsById={terminalLabelsById}
         terminalLaunchLocationsById={terminalLaunchLocationsById}
       />
-    </div>
+    </PanelCollapseFrame>
   );
 });
 
@@ -2928,6 +2941,16 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeThreadRef, storeSetTerminalOpen],
   );
+  // The active drawer's close is deferred until its height collapse lands,
+  // so during the animation every reader of terminalOpen still sees open.
+  const panelAnimationsEnabled = usePanelAnimations();
+  const drawerCollapse = usePanelCollapse({
+    open: Boolean(activeThreadKey && terminalUiState.terminalOpen),
+    enabled: panelAnimationsEnabled,
+    dimension: "height",
+    identity: routeThreadKey,
+    onClose: () => setTerminalOpen(false),
+  });
   const toggleTerminalVisibility = useCallback(() => {
     if (!activeThreadRef) return;
     const nextOpen = !terminalUiState.terminalOpen;
@@ -2956,13 +2979,24 @@ function ChatViewContent(props: ChatViewProps) {
       });
       return;
     }
-    setTerminalOpen(nextOpen);
+    if (nextOpen) {
+      setTerminalOpen(true);
+      return;
+    }
+    // A second toggle mid-collapse finishes the close instead of queueing a
+    // reopen; otherwise the close animates and the store flips when it lands.
+    if (drawerCollapse.flight?.direction === "out") {
+      drawerCollapse.settle();
+      return;
+    }
+    drawerCollapse.requestClose();
   }, [
     activeProject,
     activeThreadId,
     activeThreadRef,
     activeThreadWorktreePath,
     allocatableActiveTerminalIds,
+    drawerCollapse,
     environmentId,
     gitCwd,
     openTerminal,
@@ -3448,6 +3482,20 @@ function ChatViewContent(props: ChatViewProps) {
       useRightPanelStore.getState().close(activeThreadRef);
     }
   }, [activeThreadRef]);
+  // Same deferred-close contract as the drawer: the store stays open for the
+  // width collapse, so titlebar and layout reads need no animation awareness.
+  const rightPanelCollapse = usePanelCollapse({
+    open: rightPanelOpen,
+    enabled: panelAnimationsEnabled,
+    dimension: "width",
+    identity: routeThreadKey,
+    onClose: () => closePreviewPanel(),
+  });
+  // During a close from maximized, the wrapper is pinned to its measured px
+  // width and the chat column takes the row back while the panel collapses;
+  // the panel's own content stays maximized-styled and just gets clipped.
+  const rightPanelMaximizedLayout =
+    rightPanelMaximized && rightPanelCollapse.flight?.direction !== "out";
   const addTerminalSurface = useCallback(() => {
     if (!activeThreadRef || !activeThreadId || !activeProject) return;
     const cwd = gitCwd ?? activeProject.workspaceRoot;
@@ -3582,12 +3630,16 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const toggleRightPanel = useCallback(() => {
     if (!activeThreadRef) return;
+    if (rightPanelCollapse.flight?.direction === "out") {
+      rightPanelCollapse.settle();
+      return;
+    }
     if (rightPanelOpen) {
-      closePreviewPanel();
+      rightPanelCollapse.requestClose();
       return;
     }
     useRightPanelStore.getState().toggleVisibility(activeThreadRef);
-  }, [activeThreadRef, closePreviewPanel, rightPanelOpen]);
+  }, [activeThreadRef, rightPanelCollapse, rightPanelOpen]);
   const toggleRightPanelMaximized = useCallback(() => {
     if (!canMaximizeRightPanel) return;
     setMaximizedRightPanelThreadKey((threadKey) =>
@@ -6607,9 +6659,9 @@ function ChatViewContent(props: ChatViewProps) {
       <div
         className={cn(
           "flex min-h-0 min-w-0 flex-col overflow-x-hidden",
-          rightPanelMaximized ? "w-0 flex-none" : "flex-1",
+          rightPanelMaximizedLayout ? "w-0 flex-none" : "flex-1",
         )}
-        data-chat-column-maximized-away={rightPanelMaximized ? "true" : "false"}
+        data-chat-column-maximized-away={rightPanelMaximizedLayout ? "true" : "false"}
       >
         {/* Top bar */}
         <WorkspacePageHeader
@@ -6997,60 +7049,71 @@ function ChatViewContent(props: ChatViewProps) {
         </div>
         {/* end horizontal flex container */}
 
-        {mountedTerminalThreadRefs.map(({ key: mountedThreadKey, threadRef: mountedThreadRef }) => (
-          <PersistentThreadTerminalDrawer
-            key={mountedThreadKey}
-            threadRef={mountedThreadRef}
-            threadId={mountedThreadRef.threadId}
-            visible={mountedThreadKey === activeThreadKey && terminalUiState.terminalOpen}
-            launchContext={
-              mountedThreadKey === activeThreadKey ? (activeTerminalLaunchContext ?? null) : null
-            }
-            focusRequestId={mountedThreadKey === activeThreadKey ? terminalFocusRequestId : 0}
-            splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
-            splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
-            newShortcutLabel={newTerminalShortcutLabel ?? undefined}
-            closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
-            keybindings={keybindings}
-            onAddTerminalContext={addTerminalContextToDraft}
-          />
-        ))}
+        {mountedTerminalThreadRefs.map(({ key: mountedThreadKey, threadRef: mountedThreadRef }) => {
+          const isActiveDrawer = mountedThreadKey === activeThreadKey;
+          return (
+            <PersistentThreadTerminalDrawer
+              key={mountedThreadKey}
+              threadRef={mountedThreadRef}
+              threadId={mountedThreadRef.threadId}
+              visible={isActiveDrawer && terminalUiState.terminalOpen}
+              launchContext={isActiveDrawer ? (activeTerminalLaunchContext ?? null) : null}
+              focusRequestId={isActiveDrawer ? terminalFocusRequestId : 0}
+              collapseRef={isActiveDrawer ? drawerCollapse.ref : noopRef}
+              collapseFlight={isActiveDrawer ? drawerCollapse.flight : null}
+              splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
+              splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
+              newShortcutLabel={newTerminalShortcutLabel ?? undefined}
+              closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
+              keybindings={keybindings}
+              onAddTerminalContext={addTerminalContextToDraft}
+            />
+          );
+        })}
       </div>
 
-      {!shouldUseRightPanelSheet && rightPanelOpen && activeThreadRef ? (
-        <RightPanelTabs
-          mode="inline"
-          maximized={rightPanelMaximized}
-          surfaces={rightPanelState.surfaces}
-          activeSurfaceId={activeRightPanelSurface?.id ?? null}
-          pendingSurfaceIds={pendingFileSurfaceIds}
-          previewSessions={activePreviewState.sessions}
-          desktopByTabId={activePreviewState.desktopByTabId}
-          previewRuntimeTabId={resolvePreviewRuntimeTabId}
-          terminalLabelsById={activeTerminalLabelsById}
-          onActivate={activateRightPanelSurface}
-          onCloseSurface={closeRightPanelSurface}
-          onCloseOtherSurfaces={closeOtherRightPanelSurfaces}
-          onCloseSurfacesToRight={closeRightPanelSurfacesToRight}
-          onCloseAllSurfaces={closeAllRightPanelSurfaces}
-          onCopyFilePath={copyRightPanelFilePath}
-          onAddBrowser={createBrowserSurface}
-          onAddTerminal={addTerminalSurface}
-          onAddDiff={addDiffSurface}
-          onAddFiles={addFilesSurface}
-          onAddPullRequest={addPullRequestSurface}
-          onAddAgents={addAgentsSurface}
-          browserAvailable={isPreviewSupportedInRuntime()}
-          terminalAvailable={activeProject !== null}
-          diffAvailable={isServerThread && isGitRepo}
-          filesAvailable={activeProject !== null}
-          pullRequestAvailable={pullRequestSurfaceAvailable}
-          agentsAvailable
-          pullRequestStatuses={pullRequestTabStatuses}
-          liveAgentCount={agentPanelModel.liveCount}
+      {!shouldUseRightPanelSheet &&
+      (rightPanelOpen || rightPanelCollapse.flight) &&
+      activeThreadRef ? (
+        <PanelCollapseFrame
+          state={rightPanelCollapse}
+          dimension="width"
+          className={rightPanelMaximized ? "flex min-h-0 min-w-0 flex-1" : "flex-none"}
         >
-          {rightPanelContent}
-        </RightPanelTabs>
+          <RightPanelTabs
+            mode="inline"
+            maximized={rightPanelMaximized}
+            surfaces={rightPanelState.surfaces}
+            activeSurfaceId={activeRightPanelSurface?.id ?? null}
+            pendingSurfaceIds={pendingFileSurfaceIds}
+            previewSessions={activePreviewState.sessions}
+            desktopByTabId={activePreviewState.desktopByTabId}
+            previewRuntimeTabId={resolvePreviewRuntimeTabId}
+            terminalLabelsById={activeTerminalLabelsById}
+            onActivate={activateRightPanelSurface}
+            onCloseSurface={closeRightPanelSurface}
+            onCloseOtherSurfaces={closeOtherRightPanelSurfaces}
+            onCloseSurfacesToRight={closeRightPanelSurfacesToRight}
+            onCloseAllSurfaces={closeAllRightPanelSurfaces}
+            onCopyFilePath={copyRightPanelFilePath}
+            onAddBrowser={createBrowserSurface}
+            onAddTerminal={addTerminalSurface}
+            onAddDiff={addDiffSurface}
+            onAddFiles={addFilesSurface}
+            onAddPullRequest={addPullRequestSurface}
+            onAddAgents={addAgentsSurface}
+            browserAvailable={isPreviewSupportedInRuntime()}
+            terminalAvailable={activeProject !== null}
+            diffAvailable={isServerThread && isGitRepo}
+            filesAvailable={activeProject !== null}
+            pullRequestAvailable={pullRequestSurfaceAvailable}
+            agentsAvailable
+            pullRequestStatuses={pullRequestTabStatuses}
+            liveAgentCount={agentPanelModel.liveCount}
+          >
+            {rightPanelContent}
+          </RightPanelTabs>
+        </PanelCollapseFrame>
       ) : null}
       {shouldUseRightPanelSheet && rightPanelOpen && activeThreadRef ? (
         <RightPanelSheet open onClose={closePreviewPanel}>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2949,6 +2949,8 @@ function ChatViewContent(props: ChatViewProps) {
     enabled: panelAnimationsEnabled,
     dimension: "height",
     identity: routeThreadKey,
+    // Opening/closing sessions mid-collapse supersedes a pending hide.
+    supersedeKey: terminalUiState.terminalIds.join("|"),
     onClose: () => setTerminalOpen(false),
   });
   const toggleTerminalVisibility = useCallback(() => {
@@ -3489,6 +3491,10 @@ function ChatViewContent(props: ChatViewProps) {
     enabled: panelAnimationsEnabled,
     dimension: "width",
     identity: routeThreadKey,
+    // Opening or closing surfaces mid-collapse supersedes a pending close.
+    supersedeKey: `${rightPanelState.surfaces.map((surface) => surface.id).join("|")}:${
+      activeRightPanelSurface?.id ?? ""
+    }`,
     onClose: () => closePreviewPanel(),
   });
   // During a close from maximized, the wrapper is pinned to its measured px

--- a/apps/web/src/components/PanelCollapse.logic.test.ts
+++ b/apps/web/src/components/PanelCollapse.logic.test.ts
@@ -94,15 +94,14 @@ describe("usePanelCollapse", () => {
     expect(panel.flight).toBeNull();
   });
 
-  it("drops a deferred close when the supersede key changed mid-flight", () => {
+  it("explicit settle commits even when the supersede key changed", () => {
     const onClose = vi.fn();
     let panel = renderCollapse({ open: true, onClose, supersedeKey: "a" });
     panel.ref(makeNode(420));
     panel.requestClose();
-    // Something else interacted with the panel while the collapse ran.
     panel = renderCollapse({ open: true, onClose, supersedeKey: "b" });
     panel.settle();
-    expect(onClose).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
     panel = renderCollapse({ open: true, onClose, supersedeKey: "b" });
     expect(panel.flight).toBeNull();
   });

--- a/apps/web/src/components/PanelCollapse.logic.test.ts
+++ b/apps/web/src/components/PanelCollapse.logic.test.ts
@@ -11,6 +11,7 @@ vi.mock("react", async (importOriginal) => {
   return {
     ...actual,
     useCallback: reactHookHarness.useCallback,
+    useMemo: reactHookHarness.useMemo,
     useRef: reactHookHarness.useRef,
     useState: reactHookHarness.useState,
     // Effects never run under the plain-function harness; register nothing.

--- a/apps/web/src/components/PanelCollapse.logic.test.ts
+++ b/apps/web/src/components/PanelCollapse.logic.test.ts
@@ -28,7 +28,12 @@ function makeNode(size: number): HTMLElement {
   } as unknown as HTMLElement;
 }
 
-function renderCollapse(input: { open: boolean; enabled?: boolean; onClose: () => void }) {
+function renderCollapse(input: {
+  open: boolean;
+  enabled?: boolean;
+  supersedeKey?: string;
+  onClose: () => void;
+}) {
   reactHookHarness.beginRender();
   return usePanelCollapse({
     enabled: input.enabled ?? true,
@@ -87,6 +92,29 @@ describe("usePanelCollapse", () => {
     panel.requestClose();
     expect(onClose).not.toHaveBeenCalled();
     expect(panel.flight).toBeNull();
+  });
+
+  it("drops a deferred close when the supersede key changed mid-flight", () => {
+    const onClose = vi.fn();
+    let panel = renderCollapse({ open: true, onClose, supersedeKey: "a" });
+    panel.ref(makeNode(420));
+    panel.requestClose();
+    // Something else interacted with the panel while the collapse ran.
+    panel = renderCollapse({ open: true, onClose, supersedeKey: "b" });
+    panel.settle();
+    expect(onClose).not.toHaveBeenCalled();
+    panel = renderCollapse({ open: true, onClose, supersedeKey: "b" });
+    expect(panel.flight).toBeNull();
+  });
+
+  it("commits when the supersede key is unchanged", () => {
+    const onClose = vi.fn();
+    let panel = renderCollapse({ open: true, onClose, supersedeKey: "a" });
+    panel.ref(makeNode(420));
+    panel.requestClose();
+    panel = renderCollapse({ open: true, onClose, supersedeKey: "a" });
+    panel.settle();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the captured onClose across re-renders mid-flight", () => {

--- a/apps/web/src/components/PanelCollapse.logic.test.ts
+++ b/apps/web/src/components/PanelCollapse.logic.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from "@effect/vitest";
+import { vi } from "vite-plus/test";
+
+import { reactHookHarness } from "~/test/reactHookHarness";
+
+import { usePanelCollapse } from "./PanelCollapse";
+
+vi.mock("react", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("react");
+  const { reactHookHarness } = await import("~/test/reactHookHarness");
+  return {
+    ...actual,
+    useCallback: reactHookHarness.useCallback,
+    useRef: reactHookHarness.useRef,
+    useState: reactHookHarness.useState,
+    // Effects never run under the plain-function harness; register nothing.
+    useEffect: () => undefined,
+    useLayoutEffect: () => undefined,
+  };
+});
+
+function makeNode(size: number): HTMLElement {
+  return {
+    getBoundingClientRect: () => ({ width: size, height: size }) as unknown as DOMRect,
+    style: {},
+    offsetWidth: size,
+  } as unknown as HTMLElement;
+}
+
+function renderCollapse(input: { open: boolean; enabled?: boolean; onClose: () => void }) {
+  reactHookHarness.beginRender();
+  return usePanelCollapse({
+    enabled: input.enabled ?? true,
+    dimension: "width",
+    ...input,
+  });
+}
+
+describe("usePanelCollapse", () => {
+  beforeEach(() => {
+    reactHookHarness.reset();
+  });
+
+  it("defers onClose until the collapse settles", () => {
+    const onClose = vi.fn();
+    let panel = renderCollapse({ open: true, onClose });
+    panel.ref(makeNode(420));
+
+    panel.requestClose();
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Re-render mirrors React reading the armed flight state.
+    panel = renderCollapse({ open: true, onClose });
+    expect(panel.flight?.direction).toBe("out");
+
+    panel.settle();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    panel = renderCollapse({ open: false, onClose });
+    expect(panel.flight).toBeNull();
+  });
+
+  it("settles exactly once when called repeatedly", () => {
+    const onClose = vi.fn();
+    const panel = renderCollapse({ open: true, onClose });
+    panel.ref(makeNode(420));
+    panel.requestClose();
+    panel.settle();
+    panel.settle();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("snaps closed without a flight when animations are disabled", () => {
+    const onClose = vi.fn();
+    let panel = renderCollapse({ open: true, enabled: false, onClose });
+    panel.ref(makeNode(420));
+    panel.requestClose();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    panel = renderCollapse({ open: false, enabled: false, onClose });
+    expect(panel.flight).toBeNull();
+  });
+
+  it("ignores requestClose while already closed", () => {
+    const onClose = vi.fn();
+    const panel = renderCollapse({ open: false, onClose });
+    panel.ref(makeNode(420));
+    panel.requestClose();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(panel.flight).toBeNull();
+  });
+
+  it("keeps the captured onClose across re-renders mid-flight", () => {
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+    let panel = renderCollapse({ open: true, onClose: firstClose });
+    panel.ref(makeNode(420));
+    panel.requestClose();
+    // The owning component re-renders with a new callback before landing.
+    panel = renderCollapse({ open: true, onClose: secondClose });
+    panel.settle();
+    expect(firstClose).toHaveBeenCalledTimes(1);
+    expect(secondClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -56,6 +56,11 @@ export function usePanelCollapse(input: {
   const nodeRef = React.useRef<HTMLElement | null>(null);
   const [flight, setFlight] = React.useState<PanelCollapseFlight | null>(null);
   const flightRef = React.useRef<PanelCollapseFlight | null>(null);
+  // Captured at arm time. Retirement must clean up THIS element: the shared
+  // ref can be reattached to another drawer's wrapper before the old
+  // wrapper's detach runs (thread switches), so nodeRef cannot be trusted
+  // to point at the flying node.
+  const flightNodeRef = React.useRef<HTMLElement | null>(null);
   const endTimerRef = React.useRef<number | null>(null);
   // Captured at requestClose so a late commit targets the panel that began
   // closing, even if the surrounding component re-rendered meanwhile.
@@ -72,8 +77,8 @@ export function usePanelCollapse(input: {
   const latestRef = React.useRef(latest);
   latestRef.current = latest;
 
-  const clearWrapperStyles = React.useCallback(() => {
-    const node = nodeRef.current;
+  const clearWrapperStyles = React.useCallback((target?: HTMLElement | null) => {
+    const node = target ?? nodeRef.current;
     if (!node) return;
     node.style.transition = "";
     node.style.width = "";
@@ -95,16 +100,18 @@ export function usePanelCollapse(input: {
         endTimerRef.current = null;
       }
       flightRef.current = null;
-      clearWrapperStyles();
+      clearWrapperStyles(flightNodeRef.current ?? nodeRef.current);
+      flightNodeRef.current = null;
       setFlight(null);
+      const onClose = pendingOnCloseRef.current;
       const superseded =
         pendingSupersedeRef.current !== undefined &&
         pendingSupersedeRef.current !== latestRef.current.supersedeKey;
-      if (current.direction === "out" && (options.commit || !superseded)) {
-        pendingOnCloseRef.current?.();
-      }
       pendingOnCloseRef.current = null;
       pendingSupersedeRef.current = undefined;
+      if (current.direction === "out" && (options.commit || !superseded)) {
+        onClose?.();
+      }
     },
     [clearWrapperStyles],
   );
@@ -118,7 +125,7 @@ export function usePanelCollapse(input: {
   // transition actually interpolates between the pinned start and end values.
   React.useEffect(() => {
     if (!flight) return;
-    const node = nodeRef.current;
+    const node = flightNodeRef.current ?? nodeRef.current;
     if (!node) {
       // The wrapper never mounted or already detached (caller bailed on
       // missing data); retire synchronously instead of sticking in flight.
@@ -154,7 +161,7 @@ export function usePanelCollapse(input: {
   // flight, then let the effect above flip to the end value next frame.
   React.useLayoutEffect(() => {
     if (!flight) return;
-    const node = nodeRef.current;
+    const node = flightNodeRef.current ?? nodeRef.current;
     if (!node) return;
     node.style.flex = "0 0 auto";
     node.style.transition = "none";
@@ -190,6 +197,7 @@ export function usePanelCollapse(input: {
     const natural = Math.ceil(dimension === "width" ? rect.width : rect.height);
     if (natural <= 0) return;
     const nextFlight: PanelCollapseFlight = { direction: "in", size: natural };
+    flightNodeRef.current = node;
     flightRef.current = nextFlight;
     setFlight(nextFlight);
   }, [open, input.identity]);
@@ -229,6 +237,7 @@ export function usePanelCollapse(input: {
     pendingOnCloseRef.current = current.onClose;
     pendingSupersedeRef.current = current.supersedeKey;
     const nextFlight: PanelCollapseFlight = { direction: "out", size };
+    flightNodeRef.current = node;
     flightRef.current = nextFlight;
     setFlight(nextFlight);
   }, []);

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -237,6 +237,10 @@ export function PanelCollapseFrame(props: {
             flight
               ? {
                   [props.dimension]: `${flight.size}px`,
+                  // Pin the cross axis too: the wrapper is a plain block at
+                  // both width call sites, so an auto-height box would let
+                  // h-full content shrink to intrinsic height mid-flight.
+                  ...(props.dimension === "width" ? { height: "100%" } : { width: "100%" }),
                   flex: "0 0 auto",
                   minWidth: 0,
                   minHeight: 0,

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -205,11 +205,16 @@ export type PanelCollapseState = ReturnType<typeof usePanelCollapse>;
 
 /**
  * Wrapper around a collapsible panel. Renders identically to the bare panel
- * while idle; while a flight runs it pins the animated dimension and clips
+ * while idle; while a flight runs it pins the animated dimension, clips
  * overflow, and holds the content box at its measured size so flexible
  * children (a maximized `flex-1` shell) get clipped instead of reflowing on
- * every frame. The pinned box carries `data-panel-collapse` too so
- * PreviewPanelShell's clamp walk still reaches past both wrappers.
+ * every frame.
+ *
+ * The content box stays mounted in every state (`display: contents` while
+ * idle): swapping element types at this slot would remount the whole panel
+ * subtree on each animated open and close, tearing down terminals, previews,
+ * and other local state mid-transition. Both boxes carry
+ * `data-panel-collapse` so PreviewPanelShell's clamp walk reaches past them.
  */
 export function PanelCollapseFrame(props: {
   state: Pick<PanelCollapseState, "ref" | "flight">;
@@ -226,21 +231,21 @@ export function PanelCollapseFrame(props: {
       style={flight ? { flex: "0 0 auto" } : undefined}
     >
       <React.Suspense fallback={null}>
-        {flight ? (
-          <div
-            data-panel-collapse=""
-            style={{
-              [props.dimension]: `${flight.size}px`,
-              flex: "0 0 auto",
-              minWidth: 0,
-              minHeight: 0,
-            }}
-          >
-            {props.children}
-          </div>
-        ) : (
-          props.children
-        )}
+        <div
+          data-panel-collapse=""
+          style={
+            flight
+              ? {
+                  [props.dimension]: `${flight.size}px`,
+                  flex: "0 0 auto",
+                  minWidth: 0,
+                  minHeight: 0,
+                }
+              : { display: "contents" }
+          }
+        >
+          {props.children}
+        </div>
       </React.Suspense>
     </div>
   );

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -221,14 +221,16 @@ export function usePanelCollapse(input: {
 
   const ref = React.useCallback(
     (node: HTMLElement | null) => {
-      nodeRef.current = node;
       if (node == null && flightRef.current) {
-        // Detached mid-flight (caller bailed); retire with supersession
-        // semantics so a bail cannot wipe newer panel intent.
-        retireFlight();
+        // Retire before dropping the reference so clearWrapperStyles can
+        // reset the inline animation styles on the detaching element, and
+        // commit so an active-drawer ref swap cannot pre-empt the
+        // identity-switch close below.
+        settle();
       }
+      nodeRef.current = node;
     },
-    [retireFlight],
+    [settle],
   );
 
   // Memoized so consumers can list the state object in dependency arrays

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -111,6 +111,12 @@ export function usePanelCollapse(input: {
     return () => {
       window.cancelAnimationFrame(raf);
       node.removeEventListener("transitionend", onTransitionEnd);
+      // Retargeting a flight must retire its fallback timer too, or the old
+      // timer settles the replacement flight early.
+      if (endTimerRef.current != null) {
+        window.clearTimeout(endTimerRef.current);
+        endTimerRef.current = null;
+      }
     };
   }, [flight]);
 
@@ -135,9 +141,9 @@ export function usePanelCollapse(input: {
     firstRenderRef.current = false;
     const switchedIdentity = prevIdentityRef.current !== input.identity;
     prevIdentityRef.current = input.identity;
-    // A pending exit commits right away so the old close lands against its
-    // own identity instead of leaking into the new one.
-    if (switchedIdentity && flightRef.current?.direction === "out") {
+    // An identity switch retires any flight: an exit commits against its own
+    // identity, an entrance snaps so it cannot grow the new identity's panel.
+    if (switchedIdentity) {
       settle();
     }
     if (wasFirstRender || switchedIdentity) return;
@@ -151,6 +157,13 @@ export function usePanelCollapse(input: {
     flightRef.current = nextFlight;
     setFlight(nextFlight);
   }, [open, input.identity]);
+
+  // Disabling animations mid-flight (setting toggle, OS reduced motion)
+  // snaps the panel to its current endpoint instead of finishing animated.
+  React.useLayoutEffect(() => {
+    if (enabled) return;
+    settle();
+  }, [enabled, settle]);
 
   const requestClose = React.useCallback(() => {
     const current = latestRef.current;
@@ -180,7 +193,12 @@ export function usePanelCollapse(input: {
     [settle],
   );
 
-  return { ref, requestClose, settle, flight };
+  // Memoized so consumers can list the state object in dependency arrays
+  // without resubscribing effects on every render.
+  return React.useMemo(
+    () => ({ ref, requestClose, settle, flight }),
+    [ref, requestClose, settle, flight],
+  );
 }
 
 export type PanelCollapseState = ReturnType<typeof usePanelCollapse>;
@@ -188,7 +206,10 @@ export type PanelCollapseState = ReturnType<typeof usePanelCollapse>;
 /**
  * Wrapper around a collapsible panel. Renders identically to the bare panel
  * while idle; while a flight runs it pins the animated dimension and clips
- * overflow so content holds still instead of squashing.
+ * overflow, and holds the content box at its measured size so flexible
+ * children (a maximized `flex-1` shell) get clipped instead of reflowing on
+ * every frame. The pinned box carries `data-panel-collapse` too so
+ * PreviewPanelShell's clamp walk still reaches past both wrappers.
  */
 export function PanelCollapseFrame(props: {
   state: Pick<PanelCollapseState, "ref" | "flight">;
@@ -204,7 +225,23 @@ export function PanelCollapseFrame(props: {
       className={cn(props.className, flight && "overflow-hidden")}
       style={flight ? { flex: "0 0 auto" } : undefined}
     >
-      <React.Suspense fallback={null}>{props.children}</React.Suspense>
+      <React.Suspense fallback={null}>
+        {flight ? (
+          <div
+            data-panel-collapse=""
+            style={{
+              [props.dimension]: `${flight.size}px`,
+              flex: "0 0 auto",
+              minWidth: 0,
+              minHeight: 0,
+            }}
+          >
+            {props.children}
+          </div>
+        ) : (
+          props.children
+        )}
+      </React.Suspense>
     </div>
   );
 }

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -201,6 +201,20 @@ export function usePanelCollapse(input: {
     retireFlight();
   }, [enabled, retireFlight]);
 
+  // A newer interaction supersedes an active close; cancel it immediately
+  // instead of letting the collapse run out over the newer intent and snap
+  // back at completion.
+  React.useLayoutEffect(() => {
+    if (flightRef.current?.direction !== "out") return;
+    if (
+      pendingSupersedeRef.current === undefined ||
+      pendingSupersedeRef.current === latestRef.current.supersedeKey
+    ) {
+      return;
+    }
+    endFlight({ commit: false });
+  }, [input.supersedeKey, endFlight]);
+
   const requestClose = React.useCallback(() => {
     const current = latestRef.current;
     if (!current.open || flightRef.current?.direction === "out") return;

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -81,29 +81,38 @@ export function usePanelCollapse(input: {
     node.style.flex = "";
   }, []);
 
-  const settle = React.useCallback(() => {
-    const current = flightRef.current;
-    if (!current) return;
-    if (endTimerRef.current != null) {
-      window.clearTimeout(endTimerRef.current);
-      endTimerRef.current = null;
-    }
-    flightRef.current = null;
-    clearWrapperStyles();
-    setFlight(null);
-    if (current.direction === "out") {
-      // A changed supersede key means newer panel intent landed while the
-      // collapse ran; drop the stale close instead of wiping it.
+  /**
+   * Ends the current flight. Explicit finishes (`commit: true`) always run
+   * the captured close; natural completion (transitionend, fallback timer,
+   * detach) honors supersession so a stale close cannot wipe newer intent.
+   */
+  const endFlight = React.useCallback(
+    (options: { commit: boolean }) => {
+      const current = flightRef.current;
+      if (!current) return;
+      if (endTimerRef.current != null) {
+        window.clearTimeout(endTimerRef.current);
+        endTimerRef.current = null;
+      }
+      flightRef.current = null;
+      clearWrapperStyles();
+      setFlight(null);
       const superseded =
         pendingSupersedeRef.current !== undefined &&
         pendingSupersedeRef.current !== latestRef.current.supersedeKey;
-      if (!superseded) {
+      if (current.direction === "out" && (options.commit || !superseded)) {
         pendingOnCloseRef.current?.();
       }
-    }
-    pendingOnCloseRef.current = null;
-    pendingSupersedeRef.current = undefined;
-  }, [clearWrapperStyles]);
+      pendingOnCloseRef.current = null;
+      pendingSupersedeRef.current = undefined;
+    },
+    [clearWrapperStyles],
+  );
+
+  /** Ends the current flight now: an exit commits, an entrance cancels. */
+  const settle = React.useCallback(() => endFlight({ commit: true }), [endFlight]);
+  /** Natural completion: an exit commits unless superseded mid-flight. */
+  const retireFlight = React.useCallback(() => endFlight({ commit: false }), [endFlight]);
 
   // Runs one animation frame after a flight's styles are applied so the
   // transition actually interpolates between the pinned start and end values.
@@ -112,21 +121,21 @@ export function usePanelCollapse(input: {
     const node = nodeRef.current;
     if (!node) {
       // The wrapper never mounted or already detached (caller bailed on
-      // missing data); settle synchronously instead of sticking in flight.
-      settle();
+      // missing data); retire synchronously instead of sticking in flight.
+      retireFlight();
       return;
     }
     const raf = window.requestAnimationFrame(() => {
       node.style.transition = `${dimension} ${PANEL_COLLAPSE_DURATION_MS}ms linear`;
       node.style[dimension] = flight.direction === "in" ? `${flight.size}px` : "0px";
       endTimerRef.current = window.setTimeout(
-        () => settle(),
+        () => retireFlight(),
         PANEL_COLLAPSE_DURATION_MS + PANEL_COLLAPSE_TIMER_SLACK_MS,
       );
     });
     const onTransitionEnd = (event: TransitionEvent) => {
       if (event.target !== node || event.propertyName !== dimension) return;
-      settle();
+      retireFlight();
     };
     node.addEventListener("transitionend", onTransitionEnd);
     return () => {
@@ -139,7 +148,7 @@ export function usePanelCollapse(input: {
         endTimerRef.current = null;
       }
     };
-  }, [flight]);
+  }, [flight, retireFlight]);
 
   // Apply the pinned start value in the same pre-paint pass that mounts the
   // flight, then let the effect above flip to the end value next frame.
@@ -189,8 +198,8 @@ export function usePanelCollapse(input: {
   // snaps the panel to its current endpoint instead of finishing animated.
   React.useLayoutEffect(() => {
     if (enabled) return;
-    settle();
-  }, [enabled, settle]);
+    retireFlight();
+  }, [enabled, retireFlight]);
 
   const requestClose = React.useCallback(() => {
     const current = latestRef.current;
@@ -214,11 +223,12 @@ export function usePanelCollapse(input: {
     (node: HTMLElement | null) => {
       nodeRef.current = node;
       if (node == null && flightRef.current) {
-        // Detached mid-flight (caller bailed); commit or drop without styles.
-        settle();
+        // Detached mid-flight (caller bailed); retire with supersession
+        // semantics so a bail cannot wipe newer panel intent.
+        retireFlight();
       }
     },
-    [settle],
+    [retireFlight],
   );
 
   // Memoized so consumers can list the state object in dependency arrays

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -37,6 +37,12 @@ export function usePanelCollapse(input: {
    * leak into another thread's panel layout.
    */
   identity?: string | number;
+  /**
+   * Snapshot at requestClose; if it differs at settle time, something else
+   * interacted with the panel meanwhile (a row picked, a surface opened) and
+   * the deferred close is dropped instead of wiping that newer intent.
+   */
+  supersedeKey?: string;
   onClose: () => void;
 }): {
   ref: (node: HTMLElement | null) => void;
@@ -54,8 +60,15 @@ export function usePanelCollapse(input: {
   // Captured at requestClose so a late commit targets the panel that began
   // closing, even if the surrounding component re-rendered meanwhile.
   const pendingOnCloseRef = React.useRef<(() => void) | null>(null);
+  const pendingSupersedeRef = React.useRef<string | undefined>(undefined);
 
-  const latest = { open, enabled, dimension, onClose: input.onClose };
+  const latest = {
+    open,
+    enabled,
+    dimension,
+    supersedeKey: input.supersedeKey,
+    onClose: input.onClose,
+  };
   const latestRef = React.useRef(latest);
   latestRef.current = latest;
 
@@ -79,9 +92,17 @@ export function usePanelCollapse(input: {
     clearWrapperStyles();
     setFlight(null);
     if (current.direction === "out") {
-      pendingOnCloseRef.current?.();
+      // A changed supersede key means newer panel intent landed while the
+      // collapse ran; drop the stale close instead of wiping it.
+      const superseded =
+        pendingSupersedeRef.current !== undefined &&
+        pendingSupersedeRef.current !== latestRef.current.supersedeKey;
+      if (!superseded) {
+        pendingOnCloseRef.current?.();
+      }
     }
     pendingOnCloseRef.current = null;
+    pendingSupersedeRef.current = undefined;
   }, [clearWrapperStyles]);
 
   // Runs one animation frame after a flight's styles are applied so the
@@ -146,6 +167,12 @@ export function usePanelCollapse(input: {
     if (switchedIdentity) {
       settle();
     }
+    // An exit bypassed by a direct store close (tab/session close paths that
+    // never went through requestClose) commits immediately; its onClose is
+    // idempotent against the already-closed store.
+    if (!open && flightRef.current?.direction === "out") {
+      settle();
+    }
     if (wasFirstRender || switchedIdentity) return;
     if (!open || flightRef.current || !latestRef.current.enabled) return;
     const node = nodeRef.current;
@@ -177,6 +204,7 @@ export function usePanelCollapse(input: {
       return;
     }
     pendingOnCloseRef.current = current.onClose;
+    pendingSupersedeRef.current = current.supersedeKey;
     const nextFlight: PanelCollapseFlight = { direction: "out", size };
     flightRef.current = nextFlight;
     setFlight(nextFlight);

--- a/apps/web/src/components/PanelCollapse.tsx
+++ b/apps/web/src/components/PanelCollapse.tsx
@@ -1,0 +1,210 @@
+import * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+/** Matches the left sidebar's collapse timing (`duration-200 ease-linear`). */
+export const PANEL_COLLAPSE_DURATION_MS = 200;
+/** Slack over the transition duration before the timeout fallback commits. */
+const PANEL_COLLAPSE_TIMER_SLACK_MS = 60;
+
+export type CollapseDimension = "width" | "height";
+
+export interface PanelCollapseFlight {
+  direction: "in" | "out";
+  /** Wrapper size in px when the flight started; the wrapper is pinned to it. */
+  size: number;
+}
+
+/**
+ * Animates a panel collapsing to zero and growing back with a CSS transition
+ * while keeping a single source of truth: the store stays "open" for the
+ * whole exit, so nothing downstream needs a mounted-vs-open workaround.
+ *
+ * - `requestClose()` starts the collapse and defers `onClose` until the
+ *   flight lands (transitionend, with a timer as the primary fallback).
+ *   The callback is captured at call time, so identity changes mid-flight
+ *   still commit against the panel that started closing.
+ * - Opening animates the entrance of a freshly mounted wrapper.
+ * - With `enabled` false every path snaps and the wrapper renders exactly
+ *   like the unwrapped panel.
+ */
+export function usePanelCollapse(input: {
+  open: boolean;
+  enabled: boolean;
+  dimension: CollapseDimension;
+  /**
+   * Switching identity mid-flight settles it immediately so an exit cannot
+   * leak into another thread's panel layout.
+   */
+  identity?: string | number;
+  onClose: () => void;
+}): {
+  ref: (node: HTMLElement | null) => void;
+  requestClose: () => void;
+  /** Ends the current flight now: an exit commits, an entrance cancels. */
+  settle: () => void;
+  flight: PanelCollapseFlight | null;
+} {
+  const { open, enabled, dimension } = input;
+
+  const nodeRef = React.useRef<HTMLElement | null>(null);
+  const [flight, setFlight] = React.useState<PanelCollapseFlight | null>(null);
+  const flightRef = React.useRef<PanelCollapseFlight | null>(null);
+  const endTimerRef = React.useRef<number | null>(null);
+  // Captured at requestClose so a late commit targets the panel that began
+  // closing, even if the surrounding component re-rendered meanwhile.
+  const pendingOnCloseRef = React.useRef<(() => void) | null>(null);
+
+  const latest = { open, enabled, dimension, onClose: input.onClose };
+  const latestRef = React.useRef(latest);
+  latestRef.current = latest;
+
+  const clearWrapperStyles = React.useCallback(() => {
+    const node = nodeRef.current;
+    if (!node) return;
+    node.style.transition = "";
+    node.style.width = "";
+    node.style.height = "";
+    node.style.flex = "";
+  }, []);
+
+  const settle = React.useCallback(() => {
+    const current = flightRef.current;
+    if (!current) return;
+    if (endTimerRef.current != null) {
+      window.clearTimeout(endTimerRef.current);
+      endTimerRef.current = null;
+    }
+    flightRef.current = null;
+    clearWrapperStyles();
+    setFlight(null);
+    if (current.direction === "out") {
+      pendingOnCloseRef.current?.();
+    }
+    pendingOnCloseRef.current = null;
+  }, [clearWrapperStyles]);
+
+  // Runs one animation frame after a flight's styles are applied so the
+  // transition actually interpolates between the pinned start and end values.
+  React.useEffect(() => {
+    if (!flight) return;
+    const node = nodeRef.current;
+    if (!node) {
+      // The wrapper never mounted or already detached (caller bailed on
+      // missing data); settle synchronously instead of sticking in flight.
+      settle();
+      return;
+    }
+    const raf = window.requestAnimationFrame(() => {
+      node.style.transition = `${dimension} ${PANEL_COLLAPSE_DURATION_MS}ms linear`;
+      node.style[dimension] = flight.direction === "in" ? `${flight.size}px` : "0px";
+      endTimerRef.current = window.setTimeout(
+        () => settle(),
+        PANEL_COLLAPSE_DURATION_MS + PANEL_COLLAPSE_TIMER_SLACK_MS,
+      );
+    });
+    const onTransitionEnd = (event: TransitionEvent) => {
+      if (event.target !== node || event.propertyName !== dimension) return;
+      settle();
+    };
+    node.addEventListener("transitionend", onTransitionEnd);
+    return () => {
+      window.cancelAnimationFrame(raf);
+      node.removeEventListener("transitionend", onTransitionEnd);
+    };
+  }, [flight]);
+
+  // Apply the pinned start value in the same pre-paint pass that mounts the
+  // flight, then let the effect above flip to the end value next frame.
+  React.useLayoutEffect(() => {
+    if (!flight) return;
+    const node = nodeRef.current;
+    if (!node) return;
+    node.style.flex = "0 0 auto";
+    node.style.transition = "none";
+    node.style[dimension] = flight.direction === "in" ? "0px" : `${flight.size}px`;
+    void node.offsetWidth;
+  }, [flight, dimension]);
+
+  // Entrance: `open` flipping true outside the initial mount arms a grow
+  // flight measured off the freshly mounted wrapper. Identity switches snap.
+  const firstRenderRef = React.useRef(true);
+  const prevIdentityRef = React.useRef(input.identity);
+  React.useLayoutEffect(() => {
+    const wasFirstRender = firstRenderRef.current;
+    firstRenderRef.current = false;
+    const switchedIdentity = prevIdentityRef.current !== input.identity;
+    prevIdentityRef.current = input.identity;
+    // A pending exit commits right away so the old close lands against its
+    // own identity instead of leaking into the new one.
+    if (switchedIdentity && flightRef.current?.direction === "out") {
+      settle();
+    }
+    if (wasFirstRender || switchedIdentity) return;
+    if (!open || flightRef.current || !latestRef.current.enabled) return;
+    const node = nodeRef.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    const natural = Math.ceil(dimension === "width" ? rect.width : rect.height);
+    if (natural <= 0) return;
+    const nextFlight: PanelCollapseFlight = { direction: "in", size: natural };
+    flightRef.current = nextFlight;
+    setFlight(nextFlight);
+  }, [open, input.identity]);
+
+  const requestClose = React.useCallback(() => {
+    const current = latestRef.current;
+    if (!current.open || flightRef.current?.direction === "out") return;
+    // An entrance still running retargets into an exit from wherever it is.
+    const node = nodeRef.current;
+    const rect = node?.getBoundingClientRect();
+    const size = Math.ceil(rect ? (current.dimension === "width" ? rect.width : rect.height) : 0);
+    if (!node || !current.enabled || size <= 1) {
+      current.onClose();
+      return;
+    }
+    pendingOnCloseRef.current = current.onClose;
+    const nextFlight: PanelCollapseFlight = { direction: "out", size };
+    flightRef.current = nextFlight;
+    setFlight(nextFlight);
+  }, []);
+
+  const ref = React.useCallback(
+    (node: HTMLElement | null) => {
+      nodeRef.current = node;
+      if (node == null && flightRef.current) {
+        // Detached mid-flight (caller bailed); commit or drop without styles.
+        settle();
+      }
+    },
+    [settle],
+  );
+
+  return { ref, requestClose, settle, flight };
+}
+
+export type PanelCollapseState = ReturnType<typeof usePanelCollapse>;
+
+/**
+ * Wrapper around a collapsible panel. Renders identically to the bare panel
+ * while idle; while a flight runs it pins the animated dimension and clips
+ * overflow so content holds still instead of squashing.
+ */
+export function PanelCollapseFrame(props: {
+  state: Pick<PanelCollapseState, "ref" | "flight">;
+  dimension: CollapseDimension;
+  className?: string | undefined;
+  children: React.ReactNode;
+}) {
+  const flight = props.state.flight;
+  return (
+    <div
+      ref={props.state.ref}
+      data-panel-collapse=""
+      className={cn(props.className, flight && "overflow-hidden")}
+      style={flight ? { flex: "0 0 auto" } : undefined}
+    >
+      <React.Suspense fallback={null}>{props.children}</React.Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspacePageHeader.tsx
+++ b/apps/web/src/components/WorkspacePageHeader.tsx
@@ -1,5 +1,6 @@
 import type { ComponentPropsWithoutRef } from "react";
 
+import { usePanelAnimations } from "../hooks/useSettings";
 import { cn } from "../lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "../workspaceTitlebar";
 
@@ -13,10 +14,13 @@ export function WorkspacePageHeader({
   readonly electron?: boolean;
   readonly reserveNativeControls?: boolean;
 }) {
+  const animate = usePanelAnimations();
   return (
     <header
       className={cn(
-        "flex h-[var(--workspace-topbar-height)] min-h-[var(--workspace-topbar-height)] shrink-0 items-center gap-3 pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)]",
+        "flex h-[var(--workspace-topbar-height)] min-h-[var(--workspace-topbar-height)] shrink-0 items-center gap-3 pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)]",
+        animate &&
+          "transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none",
         electron && "drag-region",
         reserveNativeControls && "wco:pr-[var(--workspace-native-controls-inset)]",
         COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,

--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -130,7 +130,13 @@ function useClampedMaxWidth(hostRef: RefObject<HTMLDivElement | null>, enabled: 
   }, []);
   useLayoutEffect(() => {
     if (!enabled) return;
-    const parent = hostRef.current?.parentElement;
+    // PanelCollapseFrame wraps the panel while it animates open/closed;
+    // measure through that wrapper so the clamp tracks the flex row the
+    // panel actually shares with its sibling column.
+    let parent = hostRef.current?.parentElement;
+    while (parent?.hasAttribute("data-panel-collapse")) {
+      parent = parent.parentElement;
+    }
     if (!parent) return;
     // Measure before first paint: the persisted width must be clamped
     // against the row on the initial render, not one observer tick later

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -481,6 +481,9 @@ export function useSettingsRestore(onRestored?: () => void) {
         ? ["Contrast"]
         : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
+      ...(settings.panelAnimations !== DEFAULT_UNIFIED_SETTINGS.panelAnimations
+        ? ["Panel animations"]
+        : []),
       ...(settings.environmentIdentificationMode !==
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
         ? ["Environment identification"]
@@ -570,6 +573,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.fontSizePrompt,
       settings.fontSizeTerminal,
       settings.glassOpacity,
+      settings.panelAnimations,
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
       settings.sidebarAutoSettleAfterDays,
@@ -655,6 +659,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+      panelAnimations: DEFAULT_UNIFIED_SETTINGS.panelAnimations,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
@@ -1119,6 +1124,8 @@ export function AppearanceSettingsPanel() {
           }
         />
 
+        <PanelAnimationsRow />
+
         {showEnvironmentIdentification ? (
           <SettingsRow
             {...searchableSetting("environment-identification")}
@@ -1325,6 +1332,34 @@ function TerminalFontRow() {
             terminal: settings.fontFamilyTerminal,
           })}
           size={settings.fontSizeTerminal}
+        />
+      }
+    />
+  );
+}
+
+function PanelAnimationsRow() {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+  return (
+    <SettingsRow
+      {...searchableSetting("panel-animations")}
+      description="Animate collapsing and expanding the sidebar, right panel, and terminal drawer."
+      resetAction={
+        settings.panelAnimations !== DEFAULT_UNIFIED_SETTINGS.panelAnimations ? (
+          <SettingResetButton
+            label="panel animations"
+            onClick={() =>
+              updateSettings({ panelAnimations: DEFAULT_UNIFIED_SETTINGS.panelAnimations })
+            }
+          />
+        ) : null
+      }
+      control={
+        <Switch
+          checked={settings.panelAnimations}
+          onCheckedChange={(checked) => updateSettings({ panelAnimations: Boolean(checked) })}
+          aria-label="Panel animations"
         />
       }
     />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -70,6 +70,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/appearance",
   },
   {
+    id: "panel-animations",
+    title: "Panel animations",
+    to: "/settings/appearance",
+  },
+  {
     id: "environment-identification",
     title: "Environment identification",
     to: "/settings/appearance",

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
+import { usePanelAnimations } from "~/hooks/useSettings";
 import { resolveSidebarState, type ResponsiveSidebarState } from "./sidebarState";
 import * as Schema from "effect/Schema";
 
@@ -194,6 +195,9 @@ function Sidebar({
   resizable?: boolean | SidebarResizableOptions;
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+  // Collapse/expand transitions are opt-in (Settings → Appearance); off means
+  // the panel snaps so toggling feels immediate.
+  const animate = usePanelAnimations();
   const resolvedResizable = React.useMemo<SidebarResolvedResizableOptions | null>(() => {
     if (isMobile || collapsible === "none" || !resizable) {
       return null;
@@ -281,7 +285,8 @@ function Sidebar({
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+            "relative w-(--sidebar-width) bg-transparent",
+            animate ? "transition-[width] duration-200 ease-linear" : undefined,
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
@@ -292,7 +297,8 @@ function Sidebar({
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) md:flex",
+            animate ? "transition-[left,right,width] duration-200 ease-linear" : undefined,
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -726,9 +732,11 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function SidebarGroupLabel({ className, render, ...props }: useRender.ComponentProps<"div">) {
+  const animate = usePanelAnimations();
   const defaultProps = {
     className: cn(
-      "flex h-8 shrink-0 items-center rounded-lg px-2 font-medium text-sidebar-foreground text-xs outline-hidden ring-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+      "flex h-8 shrink-0 items-center rounded-lg px-2 font-medium text-sidebar-foreground text-xs outline-hidden ring-ring focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+      animate && "transition-[margin,opacity] duration-200 ease-linear",
       "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
       className,
     ),

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -38,6 +38,7 @@ import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
 import { usePrimaryEnvironment } from "~/state/environments";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { useTheme } from "./useTheme";
+import { useMediaQuery } from "./useMediaQuery";
 
 const CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE = "[CLIENT_SETTINGS]";
 
@@ -287,6 +288,19 @@ export function useLegacySidebarEnabled(): boolean {
   const settingsHydrated = useClientSettingsHydrated();
   const legacySidebarEnabled = useClientSettingsValue().legacySidebarEnabled;
   return settingsHydrated && legacySidebarEnabled;
+}
+
+/**
+ * Whether collapsing/expanding the left sidebar, right panel, and terminal
+ * drawer animates. Opt-in via Settings → Appearance; panels snap until then.
+ * The OS reduce-motion preference wins over the setting. Resolves false
+ * until client settings hydrate so the first paint is stable.
+ */
+export function usePanelAnimations(): boolean {
+  const settingsHydrated = useClientSettingsHydrated();
+  const panelAnimations = useClientSettingsValue().panelAnimations;
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  return settingsHydrated && panelAnimations && !prefersReducedMotion;
 }
 
 /** Read current settings for one environment, merged with client-local preferences. */

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -26,7 +26,15 @@ import {
   RefreshCwIcon,
   SearchIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import {
   filterPullRequestsByInvolvement,
@@ -1217,6 +1225,18 @@ function PullRequestsRouteView() {
 
   // The panel close is deferred until its width collapse lands, so during
   // the animation the store, URL selection, and titlebar all still read open.
+  // The panel close is deferred until its width collapse lands, so during
+  // the animation the store, URL selection, and titlebar all still read open.
+  // The deferred URL write must not fire after the route unmounted
+  // mid-collapse: updateSearch is bound to this route's path with
+  // replace, which would yank the user back here from wherever they went.
+  const routeAliveRef = useRef(true);
+  useLayoutEffect(() => {
+    routeAliveRef.current = true;
+    return () => {
+      routeAliveRef.current = false;
+    };
+  }, []);
   const panelCollapse = usePanelCollapse({
     open:
       rightPanelState.isOpen && activePullRequestSurface !== null && panelEnvironmentId !== null,
@@ -1230,6 +1250,7 @@ function PullRequestsRouteView() {
     onClose: () => {
       if (rightPanelRef === null) return;
       useRightPanelStore.getState().close(rightPanelRef);
+      if (!routeAliveRef.current) return;
       updateSearch(clearedSelection);
     },
   });

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -11,7 +11,7 @@ import type {
   PullRequestListState,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useRouter } from "@tanstack/react-router";
 import {
   ChevronDownIcon,
   EyeIcon,
@@ -26,15 +26,7 @@ import {
   RefreshCwIcon,
   SearchIcon,
 } from "lucide-react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import {
   filterPullRequestsByInvolvement,
@@ -1227,16 +1219,12 @@ function PullRequestsRouteView() {
   // the animation the store, URL selection, and titlebar all still read open.
   // The panel close is deferred until its width collapse lands, so during
   // the animation the store, URL selection, and titlebar all still read open.
-  // The deferred URL write must not fire after the route unmounted
-  // mid-collapse: updateSearch is bound to this route's path with
-  // replace, which would yank the user back here from wherever they went.
-  const routeAliveRef = useRef(true);
-  useLayoutEffect(() => {
-    routeAliveRef.current = true;
-    return () => {
-      routeAliveRef.current = false;
-    };
-  }, []);
+  // The deferred URL write only makes sense while this route is the one on
+  // screen: updateSearch is bound to its path with replace, and running it
+  // after navigating away mid-collapse would yank the user back here. The
+  // router's live location is checked at commit time rather than a mount
+  // flag because ref detach can outrun any unmount cleanup.
+  const router = useRouter();
   const panelCollapse = usePanelCollapse({
     open:
       rightPanelState.isOpen && activePullRequestSurface !== null && panelEnvironmentId !== null,
@@ -1250,7 +1238,7 @@ function PullRequestsRouteView() {
     onClose: () => {
       if (rightPanelRef === null) return;
       useRightPanelStore.getState().close(rightPanelRef);
-      if (!routeAliveRef.current) return;
+      if (router.state.location.pathname !== Route.fullPath) return;
       updateSearch(clearedSelection);
     },
   });

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1222,6 +1222,9 @@ function PullRequestsRouteView() {
       rightPanelState.isOpen && activePullRequestSurface !== null && panelEnvironmentId !== null,
     enabled: usePanelAnimations(),
     dimension: "width",
+    // Picking a different row mid-collapse supersedes the pending close so
+    // its deferred commit cannot clear the newer selection.
+    supersedeKey: rightPanelState.surfaces.map((surface) => surface.id).join("|"),
     onClose: () => {
       if (rightPanelRef === null) return;
       useRightPanelStore.getState().close(rightPanelRef);

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -69,6 +69,8 @@ import { PullRequestListGhost } from "../components/pullRequest/PullRequestGhost
 import { PullRequestRow } from "../components/pullRequest/PullRequestRow";
 import { PullRequestsUnavailableState } from "../components/pullRequest/PullRequestsUnavailableState";
 import { RightPanelTabs, type PullRequestTabStatus } from "../components/RightPanelTabs";
+import { PanelCollapseFrame, usePanelCollapse } from "../components/PanelCollapse";
+import { usePanelAnimations } from "../hooks/useSettings";
 import {
   WorkspaceBreadcrumb,
   WorkspaceBreadcrumbItem,
@@ -1213,11 +1215,28 @@ function PullRequestsRouteView() {
           },
     );
 
-  const toggleRightPanel = () => {
-    if (rightPanelRef === null) return;
-    if (rightPanelState.isOpen) {
+  // The panel close is deferred until its width collapse lands, so during
+  // the animation the store, URL selection, and titlebar all still read open.
+  const panelCollapse = usePanelCollapse({
+    open:
+      rightPanelState.isOpen && activePullRequestSurface !== null && panelEnvironmentId !== null,
+    enabled: usePanelAnimations(),
+    dimension: "width",
+    onClose: () => {
+      if (rightPanelRef === null) return;
       useRightPanelStore.getState().close(rightPanelRef);
       updateSearch(clearedSelection);
+    },
+  });
+
+  const toggleRightPanel = () => {
+    if (rightPanelRef === null) return;
+    if (panelCollapse.flight?.direction === "out") {
+      panelCollapse.settle();
+      return;
+    }
+    if (rightPanelState.isOpen) {
+      panelCollapse.requestClose();
       return;
     }
     if (selectedPullRequestSurface === null) return;
@@ -1550,72 +1569,78 @@ function PullRequestsRouteView() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="relative flex min-h-0 flex-1">
-        {pullRequestsSupported && rightPanelState.isOpen ? openPanelControls : null}
+        {pullRequestsSupported && (rightPanelState.isOpen || panelCollapse.flight)
+          ? openPanelControls
+          : null}
         <PullRequestsColumn {...columnProps} />
 
-        {rightPanelState.isOpen && activePullRequestSurface && panelEnvironmentId !== null ? (
-          <RightPanelTabs
-            mode="inline"
-            widthStorageKey="t3code:pull-request-panel-width"
-            // Default to roughly half the viewport: the PR list needs more
-            // room than a chat, so the 540px chat-preview default squashes
-            // it. SSR has no window, so fall back to a reasonable width.
-            defaultWidth={typeof window === "undefined" ? 640 : Math.floor(window.innerWidth / 2)}
-            surfaces={rightPanelState.surfaces}
-            activeSurfaceId={activePullRequestSurface.id}
-            pendingSurfaceIds={EMPTY_PENDING_SURFACES}
-            previewSessions={EMPTY_PREVIEW_SESSIONS}
-            desktopByTabId={EMPTY_PREVIEW_DESKTOP_STATE}
-            terminalLabelsById={EMPTY_TERMINAL_LABELS}
-            onActivate={(surface) => {
-              if (surface.kind === "pull-request") activateSurface(surface);
-            }}
-            onCloseSurface={(surface) => {
-              if (surface.kind === "pull-request") closeSurface(surface);
-            }}
-            onCloseOtherSurfaces={(surface) => {
-              if (surface.kind === "pull-request") closeOtherSurfaces(surface);
-            }}
-            onCloseSurfacesToRight={(surface) => {
-              if (surface.kind === "pull-request") closeSurfacesToRight(surface);
-            }}
-            onCloseAllSurfaces={closeAllSurfaces}
-            onCopyFilePath={() => undefined}
-            onAddBrowser={() => undefined}
-            onAddTerminal={() => undefined}
-            onAddDiff={() => undefined}
-            onAddFiles={() => undefined}
-            onAddPullRequest={() => undefined}
-            onAddAgents={() => undefined}
-            browserAvailable={false}
-            terminalAvailable={false}
-            diffAvailable={false}
-            filesAvailable={false}
-            pullRequestAvailable={false}
-            agentsAvailable={false}
-            liveAgentCount={0}
-            pullRequestStatuses={pullRequestTabStatuses}
-          >
-            <PullRequestDetailPanel
-              key={activePullRequestSurface.id}
-              environmentId={panelEnvironmentId}
-              reference={{
-                projectId: activePullRequestSurface.projectId as ProjectId,
-                repository: activePullRequestSurface.repository,
-                number: activePullRequestSurface.number,
+        {(rightPanelState.isOpen || panelCollapse.flight) &&
+        activePullRequestSurface &&
+        panelEnvironmentId !== null ? (
+          <PanelCollapseFrame state={panelCollapse} dimension="width" className="flex-none">
+            <RightPanelTabs
+              mode="inline"
+              widthStorageKey="t3code:pull-request-panel-width"
+              // Default to roughly half the viewport: the PR list needs more
+              // room than a chat, so the 540px chat-preview default squashes
+              // it. SSR has no window, so fall back to a reasonable width.
+              defaultWidth={typeof window === "undefined" ? 640 : Math.floor(window.innerWidth / 2)}
+              surfaces={rightPanelState.surfaces}
+              activeSurfaceId={activePullRequestSurface.id}
+              pendingSurfaceIds={EMPTY_PENDING_SURFACES}
+              previewSessions={EMPTY_PREVIEW_SESSIONS}
+              desktopByTabId={EMPTY_PREVIEW_DESKTOP_STATE}
+              terminalLabelsById={EMPTY_TERMINAL_LABELS}
+              onActivate={(surface) => {
+                if (surface.kind === "pull-request") activateSurface(surface);
               }}
-              refreshToken={detailRefreshToken}
-              // Merging, closing or reopening changes the row this panel was opened from, so
-              // the list behind it is out of date the moment the host takes the action.
-              onActed={() => {
-                refreshList();
-                baselineQuery.refresh();
-                authoredQuery.refresh();
-                reviewingQuery.refresh();
+              onCloseSurface={(surface) => {
+                if (surface.kind === "pull-request") closeSurface(surface);
               }}
-              onStateChange={handlePullRequestTabStatusChange}
-            />
-          </RightPanelTabs>
+              onCloseOtherSurfaces={(surface) => {
+                if (surface.kind === "pull-request") closeOtherSurfaces(surface);
+              }}
+              onCloseSurfacesToRight={(surface) => {
+                if (surface.kind === "pull-request") closeSurfacesToRight(surface);
+              }}
+              onCloseAllSurfaces={closeAllSurfaces}
+              onCopyFilePath={() => undefined}
+              onAddBrowser={() => undefined}
+              onAddTerminal={() => undefined}
+              onAddDiff={() => undefined}
+              onAddFiles={() => undefined}
+              onAddPullRequest={() => undefined}
+              onAddAgents={() => undefined}
+              browserAvailable={false}
+              terminalAvailable={false}
+              diffAvailable={false}
+              filesAvailable={false}
+              pullRequestAvailable={false}
+              agentsAvailable={false}
+              liveAgentCount={0}
+              pullRequestStatuses={pullRequestTabStatuses}
+            >
+              <PullRequestDetailPanel
+                key={activePullRequestSurface.id}
+                environmentId={panelEnvironmentId}
+                reference={{
+                  projectId: activePullRequestSurface.projectId as ProjectId,
+                  repository: activePullRequestSurface.repository,
+                  number: activePullRequestSurface.number,
+                }}
+                refreshToken={detailRefreshToken}
+                // Merging, closing or reopening changes the row this panel was opened from, so
+                // the list behind it is out of date the moment the host takes the action.
+                onActed={() => {
+                  refreshList();
+                  baselineQuery.refresh();
+                  authoredQuery.refresh();
+                  reviewingQuery.refresh();
+                }}
+                onStateChange={handlePullRequestTabStatusChange}
+              />
+            </RightPanelTabs>
+          </PanelCollapseFrame>
         ) : null}
       </div>
     </SidebarInset>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1224,7 +1224,9 @@ function PullRequestsRouteView() {
     dimension: "width",
     // Picking a different row mid-collapse supersedes the pending close so
     // its deferred commit cannot clear the newer selection.
-    supersedeKey: rightPanelState.surfaces.map((surface) => surface.id).join("|"),
+    supersedeKey: `${rightPanelState.surfaces.map((surface) => surface.id).join("|")}:${
+      activePullRequestSurface?.id ?? ""
+    }`,
     onClose: () => {
       if (rightPanelRef === null) return;
       useRightPanelStore.getState().close(rightPanelRef);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -196,6 +196,9 @@ export const ClientSettingsSchema = Schema.Struct({
   // Grayscale `-webkit-font-smoothing: antialiased` (thinner strokes);
   // disabling restores the platform's heavier default. No effect off macOS.
   fontSmoothing: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  // Animate collapsing/expanding the left sidebar, right panel, and terminal
+  // drawer. Off by default: panels snap so toggling feels immediate.
+  panelAnimations: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   // Model favorites. Historically keyed by provider kind, now
   // widened to `ProviderInstanceId` so users can favorite a specific model
   // on a custom provider instance (e.g. "Codex Personal · gpt-5") without
@@ -892,6 +895,7 @@ export const ClientSettingsPatch = Schema.Struct({
   fontFamilySans: Schema.optionalKey(FontFamilyPreference),
   fontFamilyTerminal: Schema.optionalKey(FontFamilyPreference),
   fontSmoothing: Schema.optionalKey(Schema.Boolean),
+  panelAnimations: Schema.optionalKey(Schema.Boolean),
   favorites: Schema.optionalKey(
     Schema.Array(
       Schema.Struct({


### PR DESCRIPTION
## What Changed

- New client setting `panelAnimations` (default **off**), surfaced as Settings -> Appearance -> "Panel animations" and registered in settings search.
- New `PanelCollapse` primitive (`apps/web/src/components/PanelCollapse.tsx`): when enabled, closing a panel starts a 200ms CSS transition and **defers the store close until the transition lands**. Opening animates the entrance of the freshly mounted wrapper.
- Wired into all three surfaces: left sidebar and titlebar padding (CSS-transition gating, unchanged from before), right panel in ChatView and on the pull requests page, and the terminal drawer.

## Why

The previous iteration kept panels mounted through an exit animation while flipping the store closed instantly. That split one truth into two ("open" vs "still visible"), so every consumer needed `open || mounted` workarounds, frozen child snapshots, and phase bookkeeping - and each fix seeded the next bug (stuck phases, flicker on close, deadlocked toggles).

This version keeps a single source of truth: the panel is semantically open for as long as it is visually open. Titlebar placement, badge suppression, terminal reconcile, and focus logic all read the store with zero animation awareness. Reopen mid-collapse cancels the pending commit and CSS retargets natively; a second toggle mid-collapse finishes the close; switching threads commits the old panel's close against its own identity so nothing leaks across threads.

With the setting off, the wrapper renders byte-for-byte like the unwrapped panel - the dormant path is "no class", not an idle engine.

## Behavior notes

- Only explicit toggles animate. Closes that bypass toggles (closing the last terminal session via its X, closing the final tab) snap, matching pre-PR behavior; routing them through later is trivial.
- Thread switches snap by contract; identity changes settle any flight immediately.
- Reduced motion wins over the setting at both the hook (`usePanelAnimations`) and flight level.

## Testing

- `PanelCollapse.logic.test.ts` covers the close contract: deferral, single commit, snap-when-disabled, no-op when closed, callback capture across re-renders.
- Targeted typecheck, lint, and the PreviewPanelShell / ChatView logic suites pass.

Happy to attach a short clip of the opted-in behavior if useful.

Worked by ox-alpha via opencode.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in `panelAnimations` setting with deferred-close panel transitions
> - Adds a `panelAnimations` setting (default `false`) to `ClientSettingsSchema` with a toggle in the Appearance settings page.
> - Introduces `usePanelCollapse` and `PanelCollapseFrame` in `PanelCollapse.tsx` to coordinate animated panel close/expand, keeping the DOM mounted and deferring `onClose` until the transition completes.
> - Applies animated transitions to the desktop sidebar, terminal drawer in `ChatView`, and right panels in `ChatView` and `PullRequestsRouteView`.
> - Risk: Panels stay logically open in state until the animation completes; `PreviewPanelShell.useClampedMaxWidth` was updated to bypass `data-panel-collapse` wrappers to avoid miscalculated widths during the transition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65e0d05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout and close timing for the right panel and terminal drawer now defer store/URL updates until a CSS transition settles, which can race with thread switches, maximized layout, and PR route navigation if a flight is superseded incorrectly.
> 
> **Overview**
> Adds an opt-in **Panel animations** client setting (default off) so the left sidebar, chat right panel, terminal drawer, and PR detail panel can collapse and expand with a 200ms CSS transition instead of snapping.
> 
> A new `usePanelCollapse` / `PanelCollapseFrame` primitive keeps the store **open until the exit animation lands**. Toggling mid-collapse finishes the close; a newer surface or thread identity supersedes a pending hide so it cannot wipe later intent. With the setting off (or OS reduced motion), wrappers behave like the unwrapped panels.
> 
> Sidebar and titlebar padding transitions are gated on the same setting. Preview width clamping walks past collapse wrappers so row measurement stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e0d059149d71cb7c3d7a6b843b94ef1b52b7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->