### PR TITLE
fix(clients): dedupe skills in composer menus

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -9,7 +9,10 @@ import {
   normalizeSearchQuery,
   scoreQueryMatch,
 } from "@t3tools/shared/searchRanking";
-import { dedupeProviderSkillsByName } from "@t3tools/client-runtime/providerSkills";
+import {
+  dedupeProviderSkillsByName,
+  getProviderSkillsForSlashMenu,
+} from "@t3tools/client-runtime/providerSkills";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ComposerEditorSelection } from "../../components/ComposerEditor";
@@ -131,7 +134,10 @@ export function useComposerCommandMenu({
         });
       }
 
-      const skillItems = dedupeProviderSkillsByName(selectedProviderStatus?.skills ?? [])
+      const skillItems = getProviderSkillsForSlashMenu(
+        selectedProviderStatus?.skills ?? [],
+        true,
+      )
         .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
           id: `skill:${skill.name}`,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -9,6 +9,7 @@ import {
   normalizeSearchQuery,
   scoreQueryMatch,
 } from "@t3tools/shared/searchRanking";
+import { dedupeProviderSkillsByName } from "@t3tools/client-runtime/providerSkills";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ComposerEditorSelection } from "../../components/ComposerEditor";
@@ -130,7 +131,7 @@ export function useComposerCommandMenu({
         });
       }
 
-      const skillItems = (selectedProviderStatus?.skills ?? [])
+      const skillItems = dedupeProviderSkillsByName(selectedProviderStatus?.skills ?? [])
         .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
           id: `skill:${skill.name}`,
@@ -144,7 +145,9 @@ export function useComposerCommandMenu({
     }
 
     if (trigger.kind === "skill") {
-      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((skill) => skill.enabled);
+      const enabledSkills = dedupeProviderSkillsByName(
+        (selectedProviderStatus?.skills ?? []).filter((skill) => skill.enabled),
+      );
       const normalizedQuery = normalizeSearchQuery(trigger.query, {
         trimLeadingPattern: /^\$+/,
       });

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -134,10 +134,7 @@ export function useComposerCommandMenu({
         });
       }
 
-      const skillItems = getProviderSkillsForSlashMenu(
-        selectedProviderStatus?.skills ?? [],
-        true,
-      )
+      const skillItems = getProviderSkillsForSlashMenu(selectedProviderStatus?.skills ?? [], true)
         .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
           id: `skill:${skill.name}`,

--- a/apps/web/src/providerSkillSearch.test.ts
+++ b/apps/web/src/providerSkillSearch.test.ts
@@ -69,4 +69,17 @@ describe("searchProviderSkills", () => {
       "browser",
     ]);
   });
+
+  it("returns the first enabled definition for each skill name", () => {
+    const skills = [
+      makeSkill({ name: "branch-audit", path: "/Users/matt/.codex/skills/branch-audit/SKILL.md" }),
+      makeSkill({ name: "browser" }),
+      makeSkill({ name: "branch-audit", path: "/Users/matt/.agents/skills/branch-audit/SKILL.md" }),
+    ];
+
+    expect(searchProviderSkills(skills, "").map((skill) => skill.path)).toEqual([
+      "/Users/matt/.codex/skills/branch-audit/SKILL.md",
+      "/tmp/browser/SKILL.md",
+    ]);
+  });
 });

--- a/apps/web/src/providerSkillSearch.ts
+++ b/apps/web/src/providerSkillSearch.ts
@@ -1,5 +1,8 @@
 import type { ServerProviderSkill } from "@t3tools/contracts";
