### PR TITLE
fix(web): harden Open VSX theme imports

### DIFF
--- a/apps/web/src/openVsxThemes.test.ts
+++ b/apps/web/src/openVsxThemes.test.ts
@@ -20,6 +20,8 @@ function extensionDetail(overrides: Record<string, unknown> = {}) {
     version: "1.0.0",
     downloadCount: 123456,
     license: "MIT",
+    verified: true,
+    publishedBy: { loginName: "demo-publisher" },
     repository: "https://github.com/demo/theme",
     files: {
       icon: `${ASSET_ROOT}/icon.png`,
@@ -31,13 +33,122 @@ function extensionDetail(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function selectedExtension(overrides: Partial<OpenVsxThemeExtension> = {}): OpenVsxThemeExtension {
+  return {
+    collectionId: "open-vsx:demo.theme",
+    id: "demo.theme",
+    extensionName: "theme",
+    name: "Demo Theme",
+    publisher: "demo",
+    publishedBy: "demo-publisher",
+    description: "",
+    downloadCount: 1,
+    iconUrl: null,
+    repositoryUrl: "https://github.com/demo/theme",
+    sourceUrl: "https://github.com/demo/theme",
+    license: "MIT",
+    manifestUrl: `${ASSET_ROOT}/package.json`,
+    sha256Url: `${ASSET_ROOT}/demo.theme-1.0.0.sha256`,
+    version: "1.0.0",
+    verified: true,
+    vsixUrl: `${ASSET_ROOT}/demo.theme-1.0.0.vsix`,
+    ...overrides,
+  };
+}
+
+function responseAt(response: Response, url?: string): Response {
+  if (url) Object.defineProperty(response, "url", { value: url });
+  return response;
+}
+
+function packageChecksum(bytes: Uint8Array): string {
+  return [...sha256(bytes)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function buildThemePackage({
+  contributionPath = "./themes/theme.json",
+  files = {
+    "themes/theme.json": JSON.stringify({ colors: { "editor.background": "#181818" } }),
+  },
+  compression = "STORE",
+}: {
+  contributionPath?: string;
+  files?: Readonly<Record<string, string>>;
+  compression?: "STORE" | "DEFLATE";
+} = {}): Promise<{ bytes: Uint8Array; checksum: string }> {
+  const zip = new JSZip();
+  zip.file(
+    "extension/package.json",
+    JSON.stringify({
+      publisher: "demo",
+      name: "theme",
+      version: "1.0.0",
+      license: "MIT",
+      contributes: {
+        themes: [{ label: "Demo", uiTheme: "vs-dark", path: contributionPath }],
+      },
+    }),
+  );
+  for (const [path, source] of Object.entries(files)) zip.file(`extension/${path}`, source);
+  const bytes = await zip.generateAsync({
+    type: "uint8array",
+    compression,
+    ...(compression === "DEFLATE" ? { compressionOptions: { level: 9 } } : {}),
+  });
+  return { bytes, checksum: packageChecksum(bytes) };
+}
+
+function stubThemeImport(
+  fixture: { bytes: Uint8Array; checksum: string },
+  {
+    detail = extensionDetail(),
+    finalUrls = {},
+  }: {
+    detail?: unknown;
+    finalUrls?: Partial<Record<"manifest" | "package" | "checksum", string>>;
+  } = {},
+): void {
+  const extension = selectedExtension();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === "https://open-vsx.org/api/demo/theme/1.0.0") {
+        return new Response(JSON.stringify(detail), { status: 200 });
+      }
+      if (url === extension.manifestUrl) {
+        return responseAt(
+          new Response(
+            JSON.stringify({ license: "MIT", contributes: { themes: [{ path: "./theme.json" }] } }),
+            { status: 200 },
+          ),
+          finalUrls.manifest,
+        );
+      }
+      if (url === extension.sha256Url) {
+        return responseAt(new Response(fixture.checksum), finalUrls.checksum);
+      }
+      if (url === extension.vsixUrl) {
+        return responseAt(
+          new Response(new Uint8Array(fixture.bytes).buffer, {
+            status: 200,
+            headers: { "Content-Length": String(fixture.bytes.byteLength) },
+          }),
+          finalUrls.package,
+        );
+      }
+      return new Response(null, { status: 404 });
+    }),
+  );
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
 describe("Open VSX themes", () => {
-  it("searches theme extensions and keeps only supported open-source licenses", async () => {
+  it("searches theme extensions and keeps only verified open-source results", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/-/search?")) {
@@ -50,6 +161,7 @@ describe("Open VSX themes", () => {
               { namespace: "unlicensed", name: "theme" },
               { namespace: "unavailable", name: "theme" },
               { namespace: "closed", name: "theme" },
+              { namespace: "unverified", name: "theme" },
               { namespace: "huge", name: "theme" },
             ],
           }),
@@ -119,6 +231,12 @@ describe("Open VSX themes", () => {
           { status: 200 },
         );
       }
+      if (url.endsWith("/unverified/theme")) {
+        return new Response(
+          JSON.stringify(extensionDetail({ namespace: "unverified", verified: false })),
+          { status: 200 },
+        );
+      }
       if (url.endsWith("/huge/theme")) {
         return new Response(JSON.stringify({ padding: "x".repeat(256 * 1024) }), { status: 200 });
       }
@@ -170,6 +288,8 @@ describe("Open VSX themes", () => {
         iconUrl: `${ASSET_ROOT}/icon.png`,
         sourceUrl: "https://github.com/demo/theme",
         license: "MIT",
+        publishedBy: "demo-publisher",
+        verified: true,
       }),
     ]);
     const searchUrl = new URL(String(fetchMock.mock.calls[0]![0]));
@@ -365,25 +485,14 @@ describe("Open VSX themes", () => {
     const manifest = {
       contributes: { themes: [{ label: "Wrong", path: "./themes/missing.json" }] },
     };
-    const extension: OpenVsxThemeExtension = {
-      collectionId: "open-vsx:demo.theme",
-      id: "demo.theme",
-      name: "Demo Theme",
-      publisher: "demo",
-      description: "",
-      downloadCount: 1,
-      iconUrl: null,
-      sourceUrl: null,
-      license: "MIT",
-      manifestUrl: `${ASSET_ROOT}/package.json`,
-      sha256Url: `${ASSET_ROOT}/demo.theme-1.0.0.sha256`,
-      version: "1.0.0",
-      vsixUrl: `${ASSET_ROOT}/demo.theme-1.0.0.vsix`,
-    };
+    const extension = selectedExtension();
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request) => {
         const url = String(input);
+        if (url === "https://open-vsx.org/api/demo/theme/1.0.0") {
+          return new Response(JSON.stringify(extensionDetail()), { status: 200 });
+        }
         if (url === extension.manifestUrl) {
           return new Response(JSON.stringify(manifest), { status: 200 });
         }
@@ -459,25 +568,14 @@ describe("Open VSX themes", () => {
       .map((byte) => byte.toString(16).padStart(2, "0"))
       .join("");
     const controller = new AbortController();
-    const extension: OpenVsxThemeExtension = {
-      collectionId: "open-vsx:demo.theme",
-      id: "demo.theme",
-      name: "Demo Theme",
-      publisher: "demo",
-      description: "",
-      downloadCount: 1,
-      iconUrl: null,
-      sourceUrl: null,
-      license: "MIT",
-      manifestUrl: `${ASSET_ROOT}/package.json`,
-      sha256Url: `${ASSET_ROOT}/demo.theme-1.0.0.sha256`,
-      version: "1.0.0",
-      vsixUrl: `${ASSET_ROOT}/demo.theme-1.0.0.vsix`,
-    };
+    const extension = selectedExtension();
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request) => {
         const url = String(input);
+        if (url === "https://open-vsx.org/api/demo/theme/1.0.0") {
+          return new Response(JSON.stringify(extensionDetail()), { status: 200 });
+        }
         if (url === extension.manifestUrl) {
           return new Response(
             JSON.stringify({ contributes: { themes: [{ path: "./theme.json" }] } }),
@@ -497,25 +595,14 @@ describe("Open VSX themes", () => {
   });
 
   it("rejects a package whose Open VSX checksum does not match", async () => {
-    const extension: OpenVsxThemeExtension = {
-      collectionId: "open-vsx:demo.theme",
-      id: "demo.theme",
-      name: "Demo Theme",
-      publisher: "demo",
-      description: "",
-      downloadCount: 1,
-      iconUrl: null,
-      sourceUrl: null,
-      license: "MIT",
-      manifestUrl: `${ASSET_ROOT}/package.json`,
-      sha256Url: `${ASSET_ROOT}/demo.theme-1.0.0.sha256`,
-      version: "1.0.0",
-      vsixUrl: `${ASSET_ROOT}/demo.theme-1.0.0.vsix`,
-    };
+    const extension = selectedExtension();
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request) => {
         const url = String(input);
+        if (url === "https://open-vsx.org/api/demo/theme/1.0.0") {
+          return new Response(JSON.stringify(extensionDetail()), { status: 200 });
+        }
         if (url === extension.manifestUrl) {
           return new Response(
             JSON.stringify({ contributes: { themes: [{ path: "./theme.json" }] } }),
@@ -527,5 +614,150 @@ describe("Open VSX themes", () => {
     );
 
     await expect(importOpenVsxThemeExtension(extension)).rejects.toThrow("integrity check");
+  });
+
+  it("revalidates publisher identity before downloading an extension", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify(extensionDetail({ publishedBy: { loginName: "replacement-publisher" } })),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "changed publisher identity",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an extension that is no longer verified", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(extensionDetail({ verified: false })), { status: 200 }),
+      ),
+    );
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "no longer published by a verified source",
+    );
+  });
+
+  it("rejects resources redirected outside official Open VSX origins", async () => {
+    const fixture = await buildThemePackage();
+    stubThemeImport(fixture, {
+      finalUrls: { manifest: "https://packages.example/extension/package.json" },
+    });
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "redirected to an untrusted resource URL",
+    );
+  });
+
+  it("accepts package redirects to the official Open VSX asset origin", async () => {
+    const fixture = await buildThemePackage();
+    const cdnRoot = "https://openvsx.eclipsecontent.org/demo/theme/1.0.0";
+    stubThemeImport(fixture, {
+      finalUrls: {
+        manifest: `${cdnRoot}/package.json`,
+        package: `${cdnRoot}/demo.theme-1.0.0.vsix`,
+        checksum: `${cdnRoot}/demo.theme-1.0.0.sha256`,
+      },
+    });
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).resolves.toHaveLength(1);
+  });
+
+  it("times out a stalled import request", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          }),
+      ),
+    );
+
+    const importing = expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "took too long to import",
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await importing;
+  });
+
+  it("rejects theme paths that escape the extension package", async () => {
+    const fixture = await buildThemePackage({ contributionPath: "../../theme.json" });
+    stubThemeImport(fixture);
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "could not be imported safely",
+    );
+  });
+
+  it("rejects cyclic theme includes", async () => {
+    const fixture = await buildThemePackage({
+      contributionPath: "./themes/a.json",
+      files: {
+        "themes/a.json": JSON.stringify({ include: "./b.json" }),
+        "themes/b.json": JSON.stringify({ include: "./a.json" }),
+      },
+    });
+    stubThemeImport(fixture);
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "could not be imported safely",
+    );
+  });
+
+  it("rejects oversized theme files", async () => {
+    const fixture = await buildThemePackage({
+      files: {
+        "themes/theme.json": JSON.stringify({
+          colors: { "editor.background": "#181818" },
+          padding: "x".repeat(256 * 1024),
+        }),
+      },
+    });
+    stubThemeImport(fixture);
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "could not be imported safely",
+    );
+  });
+
+  it("rejects packages with an unsafe compression ratio", async () => {
+    const fixture = await buildThemePackage({
+      files: {
+        "themes/theme.json": JSON.stringify({ colors: { "editor.background": "#181818" } }),
+        "padding.txt": "x".repeat(300_000),
+      },
+      compression: "DEFLATE",
+    });
+    stubThemeImport(fixture);
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "unsafe compression ratio",
+    );
+  });
+
+  it("rejects packages with too many files", async () => {
+    const files = Object.fromEntries([
+      ["themes/theme.json", JSON.stringify({ colors: { "editor.background": "#181818" } })],
+      ...Array.from({ length: 4_999 }, (_, index) => [`unused/${index}.txt`, ""]),
+    ]);
+    const fixture = await buildThemePackage({ files });
+    stubThemeImport(fixture);
+
+    await expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
+      "too many files",
+    );
   });
 });

