### PR TITLE
feat(web): allow dragging active chats to reorder

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -435,19 +435,19 @@ function SnoozePopoverButton(props: {
   );
 }
 
-// Subset of useSortable applied to a pinned card's root <li>. Listeners go
-// on the whole card (no dedicated handle): the pointer sensor's distance
+// Subset of useSortable applied to a thread row's root <li>. Listeners go
+// on the whole row (no dedicated handle): the pointer sensor's distance
 // constraint keeps plain clicks working, and we skip dnd-kit's aria
 // attributes since there is no keyboard sensor and the card body already
 // carries its own button semantics.
-type SortablePinnedRowBag = Pick<
+type SortableThreadRowBag = Pick<
   ReturnType<typeof useSortable>,
   "listeners" | "setNodeRef" | "transform" | "transition" | "isDragging"
 >;
 
-function SortablePinnedThreadRow(props: {
+function SortableThreadRow(props: {
   id: string;
-  children: (bag: SortablePinnedRowBag) => ReactNode;
+  children: (bag: SortableThreadRowBag) => ReactNode;
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: props.id,
@@ -705,10 +705,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // rows. The marker can unpin the thread when the server supports pinning.
   pinningSupported: boolean;
   isPinned: boolean;
-  // Present only on pinned cards whose server supports reordering: dnd-kit
-  // sortable bag applied to the card root so the whole card drags (the
-  // pointer sensor's distance constraint keeps plain clicks working).
-  sortable?: SortablePinnedRowBag | undefined;
+  // Present only on rows that can be reordered: dnd-kit applies the sortable
+  // bag to the card root so the whole card drags (the pointer sensor's
+  // distance constraint keeps plain clicks working).
+  sortable?: SortableThreadRowBag | undefined;
   // Compact wake countdown ("2h") for rows in the snoozed shelf.
   snoozeWakeLabelText: string | null;
   // When a snooze ended (timer or early wake); drives the Woke pill until
@@ -1707,6 +1707,8 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
 export default function Sidebar() {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const threadOrder = useUiStateStore((store) => store.threadOrder);
+  const reorderThreadOrder = useUiStateStore((store) => store.reorderThreads);
   const threads = useThreadShells();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -2564,6 +2566,29 @@ export default function Sidebar() {
         override holds until all of them appear in canonical state. */
     readonly assignedKeys: ReadonlyMap<string, string>;
   } | null>(null);
+  const activeThreadKeys = useMemo(
+    () =>
+      activeThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+    [activeThreads],
+  );
+  const currentActiveThreadOrder = useMemo(() => {
+    const activeKeys = new Set(activeThreadKeys);
+    const savedOrder = threadOrder.filter((threadKey) => activeKeys.has(threadKey));
+    const savedKeys = new Set(savedOrder);
+    const newThreadKeys = activeThreadKeys.filter((threadKey) => !savedKeys.has(threadKey));
+    return [...newThreadKeys, ...savedOrder];
+  }, [activeThreadKeys, threadOrder]);
+  const orderedActiveThreads = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: activeThreads,
+        preferredIds: currentActiveThreadOrder,
+        getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      }),
+    [activeThreads, currentActiveThreadOrder],
+  );
   const orderedPinnedThreads = useMemo(() => {
     if (optimisticPinnedOrder === null) return pinnedThreads;
     return orderItemsByPreferredIds({
@@ -2716,6 +2741,24 @@ export default function Sidebar() {
       })();
     },
     [orderedPinnedThreads, reorderPinnedThread, reorderablePinnedKeys],
+  );
+  const threadDndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+  const handleActiveThreadDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const activeKey = String(event.active.id);
+      const overKey = event.over === null ? null : String(event.over.id);
+      if (overKey === null || activeKey === overKey) return;
+      if (
+        !currentActiveThreadOrder.includes(activeKey) ||
+        !currentActiveThreadOrder.includes(overKey)
+      ) {
+        return;
+      }
+      reorderThreadOrder(currentActiveThreadOrder, [activeKey], [overKey]);
+    },
+    [currentActiveThreadOrder, reorderThreadOrder],
   );
   // One snooze per thread at a time — same double-dispatch guard as settle.
   const snoozingThreadKeysRef = useRef(new Set<string>());
@@ -3640,7 +3683,7 @@ export default function Sidebar() {
                   const renderThreadRow = (
                     thread: EnvironmentThreadShell,
                     section: "pinned" | "active" | "snoozed" | "settled",
-                    sortable?: SortablePinnedRowBag,
+                    sortable?: SortableThreadRowBag,
                   ) => {
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
@@ -3788,9 +3831,9 @@ export default function Sidebar() {
                                   return renderThreadRow(thread, "pinned");
                                 }
                                 return (
-                                  <SortablePinnedThreadRow key={threadKey} id={threadKey}>
+                                  <SortableThreadRow key={threadKey} id={threadKey}>
                                     {(bag) => renderThreadRow(thread, "pinned", bag)}
-                                  </SortablePinnedThreadRow>
+                                  </SortableThreadRow>
                                 );
                               })}
                             </ul>
