### PR TITLE
feat: panel side setting, hidden-file browsing, media previews, and video attachments

### DIFF
--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -87,6 +87,9 @@ export function makeDesktopContentSecurityPolicy(input: DesktopProtocolRegistrat
     `script-src ${scriptSources.join(" ")}`,
     `connect-src ${connectSources.join(" ")}`,
     `img-src 'self' ${input.scheme}: blob: data: http: https:`,
+    // Chat video attachments and Files-panel media previews play from the
+    // environment's signed asset URLs (http/https) and composer blob URLs.
+    `media-src 'self' ${input.scheme}: blob: http: https:`,
     "style-src 'self' 'unsafe-inline'",
     `font-src 'self' ${input.scheme}: data:`,
     "worker-src 'self' blob:",

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,7 +5,7 @@ import type {
   DesktopPreviewTabState,
 } from "@t3tools/contracts";
 import { exposeClerkBridge } from "@clerk/electron/preload";
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
 
@@ -34,6 +34,16 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       return null;
     }
     return result as ReturnType<DesktopBridge["getAppBranding"]>;
+  },
+  getPathForFile: (file: File) => {
+    try {
+      const filePath = webUtils.getPathForFile(file);
+      return filePath.length > 0 ? filePath : null;
+    } catch {
+      // Files synthesised in the renderer (clipboard, generated blobs) have
+      // no path on disk; the caller falls back to attaching or reporting.
+      return null;
+    }
   },
   getSystemLocale: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_SYSTEM_LOCALE_CHANNEL);

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -38,6 +38,7 @@ const clientSettings: ClientSettings = {
   planModeEnabled: false,
   showSkillsInSlashMenu: false,
   providerModelPreferences: {},
+  rightPanelSide: "right",
   sidebarAutoSettleAfterDays: 3,
   sidebarAutoSettleOnMerge: true,
   sidebarProjectGroupingMode: "repository_path",

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -39,6 +39,7 @@ const clientSettings: ClientSettings = {
   showSkillsInSlashMenu: false,
   providerModelPreferences: {},
   rightPanelSide: "right",
+  appSidebarSide: "left",
   sidebarAutoSettleAfterDays: 3,
   sidebarAutoSettleOnMerge: true,
   sidebarProjectGroupingMode: "repository_path",

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -15,6 +15,7 @@ import {
 } from "@t3tools/contracts";
 import {
   isWorkspaceImagePreviewPath,
+  isWorkspaceMediaPreviewPath,
   isWorkspacePreviewEntryPath,
   WORKSPACE_BROWSER_PREVIEW_EXTENSIONS,
   WORKSPACE_IMAGE_PREVIEW_EXTENSIONS,
@@ -257,7 +258,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      claims = isWorkspaceImagePreviewPath(resolved.relativePath)
+      claims = isWorkspaceMediaPreviewPath(resolved.relativePath)
         ? {
             version: 1,
             kind: "workspace-file-exact",

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -8,9 +8,18 @@ import {
   normalizeAttachmentRelativePath,
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
-import { inferImageExtension, SAFE_IMAGE_FILE_EXTENSIONS } from "./imageMime.ts";
+import {
+  inferImageExtension,
+  inferVideoExtension,
+  SAFE_IMAGE_FILE_EXTENSIONS,
+  SAFE_VIDEO_FILE_EXTENSIONS,
+} from "./imageMime.ts";
 
-const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".bin"];
+const ATTACHMENT_FILENAME_EXTENSIONS = [
+  ...SAFE_IMAGE_FILE_EXTENSIONS,
+  ...SAFE_VIDEO_FILE_EXTENSIONS,
+  ".bin",
+];
 const ATTACHMENT_ID_THREAD_SEGMENT_MAX_CHARS = 80;
 const ATTACHMENT_ID_THREAD_SEGMENT_PATTERN = "[a-z0-9_]+(?:-[a-z0-9_]+)*";
 const ATTACHMENT_ID_UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
@@ -63,7 +72,25 @@ export function attachmentRelativePath(attachment: ChatAttachment): string {
       });
       return `${attachment.id}${extension}`;
     }
+    case "video": {
+      const extension = inferVideoExtension({
+        mimeType: attachment.mimeType,
+        fileName: attachment.name,
+      });
+      return `${attachment.id}${extension}`;
+    }
   }
+}
+
+/**
+ * No provider ingests raw video, so adapters forward a video attachment as
+ * this prompt line; the agent can then read or process the file with tools.
+ */
+export function videoAttachmentPromptText(input: {
+  readonly name: string;
+  readonly path: string;
+}): string {
+  return `[The user attached the video file '${input.name}'. It is saved at: ${input.path}]`;
 }
 
 export function resolveAttachmentPath(input: {

--- a/apps/server/src/imageMime.ts
+++ b/apps/server/src/imageMime.ts
@@ -29,6 +29,15 @@ export const SAFE_IMAGE_FILE_EXTENSIONS = new Set([
   ".webp",
 ]);
 
+export const VIDEO_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  "video/mp4": ".mp4",
+  "video/quicktime": ".mov",
+  "video/webm": ".webm",
+  "video/x-m4v": ".m4v",
+};
+
+export const SAFE_VIDEO_FILE_EXTENSIONS = new Set([".m4v", ".mov", ".mp4", ".webm"]);
+
 // Whether `code` is a character the base64 payload may contain, aside from
 // the whitespace handled separately below.
 function isBase64Char(code: number): boolean {
@@ -112,26 +121,36 @@ export function parseBase64DataUrl(
   return { mimeType, base64 };
 }
 
-export function inferImageExtension(input: { mimeType: string; fileName?: string }): string {
+function inferAttachmentExtension(
+  input: { mimeType: string; fileName?: string },
+  extensionByMimeType: Record<string, string>,
+  safeExtensions: ReadonlySet<string>,
+): string {
   const key = input.mimeType.toLowerCase();
-  const fromMime = Object.hasOwn(IMAGE_EXTENSION_BY_MIME_TYPE, key)
-    ? IMAGE_EXTENSION_BY_MIME_TYPE[key]
-    : undefined;
+  const fromMime = Object.hasOwn(extensionByMimeType, key) ? extensionByMimeType[key] : undefined;
   if (fromMime) {
     return fromMime;
   }
 
   const fromMimeExtension = Mime.getExtension(input.mimeType);
-  if (fromMimeExtension && SAFE_IMAGE_FILE_EXTENSIONS.has(fromMimeExtension)) {
+  if (fromMimeExtension && safeExtensions.has(fromMimeExtension)) {
     return fromMimeExtension;
   }
 
   const fileName = input.fileName?.trim() ?? "";
   const extensionMatch = /\.([a-z0-9]{1,8})$/i.exec(fileName);
   const fileNameExtension = extensionMatch ? `.${extensionMatch[1]!.toLowerCase()}` : "";
-  if (SAFE_IMAGE_FILE_EXTENSIONS.has(fileNameExtension)) {
+  if (safeExtensions.has(fileNameExtension)) {
     return fileNameExtension;
   }
 
   return ".bin";
+}
+
+export function inferImageExtension(input: { mimeType: string; fileName?: string }): string {
+  return inferAttachmentExtension(input, IMAGE_EXTENSION_BY_MIME_TYPE, SAFE_IMAGE_FILE_EXTENSIONS);
+}
+
+export function inferVideoExtension(input: { mimeType: string; fileName?: string }): string {
+  return inferAttachmentExtension(input, VIDEO_EXTENSION_BY_MIME_TYPE, SAFE_VIDEO_FILE_EXTENSIONS);
 }

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -338,9 +338,6 @@ function collectThreadAttachmentRelativePaths(
   const relativePaths = new Set<string>();
   for (const message of messages) {
     for (const attachment of message.attachments ?? []) {
-      if (attachment.type !== "image") {
-        continue;
-      }
       const attachmentThreadSegment = parseThreadSegmentFromAttachmentId(attachment.id);
       if (!attachmentThreadSegment || attachmentThreadSegment !== threadSegment) {
         continue;

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -7,7 +7,9 @@ import {
   type IsoDateTime,
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
+  isProviderSendTurnSupportedVideoMimeType,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  PROVIDER_SEND_TURN_MAX_VIDEO_BYTES,
 } from "@t3tools/contracts";
 
 import { createAttachmentId, resolveAttachmentPath } from "../attachmentStore.ts";
@@ -109,16 +111,25 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       (attachment) =>
         Effect.gen(function* () {
           const parsed = parseBase64DataUrl(attachment.dataUrl);
-          if (!parsed || !parsed.mimeType.startsWith("image/")) {
+          const parsedMimeAccepted =
+            parsed !== null &&
+            (attachment.type === "video"
+              ? isProviderSendTurnSupportedVideoMimeType(parsed.mimeType)
+              : parsed.mimeType.startsWith("image/"));
+          if (!parsed || !parsedMimeAccepted) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Invalid image attachment payload for '${attachment.name}'.`,
+              message: `Invalid ${attachment.type} attachment payload for '${attachment.name}'.`,
             });
           }
 
+          const maxBytes =
+            attachment.type === "video"
+              ? PROVIDER_SEND_TURN_MAX_VIDEO_BYTES
+              : PROVIDER_SEND_TURN_MAX_IMAGE_BYTES;
           const bytes = Buffer.from(parsed.base64, "base64");
-          if (bytes.byteLength === 0 || bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+          if (bytes.byteLength === 0 || bytes.byteLength > maxBytes) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Image attachment '${attachment.name}' is empty or too large.`,
+              message: `Attachment '${attachment.name}' is empty or too large.`,
             });
           }
 
@@ -129,13 +140,22 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
             });
           }
 
-          const persistedAttachment = {
-            type: "image" as const,
-            id: attachmentId,
-            name: attachment.name,
-            mimeType: parsed.mimeType.toLowerCase(),
-            sizeBytes: bytes.byteLength,
-          };
+          const persistedAttachment =
+            attachment.type === "video"
+              ? {
+                  type: "video" as const,
+                  id: attachmentId,
+                  name: attachment.name,
+                  mimeType: parsed.mimeType.toLowerCase(),
+                  sizeBytes: bytes.byteLength,
+                }
+              : {
+                  type: "image" as const,
+                  id: attachmentId,
+                  name: attachment.name,
+                  mimeType: parsed.mimeType.toLowerCase(),
+                  sizeBytes: bytes.byteLength,
+                };
 
           const attachmentPath = resolveAttachmentPath({
             attachmentsDir: serverConfig.attachmentsDir,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -72,7 +72,7 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
-import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { resolveAttachmentPath, videoAttachmentPromptText } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
@@ -1265,6 +1265,17 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
 
   for (const attachment of input.attachments ?? []) {
     if (attachment.type !== "image") {
+      // Claude ingests no raw video; hand the agent the stored file's path.
+      const videoPath = resolveAttachmentPath({
+        attachmentsDir: dependencies.attachmentsDir,
+        attachment,
+      });
+      if (videoPath) {
+        sdkContent.push({
+          type: "text",
+          text: videoAttachmentPromptText({ name: attachment.name, path: videoPath }),
+        });
+      }
       continue;
     }
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -52,7 +52,7 @@ import {
   type ProviderAdapterError,
 } from "../Errors.ts";
 import { type CodexAdapterShape } from "../Services/CodexAdapter.ts";
-import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { resolveAttachmentPath, videoAttachmentPromptText } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import {
   CodexResumeCursorSchema,
@@ -1779,6 +1779,13 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         method: "turn/start",
         detail: `Invalid attachment id '${attachment.id}'.`,
       });
+    }
+    if (attachment.type !== "image") {
+      // No raw-video ingestion; pass the stored file's path.
+      return {
+        type: "text" as const,
+        text: videoAttachmentPromptText({ name: attachment.name, path: attachmentPath }),
+      };
     }
     const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
       Effect.mapError(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -111,10 +111,9 @@ export interface CodexSessionRuntimeOptions {
 
 export interface CodexSessionRuntimeSendTurnInput {
   readonly input?: string;
-  readonly attachments?: ReadonlyArray<{
-    readonly type: "image";
-    readonly url: string;
-  }>;
+  readonly attachments?: ReadonlyArray<
+    { readonly type: "image"; readonly url: string } | { readonly type: "text"; readonly text: string }
+  >;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort | undefined;
@@ -368,10 +367,9 @@ export function buildTurnStartParams(input: {
   readonly threadId: string;
   readonly runtimeMode: RuntimeMode;
   readonly prompt?: string;
-  readonly attachments?: ReadonlyArray<{
-    readonly type: "image";
-    readonly url: string;
-  }>;
+  readonly attachments?: ReadonlyArray<
+    { readonly type: "image"; readonly url: string } | { readonly type: "text"; readonly text: string }
+  >;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -40,7 +40,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { resolveAttachmentPath, videoAttachmentPromptText } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import {
@@ -982,6 +982,17 @@ export function makeCursorAdapter(
                   method: "session/prompt",
                   detail: `Invalid attachment id '${attachment.id}'.`,
                 });
+              }
+              if (attachment.type !== "image") {
+                // No raw-video ingestion; pass the stored file's path.
+                promptParts.push({
+                  type: "text",
+                  text: videoAttachmentPromptText({
+                    name: attachment.name,
+                    path: attachmentPath,
+                  }),
+                });
+                continue;
               }
               const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
                 Effect.mapError(

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -32,7 +32,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { resolveAttachmentPath, videoAttachmentPromptText } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import {
@@ -971,6 +971,16 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         method: "session/prompt",
                         detail: `Invalid attachment id '${attachment.id}'.`,
                       });
+                    }
+                    if (attachment.type !== "image") {
+                      // No raw-video ingestion; pass the stored file's path.
+                      return {
+                        type: "text",
+                        text: videoAttachmentPromptText({
+                          name: attachment.name,
+                          path: attachmentPath,
+                        }),
+                      } satisfies EffectAcpSchema.ContentBlock;
                     }
                     const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
                       Effect.mapError(

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -121,6 +121,30 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result.truncated).toBe(false);
       }),
     );
+
+    it.effect("includeHidden lists dotfiles and gitignored files, still skipping .git and node_modules", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/index.ts");
+        yield* writeTextFile(cwd, ".env");
+        yield* writeTextFile(cwd, ".gitignore", "media/\n");
+        yield* writeTextFile(cwd, "media/clip.mp4");
+        yield* writeTextFile(cwd, ".git/HEAD");
+        yield* writeTextFile(cwd, "node_modules/pkg/index.js");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd, includeHidden: true });
+        const paths = result.entries.map((entry) => entry.path);
+
+        expect(paths).toContain("src/index.ts");
+        expect(paths).toContain(".env");
+        expect(paths).toContain("media");
+        expect(paths).toContain("media/clip.mp4");
+        expect(paths.some((entryPath) => entryPath.startsWith(".git/") || entryPath === ".git")).toBe(false);
+        expect(paths.some((entryPath) => entryPath.startsWith("node_modules"))).toBe(false);
+        expect(result.truncated).toBe(false);
+      }),
+    );
   });
 
   describe("search", () => {

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -138,6 +138,52 @@ const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(fu
   return path.resolve(expandHomePath(input.cwd, path), input.partialPath);
 });
 
+// The search index honors gitignore, so ignored and dot-prefixed entries never
+// reach it. `includeHidden` listings walk the filesystem directly instead;
+// these two are still skipped so the tree stays usable.
+const HIDDEN_WALK_SKIP_DIRS = new Set([".git", "node_modules"]);
+const HIDDEN_WALK_MAX_ENTRIES = 25_000;
+
+async function walkWorkspaceEntries(
+  root: string,
+  join: (left: string, right: string) => string,
+): Promise<ProjectListEntriesResult> {
+  const entries: Array<ProjectListEntriesResult["entries"][number]> = [];
+  let truncated = false;
+  // Breadth-first so a truncated listing keeps the shallow structure intact.
+  const pendingDirs = [""];
+  for (let index = 0; index < pendingDirs.length && !truncated; index += 1) {
+    const relativeDir = pendingDirs[index]!;
+    let dirents: ReadonlyArray<{ readonly name: string; isDirectory(): boolean }>;
+    try {
+      dirents = await NodeFSP.readdir(join(root, relativeDir), { withFileTypes: true });
+    } catch {
+      // Unreadable directories (permissions, races) are skipped, not fatal.
+      continue;
+    }
+    for (const dirent of dirents) {
+      const name = dirent.name;
+      if (entries.length >= HIDDEN_WALK_MAX_ENTRIES) {
+        truncated = true;
+        break;
+      }
+      const relativePath = relativeDir ? `${relativeDir}/${name}` : name;
+      if (dirent.isDirectory()) {
+        if (HIDDEN_WALK_SKIP_DIRS.has(name)) continue;
+        entries.push({ path: relativePath, kind: "directory" });
+        pendingDirs.push(relativePath);
+      } else {
+        // Symlinks are listed but not followed, so cycles cannot recurse.
+        entries.push({ path: relativePath, kind: "file" });
+      }
+    }
+  }
+  return {
+    entries: entries.toSorted((left, right) => left.path.localeCompare(right.path)),
+    truncated,
+  };
+}
+
 export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
@@ -275,6 +321,11 @@ export const make = Effect.gen(function* () {
   const list: WorkspaceEntries["Service"]["list"] = Effect.fn("WorkspaceEntries.list")(
     function* (input) {
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
+      if (input.includeHidden === true) {
+        return yield* Effect.promise(() =>
+          walkWorkspaceEntries(normalizedCwd, (left, right) => path.join(left, right)),
+        );
+      }
       return yield* Effect.gen(function* () {
         const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
         return yield* searchIndex.list();

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -14,7 +14,11 @@ import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalSt
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
 import { primaryServerKeybindingsAtom } from "../state/server";
-import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
+import {
+  useClientSettings,
+  useEnvironmentIdentificationMode,
+  useLegacySidebarEnabled,
+} from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
@@ -139,6 +143,7 @@ function ProjectProjectionRetention() {
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const legacySidebarEnabled = useLegacySidebarEnabled();
+  const sidebarSide = useClientSettings((settings) => settings.appSidebarSide);
   // Settings routes show the settings nav in place of whichever thread
   // sidebar is active.
   const pathname = useLocation({ select: (location) => location.pathname });
@@ -209,13 +214,22 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   }, [navigate, pathname]);
 
   return (
-    <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={sidebarProviderStyle}>
+    <SidebarProvider
+      // Docked right, the sidebar renders after the content in the flex row;
+      // the primitive already handles its own borders and rail per side.
+      className={cn("h-dvh! min-h-0!", sidebarSide === "right" && "flex-row-reverse")}
+      defaultOpen
+      style={sidebarProviderStyle}
+    >
       <ProjectProjectionRetention />
       <Sidebar
-        side="left"
+        side={sidebarSide}
         collapsible="offcanvas"
         data-app-sidebar=""
-        className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
+        className={cn(
+          "bg-sidebar text-sidebar-foreground",
+          sidebarSide === "right" ? "border-l border-sidebar-border" : "border-r border-sidebar-border",
+        )}
         resizable={{
           maxWidth: sidebarMaximumWidth,
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -277,9 +277,6 @@ export function revokeUserMessagePreviewUrls(message: ChatMessage): void {
     return;
   }
   for (const attachment of message.attachments) {
-    if (attachment.type !== "image") {
-      continue;
-    }
     revokeBlobPreviewUrl(attachment.previewUrl);
   }
 }
@@ -289,8 +286,10 @@ export function collectUserMessageBlobPreviewUrls(message: ChatMessage): string[
     return [];
   }
   const previewUrls: string[] = [];
+  // Every attachment kind (image and video) stages a blob preview, and the
+  // handoff promotion compares counts against all server preview URLs — an
+  // image-only collection here would leave mixed messages stuck on blobs.
   for (const attachment of message.attachments) {
-    if (attachment.type !== "image") continue;
     if (!attachment.previewUrl || !attachment.previewUrl.startsWith("blob:")) continue;
     previewUrls.push(attachment.previewUrl);
   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1725,7 +1725,12 @@ function ChatViewContent(props: ChatViewProps) {
   const canMaximizeRightPanel = rightPanelOpen && !shouldUseRightPanelSheet;
   const rightPanelMaximized =
     canMaximizeRightPanel && maximizedRightPanelThreadKey === routeThreadKey;
-  const inlineRightPanelOwnsTitleBar = rightPanelOpen && !shouldUseRightPanelSheet;
+  const rightPanelSide = useClientSettings((settings) => settings.rightPanelSide);
+  const rightPanelDockedLeft = rightPanelSide === "left" && !shouldUseRightPanelSheet;
+  // Docked left (and not maximized), the chat column reaches the workspace's
+  // right edge, so the chat header is what sits under the titlebar controls.
+  const inlineRightPanelOwnsTitleBar =
+    rightPanelOpen && !shouldUseRightPanelSheet && (!rightPanelDockedLeft || rightPanelMaximized);
 
   useEffect(() => {
     if (!activeThreadRef) return;
@@ -2526,13 +2531,13 @@ function ChatViewContent(props: ChatViewProps) {
         continue;
       }
 
-      const serverPreviewUrls = serverMessage.attachments.flatMap((attachment) =>
-        attachment.type === "image" && attachment.previewUrl ? [attachment.previewUrl] : [],
+      const serverPreviews = serverMessage.attachments.flatMap((attachment) =>
+        attachment.previewUrl ? [{ previewUrl: attachment.previewUrl, type: attachment.type }] : [],
       );
       if (
-        serverPreviewUrls.length === 0 ||
-        serverPreviewUrls.length !== handoffPreviewUrls.length ||
-        serverPreviewUrls.some((previewUrl) => previewUrl.startsWith("blob:"))
+        serverPreviews.length === 0 ||
+        serverPreviews.length !== handoffPreviewUrls.length ||
+        serverPreviews.some((preview) => preview.previewUrl.startsWith("blob:"))
       ) {
         continue;
       }
@@ -2543,19 +2548,21 @@ function ChatViewContent(props: ChatViewProps) {
       const imageInstances: HTMLImageElement[] = [];
 
       const preloadServerPreviews = Promise.all(
-        serverPreviewUrls.map(
-          (previewUrl) =>
-            new Promise<void>((resolve, reject) => {
-              const image = new Image();
-              imageInstances.push(image);
-              const handleLoad = () => resolve();
-              const handleError = () =>
-                reject(new Error(`Failed to load server preview for ${messageId}.`));
-              image.addEventListener("load", handleLoad, { once: true });
-              image.addEventListener("error", handleError, { once: true });
-              image.src = previewUrl;
-            }),
-        ),
+        serverPreviews.map(({ previewUrl, type }) => {
+          // Only images are preload-verified; a video swaps to its asset URL
+          // directly and the <video> element re-buffers from there.
+          if (type !== "image") return Promise.resolve();
+          return new Promise<void>((resolve, reject) => {
+            const image = new Image();
+            imageInstances.push(image);
+            const handleLoad = () => resolve();
+            const handleError = () =>
+              reject(new Error(`Failed to load server preview for ${messageId}.`));
+            image.addEventListener("load", handleLoad, { once: true });
+            image.addEventListener("error", handleError, { once: true });
+            image.src = previewUrl;
+          });
+        }),
       );
 
       void preloadServerPreviews
@@ -5439,22 +5446,30 @@ function ChatViewContent(props: ChatViewProps) {
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
     const turnAttachmentsPromise = Promise.all(
-      composerImagesSnapshot.map(async (image) => ({
-        type: "image" as const,
+      composerImagesSnapshot.map(async (image) => {
+        const base = {
+          name: image.name,
+          mimeType: image.mimeType,
+          sizeBytes: image.sizeBytes,
+          dataUrl: await readFileAsDataUrl(image.file),
+        };
+        return image.type === "video"
+          ? { type: "video" as const, ...base }
+          : { type: "image" as const, ...base };
+      }),
+    );
+    const optimisticAttachments = composerImagesSnapshot.map((image) => {
+      const base = {
+        id: image.id,
         name: image.name,
         mimeType: image.mimeType,
         sizeBytes: image.sizeBytes,
-        dataUrl: await readFileAsDataUrl(image.file),
-      })),
-    );
-    const optimisticAttachments = composerImagesSnapshot.map((image) => ({
-      type: "image" as const,
-      id: image.id,
-      name: image.name,
-      mimeType: image.mimeType,
-      sizeBytes: image.sizeBytes,
-      previewUrl: image.previewUrl,
-    }));
+        previewUrl: image.previewUrl,
+      };
+      return image.type === "video"
+        ? { type: "video" as const, ...base }
+        : { type: "image" as const, ...base };
+    });
     const shouldAnchorFirstMessage =
       activeThread.latestTurn === null &&
       !timelineMessages.some((message) => message.role === "user");
@@ -6553,6 +6568,7 @@ function ChatViewContent(props: ChatViewProps) {
           }
           revealLine={activeFileSurface?.revealLine ?? null}
           revealRequestId={activeFileSurface?.revealRequestId ?? 0}
+          explorerSide={rightPanelDockedLeft ? "left" : "right"}
           onOpenFile={openFileSurface}
           onPendingChange={handleFilePendingChange}
         />
@@ -6568,7 +6584,12 @@ function ChatViewContent(props: ChatViewProps) {
     composerBannerItems.length > 0 || Boolean(threadSyncPhase && !activeEnvironmentUnavailable);
 
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+    <div
+      className={cn(
+        "relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background",
+        rightPanelDockedLeft && "flex-row-reverse",
+      )}
+    >
       {rightPanelOpen && !shouldUseRightPanelSheet ? panelLayoutControls : null}
       <div
         className={cn(
@@ -6582,6 +6603,12 @@ function ChatViewContent(props: ChatViewProps) {
           data-chat-header
           electron={isElectron}
           reserveNativeControls={reserveTitleBarControlInset && !inlineRightPanelOwnsTitleBar}
+          // Docked left (non-maximized), the panel owns the workspace's left
+          // edge and its tab bar reserves the collapsed-sidebar toggle inset;
+          // the chat header reserving it too would indent the breadcrumb.
+          reserveCollapsedSidebarInset={
+            !(rightPanelOpen && rightPanelDockedLeft && !rightPanelMaximized)
+          }
           className="relative bg-background"
         >
           {!rightPanelOpen ? panelLayoutControls : null}
@@ -6605,7 +6632,7 @@ function ChatViewContent(props: ChatViewProps) {
             }
             keybindings={keybindings}
             availableEditors={availableEditors}
-            rightPanelOpen={rightPanelOpen}
+            rightPanelOpen={rightPanelOpen && inlineRightPanelOwnsTitleBar}
             gitCwd={gitCwd}
             onNewThreadInProject={handleNewThreadInActiveProject}
             onRunProjectScript={runProjectScript}
@@ -6984,6 +7011,7 @@ function ChatViewContent(props: ChatViewProps) {
       {!shouldUseRightPanelSheet && rightPanelOpen && activeThreadRef ? (
         <RightPanelTabs
           mode="inline"
+          side={rightPanelSide}
           maximized={rightPanelMaximized}
           surfaces={rightPanelState.surfaces}
           activeSurfaceId={activeRightPanelSurface?.id ?? null}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2615,13 +2615,14 @@ function ChatViewContent(props: ChatViewProps) {
             }
 
             let changed = false;
-            let imageIndex = 0;
+            // The handoff list is positional over every attachment (images
+            // and videos both stage blob previews), so the index advances
+            // for each one — a type-filtered walk would pair attachments
+            // with the wrong URLs in mixed messages.
+            let attachmentIndex = 0;
             const attachments = message.attachments.map((attachment) => {
-              if (attachment.type !== "image") {
-                return attachment;
-              }
-              const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
-              imageIndex += 1;
+              const handoffPreviewUrl = handoffPreviewUrls[attachmentIndex];
+              attachmentIndex += 1;
               if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
                 return attachment;
               }
@@ -5520,17 +5521,17 @@ function ChatViewContent(props: ChatViewProps) {
     clearComposerDraftContent(composerDraftTarget);
     composerRef.current?.resetCursorState();
 
-    let firstComposerImageName: string | null = null;
+    let firstComposerAttachmentLabel: string | null = null;
     if (composerImagesSnapshot.length > 0) {
       const firstComposerImage = composerImagesSnapshot[0];
       if (firstComposerImage) {
-        firstComposerImageName = firstComposerImage.name;
+        firstComposerAttachmentLabel = `${firstComposerImage.type === "video" ? "Video" : "Image"}: ${firstComposerImage.name}`;
       }
     }
     let titleSeed = trimmed;
     if (!titleSeed) {
-      if (firstComposerImageName) {
-        titleSeed = `Image: ${firstComposerImageName}`;
+      if (firstComposerAttachmentLabel) {
+        titleSeed = firstComposerAttachmentLabel;
       } else if (composerTerminalContextsSnapshot.length > 0) {
         titleSeed = formatTerminalContextLabel(composerTerminalContextsSnapshot[0]!);
       } else if (composerElementContextsSnapshot.length > 0) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6672,7 +6672,7 @@ function ChatViewContent(props: ChatViewProps) {
                   className="flex items-center gap-2 rounded-full border border-primary/25 bg-background/95 px-4 py-2.5 text-sm font-medium text-foreground shadow-lg"
                 >
                   <PaperclipIcon className="size-4 text-primary" aria-hidden="true" />
-                  Drop files to attach
+                  Drop files to attach or add their paths
                 </div>
               </div>
             ) : null}

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -44,6 +44,8 @@ import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 
 interface RightPanelTabsProps {
   mode: PreviewPanelMode;
+  /** Which side of the workspace the panel docks on (inline mode only). */
+  side?: "left" | "right";
   maximized?: boolean;
   /** Forwarded to PreviewPanelShell so this surface persists its own width. */
   widthStorageKey?: string;
@@ -772,6 +774,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
   return (
     <PreviewPanelShell
       mode={props.mode}
+      {...(props.side !== undefined ? { side: props.side } : {})}
       {...(props.maximized !== undefined ? { maximized: props.maximized } : {})}
       {...(props.widthStorageKey !== undefined ? { widthStorageKey: props.widthStorageKey } : {})}
       {...(props.defaultWidth !== undefined ? { defaultWidth: props.defaultWidth } : {})}
@@ -782,9 +785,21 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           // The sheet overlays from the viewport top, so its tab bar keeps
           // the titlebar's height: a compact row re-centers the layout
           // controls a few pixels higher and the cluster jumps on open.
-          props.mode === "inline" && !props.layoutControls ? "pr-28" : "pr-3",
-          ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
-          props.mode === "inline" && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
+          // Docked left (non-maximized) the titlebar controls sit over the
+          // chat column instead, so the tab bar keeps its full width.
+          props.mode === "inline" &&
+            !props.layoutControls &&
+            (props.side !== "left" || props.maximized)
+            ? "pr-28"
+            : "pr-3",
+          ownsDesktopTitleBar &&
+            (props.side !== "left" || props.maximized) &&
+            "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
+          // Maximized — or docked left — the panel reaches the workspace's
+          // left edge, where the collapsed app sidebar's toggle floats.
+          props.mode === "inline" &&
+            (props.maximized || props.side === "left") &&
+            COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
         data-right-panel-tabbar
       >

--- a/apps/web/src/components/WorkspacePageHeader.tsx
+++ b/apps/web/src/components/WorkspacePageHeader.tsx
@@ -7,11 +7,18 @@ import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "../workspaceTitlebar";
 export function WorkspacePageHeader({
   electron = false,
   reserveNativeControls = electron,
+  reserveCollapsedSidebarInset = true,
   className,
   ...props
 }: ComponentPropsWithoutRef<"header"> & {
   readonly electron?: boolean;
   readonly reserveNativeControls?: boolean;
+  /**
+   * Reserve left padding for the collapsed app sidebar's floating toggle.
+   * Callers whose header no longer touches the workspace's left edge (chat
+   * column with the tool panel docked left) pass false to avoid dead indent.
+   */
+  readonly reserveCollapsedSidebarInset?: boolean;
 }) {
   return (
     <header
@@ -19,7 +26,7 @@ export function WorkspacePageHeader({
         "flex h-[var(--workspace-topbar-height)] min-h-[var(--workspace-topbar-height)] shrink-0 items-center gap-3 pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] transition-[padding-left] duration-200 ease-linear motion-reduce:transition-none sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)]",
         electron && "drag-region",
         reserveNativeControls && "wco:pr-[var(--workspace-native-controls-inset)]",
-        COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
+        reserveCollapsedSidebarInset && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         className,
       )}
       {...props}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -13,13 +13,10 @@ import type {
   TurnId,
 } from "@t3tools/contracts";
 import {
-  isProviderSendTurnSupportedImageMimeType,
-  isProviderSendTurnSupportedVideoMimeType,
   ProviderDriverKind,
   ProviderInstanceId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
-  PROVIDER_SEND_TURN_MAX_VIDEO_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
@@ -226,6 +223,8 @@ import { Button } from "../ui/button";
 import { Select, SelectItem, SelectPopup, SelectValue } from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
+import { isElectron } from "~/env";
+import { isInlineAttachableFile } from "./composerFileIntake";
 import {
   BotIcon,
   CircleAlertIcon,
@@ -2474,6 +2473,42 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     terminalOpen,
   ]);
 
+  /**
+   * Appends the on-disk paths of files the agent can't receive inline, and
+   * returns the names of files whose path could not be resolved (browser
+   * builds, or clipboard-synthesised files with no path).
+   */
+  const insertDroppedFilePaths = (droppedFiles: readonly File[]): string[] => {
+    const resolvedPaths: string[] = [];
+    const unresolvedNames: string[] = [];
+    for (const file of droppedFiles) {
+      const filePath = window.desktopBridge?.getPathForFile?.(file) ?? null;
+      if (filePath) {
+        resolvedPaths.push(filePath);
+      } else {
+        unresolvedNames.push(`'${file.name}'`);
+      }
+    }
+    if (resolvedPaths.length === 0) {
+      return unresolvedNames;
+    }
+    // Quoted so paths containing spaces survive being pasted into a shell
+    // command, and newline-separated so several drops stay readable.
+    const insertion = resolvedPaths.map((filePath) => `"${filePath}"`).join("\n");
+    if (!insertComposerTextAtEnd(insertion, { ensureLeadingBoundary: true })) {
+      return [...unresolvedNames, ...resolvedPaths.map((filePath) => `'${filePath}'`)];
+    }
+    toastManager.add({
+      type: "success",
+      title:
+        resolvedPaths.length === 1
+          ? "Added the file path to your message."
+          : `Added ${resolvedPaths.length} file paths to your message.`,
+      description: "The agent can read these files from disk.",
+    });
+    return unresolvedNames;
+  };
+
   // ------------------------------------------------------------------
   // Callbacks: images
   // ------------------------------------------------------------------
@@ -2498,21 +2533,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     let reservedCount = composerImagesRef.current.length + pendingCount;
     const acceptedFiles: File[] = [];
     let error: string | null = null;
+    // Files the agent cannot receive inline (CSV, PDF, archives, oversized or
+    // exotic media) are referenced by their path instead of rejected, so the
+    // agent can open them with its own tools.
+    const pathOnlyFiles: File[] = [];
     for (const file of files) {
-      if (file.type.startsWith("video/")) {
-        if (!isProviderSendTurnSupportedVideoMimeType(file.type)) {
-          error = `'${file.name}' is not a supported video type. Attach MP4, MOV, or WebM videos.`;
-          continue;
-        }
-        if (file.size === 0 || file.size > PROVIDER_SEND_TURN_MAX_VIDEO_BYTES) {
-          error = `'${file.name}' is too large to attach. Videos can be up to ${Math.floor(PROVIDER_SEND_TURN_MAX_VIDEO_BYTES / (1024 * 1024))} MB.`;
-          continue;
-        }
-      } else if (!file.type.startsWith("image/")) {
-        error = `Unsupported file type for '${file.name}'. Please attach image or video files only.`;
-        continue;
-      } else if (!isProviderSendTurnSupportedImageMimeType(file.type)) {
-        error = `'${file.name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+      if (!isInlineAttachableFile(file)) {
+        pathOnlyFiles.push(file);
         continue;
       }
       if (reservedCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
@@ -2521,6 +2548,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
       acceptedFiles.push(file);
       reservedCount += 1;
+    }
+
+    if (pathOnlyFiles.length > 0) {
+      const unresolvedNames = insertDroppedFilePaths(pathOnlyFiles);
+      if (unresolvedNames.length > 0) {
+        error = isElectron
+          ? `Could not resolve a file path for ${unresolvedNames.join(", ")}.`
+          : `${unresolvedNames.join(", ")} can't be attached here. Open the desktop app to reference files by path, or attach GIF, JPEG, PNG, or WebP images.`;
+      }
     }
     setThreadError(threadId, error);
     if (acceptedFiles.length === 0) return;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -14,10 +14,12 @@ import type {
 } from "@t3tools/contracts";
 import {
   isProviderSendTurnSupportedImageMimeType,
+  isProviderSendTurnSupportedVideoMimeType,
   ProviderDriverKind,
   ProviderInstanceId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  PROVIDER_SEND_TURN_MAX_VIDEO_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
@@ -1558,6 +1560,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         const stagedAttachmentById = new Map<string, PersistedComposerImageAttachment>();
         await Promise.all(
           composerImages.map(async (image) => {
+            // Videos are too large for the localStorage-backed draft store;
+            // they stay in-memory only and show the non-persisted badge.
+            if (image.type !== "image") return;
             try {
               const dataUrl = await readFileAsDataUrl(image.file);
               stagedAttachmentById.set(image.id, {
@@ -2494,16 +2499,24 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const acceptedFiles: File[] = [];
     let error: string | null = null;
     for (const file of files) {
-      if (!file.type.startsWith("image/")) {
-        error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
+      if (file.type.startsWith("video/")) {
+        if (!isProviderSendTurnSupportedVideoMimeType(file.type)) {
+          error = `'${file.name}' is not a supported video type. Attach MP4, MOV, or WebM videos.`;
+          continue;
+        }
+        if (file.size === 0 || file.size > PROVIDER_SEND_TURN_MAX_VIDEO_BYTES) {
+          error = `'${file.name}' is too large to attach. Videos can be up to ${Math.floor(PROVIDER_SEND_TURN_MAX_VIDEO_BYTES / (1024 * 1024))} MB.`;
+          continue;
+        }
+      } else if (!file.type.startsWith("image/")) {
+        error = `Unsupported file type for '${file.name}'. Please attach image or video files only.`;
         continue;
-      }
-      if (!isProviderSendTurnSupportedImageMimeType(file.type)) {
+      } else if (!isProviderSendTurnSupportedImageMimeType(file.type)) {
         error = `'${file.name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
         continue;
       }
       if (reservedCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
+        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} files per message.`;
         break;
       }
       acceptedFiles.push(file);
@@ -2517,6 +2530,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       const nextImages: ComposerImageAttachment[] = [];
       let compressionError: string | null = null;
       for (const file of acceptedFiles) {
+        if (file.type.startsWith("video/")) {
+          // Videos ship byte-for-byte; there is no client-side recompression.
+          nextImages.push({
+            type: "video",
+            id: randomUUID(),
+            name: file.name || "video",
+            mimeType: file.type,
+            sizeBytes: file.size,
+            previewUrl: URL.createObjectURL(file),
+            file,
+          });
+          continue;
+        }
         // Images over the wire cap are downscaled to fit rather than
         // refused; files already within it pass through byte-for-byte.
         const compressed = await compressImageToByteLimit(file, PROVIDER_SEND_TURN_MAX_IMAGE_BYTES);
@@ -2572,10 +2598,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) return;
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
+    const mediaFiles = files.filter(
+      (file) => file.type.startsWith("image/") || file.type.startsWith("video/"),
+    );
+    if (mediaFiles.length === 0) return;
     event.preventDefault();
-    void addComposerImages(imageFiles);
+    void addComposerImages(mediaFiles);
   };
 
   const insertComposerTextAtEnd = (
@@ -3161,7 +3189,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           key={image.id}
                           className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
                         >
-                          {image.previewUrl ? (
+                          {image.previewUrl && image.type === "video" ? (
+                            <video
+                              src={image.previewUrl}
+                              muted
+                              playsInline
+                              preload="metadata"
+                              aria-label={image.name}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : image.previewUrl ? (
                             <button
                               type="button"
                               className="h-full w-full cursor-zoom-in"

--- a/apps/web/src/components/chat/ExpandedImagePreview.tsx
+++ b/apps/web/src/components/chat/ExpandedImagePreview.tsx
@@ -9,11 +9,15 @@ export interface ExpandedImagePreview {
 }
 
 export function buildExpandedImagePreview(
-  images: ReadonlyArray<{ id: string; name: string; previewUrl?: string }>,
+  images: ReadonlyArray<{ id: string; name: string; previewUrl?: string; type?: string }>,
   selectedImageId: string,
 ): ExpandedImagePreview | null {
+  // The dialog renders every entry as an <img>; attachment lists can carry
+  // videos alongside images, and those must not enter the gallery.
   const previewableImages = images.flatMap((image) =>
-    image.previewUrl ? [{ id: image.id, src: image.previewUrl, name: image.name }] : [],
+    image.previewUrl && image.type !== "video"
+      ? [{ id: image.id, src: image.previewUrl, name: image.name }]
+      : [],
   );
   if (previewableImages.length === 0) {
     return null;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1017,7 +1017,16 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
                 key={image.id}
                 className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
               >
-                {image.previewUrl ? (
+                {image.previewUrl && image.type === "video" ? (
+                  <video
+                    src={image.previewUrl}
+                    controls
+                    playsInline
+                    preload="metadata"
+                    aria-label={image.name}
+                    className="block h-auto max-h-[220px] w-full object-contain"
+                  />
+                ) : image.previewUrl ? (
                   <button
                     type="button"
                     className="h-full w-full cursor-zoom-in"

--- a/apps/web/src/components/chat/composerFileIntake.test.ts
+++ b/apps/web/src/components/chat/composerFileIntake.test.ts
@@ -1,0 +1,30 @@
+import { PROVIDER_SEND_TURN_MAX_VIDEO_BYTES } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { isInlineAttachableFile } from "./composerFileIntake";
+
+describe("isInlineAttachableFile", () => {
+  it("accepts supported images and videos", () => {
+    expect(isInlineAttachableFile({ type: "image/png", size: 1024 })).toBe(true);
+    expect(isInlineAttachableFile({ type: "video/mp4", size: 1024 })).toBe(true);
+  });
+
+  it("routes unsupported file types to path references", () => {
+    expect(isInlineAttachableFile({ type: "text/csv", size: 1024 })).toBe(false);
+    expect(isInlineAttachableFile({ type: "application/pdf", size: 1024 })).toBe(false);
+    // Dropped from some file managers with no detected type at all.
+    expect(isInlineAttachableFile({ type: "", size: 1024 })).toBe(false);
+  });
+
+  it("routes unsupported media variants to path references", () => {
+    expect(isInlineAttachableFile({ type: "image/heic", size: 1024 })).toBe(false);
+    expect(isInlineAttachableFile({ type: "video/x-msvideo", size: 1024 })).toBe(false);
+  });
+
+  it("routes empty or oversized videos to path references", () => {
+    expect(isInlineAttachableFile({ type: "video/mp4", size: 0 })).toBe(false);
+    expect(
+      isInlineAttachableFile({ type: "video/mp4", size: PROVIDER_SEND_TURN_MAX_VIDEO_BYTES + 1 }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/composerFileIntake.ts
+++ b/apps/web/src/components/chat/composerFileIntake.ts
@@ -1,0 +1,27 @@
+import {
+  isProviderSendTurnSupportedImageMimeType,
+  isProviderSendTurnSupportedVideoMimeType,
+  PROVIDER_SEND_TURN_MAX_VIDEO_BYTES,
+} from "@t3tools/contracts";
+
+/** The `File` fields the drop classification actually reads. */
+export interface ComposerCandidateFile {
+  readonly type: string;
+  readonly size: number;
+}
+
+/**
+ * Whether a dropped file can ride inside the message itself. Everything else —
+ * CSVs, PDFs, archives, exotic or oversized media — is referenced by its path
+ * so the agent opens it from disk instead of the drop being rejected.
+ */
+export function isInlineAttachableFile(file: ComposerCandidateFile): boolean {
+  if (file.type.startsWith("video/")) {
+    return (
+      isProviderSendTurnSupportedVideoMimeType(file.type) &&
+      file.size > 0 &&
+      file.size <= PROVIDER_SEND_TURN_MAX_VIDEO_BYTES
+    );
+  }
+  return file.type.startsWith("image/") && isProviderSendTurnSupportedImageMimeType(file.type);
+}

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -5,15 +5,18 @@ import type {
 import type { EnvironmentId, ProjectEntry } from "@t3tools/contracts";
 import { FileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
-import { RotateCw } from "lucide-react";
+import * as Schema from "effect/Schema";
+import { Eye, EyeOff, RotateCw } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { Button } from "~/components/ui/button";
+import { Toggle } from "~/components/ui/toggle";
 import { InputGroup, InputGroupInput } from "~/components/ui/input-group";
 import { toastManager } from "~/components/ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useComposerHandleContext } from "~/composerHandleContext";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useTheme } from "~/hooks/useTheme";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
@@ -48,6 +51,30 @@ const TREE_UNSAFE_CSS = `
 
 function treePath(entry: ProjectEntry): string {
   return entry.kind === "directory" ? `${entry.path}/` : entry.path;
+}
+
+const SHOW_HIDDEN_FILES_STORAGE_KEY = "t3code:file-browser-show-hidden";
+
+function ShowHiddenFilesButton(props: { showHidden: boolean; onToggle: () => void }) {
+  const label = props.showHidden ? "Hide hidden and ignored files" : "Show hidden and ignored files";
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Toggle
+            pressed={props.showHidden}
+            onPressedChange={props.onToggle}
+            variant="ghost"
+            size="xs"
+            aria-label={label}
+          />
+        }
+      >
+        {props.showHidden ? <Eye /> : <EyeOff />}
+      </TooltipTrigger>
+      <TooltipPopup>{label}</TooltipPopup>
+    </Tooltip>
+  );
 }
 
 function RefreshFilesButton(props: { isPending: boolean; onRefresh: () => void }) {
@@ -110,7 +137,12 @@ export default function FileBrowserPanel({
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
-  const entriesQuery = useProjectEntriesQuery(environmentId, cwd);
+  const [showHidden, setShowHidden] = useLocalStorage(
+    SHOW_HIDDEN_FILES_STORAGE_KEY,
+    false,
+    Schema.Boolean,
+  );
+  const entriesQuery = useProjectEntriesQuery(environmentId, cwd, showHidden);
   const entries = entriesQuery.data?.entries ?? [];
   const entryKinds = useMemo(
     () => new Map(entries.map((entry) => [entry.path, entry.kind] as const)),
@@ -361,6 +393,10 @@ export default function FileBrowserPanel({
         data-surface-subheader
       >
         <RefreshFilesButton isPending={entriesQuery.isPending} onRefresh={handleRefresh} />
+        <ShowHiddenFilesButton
+          showHidden={showHidden}
+          onToggle={() => setShowHidden((value) => !value)}
+        />
         <FileSearchField
           name="project-files-search"
           ariaLabel={`Search ${projectName} files`}

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -70,7 +70,7 @@ function ShowHiddenFilesButton(props: { showHidden: boolean; onToggle: () => voi
           />
         }
       >
-        {props.showHidden ? <Eye /> : <EyeOff />}
+        {props.showHidden ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
       </TooltipTrigger>
       <TooltipPopup>{label}</TooltipPopup>
     </Tooltip>

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -4,7 +4,11 @@ import type {
   ResolvedKeybindingsConfig,
   ScopedThreadRef,
 } from "@t3tools/contracts";
-import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
+import {
+  isWorkspaceAudioPreviewPath,
+  isWorkspaceImagePreviewPath,
+  isWorkspaceVideoPreviewPath,
+} from "@t3tools/shared/filePreview";
 import { VirtualizedFile, type SelectedLineRange } from "@pierre/diffs";
 import { Editor } from "@pierre/diffs/editor";
 import { EditProvider, File, type FileOptions, Virtualizer } from "@pierre/diffs/react";
@@ -78,6 +82,12 @@ interface FilePreviewPanelProps {
   revealRequestId: number;
   onOpenFile: (relativePath: string) => void;
   onPendingChange: (relativePath: string, pending: boolean) => void;
+  /**
+   * Which side the explorer tree hugs. Defaults to "right" (panel docked on
+   * the workspace's right edge); a left-docked panel passes "left" so the
+   * tree stays on the outer edge and files open toward the chat.
+   */
+  explorerSide?: "left" | "right";
 }
 
 const FILE_EXPLORER_STORAGE_KEY = "t3code.fileExplorerOpen";
@@ -128,11 +138,12 @@ const FILE_LINK_REVEAL_UNSAFE_CSS = `
 `;
 type FilePostRender = NonNullable<FileOptions<unknown>["onPostRender"]>;
 
-function WorkspaceImagePreview(props: {
+function WorkspaceMediaPreview(props: {
   readonly environmentId: EnvironmentId;
   readonly threadRef: ScopedThreadRef;
   readonly absolutePath: string;
   readonly alt: string;
+  readonly kind: "image" | "video" | "audio";
 }) {
   const assetUrl = useAssetUrlState(props.environmentId, {
     _tag: "workspace-file",
@@ -144,19 +155,39 @@ function WorkspaceImagePreview(props: {
   if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
-        Unable to load workspace image.
+        Unable to load workspace {props.kind}.
       </div>
     );
   }
 
   return assetUrl._tag === "Success" ? (
     <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
-      <img
-        className="max-h-full max-w-full object-contain"
-        src={assetUrl.url}
-        alt={props.alt}
-        onError={() => setFailedUrl(assetUrl.url)}
-      />
+      {props.kind === "image" ? (
+        <img
+          className="max-h-full max-w-full object-contain"
+          src={assetUrl.url}
+          alt={props.alt}
+          onError={() => setFailedUrl(assetUrl.url)}
+        />
+      ) : props.kind === "video" ? (
+        <video
+          className="max-h-full max-w-full object-contain"
+          src={assetUrl.url}
+          controls
+          preload="metadata"
+          aria-label={props.alt}
+          onError={() => setFailedUrl(assetUrl.url)}
+        />
+      ) : (
+        <audio
+          className="w-full max-w-md"
+          src={assetUrl.url}
+          controls
+          preload="metadata"
+          aria-label={props.alt}
+          onError={() => setFailedUrl(assetUrl.url)}
+        />
+      )}
     </div>
   ) : (
     <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
@@ -768,6 +799,7 @@ export default function FilePreviewPanel({
   revealRequestId,
   onOpenFile,
   onPendingChange,
+  explorerSide = "right",
 }: FilePreviewPanelProps) {
   const { resolvedTheme } = useTheme();
   const wordWrap = useClientSettings((settings) => settings.wordWrap);
@@ -780,8 +812,18 @@ export default function FilePreviewPanel({
   const openPreview = useAtomCommand(previewEnvironment.open, {
     reportFailure: false,
   });
-  const isImage = relativePath !== null && isWorkspaceImagePreviewPath(relativePath);
-  const file = useProjectFileQuery(environmentId, cwd, relativePath, !isImage);
+  const mediaKind: "image" | "video" | "audio" | null =
+    relativePath === null
+      ? null
+      : isWorkspaceImagePreviewPath(relativePath)
+        ? "image"
+        : isWorkspaceVideoPreviewPath(relativePath)
+          ? "video"
+          : isWorkspaceAudioPreviewPath(relativePath)
+            ? "audio"
+            : null;
+  const isMedia = mediaKind !== null;
+  const file = useProjectFileQuery(environmentId, cwd, relativePath, !isMedia);
   const [explorerOpen, setExplorerOpen] = useState(initialExplorerOpen);
   // Reading markdown rendered is a preference, not a property of one file. Keeping
   // it on the panel meant a thread switch dropped it and forced source back.
@@ -987,20 +1029,26 @@ export default function FilePreviewPanel({
           Preview limited to the first 1 MB of a {file.data.byteLength.toLocaleString()} byte file.
         </div>
       ) : null}
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 overflow-hidden",
+          explorerSide === "left" && "flex-row-reverse",
+        )}
+      >
         <div
           className={cn(
             "min-w-0 flex-1 flex-col overflow-hidden",
             relativePath ? "flex" : "hidden",
           )}
         >
-          {relativePath && isImage && absolutePath ? (
-            <WorkspaceImagePreview
+          {relativePath && mediaKind && absolutePath ? (
+            <WorkspaceMediaPreview
               key={absolutePath}
               environmentId={environmentId}
               threadRef={threadRef}
               absolutePath={absolutePath}
               alt={relativePath}
+              kind={mediaKind}
             />
           ) : relativePath && file.error && file.data === null ? (
             <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
@@ -1068,7 +1116,12 @@ export default function FilePreviewPanel({
             className={cn(
               "flex min-h-0 shrink-0 bg-background",
               relativePath
-                ? "w-[min(22rem,46%)] min-w-64 border-l border-border/60"
+                ? cn(
+                    "w-[min(22rem,46%)] min-w-64",
+                    explorerSide === "left"
+                      ? "border-r border-border/60"
+                      : "border-l border-border/60",
+                  )
                 : "min-w-0 flex-1",
             )}
           >
@@ -1080,7 +1133,7 @@ export default function FilePreviewPanel({
               selectedPath={relativePath}
               selectedPathRevealId={revealRequestId}
               onOpenFile={onOpenFile}
-              {...(relativePath && !isImage ? { onRefreshSelectedFile: file.refresh } : {})}
+              {...(relativePath && !isMedia ? { onRefreshSelectedFile: file.refresh } : {})}
             />
           </aside>
         ) : null}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -16,7 +16,15 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { ChevronRight, Code2, Eye, FolderTree, Globe2, LoaderCircle } from "lucide-react";
+import {
+  ChevronRight,
+  Code2,
+  Eye,
+  FileQuestionIcon,
+  FolderTree,
+  Globe2,
+  LoaderCircle,
+} from "lucide-react";
 import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -1050,6 +1058,15 @@ export default function FilePreviewPanel({
               alt={relativePath}
               kind={mediaKind}
             />
+          ) : relativePath && file.failure === "binary_file" && file.data === null ? (
+            // An expected outcome, not a failure: binary files simply have no
+            // text preview, and listing hidden/ignored files surfaces plenty.
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-1 px-6 text-center">
+              <FileQuestionIcon className="size-5 text-muted-foreground" aria-hidden />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                No preview available for this file type.
+              </p>
+            </div>
           ) : relativePath && file.error && file.data === null ? (
             <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
               {file.error}

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -29,8 +29,16 @@ interface ProjectQueryState<A> {
   readonly refresh: () => void;
 }
 
-export function getProjectEntriesQueryAtom(environmentId: EnvironmentId, cwd: string) {
-  return projectEnvironment.listEntries({ environmentId, input: { cwd } });
+export function getProjectEntriesQueryAtom(
+  environmentId: EnvironmentId,
+  cwd: string,
+  includeHidden = false,
+) {
+  // Omit the flag when off so existing consumers keep sharing one atom key.
+  return projectEnvironment.listEntries({
+    environmentId,
+    input: includeHidden ? { cwd, includeHidden: true } : { cwd },
+  });
 }
 
 export function getProjectFileQueryAtom(
@@ -124,8 +132,9 @@ function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | 
 export function useProjectEntriesQuery(
   environmentId: EnvironmentId,
   cwd: string,
+  includeHidden = false,
 ): ProjectQueryState<ProjectListEntriesResult> {
-  const atom = getProjectEntriesQueryAtom(environmentId, cwd);
+  const atom = getProjectEntriesQueryAtom(environmentId, cwd, includeHidden);
   const result = useAtomValue(atom);
   const refreshAtom = useAtomRefresh(atom);
   const refresh = useCallback(() => refreshAtom(), [refreshAtom]);

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -25,6 +25,8 @@ function optimisticFileAtom(environmentId: EnvironmentId, cwd: string, relativeP
 interface ProjectQueryState<A> {
   readonly data: A | null;
   readonly error: string | null;
+  /** Structured failure tag from the server, when it sent one. */
+  readonly failure: string | null;
   readonly isPending: boolean;
   readonly refresh: () => void;
 }
@@ -129,6 +131,18 @@ function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | 
   return cause instanceof Error ? cause.message : "Workspace query failed.";
 }
 
+/**
+ * The server's structured failure tag (e.g. `binary_file`), so callers can
+ * render an expected outcome as its own state instead of a generic error.
+ */
+function errorFailure<A>(result: AsyncResult.AsyncResult<A, unknown>): string | null {
+  if (result._tag !== "Failure") return null;
+  const cause: unknown = Cause.squash(result.cause);
+  if (typeof cause !== "object" || cause === null || !("failure" in cause)) return null;
+  const failure = (cause as { readonly failure?: unknown }).failure;
+  return typeof failure === "string" ? failure : null;
+}
+
 export function useProjectEntriesQuery(
   environmentId: EnvironmentId,
   cwd: string,
@@ -141,6 +155,7 @@ export function useProjectEntriesQuery(
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
     error: errorMessage(result),
+    failure: errorFailure(result),
     isPending: result.waiting,
     refresh,
   };
@@ -202,6 +217,7 @@ export function useProjectFileQuery(
   return {
     data: optimisticFile?.data ?? data,
     error: errorMessage(result),
+    failure: errorFailure(result),
     isPending: result.waiting,
     refresh,
   };

--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -61,10 +61,13 @@ export function PreviewPanelShell(props: {
   widthStorageKey?: string;
   /** Overrides the initial width (px) before the user has resized the panel. */
   defaultWidth?: number;
+  /** Which side of the workspace the panel is docked on (inline mode only). */
+  side?: "left" | "right";
   children: ReactNode;
 }) {
   const useDragRegion = isElectron && props.mode !== "sheet" && props.mode !== "embedded";
   const isInline = props.mode === "inline";
+  const side = props.side ?? "right";
   const hostRef = useRef<HTMLDivElement | null>(null);
   // Only inline non-maximized mode applies `width`/`maxWidth`; skip the
   // container measurement (and its re-renders) everywhere else.
@@ -74,7 +77,7 @@ export function PreviewPanelShell(props: {
     defaultWidth: props.defaultWidth ?? PREVIEW_PANEL_DEFAULT_WIDTH,
     minWidth: PREVIEW_PANEL_MIN_WIDTH,
     maxWidth,
-    edge: "left",
+    edge: side === "right" ? "left" : "right",
   });
 
   return (
@@ -83,16 +86,19 @@ export function PreviewPanelShell(props: {
       className={cn(
         "relative flex h-full min-h-0 min-w-0 max-w-full flex-col self-stretch bg-background",
         isInline
-          ? props.maximized
-            ? "flex-1 border-l border-border"
-            : "shrink-0 border-l border-border"
+          ? cn(
+              props.maximized ? "flex-1" : "shrink-0",
+              side === "right" ? "border-l border-border" : "border-r border-border",
+            )
           : "w-full",
       )}
       style={isInline && !props.maximized ? { width: `${width}px` } : undefined}
       data-preview-panel-mode={props.mode}
       data-preview-panel-maximized={props.maximized ? "true" : "false"}
     >
-      {isInline && !props.maximized ? <RightPanelResizeHandle handlers={handlers} /> : null}
+      {isInline && !props.maximized ? (
+        <RightPanelResizeHandle handlers={handlers} side={side} />
+      ) : null}
       {useDragRegion ? <div className="electron-drag-region h-0 w-full" aria-hidden /> : null}
       {props.children}
     </div>

--- a/apps/web/src/components/preview/RightPanelResizeHandle.tsx
+++ b/apps/web/src/components/preview/RightPanelResizeHandle.tsx
@@ -3,24 +3,27 @@ import { cn } from "~/lib/utils";
 
 interface Props {
   handlers: ResizableWidthHandlers;
+  /** Which side the panel is docked on; the handle sits on the opposite edge. */
+  side?: "left" | "right";
   className?: string;
 }
 
 /**
- * Hit target for resizing a right-anchored panel via its left edge.
+ * Hit target for resizing a side-anchored panel via its inner edge.
  *
  * - Sits on top of the panel's border with a 4px overlap on each side so the
  *   user can grab a few pixels off the edge without aiming.
  * - Visual indicator is a 1px line that lights up on hover/active to mirror
  *   VS Code / Cursor.
  */
-export function RightPanelResizeHandle({ handlers, className }: Props) {
+export function RightPanelResizeHandle({ handlers, side = "right", className }: Props) {
   return (
     <div
       role="separator"
       aria-orientation="vertical"
       className={cn(
-        "group absolute inset-y-0 -left-1 z-20 w-2 cursor-col-resize select-none",
+        "group absolute inset-y-0 z-20 w-2 cursor-col-resize select-none",
+        side === "right" ? "-left-1" : "-right-1",
         className,
       )}
       {...handlers}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1160,6 +1160,42 @@ export function AppearanceSettingsPanel() {
             }
           />
         ) : null}
+        <SettingsRow
+          {...searchableSetting("panel-side")}
+          description="Choose which side of the workspace the files, terminal, diff, and preview panel docks on."
+          resetAction={
+            settings.rightPanelSide !== DEFAULT_UNIFIED_SETTINGS.rightPanelSide ? (
+              <SettingResetButton
+                label="panel side"
+                onClick={() =>
+                  updateSettings({ rightPanelSide: DEFAULT_UNIFIED_SETTINGS.rightPanelSide })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.rightPanelSide}
+              onValueChange={(value) => {
+                if (value === "left" || value === "right") {
+                  updateSettings({ rightPanelSide: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Panel side">
+                <SelectValue>{settings.rightPanelSide === "left" ? "Left" : "Right"}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="right">
+                  Right
+                </SelectItem>
+                <SelectItem hideIndicator value="left">
+                  Left
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
       </SettingsSection>
 
       <TypographySection />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1196,6 +1196,43 @@ export function AppearanceSettingsPanel() {
             </Select>
           }
         />
+
+        <SettingsRow
+          {...searchableSetting("sidebar-side")}
+          description="Choose which side the projects and threads sidebar docks on."
+          resetAction={
+            settings.appSidebarSide !== DEFAULT_UNIFIED_SETTINGS.appSidebarSide ? (
+              <SettingResetButton
+                label="sidebar side"
+                onClick={() =>
+                  updateSettings({ appSidebarSide: DEFAULT_UNIFIED_SETTINGS.appSidebarSide })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.appSidebarSide}
+              onValueChange={(value) => {
+                if (value === "left" || value === "right") {
+                  updateSettings({ appSidebarSide: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Sidebar side">
+                <SelectValue>{settings.appSidebarSide === "right" ? "Right" : "Left"}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="left">
+                  Left
+                </SelectItem>
+                <SelectItem hideIndicator value="right">
+                  Right
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
       </SettingsSection>
 
       <TypographySection />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -107,6 +107,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/appearance",
   },
   {
+    id: "sidebar-side",
+    title: "Sidebar side",
+    to: "/settings/appearance",
+  },
+  {
     id: "word-wrap",
     title: "Word wrap",
     to: "/settings/appearance",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -102,6 +102,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/appearance",
   },
   {
+    id: "panel-side",
+    title: "Panel side",
+    to: "/settings/appearance",
+  },
+  {
     id: "word-wrap",
     title: "Word wrap",
     to: "/settings/appearance",

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -33,7 +33,12 @@ import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model"
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatAttachment,
+  type ChatImageAttachment,
+} from "./types";
 import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
@@ -88,7 +93,9 @@ export const PersistedComposerImageAttachment = Schema.Struct({
 });
 export type PersistedComposerImageAttachment = typeof PersistedComposerImageAttachment.Type;
 
-export interface ComposerImageAttachment extends Omit<ChatImageAttachment, "previewUrl"> {
+// Named for its dominant case; also carries video attachments (type: "video").
+export interface ComposerImageAttachment extends Omit<ChatImageAttachment, "previewUrl" | "type"> {
+  type: ChatAttachment["type"];
   previewUrl: string;
   file: File;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -93,6 +93,22 @@ function RootRouteView() {
   const { authGateState } = Route.useRouteContext();
   const primaryEnvironmentAuthenticated = authGateState.status === "authenticated";
 
+  // A file dropped outside an explicit drop target must not make the browser
+  // navigate to (and render) the file, replacing the app. Window-level
+  // preventDefault only suppresses that default; real drop targets handle
+  // their events first.
+  useEffect(() => {
+    const preventWindowFileDrop = (event: DragEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener("dragover", preventWindowFileDrop);
+    window.addEventListener("drop", preventWindowFileDrop);
+    return () => {
+      window.removeEventListener("dragover", preventWindowFileDrop);
+      window.removeEventListener("drop", preventWindowFileDrop);
+    };
+  }, []);
+
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
       syncBrowserChromeTheme();

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   ChatImageAttachment as ContractChatImageAttachment,
+  ChatVideoAttachment as ContractChatVideoAttachment,
   OrchestrationCheckpointFile,
   OrchestrationCheckpointSummary,
   OrchestrationLatestTurn,
@@ -35,7 +36,11 @@ export interface ChatImageAttachment extends ContractChatImageAttachment {
   readonly previewUrl?: string;
 }
 
-export type ChatAttachment = ChatImageAttachment;
+export interface ChatVideoAttachment extends ContractChatVideoAttachment {
+  readonly previewUrl?: string;
+}
+
+export type ChatAttachment = ChatImageAttachment | ChatVideoAttachment;
 
 export interface ChatMessage extends Omit<OrchestrationMessage, "attachments"> {
   readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -19,3 +19,11 @@ On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New
 worktree** is selected, each background thread creates its own worktree.
+
+## Attachments
+
+Drop, paste, or pick images (GIF, JPEG, PNG, WebP) and videos (MP4, MOV, WebM) to attach them to a
+message. Up to 8 files per message; images over 10 MB are compressed to fit, videos can be up to
+25 MB. Attached videos play inline in the conversation. Coding agents cannot watch video directly,
+so the agent receives the saved file's path and can work on it with its tools. Video attachments in
+an unsent draft are not persisted across a reload.

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -27,3 +27,9 @@ message. Up to 8 files per message; images over 10 MB are compressed to fit, vid
 25 MB. Attached videos play inline in the conversation. Coding agents cannot watch video directly,
 so the agent receives the saved file's path and can work on it with its tools. Video attachments in
 an unsent draft are not persisted across a reload.
+
+Files the agent can't read inline — a CSV, PDF, archive, or an oversized or
+unusual media file — are not rejected: dropping one adds its full path to your
+message so the agent can open it from disk with its own tools. Paths are only
+available in the desktop app, since browsers hide the location of dropped
+files.

--- a/docs/user/workspace-panel.md
+++ b/docs/user/workspace-panel.md
@@ -1,0 +1,12 @@
+# Workspace panel
+
+The tool panel (files, terminal, diff, browser preview, agents) docks to the right of the chat by
+default. Move it to the left side in **Settings → Appearance → Panel side**; the chat column then sits
+on the right.
+
+## Files
+
+The Files tab lists your workspace. The listing follows your `.gitignore`, so ignored files and
+some dotfiles are hidden by default. Use the eye toggle in the Files tab header to show hidden and
+ignored files (`.git` and `node_modules` stay hidden). Selecting an image, video, or audio file
+previews it inline; other files open as text.

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1070,6 +1070,12 @@ export interface DesktopBridge {
    * regardless of OS settings.
    */
   getSystemLocale?: () => string | null;
+  /**
+   * Absolute filesystem path for a dragged-in `File`, which the renderer is
+   * not allowed to read for itself. Returns null when the file has no path
+   * on disk (clipboard-synthesised files), so callers must handle both.
+   */
+  getPathForFile?: (file: File) => string | null;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -159,7 +159,27 @@ const PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPE_SET = new Set<string>(
 export function isProviderSendTurnSupportedImageMimeType(mimeType: string): boolean {
   return PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPE_SET.has(mimeType.toLowerCase());
 }
+// Videos are stored with the thread and played back in the timeline; providers
+// receive them as a file-path note (no provider ingests raw video today).
+// ponytail: 25 MB keeps the one-shot data-URL upload well under WS frame
+// limits; chunked uploads are the path if users need full-length recordings.
+export const PROVIDER_SEND_TURN_MAX_VIDEO_BYTES = 25 * 1024 * 1024;
+export const PROVIDER_SEND_TURN_SUPPORTED_VIDEO_MIME_TYPES = [
+  "video/mp4",
+  "video/quicktime",
+  "video/webm",
+] as const;
+const PROVIDER_SEND_TURN_SUPPORTED_VIDEO_MIME_TYPE_SET = new Set<string>(
+  PROVIDER_SEND_TURN_SUPPORTED_VIDEO_MIME_TYPES,
+);
+
+/** Whether a dropped or picked video mime type can be sent on a provider turn. */
+export function isProviderSendTurnSupportedVideoMimeType(mimeType: string): boolean {
+  return PROVIDER_SEND_TURN_SUPPORTED_VIDEO_MIME_TYPE_SET.has(mimeType.toLowerCase());
+}
 const PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS = 14_000_000;
+// 25 MB of base64 plus the data-URL header.
+const PROVIDER_SEND_TURN_MAX_VIDEO_DATA_URL_CHARS = 35_000_000;
 const CHAT_ATTACHMENT_ID_MAX_CHARS = 128;
 // Correlation id is command id by design in this model.
 export const CorrelationId = CommandId;
@@ -191,9 +211,29 @@ const UploadChatImageAttachment = Schema.Struct({
 });
 export type UploadChatImageAttachment = typeof UploadChatImageAttachment.Type;
 
-export const ChatAttachment = Schema.Union([ChatImageAttachment]);
+export const ChatVideoAttachment = Schema.Struct({
+  type: Schema.Literal("video"),
+  id: ChatAttachmentId,
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100), Schema.isPattern(/^video\//i)),
+  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_VIDEO_BYTES)),
+});
+export type ChatVideoAttachment = typeof ChatVideoAttachment.Type;
+
+const UploadChatVideoAttachment = Schema.Struct({
+  type: Schema.Literal("video"),
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100), Schema.isPattern(/^video\//i)),
+  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_VIDEO_BYTES)),
+  dataUrl: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_VIDEO_DATA_URL_CHARS),
+  ),
+});
+export type UploadChatVideoAttachment = typeof UploadChatVideoAttachment.Type;
+
+export const ChatAttachment = Schema.Union([ChatImageAttachment, ChatVideoAttachment]);
 export type ChatAttachment = typeof ChatAttachment.Type;
-const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
+const UploadChatAttachment = Schema.Union([UploadChatImageAttachment, UploadChatVideoAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
 export const ProjectScriptIcon = Schema.Literals([

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -72,6 +72,9 @@ export type ProjectSearchContentsResult = typeof ProjectSearchContentsResult.Typ
 
 export const ProjectListEntriesInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
+  // Bypass the search index and walk the filesystem directly, so gitignored
+  // and dot-prefixed entries show up too (.git and node_modules stay hidden).
+  includeHidden: Schema.optional(Schema.Boolean),
 });
 export type ProjectListEntriesInput = typeof ProjectListEntriesInput.Type;
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -146,6 +146,12 @@ export const RightPanelSide = Schema.Literals(["left", "right"]);
 export type RightPanelSide = typeof RightPanelSide.Type;
 export const DEFAULT_RIGHT_PANEL_SIDE: RightPanelSide = "right";
 
+// Which side the app sidebar (projects and threads nav) docks on. Independent
+// of the tool panel, so either column can sit beside the chat.
+export const AppSidebarSide = Schema.Literals(["left", "right"]);
+export type AppSidebarSide = typeof AppSidebarSide.Type;
+export const DEFAULT_APP_SIDEBAR_SIDE: AppSidebarSide = "left";
+
 export const ClientSettingsSchema = Schema.Struct({
   appearanceContrast: AppearanceContrast.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_APPEARANCE_CONTRAST)),
@@ -239,6 +245,9 @@ export const ClientSettingsSchema = Schema.Struct({
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   rightPanelSide: RightPanelSide.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_RIGHT_PANEL_SIDE)),
+  ),
+  appSidebarSide: AppSidebarSide.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_APP_SIDEBAR_SIDE)),
   ),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
@@ -926,6 +935,7 @@ export const ClientSettingsPatch = Schema.Struct({
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
   rightPanelSide: Schema.optionalKey(RightPanelSide),
+  appSidebarSide: Schema.optionalKey(AppSidebarSide),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarAutoSettleOnMerge: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -140,6 +140,12 @@ export type FontFamilyPreference = typeof FontFamilyPreference.Type;
 export const DEFAULT_BROWSER_VIEWPORT: PreviewViewportSetting = FILL_PREVIEW_VIEWPORT;
 export const DEFAULT_BROWSER_AUTO_SHOW_FLOATING_PREVIEW = true;
 
+// Which side of the workspace the tool panel (files, terminal, diff, preview)
+// docks on. "left" swaps it with the chat column.
+export const RightPanelSide = Schema.Literals(["left", "right"]);
+export type RightPanelSide = typeof RightPanelSide.Type;
+export const DEFAULT_RIGHT_PANEL_SIDE: RightPanelSide = "right";
+
 export const ClientSettingsSchema = Schema.Struct({
   appearanceContrast: AppearanceContrast.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_APPEARANCE_CONTRAST)),
@@ -231,6 +237,9 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  rightPanelSide: RightPanelSide.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_RIGHT_PANEL_SIDE)),
+  ),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
   ),
@@ -916,6 +925,7 @@ export const ClientSettingsPatch = Schema.Struct({
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  rightPanelSide: Schema.optionalKey(RightPanelSide),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarAutoSettleOnMerge: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),

--- a/packages/shared/src/filePreview.ts
+++ b/packages/shared/src/filePreview.ts
@@ -11,6 +11,11 @@ export const WORKSPACE_IMAGE_PREVIEW_EXTENSIONS = [
   ".webp",
 ] as const;
 
+// Formats Chromium can decode natively; .mov/.m4v only when they carry H.264.
+export const WORKSPACE_VIDEO_PREVIEW_EXTENSIONS = [".m4v", ".mov", ".mp4", ".webm"] as const;
+
+export const WORKSPACE_AUDIO_PREVIEW_EXTENSIONS = [".flac", ".m4a", ".mp3", ".ogg", ".wav"] as const;
+
 function hasPreviewExtension(path: string, extensions: ReadonlyArray<string>): boolean {
   const pathWithoutQuery = path.split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
   return extensions.some((extension) => pathWithoutQuery.endsWith(extension));
@@ -24,6 +29,23 @@ export function isWorkspaceImagePreviewPath(path: string): boolean {
   return hasPreviewExtension(path, WORKSPACE_IMAGE_PREVIEW_EXTENSIONS);
 }
 
+export function isWorkspaceVideoPreviewPath(path: string): boolean {
+  return hasPreviewExtension(path, WORKSPACE_VIDEO_PREVIEW_EXTENSIONS);
+}
+
+export function isWorkspaceAudioPreviewPath(path: string): boolean {
+  return hasPreviewExtension(path, WORKSPACE_AUDIO_PREVIEW_EXTENSIONS);
+}
+
+/** Image, video, or audio: previewed via a signed asset URL instead of a file read. */
+export function isWorkspaceMediaPreviewPath(path: string): boolean {
+  return (
+    isWorkspaceImagePreviewPath(path) ||
+    isWorkspaceVideoPreviewPath(path) ||
+    isWorkspaceAudioPreviewPath(path)
+  );
+}
+
 export function isWorkspacePreviewEntryPath(path: string): boolean {
-  return isWorkspaceBrowserPreviewPath(path) || isWorkspaceImagePreviewPath(path);
+  return isWorkspaceBrowserPreviewPath(path) || isWorkspaceMediaPreviewPath(path);
 }


### PR DESCRIPTION
## What changed

**1. Panel side preference (Settings → Appearance → "Panel side")**
- New `rightPanelSide` client setting in `packages/contracts` (synced on web and desktop, searchable in settings search).
- Setting it to **Left** docks the tool panel (files, terminal, diff, browser preview, agents) on the left and moves the chat column to the right.
- The resize handle, panel border, maximize control, and titlebar button reservations all follow the chosen side.
- Inside the Files surface, the tree mirrors too: docked left, the explorer hugs the outer edge and files open toward the chat.

**2. Hidden files in the workspace file browser**
- The file tree is fed by the native search index, which bakes in `.gitignore` — so ignored files and some dotfiles could never be shown, and the indexer exposes no option to include them.
- Added an eye toggle in the Files tab header ("Show hidden and ignored files") backed by a new `includeHidden` flag on `projectsListEntries`: the server walks the filesystem directly (breadth-first, `.git` and `node_modules` still skipped, same 25k entry cap). Ships with a server test.

**3. Video/audio preview in the Files panel**
- Selecting an `.mp4`/`.mov`/`.webm`/`.m4v` used to fail the binary-file check; media files now render inline players via signed asset URLs (audio too: mp3, wav, ogg, flac, m4a). Extension allowlists extended in `packages/shared/filePreview` and the asset access layer.

**4. Video attachments in chat**
- New `ChatVideoAttachment` in the wire contract: MP4/MOV/WebM up to 25 MB per file (kept as a one-shot data-URL upload, same transport as images).
- Composer accepts drop/paste/pick, shows a first-frame chip; the timeline renders an inline `<video>` player that persists with the thread.
- No provider ingests raw video, so each adapter passes the stored file's absolute path as a text part (OpenCode gets a real file part) — agents can then work on the file with their tools. Videos are skipped in localStorage draft persistence (too large) and show the existing "may not persist" badge.
- Mobile renders video attachments as a plain tile for now (decision: not supported there yet).

## Bugs found and fixed along the way

- **Revert prune deleted non-image attachments from disk**: the keep-set builder in `ProjectionPipeline` skipped any attachment whose type wasn't `"image"`, so any future non-image attachment was deleted on the next thread revert. The skip is removed; `attachmentRelativePath` now covers every attachment type.
- **A file dropped outside the chat column navigated the whole app to the file** (Chromium default): a dropped video would play full-window and then "disappear". A window-level `dragover`/`drop` preventDefault guard in the root route suppresses the default without interfering with real drop targets.
- **Left-docked panel clipped under floating titlebar controls**: the collapsed-sidebar toggle and the maximize/panel cluster overlap the top corners; the tab bar and chat header now reserve space based on which side the panel is docked.

## Notes / known ceilings

- Videos over 25 MB are refused with a clear error; chunked upload is the path if larger recordings are needed.
- Video seeking before full buffer is limited (asset endpoint doesn't serve range requests yet).
- Verified: typecheck across contracts/shared/server/web/desktop/client-runtime; focused tests for WorkspaceEntries, attachmentStore, imageMime, Normalizer, ProjectionPipeline, AssetAccess, the five provider adapters, composer draft store, and desktop client settings all pass. Tested live in the web app on macOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration attachment persistence, multiple provider turn payloads, and a new filesystem listing path; regressions could affect message sends, agent context, or large workspace trees when showing hidden files.
> 
> **Overview**
> Adds **video chat attachments** (MP4/MOV/WebM up to 25 MB): contracts and the turn normalizer persist `video` attachments, the composer/timeline render inline players, and Claude/Codex/Cursor/Grok adapters send a **text note with the on-disk path** instead of raw video. Desktop exposes `getPathForFile` so non-inline drops (PDF, CSV, oversized media) insert quoted paths into the message; CSP gains `media-src` for blob and signed asset playback.
> 
> **Workspace layout** gains **Panel side** and **Sidebar side** settings: the tool panel and thread sidebar can dock left or right, with resize handles, titlebar insets, and file-explorer placement updated to match.
> 
> **Files panel** adds a persisted **show hidden/ignored** toggle backed by a direct filesystem walk when `includeHidden` is set (still skips `.git` / `node_modules`, caps at 25k entries). **Image, video, and audio** workspace files preview via signed URLs; asset signing treats all media extensions as exact-path claims.
> 
> Smaller fixes: attachment cleanup on revert includes non-image types, blob preview handoff/revocation covers videos, window-level drag/drop prevents navigating away from the app, and binary files get a neutral “no preview” state instead of a generic error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaac3c505b98cf40a8bf285d7a0769f407c7acf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add video attachments, panel docking sides, hidden-file browsing, and media previews
> - Adds video attachment support end-to-end: [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) accepts MP4/MOV/WebM (≤25 MiB), provider adapters (Claude, Codex, Cursor, Grok) pass non-image attachments as text path prompts via `videoAttachmentPromptText`, and [Normalizer.ts](https://github.com/pingdotgg/t3code/pull/8047/files#diff-751e99c6b2a5986d684c4717507023bfb24d6250386e071d6b48dd195e10c5ea) validates and persists `video` types with `PROVIDER_SEND_TURN_MAX_VIDEO_BYTES`.
> - Adds configurable docking sides for the right panel (`rightPanelSide`) and app sidebar (`appSidebarSide`) in client settings, with layout, border, and resize handle adjustments across [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91), [PreviewPanelShell.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-2bc30e0009261fedf96201eed47a807896930a736b4d944b9393ec09c4a72396), and [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301).
> - Adds hidden/ignored file browsing via a toggle in [FileBrowserPanel.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-aeb8bbbac738f422eace5ad6cee4745362f7559fdd5668df4eb1be558f4b5fb3), backed by a filesystem walker in [WorkspaceEntries.ts](https://github.com/pingdotgg/t3code/pull/8047/files#diff-26feb5e4175dd3c4b97bf023c259c336abef121574cd5665d06d3e4dbf1b15b8) that includes dotfiles and gitignored entries while skipping `.git` and `node_modules`.
> - Adds inline media previews (image, video, audio) in [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/8047/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea) and updates desktop CSP `media-src` in [ElectronProtocol.ts](https://github.com/pingdotgg/t3code/pull/8047/files#diff-25fd7328df6d1131991bc9498d73c423aef7bf0aee3e8b2c863c05b908090f78) to allow `blob:` playback.
> - Risk: video attachments are in-memory only and not persisted in composer drafts; non-image adapters receive resolved file paths as text prompts, not raw file bytes. Dropped non-inline files on desktop insert their on-disk paths into the composer text via `desktopBridge.getPathForFile`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eaac3c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->