### PR TITLE
fix(cursor): discover skills for provider snapshots

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -21,7 +21,12 @@ import { parse as parseYamlDocument } from "yaml";
 
 import { expandHomePath } from "../../pathExpansion.ts";
 
-type ClaudeSkillScope = "user" | "project";
+type SkillScope = "user" | "project";
+
+export interface SkillDiscoveryRoot {
+  readonly directory: string;
+  readonly scope: SkillScope;
+}
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
@@ -55,6 +60,52 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
     ...(description ? { description } : {}),
   };
 }
+
+export const discoverSkillsFromRoots = Effect.fn("discoverSkillsFromRoots")(function* (
+  roots: ReadonlyArray<SkillDiscoveryRoot>,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillsByName = new Map<string, ServerProviderSkill>();
+
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory)
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].sort()) {
+      const skillPath = path.join(root.directory, entry, "SKILL.md");
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+
+      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
+      if (!name) {
+        continue;
+      }
+
+      skillsByName.set(name, {
+        name,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+        ...(frontmatter.kind === "parsed" && frontmatter.description
+          ? { description: frontmatter.description }
+          : {}),
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});
 
 /**
  * Resolve the Claude config directory the CLI would use, matching the
@@ -97,11 +148,10 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
   cwd?: string,
   environment?: NodeJS.ProcessEnv,
 ): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
-  const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env, cwd);
 
-  const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
+  const roots: ReadonlyArray<SkillDiscoveryRoot> = [
     { directory: path.join(configDirPath, "skills"), scope: "user" },
     ...(cwd
       ? [
@@ -111,45 +161,5 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       : []),
   ];
 
-  const skillsByName = new Map<string, ServerProviderSkill>();
-  for (const root of roots) {
-    const entries = yield* fileSystem
-      .readDirectory(root.directory)
-      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
-
-    for (const entry of [...entries].sort()) {
-      const skillPath = path.join(root.directory, entry, "SKILL.md");
-      const contents = yield* fileSystem
-        .readFileString(skillPath)
-        .pipe(Effect.orElseSucceed(() => undefined));
-      if (contents === undefined) {
-        continue;
-      }
-
-      const frontmatter = parseSkillFrontmatter(contents);
-      // Malformed frontmatter means the skill won't load in Claude Code
-      // either — skip it rather than surfacing a broken entry under its
-      // directory name.
-      if (frontmatter.kind === "malformed") {
-        continue;
-      }
-
-      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
-      if (!name) {
-        continue;
-      }
-
-      skillsByName.set(name, {
-        name,
-        path: skillPath,
-        enabled: true,
-        scope: root.scope,
-        ...(frontmatter.kind === "parsed" && frontmatter.description
-          ? { description: frontmatter.description }
-          : {}),
-      });
-    }
-  }
-
-  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+  return yield* discoverSkillsFromRoots(roots);
 });

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -83,6 +83,8 @@ export const discoverSkillsFromRoots = Effect.fn("discoverSkillsFromRoots")(func
       }
 
       const frontmatter = parseSkillFrontmatter(contents);
+      // Malformed frontmatter means the provider will not load the skill
+      // either, so skip it rather than publishing a broken inventory entry.
       if (frontmatter.kind === "malformed") {
         continue;
       }

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -105,6 +105,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
+      const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -132,7 +133,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       });
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -105,7 +105,6 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
-      const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -133,7 +132,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       });
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv, cwd).pipe(
+      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/CursorSkills.test.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.test.ts
@@ -22,19 +22,17 @@ const writeSkill = Effect.fn(function* (
 });
 
 it.layer(NodeServices.layer)("discoverCursorSkills", (it) => {
-  it.effect("discovers Cursor's user and project skill roots with native precedence", () =>
+  it.effect("discovers Cursor's global skill roots with native precedence", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const home = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-home-" });
-      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-workspace-" });
 
       yield* writeSkill(path.join(home, ".agents", "skills"), "review", "User review.");
       yield* writeSkill(path.join(home, ".cursor", "skills"), "deploy", "User deploy.");
-      yield* writeSkill(path.join(cwd, ".agents", "skills"), "review", "Project review.");
-      yield* writeSkill(path.join(cwd, ".cursor", "skills"), "review", "Cursor review.");
+      yield* writeSkill(path.join(home, ".cursor", "skills"), "review", "Cursor review.");
 
-      const skills = yield* discoverCursorSkills(cwd, home);
+      const skills = yield* discoverCursorSkills(home);
 
       assert.deepEqual(skills, [
         {
@@ -46,9 +44,9 @@ it.layer(NodeServices.layer)("discoverCursorSkills", (it) => {
         },
         {
           name: "review",
-          path: path.join(cwd, ".cursor", "skills", "review", "SKILL.md"),
+          path: path.join(home, ".cursor", "skills", "review", "SKILL.md"),
           enabled: true,
-          scope: "project",
+          scope: "user",
           description: "Cursor review.",
         },
       ]);

--- a/apps/server/src/provider/Drivers/CursorSkills.test.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.test.ts
@@ -1,0 +1,57 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverCursorSkills } from "./CursorSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  description: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(
+    path.join(skillDir, "SKILL.md"),
+    ["---", `name: ${directoryName}`, `description: ${description}`, "---"].join("\n"),
+  );
+});
+
+it.layer(NodeServices.layer)("discoverCursorSkills", (it) => {
+  it.effect("discovers Cursor's user and project skill roots with native precedence", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const home = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-home-" });
+      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cursor-workspace-" });
+
+      yield* writeSkill(path.join(home, ".agents", "skills"), "review", "User review.");
+      yield* writeSkill(path.join(home, ".cursor", "skills"), "deploy", "User deploy.");
+      yield* writeSkill(path.join(cwd, ".agents", "skills"), "review", "Project review.");
+      yield* writeSkill(path.join(cwd, ".cursor", "skills"), "review", "Cursor review.");
+
+      const skills = yield* discoverCursorSkills(cwd, home);
+
+      assert.deepEqual(skills, [
+        {
+          name: "deploy",
+          path: path.join(home, ".cursor", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "user",
+          description: "User deploy.",
+        },
+        {
+          name: "review",
+          path: path.join(cwd, ".cursor", "skills", "review", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Cursor review.",
+        },
+      ]);
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,0 +1,31 @@
+import * as NodeOS from "node:os";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverSkillsFromRoots, type SkillDiscoveryRoot } from "./ClaudeSkills.ts";
+
+export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* (
+  cwd?: string,
+  home = NodeOS.homedir(),
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const roots: ReadonlyArray<SkillDiscoveryRoot> = [
+    { directory: path.join(home, ".claude", "skills"), scope: "user" },
+    { directory: path.join(home, ".codex", "skills"), scope: "user" },
+    { directory: path.join(home, ".agents", "skills"), scope: "user" },
+    { directory: path.join(home, ".cursor", "skills"), scope: "user" },
+    ...(cwd
+      ? [
+          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".codex", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".cursor", "skills"), scope: "project" as const },
+        ]
+      : []),
+  ];
+
+  return yield* discoverSkillsFromRoots(roots);
+});

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -8,7 +8,6 @@ import * as Path from "effect/Path";
 import { discoverSkillsFromRoots, type SkillDiscoveryRoot } from "./ClaudeSkills.ts";
 
 export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* (
-  cwd?: string,
   home = NodeOS.homedir(),
 ): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
   const path = yield* Path.Path;
@@ -17,14 +16,6 @@ export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* 
     { directory: path.join(home, ".codex", "skills"), scope: "user" },
     { directory: path.join(home, ".agents", "skills"), scope: "user" },
     { directory: path.join(home, ".cursor", "skills"), scope: "user" },
-    ...(cwd
-      ? [
-          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
-          { directory: path.join(cwd, ".codex", "skills"), scope: "project" as const },
-          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
-          { directory: path.join(cwd, ".cursor", "skills"), scope: "project" as const },
-        ]
-      : []),
   ];
 
   return yield* discoverSkillsFromRoots(roots);

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -323,6 +323,37 @@ describe("getCursorFallbackModels", () => {
 });
 
 describe("buildCursorProviderSnapshot", () => {
+  it("includes discovered skills", () => {
+    expect(
+      buildCursorProviderSnapshot({
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        cursorSettings: baseCursorSettings,
+        parsed: {
+          version: "2026.04.09-f2b0fcd",
+          status: "ready",
+          auth: { status: "authenticated", type: "Team", label: "Cursor Team Subscription" },
+        },
+        skills: [
+          {
+            name: "review",
+            path: "/home/user/.agents/skills/review/SKILL.md",
+            enabled: true,
+            scope: "user",
+          },
+        ],
+      }),
+    ).toMatchObject({
+      skills: [
+        {
+          name: "review",
+          path: "/home/user/.agents/skills/review/SKILL.md",
+          enabled: true,
+          scope: "user",
+        },
+      ],
+    });
+  });
+
   it("downgrades ready status to warning when ACP model discovery times out", () => {
     expect(
       buildCursorProviderSnapshot({

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -459,7 +459,7 @@ describe("buildCursorCapabilitiesFromConfigOptions", () => {
 });
 
 describe("checkCursorProviderStatus", () => {
-  it("reports the install docs when the Cursor CLI command is missing", async () => {
+  it("reports the install docs and USERPROFILE skills when the Cursor CLI is missing", async () => {
     const provider = await runNode(
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;
@@ -478,7 +478,7 @@ describe("checkCursorProviderStatus", () => {
             apiEndpoint: "",
             customModels: [],
           },
-          { ...process.env, HOME: home },
+          { USERPROFILE: home },
         );
       }),
     );

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -461,11 +461,25 @@ describe("buildCursorCapabilitiesFromConfigOptions", () => {
 describe("checkCursorProviderStatus", () => {
   it("reports the install docs when the Cursor CLI command is missing", async () => {
     const provider = await runNode(
-      checkCursorProviderStatus({
-        enabled: true,
-        binaryPath: missingCursorBinaryPath,
-        apiEndpoint: "",
-        customModels: [],
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const home = yield* fileSystem.makeTempDirectory({ prefix: "cursor-home-" });
+        const skillDir = path.join(home, ".agents", "skills", "review");
+        yield* fileSystem.makeDirectory(skillDir, { recursive: true });
+        yield* fileSystem.writeFileString(
+          path.join(skillDir, "SKILL.md"),
+          ["---", "name: review", "description: Review changes.", "---"].join("\n"),
+        );
+        return yield* checkCursorProviderStatus(
+          {
+            enabled: true,
+            binaryPath: missingCursorBinaryPath,
+            apiEndpoint: "",
+            customModels: [],
+          },
+          { ...process.env, HOME: home },
+        );
       }),
     );
 
@@ -474,6 +488,14 @@ describe("checkCursorProviderStatus", () => {
       status: "error",
       auth: { status: "unknown" },
       message: cursorCliCommandMissingMessage,
+      skills: [
+        {
+          name: "review",
+          description: "Review changes.",
+          enabled: true,
+          scope: "user",
+        },
+      ],
     });
   });
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -6,6 +6,7 @@ import type {
   ServerProvider,
   ServerProviderAuth,
   ServerProviderModel,
+  ServerProviderSkill,
   ServerProviderState,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -45,6 +46,7 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import { discoverCursorSkills } from "../Drivers/CursorSkills.ts";
 import { CursorListAvailableModelsResponse } from "../acp/CursorAcpExtension.ts";
 
 const decodeCursorListAvailableModelsResponse = Schema.decodeUnknownEffect(
@@ -627,6 +629,7 @@ export function buildCursorProviderSnapshot(input: {
   readonly cursorSettings: CursorSettings;
   readonly parsed: CursorAboutResult;
   readonly discoveredModels?: ReadonlyArray<ServerProviderModel>;
+  readonly skills?: ReadonlyArray<ServerProviderSkill>;
   readonly discoveryWarning?: string;
 }): ServerProviderDraft {
   const message = joinProviderMessages(input.parsed.message, input.discoveryWarning);
@@ -639,6 +642,7 @@ export function buildCursorProviderSnapshot(input: {
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
     ),
+    ...(input.skills ? { skills: input.skills } : {}),
     probe: {
       installed: true,
       version: input.parsed.version,
@@ -987,6 +991,7 @@ const runCursorAboutCommand = (cursorSettings: CursorSettings, environment?: Nod
 export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(function* (
   cursorSettings: CursorSettings,
   environment?: NodeJS.ProcessEnv,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -1101,6 +1106,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       discoveredModels = discoveryExit.value;
     }
   }
+  const skills = yield* discoverCursorSkills(cwd, environment?.HOME);
   return buildCursorProviderSnapshot({
     checkedAt,
     cursorSettings,
@@ -1109,6 +1115,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       Option.filter(discoveredModels, (models) => models.length > 0),
       () => [] as const,
     ),
+    skills,
     ...(discoveryWarning ? { discoveryWarning } : {}),
   });
 });

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -998,6 +998,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = getCursorFallbackModels(cursorSettings);
+  const skills = yield* discoverCursorSkills(environment?.HOME);
 
   if (!cursorSettings.enabled) {
     return buildServerProvider({
@@ -1005,6 +1006,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: false,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: false,
         version: null,
@@ -1031,6 +1033,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: !isCommandMissingCause(error),
         version: null,
@@ -1049,6 +1052,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version: null,
@@ -1072,6 +1076,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version: parsed.version,
@@ -1105,7 +1110,6 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       discoveredModels = discoveryExit.value;
     }
   }
-  const skills = yield* discoverCursorSkills(environment?.HOME);
   return buildCursorProviderSnapshot({
     checkedAt,
     cursorSettings,

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -991,7 +991,6 @@ const runCursorAboutCommand = (cursorSettings: CursorSettings, environment?: Nod
 export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(function* (
   cursorSettings: CursorSettings,
   environment?: NodeJS.ProcessEnv,
-  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -1106,7 +1105,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       discoveredModels = discoveryExit.value;
     }
   }
-  const skills = yield* discoverCursorSkills(cwd, environment?.HOME);
+  const skills = yield* discoverCursorSkills(environment?.HOME);
   return buildCursorProviderSnapshot({
     checkedAt,
     cursorSettings,

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -998,7 +998,8 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = getCursorFallbackModels(cursorSettings);
-  const skills = yield* discoverCursorSkills(environment?.HOME);
+  const cursorHome = environment?.HOME ?? environment?.USERPROFILE;
+  const skills = yield* discoverCursorSkills(cursorHome);
 
   if (!cursorSettings.enabled) {
     return buildServerProvider({


### PR DESCRIPTION
## What changed

Cursor provider snapshots now discover global skills from the user-level directories supported by Cursor. The implementation reuses the existing best-effort skill frontmatter scanner instead of adding a new RPC or client state.

Discovery checks ~/.claude/skills, ~/.codex/skills, ~/.agents/skills, and ~/.cursor/skills. Later native roots win name collisions.

## Why

The Cursor provider omitted skills when building its snapshot, so T3 Code always showed an empty skill picker even when Cursor loaded the same global skills from disk.

Addresses the global Cursor portion of #2736. Project-scoped Cursor discovery and OpenCode remain outside this PR.

## Verification

- 34 focused provider and skill-discovery tests pass
- Server typecheck passes
- Formatting and targeted lint pass
- Local probe discovers all 13 skills currently installed under ~/.agents/skills

## UI changes

The existing skill picker is populated for global Cursor skills. No client code or layout changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skill discovery to Cursor provider snapshots via reusable `discoverSkillsFromRoots`
> - Extracts a reusable `discoverSkillsFromRoots` routine from `discoverClaudeSkills` that scans ordered root directories, reads `SKILL.md` frontmatter, and returns a de-duplicated, name-sorted skill list with later-root precedence.
> - Adds `discoverCursorSkills` covering `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills`, and `~/.cursor/skills`.
> - Threads discovered skills through all branches of `checkCursorProviderStatus` so provider snapshots include user-scope skills regardless of CLI status.
> - Behavioral Change: `checkCursorProviderStatus` now always attempts skill discovery from `HOME`/`USERPROFILE` (or OS homedir fallback) and includes skills in snapshot responses even when the CLI is disabled, missing, or times out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98214ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort filesystem reads of user skill dirs and snapshot fields only; no auth, execution, or client behavior changes.
> 
> **Overview**
> Cursor provider snapshots now include **user-level skills** scanned from disk, so the skill picker is no longer empty when Cursor already loads those same global skills.
> 
> Discovery reuses the existing `SKILL.md` frontmatter scanner via a shared `discoverSkillsFromRoots` helper. Cursor checks `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills`, and `~/.cursor/skills` (later roots win on name collisions). Skills are attached on every status path, including disabled/CLI-missing, using `HOME`/`USERPROFILE` when provided.
> 
> Project-scoped Cursor skills are not included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98214ad70651203d79a76abdbbb2611c91562bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->