@@ -3809,8 +3852,39 @@ export default function Sidebar() {
                       />,
                     );
                   }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
+                  if (orderedActiveThreads.length > 0) {
+                    items.push(
+                      <li key="active-dnd" className="list-none">
+                        <DndContext
+                          sensors={threadDndSensors}
+                          collisionDetection={closestCenter}
+                          modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                          onDragEnd={handleActiveThreadDragEnd}
+                        >
+                          <SortableContext
+                            items={currentActiveThreadOrder}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            <ul
+                              role="list"
+                              aria-label="Active threads"
+                              className="flex flex-col gap-px"
+                            >
+                              {orderedActiveThreads.map((thread) => {
+                                const threadKey = scopedThreadKey(
+                                  scopeThreadRef(thread.environmentId, thread.id),
+                                );
+                                return (
+                                  <SortableThreadRow key={threadKey} id={threadKey}>
+                                    {(bag) => renderThreadRow(thread, "active", bag)}
+                                  </SortableThreadRow>
+                                );
+                              })}
+                            </ul>
+                          </SortableContext>
+                        </DndContext>
+                      </li>,
+                    );
                   }
                   // Snoozed shelf: between the inbox and Settled — out of the
                   // way, never gone. The header always renders while anything

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -10,6 +10,7 @@ import {
   type PersistedUiState,
   persistState,
   reorderProjects,
+  reorderThreads,
   resolveProjectExpanded,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
@@ -21,6 +22,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
   return {
     projectExpandedById: {},
     projectOrder: [],
+    threadOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
@@ -116,6 +118,14 @@ describe("uiStateStore pure functions", () => {
     );
   });
 
+  it("reorders chats from the current sidebar order", () => {
+    const currentOrder = ["thread-1", "thread-2", "thread-3"];
+
+    const next = reorderThreads(makeUiState(), currentOrder, ["thread-1"], ["thread-3"]);
+
+    expect(next.threadOrder).toEqual(["thread-2", "thread-3", "thread-1"]);
+  });
+
   it("stores explicit changed-file expansion choices", () => {
     const threadId = ThreadId.make("thread-1");
     const collapsed = setThreadChangedFilesExpanded(makeUiState(), threadId, "turn-1", false);
@@ -154,6 +164,7 @@ describe("parsePersistedState", () => {
         invalid: "no" as unknown as boolean,
       },
       projectOrder: ["physical-b", "", "physical-a", "physical-b"],
+      threadOrder: ["environment:thread-2", "environment:thread-1", "environment:thread-2"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
@@ -173,6 +184,7 @@ describe("parsePersistedState", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrder: ["environment:thread-2", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -270,6 +282,7 @@ describe("uiStateStore persistence", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrder: ["environment:thread-2", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -292,6 +305,7 @@ describe("uiStateStore persistence", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrder: ["environment:thread-2", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -20,6 +20,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
+  threadOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
@@ -35,6 +36,7 @@ export interface UiProjectState {
 }
 
 export interface UiThreadState {
+  threadOrder: string[];
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
@@ -48,6 +50,7 @@ export interface UiState extends UiProjectState, UiThreadState, UiEndpointState 
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
+  threadOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
@@ -125,6 +128,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
   return {
     projectExpandedById,
     projectOrder,
+    threadOrder: sanitizeStringArray(parsed.threadOrder),
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
@@ -203,6 +207,7 @@ export function persistState(state: UiState): void {
       JSON.stringify({
         projectExpandedById,
         projectOrder: state.projectOrder,
+        threadOrder: state.threadOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
@@ -381,12 +386,60 @@ export function reorderProjects(
   };
 }
 
+export function reorderThreads(
+  state: UiState,
+  currentThreadOrder: readonly string[],
+  draggedThreadIds: readonly string[],
+  targetThreadIds: readonly string[],
+): UiState {
+  if (draggedThreadIds.length === 0) {
+    return state;
+  }
+  const draggedSet = new Set(draggedThreadIds);
+  const targetSet = new Set(targetThreadIds);
+  if (draggedThreadIds.every((id) => targetSet.has(id))) {
+    return state;
+  }
+
+  const originalTargetIndex = currentThreadOrder.findIndex((id) => targetSet.has(id));
+  if (originalTargetIndex < 0) {
+    return state;
+  }
+
+  const threadOrder = [...currentThreadOrder];
+  const removed: string[] = [];
+  let draggedBeforeTarget = 0;
+  for (let i = threadOrder.length - 1; i >= 0; i--) {
+    if (draggedSet.has(threadOrder[i]!)) {
+      removed.unshift(threadOrder.splice(i, 1)[0]!);
+      if (i < originalTargetIndex) {
+        draggedBeforeTarget++;
+      }
+    }
+  }
+  if (removed.length === 0) {
+    return state;
+  }
+
+  const insertIndex = originalTargetIndex - Math.max(0, draggedBeforeTarget - 1);
+  threadOrder.splice(insertIndex, 0, ...removed);
+  return {
+    ...state,
+    threadOrder,
+  };
+}
+
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
+  reorderThreads: (
+    currentThreadOrder: readonly string[],
+    draggedThreadIds: readonly string[],
+    targetThreadIds: readonly string[],
+  ) => void;
   reorderProjects: (
     currentProjectOrder: readonly string[],
     draggedProjectIds: readonly string[],
@@ -406,6 +459,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
+  reorderThreads: (currentThreadOrder, draggedThreadIds, targetThreadIds) =>
+    set((state) => reorderThreads(state, currentThreadOrder, draggedThreadIds, targetThreadIds)),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>
     set((state) =>
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),


### PR DESCRIPTION
## Why\nUsers can organize active chats in the left sidebar by dragging rows into a preferred order.\n\n## What changed\n- Added vertical drag-and-drop to active sidebar chat rows using the existing dnd-kit primitives.\n- Persisted the order in browser-owned UI state so it survives reloads without changing the server protocol.\n- Kept pinned-thread ordering and unrelated work separate.\n\n## Verification\n- 121 focused sidebar and UI-state tests passed.\n- Web typecheck passed.\n- Formatting and diff checks passed.\n- Automated opus-review was unavailable because its configured module is missing; direct feature-diff review completed.\n\nImplemented by GPT-5.6 Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sidebar interaction and persisted client UI state. Risk is mainly ordering bugs or drag vs click conflicts, not auth or server data.
> 
> **Overview**
> Lets users drag active sidebar chats into a custom order. The order is stored in local UI state (`threadOrder`) so it survives reloads without a server protocol change.
> 
> Active rows now use the same dnd-kit vertical sortable pattern as pinned threads (whole-row drag, 6px activation so clicks still work). New chats prepend; saved keys that are still active keep their place. Pinned reorder is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a563e5644f8ee74a76043c2734fdbba8a729df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow dragging active chats to reorder in `Sidebar` and persist order in UI state
> - Wraps the Active threads section in `DndContext`/`SortableContext` with a 6px `PointerSensor` activation threshold so users can drag active chat rows to reorder them
> - Adds `threadOrder: string[]` to `UiThreadState` and `PersistedUiState`, persisted to localStorage via `persistState` and hydrated by `parsePersistedState`
> - Adds `reorderThreads` reducer in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/8039/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) that removes dragged ids and reinserts them before the target position, preserving relative order; wired into the Zustand store as a new action
> - Renames `SortablePinnedRowBag` → `SortableThreadRowBag` and `SortablePinnedThreadRow` → `SortableThreadRow` so the sortable row component is shared by both pinned and active sections
> - Behavioral Change: new active threads not present in saved `threadOrder` are placed before previously saved entries; `initialState.threadOrder` defaults to an empty array
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b0a563e. 2 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/uiStateStore.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 409](https://github.com/pingdotgg/t3code/blob/b0a563e5644f8ee74a76043c2734fdbba8a729df/apps/web/src/uiStateStore.ts#L409): `reorderThreads` replaces the persisted global `threadOrder` with `currentThreadOrder`, even though the caller builds that array only from currently visible active threads. Dragging while a project scope is selected therefore deletes every other project's saved thread ordering; clearing the scope makes those omitted threads appear as new and move to the front. The same loss occurs for temporarily non-active threads (for example snoozed or settled threads), whose prior position is discarded by any drag performed while they are absent. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->