### PR TITLE
feat(web): show notice instead of app in Tesla in-car browsers

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -42,7 +42,9 @@ const isTeslaCarBrowser = /Tesla\/|QtCarBrowser/.test(navigator.userAgent);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   isTeslaCarBrowser ? (
-    "T3 Code does not endorse this behavior"
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-center text-foreground">
+      <p className="max-w-md text-lg font-medium">T3 Code does not endorse this behavior</p>
+    </div>
   ) : (
     <React.StrictMode>
       {clerkPublishableKey && hasCloudPublicConfig() ? (

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -37,25 +37,32 @@ const electronClerkUI = {
 
 const app = <AppRoot router={router} />;
 
+// Tesla in-car browsers send a "Tesla/<version>" UA token (older models: QtCarBrowser).
+const isTeslaCarBrowser = /Tesla\/|QtCarBrowser/.test(navigator.userAgent);
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    {clerkPublishableKey && hasCloudPublicConfig() ? (
-      isElectron ? (
-        <ElectronClerkProvider
-          {...electronClerkUI}
-          appearance={clerkAppearance}
-          publishableKey={clerkPublishableKey}
-          passkeys={passkeys}
-        >
-          <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
-        </ElectronClerkProvider>
+  isTeslaCarBrowser ? (
+    "T3 Code does not endorse this behavior"
+  ) : (
+    <React.StrictMode>
+      {clerkPublishableKey && hasCloudPublicConfig() ? (
+        isElectron ? (
+          <ElectronClerkProvider
+            {...electronClerkUI}
+            appearance={clerkAppearance}
+            publishableKey={clerkPublishableKey}
+            passkeys={passkeys}
+          >
+            <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
+          </ElectronClerkProvider>
+        ) : (
+          <ClerkProvider appearance={clerkAppearance} publishableKey={clerkPublishableKey}>
+            <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
+          </ClerkProvider>
+        )
       ) : (
-        <ClerkProvider appearance={clerkAppearance} publishableKey={clerkPublishableKey}>
-          <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
-        </ClerkProvider>
-      )
-    ) : (
-      app
-    )}
-  </React.StrictMode>,
+        app
+      )}
+    </React.StrictMode>
+  ),
 );


### PR DESCRIPTION
## Summary
- Detect Tesla in-car browser user agents (`Tesla/<version>` token; `QtCarBrowser` on older Model S/X) in the web entry point
- When detected, render only the text "T3 Code does not endorse this behavior" instead of the app

## Test plan
- `npm run typecheck` in `apps/web` passes
- Spoof UA containing `Tesla/2024.x` and load the web UI: only the notice renders
- Normal browsers and Electron are unaffected (UA does not match)

## Screenshots

#### Before (normal browser) 
![Before: app boots normally](https://raw.githubusercontent.com/abcdmku/t3libre-paid/tesla-ua-screenshots/before-normal-ua.png)

#### After (Tesla in-car UA)
 ![After: only the notice renders](https://raw.githubusercontent.com/abcdmku/t3libre-paid/tesla-ua-screenshots/after-tesla-ua.png) 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side UA gate at bootstrap only; no auth, data, or API changes. False positives would hide the app for matching UAs.
> 
> **Overview**
> Tesla in-car browsers no longer boot the web app. `main.tsx` matches `Tesla/` or `QtCarBrowser` in the user agent and renders a centered “T3 Code does not endorse this behavior” message instead of Clerk, auth, and `AppRoot`. Other browsers and Electron are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a231dfbd31000da0c2486381e6cac8870c4c4e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show static notice instead of app for Tesla browsers in `main.tsx`
> - Adds `isTeslaCarBrowser` detection by testing `navigator.userAgent` against `/Tesla\/|QtCarBrowser/`
> - Updates the `ReactDOM.createRoot` bootstrap in [main.tsx](https://github.com/pingdotgg/t3code/pull/8032/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) to render a centered static message div when the Tesla browser is detected
> - Behavioral Change: Tesla in-car browsers bypass `React.StrictMode` and `Clerk`/`ElectronClerk` providers, receiving a static message instead of mounting the full application
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a231dfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->