### PR TITLE
fix(web): align project menu labels

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3521,7 +3521,7 @@ export default function Sidebar() {
                               environmentId={project.environmentId}
                               cwd={project.workspaceRoot}
                               faviconPath={project.faviconPath}
-                              className="size-4 shrink-0"
+                              className="-mx-0.5 size-4 shrink-0"
                             />
                             <span className="min-w-0 truncate text-sm">{project.displayName}</span>
                             <Button


### PR DESCRIPTION
Project rows using detected favicon images placed their labels farther right than rows using fallback folder SVGs.

Pass matching horizontal margin through the Sidebar project favicon slot, so loaded images and SVG fallbacks share the same geometry without changing the shared menu primitive.

UI evidence: to be added by maintainer.

Model: GPT-5.6
Harness: Codex in T3 Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project menu icon alignment by adding `-mx-0.5` to `ProjectFavicon` in `Sidebar`
> Adjusts the horizontal margin of the project favicon in the project scope selection menu so icons align with menu labels. Adds the Tailwind class `-mx-0.5` to the existing `size-4 shrink-0` classes in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/8029/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 958c1ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->