-import { formatProviderSkillDisplayName } from "@t3tools/client-runtime/providerSkills";
+import {
+  dedupeProviderSkillsByName,
+  formatProviderSkillDisplayName,
+} from "@t3tools/client-runtime/providerSkills";
 import {
   insertRankedSearchResult,
   normalizeSearchQuery,
@@ -70,7 +73,7 @@ export function searchProviderSkills(
   query: string,
   limit = Number.POSITIVE_INFINITY,
 ): ServerProviderSkill[] {
-  const enabledSkills = skills.filter((skill) => skill.enabled);
+  const enabledSkills = dedupeProviderSkillsByName(skills.filter((skill) => skill.enabled));
   const normalizedQuery = normalizeSearchQuery(query, { trimLeadingPattern: /^\$+/ });
 
   if (!normalizedQuery) {

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  dedupeProviderSkillsByName,
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
@@ -26,6 +27,31 @@ describe("formatProviderSkillDisplayName", () => {
   });
 });
 
+describe("dedupeProviderSkillsByName", () => {
+  it("keeps the first resolved skill and preserves unrelated skill order", () => {
+    const firstSkill = {
+      name: "branch-audit",
+      path: "/Users/matt/.codex/skills/branch-audit/SKILL.md",
+      enabled: true,
+    };
+    const otherSkill = {
+      name: "browser",
+      path: "/Users/matt/.agents/skills/browser/SKILL.md",
+      enabled: true,
+    };
+    const duplicateSkill = {
+      name: "Branch-Audit",
+      path: "/Users/matt/.agents/skills/branch-audit/SKILL.md",
+      enabled: true,
+    };
+
+    expect(dedupeProviderSkillsByName([firstSkill, otherSkill, duplicateSkill])).toEqual([
+      firstSkill,
+      otherSkill,
+    ]);
+  });
+});
+
 describe("getProviderSkillsForSlashMenu", () => {
   it("keeps the skill alias when the provider also exposes it as a slash command", () => {
     const askMatt = {
@@ -35,6 +61,31 @@ describe("getProviderSkillsForSlashMenu", () => {
     };
     expect(getProviderSkillsForSlashMenu([askMatt], true).map((skill) => skill.name)).toEqual([
       "ask-matt",
+    ]);
+  });
+
+  it("shows one row when enabled skills share a name", () => {
+    const skills = [
+      {
+        name: "babysit-pr",
+        path: "/Users/matt/.codex/skills/babysit-pr/SKILL.md",
+        enabled: true,
+      },
+      {
+        name: "browser",
+        path: "/Users/matt/.agents/skills/browser/SKILL.md",
+        enabled: true,
+      },
+      {
+        name: "babysit-pr",
+        path: "/Users/matt/.agents/skills/babysit-pr/SKILL.md",
+        enabled: true,
+      },
+    ];
+
+    expect(getProviderSkillsForSlashMenu(skills, true).map((skill) => skill.name)).toEqual([
+      "babysit-pr",
+      "browser",
     ]);
   });
 });

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -88,6 +88,24 @@ describe("getProviderSkillsForSlashMenu", () => {
       "browser",
     ]);
   });
+
+  it("keeps an enabled skill when a disabled duplicate appears first", () => {
+    const enabledSkill = {
+      name: "babysit-pr",
+      path: "/Users/matt/.agents/skills/babysit-pr/SKILL.md",
+      enabled: true,
+    };
+    const skills = [
+      {
+        name: "babysit-pr",
+        path: "/Users/matt/.codex/skills/babysit-pr/SKILL.md",
+        enabled: false,
+      },
+      enabledSkill,
+    ];
+
+    expect(getProviderSkillsForSlashMenu(skills, true)).toEqual([enabledSkill]);
+  });
 });
 
 describe("getProviderSlashCommandsForSlashMenu", () => {

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -25,11 +25,27 @@ export function formatProviderSkillDisplayName(
   return titleCaseWords(skill.name);
 }
 
+export function dedupeProviderSkillsByName(
+  skills: ReadonlyArray<ServerProviderSkill>,
+): ServerProviderSkill[] {
+  const seenNames = new Set<string>();
+  return skills.filter((skill) => {
+    const normalizedName = skill.name.trim().toLowerCase();
+    if (seenNames.has(normalizedName)) {
+      return false;
+    }
+    seenNames.add(normalizedName);
+    return true;
+  });
+}
+
 export function getProviderSkillsForSlashMenu(
   skills: ReadonlyArray<ServerProviderSkill>,
   showSkillsInSlashMenu: boolean,
 ): ServerProviderSkill[] {
-  return showSkillsInSlashMenu ? skills.filter((skill) => skill.enabled) : [];
+  return showSkillsInSlashMenu
+    ? dedupeProviderSkillsByName(skills.filter((skill) => skill.enabled))
+    : [];
 }
 
 export function getProviderSlashCommandsForSlashMenu(


### PR DESCRIPTION
## What Changed

- Collapse enabled provider skills by case-insensitive name before building composer menu rows.
- Preserve the provider's first resolved definition and the order of unrelated skills.
- Apply the same rule to `/` and `$` menus on web and mobile.
- Add regression coverage for duplicate names separated by another skill.

## Why

Codex can report the same skill name from both `.codex` and `.agents`. The composer rendered every definition with the same row ID, so duplicate rows highlighted together. Hovering a later duplicate also scrolled the menu to the first row with that ID, skipping entries between them.

Skill invocation is name-based, so multiple same-name rows are not independently selectable. Keeping one row per name makes the menu match what the user can invoke and restores one-to-one highlight and scroll targets.

## Original UI Verification

Existing UI evidence from the original PR. It was not rerun during this rebase.

| Before | After |
| --- | --- |
| ![Duplicate skills before](https://github.com/user-attachments/assets/5e536b93-d9f2-4d29-a1cb-b6f3aa37ddb8) | ![Deduplicated skills after](https://github.com/user-attachments/assets/cf5f1a45-ef25-4295-bcb2-f5f3c890ad56) |

The after image uses the same duplicated `.codex` and `.agents` skill setup. Each skill now has one row and one hover target.

## Validation

- `vp test run packages/client-runtime/src/providerSkills.test.ts apps/web/src/providerSkillSearch.test.ts apps/web/src/components/chat/composerSlashCommandSearch.test.ts apps/mobile/src/features/threads/use-composer-command-menu.test.ts` (24 tests passed)
- `vp run --filter @t3tools/client-runtime --filter @t3tools/web --filter @t3tools/mobile --concurrency-limit 2 typecheck`
- Targeted `vp lint --report-unused-disable-directives` on all five changed files
- Targeted `vp fmt --check` on all five changed files
- Original integrated desktop verification with the reported duplicated skill directories: `Babysit Pr` and `Branch Audit` each rendered once
- Original hover verification moved from `Branch Audit` to `Babysit Pr` without highlighting another row or jumping the menu
- Original `$` skill menu verification applied the same deduplication

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or timing behavior changed

Model: GPT-5.6 Sol  
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only menu filtering; duplicate same-name skills collapse to the first definition, which matches name-based invocation and fixes incorrect duplicate rows.
> 
> **Overview**
> Fixes duplicate skill rows in composer autocomplete when the same skill name is reported from multiple paths (e.g. `.codex` and `.agents`), which caused shared row IDs, broken hover/highlight, and menu scroll jumps.
> 
> Adds **`dedupeProviderSkillsByName`** in `client-runtime` to keep one entry per trimmed, case-insensitive skill name (first occurrence wins, order of other skills unchanged). **`getProviderSkillsForSlashMenu`** and web **`searchProviderSkills`** now apply that dedup for enabled skills.
> 
> Mobile **`use-composer-command-menu`** uses **`getProviderSkillsForSlashMenu`** for `/` skill rows and **`dedupeProviderSkillsByName`** on the `$` skill picker so `/` and `$` behave like web.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3847cd4f4ba3b64535cbaf3ce382016e2154d69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dedupe skills by normalized name in composer menus
> - Adds `dedupeProviderSkillsByName` to [providerSkills.ts](https://github.com/pingdotgg/t3code/pull/8043/files#diff-476dddad7957a4fde40db8096524533f59b357b62c8d01c6d9f05f2c0b12c63c), which keeps the first resolved skill per trimmed, lowercased name while preserving order
> - Updates `getProviderSkillsForSlashMenu` to apply this dedup when `showSkillsInSlashMenu` is true, and updates web `searchProviderSkills` to dedupe before ranking
> - Mobile composer command menu ([use-composer-command-menu.ts](https://github.com/pingdotgg/t3code/pull/8043/files#diff-765bb6c8049500163389336a7a5e0c83873e041f5b14c72e5f5804359e6492d9)) now sources slash-menu skills via `getProviderSkillsForSlashMenu` and wraps the enabled-skill list with `dedupeProviderSkillsByName` for `$` skill triggers
> - Risk: duplicate skills with the same normalized name now collapse to the first occurrence, so any consumers relying on seeing multiple entries per name will only get one
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3847cd4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
