### PR TITLE
fix(server): classify successful MCP results correctly

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -168,6 +168,25 @@ describe("projectActivityPayload", () => {
     expect(JSON.stringify(projected.payload).length).toBeLessThan(500);
   });
 
+  it("does not restore a failed status for a successful Codex MCP result", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "mcp_tool_call",
+        status: "completed",
+        data: {
+          item: {
+            type: "mcpToolCall",
+            status: "failed",
+            result: { content: [{ type: "text", text: "diff details" }] },
+            error: null,
+          },
+        },
+      }),
+    );
+
+    expect((projected.payload as Record<string, unknown>).status).toBe("completed");
+  });
+
   it("slims Claude-shaped mcp_tool_call data (toolName/input/result block)", () => {
     const projected = projectActivityPayload(
       activity({

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -329,6 +329,11 @@ function projectAcpContent(value: unknown): Record<string, unknown> | undefined 
   return summary ? { content: summary } : undefined;
 }
 
+function hasSuccessfulMcpResult(data: Record<string, unknown>): boolean {
+  const item = asRecord(data.item);
+  return item?.type === "mcpToolCall" && item.result != null && item.error == null;
+}
+
 /**
  * Removes activity payload fields that no current client reads while retaining
  * the full payload in persistence and the event store.
@@ -344,7 +349,9 @@ export function projectActivityPayload(
 
   const itemStatus = asRecord(data.item)?.status;
   const projectedPayload =
-    payload.status === "completed" && (itemStatus === "failed" || itemStatus === "declined")
+    payload.status === "completed" &&
+    (itemStatus === "failed" || itemStatus === "declined") &&
+    !hasSuccessfulMcpResult(data)
       ? { ...payload, status: itemStatus }
       : payload;
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -742,6 +742,16 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
           status: "failed",
         },
         {
+          type: "mcpToolCall",
+          id: "successful-mcp-with-failed-status",
+          server: "t3-code",
+          tool: "inspectTaskChanges",
+          arguments: {},
+          error: null,
+          result: { content: [{ type: "text", text: "diff details" }] },
+          status: "failed",
+        },
+        {
           type: "fileChange",
           id: "declined-change",
           changes: [],
@@ -774,7 +784,10 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         if (firstEvent._tag !== "Some" || firstEvent.value.type !== "item.completed") {
           return;
         }
-        NodeAssert.equal(firstEvent.value.payload.status, item.status);
+        NodeAssert.equal(
+          firstEvent.value.payload.status,
+          item.id === "successful-mcp-with-failed-status" ? "completed" : item.status,
+        );
       }
     }),
   );

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -294,6 +294,36 @@ function itemDetail(itemType: CanonicalItemType, item: CodexLifecycleItem): stri
   return undefined;
 }
 
+function hasSuccessfulToolResult(item: CodexLifecycleItem): boolean {
+  if (item.type !== "mcpToolCall") {
+    return false;
+  }
+  return item.result != null && item.error == null;
+}
+
+function itemLifecycleStatus(
+  item: CodexLifecycleItem,
+  lifecycle: "item.started" | "item.updated" | "item.completed",
+): "inProgress" | "failed" | "declined" | "completed" | undefined {
+  if (lifecycle === "item.started") {
+    return "inProgress";
+  }
+
+  if (lifecycle !== "item.completed") {
+    return undefined;
+  }
+
+  if (
+    "status" in item &&
+    (item.status === "failed" || item.status === "declined") &&
+    !hasSuccessfulToolResult(item)
+  ) {
+    return item.status;
+  }
+
+  return "completed";
+}
+
 function toRequestTypeFromMethod(method: string): CanonicalRequestType {
   switch (method) {
     case "item/commandExecution/requestApproval":
@@ -476,14 +506,7 @@ function mapItemLifecycle(
   }
 
   const detail = itemDetail(itemType, item);
-  const status =
-    lifecycle === "item.started"
-      ? "inProgress"
-      : lifecycle === "item.completed"
-        ? "status" in item && (item.status === "failed" || item.status === "declined")
-          ? item.status
-          : "completed"
-        : undefined;
+  const status = itemLifecycleStatus(item, lifecycle);
 
   return {
     ...runtimeEventBase(event, canonicalThreadId),


### PR DESCRIPTION
## What Changed

- Treat a Codex MCP tool call as completed when it includes a non-null result and no error, even if the upstream status is `failed`.
- Keep genuine failed and declined item statuses unchanged.
- Refactor lifecycle status selection into a named helper for readability.
- Add regression coverage for `inspectTaskChanges` returning a result with an incorrect failed status.

## Why

Codex can report an MCP tool call with `status: "failed"` while also returning a valid result and no error. T3 Code displayed these calls as failed even though the agent received and used the result. This change uses the result and error fields to classify the call correctly.

## UI Changes

Not applicable. This is a server/provider lifecycle classification fix. The visible effect is limited to the activity status shown for affected tool calls.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

## Verification

- `git diff --check` passed.
- The focused test could not run locally because `vp` is not installed and workspace dependencies are not present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow status-classification fix for MCP tool-call lifecycle events; genuine failed/declined items are unchanged.
> 
> **Overview**
> Treats Codex MCP tool calls as **completed** when they have a non-null `result` and no `error`, even if Codex reports `status: "failed"`. Genuine failed and declined items are unchanged.
> 
> `CodexAdapter` now uses `itemLifecycleStatus` / `hasSuccessfulToolResult` for that override. `projectActivityPayload` no longer copies the nested failed status onto a successful MCP result, so the UI does not flip those calls back to failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da849275c53f4531f63a7d80e598aa5168d3941f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mcpToolCall` items with successful results being classified as `failed` or `declined`
> - When an `mcpToolCall` item has a non-null `result` and null `error`, it is now treated as successful regardless of the item's `status` field
> - Adds `hasSuccessfulMcpResult` helper in [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/8030/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) to prevent downgrading top-level `completed` status
> - Adds `hasSuccessfulToolResult` and `itemLifecycleStatus` helpers in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/8030/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) so `mapItemLifecycle` emits `completed` for successful MCP tool calls even when source status is `failed` or `declined`
> - Risk: any consumer relying on the nested `status` of `failed`/`declined` for MCP calls that actually have results will now see `completed` instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da84927.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->