--- a/apps/web/src/openVsxThemes.test.ts
+++ b/apps/web/src/openVsxThemes.test.ts
@@ -673,16 +673,13 @@ describe("Open VSX themes", () => {
 
   it("times out a stalled import request", async () => {
     vi.useFakeTimers();
+    const requestSignals: AbortSignal[] = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        (_input: RequestInfo | URL, init?: RequestInit) =>
-          new Promise<Response>((_resolve, reject) => {
-            init?.signal?.addEventListener("abort", () => {
-              reject(new DOMException("The operation was aborted.", "AbortError"));
-            });
-          }),
-      ),
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.signal) requestSignals.push(init.signal);
+        return new Promise<Response>(() => undefined);
+      }),
     );
 
     const importing = expect(importOpenVsxThemeExtension(selectedExtension())).rejects.toThrow(
@@ -691,6 +688,8 @@ describe("Open VSX themes", () => {
     await vi.advanceTimersByTimeAsync(30_000);
 
     await importing;
+    expect(requestSignals).toHaveLength(1);
+    expect(requestSignals[0]!.aborted).toBe(true);
   });
 
   it("rejects theme paths that escape the extension package", async () => {

--- a/apps/web/src/openVsxThemes.ts
+++ b/apps/web/src/openVsxThemes.ts
@@ -10,12 +10,15 @@ import {
   resolveThemeLabelCollisions,
 } from "./vscodeThemeImport";
 
-const OPEN_VSX_SEARCH_URL = "https://open-vsx.org/api/-/search";
+const OPEN_VSX_ORIGIN = "https://open-vsx.org";
+const OPEN_VSX_ASSET_ORIGINS = new Set([OPEN_VSX_ORIGIN, "https://openvsx.eclipsecontent.org"]);
+const OPEN_VSX_SEARCH_URL = `${OPEN_VSX_ORIGIN}/api/-/search`;
 const MAX_VSIX_BYTES = 20 * 1024 * 1024;
 const MAX_SEARCH_BYTES = 512 * 1024;
 const MAX_DETAIL_BYTES = 256 * 1024;
 const MAX_MANIFEST_BYTES = 256 * 1024;
 const SEARCH_REQUEST_TIMEOUT_MS = 10_000;
+const IMPORT_REQUEST_TIMEOUT_MS = 30_000;
 const MAX_THEME_BYTES = 256 * 1024;
 const MAX_ZIP_ENTRIES = 5_000;
 const MAX_UNCOMPRESSED_BYTES = 100 * 1024 * 1024;
@@ -86,17 +89,21 @@ export type OpenVsxThemeSort = "downloadCount" | "rating" | "timestamp" | "relev
 export type OpenVsxThemeExtension = {
   id: string;
   collectionId: string;
+  extensionName: string;
   name: string;
   publisher: string;
+  publishedBy: string;
   description: string;
   downloadCount: number;
   iconUrl: string | null;
+  repositoryUrl: string | null;
   sourceUrl: string | null;
   manifestUrl: string;
   sha256Url: string;
   vsixUrl: string;
   version: string;
   license: string;
+  verified: true;
 };
 
 export type OpenVsxThemeSearchOptions = {
@@ -132,12 +139,40 @@ function trustedOpenVsxUrl(value: unknown): string | null {
   if (typeof value !== "string") return null;
   try {
     const url = new URL(value);
-    return url.protocol === "https:" && url.hostname.toLowerCase() === "open-vsx.org"
-      ? url.toString()
-      : null;
+    return url.origin === OPEN_VSX_ORIGIN && !url.username && !url.password ? url.toString() : null;
   } catch {
     return null;
   }
+}
+
+function isTrustedOpenVsxResourceUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return !url.username && !url.password && OPEN_VSX_ASSET_ORIGINS.has(url.origin);
+  } catch {
+    return false;
+  }
+}
+
+async function fetchOpenVsxResource(
+  value: string,
+  init: RequestInit,
+  signal: AbortSignal,
+): Promise<Response> {
+  const url = trustedOpenVsxUrl(value);
+  if (!url) throw new Error("Open VSX returned an untrusted resource URL.");
+  const response = await fetch(url, { ...init, signal });
+  // Browser responses carry the final URL after redirects. Test Response
+  // objects leave it empty unless a fixture supplies one explicitly.
+  if (response.url && !isTrustedOpenVsxResourceUrl(response.url)) {
+    try {
+      await response.body?.cancel();
+    } catch {
+      // The trust error below is more useful than a stream cancellation error.
+    }
+    throw new Error("Open VSX redirected to an untrusted resource URL.");
+  }
+  return response;
 }
 
 function publicSourceUrl(value: unknown): string | null {
@@ -180,51 +215,67 @@ function extensionFromDetail(value: unknown): OpenVsxThemeExtension | null {
     (typeof value.displayName === "string" ? value.displayName.trim() : "") || extensionName;
   const version = typeof value.version === "string" ? value.version.trim() : "";
   const license = typeof value.license === "string" ? value.license.trim() : "";
+  const publishedBy =
+    isRecord(value.publishedBy) && typeof value.publishedBy.loginName === "string"
+      ? value.publishedBy.loginName.trim().toLowerCase()
+      : "";
   const manifestUrl = trustedOpenVsxUrl(value.files.manifest);
   const sha256Url = trustedOpenVsxUrl(value.files.sha256);
   const vsixUrl = trustedOpenVsxUrl(value.files.download);
-  if (!namespace || !extensionName || !version || !manifestUrl || !sha256Url || !vsixUrl) {
+  if (
+    !namespace ||
+    !extensionName ||
+    !version ||
+    !publishedBy ||
+    !manifestUrl ||
+    !sha256Url ||
+    !vsixUrl
+  ) {
     throw new Error("Open VSX returned malformed theme details.");
   }
-  if (!SUPPORTED_LICENSES.has(license)) return null;
+  if (value.verified !== true || !SUPPORTED_LICENSES.has(license)) return null;
   const id = `${namespace}.${extensionName}`;
+  const repositoryUrl = publicSourceUrl(value.repository);
   return {
     id,
     collectionId: openVsxCollectionId(id),
+    extensionName,
     name: displayName,
     publisher: namespace,
+    publishedBy,
     description: typeof value.description === "string" ? value.description : "",
     downloadCount:
       typeof value.downloadCount === "number" && Number.isFinite(value.downloadCount)
         ? value.downloadCount
         : 0,
     iconUrl: trustedOpenVsxUrl(value.files.icon),
-    sourceUrl:
-      publicSourceUrl(value.repository) ??
-      publicSourceUrl(value.homepage) ??
-      publicSourceUrl(value.url),
+    repositoryUrl,
+    sourceUrl: repositoryUrl ?? publicSourceUrl(value.homepage) ?? publicSourceUrl(value.url),
     manifestUrl,
     sha256Url,
     vsixUrl,
     version,
     license,
+    verified: true,
   };
 }
 
-async function withSearchTimeout<T>(
+async function withRequestTimeout<T>(
   operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
   parentSignal?: AbortSignal,
 ): Promise<T> {
   const controller = new AbortController();
   const abort = () => controller.abort();
   if (parentSignal?.aborted) abort();
   else parentSignal?.addEventListener("abort", abort, { once: true });
-  const timeout = setTimeout(abort, SEARCH_REQUEST_TIMEOUT_MS);
+  const timeout = setTimeout(abort, timeoutMs);
   try {
     return await operation(controller.signal);
   } catch (cause) {
     if (controller.signal.aborted && !parentSignal?.aborted) {
-      throw new Error("Open VSX took too long to respond.", { cause });
+      throw new Error(timeoutMessage, { cause });
     }
     throw cause;
   } finally {
@@ -244,23 +295,28 @@ export async function searchOpenVsxThemes(
   url.searchParams.set("category", "Themes");
   url.searchParams.set("sortBy", sortBy);
   url.searchParams.set("sortOrder", "desc");
-  // Ask for a few extras because results without a supported SPDX license
+  // Ask for a few extras because unverified results and unsupported licenses
   // are intentionally omitted.
   url.searchParams.set("size", "16");
-  const value = await withSearchTimeout(async (requestSignal) => {
-    const response = await fetch(url, { signal: requestSignal });
-    if (!response.ok) throw new Error("Open VSX search is unavailable right now.");
-    const searchBytes = await readCappedResponse(
-      response,
-      MAX_SEARCH_BYTES,
-      "Open VSX returned an unexpectedly large response.",
-    );
-    try {
-      return JSON.parse(new TextDecoder().decode(searchBytes)) as unknown;
-    } catch {
-      throw new Error("Open VSX returned an unreadable response.");
-    }
-  }, signal);
+  const value = await withRequestTimeout(
+    async (requestSignal) => {
+      const response = await fetchOpenVsxResource(url.toString(), {}, requestSignal);
+      if (!response.ok) throw new Error("Open VSX search is unavailable right now.");
+      const searchBytes = await readCappedResponse(
+        response,
+        MAX_SEARCH_BYTES,
+        "Open VSX returned an unexpectedly large response.",
+      );
+      try {
+        return JSON.parse(new TextDecoder().decode(searchBytes)) as unknown;
+      } catch {
+        throw new Error("Open VSX returned an unreadable response.");
+      }
+    },
+    SEARCH_REQUEST_TIMEOUT_MS,
+    "Open VSX took too long to respond.",
+    signal,
+  );
   if (!isRecord(value) || !Array.isArray(value.extensions)) {
     throw new Error("Open VSX returned an unreadable search response.");
   }
@@ -272,45 +328,52 @@ export async function searchOpenVsxThemes(
   });
   const details = await Promise.allSettled(
     identities.slice(0, 16).map(([namespace, name]) =>
-      withSearchTimeout(async (requestSignal) => {
-        const detailUrl = `https://open-vsx.org/api/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
-        const detailResponse = await fetch(detailUrl, { signal: requestSignal });
-        if (!detailResponse.ok) throw new Error("Open VSX theme details are unavailable.");
-        const detailBytes = await readCappedResponse(
-          detailResponse,
-          MAX_DETAIL_BYTES,
-          "Open VSX returned an unexpectedly large detail response.",
-        );
-        try {
-          const extension = extensionFromDetail(JSON.parse(new TextDecoder().decode(detailBytes)));
-          if (!extension) return null;
-          const [manifestResponse, packageResponse] = await Promise.all([
-            fetch(extension.manifestUrl, { signal: requestSignal }),
-            fetch(extension.vsixUrl, { method: "HEAD", signal: requestSignal }),
-          ]);
-          if (!manifestResponse.ok) throw new Error("manifest unavailable");
-          if (!packageResponse.ok) return null;
-          const packageLength = Number(packageResponse.headers.get("content-length"));
-          if (Number.isFinite(packageLength) && packageLength > MAX_VSIX_BYTES) {
-            return null;
+      withRequestTimeout(
+        async (requestSignal) => {
+          const detailUrl = `${OPEN_VSX_ORIGIN}/api/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
+          const detailResponse = await fetchOpenVsxResource(detailUrl, {}, requestSignal);
+          if (!detailResponse.ok) throw new Error("Open VSX theme details are unavailable.");
+          const detailBytes = await readCappedResponse(
+            detailResponse,
+            MAX_DETAIL_BYTES,
+            "Open VSX returned an unexpectedly large detail response.",
+          );
+          try {
+            const extension = extensionFromDetail(
+              JSON.parse(new TextDecoder().decode(detailBytes)),
+            );
+            if (!extension) return null;
+            const [manifestResponse, packageResponse] = await Promise.all([
+              fetchOpenVsxResource(extension.manifestUrl, {}, requestSignal),
+              fetchOpenVsxResource(extension.vsixUrl, { method: "HEAD" }, requestSignal),
+            ]);
+            if (!manifestResponse.ok) throw new Error("manifest unavailable");
+            if (!packageResponse.ok) return null;
+            const packageLength = Number(packageResponse.headers.get("content-length"));
+            if (Number.isFinite(packageLength) && packageLength > MAX_VSIX_BYTES) {
+              return null;
+            }
+            const manifestBytes = await readCappedResponse(
+              manifestResponse,
+              MAX_MANIFEST_BYTES,
+              "Open VSX returned an unexpectedly large manifest.",
+            );
+            const manifest = parseJsoncObject(
+              new TextDecoder().decode(manifestBytes),
+              "Extension manifest",
+            );
+            return themeContributions(manifest).length > 0 &&
+              manifestLicenseMatches(manifest, extension.license)
+              ? extension
+              : null;
+          } catch {
+            throw new Error("Open VSX returned unreadable theme details.");
           }
-          const manifestBytes = await readCappedResponse(
-            manifestResponse,
-            MAX_MANIFEST_BYTES,
-            "Open VSX returned an unexpectedly large manifest.",
-          );
-          const manifest = parseJsoncObject(
-            new TextDecoder().decode(manifestBytes),
-            "Extension manifest",
-          );
-          return themeContributions(manifest).length > 0 &&
-            manifestLicenseMatches(manifest, extension.license)
-            ? extension
-            : null;
-        } catch {
-          throw new Error("Open VSX returned unreadable theme details.");
-        }
-      }, signal),
+        },
+        SEARCH_REQUEST_TIMEOUT_MS,
+        "Open VSX took too long to respond.",
+        signal,
+      ),
     ),
   );
   if (signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
@@ -611,8 +674,8 @@ async function readCappedResponse(
   return result;
 }
 
-async function fetchPackage(url: string, signal?: AbortSignal): Promise<Uint8Array> {
-  const response = await fetch(url, signal ? { signal } : {});
+async function fetchPackage(url: string, signal: AbortSignal): Promise<Uint8Array> {
+  const response = await fetchOpenVsxResource(url, {}, signal);
   if (!response.ok) throw new Error("That Open VSX theme could not be downloaded.");
   return readCappedResponse(
     response,
@@ -621,11 +684,46 @@ async function fetchPackage(url: string, signal?: AbortSignal): Promise<Uint8Arr
   );
 }
 
-export async function importOpenVsxThemeExtension(
-  extension: OpenVsxThemeExtension,
-  signal?: AbortSignal,
+async function refreshSelectedExtension(
+  selected: OpenVsxThemeExtension,
+  signal: AbortSignal,
+): Promise<OpenVsxThemeExtension> {
+  const detailUrl = `${OPEN_VSX_ORIGIN}/api/${encodeURIComponent(selected.publisher)}/${encodeURIComponent(selected.extensionName)}/${encodeURIComponent(selected.version)}`;
+  const response = await fetchOpenVsxResource(detailUrl, {}, signal);
+  if (!response.ok) throw new Error("That Open VSX theme is no longer available.");
+  const detailBytes = await readCappedResponse(
+    response,
+    MAX_DETAIL_BYTES,
+    "Open VSX returned an unexpectedly large detail response.",
+  );
+  let current: OpenVsxThemeExtension | null;
+  try {
+    current = extensionFromDetail(JSON.parse(new TextDecoder().decode(detailBytes)));
+  } catch (cause) {
+    throw new Error("Open VSX returned unreadable theme details.", { cause });
+  }
+  if (!current) {
+    throw new Error("That Open VSX theme is no longer published by a verified source.");
+  }
+  if (
+    current.id.toLowerCase() !== selected.id.toLowerCase() ||
+    current.version !== selected.version ||
+    current.publishedBy !== selected.publishedBy ||
+    current.repositoryUrl !== selected.repositoryUrl
+  ) {
+    throw new Error(
+      "That Open VSX theme changed publisher identity. Search again before importing.",
+    );
+  }
+  return current;
+}
+
+async function importVerifiedOpenVsxThemeExtension(
+  selectedExtension: OpenVsxThemeExtension,
+  signal: AbortSignal,
 ): Promise<ReadonlyArray<ThemeDefinition>> {
-  const manifestResponse = await fetch(extension.manifestUrl, signal ? { signal } : {});
+  const extension = await refreshSelectedExtension(selectedExtension, signal);
+  const manifestResponse = await fetchOpenVsxResource(extension.manifestUrl, {}, signal);
   if (!manifestResponse.ok) throw new Error("That Open VSX extension has no readable manifest.");
   const manifestBytes = await readCappedResponse(
     manifestResponse,
@@ -643,7 +741,7 @@ export async function importOpenVsxThemeExtension(
 
   const packageBytes = await fetchPackage(extension.vsixUrl, signal);
   signal?.throwIfAborted();
-  const checksumResponse = await fetch(extension.sha256Url, signal ? { signal } : {});
+  const checksumResponse = await fetchOpenVsxResource(extension.sha256Url, {}, signal);
   if (!checksumResponse.ok) throw new Error("That Open VSX theme has no readable checksum.");
   const expectedChecksum = new TextDecoder()
     .decode(
@@ -773,4 +871,16 @@ export async function importOpenVsxThemeExtension(
     label: extension.name.slice(0, 48),
   };
   return themes.map((theme) => ({ ...theme, collection }));
+}
+
+export function importOpenVsxThemeExtension(
+  extension: OpenVsxThemeExtension,
+  signal?: AbortSignal,
+): Promise<ReadonlyArray<ThemeDefinition>> {
+  return withRequestTimeout(
+    (requestSignal) => importVerifiedOpenVsxThemeExtension(extension, requestSignal),
+    IMPORT_REQUEST_TIMEOUT_MS,
+    "That Open VSX theme took too long to import.",
+    signal,
+  );
 }

--- a/apps/web/src/openVsxThemes.ts
+++ b/apps/web/src/openVsxThemes.ts
@@ -267,14 +267,29 @@ async function withRequestTimeout<T>(
   parentSignal?: AbortSignal,
 ): Promise<T> {
   const controller = new AbortController();
-  const abort = () => controller.abort();
+  let rejectInterruption = (_cause: unknown) => {};
+  const interruption = new Promise<never>((_resolve, reject) => {
+    rejectInterruption = reject;
+  });
+  const abort = () => {
+    const cause =
+      parentSignal?.reason ?? new DOMException("The operation was aborted.", "AbortError");
+    controller.abort(cause);
+    rejectInterruption(cause);
+  };
   if (parentSignal?.aborted) abort();
   else parentSignal?.addEventListener("abort", abort, { once: true });
-  const timeout = setTimeout(abort, timeoutMs);
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    const cause = new Error(timeoutMessage);
+    controller.abort(cause);
+    rejectInterruption(cause);
+  }, timeoutMs);
   try {
-    return await operation(controller.signal);
+    return await Promise.race([operation(controller.signal), interruption]);
   } catch (cause) {
-    if (controller.signal.aborted && !parentSignal?.aborted) {
+    if (timedOut && !parentSignal?.aborted) {
       throw new Error(timeoutMessage, { cause });
     }
     throw cause;


### PR DESCRIPTION
## Problem

Open VSX theme imports already treated VSIX packages as data and enforced archive limits, but search accepted unverified publishers and import reused metadata captured during search. Resource redirects were not checked against the official delivery origins, and imports had no end-to-end timeout.

## Solution

- only surface theme extensions from verified Open VSX publishers
- refetch the exact selected version before import and reject publisher or repository identity drift
- validate final response origins while allowing Open VSX's official Eclipse content CDN
- cap the full import at 30 seconds
- cover trust changes, redirect handling, cancellation, path traversal, include cycles, oversized files, compression bombs, and archive entry limits with focused tests

## Validation

- `vp test run apps/web/src/openVsxThemes.test.ts apps/web/src/vscodeThemeImport.test.ts` (35 tests)
- `vp run --filter @t3tools/web typecheck`
- `vp fmt --check apps/web/src/openVsxThemes.ts apps/web/src/openVsxThemes.test.ts`
- `vp lint apps/web/src/openVsxThemes.ts apps/web/src/openVsxThemes.test.ts`

Built with GPT-5.6-Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches supply-chain trust for third-party theme downloads (URL allowlisting, publisher identity, verification). Unverified themes will now be omitted from search rather than importable.
> 
> **Overview**
> Tightens Open VSX theme search and import so only **verified** publishers are shown, and the selected version is **refetched** before download to reject publisher, repository, or verification drift.
> 
> All fetches now go through trusted `open-vsx.org` URLs, reject credentialed URLs, and check the **final redirect origin** (allowing the official Eclipse asset CDN). Imports are capped at **30s**. Tests cover identity drift, untrusted redirects, timeouts, path traversal, include cycles, oversized files, compression bombs, and zip entry limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3280205adc1bb7a59456dc52147ca579232ab22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Open VSX theme imports with origin validation, verification checks, and 30s timeout
> - Tightens URL trust rules in [openVsxThemes.ts](https://github.com/pingdotgg/t3code/pull/8063/files#diff-1c6fbc67d2e7c0f4de9134cb0f2af3a7cd34e4b8342522a5cb0f83408a8295c6) to require exact `https://open-vsx.org` origin and reject credentials; redirects only allowed to official Open VSX CDN origins via new `isTrustedOpenVsxResourceUrl` and `fetchOpenVsxResource` helpers
> - Rejects unverified extensions and those lacking `publishedBy`; `extensionFromDetail` now extracts publisher identity, repository URL, and sets `verified: true`
> - Adds `refreshSelectedExtension` to re-fetch extension details before import, rejecting if publisher identity, version, or repository URL changed since selection
> - Introduces `withRequestTimeout` with `IMPORT_REQUEST_TIMEOUT_MS = 30_000`; imports abort and throw a contextual timeout error after 30 seconds
> - Risk: `trustedOpenVsxUrl` now rejects URLs with username/password and non-exact origin matches, which may break any caller relying on loose origin matching or authenticated Open VSX URLs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e328020.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->