### PR TITLE
fix(web): use user keybind shortcut in prompt stash hint

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3075,7 +3075,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 <ComposerCommandMenuLayer anchor={composerMenuAnchor}>
                   <ComposerStashMenu
                     entries={stashQueue}
-                    shortcutLabel={shortcutLabelForCommand(keybindings, "composer.stash")}
+                    shortcutLabel={shortcutLabelForCommand(keybindings, "composer.stash", {
+                      context: {
+                        terminalFocus: getTerminalFocusOwner() !== null,
+                        terminalOpen,
+                        modelPickerOpen: isComposerModelPickerOpen,
+                      },
+                    })}
                     onRestore={restoreStashEntry}
                     onDelete={deleteStashEntry}
                     onClose={() => setIsStashMenuOpen(false)}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -76,7 +76,7 @@ import {
 import { compressImageForStash, compressImageToByteLimit } from "../../lib/imageCompression";
 import { isCommandPaletteOpen } from "../../commandPaletteBus";
 import { getTerminalFocusOwner } from "../../lib/terminalFocus";
-import { resolveShortcutCommand } from "../../keybindings";
+import { resolveShortcutCommand, shortcutLabelForCommand } from "../../keybindings";
 import {
   type TerminalContextDraft,
   type TerminalContextSelection,
@@ -3075,6 +3075,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 <ComposerCommandMenuLayer anchor={composerMenuAnchor}>
                   <ComposerStashMenu
                     entries={stashQueue}
+                    shortcutLabel={shortcutLabelForCommand(keybindings, "composer.stash")}
                     onRestore={restoreStashEntry}
                     onDelete={deleteStashEntry}
                     onClose={() => setIsStashMenuOpen(false)}

--- a/apps/web/src/components/chat/ComposerStashMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.test.tsx
@@ -71,4 +71,51 @@ describe("ComposerStashMenu", () => {
     expect(markup).toContain("size-3.5 stroke-2");
     expect(markup).not.toContain("bg-background/90");
   });
+
+  it("renders empty state hint with provided shortcutLabel", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerStashMenu
+        entries={[]}
+        shortcutLabel="Ctrl+S"
+        onRestore={() => {}}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain(
+      "Nothing stashed yet. Press Ctrl+S with a prompt in the composer to stash it.",
+    );
+  });
+
+  it("renders empty state hint with macOS shortcutLabel", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerStashMenu
+        entries={[]}
+        shortcutLabel="⌘S"
+        onRestore={() => {}}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain(
+      "Nothing stashed yet. Press ⌘S with a prompt in the composer to stash it.",
+    );
+  });
+
+  it("renders base empty state message when shortcutLabel is null or omitted", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerStashMenu
+        entries={[]}
+        shortcutLabel={null}
+        onRestore={() => {}}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain("Nothing stashed yet.");
+    expect(markup).not.toContain("Press");
+  });
 });

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -24,18 +24,19 @@ function stashEntrySnippet(entry: PromptStashEntry): string {
 }
 
 /**
- * Popover listing the stashed prompts. Keyboard-first: opened by ⌘S on an
+ * Popover listing the stashed prompts. Keyboard-first: opened by Mod+S on an
  * empty composer, navigated with arrows, restored with Enter, dismissed
  * with Escape. The listener runs capture-phase on window so it wins over
  * the Lexical editor's handlers while the menu is open.
  */
 export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
   entries: ReadonlyArray<PromptStashEntry>;
+  shortcutLabel?: string | null;
   onRestore: (entry: PromptStashEntry) => void;
   onDelete: (entry: PromptStashEntry) => void;
   onClose: () => void;
 }) {
-  const { entries, onRestore, onDelete, onClose } = props;
+  const { entries, shortcutLabel, onRestore, onDelete, onClose } = props;
   const drawerRef = useRef<HTMLDivElement>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(entries[0]?.id ?? null);
 
@@ -128,7 +129,9 @@ export const ComposerStashMenu = memo(function ComposerStashMenu(props: {
           <CommandGroup>
             {entries.length === 0 ? (
               <p className="px-3 py-1.5 text-secondary-label text-xs">
-                Nothing stashed yet. Press ⌘S with a prompt in the composer to stash it.
+                {shortcutLabel
+                  ? `Nothing stashed yet. Press ${shortcutLabel} with a prompt in the composer to stash it.`
+                  : "Nothing stashed yet."}
               </p>
             ) : (
               entries.map((entry) => (


### PR DESCRIPTION
## What Changed

Prompt stash now uses the key binding resolver to display the user's actual shortcut instead of a hardcoded key combination when empty.

## Why

The hint when empty previously hardcoded macOS `⌘S` unconditionally, showing the wrong shortcut on non-macOS platforms and ignoring custom keybindings.

## UI Changes

### Before

<img width="757" height="98" alt="image" src="https://github.com/user-attachments/assets/a5794676-82ae-4325-b919-41adcfdac92f" />

### After

**Default**

<img width="752" height="95" alt="image" src="https://github.com/user-attachments/assets/554afcb3-6f22-4873-afec-b644bf08be11" />

<br>
<br>

**Custom Keybind**

<img width="755" height="105" alt="image" src="https://github.com/user-attachments/assets/231de117-f577-4505-a6b6-28443788a416" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy-only change in the stash empty state; no behavior, auth, or data-path changes.
> 
> **Overview**
> The empty prompt-stash menu no longer hardcodes macOS `⌘S`. It now shows the user's resolved `composer.stash` shortcut (including custom bindings and non-mac platforms).
> 
> `ChatComposer` passes `shortcutLabelForCommand(...)` into `ComposerStashMenu`. If no label is available, the hint falls back to "Nothing stashed yet." Tests cover default, macOS, and missing-label cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2aa5457154e6b4e73d7c62853e1fd0c3f12aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix prompt stash hint to use user's keybind shortcut in `ComposerStashMenu`
> - [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/8053/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) now computes a context-aware shortcut label for the `composer.stash` command via `shortcutLabelForCommand` and passes it to `ComposerStashMenu`.
> - [ComposerStashMenu.tsx](https://github.com/pingdotgg/t3code/pull/8053/files#diff-2fcc66d7913594ea9e35be547ee395de158ea142ad58496a4f8089f6ca66ebff) accepts an optional `shortcutLabel` prop. The empty state shows `Nothing stashed yet. Press {shortcutLabel}...` when a label is provided, or just `Nothing stashed yet.` when it is null or omitted.
> - Tests in [ComposerStashMenu.test.tsx](https://github.com/pingdotgg/t3code/pull/8053/files#diff-f3313ed7245bd11af86146aa217fb9bffa3f0017858b46a0a4e135849b8d0b06) cover the provided-label, macOS (`⌘S`), and null-label cases.
> - Behavioral Change: the stash menu empty state no longer hardcodes `⌘S`; it now reflects the user's actual configured shortcut, which may differ across platforms and keybind settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa2aa54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->