### PR TITLE
feat(web): import recent Codex and Claude threads during onboarding

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.test.ts
+++ b/apps/server/src/auth/RpcAuthorization.test.ts
@@ -43,6 +43,15 @@ describe("RPC authorization scopes", () => {
     );
   });
 
+  it("requires write access to import agent session history", () => {
+    expect(requiredScopeForRpcMethod(WS_METHODS.agentSessionsScan)).toBe(
+      AuthOrchestrationReadScope,
+    );
+    expect(requiredScopeForRpcMethod(WS_METHODS.agentSessionsImport)).toBe(
+      AuthOrchestrationOperateScope,
+    );
+  });
+
   it("reads the reviewer menu under the same scope as the pull request it belongs to", () => {
     // The candidate list is a read like the detail beside it, and asking somebody for a review is
     // a write like every other pull request operation.

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -84,6 +84,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.shellOpenInEditor]: AuthOrchestrationOperateScope,
   [WS_METHODS.filesystemBrowse]: AuthOrchestrationReadScope,
   [WS_METHODS.agentSessionsScan]: AuthOrchestrationReadScope,
+  [WS_METHODS.agentSessionsImport]: AuthOrchestrationOperateScope,
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,
   [WS_METHODS.attachmentsCreateUploadUrl]: AuthOrchestrationOperateScope,
   [WS_METHODS.attachmentsDelete]: AuthOrchestrationOperateScope,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -855,8 +855,9 @@ describe("CheckpointReactor", () => {
       seedFilesystemCheckpoints: false,
       threadWorktreePath: null,
     });
+    if (runtime === null) throw new Error("Checkpoint test runtime was not initialized.");
 
-    await Effect.runPromise(
+    await runtime.runPromise(
       harness.engine.dispatch({
         type: "thread.history.import",
         commandId: CommandId.make("cmd-import-history-without-checkpoint"),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -849,6 +849,35 @@ describe("CheckpointReactor", () => {
     ).toBe("v1\n");
   });
 
+  it("does not create checkpoints while importing historical user messages", async () => {
+    const harness = await createHarness({
+      hasSession: false,
+      seedFilesystemCheckpoints: false,
+      threadWorktreePath: null,
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.history.import",
+        commandId: CommandId.make("cmd-import-history-without-checkpoint"),
+        threadId: ThreadId.make("thread-1"),
+        messages: [
+          {
+            messageId: MessageId.make("imported-user-message"),
+            role: "user",
+            text: "A message from an existing agent session",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+    await harness.drain();
+
+    expect(
+      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0)),
+    ).toBe(false);
+  });
+
   it("captures turn completion checkpoint from project workspace root when provider session cwd is unavailable", async () => {
     const harness = await createHarness({
       hasSession: false,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -636,6 +636,7 @@ const make = Effect.gen(function* () {
   ) {
     if (event.type === "thread.message-sent") {
       if (
+        event.metadata.historyImport === true ||
         event.payload.role !== "user" ||
         event.payload.streaming ||
         event.payload.turnId !== null

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -54,6 +54,75 @@ const exists = (filePath: string) =>
 
 const BaseTestLayer = makeProjectionPipelinePrefixedTestLayer("t3-projection-pipeline-test-");
 
+it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-import-shell-")))(
+  "imported thread shell projection",
+  (it) => {
+    it.effect("does not mark imported user messages as queued work in thread shells", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const createdAt = "2026-08-24T10:00:00.000Z";
+        const threadId = ThreadId.make("import:codex:shell-session");
+
+        yield* eventStore.append({
+          type: "thread.created",
+          eventId: EventId.make("evt-import-shell-thread"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: createdAt,
+          commandId: CommandId.make("cmd-import-shell-thread"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-import-shell-thread"),
+          metadata: {},
+          payload: {
+            threadId,
+            projectId: ProjectId.make("project-import-shell"),
+            title: "Imported thread",
+            modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt,
+            updatedAt: createdAt,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.message-sent",
+          eventId: EventId.make("evt-import-shell-message"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: createdAt,
+          commandId: CommandId.make("cmd-import-shell-message"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-import-shell-message"),
+          metadata: { historyImport: true },
+          payload: {
+            threadId,
+            messageId: MessageId.make("import:codex:shell-session:0"),
+            role: "user",
+            text: "Imported user prompt",
+            turnId: null,
+            streaming: false,
+            createdAt,
+            updatedAt: createdAt,
+          },
+        });
+
+        yield* projectionPipeline.bootstrap;
+
+        const rows = yield* sql<{ readonly latestUserMessageAt: string | null }>`
+        SELECT latest_user_message_at AS "latestUserMessageAt"
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+        assert.deepEqual(rows, [{ latestUserMessageAt: null }]);
+      }),
+    );
+  },
+);
+
 it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
   it.effect("bootstraps all projection states and writes projection rows", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1,5 +1,6 @@
 import {
   ApprovalRequestId,
+  isImportedAgentSessionMessageId,
   type ChatAttachment,
   type OrchestrationEvent,
   type OrchestrationSessionStatus,
@@ -596,6 +597,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       for (const message of messages) {
         if (
           message.role === "user" &&
+          !isImportedAgentSessionMessageId(message.messageId) &&
           (latestUserMessageAt === null || message.createdAt > latestUserMessageAt)
         ) {
           latestUserMessageAt = message.createdAt;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -253,7 +253,7 @@ function retainProjectionMessagesAfterRevert(
   }
 
   for (const message of messages) {
-    if (message.role === "system") {
+    if (message.role === "system" || isImportedAgentSessionMessageId(message.messageId)) {
       retainedMessageIds.add(message.messageId);
       continue;
     }
@@ -263,7 +263,10 @@ function retainProjectionMessagesAfterRevert(
   }
 
   const retainedUserCount = messages.filter(
-    (message) => message.role === "user" && retainedMessageIds.has(message.messageId),
+    (message) =>
+      message.role === "user" &&
+      !isImportedAgentSessionMessageId(message.messageId) &&
+      retainedMessageIds.has(message.messageId),
   ).length;
   const missingUserCount = Math.max(0, turnCount - retainedUserCount);
   if (missingUserCount > 0) {
@@ -286,7 +289,10 @@ function retainProjectionMessagesAfterRevert(
   }
 
   const retainedAssistantCount = messages.filter(
-    (message) => message.role === "assistant" && retainedMessageIds.has(message.messageId),
+    (message) =>
+      message.role === "assistant" &&
+      !isImportedAgentSessionMessageId(message.messageId) &&
+      retainedMessageIds.has(message.messageId),
   ).length;
   const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
   if (missingAssistantCount > 0) {

--- a/apps/server/src/orchestration/decider.import.test.ts
+++ b/apps/server/src/orchestration/decider.import.test.ts
@@ -1,0 +1,83 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import {
+  CommandId,
+  EventId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+it.layer(NodeServices.layer)("thread history import", (it) => {
+  it.effect("emits completed user and assistant messages without starting a turn", () =>
+    Effect.gen(function* () {
+      const createdAt = "2026-08-24T10:00:00.000Z";
+      const threadId = ThreadId.make("thread-imported");
+      const readModel = yield* projectEvent(createEmptyReadModel(createdAt), {
+        sequence: 1,
+        eventId: EventId.make("event-thread-created"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        type: "thread.created",
+        occurredAt: createdAt,
+        commandId: CommandId.make("command-thread-created"),
+        causationEventId: null,
+        correlationId: CommandId.make("command-thread-created"),
+        metadata: {},
+        payload: {
+          threadId,
+          projectId: ProjectId.make("project-1"),
+          title: "Imported thread",
+          modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+
+      const events = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.history.import",
+          commandId: CommandId.make("command-import-history"),
+          threadId,
+          messages: [
+            {
+              messageId: MessageId.make("message-user"),
+              role: "user",
+              text: "Fix the bug",
+              createdAt,
+            },
+            {
+              messageId: MessageId.make("message-assistant"),
+              role: "assistant",
+              text: "Fixed",
+              createdAt: "2026-08-24T10:01:00.000Z",
+            },
+          ],
+        },
+        readModel,
+      });
+
+      expect(events).toMatchObject([
+        {
+          type: "thread.message-sent",
+          metadata: { historyImport: true },
+          payload: { role: "user", text: "Fix the bug", turnId: null, streaming: false },
+        },
+        {
+          type: "thread.message-sent",
+          metadata: { historyImport: true },
+          payload: { role: "assistant", text: "Fixed", turnId: null, streaming: false },
+        },
+      ]);
+    }),
+  );
+});

--- a/apps/server/src/orchestration/decider.import.test.ts
+++ b/apps/server/src/orchestration/decider.import.test.ts
@@ -9,6 +9,7 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
 
 import { decideOrchestrationCommand } from "./decider.ts";
 import { createEmptyReadModel, projectEvent } from "./projector.ts";
@@ -78,6 +79,71 @@ it.layer(NodeServices.layer)("thread history import", (it) => {
           payload: { role: "assistant", text: "Fixed", turnId: null, streaming: false },
         },
       ]);
+    }),
+  );
+
+  it.effect("allows a thread with a newly imported user message to be settled", () =>
+    Effect.gen(function* () {
+      const createdAt = "2026-08-24T10:00:00.000Z";
+      yield* TestClock.setTime(Date.parse("2026-08-24T10:00:30.000Z"));
+      const threadId = ThreadId.make("import:codex:session-1");
+      const withThread = yield* projectEvent(createEmptyReadModel(createdAt), {
+        sequence: 1,
+        eventId: EventId.make("event-import-thread-created"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        type: "thread.created",
+        occurredAt: createdAt,
+        commandId: CommandId.make("command-import-thread-created"),
+        causationEventId: null,
+        correlationId: CommandId.make("command-import-thread-created"),
+        metadata: {},
+        payload: {
+          threadId,
+          projectId: ProjectId.make("project-1"),
+          title: "Imported thread",
+          modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+      const readModel = yield* projectEvent(withThread, {
+        sequence: 2,
+        eventId: EventId.make("event-import-user-message"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        type: "thread.message-sent",
+        occurredAt: createdAt,
+        commandId: CommandId.make("command-import-user-message"),
+        causationEventId: null,
+        correlationId: CommandId.make("command-import-user-message"),
+        metadata: { historyImport: true },
+        payload: {
+          threadId,
+          messageId: MessageId.make("import:codex:session-1:0"),
+          role: "user",
+          text: "Existing prompt",
+          turnId: null,
+          streaming: false,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.settle",
+          commandId: CommandId.make("command-settle-imported-thread"),
+          threadId,
+        },
+        readModel,
+      });
+
+      expect(result).toMatchObject({ type: "thread.settled" });
     }),
   );
 });

--- a/apps/server/src/orchestration/decider.import.test.ts
+++ b/apps/server/src/orchestration/decider.import.test.ts
@@ -178,4 +178,81 @@ it.layer(NodeServices.layer)("thread history import", (it) => {
       expect(result).toMatchObject({ type: "thread.settled" });
     }),
   );
+
+  it.effect("rejects history import after a client message reaches the thread", () =>
+    Effect.gen(function* () {
+      const createdAt = "2026-08-24T10:00:00.000Z";
+      const liveMessageAt = "2026-08-24T10:02:00.000Z";
+      const threadId = ThreadId.make("import:codex:client-race");
+      const withThread = yield* projectEvent(createEmptyReadModel(createdAt), {
+        sequence: 1,
+        eventId: EventId.make("event-client-race-thread-created"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        type: "thread.created",
+        occurredAt: createdAt,
+        commandId: CommandId.make("command-client-race-thread-created"),
+        causationEventId: null,
+        correlationId: CommandId.make("command-client-race-thread-created"),
+        metadata: {},
+        payload: {
+          threadId,
+          projectId: ProjectId.make("project-1"),
+          title: "Imported thread",
+          modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+      const readModel = yield* projectEvent(withThread, {
+        sequence: 2,
+        eventId: EventId.make("event-client-race-message"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        type: "thread.message-sent",
+        occurredAt: liveMessageAt,
+        commandId: CommandId.make("command-client-race-message"),
+        causationEventId: null,
+        correlationId: CommandId.make("command-client-race-message"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("client-race-message"),
+          role: "user",
+          text: "Start live work",
+          turnId: null,
+          streaming: false,
+          createdAt: liveMessageAt,
+          updatedAt: liveMessageAt,
+        },
+      });
+
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.history.import",
+            commandId: CommandId.make("command-client-race-import"),
+            threadId,
+            messages: [
+              {
+                messageId: MessageId.make(`${threadId}:000000`),
+                role: "user",
+                text: "Old work",
+                createdAt,
+              },
+            ],
+          },
+          readModel,
+        }),
+      );
+
+      expect(error._tag).toBe("OrchestrationCommandInvariantError");
+      expect(error.message).toContain("must be active and empty");
+      expect(readModel.threads[0]?.updatedAt).toBe(liveMessageAt);
+    }),
+  );
 });

--- a/apps/server/src/orchestration/decider.import.test.ts
+++ b/apps/server/src/orchestration/decider.import.test.ts
@@ -18,7 +18,7 @@ it.layer(NodeServices.layer)("thread history import", (it) => {
   it.effect("emits completed user and assistant messages without starting a turn", () =>
     Effect.gen(function* () {
       const createdAt = "2026-08-24T10:00:00.000Z";
-      const threadId = ThreadId.make("thread-imported");
+      const threadId = ThreadId.make("import:codex:session-1");
       const readModel = yield* projectEvent(createEmptyReadModel(createdAt), {
         sequence: 1,
         eventId: EventId.make("event-thread-created"),
@@ -51,13 +51,13 @@ it.layer(NodeServices.layer)("thread history import", (it) => {
           threadId,
           messages: [
             {
-              messageId: MessageId.make("message-user"),
+              messageId: MessageId.make(`${threadId}:000000`),
               role: "user",
               text: "Fix the bug",
               createdAt,
             },
             {
-              messageId: MessageId.make("message-assistant"),
+              messageId: MessageId.make(`${threadId}:000001`),
               role: "assistant",
               text: "Fixed",
               createdAt: "2026-08-24T10:01:00.000Z",
@@ -78,6 +78,38 @@ it.layer(NodeServices.layer)("thread history import", (it) => {
           metadata: { historyImport: true },
           payload: { role: "assistant", text: "Fixed", turnId: null, streaming: false },
         },
+        {
+          type: "thread.settled",
+          metadata: { historyImport: true },
+          occurredAt: "2026-08-24T10:01:00.000Z",
+          payload: {
+            settledAt: "2026-08-24T10:01:00.000Z",
+            updatedAt: "2026-08-24T10:01:00.000Z",
+          },
+        },
+      ]);
+
+      let projected = readModel;
+      const plannedEvents = Array.isArray(events) ? events : [events];
+      for (const [index, event] of plannedEvents.entries()) {
+        projected = yield* projectEvent(projected, { ...event, sequence: index + 2 });
+      }
+      projected = yield* projectEvent(projected, {
+        sequence: 5,
+        eventId: EventId.make("event-import-reverted"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        type: "thread.reverted",
+        occurredAt: "2026-08-24T10:02:00.000Z",
+        commandId: CommandId.make("command-import-reverted"),
+        causationEventId: null,
+        correlationId: CommandId.make("command-import-reverted"),
+        metadata: {},
+        payload: { threadId, turnCount: 0 },
+      });
+      expect(projected.threads[0]?.messages.map((message) => message.text)).toEqual([
+        "Fix the bug",
+        "Fixed",
       ]);
     }),
   );

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1,5 +1,6 @@
 import {
   EventId,
+  isImportedAgentSessionMessageId,
   type OrchestrationCommand,
   type OrchestrationEvent,
   type OrchestrationReadModel,
@@ -106,7 +107,11 @@ function hasOpenBlockingRequest(thread: {
  */
 function threadHasQueuedTurnStart(
   thread: {
-    readonly messages: ReadonlyArray<{ readonly role: string; readonly createdAt: string }>;
+    readonly messages: ReadonlyArray<{
+      readonly id: string;
+      readonly role: string;
+      readonly createdAt: string;
+    }>;
     readonly latestTurn: {
       readonly requestedAt: string;
       readonly startedAt: string | null;
@@ -118,7 +123,9 @@ function threadHasQueuedTurnStart(
 ): boolean {
   const latestUserMessageAtMs = thread.messages.reduce(
     (latest, message) =>
-      message.role === "user" ? Math.max(latest, Date.parse(message.createdAt)) : latest,
+      message.role === "user" && !isImportedAgentSessionMessageId(message.id)
+        ? Math.max(latest, Date.parse(message.createdAt))
+        : latest,
     Number.NEGATIVE_INFINITY,
   );
   const latestTurnAtMs =

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1282,6 +1282,39 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.history.import": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+
+      const events: Array<PlannedOrchestrationEvent> = [];
+      for (const message of command.messages) {
+        events.push({
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: message.createdAt,
+            commandId: command.commandId,
+            metadata: { historyImport: true },
+          })),
+          type: "thread.message-sent",
+          payload: {
+            threadId: command.threadId,
+            messageId: message.messageId,
+            role: message.role,
+            text: message.text,
+            turnId: null,
+            streaming: false,
+            createdAt: message.createdAt,
+            updatedAt: message.createdAt,
+          },
+        });
+      }
+      return events;
+    }
+
     case "thread.proposed-plan.upsert": {
       yield* requireThread({
         readModel,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1295,6 +1295,13 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      const firstMessage = command.messages[0];
+      if (firstMessage === undefined) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: "Thread history imports require at least one message.",
+        });
+      }
 
       const events: Array<PlannedOrchestrationEvent> = [];
       for (const message of command.messages) {
@@ -1319,6 +1326,25 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           },
         });
       }
+      const settledAt = command.messages.reduce(
+        (latest, message) => (message.createdAt > latest ? message.createdAt : latest),
+        firstMessage.createdAt,
+      );
+      events.push({
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: settledAt,
+          commandId: command.commandId,
+          metadata: { historyImport: true },
+        })),
+        type: "thread.settled",
+        payload: {
+          threadId: command.threadId,
+          settledAt,
+          updatedAt: settledAt,
+        },
+      });
       return events;
     }
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1290,11 +1290,23 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.history.import": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
+      if (
+        thread.deletedAt !== null ||
+        thread.archivedAt !== null ||
+        thread.messages.length > 0 ||
+        thread.latestTurn !== null ||
+        thread.session !== null
+      ) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' must be active and empty before history can be imported.`,
+        });
+      }
       const firstMessage = command.messages[0];
       if (firstMessage === undefined) {
         return yield* new OrchestrationCommandInvariantError({

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,5 +1,6 @@
 import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@t3tools/contracts";
 import {
+  isImportedAgentSessionMessageId,
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
   OrchestrationSession,
@@ -94,7 +95,7 @@ function retainThreadMessagesAfterRevert(
 ): ReadonlyArray<OrchestrationMessage> {
   const retainedMessageIds = new Set<string>();
   for (const message of messages) {
-    if (message.role === "system") {
+    if (message.role === "system" || isImportedAgentSessionMessageId(message.id)) {
       retainedMessageIds.add(message.id);
       continue;
     }
@@ -104,7 +105,10 @@ function retainThreadMessagesAfterRevert(
   }
 
   const retainedUserCount = messages.filter(
-    (message) => message.role === "user" && retainedMessageIds.has(message.id),
+    (message) =>
+      message.role === "user" &&
+      !isImportedAgentSessionMessageId(message.id) &&
+      retainedMessageIds.has(message.id),
   ).length;
   const missingUserCount = Math.max(0, turnCount - retainedUserCount);
   if (missingUserCount > 0) {
@@ -126,7 +130,10 @@ function retainThreadMessagesAfterRevert(
   }
 
   const retainedAssistantCount = messages.filter(
-    (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
+    (message) =>
+      message.role === "assistant" &&
+      !isImportedAgentSessionMessageId(message.id) &&
+      retainedMessageIds.has(message.id),
   ).length;
   const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
   if (missingAssistantCount > 0) {

--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -58,6 +58,10 @@ export type GetProviderSessionRuntimeInput = typeof GetProviderSessionRuntimeInp
 export const DeleteProviderSessionRuntimeInput = Schema.Struct({ threadId: ThreadId });
 export type DeleteProviderSessionRuntimeInput = typeof DeleteProviderSessionRuntimeInput.Type;
 
+export interface ProviderSessionRuntimeUpsertOptions {
+  readonly onConflict?: "update" | "ignore";
+}
+
 /**
  * ProviderSessionRuntimeRepository - Service tag for provider runtime persistence.
  */
@@ -71,6 +75,7 @@ export class ProviderSessionRuntimeRepository extends Context.Service<
      */
     readonly upsert: (
       runtime: ProviderSessionRuntime,
+      options?: ProviderSessionRuntimeUpsertOptions,
     ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
 
     /**
@@ -186,6 +191,36 @@ export const make = Effect.gen(function* () {
       `,
   });
 
+  const insertRuntimeRow = SqlSchema.void({
+    Request: ProviderSessionRuntimeDbRowSchema,
+    execute: (runtime) =>
+      sql`
+        INSERT INTO provider_session_runtime (
+          thread_id,
+          provider_name,
+          provider_instance_id,
+          adapter_key,
+          runtime_mode,
+          status,
+          last_seen_at,
+          resume_cursor_json,
+          runtime_payload_json
+        )
+        VALUES (
+          ${runtime.threadId},
+          ${runtime.providerName},
+          ${runtime.providerInstanceId},
+          ${runtime.adapterKey},
+          ${runtime.runtimeMode},
+          ${runtime.status},
+          ${runtime.lastSeenAt},
+          ${runtime.resumeCursor},
+          ${runtime.runtimePayload}
+        )
+        ON CONFLICT (thread_id) DO NOTHING
+      `,
+  });
+
   const getRuntimeRowByThreadId = SqlSchema.findOneOption({
     Request: GetRuntimeRequestSchema,
     Result: ProviderSessionRuntimeRawDbRowSchema,
@@ -235,8 +270,8 @@ export const make = Effect.gen(function* () {
       `,
   });
 
-  const upsert: ProviderSessionRuntimeRepository["Service"]["upsert"] = (runtime) =>
-    upsertRuntimeRow(runtime).pipe(
+  const upsert: ProviderSessionRuntimeRepository["Service"]["upsert"] = (runtime, options) =>
+    (options?.onConflict === "ignore" ? insertRuntimeRow(runtime) : upsertRuntimeRow(runtime)).pipe(
       Effect.mapError(
         toPersistenceSqlOrDecodeError(
           "ProviderSessionRuntimeRepository.upsert:query",

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -1,0 +1,139 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import { ProjectId, ProviderInstanceId, type OrchestrationCommand } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+
+import { OrchestrationCommandInvariantError } from "../orchestration/Errors.ts";
+import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
+import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
+import { importRecentAgentThreads } from "./AgentSessionImporter.ts";
+import * as AgentSessionScanner from "./AgentSessionScanner.ts";
+
+const makeThread = (source: "codex" | "claudeAgent"): AgentSessionScanner.AgentSessionThread => ({
+  source,
+  providerInstanceId: ProviderInstanceId.make(source),
+  providerSessionId: source === "codex" ? "codex-session" : "claude-session",
+  title: `Imported ${source} thread`,
+  model: null,
+  createdAt: "2026-08-24T10:00:00.000Z",
+  updatedAt: "2026-08-24T10:01:00.000Z",
+  messages: [
+    { role: "user", text: "Fix the bug", createdAt: "2026-08-24T10:00:00.000Z" },
+    { role: "assistant", text: "Fixed", createdAt: "2026-08-24T10:01:00.000Z" },
+  ],
+});
+
+it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
+  describe("importRecentAgentThreads", () => {
+    it.effect("creates transcript history and stores provider-specific resume cursors", () =>
+      Effect.gen(function* () {
+        const commands: Array<OrchestrationCommand> = [];
+        const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
+        const scanner = AgentSessionScanner.AgentSessionScanner.of({
+          scan: Effect.die("unused"),
+          recentThreads: () => Effect.succeed([makeThread("codex"), makeThread("claudeAgent")]),
+        });
+        const engine = OrchestrationEngine.OrchestrationEngineService.of({
+          dispatch: (command) => {
+            commands.push(command);
+            return Effect.succeed({ sequence: commands.length });
+          },
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        });
+        const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
+          upsert: (binding) => {
+            bindings.push(binding);
+            return Effect.void;
+          },
+          getProvider: () => Effect.die("unused"),
+          getBinding: () => Effect.die("unused"),
+          listThreadIds: () => Effect.die("unused"),
+          listBindings: () => Effect.die("unused"),
+        });
+
+        const result = yield* importRecentAgentThreads({
+          projectId: ProjectId.make("project-1"),
+          workspaceRoot: "/tmp/project",
+        }).pipe(
+          Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
+          Effect.provideService(OrchestrationEngine.OrchestrationEngineService, engine),
+          Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, directory),
+        );
+
+        expect(result).toEqual({ importedCount: 2, skippedCount: 0 });
+        expect(commands.map((command) => command.type)).toEqual([
+          "thread.create",
+          "thread.history.import",
+          "thread.create",
+          "thread.history.import",
+        ]);
+        expect(bindings).toMatchObject([
+          {
+            provider: "codex",
+            providerInstanceId: "codex",
+            status: "stopped",
+            resumeCursor: { threadId: "codex-session" },
+          },
+          {
+            provider: "claudeAgent",
+            providerInstanceId: "claudeAgent",
+            status: "stopped",
+            resumeCursor: {
+              threadId: "import:claudeAgent:claude-session",
+              resume: "claude-session",
+            },
+          },
+        ]);
+      }),
+    );
+
+    it.effect("skips a rejected session and continues importing later sessions", () =>
+      Effect.gen(function* () {
+        const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
+        const scanner = AgentSessionScanner.AgentSessionScanner.of({
+          scan: Effect.die("unused"),
+          recentThreads: () => Effect.succeed([makeThread("codex"), makeThread("claudeAgent")]),
+        });
+        const engine = OrchestrationEngine.OrchestrationEngineService.of({
+          dispatch: (command) =>
+            command.type === "thread.create" && command.threadId.includes("codex-session")
+              ? Effect.fail(
+                  new OrchestrationCommandInvariantError({
+                    commandType: command.type,
+                    detail: "The thread already exists.",
+                  }),
+                )
+              : Effect.succeed({ sequence: 1 }),
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        });
+        const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
+          upsert: (binding) => {
+            bindings.push(binding);
+            return Effect.void;
+          },
+          getProvider: () => Effect.die("unused"),
+          getBinding: () => Effect.die("unused"),
+          listThreadIds: () => Effect.die("unused"),
+          listBindings: () => Effect.die("unused"),
+        });
+
+        const result = yield* importRecentAgentThreads({
+          projectId: ProjectId.make("project-1"),
+          workspaceRoot: "/tmp/project",
+        }).pipe(
+          Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
+          Effect.provideService(OrchestrationEngine.OrchestrationEngineService, engine),
+          Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, directory),
+        );
+
+        expect(result).toEqual({ importedCount: 1, skippedCount: 1 });
+        expect(bindings[0]?.provider).toBe("claudeAgent");
+      }),
+    );
+  });
+});

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -6,6 +6,7 @@ import * as Stream from "effect/Stream";
 
 import { OrchestrationCommandInvariantError } from "../orchestration/Errors.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
+import { ProviderSessionDirectoryPersistenceError } from "../provider/Errors.ts";
 import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
 import { importRecentAgentThreads } from "./AgentSessionImporter.ts";
 import * as AgentSessionScanner from "./AgentSessionScanner.ts";
@@ -133,6 +134,88 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
 
         expect(result).toEqual({ importedCount: 1, skippedCount: 1 });
         expect(bindings[0]?.provider).toBe("claudeAgent");
+      }),
+    );
+
+    it.effect("retries a partially imported session with the original command receipts", () =>
+      Effect.gen(function* () {
+        const acceptedCommandIds = new Set<string>();
+        const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
+        let threadCreated = false;
+        let historyAttemptCount = 0;
+        let bindingAttemptCount = 0;
+        const scanner = AgentSessionScanner.AgentSessionScanner.of({
+          scan: Effect.die("unused"),
+          recentThreads: () => Effect.succeed([makeThread("codex")]),
+        });
+        const engine = OrchestrationEngine.OrchestrationEngineService.of({
+          dispatch: (command) => {
+            if (acceptedCommandIds.has(command.commandId)) {
+              return Effect.succeed({ sequence: 1 });
+            }
+            if (command.type === "thread.create") {
+              if (threadCreated) {
+                return Effect.fail(
+                  new OrchestrationCommandInvariantError({
+                    commandType: command.type,
+                    detail: "The thread already exists.",
+                  }),
+                );
+              }
+              threadCreated = true;
+              acceptedCommandIds.add(command.commandId);
+              return Effect.succeed({ sequence: 1 });
+            }
+            historyAttemptCount += 1;
+            if (historyAttemptCount === 1) {
+              return Effect.fail(
+                new OrchestrationCommandInvariantError({
+                  commandType: command.type,
+                  detail: "Temporary history import failure.",
+                }),
+              );
+            }
+            acceptedCommandIds.add(command.commandId);
+            return Effect.succeed({ sequence: 2 });
+          },
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        });
+        const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
+          upsert: (binding) => {
+            bindingAttemptCount += 1;
+            if (bindingAttemptCount === 1) {
+              return Effect.fail(
+                new ProviderSessionDirectoryPersistenceError({
+                  operation: "upsert",
+                  detail: "Temporary session storage failure.",
+                }),
+              );
+            }
+            bindings.push(binding);
+            return Effect.void;
+          },
+          getProvider: () => Effect.die("unused"),
+          getBinding: () => Effect.die("unused"),
+          listThreadIds: () => Effect.die("unused"),
+          listBindings: () => Effect.die("unused"),
+        });
+        const runImport = () =>
+          importRecentAgentThreads({
+            projectId: ProjectId.make("project-1"),
+            workspaceRoot: "/tmp/project",
+          }).pipe(
+            Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
+            Effect.provideService(OrchestrationEngine.OrchestrationEngineService, engine),
+            Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, directory),
+          );
+
+        expect(yield* runImport()).toEqual({ importedCount: 0, skippedCount: 1 });
+        expect(yield* runImport()).toEqual({ importedCount: 0, skippedCount: 1 });
+        expect(yield* runImport()).toEqual({ importedCount: 1, skippedCount: 0 });
+        expect(bindings).toHaveLength(1);
+        expect(historyAttemptCount).toBe(2);
       }),
     );
   });

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -1,20 +1,49 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
-import { ProjectId, ProviderInstanceId, type OrchestrationCommand } from "@t3tools/contracts";
+import {
+  CommandId,
+  MessageId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationCommand,
+  type OrchestrationProjectShell,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
+import { ServerConfig } from "../config.ts";
+import { OrchestrationCommandReceiptRepositoryLive } from "../persistence/Layers/OrchestrationCommandReceipts.ts";
+import { OrchestrationEventStoreLive } from "../persistence/Layers/OrchestrationEventStore.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import * as ProviderSessionRuntime from "../persistence/ProviderSessionRuntime.ts";
+import { OrchestrationEngineLive } from "../orchestration/Layers/OrchestrationEngine.ts";
+import { OrchestrationProjectionPipelineLive } from "../orchestration/Layers/ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "../orchestration/Layers/ProjectionSnapshotQuery.ts";
 import { OrchestrationCommandInvariantError } from "../orchestration/Errors.ts";
+import * as ThreadBackgroundLiveness from "../orchestration/ThreadBackgroundLiveness.ts";
+import * as ThreadPlanProgress from "../orchestration/ThreadPlanProgress.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProviderSessionDirectoryLive } from "../provider/Layers/ProviderSessionDirectory.ts";
 import { ProviderSessionDirectoryPersistenceError } from "../provider/Errors.ts";
 import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
+import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
 import { importRecentAgentThreads } from "./AgentSessionImporter.ts";
 import * as AgentSessionScanner from "./AgentSessionScanner.ts";
+
+const PROJECT_ID = ProjectId.make("project-1");
+const WORKSPACE_ROOT = "/tmp/project-from-server";
+const CLAUDE_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
 
 const makeThread = (source: "codex" | "claudeAgent"): AgentSessionScanner.AgentSessionThread => ({
   source,
   providerInstanceId: ProviderInstanceId.make(source),
-  providerSessionId: source === "codex" ? "codex-session" : "claude-session",
+  providerSessionId: source === "codex" ? "codex-session" : CLAUDE_SESSION_ID,
   title: `Imported ${source} thread`,
   model: null,
   createdAt: "2026-08-24T10:00:00.000Z",
@@ -25,158 +54,208 @@ const makeThread = (source: "codex" | "claudeAgent"): AgentSessionScanner.AgentS
   ],
 });
 
+const makeProject = (): OrchestrationProjectShell => ({
+  id: PROJECT_ID,
+  title: "Project",
+  workspaceRoot: WORKSPACE_ROOT,
+  defaultModelSelection: null,
+  scripts: [],
+  createdAt: "2026-08-24T09:00:00.000Z",
+  updatedAt: "2026-08-24T09:00:00.000Z",
+});
+
+const makeProjectedThread = (input: {
+  readonly source: "codex" | "claudeAgent";
+  readonly projectId?: ProjectId;
+  readonly imported?: boolean;
+  readonly includeFollowup?: boolean;
+}): OrchestrationThread => {
+  const sourceThread = makeThread(input.source);
+  const threadId = ThreadId.make(
+    `import:${sourceThread.providerInstanceId}:${sourceThread.providerSessionId}`,
+  );
+  return {
+    id: threadId,
+    projectId: input.projectId ?? PROJECT_ID,
+    title: sourceThread.title,
+    modelSelection: { instanceId: sourceThread.providerInstanceId, model: "default" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: sourceThread.createdAt,
+    updatedAt: sourceThread.updatedAt,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    deletedAt: null,
+    messages: input.imported
+      ? [
+          {
+            id: MessageId.make(`${threadId}:000000`),
+            role: "user",
+            text: "Fix the bug",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-08-24T10:00:00.000Z",
+            updatedAt: "2026-08-24T10:00:00.000Z",
+          },
+          ...(input.includeFollowup
+            ? [
+                {
+                  id: MessageId.make("user-followup"),
+                  role: "user" as const,
+                  text: "Keep going",
+                  turnId: null,
+                  streaming: false,
+                  createdAt: "2026-08-24T10:02:00.000Z",
+                  updatedAt: "2026-08-24T10:02:00.000Z",
+                },
+              ]
+            : []),
+        ]
+      : [],
+    proposedPlans: [],
+    activities: [],
+    checkpoints: [],
+    session: null,
+  };
+};
+
+const makeSnapshotsLayer = (input: {
+  readonly project?: OrchestrationProjectShell;
+  readonly getThread?: (threadId: ThreadId) => Option.Option<OrchestrationThread>;
+}) =>
+  Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+    getProjectShellById: () =>
+      Effect.succeed(input.project === undefined ? Option.none() : Option.some(input.project)),
+    getThreadDetailById: (threadId) => Effect.succeed(input.getThread?.(threadId) ?? Option.none()),
+  });
+
+const runImport = (input: {
+  readonly scanner: AgentSessionScanner.AgentSessionScanner["Service"];
+  readonly engine: OrchestrationEngine.OrchestrationEngineService["Service"];
+  readonly directory: ProviderSessionDirectory.ProviderSessionDirectory["Service"];
+  readonly snapshots: ReturnType<typeof makeSnapshotsLayer>;
+}) =>
+  importRecentAgentThreads({ projectId: PROJECT_ID }).pipe(
+    Effect.provideService(AgentSessionScanner.AgentSessionScanner, input.scanner),
+    Effect.provideService(OrchestrationEngine.OrchestrationEngineService, input.engine),
+    Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, input.directory),
+    Effect.provide(input.snapshots),
+  );
+
 it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
   describe("importRecentAgentThreads", () => {
-    it.effect("creates transcript history and stores provider-specific resume cursors", () =>
+    it.effect("uses the project root and stores provider-specific resume cursors", () =>
       Effect.gen(function* () {
         const commands: Array<OrchestrationCommand> = [];
         const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
+        let scannedRoot: string | undefined;
         const scanner = AgentSessionScanner.AgentSessionScanner.of({
           scan: Effect.die("unused"),
-          recentThreads: () => Effect.succeed([makeThread("codex"), makeThread("claudeAgent")]),
+          recentThreads: (workspaceRoot) => {
+            scannedRoot = workspaceRoot;
+            return Effect.succeed([makeThread("codex"), makeThread("claudeAgent")]);
+          },
         });
         const engine = OrchestrationEngine.OrchestrationEngineService.of({
-          dispatch: (command) => {
-            commands.push(command);
-            return Effect.succeed({ sequence: commands.length });
-          },
+          dispatch: (command) => Effect.sync(() => ({ sequence: commands.push(command) })),
           readEvents: () => Stream.empty,
           streamDomainEvents: Stream.empty,
           latestSequence: Effect.succeed(0),
         });
         const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
-          upsert: (binding) => {
-            bindings.push(binding);
-            return Effect.void;
-          },
+          upsert: (binding) => Effect.sync(() => void bindings.push(binding)),
           getProvider: () => Effect.die("unused"),
-          getBinding: () => Effect.die("unused"),
+          getBinding: () => Effect.succeed(Option.none()),
           listThreadIds: () => Effect.die("unused"),
           listBindings: () => Effect.die("unused"),
         });
 
-        const result = yield* importRecentAgentThreads({
-          projectId: ProjectId.make("project-1"),
-          workspaceRoot: "/tmp/project",
-        }).pipe(
-          Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
-          Effect.provideService(OrchestrationEngine.OrchestrationEngineService, engine),
-          Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, directory),
-        );
+        const result = yield* runImport({
+          scanner,
+          engine,
+          directory,
+          snapshots: makeSnapshotsLayer({ project: makeProject() }),
+        });
 
         expect(result).toEqual({ importedCount: 2, skippedCount: 0 });
+        expect(scannedRoot).toBe(WORKSPACE_ROOT);
         expect(commands.map((command) => command.type)).toEqual([
           "thread.create",
           "thread.history.import",
           "thread.create",
           "thread.history.import",
         ]);
+        expect(
+          commands
+            .filter((command) => command.type === "thread.history.import")
+            .flatMap((command) => command.messages.map((message) => message.messageId)),
+        ).toEqual([
+          "import:codex:codex-session:000000",
+          "import:codex:codex-session:000001",
+          `import:claudeAgent:${CLAUDE_SESSION_ID}:000000`,
+          `import:claudeAgent:${CLAUDE_SESSION_ID}:000001`,
+        ]);
         expect(bindings).toMatchObject([
           {
             provider: "codex",
             providerInstanceId: "codex",
-            status: "stopped",
             resumeCursor: { threadId: "codex-session" },
+            runtimePayload: { cwd: WORKSPACE_ROOT },
           },
           {
             provider: "claudeAgent",
             providerInstanceId: "claudeAgent",
-            status: "stopped",
             resumeCursor: {
-              threadId: "import:claudeAgent:claude-session",
-              resume: "claude-session",
+              threadId: `import:claudeAgent:${CLAUDE_SESSION_ID}`,
+              resume: CLAUDE_SESSION_ID,
             },
+            runtimePayload: { cwd: WORKSPACE_ROOT },
           },
         ]);
       }),
     );
 
-    it.effect("skips a rejected session and continues importing later sessions", () =>
+    it.effect("recovers after a rejected history receipt and a failed binding write", () =>
       Effect.gen(function* () {
-        const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
-        const scanner = AgentSessionScanner.AgentSessionScanner.of({
-          scan: Effect.die("unused"),
-          recentThreads: () => Effect.succeed([makeThread("codex"), makeThread("claudeAgent")]),
-        });
-        const engine = OrchestrationEngine.OrchestrationEngineService.of({
-          dispatch: (command) =>
-            command.type === "thread.create" && command.threadId.includes("codex-session")
-              ? Effect.fail(
-                  new OrchestrationCommandInvariantError({
-                    commandType: command.type,
-                    detail: "The thread already exists.",
-                  }),
-                )
-              : Effect.succeed({ sequence: 1 }),
-          readEvents: () => Stream.empty,
-          streamDomainEvents: Stream.empty,
-          latestSequence: Effect.succeed(0),
-        });
-        const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
-          upsert: (binding) => {
-            bindings.push(binding);
-            return Effect.void;
-          },
-          getProvider: () => Effect.die("unused"),
-          getBinding: () => Effect.die("unused"),
-          listThreadIds: () => Effect.die("unused"),
-          listBindings: () => Effect.die("unused"),
-        });
-
-        const result = yield* importRecentAgentThreads({
-          projectId: ProjectId.make("project-1"),
-          workspaceRoot: "/tmp/project",
-        }).pipe(
-          Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
-          Effect.provideService(OrchestrationEngine.OrchestrationEngineService, engine),
-          Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, directory),
-        );
-
-        expect(result).toEqual({ importedCount: 1, skippedCount: 1 });
-        expect(bindings[0]?.provider).toBe("claudeAgent");
-      }),
-    );
-
-    it.effect("retries a partially imported session with the original command receipts", () =>
-      Effect.gen(function* () {
-        const acceptedCommandIds = new Set<string>();
-        const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
         let threadCreated = false;
+        let historyImported = false;
         let historyAttemptCount = 0;
         let bindingAttemptCount = 0;
+        const rejectedCommandIds = new Set<string>();
+        const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
         const scanner = AgentSessionScanner.AgentSessionScanner.of({
           scan: Effect.die("unused"),
           recentThreads: () => Effect.succeed([makeThread("codex")]),
         });
         const engine = OrchestrationEngine.OrchestrationEngineService.of({
           dispatch: (command) => {
-            if (acceptedCommandIds.has(command.commandId)) {
-              return Effect.succeed({ sequence: 1 });
-            }
-            if (command.type === "thread.create") {
-              if (threadCreated) {
-                return Effect.fail(
-                  new OrchestrationCommandInvariantError({
-                    commandType: command.type,
-                    detail: "The thread already exists.",
-                  }),
-                );
-              }
-              threadCreated = true;
-              acceptedCommandIds.add(command.commandId);
-              return Effect.succeed({ sequence: 1 });
-            }
-            historyAttemptCount += 1;
-            if (historyAttemptCount === 1) {
+            if (rejectedCommandIds.has(command.commandId)) {
               return Effect.fail(
                 new OrchestrationCommandInvariantError({
                   commandType: command.type,
-                  detail: "Temporary history import failure.",
+                  detail: "Previously rejected.",
                 }),
               );
             }
-            acceptedCommandIds.add(command.commandId);
-            return Effect.succeed({ sequence: 2 });
+            if (command.type === "thread.create") threadCreated = true;
+            if (command.type === "thread.history.import") {
+              historyAttemptCount += 1;
+              if (historyAttemptCount === 1) {
+                rejectedCommandIds.add(command.commandId);
+                return Effect.fail(
+                  new OrchestrationCommandInvariantError({
+                    commandType: command.type,
+                    detail: "Temporary history import failure.",
+                  }),
+                );
+              }
+              historyImported = true;
+            }
+            return Effect.succeed({ sequence: 1 });
           },
           readEvents: () => Stream.empty,
           streamDomainEvents: Stream.empty,
@@ -197,26 +276,225 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
             return Effect.void;
           },
           getProvider: () => Effect.die("unused"),
-          getBinding: () => Effect.die("unused"),
+          getBinding: () =>
+            Effect.succeed(bindings[0] === undefined ? Option.none() : Option.some(bindings[0])),
           listThreadIds: () => Effect.die("unused"),
           listBindings: () => Effect.die("unused"),
         });
-        const runImport = () =>
-          importRecentAgentThreads({
-            projectId: ProjectId.make("project-1"),
-            workspaceRoot: "/tmp/project",
-          }).pipe(
-            Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
-            Effect.provideService(OrchestrationEngine.OrchestrationEngineService, engine),
-            Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, directory),
-          );
+        const snapshots = makeSnapshotsLayer({
+          project: makeProject(),
+          getThread: () =>
+            threadCreated
+              ? Option.some(makeProjectedThread({ source: "codex", imported: historyImported }))
+              : Option.none(),
+        });
+        const importOnce = () => runImport({ scanner, engine, directory, snapshots });
 
-        expect(yield* runImport()).toEqual({ importedCount: 0, skippedCount: 1 });
-        expect(yield* runImport()).toEqual({ importedCount: 0, skippedCount: 1 });
-        expect(yield* runImport()).toEqual({ importedCount: 1, skippedCount: 0 });
-        expect(bindings).toHaveLength(1);
+        expect(yield* importOnce()).toEqual({ importedCount: 0, skippedCount: 1 });
+        expect(yield* importOnce()).toEqual({ importedCount: 0, skippedCount: 1 });
+        expect(yield* importOnce()).toEqual({ importedCount: 1, skippedCount: 0 });
+        const historyAttemptsAfterCompletion = historyAttemptCount;
+        expect(yield* importOnce()).toEqual({ importedCount: 1, skippedCount: 0 });
+        expect(historyAttemptCount).toBe(historyAttemptsAfterCompletion);
         expect(historyAttemptCount).toBe(2);
+        expect(bindings).toHaveLength(1);
+      }),
+    );
+
+    it.effect("does not replace completed history or an active binding on retry", () =>
+      Effect.gen(function* () {
+        const scanner = AgentSessionScanner.AgentSessionScanner.of({
+          scan: Effect.die("unused"),
+          recentThreads: () => Effect.succeed([makeThread("codex")]),
+        });
+        const runningBinding: ProviderSessionDirectory.ProviderRuntimeBinding = {
+          threadId: ThreadId.make("import:codex:codex-session"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          status: "running",
+          resumeCursor: { threadId: "newer-codex-session" },
+        };
+        const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
+          upsert: () => Effect.die("must not replace an active binding"),
+          getProvider: () => Effect.die("unused"),
+          getBinding: () => Effect.succeed(Option.some(runningBinding)),
+          listThreadIds: () => Effect.die("unused"),
+          listBindings: () => Effect.die("unused"),
+        });
+        const engine = OrchestrationEngine.OrchestrationEngineService.of({
+          dispatch: () => Effect.die("must not replay history or settle active work"),
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        });
+
+        const result = yield* runImport({
+          scanner,
+          engine,
+          directory,
+          snapshots: makeSnapshotsLayer({
+            project: makeProject(),
+            getThread: () =>
+              Option.some(
+                makeProjectedThread({ source: "codex", imported: true, includeFollowup: true }),
+              ),
+          }),
+        });
+
+        expect(result).toEqual({ importedCount: 1, skippedCount: 0 });
+      }),
+    );
+
+    it.effect("skips malformed Claude ids and wrong-project thread collisions", () =>
+      Effect.gen(function* () {
+        const scanner = AgentSessionScanner.AgentSessionScanner.of({
+          scan: Effect.die("unused"),
+          recentThreads: () =>
+            Effect.succeed([
+              { ...makeThread("claudeAgent"), providerSessionId: "not-a-uuid" },
+              makeThread("codex"),
+            ]),
+        });
+        const commands: Array<OrchestrationCommand> = [];
+        const engine = OrchestrationEngine.OrchestrationEngineService.of({
+          dispatch: (command) => Effect.sync(() => ({ sequence: commands.push(command) })),
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        });
+        const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
+          upsert: () => Effect.void,
+          getProvider: () => Effect.die("unused"),
+          getBinding: () => Effect.succeed(Option.none()),
+          listThreadIds: () => Effect.die("unused"),
+          listBindings: () => Effect.die("unused"),
+        });
+
+        const result = yield* runImport({
+          scanner,
+          engine,
+          directory,
+          snapshots: makeSnapshotsLayer({
+            project: makeProject(),
+            getThread: (threadId) =>
+              threadId === "import:codex:codex-session"
+                ? Option.some(
+                    makeProjectedThread({
+                      source: "codex",
+                      projectId: ProjectId.make("project-other"),
+                    }),
+                  )
+                : Option.none(),
+          }),
+        });
+
+        expect(result).toEqual({ importedCount: 0, skippedCount: 2 });
+        expect(commands).toHaveLength(0);
       }),
     );
   });
+});
+
+const integrationThread = {
+  ...makeThread("codex"),
+  updatedAt: "2026-08-24T10:00:00.000Z",
+  messages: Array.from({ length: 12 }, (_, index) => ({
+    role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    text: `Message ${index}`,
+    createdAt: "2026-08-24T10:00:00.000Z",
+  })),
+};
+const integrationScanner = AgentSessionScanner.AgentSessionScanner.of({
+  scan: Effect.die("unused"),
+  recentThreads: () => Effect.succeed([integrationThread]),
+});
+const integrationServerConfig = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-agent-session-importer-test-",
+});
+const integrationRuntimeRepository = ProviderSessionRuntime.layer.pipe(
+  Layer.provide(SqlitePersistenceMemory),
+);
+const integrationLayer = Layer.mergeAll(
+  OrchestrationEngineLive.pipe(
+    Layer.provide(OrchestrationProjectionSnapshotQueryLive),
+    Layer.provide(OrchestrationProjectionPipelineLive),
+  ),
+  OrchestrationProjectionSnapshotQueryLive,
+  ProviderSessionDirectoryLive.pipe(Layer.provide(integrationRuntimeRepository)),
+  Layer.succeed(AgentSessionScanner.AgentSessionScanner, integrationScanner),
+).pipe(
+  Layer.provide(ThreadBackgroundLiveness.layer),
+  Layer.provide(ThreadPlanProgress.layer),
+  Layer.provide(OrchestrationEventStoreLive),
+  Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+  Layer.provide(RepositoryIdentityResolver.layer),
+  Layer.provide(SqlitePersistenceMemory),
+  Layer.provideMerge(integrationServerConfig),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
+  it.effect("imports once after the real engine persists an old rejected receipt", () =>
+    Effect.gen(function* () {
+      const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+      const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const threadId = ThreadId.make("import:codex:codex-session");
+
+      yield* engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.make("create-import-integration-project"),
+        projectId: PROJECT_ID,
+        title: "Project",
+        workspaceRoot: WORKSPACE_ROOT,
+        defaultModelSelection: null,
+        createdAt: "2026-08-24T09:00:00.000Z",
+      });
+      const rejected = yield* Effect.result(
+        engine.dispatch({
+          type: "thread.history.import",
+          commandId: CommandId.make(`agent-session:history:${threadId}`),
+          threadId,
+          messages: [
+            {
+              messageId: MessageId.make(`${threadId}:000000`),
+              role: "user",
+              text: "Fix the bug",
+              createdAt: "2026-08-24T10:00:00.000Z",
+            },
+          ],
+        }),
+      );
+      expect(rejected._tag).toBe("Failure");
+
+      const result = yield* importRecentAgentThreads({ projectId: PROJECT_ID });
+      const importedThread = yield* snapshots.getThreadDetailById(threadId);
+      const binding = yield* directory.getBinding(threadId);
+
+      expect(result).toEqual({ importedCount: 1, skippedCount: 0 });
+      expect(Option.getOrThrow(importedThread).messages.map((message) => message.text)).toEqual(
+        integrationThread.messages.map((message) => message.text),
+      );
+      expect(Option.getOrThrow(importedThread).settledOverride).toBe("settled");
+      expect(Option.getOrThrow(importedThread).updatedAt).toBe("2026-08-24T10:00:00.000Z");
+      expect(Option.getOrThrow(binding)).toMatchObject({
+        provider: "codex",
+        providerInstanceId: "codex",
+        resumeCursor: { threadId: "codex-session" },
+        runtimePayload: { cwd: WORKSPACE_ROOT },
+      });
+
+      yield* engine.dispatch({
+        type: "thread.revert.complete",
+        commandId: CommandId.make("revert-imported-thread-to-baseline"),
+        threadId,
+        turnCount: 0,
+        createdAt: "2026-08-24T10:05:00.000Z",
+      });
+      const afterRevert = yield* snapshots.getThreadDetailById(threadId);
+      expect(Option.getOrThrow(afterRevert).messages.map((message) => message.text)).toEqual(
+        integrationThread.messages.map((message) => message.text),
+      );
+    }),
+  );
 });

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -12,6 +12,8 @@ import {
   type OrchestrationThread,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
@@ -29,7 +31,10 @@ import * as ThreadBackgroundLiveness from "../orchestration/ThreadBackgroundLive
 import * as ThreadPlanProgress from "../orchestration/ThreadPlanProgress.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
-import { ProviderSessionDirectoryLive } from "../provider/Layers/ProviderSessionDirectory.ts";
+import {
+  makeProviderSessionDirectoryLive,
+  ProviderSessionDirectoryLive,
+} from "../provider/Layers/ProviderSessionDirectory.ts";
 import { ProviderSessionDirectoryPersistenceError } from "../provider/Errors.ts";
 import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
 import * as RepositoryIdentityResolver from "./RepositoryIdentityResolver.ts";
@@ -428,6 +433,7 @@ const integrationLayer = Layer.mergeAll(
     Layer.provide(OrchestrationProjectionPipelineLive),
   ),
   OrchestrationProjectionSnapshotQueryLive,
+  integrationRuntimeRepository,
   ProviderSessionDirectoryLive.pipe(Layer.provide(integrationRuntimeRepository)),
   Layer.succeed(AgentSessionScanner.AgentSessionScanner, integrationScanner),
 ).pipe(
@@ -503,6 +509,97 @@ it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
       expect(Option.getOrThrow(afterRevert).messages.map((message) => message.text)).toEqual(
         integrationThread.messages.map((message) => message.text),
       );
+    }),
+  );
+
+  it.effect("keeps a binding created while an import is in progress", () =>
+    Effect.gen(function* () {
+      const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+      const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+      const projectId = ProjectId.make("project-import-binding-race");
+      const workspaceRoot = "/tmp/project-import-binding-race";
+      const providerSessionId = "codex-binding-race";
+      const threadId = ThreadId.make(`import:codex:${providerSessionId}`);
+      const scanner = AgentSessionScanner.AgentSessionScanner.of({
+        scan: Effect.die("unused"),
+        recentThreads: () =>
+          Stream.succeed({ ...integrationThread, providerSessionId, title: "Binding race" }),
+      });
+      const importerAtBindingWrite = yield* Deferred.make<void>();
+      const releaseImporter = yield* Deferred.make<void>();
+      const importerRepository = ProviderSessionRuntime.ProviderSessionRuntimeRepository.of({
+        ...repository,
+        upsert: (runtime, options) =>
+          options?.onConflict === "ignore"
+            ? Deferred.succeed(importerAtBindingWrite, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseImporter)),
+                Effect.andThen(repository.upsert(runtime, options)),
+              )
+            : repository.upsert(runtime, options),
+      });
+      const importerDirectory = yield* ProviderSessionDirectory.ProviderSessionDirectory.pipe(
+        Effect.provide(
+          makeProviderSessionDirectoryLive().pipe(
+            Layer.provide(
+              Layer.succeed(
+                ProviderSessionRuntime.ProviderSessionRuntimeRepository,
+                importerRepository,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      yield* engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.make("create-import-binding-race-project"),
+        projectId,
+        title: "Binding race",
+        workspaceRoot,
+        defaultModelSelection: null,
+        createdAt: "2026-08-24T09:00:00.000Z",
+      });
+
+      const importFiber = yield* importRecentAgentThreads({ projectId }).pipe(
+        Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
+        Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, importerDirectory),
+        Effect.forkChild,
+      );
+
+      yield* Effect.raceFirst(
+        Deferred.await(importerAtBindingWrite),
+        Fiber.join(importFiber).pipe(
+          Effect.flatMap((result) =>
+            Effect.die(
+              new Error(`Import completed before the binding write: ${JSON.stringify(result)}`),
+            ),
+          ),
+        ),
+      );
+      expect(
+        Option.getOrThrow(yield* snapshots.getThreadDetailById(threadId)).messages.map(
+          (message) => message.text,
+        ),
+      ).toEqual(integrationThread.messages.map((message) => message.text));
+
+      yield* directory.upsert({
+        threadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        status: "running",
+        resumeCursor: { threadId: "active-client-session" },
+        runtimePayload: { cwd: workspaceRoot, activeTurnId: "turn-active" },
+      });
+      yield* Deferred.succeed(releaseImporter, undefined);
+
+      expect(yield* Fiber.join(importFiber)).toEqual({ importedCount: 1, skippedCount: 0 });
+      expect(Option.getOrThrow(yield* directory.getBinding(threadId))).toMatchObject({
+        status: "running",
+        resumeCursor: { threadId: "active-client-session" },
+        runtimePayload: { cwd: workspaceRoot, activeTurnId: "turn-active" },
+      });
     }),
   );
 });

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -157,7 +157,15 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           scan: Effect.die("unused"),
           recentThreads: (workspaceRoot) => {
             scannedRoot = workspaceRoot;
-            return Effect.succeed([makeThread("codex"), makeThread("claudeAgent")]);
+            return Stream.concat(
+              Stream.succeed(makeThread("codex")),
+              Stream.fromEffect(
+                Effect.sync(() => {
+                  expect(bindings).toHaveLength(1);
+                  return makeThread("claudeAgent");
+                }),
+              ),
+            );
           },
         });
         const engine = OrchestrationEngine.OrchestrationEngineService.of({
@@ -229,7 +237,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
         const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
         const scanner = AgentSessionScanner.AgentSessionScanner.of({
           scan: Effect.die("unused"),
-          recentThreads: () => Effect.succeed([makeThread("codex")]),
+          recentThreads: () => Stream.fromIterable([makeThread("codex")]),
         });
         const engine = OrchestrationEngine.OrchestrationEngineService.of({
           dispatch: (command) => {
@@ -305,7 +313,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
       Effect.gen(function* () {
         const scanner = AgentSessionScanner.AgentSessionScanner.of({
           scan: Effect.die("unused"),
-          recentThreads: () => Effect.succeed([makeThread("codex")]),
+          recentThreads: () => Stream.fromIterable([makeThread("codex")]),
         });
         const runningBinding: ProviderSessionDirectory.ProviderRuntimeBinding = {
           threadId: ThreadId.make("import:codex:codex-session"),
@@ -350,7 +358,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
         const scanner = AgentSessionScanner.AgentSessionScanner.of({
           scan: Effect.die("unused"),
           recentThreads: () =>
-            Effect.succeed([
+            Stream.fromIterable([
               { ...makeThread("claudeAgent"), providerSessionId: "not-a-uuid" },
               makeThread("codex"),
             ]),
@@ -406,7 +414,7 @@ const integrationThread = {
 };
 const integrationScanner = AgentSessionScanner.AgentSessionScanner.of({
   scan: Effect.die("unused"),
-  recentThreads: () => Effect.succeed([integrationThread]),
+  recentThreads: () => Stream.fromIterable([integrationThread]),
 });
 const integrationServerConfig = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-agent-session-importer-test-",

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -1,0 +1,96 @@
+import {
+  CommandId,
+  DEFAULT_MODEL,
+  DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  MessageId,
+  ProviderDriverKind,
+  ThreadId,
+  type AgentSessionImportInput,
+  type AgentSessionImportResult,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+
+import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
+import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
+import * as AgentSessionScanner from "./AgentSessionScanner.ts";
+
+/** Import recent transcript text and persist the cursor needed to resume its provider session. */
+export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(function* (
+  input: AgentSessionImportInput,
+) {
+  const scanner = yield* AgentSessionScanner.AgentSessionScanner;
+  const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+  const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+  const crypto = yield* Crypto.Crypto;
+  const threads = yield* scanner.recentThreads(input.workspaceRoot);
+  let importedCount = 0;
+  let skippedCount = 0;
+
+  for (const thread of threads) {
+    const imported = yield* Effect.gen(function* () {
+      const threadId = ThreadId.make(
+        `import:${thread.providerInstanceId}:${thread.providerSessionId}`,
+      );
+      const provider = ProviderDriverKind.make(thread.source);
+      const model = thread.model ?? DEFAULT_MODEL_BY_PROVIDER[provider] ?? DEFAULT_MODEL;
+      const createCommandId = CommandId.make(yield* crypto.randomUUIDv4);
+
+      yield* engine.dispatch({
+        type: "thread.create",
+        commandId: createCommandId,
+        threadId,
+        projectId: input.projectId,
+        title: thread.title,
+        modelSelection: { instanceId: thread.providerInstanceId, model },
+        runtimeMode: DEFAULT_RUNTIME_MODE,
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        branch: null,
+        worktreePath: null,
+        createdAt: thread.createdAt,
+      });
+
+      yield* engine.dispatch({
+        type: "thread.history.import",
+        commandId: CommandId.make(yield* crypto.randomUUIDv4),
+        threadId,
+        messages: thread.messages.map((message, index) => ({
+          messageId: MessageId.make(`${threadId}:${index}`),
+          role: message.role,
+          text: message.text,
+          createdAt: message.createdAt,
+        })),
+      });
+
+      yield* directory.upsert({
+        threadId,
+        provider,
+        providerInstanceId: thread.providerInstanceId,
+        status: "stopped",
+        runtimeMode: DEFAULT_RUNTIME_MODE,
+        resumeCursor:
+          thread.source === "codex"
+            ? { threadId: thread.providerSessionId }
+            : { threadId, resume: thread.providerSessionId },
+        runtimePayload: { cwd: input.workspaceRoot },
+      });
+
+      return true;
+    }).pipe(
+      Effect.catch((cause) =>
+        Effect.logWarning("Could not import an agent session", {
+          provider: thread.source,
+          sessionId: thread.providerSessionId,
+          cause,
+        }).pipe(Effect.as(false)),
+      ),
+    );
+
+    if (imported) importedCount += 1;
+    else skippedCount += 1;
+  }
+
+  return { importedCount, skippedCount } satisfies AgentSessionImportResult;
+});

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -10,7 +10,6 @@ import {
   type AgentSessionImportInput,
   type AgentSessionImportResult,
 } from "@t3tools/contracts";
-import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
@@ -24,7 +23,6 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
   const scanner = yield* AgentSessionScanner.AgentSessionScanner;
   const engine = yield* OrchestrationEngine.OrchestrationEngineService;
   const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
-  const crypto = yield* Crypto.Crypto;
   const threads = yield* scanner.recentThreads(input.workspaceRoot);
   let importedCount = 0;
   let skippedCount = 0;
@@ -36,11 +34,10 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
       );
       const provider = ProviderDriverKind.make(thread.source);
       const model = thread.model ?? DEFAULT_MODEL_BY_PROVIDER[provider] ?? DEFAULT_MODEL;
-      const createCommandId = CommandId.make(yield* crypto.randomUUIDv4);
 
       yield* engine.dispatch({
         type: "thread.create",
-        commandId: createCommandId,
+        commandId: CommandId.make(`agent-session:create:${threadId}`),
         threadId,
         projectId: input.projectId,
         title: thread.title,
@@ -54,7 +51,7 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
 
       yield* engine.dispatch({
         type: "thread.history.import",
-        commandId: CommandId.make(yield* crypto.randomUUIDv4),
+        commandId: CommandId.make(`agent-session:history:${threadId}`),
         threadId,
         messages: thread.messages.map((message, index) => ({
           messageId: MessageId.make(`${threadId}:${index}`),

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -4,17 +4,27 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
+  AgentSessionImportProjectNotFoundError,
+  AgentSessionScanError,
+  isImportedAgentSessionMessageId,
   MessageId,
   ProviderDriverKind,
   ThreadId,
   type AgentSessionImportInput,
   type AgentSessionImportResult,
 } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 
+import { OrchestrationCommandInvariantError } from "../orchestration/Errors.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
 import * as AgentSessionScanner from "./AgentSessionScanner.ts";
+
+const CLAUDE_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** Import recent transcript text and persist the cursor needed to resume its provider session. */
 export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(function* (
@@ -22,8 +32,21 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
 ) {
   const scanner = yield* AgentSessionScanner.AgentSessionScanner;
   const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+  const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
-  const threads = yield* scanner.recentThreads(input.workspaceRoot);
+  const crypto = yield* Crypto.Crypto;
+  const project = yield* snapshots.getProjectShellById(input.projectId).pipe(
+    Effect.mapError((cause) => new AgentSessionScanError({ operation: "read-projects", cause })),
+    Effect.flatMap(
+      Option.match({
+        onNone: () =>
+          Effect.fail(new AgentSessionImportProjectNotFoundError({ projectId: input.projectId })),
+        onSome: Effect.succeed,
+      }),
+    ),
+  );
+  const workspaceRoot = project.workspaceRoot;
+  const threads = yield* scanner.recentThreads(workspaceRoot);
   let importedCount = 0;
   let skippedCount = 0;
 
@@ -34,45 +57,81 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
       );
       const provider = ProviderDriverKind.make(thread.source);
       const model = thread.model ?? DEFAULT_MODEL_BY_PROVIDER[provider] ?? DEFAULT_MODEL;
+      const existingThread = yield* snapshots.getThreadDetailById(threadId);
+      const existingBinding = yield* directory.getBinding(threadId);
 
-      yield* engine.dispatch({
-        type: "thread.create",
-        commandId: CommandId.make(`agent-session:create:${threadId}`),
-        threadId,
-        projectId: input.projectId,
-        title: thread.title,
-        modelSelection: { instanceId: thread.providerInstanceId, model },
-        runtimeMode: DEFAULT_RUNTIME_MODE,
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        branch: null,
-        worktreePath: null,
-        createdAt: thread.createdAt,
-      });
+      if (
+        thread.source === "claudeAgent" &&
+        !CLAUDE_SESSION_ID_PATTERN.test(thread.providerSessionId)
+      ) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: "agentSessions.import",
+          detail: `Claude session '${thread.providerSessionId}' cannot be resumed.`,
+        });
+      }
 
-      yield* engine.dispatch({
-        type: "thread.history.import",
-        commandId: CommandId.make(`agent-session:history:${threadId}`),
-        threadId,
-        messages: thread.messages.map((message, index) => ({
-          messageId: MessageId.make(`${threadId}:${index}`),
-          role: message.role,
-          text: message.text,
-          createdAt: message.createdAt,
-        })),
-      });
+      if (Option.isSome(existingThread) && existingThread.value.projectId !== input.projectId) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: "agentSessions.import",
+          detail: `Imported thread '${threadId}' already belongs to project '${existingThread.value.projectId}'.`,
+        });
+      }
 
-      yield* directory.upsert({
-        threadId,
-        provider,
-        providerInstanceId: thread.providerInstanceId,
-        status: "stopped",
-        runtimeMode: DEFAULT_RUNTIME_MODE,
-        resumeCursor:
-          thread.source === "codex"
-            ? { threadId: thread.providerSessionId }
-            : { threadId, resume: thread.providerSessionId },
-        runtimePayload: { cwd: input.workspaceRoot },
-      });
+      // The binding is the last import step. Its presence marks a complete
+      // one-shot import and protects an active session from retry writes.
+      if (Option.isSome(existingThread) && Option.isSome(existingBinding)) {
+        return true;
+      }
+
+      if (Option.isNone(existingThread)) {
+        yield* engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make(yield* crypto.randomUUIDv4),
+          threadId,
+          projectId: input.projectId,
+          title: thread.title,
+          modelSelection: { instanceId: thread.providerInstanceId, model },
+          runtimeMode: DEFAULT_RUNTIME_MODE,
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          branch: null,
+          worktreePath: null,
+          createdAt: thread.createdAt,
+        });
+      }
+
+      const hasImportedHistory = Option.isSome(existingThread)
+        ? existingThread.value.messages.some((message) =>
+            isImportedAgentSessionMessageId(message.id),
+          )
+        : false;
+      if (!hasImportedHistory) {
+        yield* engine.dispatch({
+          type: "thread.history.import",
+          commandId: CommandId.make(yield* crypto.randomUUIDv4),
+          threadId,
+          messages: thread.messages.map((message, index) => ({
+            messageId: MessageId.make(`${threadId}:${String(index).padStart(6, "0")}`),
+            role: message.role,
+            text: message.text,
+            createdAt: message.createdAt,
+          })),
+        });
+      }
+
+      if (Option.isNone(existingBinding)) {
+        yield* directory.upsert({
+          threadId,
+          provider,
+          providerInstanceId: thread.providerInstanceId,
+          status: "stopped",
+          runtimeMode: DEFAULT_RUNTIME_MODE,
+          resumeCursor:
+            thread.source === "codex"
+              ? { threadId: thread.providerSessionId }
+              : { threadId, resume: thread.providerSessionId },
+          runtimePayload: { cwd: workspaceRoot },
+        });
+      }
 
       return true;
     }).pipe(

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -5,9 +5,11 @@ import {
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   AgentSessionImportProjectNotFoundError,
+  AgentSessionSource,
   AgentSessionScanError,
   isImportedAgentSessionMessageId,
   MessageId,
+  ProjectId,
   ProviderDriverKind,
   ThreadId,
   type AgentSessionImportInput,
@@ -16,8 +18,9 @@ import {
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 
-import { OrchestrationCommandInvariantError } from "../orchestration/Errors.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as ProviderSessionDirectory from "../provider/Services/ProviderSessionDirectory.ts";
@@ -25,6 +28,31 @@ import * as AgentSessionScanner from "./AgentSessionScanner.ts";
 
 const CLAUDE_SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+class AgentSessionUnresumableSessionError extends Schema.TaggedErrorClass<AgentSessionUnresumableSessionError>()(
+  "AgentSessionUnresumableSessionError",
+  {
+    source: AgentSessionSource,
+    providerSessionId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Session '${this.providerSessionId}' from '${this.source}' cannot be resumed.`;
+  }
+}
+
+class AgentSessionThreadProjectConflictError extends Schema.TaggedErrorClass<AgentSessionThreadProjectConflictError>()(
+  "AgentSessionThreadProjectConflictError",
+  {
+    threadId: ThreadId,
+    expectedProjectId: ProjectId,
+    actualProjectId: ProjectId,
+  },
+) {
+  override get message(): string {
+    return `Imported thread '${this.threadId}' belongs to project '${this.actualProjectId}', not '${this.expectedProjectId}'.`;
+  }
+}
 
 /** Import recent transcript text and persist the cursor needed to resume its provider session. */
 export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(function* (
@@ -46,107 +74,110 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
     ),
   );
   const workspaceRoot = project.workspaceRoot;
-  const threads = yield* scanner.recentThreads(workspaceRoot);
+  const threads = scanner.recentThreads(workspaceRoot);
   let importedCount = 0;
   let skippedCount = 0;
 
-  for (const thread of threads) {
-    const imported = yield* Effect.gen(function* () {
-      const threadId = ThreadId.make(
-        `import:${thread.providerInstanceId}:${thread.providerSessionId}`,
-      );
-      const provider = ProviderDriverKind.make(thread.source);
-      const model = thread.model ?? DEFAULT_MODEL_BY_PROVIDER[provider] ?? DEFAULT_MODEL;
-      const existingThread = yield* snapshots.getThreadDetailById(threadId);
-      const existingBinding = yield* directory.getBinding(threadId);
+  yield* Stream.runForEach(threads, (thread) =>
+    Effect.gen(function* () {
+      const imported = yield* Effect.gen(function* () {
+        const threadId = ThreadId.make(
+          `import:${thread.providerInstanceId}:${thread.providerSessionId}`,
+        );
+        const provider = ProviderDriverKind.make(thread.source);
+        const model = thread.model ?? DEFAULT_MODEL_BY_PROVIDER[provider] ?? DEFAULT_MODEL;
+        const existingThread = yield* snapshots.getThreadDetailById(threadId);
+        const existingBinding = yield* directory.getBinding(threadId);
 
-      if (
-        thread.source === "claudeAgent" &&
-        !CLAUDE_SESSION_ID_PATTERN.test(thread.providerSessionId)
-      ) {
-        return yield* new OrchestrationCommandInvariantError({
-          commandType: "agentSessions.import",
-          detail: `Claude session '${thread.providerSessionId}' cannot be resumed.`,
-        });
-      }
+        if (
+          thread.source === "claudeAgent" &&
+          !CLAUDE_SESSION_ID_PATTERN.test(thread.providerSessionId)
+        ) {
+          return yield* new AgentSessionUnresumableSessionError({
+            source: thread.source,
+            providerSessionId: thread.providerSessionId,
+          });
+        }
 
-      if (Option.isSome(existingThread) && existingThread.value.projectId !== input.projectId) {
-        return yield* new OrchestrationCommandInvariantError({
-          commandType: "agentSessions.import",
-          detail: `Imported thread '${threadId}' already belongs to project '${existingThread.value.projectId}'.`,
-        });
-      }
+        if (Option.isSome(existingThread) && existingThread.value.projectId !== input.projectId) {
+          return yield* new AgentSessionThreadProjectConflictError({
+            threadId,
+            expectedProjectId: input.projectId,
+            actualProjectId: existingThread.value.projectId,
+          });
+        }
 
-      // The binding is the last import step. Its presence marks a complete
-      // one-shot import and protects an active session from retry writes.
-      if (Option.isSome(existingThread) && Option.isSome(existingBinding)) {
+        // The binding is the last import step. Its presence marks a complete
+        // one-shot import and protects an active session from retry writes.
+        if (Option.isSome(existingThread) && Option.isSome(existingBinding)) {
+          return true;
+        }
+
+        if (Option.isNone(existingThread)) {
+          yield* engine.dispatch({
+            type: "thread.create",
+            commandId: CommandId.make(yield* crypto.randomUUIDv4),
+            threadId,
+            projectId: input.projectId,
+            title: thread.title,
+            modelSelection: { instanceId: thread.providerInstanceId, model },
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            branch: null,
+            worktreePath: null,
+            createdAt: thread.createdAt,
+          });
+        }
+
+        const hasImportedHistory = Option.isSome(existingThread)
+          ? existingThread.value.messages.some((message) =>
+              isImportedAgentSessionMessageId(message.id),
+            )
+          : false;
+        if (!hasImportedHistory) {
+          yield* engine.dispatch({
+            type: "thread.history.import",
+            commandId: CommandId.make(yield* crypto.randomUUIDv4),
+            threadId,
+            messages: thread.messages.map((message, index) => ({
+              messageId: MessageId.make(`${threadId}:${String(index).padStart(6, "0")}`),
+              role: message.role,
+              text: message.text,
+              createdAt: message.createdAt,
+            })),
+          });
+        }
+
+        if (Option.isNone(existingBinding)) {
+          yield* directory.upsert({
+            threadId,
+            provider,
+            providerInstanceId: thread.providerInstanceId,
+            status: "stopped",
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            resumeCursor:
+              thread.source === "codex"
+                ? { threadId: thread.providerSessionId }
+                : { threadId, resume: thread.providerSessionId },
+            runtimePayload: { cwd: workspaceRoot },
+          });
+        }
+
         return true;
-      }
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logWarning("Could not import an agent session", {
+            provider: thread.source,
+            sessionId: thread.providerSessionId,
+            cause,
+          }).pipe(Effect.as(false)),
+        ),
+      );
 
-      if (Option.isNone(existingThread)) {
-        yield* engine.dispatch({
-          type: "thread.create",
-          commandId: CommandId.make(yield* crypto.randomUUIDv4),
-          threadId,
-          projectId: input.projectId,
-          title: thread.title,
-          modelSelection: { instanceId: thread.providerInstanceId, model },
-          runtimeMode: DEFAULT_RUNTIME_MODE,
-          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-          branch: null,
-          worktreePath: null,
-          createdAt: thread.createdAt,
-        });
-      }
-
-      const hasImportedHistory = Option.isSome(existingThread)
-        ? existingThread.value.messages.some((message) =>
-            isImportedAgentSessionMessageId(message.id),
-          )
-        : false;
-      if (!hasImportedHistory) {
-        yield* engine.dispatch({
-          type: "thread.history.import",
-          commandId: CommandId.make(yield* crypto.randomUUIDv4),
-          threadId,
-          messages: thread.messages.map((message, index) => ({
-            messageId: MessageId.make(`${threadId}:${String(index).padStart(6, "0")}`),
-            role: message.role,
-            text: message.text,
-            createdAt: message.createdAt,
-          })),
-        });
-      }
-
-      if (Option.isNone(existingBinding)) {
-        yield* directory.upsert({
-          threadId,
-          provider,
-          providerInstanceId: thread.providerInstanceId,
-          status: "stopped",
-          runtimeMode: DEFAULT_RUNTIME_MODE,
-          resumeCursor:
-            thread.source === "codex"
-              ? { threadId: thread.providerSessionId }
-              : { threadId, resume: thread.providerSessionId },
-          runtimePayload: { cwd: workspaceRoot },
-        });
-      }
-
-      return true;
-    }).pipe(
-      Effect.catch((cause) =>
-        Effect.logWarning("Could not import an agent session", {
-          provider: thread.source,
-          sessionId: thread.providerSessionId,
-          cause,
-        }).pipe(Effect.as(false)),
-      ),
-    );
-
-    if (imported) importedCount += 1;
-    else skippedCount += 1;
-  }
+      if (imported) importedCount += 1;
+      else skippedCount += 1;
+    }),
+  );
 
   return { importedCount, skippedCount } satisfies AgentSessionImportResult;
 });

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -149,18 +149,21 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
         }
 
         if (Option.isNone(existingBinding)) {
-          yield* directory.upsert({
-            threadId,
-            provider,
-            providerInstanceId: thread.providerInstanceId,
-            status: "stopped",
-            runtimeMode: DEFAULT_RUNTIME_MODE,
-            resumeCursor:
-              thread.source === "codex"
-                ? { threadId: thread.providerSessionId }
-                : { threadId, resume: thread.providerSessionId },
-            runtimePayload: { cwd: workspaceRoot },
-          });
+          yield* directory.upsert(
+            {
+              threadId,
+              provider,
+              providerInstanceId: thread.providerInstanceId,
+              status: "stopped",
+              runtimeMode: DEFAULT_RUNTIME_MODE,
+              resumeCursor:
+                thread.source === "codex"
+                  ? { threadId: thread.providerSessionId }
+                  : { threadId, resume: thread.providerSessionId },
+              runtimePayload: { cwd: workspaceRoot },
+            },
+            { onConflict: "ignore" },
+          );
         }
 
         return true;

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -12,6 +12,8 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 
 import * as ServerConfig from "../config.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -58,41 +60,48 @@ const makeProjectionSnapshotQueryLayer = (importedWorkspaceRoots: ReadonlyArray<
  * Run a scan against the given homes. Homes are temp dirs created inside the
  * test, so the layer is built per run rather than shared.
  */
-const runScan = (input: {
+interface ScannerTestInput {
   readonly claudeHomePath: string;
   readonly codexHomePath: string;
   readonly importedWorkspaceRoots?: ReadonlyArray<string>;
   /** Base dir for the test ServerConfig; worktreesDir derives from it. */
   readonly configBaseDir?: string;
   readonly providerInstances?: ContractServerSettings["providerInstances"];
-}) =>
-  Effect.gen(function* () {
-    const scanner = yield* AgentSessionScanner.AgentSessionScanner;
-    return yield* scanner.scan;
-  }).pipe(
-    Effect.provide(
-      AgentSessionScanner.layer.pipe(
-        Layer.provide(
-          Layer.mergeAll(
-            ServerSettings.layerTest({
-              providers: {
-                claudeAgent: { homePath: input.claudeHomePath },
-                codex: { homePath: input.codexHomePath },
-              },
-              ...(input.providerInstances === undefined
-                ? {}
-                : { providerInstances: input.providerInstances }),
-            }),
-            ServerConfig.layerTest(
-              input.claudeHomePath,
-              input.configBaseDir ?? { prefix: "t3code-scanner-config-" },
-            ),
-            makeProjectionSnapshotQueryLayer(input.importedWorkspaceRoots ?? []),
-          ),
+}
+
+const makeScannerTestLayer = (input: ScannerTestInput) =>
+  AgentSessionScanner.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        ServerSettings.layerTest({
+          providers: {
+            claudeAgent: { homePath: input.claudeHomePath },
+            codex: { homePath: input.codexHomePath },
+          },
+          ...(input.providerInstances === undefined
+            ? {}
+            : { providerInstances: input.providerInstances }),
+        }),
+        ServerConfig.layerTest(
+          input.claudeHomePath,
+          input.configBaseDir ?? { prefix: "t3code-scanner-config-" },
         ),
+        makeProjectionSnapshotQueryLayer(input.importedWorkspaceRoots ?? []),
       ),
     ),
   );
+
+const runScan = (input: ScannerTestInput) =>
+  Effect.gen(function* () {
+    const scanner = yield* AgentSessionScanner.AgentSessionScanner;
+    return yield* scanner.scan;
+  }).pipe(Effect.provide(makeScannerTestLayer(input)));
+
+const runRecentThreads = (input: ScannerTestInput & { readonly workspaceRoot: string }) =>
+  Effect.gen(function* () {
+    const scanner = yield* AgentSessionScanner.AgentSessionScanner;
+    return yield* scanner.recentThreads(input.workspaceRoot);
+  }).pipe(Effect.provide(makeScannerTestLayer(input)));
 
 const makeTempDir = Effect.fn("AgentSessionScanner.test.makeTempDir")(function* (prefix: string) {
   const fileSystem = yield* FileSystem.FileSystem;
@@ -121,6 +130,8 @@ const claudeSessionLine = (cwd: string) =>
 /** Codex rollout line: session metadata is nested under `payload`. */
 const codexRolloutLine = (cwd: string) =>
   `${JSON.stringify({ timestamp: "2026-01-01T00:00:00.000Z", type: "session_meta", payload: { id: "r1", cwd } })}\n`;
+
+const encodeTranscriptRecord = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
 
 it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
   describe("scan", () => {
@@ -702,5 +713,261 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         expect(result.scannedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       }),
     );
+  });
+
+  describe("recentThreads", () => {
+    it.effect("imports recent Claude and Codex sessions for the selected project only", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+        yield* TestClock.setTime(nowMs);
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const workspace = yield* makeTempDir("t3code-workspace-");
+        const otherWorkspace = yield* makeTempDir("t3code-workspace-other-");
+
+        const claudeTranscript = (cwd: string, sessionId: string) =>
+          `${JSON.stringify({
+            type: "user",
+            cwd,
+            sessionId,
+            timestamp: "2026-08-23T12:00:00.000Z",
+            message: { role: "user", content: "Fix the project" },
+          })}\n${JSON.stringify({
+            type: "assistant",
+            sessionId,
+            timestamp: "2026-08-23T12:01:00.000Z",
+            message: { role: "assistant", content: [{ type: "text", text: "Done" }] },
+          })}\n`;
+
+        yield* writeTranscript({
+          filePath: path.join(claudeHomePath, "projects", "-selected", "claude-recent.jsonl"),
+          contents: claudeTranscript(workspace, "claude-recent"),
+          mtimeMs: nowMs - 24 * 60 * 60 * 1000,
+        });
+        yield* writeTranscript({
+          filePath: path.join(claudeHomePath, "projects", "-selected", "claude-old.jsonl"),
+          contents: claudeTranscript(workspace, "claude-old"),
+          mtimeMs: nowMs - 31 * 24 * 60 * 60 * 1000,
+        });
+        yield* writeTranscript({
+          filePath: path.join(claudeHomePath, "projects", "-other", "claude-other.jsonl"),
+          contents: claudeTranscript(otherWorkspace, "claude-other"),
+          mtimeMs: nowMs - 24 * 60 * 60 * 1000,
+        });
+        yield* writeTranscript({
+          filePath: path.join(
+            codexHomePath,
+            "sessions",
+            "2026",
+            "08",
+            "24",
+            "rollout-codex-recent.jsonl",
+          ),
+          contents: [
+            encodeTranscriptRecord({
+              type: "session_meta",
+              payload: { id: "codex-recent", cwd: workspace },
+            }),
+            encodeTranscriptRecord({
+              type: "event_msg",
+              timestamp: "2026-08-24T10:00:00.000Z",
+              payload: { type: "user_message", message: "Review this code" },
+            }),
+            encodeTranscriptRecord({
+              type: "response_item",
+              timestamp: "2026-08-24T10:01:00.000Z",
+              payload: {
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: "Looks good" }],
+              },
+            }),
+          ].join("\n"),
+          mtimeMs: nowMs - 60 * 60 * 1000,
+        });
+
+        const threads = yield* runRecentThreads({
+          claudeHomePath,
+          codexHomePath,
+          workspaceRoot: workspace,
+        });
+
+        expect(threads.map((thread) => thread.providerSessionId)).toEqual([
+          "codex-recent",
+          "claude-recent",
+        ]);
+        expect(threads.map((thread) => thread.messages.map((message) => message.text))).toEqual([
+          ["Review this code", "Looks good"],
+          ["Fix the project", "Done"],
+        ]);
+      }),
+    );
+
+    it.effect("keeps the provider instance that owns a custom session home", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+        yield* TestClock.setTime(nowMs);
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const customHome = yield* makeTempDir("t3code-codex-custom-");
+        const workspace = yield* makeTempDir("t3code-workspace-");
+
+        yield* writeTranscript({
+          filePath: path.join(customHome, "sessions", "2026", "08", "24", "rollout-custom.jsonl"),
+          contents: [
+            encodeTranscriptRecord({
+              type: "session_meta",
+              payload: { id: "custom-session", cwd: workspace },
+            }),
+            encodeTranscriptRecord({
+              type: "event_msg",
+              payload: { type: "user_message", message: "Use my work account" },
+            }),
+          ].join("\n"),
+          mtimeMs: nowMs,
+        });
+
+        const threads = yield* runRecentThreads({
+          claudeHomePath,
+          codexHomePath,
+          workspaceRoot: workspace,
+          providerInstances: {
+            [ProviderInstanceId.make("codex-work")]: {
+              driver: ProviderDriverKind.make("codex"),
+              config: { homePath: customHome },
+            },
+          },
+        });
+
+        expect(threads[0]?.providerInstanceId).toBe("codex-work");
+      }),
+    );
+  });
+});
+
+describe("parseAgentSessionTranscript", () => {
+  it("keeps Claude text and titles while dropping malformed and tool records", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        "not valid json",
+        JSON.stringify({ type: "ai-title", aiTitle: "Fix authentication" }),
+        JSON.stringify({
+          type: "user",
+          sessionId: "claude-session",
+          timestamp: "2026-08-24T10:00:00.000Z",
+          message: { role: "user", content: [{ type: "text", text: "Fix authentication" }] },
+        }),
+        JSON.stringify({
+          type: "user",
+          sessionId: "claude-session",
+          message: { role: "user", content: [{ type: "tool_result", text: "hidden" }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          sessionId: "claude-session",
+          message: {
+            role: "assistant",
+            model: "claude-sonnet-5",
+            content: [{ type: "text", text: "Updated the login flow" }],
+          },
+        }),
+      ].join("\n"),
+      source: "claudeAgent",
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread).toMatchObject({
+      providerSessionId: "claude-session",
+      title: "Fix authentication",
+      model: "claude-sonnet-5",
+      messages: [
+        { role: "user", text: "Fix authentication" },
+        { role: "assistant", text: "Updated the login flow" },
+      ],
+    });
+  });
+
+  it("uses Codex user events instead of duplicate instruction messages", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        JSON.stringify({ type: "session_meta", payload: { id: "codex-session" } }),
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Internal setup instructions" }],
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "user_message", message: "Fix the actual bug" },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Fixed" }],
+          },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread?.messages.map((message) => message.text)).toEqual([
+      "Fix the actual bug",
+      "Fixed",
+    ]);
+  });
+
+  it("skips sessions without a visible user message", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: "Done" },
+      }),
+      source: "claudeAgent",
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      fallbackSessionId: "claude-session",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread).toBeNull();
+  });
+
+  it("keeps the first prompt when later assistant output exceeds the message limit", () => {
+    const transcript = [
+      encodeTranscriptRecord({
+        type: "user",
+        sessionId: "claude-session",
+        message: { role: "user", content: "Keep this prompt" },
+      }),
+      ...Array.from({ length: 250 }, (_, index) =>
+        encodeTranscriptRecord({
+          type: "assistant",
+          message: { role: "assistant", content: `Assistant update ${index}` },
+        }),
+      ),
+    ].join("\n");
+
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: transcript,
+      source: "claudeAgent",
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread?.messages).toHaveLength(200);
+    expect(thread?.messages[0]?.text).toBe("Keep this prompt");
+    expect(thread?.messages.at(-1)?.text).toBe("Assistant update 249");
   });
 });

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -844,6 +844,119 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         expect(threads[0]?.providerInstanceId).toBe("codex-work");
       }),
     );
+
+    it.effect("keeps every provider instance associated with a shared session home", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+        yield* TestClock.setTime(nowMs);
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const sharedHome = yield* makeTempDir("t3code-codex-shared-");
+        const workspace = yield* makeTempDir("t3code-workspace-");
+
+        yield* writeTranscript({
+          filePath: path.join(sharedHome, "sessions", "2026", "08", "24", "rollout-shared.jsonl"),
+          contents: [
+            encodeTranscriptRecord({
+              type: "session_meta",
+              payload: { id: "shared-session", cwd: workspace },
+            }),
+            encodeTranscriptRecord({
+              type: "event_msg",
+              payload: { type: "user_message", message: "Use the shared session" },
+            }),
+          ].join("\n"),
+          mtimeMs: nowMs,
+        });
+
+        const threads = yield* runRecentThreads({
+          claudeHomePath,
+          codexHomePath,
+          workspaceRoot: workspace,
+          providerInstances: {
+            [ProviderInstanceId.make("codex-personal")]: {
+              driver: ProviderDriverKind.make("codex"),
+              config: { homePath: sharedHome },
+            },
+            [ProviderInstanceId.make("codex-work")]: {
+              driver: ProviderDriverKind.make("codex"),
+              config: { homePath: sharedHome },
+            },
+          },
+        });
+
+        expect(threads.map((thread) => thread.providerInstanceId).sort()).toEqual([
+          "codex-personal",
+          "codex-work",
+        ]);
+      }),
+    );
+
+    it.effect(
+      "finds recent Claude sessions after an older directory exhausts the read budget",
+      () =>
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const fileSystem = yield* FileSystem.FileSystem;
+          const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+          yield* TestClock.setTime(nowMs);
+          const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+          const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+          const oldWorkspace = yield* makeTempDir("t3code-workspace-old-");
+          const recentWorkspace = yield* makeTempDir("t3code-workspace-recent-");
+          const oldDirectory = path.join(claudeHomePath, "projects", "-aaa-old");
+          const oldTranscript = path.join(oldDirectory, "old.jsonl");
+          const recentDirectory = path.join(claudeHomePath, "projects", "-zzz-recent");
+
+          yield* writeTranscript({
+            filePath: oldTranscript,
+            contents: encodeTranscriptRecord({
+              type: "user",
+              cwd: oldWorkspace,
+              sessionId: "old-session",
+              message: { role: "user", content: "Old work" },
+            }),
+            mtimeMs: nowMs - 45 * 24 * 60 * 60 * 1000,
+          });
+          yield* writeTranscript({
+            filePath: path.join(recentDirectory, "recent.jsonl"),
+            contents: encodeTranscriptRecord({
+              type: "user",
+              cwd: recentWorkspace,
+              sessionId: "recent-session",
+              message: { role: "user", content: "Recent work" },
+            }),
+            mtimeMs: nowMs,
+          });
+
+          const simulatedOldTranscripts = Array.from(
+            { length: 5_000 },
+            (_, index) => `old-${index}.jsonl`,
+          );
+          const resolveTranscript = (filePath: string) =>
+            path.dirname(filePath) === oldDirectory && path.basename(filePath).startsWith("old-")
+              ? oldTranscript
+              : filePath;
+          const simulatedFileSystem = FileSystem.FileSystem.of({
+            ...fileSystem,
+            readDirectory: (directory, options) =>
+              directory === oldDirectory
+                ? Effect.succeed(simulatedOldTranscripts)
+                : fileSystem.readDirectory(directory, options),
+            stat: (filePath) => fileSystem.stat(resolveTranscript(filePath)),
+            open: (filePath, options) => fileSystem.open(resolveTranscript(filePath), options),
+          });
+
+          const threads = yield* runRecentThreads({
+            claudeHomePath,
+            codexHomePath,
+            workspaceRoot: recentWorkspace,
+          }).pipe(Effect.provideService(FileSystem.FileSystem, simulatedFileSystem));
+
+          expect(threads.map((thread) => thread.providerSessionId)).toEqual(["recent-session"]);
+        }),
+    );
   });
 });
 

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -1041,6 +1041,116 @@ describe("parseAgentSessionTranscript", () => {
     ]);
   });
 
+  it("removes injected Codex environment records before choosing the thread title", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message:
+              "<environment_context>\n<cwd>/tmp/project</cwd>\n<shell>zsh</shell>\n</environment_context>",
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message:
+              "# AGENTS.md instructions for /tmp/project\n\n<INSTRUCTIONS>\nPrivate project rules\n</INSTRUCTIONS>",
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message: "Do something here so it looks like a real project.",
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Created the project." }],
+          },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe("Do something here so it looks like a real project.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([
+      "Do something here so it looks like a real project.",
+      "Created the project.",
+    ]);
+  });
+
+  it("removes injected Codex context from fallback response messages", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>",
+              },
+            ],
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Initialize Git and add a README." }],
+          },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe("Initialize Git and add a README.");
+    expect(thread?.messages.map((message) => message.text)).toEqual([
+      "Initialize Git and add a README.",
+    ]);
+  });
+
+  it("preserves a real prompt that follows injected context in the same Codex message", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message:
+              "<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>\n\nCreate a useful project.",
+          },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe("Create a useful project.");
+    expect(thread?.messages.map((message) => message.text)).toEqual(["Create a useful project."]);
+  });
+
   it("skips sessions without a visible user message", () => {
     const thread = AgentSessionScanner.parseAgentSessionTranscript({
       contents: JSON.stringify({

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -13,6 +13,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 
 import * as ServerConfig from "../config.ts";
@@ -100,7 +101,10 @@ const runScan = (input: ScannerTestInput) =>
 const runRecentThreads = (input: ScannerTestInput & { readonly workspaceRoot: string }) =>
   Effect.gen(function* () {
     const scanner = yield* AgentSessionScanner.AgentSessionScanner;
-    return yield* scanner.recentThreads(input.workspaceRoot);
+    return yield* scanner.recentThreads(input.workspaceRoot).pipe(
+      Stream.runCollect,
+      Effect.map((threads) => Array.from(threads)),
+    );
   }).pipe(Effect.provide(makeScannerTestLayer(input)));
 
 const makeTempDir = Effect.fn("AgentSessionScanner.test.makeTempDir")(function* (prefix: string) {
@@ -874,6 +878,142 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
         });
 
         expect(threads[0]?.providerInstanceId).toBe("codex-work");
+      }),
+    );
+
+    it.effect("skips a transcript that grows after its size check", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+        yield* TestClock.setTime(nowMs);
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const workspace = yield* makeTempDir("t3code-workspace-");
+        const transcriptPath = path.join(
+          codexHomePath,
+          "sessions",
+          "2026",
+          "08",
+          "24",
+          "rollout-growing.jsonl",
+        );
+        const grownPath = path.join(codexHomePath, "grown.jsonl");
+        const contents = [
+          encodeTranscriptRecord({
+            type: "session_meta",
+            payload: { id: "growing-session", cwd: workspace },
+          }),
+          encodeTranscriptRecord({
+            type: "event_msg",
+            payload: { type: "user_message", message: "Do not import a changing file" },
+          }),
+        ].join("\n");
+        yield* writeTranscript({ filePath: transcriptPath, contents, mtimeMs: nowMs });
+        yield* writeTranscript({
+          filePath: grownPath,
+          contents: `${contents}\nchanged`,
+          mtimeMs: nowMs,
+        });
+
+        let transcriptOpenCount = 0;
+        const simulatedFileSystem = FileSystem.FileSystem.of({
+          ...fileSystem,
+          open: (filePath, options) => {
+            if (filePath !== transcriptPath) return fileSystem.open(filePath, options);
+            transcriptOpenCount += 1;
+            return fileSystem.open(transcriptOpenCount === 1 ? transcriptPath : grownPath, options);
+          },
+        });
+
+        const threads = yield* runRecentThreads({
+          claudeHomePath,
+          codexHomePath,
+          workspaceRoot: workspace,
+        }).pipe(Effect.provideService(FileSystem.FileSystem, simulatedFileSystem));
+
+        expect(transcriptOpenCount).toBe(2);
+        expect(threads).toEqual([]);
+      }),
+    );
+
+    it.effect("does not read the second transcript when the consumer takes one thread", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+        yield* TestClock.setTime(nowMs);
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const workspace = yield* makeTempDir("t3code-workspace-");
+        const makeCodexTranscript = (sessionId: string, text: string) =>
+          [
+            encodeTranscriptRecord({
+              type: "session_meta",
+              payload: { id: sessionId, cwd: workspace },
+            }),
+            encodeTranscriptRecord({
+              type: "event_msg",
+              payload: { type: "user_message", message: text },
+            }),
+          ].join("\n");
+        const olderPath = path.join(
+          codexHomePath,
+          "sessions",
+          "2026",
+          "08",
+          "23",
+          "rollout-older.jsonl",
+        );
+        const newerPath = path.join(
+          codexHomePath,
+          "sessions",
+          "2026",
+          "08",
+          "24",
+          "rollout-newer.jsonl",
+        );
+        yield* writeTranscript({
+          filePath: olderPath,
+          contents: makeCodexTranscript("older-session", "Older prompt"),
+          mtimeMs: nowMs - 1_000,
+        });
+        yield* writeTranscript({
+          filePath: newerPath,
+          contents: makeCodexTranscript("newer-session", "Newer prompt"),
+          mtimeMs: nowMs,
+        });
+
+        const openCounts = new Map<string, number>();
+        const contentReads: Array<string> = [];
+        const trackedPaths = new Set([olderPath, newerPath]);
+        const simulatedFileSystem = FileSystem.FileSystem.of({
+          ...fileSystem,
+          open: (filePath, options) => {
+            if (trackedPaths.has(filePath)) {
+              const count = (openCounts.get(filePath) ?? 0) + 1;
+              openCounts.set(filePath, count);
+              if (count === 2) contentReads.push(filePath);
+            }
+            return fileSystem.open(filePath, options);
+          },
+        });
+
+        const threads = yield* Effect.gen(function* () {
+          const scanner = yield* AgentSessionScanner.AgentSessionScanner;
+          return yield* scanner.recentThreads(workspace).pipe(
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.map((items) => Array.from(items)),
+          );
+        }).pipe(
+          Effect.provide(makeScannerTestLayer({ claudeHomePath, codexHomePath })),
+          Effect.provideService(FileSystem.FileSystem, simulatedFileSystem),
+        );
+
+        expect(threads.map((thread) => thread.providerSessionId)).toEqual(["newer-session"]);
+        expect(contentReads).toEqual([newerPath]);
+        expect(openCounts.get(olderPath)).toBe(1);
       }),
     );
 

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -268,12 +268,44 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
           {
             path: workspace,
             title: path.basename(workspace),
+            projectId: ProjectId.make("project-1"),
             sources: ["claudeAgent", "codex"],
             threadCount: 2,
             lastActiveAt: "2026-04-01T09:00:00.000Z",
             alreadyImported: true,
           },
         ]);
+      }),
+    );
+
+    it.effect("returns the imported project ID through a realpath alias", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const workspace = yield* makeTempDir("t3code-workspace-");
+        const linkParent = yield* makeTempDir("t3code-scanner-links-");
+        const workspaceAlias = path.join(linkParent, "workspace-alias");
+        yield* fileSystem.symlink(workspace, workspaceAlias);
+
+        yield* writeTranscript({
+          filePath: path.join(claudeHomePath, "projects", "-slug", "a.jsonl"),
+          contents: claudeSessionLine(workspaceAlias),
+          mtimeMs: Date.parse("2026-01-01T00:00:00.000Z"),
+        });
+
+        const result = yield* runScan({
+          claudeHomePath,
+          codexHomePath,
+          importedWorkspaceRoots: [workspace],
+        });
+
+        expect(result.candidates[0]).toMatchObject({
+          path: workspaceAlias,
+          projectId: ProjectId.make("project-1"),
+          alreadyImported: true,
+        });
       }),
     );
 
@@ -845,6 +877,51 @@ it.layer(NodeServices.layer)("AgentSessionScanner", (it) => {
       }),
     );
 
+    it.effect("does not import sessions from a T3-managed worktree", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const nowMs = Date.parse("2026-08-24T12:00:00.000Z");
+        yield* TestClock.setTime(nowMs);
+        const claudeHomePath = yield* makeTempDir("t3code-claude-home-");
+        const codexHomePath = yield* makeTempDir("t3code-codex-home-");
+        const configBaseDir = yield* makeTempDir("t3code-scanner-base-");
+        const workspace = path.join(configBaseDir, "worktrees", "t3code", "managed-worktree");
+        yield* fileSystem.makeDirectory(workspace, { recursive: true });
+
+        yield* writeTranscript({
+          filePath: path.join(
+            codexHomePath,
+            "sessions",
+            "2026",
+            "08",
+            "24",
+            "rollout-managed.jsonl",
+          ),
+          contents: [
+            encodeTranscriptRecord({
+              type: "session_meta",
+              payload: { id: "managed-session", cwd: workspace },
+            }),
+            encodeTranscriptRecord({
+              type: "event_msg",
+              payload: { type: "user_message", message: "Do not import this session" },
+            }),
+          ].join("\n"),
+          mtimeMs: nowMs,
+        });
+
+        const threads = yield* runRecentThreads({
+          claudeHomePath,
+          codexHomePath,
+          configBaseDir,
+          workspaceRoot: workspace,
+        });
+
+        expect(threads).toEqual([]);
+      }),
+    );
+
     it.effect("keeps every provider instance associated with a shared session home", () =>
       Effect.gen(function* () {
         const path = yield* Path.Path;
@@ -969,6 +1046,18 @@ describe("parseAgentSessionTranscript", () => {
         JSON.stringify({
           type: "user",
           sessionId: "claude-session",
+          isMeta: true,
+          message: { role: "user", content: "Injected skill instructions" },
+        }),
+        JSON.stringify({
+          type: "user",
+          sessionId: "claude-session",
+          isCompactSummary: true,
+          message: { role: "user", content: "Injected compaction summary" },
+        }),
+        JSON.stringify({
+          type: "user",
+          sessionId: "claude-session",
           timestamp: "2026-08-24T10:00:00.000Z",
           message: { role: "user", content: [{ type: "text", text: "Fix authentication" }] },
         }),
@@ -986,6 +1075,15 @@ describe("parseAgentSessionTranscript", () => {
             content: [{ type: "text", text: "Updated the login flow" }],
           },
         }),
+        JSON.stringify({
+          type: "assistant",
+          sessionId: "claude-session",
+          message: {
+            role: "assistant",
+            model: "<synthetic>",
+            content: [{ type: "text", text: "The provider request failed" }],
+          },
+        }),
       ].join("\n"),
       source: "claudeAgent",
       providerInstanceId: ProviderInstanceId.make("claudeAgent"),
@@ -1000,11 +1098,12 @@ describe("parseAgentSessionTranscript", () => {
       messages: [
         { role: "user", text: "Fix authentication" },
         { role: "assistant", text: "Updated the login flow" },
+        { role: "assistant", text: "The provider request failed" },
       ],
     });
   });
 
-  it("uses Codex user events instead of duplicate instruction messages", () => {
+  it("drops injected Codex instructions while keeping the visible user event", () => {
     const thread = AgentSessionScanner.parseAgentSessionTranscript({
       contents: [
         JSON.stringify({ type: "session_meta", payload: { id: "codex-session" } }),
@@ -1013,7 +1112,12 @@ describe("parseAgentSessionTranscript", () => {
           payload: {
             type: "message",
             role: "user",
-            content: [{ type: "input_text", text: "Internal setup instructions" }],
+            content: [
+              {
+                type: "input_text",
+                text: "<user_instructions>\nInternal setup instructions\n</user_instructions>",
+              },
+            ],
           },
         }),
         JSON.stringify({
@@ -1039,6 +1143,101 @@ describe("parseAgentSessionTranscript", () => {
       "Fix the actual bug",
       "Fixed",
     ]);
+  });
+
+  it("keeps distinct Codex response user messages in mixed-format transcripts", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Keep this older prompt" }],
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: { type: "user_message", message: "Keep this newer prompt" },
+        }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Keep this newer prompt" }],
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Ask again when needed" }],
+          },
+        }),
+        encodeTranscriptRecord({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Keep this newer prompt" }],
+          },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread?.messages.map((message) => message.text)).toEqual([
+      "Keep this older prompt",
+      "Keep this newer prompt",
+      "Ask again when needed",
+      "Keep this newer prompt",
+    ]);
+  });
+
+  it("uses the first valid Codex session ID when a fork copies ancestor metadata", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({
+          type: "session_meta",
+          payload: { id: "fork-session", forked_from_id: "parent-session" },
+        }),
+        encodeTranscriptRecord({
+          type: "session_meta",
+          payload: { id: "parent-session" },
+        }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: { type: "user_message", message: "Continue in the fork" },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread?.providerSessionId).toBe("fork-session");
+  });
+
+  it("skips Codex transcripts without a resumable session ID", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: encodeTranscriptRecord({
+        type: "event_msg",
+        payload: { type: "user_message", message: "This transcript has no session metadata" },
+      }),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "rollout-2026-08-24T12-00-00-not-a-session-id",
+      lastActiveAtMs: Date.parse("2026-08-24T12:00:00.000Z"),
+    });
+
+    expect(thread).toBeNull();
   });
 
   it("removes injected Codex environment records before choosing the thread title", () => {
@@ -1149,6 +1348,48 @@ describe("parseAgentSessionTranscript", () => {
 
     expect(thread?.title).toBe("Create a useful project.");
     expect(thread?.messages.map((message) => message.text)).toEqual(["Create a useful project."]);
+  });
+
+  it("removes the Codex request heading after leading injected context", () => {
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message: "\n  ## My request for Codex:\n\nFix the visible bug",
+          },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.title).toBe("Fix the visible bug");
+    expect(thread?.messages.map((message) => message.text)).toEqual(["Fix the visible bug"]);
+  });
+
+  it("keeps context markup quoted inside visible Codex user text", () => {
+    const quoted =
+      "Do not remove this example:\n<environment_context>\n<cwd>/tmp/example</cwd>\n</environment_context>";
+    const thread = AgentSessionScanner.parseAgentSessionTranscript({
+      contents: [
+        encodeTranscriptRecord({ type: "session_meta", payload: { id: "codex-session" } }),
+        encodeTranscriptRecord({
+          type: "event_msg",
+          payload: { type: "user_message", message: quoted },
+        }),
+      ].join("\n"),
+      source: "codex",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      fallbackSessionId: "fallback",
+      lastActiveAtMs: Date.parse("2026-08-25T08:00:00.000Z"),
+    });
+
+    expect(thread?.messages.map((message) => message.text)).toEqual([quoted]);
   });
 
   it("skips sessions without a visible user message", () => {

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -20,6 +20,7 @@ import {
   ClaudeSettings,
   CodexSettings,
   ProviderDriverKind,
+  ProviderInstanceId,
   type AgentSessionProjectCandidate,
   type AgentSessionScanResult,
   type ProviderInstanceConfig,
@@ -61,9 +62,61 @@ const MAX_TRANSCRIPTS_PER_SOURCE = 5000;
  * indefinitely.
  */
 const MAX_STATS_PER_SOURCE = MAX_TRANSCRIPTS_PER_SOURCE * 4;
+const RECENT_THREAD_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_IMPORTED_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+const MAX_IMPORTED_MESSAGES = 200;
+
+const TranscriptContentBlock = Schema.Struct({
+  type: Schema.optional(Schema.String),
+  text: Schema.optional(Schema.String),
+});
+
+const TranscriptMessage = Schema.Struct({
+  role: Schema.optional(Schema.String),
+  content: Schema.optional(Schema.Union([Schema.String, Schema.Array(TranscriptContentBlock)])),
+  model: Schema.optional(Schema.String),
+});
+
+const TranscriptRecord = Schema.Struct({
+  type: Schema.optional(Schema.String),
+  timestamp: Schema.optional(Schema.String),
+  sessionId: Schema.optional(Schema.String),
+  aiTitle: Schema.optional(Schema.String),
+  isSidechain: Schema.optional(Schema.Boolean),
+  message: Schema.optional(TranscriptMessage),
+  payload: Schema.optional(
+    Schema.Struct({
+      id: Schema.optional(Schema.String),
+      session_id: Schema.optional(Schema.String),
+      type: Schema.optional(Schema.String),
+      role: Schema.optional(Schema.String),
+      message: Schema.optional(Schema.String),
+      model: Schema.optional(Schema.String),
+      content: Schema.optional(Schema.Array(TranscriptContentBlock)),
+    }),
+  ),
+});
 
 const decodeClaudeSettings = Schema.decodeUnknownOption(ClaudeSettings);
 const decodeCodexSettings = Schema.decodeUnknownOption(CodexSettings);
+const decodeTranscriptRecord = Schema.decodeUnknownOption(Schema.fromJsonString(TranscriptRecord));
+
+export interface AgentSessionThreadMessage {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+  readonly createdAt: string;
+}
+
+export interface AgentSessionThread {
+  readonly source: AgentSessionSource;
+  readonly providerInstanceId: ProviderInstanceId;
+  readonly providerSessionId: string;
+  readonly title: string;
+  readonly model: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly messages: ReadonlyArray<AgentSessionThreadMessage>;
+}
 
 /** Service tag for agent session discovery. */
 export class AgentSessionScanner extends Context.Service<
@@ -76,6 +129,9 @@ export class AgentSessionScanner extends Context.Service<
      * error directly — there is no server-local context worth wrapping.
      */
     readonly scan: Effect.Effect<AgentSessionScanResult, AgentSessionScanError>;
+    readonly recentThreads: (
+      workspaceRoot: string,
+    ) => Effect.Effect<ReadonlyArray<AgentSessionThread>, AgentSessionScanError>;
   }
 >()("t3/project/AgentSessionScanner") {}
 
@@ -85,8 +141,134 @@ type AgentSessionSource = AgentSessionProjectCandidate["sources"][number];
 interface RawCandidate {
   readonly cwd: string;
   readonly source: AgentSessionSource;
+  readonly providerInstanceId: ProviderInstanceId;
   readonly threadCount: number;
   readonly lastActiveAtMs: number | null;
+  readonly transcripts: ReadonlyArray<{
+    readonly filePath: string;
+    readonly mtimeMs: number | null;
+  }>;
+}
+
+function extractText(
+  content: string | ReadonlyArray<typeof TranscriptContentBlock.Type> | undefined,
+): string {
+  if (typeof content === "string") return content.trim();
+  if (content === undefined) return "";
+  return content
+    .filter(
+      (block) =>
+        block.type === "text" || block.type === "input_text" || block.type === "output_text",
+    )
+    .map((block) => block.text?.trim() ?? "")
+    .filter((text) => text.length > 0)
+    .join("\n");
+}
+
+function normalizeTimestamp(value: string | undefined, fallback: string): string {
+  if (value === undefined) return fallback;
+  const parsed = DateTime.make(value);
+  return Option.isSome(parsed) ? DateTime.formatIso(parsed.value) : fallback;
+}
+
+/** Keep visible user and assistant text while ignoring tools, reasoning, and malformed records. */
+export function parseAgentSessionTranscript(input: {
+  readonly contents: string;
+  readonly source: AgentSessionSource;
+  readonly providerInstanceId: ProviderInstanceId;
+  readonly fallbackSessionId: string;
+  readonly lastActiveAtMs: number;
+}): AgentSessionThread | null {
+  const fallbackTimestamp = DateTime.formatIso(DateTime.makeUnsafe(input.lastActiveAtMs));
+  let providerSessionId = input.fallbackSessionId;
+  let title: string | null = null;
+  let model: string | null = null;
+  let hasExplicitCodexUserMessages = false;
+  const messages: Array<AgentSessionThreadMessage & { readonly codexResponseUser: boolean }> = [];
+
+  for (const line of input.contents.split("\n")) {
+    const decoded = decodeTranscriptRecord(line);
+    if (Option.isNone(decoded)) continue;
+    const record = decoded.value;
+
+    if (input.source === "claudeAgent") {
+      if (record.sessionId?.trim()) providerSessionId = record.sessionId.trim();
+      if (record.aiTitle?.trim()) title = record.aiTitle.trim();
+      if (record.message?.model?.trim()) model = record.message.model.trim();
+      if (record.isSidechain === true || (record.type !== "user" && record.type !== "assistant")) {
+        continue;
+      }
+
+      const text = extractText(record.message?.content);
+      if (text.length === 0) continue;
+      messages.push({
+        role: record.type,
+        text,
+        createdAt: normalizeTimestamp(record.timestamp, fallbackTimestamp),
+        codexResponseUser: false,
+      });
+      continue;
+    }
+
+    if (record.type === "session_meta") {
+      providerSessionId =
+        record.payload?.id?.trim() || record.payload?.session_id?.trim() || providerSessionId;
+      continue;
+    }
+    if (record.type === "turn_context" && record.payload?.model?.trim()) {
+      model = record.payload.model.trim();
+      continue;
+    }
+    if (record.type === "event_msg" && record.payload?.type === "user_message") {
+      const text = record.payload.message?.trim() ?? "";
+      if (text.length === 0) continue;
+      hasExplicitCodexUserMessages = true;
+      messages.push({
+        role: "user",
+        text,
+        createdAt: normalizeTimestamp(record.timestamp, fallbackTimestamp),
+        codexResponseUser: false,
+      });
+      continue;
+    }
+    if (
+      record.type !== "response_item" ||
+      record.payload?.type !== "message" ||
+      (record.payload.role !== "user" && record.payload.role !== "assistant")
+    ) {
+      continue;
+    }
+
+    const text = extractText(record.payload.content);
+    if (text.length === 0) continue;
+    messages.push({
+      role: record.payload.role,
+      text,
+      createdAt: normalizeTimestamp(record.timestamp, fallbackTimestamp),
+      codexResponseUser: record.payload.role === "user",
+    });
+  }
+
+  const visibleMessages = messages
+    .filter((message) => !hasExplicitCodexUserMessages || !message.codexResponseUser)
+    .map(({ codexResponseUser: _codexResponseUser, ...message }) => message);
+  const firstUserMessage = visibleMessages.find((message) => message.role === "user");
+  if (providerSessionId.trim().length === 0 || firstUserMessage === undefined) return null;
+  const latestMessages = visibleMessages.slice(-MAX_IMPORTED_MESSAGES);
+  const retainedMessages = latestMessages.some((message) => message.role === "user")
+    ? latestMessages
+    : [firstUserMessage, ...latestMessages.slice(-(MAX_IMPORTED_MESSAGES - 1))];
+
+  return {
+    source: input.source,
+    providerInstanceId: input.providerInstanceId,
+    providerSessionId,
+    title: title ?? firstUserMessage.text.split("\n")[0]?.slice(0, 100).trim() ?? "Imported thread",
+    model,
+    createdAt: retainedMessages[0]?.createdAt ?? fallbackTimestamp,
+    updatedAt: fallbackTimestamp,
+    messages: retainedMessages,
+  };
 }
 
 /**
@@ -209,23 +391,6 @@ export const make = Effect.gen(function* () {
     ).pipe(Effect.orElseSucceed(() => null));
   });
 
-  const latestMtimeMs = Effect.fn("AgentSessionScanner.latestMtimeMs")(function* (
-    filePaths: ReadonlyArray<string>,
-  ) {
-    let latest: number | null = null;
-    for (const filePath of filePaths) {
-      const stats = yield* statOption(filePath);
-      if (Option.isNone(stats)) continue;
-      const mtime = stats.value.mtime;
-      if (Option.isNone(mtime)) continue;
-      const value = mtime.value.getTime();
-      if (latest === null || value > latest) {
-        latest = value;
-      }
-    }
-    return latest;
-  });
-
   /**
    * Resolve the Claude config directory the CLI would use, matching the
    * precedence the spawned CLI sees: the instance's `homePath` (exported as
@@ -250,7 +415,10 @@ export const make = Effect.gen(function* () {
    * `-`), so the real path comes from the `cwd` recorded in the newest
    * transcript inside it.
    */
-  const scanClaude = Effect.fn("AgentSessionScanner.scanClaude")(function* (homePath: string) {
+  const scanClaude = Effect.fn("AgentSessionScanner.scanClaude")(function* (
+    homePath: string,
+    providerInstanceId: ProviderInstanceId,
+  ) {
     const projectsDir = path.join(homePath, "projects");
     const projectDirectories = yield* listDirectory(projectsDir);
     const candidates: Array<RawCandidate> = [];
@@ -282,7 +450,14 @@ export const make = Effect.gen(function* () {
       // The slug is lossy (`/a/b.c` and `/a/b/c` share a directory), so a
       // directory can hold sessions from several distinct paths — group by
       // the recorded cwd like the Codex scan does.
-      const byCwd = new Map<string, { threadCount: number; lastActiveAtMs: number }>();
+      const byCwd = new Map<
+        string,
+        {
+          threadCount: number;
+          lastActiveAtMs: number;
+          transcripts: Array<{ filePath: string; mtimeMs: number }>;
+        }
+      >();
       for (const entry of withMtimes) {
         const cwd = yield* readCwd(entry.filePath);
         if (cwd === null) continue;
@@ -290,16 +465,23 @@ export const make = Effect.gen(function* () {
         if (existing) {
           existing.threadCount += 1;
           existing.lastActiveAtMs = Math.max(existing.lastActiveAtMs, entry.mtimeMs);
+          existing.transcripts.push(entry);
         } else {
-          byCwd.set(cwd, { threadCount: 1, lastActiveAtMs: entry.mtimeMs });
+          byCwd.set(cwd, {
+            threadCount: 1,
+            lastActiveAtMs: entry.mtimeMs,
+            transcripts: [entry],
+          });
         }
       }
       for (const [cwd, group] of byCwd) {
         candidates.push({
           cwd,
           source: "claudeAgent",
+          providerInstanceId,
           threadCount: group.threadCount,
           lastActiveAtMs: group.lastActiveAtMs,
+          transcripts: group.transcripts,
         });
       }
     }
@@ -311,7 +493,10 @@ export const make = Effect.gen(function* () {
    * Codex writes `sessions/YYYY/MM/DD/rollout-*.jsonl`. Always scan the shared
    * home: in auth-overlay mode the effective home only symlinks to it.
    */
-  const scanCodex = Effect.fn("AgentSessionScanner.scanCodex")(function* (homePath: string) {
+  const scanCodex = Effect.fn("AgentSessionScanner.scanCodex")(function* (
+    homePath: string,
+    providerInstanceId: ProviderInstanceId,
+  ) {
     const sessionsDir = path.join(homePath, "sessions");
 
     const rollouts: Array<string> = [];
@@ -337,31 +522,47 @@ export const make = Effect.gen(function* () {
       if (rollouts.length >= MAX_TRANSCRIPTS_PER_SOURCE) break;
     }
 
-    const byCwd = new Map<string, Array<string>>();
+    const byCwd = new Map<string, Array<{ filePath: string; mtimeMs: number | null }>>();
     for (const rollout of rollouts) {
       const cwd = yield* readCwd(rollout);
       if (cwd === null) continue;
+      const stats = yield* statOption(rollout);
+      const mtimeMs =
+        Option.isSome(stats) && Option.isSome(stats.value.mtime)
+          ? stats.value.mtime.value.getTime()
+          : null;
+      const transcript = { filePath: rollout, mtimeMs };
       const existing = byCwd.get(cwd);
       if (existing) {
-        existing.push(rollout);
+        existing.push(transcript);
       } else {
-        byCwd.set(cwd, [rollout]);
+        byCwd.set(cwd, [transcript]);
       }
     }
 
     const candidates: Array<RawCandidate> = [];
-    for (const [cwd, filePaths] of byCwd) {
+    for (const [cwd, transcripts] of byCwd) {
       candidates.push({
         cwd,
         source: "codex",
-        threadCount: filePaths.length,
-        lastActiveAtMs: yield* latestMtimeMs(filePaths),
+        providerInstanceId,
+        threadCount: transcripts.length,
+        lastActiveAtMs: transcripts.reduce<number | null>(
+          (latest, transcript) =>
+            transcript.mtimeMs === null
+              ? latest
+              : latest === null
+                ? transcript.mtimeMs
+                : Math.max(latest, transcript.mtimeMs),
+          null,
+        ),
+        transcripts,
       });
     }
     return candidates;
   });
 
-  const scan: AgentSessionScanner["Service"]["scan"] = Effect.gen(function* () {
+  const collectCandidates = Effect.fn("AgentSessionScanner.collectCandidates")(function* () {
     const settings = yield* serverSettings.getSettings.pipe(
       Effect.mapError((cause) => new AgentSessionScanError({ operation: "read-settings", cause })),
     );
@@ -370,17 +571,26 @@ export const make = Effect.gen(function* () {
     const scannedHomes = new Set<string>();
 
     for (const source of ["claudeAgent", "codex"] as const) {
-      const instances: Array<ProviderInstanceConfig> = Object.values(
-        settings.providerInstances,
-      ).filter((instance) => instance.driver === source);
+      const instances: Array<{
+        readonly instanceId: ProviderInstanceId;
+        readonly config: ProviderInstanceConfig;
+      }> = Object.entries(settings.providerInstances)
+        .filter(([, instance]) => instance.driver === source)
+        .map(([instanceId, config]) => ({
+          instanceId: ProviderInstanceId.make(instanceId),
+          config,
+        }));
       if (!Object.hasOwn(settings.providerInstances, source)) {
         instances.push({
-          driver: ProviderDriverKind.make(source),
-          config: settings.providers[source],
+          instanceId: ProviderInstanceId.make(source),
+          config: {
+            driver: ProviderDriverKind.make(source),
+            config: settings.providers[source],
+          },
         });
       }
 
-      for (const instance of instances) {
+      for (const { instanceId, config: instance } of instances) {
         const homeVariable = source === "claudeAgent" ? "CLAUDE_CONFIG_DIR" : "CODEX_HOME";
         const environmentHome =
           instance.environment?.findLast((variable) => variable.name === homeVariable)?.value ??
@@ -412,9 +622,22 @@ export const make = Effect.gen(function* () {
         const homeKey = `${source}\0${normalizeProjectPathForComparison(realHomePath)}`;
         if (scannedHomes.has(homeKey)) continue;
         scannedHomes.add(homeKey);
-        raw.push(...(yield* source === "claudeAgent" ? scanClaude(homePath) : scanCodex(homePath)));
+        raw.push(
+          ...(yield* source === "claudeAgent"
+            ? scanClaude(homePath, instanceId)
+            : scanCodex(homePath, instanceId)),
+        );
       }
     }
+
+    return raw;
+  });
+
+  let cachedCandidates: ReadonlyArray<RawCandidate> | null = null;
+
+  const scan: AgentSessionScanner["Service"]["scan"] = Effect.gen(function* () {
+    const raw = yield* collectCandidates();
+    cachedCandidates = raw;
 
     // Merge by resolved path first so both sources agree on a key, then by
     // realpath so a symlinked home and its target collapse into one candidate.
@@ -522,7 +745,59 @@ export const make = Effect.gen(function* () {
     };
   });
 
-  return AgentSessionScanner.of({ scan });
+  const recentThreads: AgentSessionScanner["Service"]["recentThreads"] = Effect.fn(
+    "AgentSessionScanner.recentThreads",
+  )(function* (workspaceRoot) {
+    const root = path.resolve(expandHomePath(workspaceRoot));
+    const realRoot = yield* fileSystem.realPath(root).pipe(Effect.orElseSucceed(() => root));
+    const normalizedRoot = normalizeProjectPathForComparison(realRoot);
+    const cutoffMs = DateTime.toEpochMillis(yield* DateTime.now) - RECENT_THREAD_WINDOW_MS;
+    const threads: Array<AgentSessionThread> = [];
+    const importedSessions = new Set<string>();
+
+    const candidates = cachedCandidates ?? (yield* collectCandidates());
+    cachedCandidates = candidates;
+
+    for (const candidate of candidates) {
+      const expanded = expandHomePath(candidate.cwd.trim());
+      if (!path.isAbsolute(expanded)) continue;
+      const resolved = path.resolve(expanded);
+      const realCandidate = yield* fileSystem
+        .realPath(resolved)
+        .pipe(Effect.orElseSucceed(() => resolved));
+      if (normalizeProjectPathForComparison(realCandidate) !== normalizedRoot) continue;
+
+      for (const transcript of candidate.transcripts) {
+        if (transcript.mtimeMs === null || transcript.mtimeMs < cutoffMs) continue;
+        const stats = yield* statOption(transcript.filePath);
+        if (Option.isNone(stats) || stats.value.size > BigInt(MAX_IMPORTED_TRANSCRIPT_BYTES)) {
+          continue;
+        }
+        const contents = yield* fileSystem
+          .readFileString(transcript.filePath)
+          .pipe(Effect.map(Option.some), Effect.orElseSucceed(Option.none));
+        if (Option.isNone(contents)) continue;
+
+        const thread = parseAgentSessionTranscript({
+          contents: contents.value,
+          source: candidate.source,
+          providerInstanceId: candidate.providerInstanceId,
+          fallbackSessionId: path.basename(transcript.filePath, ".jsonl"),
+          lastActiveAtMs: transcript.mtimeMs,
+        });
+        if (thread === null) continue;
+        const sessionKey = `${thread.providerInstanceId}\0${thread.providerSessionId}`;
+        if (importedSessions.has(sessionKey)) continue;
+        importedSessions.add(sessionKey);
+        threads.push(thread);
+      }
+    }
+
+    threads.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    return threads;
+  });
+
+  return AgentSessionScanner.of({ scan, recentThreads });
 });
 
 export const layer = Layer.effect(AgentSessionScanner, make);

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -171,6 +171,18 @@ function normalizeTimestamp(value: string | undefined, fallback: string): string
   return Option.isSome(parsed) ? DateTime.formatIso(parsed.value) : fallback;
 }
 
+/** Codex records injected workspace context as user input even though it is not conversation text. */
+function visibleCodexUserText(value: string): string {
+  return value
+    .replaceAll(/<environment_context>[\s\S]*?<\/environment_context>/gu, "")
+    .replaceAll(/<user_instructions>[\s\S]*?<\/user_instructions>/gu, "")
+    .replaceAll(
+      /# AGENTS\.md instructions for[^\r\n]*\s*<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>/gu,
+      "",
+    )
+    .trim();
+}
+
 /** Keep visible user and assistant text while ignoring tools, reasoning, and malformed records. */
 export function parseAgentSessionTranscript(input: {
   readonly contents: string;
@@ -220,7 +232,7 @@ export function parseAgentSessionTranscript(input: {
       continue;
     }
     if (record.type === "event_msg" && record.payload?.type === "user_message") {
-      const text = record.payload.message?.trim() ?? "";
+      const text = visibleCodexUserText(record.payload.message ?? "");
       if (text.length === 0) continue;
       hasExplicitCodexUserMessages = true;
       messages.push({
@@ -239,7 +251,9 @@ export function parseAgentSessionTranscript(input: {
       continue;
     }
 
-    const text = extractText(record.payload.content);
+    const extractedText = extractText(record.payload.content);
+    const text =
+      record.payload.role === "user" ? visibleCodexUserText(extractedText) : extractedText;
     if (text.length === 0) continue;
     messages.push({
       role: record.payload.role,

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -141,7 +141,7 @@ type AgentSessionSource = AgentSessionProjectCandidate["sources"][number];
 interface RawCandidate {
   readonly cwd: string;
   readonly source: AgentSessionSource;
-  readonly providerInstanceId: ProviderInstanceId;
+  readonly providerInstanceIds: Array<ProviderInstanceId>;
   readonly threadCount: number;
   readonly lastActiveAtMs: number | null;
   readonly transcripts: ReadonlyArray<{
@@ -421,72 +421,66 @@ export const make = Effect.gen(function* () {
   ) {
     const projectsDir = path.join(homePath, "projects");
     const projectDirectories = yield* listDirectory(projectsDir);
-    const candidates: Array<RawCandidate> = [];
-    let readBudget = MAX_TRANSCRIPTS_PER_SOURCE;
     let statBudget = MAX_STATS_PER_SOURCE;
+    const transcripts: Array<{ filePath: string; mtimeMs: number }> = [];
 
     for (const projectDirectory of projectDirectories) {
-      if (readBudget <= 0 || statBudget <= 0) break;
+      if (statBudget <= 0) break;
       const directory = path.join(projectsDir, projectDirectory);
-      const transcripts = (yield* listDirectory(directory))
+      const directoryTranscripts = (yield* listDirectory(directory))
         .filter((entry) => entry.endsWith(".jsonl"))
         .map((entry) => path.join(directory, entry));
-      if (transcripts.length === 0) continue;
+      if (directoryTranscripts.length === 0) continue;
 
-      // Stat (bounded), then spend the read budget newest-first, so the cap
-      // only ever drops the oldest transcripts.
-      const statted = transcripts.slice(0, statBudget);
+      const statted = directoryTranscripts.slice(0, statBudget);
       statBudget -= statted.length;
-      const withMtimes: Array<{ filePath: string; mtimeMs: number }> = [];
       for (const filePath of statted) {
         const stats = yield* statOption(filePath);
         if (Option.isNone(stats) || Option.isNone(stats.value.mtime)) continue;
-        withMtimes.push({ filePath, mtimeMs: stats.value.mtime.value.getTime() });
+        transcripts.push({ filePath, mtimeMs: stats.value.mtime.value.getTime() });
       }
-      withMtimes.sort((left, right) => right.mtimeMs - left.mtimeMs);
-      withMtimes.splice(readBudget);
-      readBudget -= withMtimes.length;
+    }
 
-      // The slug is lossy (`/a/b.c` and `/a/b/c` share a directory), so a
-      // directory can hold sessions from several distinct paths — group by
-      // the recorded cwd like the Codex scan does.
-      const byCwd = new Map<
-        string,
-        {
-          threadCount: number;
-          lastActiveAtMs: number;
-          transcripts: Array<{ filePath: string; mtimeMs: number }>;
-        }
-      >();
-      for (const entry of withMtimes) {
-        const cwd = yield* readCwd(entry.filePath);
-        if (cwd === null) continue;
-        const existing = byCwd.get(cwd);
-        if (existing) {
-          existing.threadCount += 1;
-          existing.lastActiveAtMs = Math.max(existing.lastActiveAtMs, entry.mtimeMs);
-          existing.transcripts.push(entry);
-        } else {
-          byCwd.set(cwd, {
-            threadCount: 1,
-            lastActiveAtMs: entry.mtimeMs,
-            transcripts: [entry],
-          });
-        }
+    // Apply the read budget across every project, not separately by directory.
+    transcripts.sort((left, right) => right.mtimeMs - left.mtimeMs);
+    transcripts.splice(MAX_TRANSCRIPTS_PER_SOURCE);
+
+    const byCwd = new Map<
+      string,
+      {
+        threadCount: number;
+        lastActiveAtMs: number;
+        transcripts: Array<{ filePath: string; mtimeMs: number }>;
       }
-      for (const [cwd, group] of byCwd) {
-        candidates.push({
-          cwd,
-          source: "claudeAgent",
-          providerInstanceId,
-          threadCount: group.threadCount,
-          lastActiveAtMs: group.lastActiveAtMs,
-          transcripts: group.transcripts,
+    >();
+    for (const entry of transcripts) {
+      const cwd = yield* readCwd(entry.filePath);
+      if (cwd === null) continue;
+      const existing = byCwd.get(cwd);
+      if (existing) {
+        existing.threadCount += 1;
+        existing.lastActiveAtMs = Math.max(existing.lastActiveAtMs, entry.mtimeMs);
+        existing.transcripts.push(entry);
+      } else {
+        byCwd.set(cwd, {
+          threadCount: 1,
+          lastActiveAtMs: entry.mtimeMs,
+          transcripts: [entry],
         });
       }
     }
 
-    return candidates;
+    return Array.from(
+      byCwd,
+      ([cwd, group]): RawCandidate => ({
+        cwd,
+        source: "claudeAgent",
+        providerInstanceIds: [providerInstanceId],
+        threadCount: group.threadCount,
+        lastActiveAtMs: group.lastActiveAtMs,
+        transcripts: group.transcripts,
+      }),
+    );
   });
 
   /**
@@ -545,7 +539,7 @@ export const make = Effect.gen(function* () {
       candidates.push({
         cwd,
         source: "codex",
-        providerInstanceId,
+        providerInstanceIds: [providerInstanceId],
         threadCount: transcripts.length,
         lastActiveAtMs: transcripts.reduce<number | null>(
           (latest, transcript) =>
@@ -568,7 +562,7 @@ export const make = Effect.gen(function* () {
     );
 
     const raw: Array<RawCandidate> = [];
-    const scannedHomes = new Set<string>();
+    const scannedHomes = new Map<string, ReadonlyArray<RawCandidate>>();
 
     for (const source of ["claudeAgent", "codex"] as const) {
       const instances: Array<{
@@ -620,13 +614,20 @@ export const make = Effect.gen(function* () {
           .realPath(homePath)
           .pipe(Effect.orElseSucceed(() => homePath));
         const homeKey = `${source}\0${normalizeProjectPathForComparison(realHomePath)}`;
-        if (scannedHomes.has(homeKey)) continue;
-        scannedHomes.add(homeKey);
-        raw.push(
-          ...(yield* source === "claudeAgent"
-            ? scanClaude(homePath, instanceId)
-            : scanCodex(homePath, instanceId)),
-        );
+        const existingCandidates = scannedHomes.get(homeKey);
+        if (existingCandidates !== undefined) {
+          for (const candidate of existingCandidates) {
+            if (!candidate.providerInstanceIds.includes(instanceId)) {
+              candidate.providerInstanceIds.push(instanceId);
+            }
+          }
+          continue;
+        }
+        const candidates = yield* source === "claudeAgent"
+          ? scanClaude(homePath, instanceId)
+          : scanCodex(homePath, instanceId);
+        scannedHomes.set(homeKey, candidates);
+        raw.push(...candidates);
       }
     }
 
@@ -778,18 +779,26 @@ export const make = Effect.gen(function* () {
           .pipe(Effect.map(Option.some), Effect.orElseSucceed(Option.none));
         if (Option.isNone(contents)) continue;
 
-        const thread = parseAgentSessionTranscript({
+        const primaryInstanceId = candidate.providerInstanceIds[0];
+        if (primaryInstanceId === undefined) continue;
+        const parsedThread = parseAgentSessionTranscript({
           contents: contents.value,
           source: candidate.source,
-          providerInstanceId: candidate.providerInstanceId,
+          providerInstanceId: primaryInstanceId,
           fallbackSessionId: path.basename(transcript.filePath, ".jsonl"),
           lastActiveAtMs: transcript.mtimeMs,
         });
-        if (thread === null) continue;
-        const sessionKey = `${thread.providerInstanceId}\0${thread.providerSessionId}`;
-        if (importedSessions.has(sessionKey)) continue;
-        importedSessions.add(sessionKey);
-        threads.push(thread);
+        if (parsedThread === null) continue;
+        for (const providerInstanceId of candidate.providerInstanceIds) {
+          const thread =
+            providerInstanceId === primaryInstanceId
+              ? parsedThread
+              : { ...parsedThread, providerInstanceId };
+          const sessionKey = `${thread.providerInstanceId}\0${thread.providerSessionId}`;
+          if (importedSessions.has(sessionKey)) continue;
+          importedSessions.add(sessionKey);
+          threads.push(thread);
+        }
       }
     }
 

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -33,6 +33,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
@@ -133,7 +134,7 @@ export class AgentSessionScanner extends Context.Service<
     readonly scan: Effect.Effect<AgentSessionScanResult, AgentSessionScanError>;
     readonly recentThreads: (
       workspaceRoot: string,
-    ) => Effect.Effect<ReadonlyArray<AgentSessionThread>, AgentSessionScanError>;
+    ) => Stream.Stream<AgentSessionThread, AgentSessionScanError>;
   }
 >()("t3/project/AgentSessionScanner") {}
 
@@ -452,6 +453,45 @@ export const make = Effect.gen(function* () {
                 const cwd = extractCwd(line.trim());
                 if (cwd !== null) return cwd;
               }
+            }
+
+            return null;
+          }),
+        ),
+      ),
+    ).pipe(Effect.orElseSucceed(() => null));
+  });
+
+  /**
+   * Read one stable transcript snapshot. The guard byte detects a file that
+   * grew after stat without reading past the hard per-file limit.
+   */
+  const readTranscript = Effect.fn("AgentSessionScanner.readTranscript")(function* (
+    filePath: string,
+    expectedSize: bigint,
+  ) {
+    if (expectedSize > BigInt(MAX_IMPORTED_TRANSCRIPT_BYTES)) return null;
+    const expectedBytes = Number(expectedSize);
+
+    return yield* Effect.scoped(
+      fileSystem.open(filePath, { flag: "r" }).pipe(
+        Effect.flatMap((file) =>
+          Effect.gen(function* () {
+            const decoder = new TextDecoder();
+            let contents = "";
+            let bytesRead = 0;
+
+            while (bytesRead <= expectedBytes) {
+              const next = yield* file.readAlloc(
+                Math.min(TRANSCRIPT_PREFIX_BYTES, expectedBytes + 1 - bytesRead),
+              );
+              if (Option.isNone(next)) {
+                return contents + decoder.decode();
+              }
+
+              bytesRead += next.value.byteLength;
+              if (bytesRead > expectedBytes) return null;
+              contents += decoder.decode(next.value, { stream: true });
             }
 
             return null;
@@ -818,20 +858,22 @@ export const make = Effect.gen(function* () {
     };
   });
 
-  const recentThreads: AgentSessionScanner["Service"]["recentThreads"] = Effect.fn(
-    "AgentSessionScanner.recentThreads",
-  )(function* (workspaceRoot) {
+  const prepareRecentThreads = Effect.fn("AgentSessionScanner.prepareRecentThreads")(function* (
+    workspaceRoot: string,
+  ) {
     const root = path.resolve(expandHomePath(workspaceRoot));
     const realRoot = yield* fileSystem.realPath(root).pipe(Effect.orElseSucceed(() => root));
-    if (isExcludedProjectPath(root) || isExcludedProjectPath(realRoot)) return [];
+    if (isExcludedProjectPath(root) || isExcludedProjectPath(realRoot)) return Stream.empty;
     const normalizedRoot = normalizeProjectPathForComparison(realRoot);
     const cutoffMs = DateTime.toEpochMillis(yield* DateTime.now) - RECENT_THREAD_WINDOW_MS;
-    const threads: Array<AgentSessionThread> = [];
-    const importedSessions = new Set<string>();
 
     const candidates = cachedCandidates ?? (yield* collectCandidates());
     cachedCandidates = candidates;
 
+    const eligibleTranscripts: Array<{
+      readonly candidate: RawCandidate;
+      readonly transcript: RawCandidate["transcripts"][number] & { readonly mtimeMs: number };
+    }> = [];
     for (const candidate of candidates) {
       const expanded = expandHomePath(candidate.cwd.trim());
       if (!path.isAbsolute(expanded)) continue;
@@ -843,41 +885,60 @@ export const make = Effect.gen(function* () {
 
       for (const transcript of candidate.transcripts) {
         if (transcript.mtimeMs === null || transcript.mtimeMs < cutoffMs) continue;
-        const stats = yield* statOption(transcript.filePath);
-        if (Option.isNone(stats) || stats.value.size > BigInt(MAX_IMPORTED_TRANSCRIPT_BYTES)) {
-          continue;
-        }
-        const contents = yield* fileSystem
-          .readFileString(transcript.filePath)
-          .pipe(Effect.map(Option.some), Effect.orElseSucceed(Option.none));
-        if (Option.isNone(contents)) continue;
-
-        const primaryInstanceId = candidate.providerInstanceIds[0];
-        if (primaryInstanceId === undefined) continue;
-        const parsedThread = parseAgentSessionTranscript({
-          contents: contents.value,
-          source: candidate.source,
-          providerInstanceId: primaryInstanceId,
-          fallbackSessionId: path.basename(transcript.filePath, ".jsonl"),
-          lastActiveAtMs: transcript.mtimeMs,
+        eligibleTranscripts.push({
+          candidate,
+          transcript: { ...transcript, mtimeMs: transcript.mtimeMs },
         });
-        if (parsedThread === null) continue;
-        for (const providerInstanceId of candidate.providerInstanceIds) {
-          const thread =
-            providerInstanceId === primaryInstanceId
-              ? parsedThread
-              : { ...parsedThread, providerInstanceId };
-          const sessionKey = `${thread.providerInstanceId}\0${thread.providerSessionId}`;
-          if (importedSessions.has(sessionKey)) continue;
-          importedSessions.add(sessionKey);
-          threads.push(thread);
-        }
       }
     }
 
-    threads.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
-    return threads;
+    eligibleTranscripts.sort((left, right) => {
+      if (left.transcript.mtimeMs !== right.transcript.mtimeMs) {
+        return right.transcript.mtimeMs - left.transcript.mtimeMs;
+      }
+      return left.transcript.filePath.localeCompare(right.transcript.filePath);
+    });
+
+    const importedSessions = new Set<string>();
+    return Stream.fromIteratorSucceed(eligibleTranscripts.values(), 1).pipe(
+      Stream.mapEffect(({ candidate, transcript }) =>
+        Effect.gen(function* () {
+          const stats = yield* statOption(transcript.filePath);
+          if (Option.isNone(stats)) return [];
+          const contents = yield* readTranscript(transcript.filePath, stats.value.size);
+          if (contents === null) return [];
+
+          const primaryInstanceId = candidate.providerInstanceIds[0];
+          if (primaryInstanceId === undefined) return [];
+          const parsedThread = parseAgentSessionTranscript({
+            contents,
+            source: candidate.source,
+            providerInstanceId: primaryInstanceId,
+            fallbackSessionId: path.basename(transcript.filePath, ".jsonl"),
+            lastActiveAtMs: transcript.mtimeMs,
+          });
+          if (parsedThread === null) return [];
+
+          const threads: Array<AgentSessionThread> = [];
+          for (const providerInstanceId of candidate.providerInstanceIds) {
+            const thread =
+              providerInstanceId === primaryInstanceId
+                ? parsedThread
+                : { ...parsedThread, providerInstanceId };
+            const sessionKey = `${thread.providerInstanceId}\0${thread.providerSessionId}`;
+            if (importedSessions.has(sessionKey)) continue;
+            importedSessions.add(sessionKey);
+            threads.push(thread);
+          }
+          return threads;
+        }),
+      ),
+      Stream.flatMap(Stream.fromIterable),
+    );
   });
+
+  const recentThreads: AgentSessionScanner["Service"]["recentThreads"] = (workspaceRoot) =>
+    Stream.unwrap(prepareRecentThreads(workspaceRoot));
 
   return AgentSessionScanner.of({ scan, recentThreads });
 });

--- a/apps/server/src/project/AgentSessionScanner.ts
+++ b/apps/server/src/project/AgentSessionScanner.ts
@@ -83,6 +83,8 @@ const TranscriptRecord = Schema.Struct({
   sessionId: Schema.optional(Schema.String),
   aiTitle: Schema.optional(Schema.String),
   isSidechain: Schema.optional(Schema.Boolean),
+  isMeta: Schema.optional(Schema.Boolean),
+  isCompactSummary: Schema.optional(Schema.Boolean),
   message: Schema.optional(TranscriptMessage),
   payload: Schema.optional(
     Schema.Struct({
@@ -171,16 +173,16 @@ function normalizeTimestamp(value: string | undefined, fallback: string): string
   return Option.isSome(parsed) ? DateTime.formatIso(parsed.value) : fallback;
 }
 
-/** Codex records injected workspace context as user input even though it is not conversation text. */
+const LEADING_CODEX_CONTEXT =
+  /^\s*(?:<environment_context>[\s\S]*?<\/environment_context>|<user_instructions>[\s\S]*?<\/user_instructions>|# AGENTS\.md instructions for[^\r\n]*\s*<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>)\s*/u;
+
+/** Codex records leading workspace context as user input even though it is not conversation text. */
 function visibleCodexUserText(value: string): string {
-  return value
-    .replaceAll(/<environment_context>[\s\S]*?<\/environment_context>/gu, "")
-    .replaceAll(/<user_instructions>[\s\S]*?<\/user_instructions>/gu, "")
-    .replaceAll(
-      /# AGENTS\.md instructions for[^\r\n]*\s*<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>/gu,
-      "",
-    )
-    .trim();
+  let visible = value;
+  while (LEADING_CODEX_CONTEXT.test(visible)) {
+    visible = visible.replace(LEADING_CODEX_CONTEXT, "");
+  }
+  return visible.replace(/^\s*## My request for Codex:\s*/u, "").trim();
 }
 
 /** Keep visible user and assistant text while ignoring tools, reasoning, and malformed records. */
@@ -192,11 +194,37 @@ export function parseAgentSessionTranscript(input: {
   readonly lastActiveAtMs: number;
 }): AgentSessionThread | null {
   const fallbackTimestamp = DateTime.formatIso(DateTime.makeUnsafe(input.lastActiveAtMs));
-  let providerSessionId = input.fallbackSessionId;
+  // Claude filenames are session IDs. Codex rollout filenames include extra
+  // timestamp text, so only transcript metadata can provide a resumable ID.
+  let providerSessionId = input.source === "codex" ? "" : input.fallbackSessionId;
   let title: string | null = null;
   let model: string | null = null;
-  let hasExplicitCodexUserMessages = false;
+  let hasCodexSessionId = false;
   const messages: Array<AgentSessionThreadMessage & { readonly codexResponseUser: boolean }> = [];
+  let firstUserMessage:
+    | (AgentSessionThreadMessage & { readonly codexResponseUser: boolean })
+    | undefined;
+
+  const retainMessage = (
+    message: AgentSessionThreadMessage & { readonly codexResponseUser: boolean },
+  ) => {
+    if (firstUserMessage === undefined && message.role === "user") {
+      firstUserMessage = message;
+    }
+    messages.push(message);
+    if (messages.length > MAX_IMPORTED_MESSAGES) messages.shift();
+  };
+
+  const hasMatchingCodexEventInTurn = (text: string) => {
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index];
+      if (message?.role === "assistant") return false;
+      if (message?.role === "user" && !message.codexResponseUser && message.text === text) {
+        return true;
+      }
+    }
+    return false;
+  };
 
   for (const line of input.contents.split("\n")) {
     const decoded = decodeTranscriptRecord(line);
@@ -204,16 +232,26 @@ export function parseAgentSessionTranscript(input: {
     const record = decoded.value;
 
     if (input.source === "claudeAgent") {
+      if (
+        record.isSidechain === true ||
+        record.isMeta === true ||
+        record.isCompactSummary === true
+      ) {
+        continue;
+      }
       if (record.sessionId?.trim()) providerSessionId = record.sessionId.trim();
       if (record.aiTitle?.trim()) title = record.aiTitle.trim();
-      if (record.message?.model?.trim()) model = record.message.model.trim();
-      if (record.isSidechain === true || (record.type !== "user" && record.type !== "assistant")) {
+      const messageModel = record.message?.model?.trim();
+      // Claude uses this sentinel for local error responses. It is not a
+      // model ID that can be selected when the imported session resumes.
+      if (messageModel && messageModel !== "<synthetic>") model = messageModel;
+      if (record.type !== "user" && record.type !== "assistant") {
         continue;
       }
 
       const text = extractText(record.message?.content);
       if (text.length === 0) continue;
-      messages.push({
+      retainMessage({
         role: record.type,
         text,
         createdAt: normalizeTimestamp(record.timestamp, fallbackTimestamp),
@@ -223,8 +261,11 @@ export function parseAgentSessionTranscript(input: {
     }
 
     if (record.type === "session_meta") {
-      providerSessionId =
-        record.payload?.id?.trim() || record.payload?.session_id?.trim() || providerSessionId;
+      const sessionId = record.payload?.id?.trim() || record.payload?.session_id?.trim();
+      if (!hasCodexSessionId && sessionId) {
+        providerSessionId = sessionId;
+        hasCodexSessionId = true;
+      }
       continue;
     }
     if (record.type === "turn_context" && record.payload?.model?.trim()) {
@@ -234,8 +275,18 @@ export function parseAgentSessionTranscript(input: {
     if (record.type === "event_msg" && record.payload?.type === "user_message") {
       const text = visibleCodexUserText(record.payload.message ?? "");
       if (text.length === 0) continue;
-      hasExplicitCodexUserMessages = true;
-      messages.push({
+      // Codex can write the same prompt as both a response item and an event.
+      // Remove only the matching response copy so mixed-format logs keep every
+      // distinct user message.
+      for (let index = messages.length - 1; index >= 0; index--) {
+        const message = messages[index];
+        if (message?.role === "assistant") break;
+        if (message?.codexResponseUser === true && message.text === text) {
+          messages.splice(index, 1);
+          break;
+        }
+      }
+      retainMessage({
         role: "user",
         text,
         createdAt: normalizeTimestamp(record.timestamp, fallbackTimestamp),
@@ -255,7 +306,10 @@ export function parseAgentSessionTranscript(input: {
     const text =
       record.payload.role === "user" ? visibleCodexUserText(extractedText) : extractedText;
     if (text.length === 0) continue;
-    messages.push({
+    if (record.payload.role === "user" && hasMatchingCodexEventInTurn(text)) {
+      continue;
+    }
+    retainMessage({
       role: record.payload.role,
       text,
       createdAt: normalizeTimestamp(record.timestamp, fallbackTimestamp),
@@ -263,21 +317,23 @@ export function parseAgentSessionTranscript(input: {
     });
   }
 
-  const visibleMessages = messages
-    .filter((message) => !hasExplicitCodexUserMessages || !message.codexResponseUser)
-    .map(({ codexResponseUser: _codexResponseUser, ...message }) => message);
-  const firstUserMessage = visibleMessages.find((message) => message.role === "user");
+  const visibleMessages = messages.map(
+    ({ codexResponseUser: _codexResponseUser, ...message }) => message,
+  );
   if (providerSessionId.trim().length === 0 || firstUserMessage === undefined) return null;
-  const latestMessages = visibleMessages.slice(-MAX_IMPORTED_MESSAGES);
-  const retainedMessages = latestMessages.some((message) => message.role === "user")
-    ? latestMessages
-    : [firstUserMessage, ...latestMessages.slice(-(MAX_IMPORTED_MESSAGES - 1))];
+  const { codexResponseUser: _codexResponseUser, ...visibleFirstUserMessage } = firstUserMessage;
+  const retainedMessages = visibleMessages.some((message) => message.role === "user")
+    ? visibleMessages
+    : [visibleFirstUserMessage, ...visibleMessages.slice(-(MAX_IMPORTED_MESSAGES - 1))];
 
   return {
     source: input.source,
     providerInstanceId: input.providerInstanceId,
     providerSessionId,
-    title: title ?? firstUserMessage.text.split("\n")[0]?.slice(0, 100).trim() ?? "Imported thread",
+    title:
+      title ??
+      visibleFirstUserMessage.text.split("\n")[0]?.slice(0, 100).trim() ??
+      "Imported thread",
     model,
     createdAt: retainedMessages[0]?.createdAt ?? fallbackTimestamp,
     updatedAt: fallbackTimestamp,
@@ -720,9 +776,10 @@ export const make = Effect.gen(function* () {
           (cause) => new AgentSessionScanError({ operation: "read-projects", cause }),
         ),
       );
-    const importedRoots = new Set(
-      shellSnapshot.projects.map((project) =>
-        normalizeProjectPathForComparison(project.workspaceRoot),
+    const importedProjectsByRoot = new Map(
+      shellSnapshot.projects.map(
+        (project) =>
+          [normalizeProjectPathForComparison(project.workspaceRoot), project.id] as const,
       ),
     );
 
@@ -730,19 +787,20 @@ export const make = Effect.gen(function* () {
     for (const [key, entry] of merged.entries()) {
       // Projects may have been created under either the recorded spelling or
       // the resolved realpath (e.g. a symlinked home) — check both.
-      const alreadyImported =
-        importedRoots.has(normalizeProjectPathForComparison(entry.path)) ||
-        importedRoots.has(normalizeProjectPathForComparison(key));
+      const projectId =
+        importedProjectsByRoot.get(normalizeProjectPathForComparison(entry.path)) ??
+        importedProjectsByRoot.get(normalizeProjectPathForComparison(key));
       candidates.push({
         path: entry.path,
         title: path.basename(entry.path) || entry.path,
+        ...(projectId === undefined ? {} : { projectId }),
         sources: entry.sources,
         threadCount: entry.threadCount,
         lastActiveAt:
           entry.lastActiveAtMs === null
             ? null
             : DateTime.formatIso(DateTime.makeUnsafe(entry.lastActiveAtMs)),
-        alreadyImported,
+        alreadyImported: projectId !== undefined,
       });
     }
 
@@ -765,6 +823,7 @@ export const make = Effect.gen(function* () {
   )(function* (workspaceRoot) {
     const root = path.resolve(expandHomePath(workspaceRoot));
     const realRoot = yield* fileSystem.realPath(root).pipe(Effect.orElseSucceed(() => root));
+    if (isExcludedProjectPath(root) || isExcludedProjectPath(realRoot)) return [];
     const normalizedRoot = normalizeProjectPathForComparison(realRoot);
     const cutoffMs = DateTime.toEpochMillis(yield* DateTime.now) - RECENT_THREAD_WINDOW_MS;
     const threads: Array<AgentSessionThread> = [];

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -4,9 +4,8 @@ import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ProviderDriverKind, ThreadId } from "@t3tools/contracts";
-import { it, assert } from "@effect/vitest";
-import { assertSome } from "@effect/vitest/utils";
+import { ProviderDriverKind, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import { assert, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -23,6 +22,7 @@ import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
 function makeDirectoryLayer<E, R>(persistenceLayer: Layer.Layer<SqlClient.SqlClient, E, R>) {
   const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(Layer.provide(persistenceLayer));
   return Layer.mergeAll(
+    persistenceLayer,
     runtimeRepositoryLayer,
     ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer)),
     NodeServices.layer,
@@ -30,7 +30,7 @@ function makeDirectoryLayer<E, R>(persistenceLayer: Layer.Layer<SqlClient.SqlCli
 }
 
 it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryLive", (it) => {
-  it("upserts and reads thread bindings", () =>
+  it.effect("upserts and reads thread bindings", () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
@@ -39,13 +39,14 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       yield* directory.upsert({
         provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
         threadId: initialThreadId,
       });
 
       const provider = yield* directory.getProvider(initialThreadId);
       assert.equal(provider, "codex");
       const resolvedBinding = yield* directory.getBinding(initialThreadId);
-      assertSome(resolvedBinding, {
+      expect(Option.getOrThrow(resolvedBinding)).toMatchObject({
         threadId: initialThreadId,
         provider: ProviderDriverKind.make("codex"),
       });
@@ -57,6 +58,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       yield* directory.upsert({
         provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
         threadId: nextThreadId,
       });
       const updatedBinding = yield* directory.getBinding(nextThreadId);
@@ -74,10 +76,11 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       }
 
       const threadIds = yield* directory.listThreadIds();
-      assert.deepEqual(threadIds, [nextThreadId]);
-    }));
+      expect(threadIds).toEqual(expect.arrayContaining([initialThreadId, nextThreadId]));
+    }),
+  );
 
-  it("persists runtime fields and merges payload updates", () =>
+  it.effect("persists runtime fields and merges payload updates", () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
@@ -86,6 +89,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       yield* directory.upsert({
         provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
         threadId,
         status: "starting",
         resumeCursor: {
@@ -99,6 +103,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       yield* directory.upsert({
         provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
         threadId,
         status: "running",
         runtimePayload: {
@@ -120,9 +125,43 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
           activeTurnId: "turn-1",
         });
       }
-    }));
+    }),
+  );
 
-  it("lists persisted bindings with metadata in oldest-first order", () =>
+  it.effect("keeps the existing binding when an insert conflicts", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = ThreadId.make("thread-insert-conflict");
+
+      yield* directory.upsert({
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        threadId,
+        status: "running",
+        resumeCursor: { threadId: "active-provider-thread" },
+      });
+
+      yield* directory.upsert(
+        {
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          threadId,
+          status: "stopped",
+          resumeCursor: { threadId: "stale-provider-thread" },
+        },
+        { onConflict: "ignore" },
+      );
+
+      const binding = yield* directory.getBinding(threadId);
+      expect(Option.getOrThrow(binding)).toMatchObject({
+        threadId,
+        status: "running",
+        resumeCursor: { threadId: "active-provider-thread" },
+      });
+    }),
+  );
+
+  it.effect("lists persisted bindings with metadata in oldest-first order", () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
@@ -162,12 +201,15 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         },
       });
 
-      const bindings = yield* directory.listBindings();
+      const bindings = (yield* directory.listBindings()).filter(
+        (binding) => binding.threadId === olderThreadId || binding.threadId === newerThreadId,
+      );
 
       assert.deepEqual(bindings, [
         {
           threadId: olderThreadId,
           provider: ProviderDriverKind.make("claudeAgent"),
+          providerInstanceId: ProviderInstanceId.make("claudeAgent"),
           adapterKey: "claudeAgent",
           runtimeMode: "approval-required",
           status: "starting",
@@ -182,6 +224,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         {
           threadId: newerThreadId,
           provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
           adapterKey: "codex",
           runtimeMode: "full-access",
           status: "running",
@@ -194,40 +237,45 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
           },
         },
       ]);
-    }));
+    }),
+  );
 
-  it("resets adapterKey to the new provider when provider changes without an explicit adapter key", () =>
-    Effect.gen(function* () {
-      const directory = yield* ProviderSessionDirectory;
-      const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
-      const threadId = ThreadId.make("thread-provider-change");
+  it.effect(
+    "resets adapterKey to the new provider when provider changes without an explicit adapter key",
+    () =>
+      Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory;
+        const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        const threadId = ThreadId.make("thread-provider-change");
 
-      yield* runtimeRepository.upsert({
-        threadId,
-        providerName: "claudeAgent",
-        providerInstanceId: null,
-        adapterKey: "claudeAgent",
-        runtimeMode: "full-access",
-        status: "running",
-        lastSeenAt: "2026-01-01T00:00:00.000Z",
-        resumeCursor: null,
-        runtimePayload: null,
-      });
+        yield* runtimeRepository.upsert({
+          threadId,
+          providerName: "claudeAgent",
+          providerInstanceId: null,
+          adapterKey: "claudeAgent",
+          runtimeMode: "full-access",
+          status: "running",
+          lastSeenAt: "2026-01-01T00:00:00.000Z",
+          resumeCursor: null,
+          runtimePayload: null,
+        });
 
-      yield* directory.upsert({
-        provider: ProviderDriverKind.make("codex"),
-        threadId,
-      });
+        yield* directory.upsert({
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          threadId,
+        });
 
-      const runtime = yield* runtimeRepository.getByThreadId({ threadId });
-      assert.equal(Option.isSome(runtime), true);
-      if (Option.isSome(runtime)) {
-        assert.equal(runtime.value.providerName, "codex");
-        assert.equal(runtime.value.adapterKey, "codex");
-      }
-    }));
+        const runtime = yield* runtimeRepository.getByThreadId({ threadId });
+        assert.equal(Option.isSome(runtime), true);
+        if (Option.isSome(runtime)) {
+          assert.equal(runtime.value.providerName, "codex");
+          assert.equal(runtime.value.adapterKey, "codex");
+        }
+      }),
+  );
 
-  it("rehydrates persisted mappings across layer restart", () =>
+  it.effect("rehydrates persisted mappings across layer restart", () =>
     Effect.gen(function* () {
       const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-directory-"));
       const dbPath = NodePath.join(tempDir, "orchestration.sqlite");
@@ -239,6 +287,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         const directory = yield* ProviderSessionDirectory;
         yield* directory.upsert({
           provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
           threadId,
         });
       }).pipe(Effect.provide(directoryLayer));
@@ -250,7 +299,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         assert.equal(provider, "codex");
 
         const resolvedBinding = yield* directory.getBinding(threadId);
-        assertSome(resolvedBinding, {
+        expect(Option.getOrThrow(resolvedBinding)).toMatchObject({
           threadId,
           provider: ProviderDriverKind.make("codex"),
         });
@@ -267,5 +316,6 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       }).pipe(Effect.provide(directoryLayer));
 
       NodeFS.rmSync(tempDir, { recursive: true, force: true });
-    }));
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -100,7 +100,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
       ),
     );
 
-  const upsert: ProviderSessionDirectoryShape["upsert"] = Effect.fn(function* (binding) {
+  const upsert: ProviderSessionDirectoryShape["upsert"] = Effect.fn(function* (binding, options) {
     const existing = yield* repository
       .getByThreadId({ threadId: binding.threadId })
       .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.upsert:getByThreadId")));
@@ -126,25 +126,30 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
       });
     }
     yield* repository
-      .upsert({
-        threadId: resolvedThreadId,
-        providerName: binding.provider,
-        providerInstanceId,
-        adapterKey:
-          binding.adapterKey ??
-          (providerChanged ? binding.provider : (existingRuntime?.adapterKey ?? binding.provider)),
-        runtimeMode: binding.runtimeMode ?? existingRuntime?.runtimeMode ?? "full-access",
-        status: binding.status ?? existingRuntime?.status ?? "running",
-        lastSeenAt: now,
-        resumeCursor:
-          binding.resumeCursor !== undefined
-            ? binding.resumeCursor
-            : (existingRuntime?.resumeCursor ?? null),
-        runtimePayload: mergeRuntimePayload(
-          existingRuntime?.runtimePayload ?? null,
-          binding.runtimePayload,
-        ),
-      })
+      .upsert(
+        {
+          threadId: resolvedThreadId,
+          providerName: binding.provider,
+          providerInstanceId,
+          adapterKey:
+            binding.adapterKey ??
+            (providerChanged
+              ? binding.provider
+              : (existingRuntime?.adapterKey ?? binding.provider)),
+          runtimeMode: binding.runtimeMode ?? existingRuntime?.runtimeMode ?? "full-access",
+          status: binding.status ?? existingRuntime?.status ?? "running",
+          lastSeenAt: now,
+          resumeCursor:
+            binding.resumeCursor !== undefined
+              ? binding.resumeCursor
+              : (existingRuntime?.resumeCursor ?? null),
+          runtimePayload: mergeRuntimePayload(
+            existingRuntime?.runtimePayload ?? null,
+            binding.runtimePayload,
+          ),
+        },
+        options,
+      )
       .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.upsert:upsert")));
   });
 

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -40,9 +40,14 @@ export type ProviderSessionDirectoryWriteError =
   | ProviderValidationError
   | ProviderSessionDirectoryPersistenceError;
 
+export interface ProviderSessionDirectoryUpsertOptions {
+  readonly onConflict?: "update" | "ignore";
+}
+
 export interface ProviderSessionDirectoryShape {
   readonly upsert: (
     binding: ProviderRuntimeBinding,
+    options?: ProviderSessionDirectoryUpsertOptions,
   ) => Effect.Effect<void, ProviderSessionDirectoryWriteError>;
 
   readonly getProvider: (

--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -201,6 +201,14 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
         },
       } as unknown as OrchestrationEvent),
     ).toBe(false);
+    expect(
+      AgentAwarenessRelay.shouldPublishAgentAwarenessEvent({
+        ...base,
+        type: "thread.settled",
+        metadata: { historyImport: true },
+        payload: { threadId: "thread-1" as ThreadId },
+      } as unknown as OrchestrationEvent),
+    ).toBe(false);
   });
 
   it("deduplicates awareness state updates whose only change is their event timestamp", () => {

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -68,6 +68,8 @@ export function eventThreadId(event: OrchestrationEvent): ThreadId | null {
 
 export function shouldPublishAgentAwarenessEvent(event: OrchestrationEvent): boolean {
   switch (event.type) {
+    case "thread.settled":
+      return event.metadata.historyImport !== true;
     case "thread.message-sent":
     case "thread.turn-start-requested":
       // These events express intent to start work, but the shell still contains

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -115,6 +115,7 @@ import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
 import * as ProviderService from "./provider/Services/ProviderService.ts";
+import * as ProviderSessionDirectory from "./provider/Services/ProviderSessionDirectory.ts";
 import { ProviderAdapterRequestError } from "./provider/Errors.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -404,6 +405,9 @@ const buildAppUnderTest = (options?: {
     projectSetupScriptRunner?: Partial<
       ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"]
     >;
+    providerSessionDirectory?: Partial<
+      ProviderSessionDirectory.ProviderSessionDirectory["Service"]
+    >;
     terminalManager?: Partial<TerminalManager.TerminalManager["Service"]>;
     orchestrationEngine?: Partial<OrchestrationEngine.OrchestrationEngineService["Service"]>;
     analyticsService?: Partial<AnalyticsService.AnalyticsService["Service"]>;
@@ -648,6 +652,13 @@ const buildAppUnderTest = (options?: {
           Layer.mock(ProviderService.ProviderService)({
             uploadFeedback: () => Effect.die("Provider feedback is not stubbed in this test"),
             ...options?.layers?.providerService,
+          }),
+          Layer.mock(ProviderSessionDirectory.ProviderSessionDirectory)({
+            upsert: () => Effect.void,
+            getBinding: () => Effect.succeed(Option.none()),
+            listThreadIds: () => Effect.succeed([]),
+            listBindings: () => Effect.succeed([]),
+            ...options?.layers?.providerSessionDirectory,
           }),
         ),
       ),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -15,7 +15,6 @@ import {
   type AuthAccessStreamEvent,
   type AuthEnvironmentScope,
   AuthSessionId,
-  AgentSessionScanError,
   ClientSurface,
   CommandId,
   type DiscoveredLocalServerList,
@@ -466,9 +465,7 @@ const makeWsRpcLayer = (
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
       const providerService = yield* ProviderService.ProviderService;
-      const providerSessionDirectory = yield* Effect.serviceOption(
-        ProviderSessionDirectory.ProviderSessionDirectory,
-      );
+      const providerSessionDirectory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
       const config = yield* ServerConfig.ServerConfig;
@@ -2005,31 +2002,17 @@ const makeWsRpcLayer = (
         [WS_METHODS.agentSessionsImport]: (input) =>
           observeRpcEffect(
             WS_METHODS.agentSessionsImport,
-            Option.match(providerSessionDirectory, {
-              onNone: () =>
-                Effect.fail(
-                  new AgentSessionScanError({
-                    operation: "read-projects",
-                    cause: new Error("Provider session storage is not available."),
-                  }),
-                ),
-              onSome: (directory) =>
-                importRecentAgentThreads(input).pipe(
-                  Effect.provideService(
-                    AgentSessionScanner.AgentSessionScanner,
-                    agentSessionScanner,
-                  ),
-                  Effect.provideService(
-                    OrchestrationEngine.OrchestrationEngineService,
-                    orchestrationEngine,
-                  ),
-                  Effect.provideService(
-                    ProviderSessionDirectory.ProviderSessionDirectory,
-                    directory,
-                  ),
-                  Effect.provideService(Crypto.Crypto, crypto),
-                ),
-            }),
+            importRecentAgentThreads(input).pipe(
+              Effect.provideService(AgentSessionScanner.AgentSessionScanner, agentSessionScanner),
+              Effect.provideService(
+                OrchestrationEngine.OrchestrationEngineService,
+                orchestrationEngine,
+              ),
+              Effect.provideService(
+                ProviderSessionDirectory.ProviderSessionDirectory,
+                providerSessionDirectory,
+              ),
+            ),
             { "rpc.aggregate": "workspace" },
           ),
         [WS_METHODS.assetsCreateUrl]: (input) =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -15,6 +15,7 @@ import {
   type AuthAccessStreamEvent,
   type AuthEnvironmentScope,
   AuthSessionId,
+  AgentSessionScanError,
   ClientSurface,
   CommandId,
   type DiscoveredLocalServerList,
@@ -86,6 +87,7 @@ import {
 } from "./observability/RpcInstrumentation.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
 import * as ProviderService from "./provider/Services/ProviderService.ts";
+import * as ProviderSessionDirectory from "./provider/Services/ProviderSessionDirectory.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -107,6 +109,7 @@ import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
 import * as AgentSessionScanner from "./project/AgentSessionScanner.ts";
+import { importRecentAgentThreads } from "./project/AgentSessionImporter.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import * as RemoteOpenTargets from "./environment/RemoteOpenTargets.ts";
 import * as BackgroundPolicy from "./background/BackgroundPolicy.ts";
@@ -463,6 +466,9 @@ const makeWsRpcLayer = (
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
       const providerService = yield* ProviderService.ProviderService;
+      const providerSessionDirectory = yield* Effect.serviceOption(
+        ProviderSessionDirectory.ProviderSessionDirectory,
+      );
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
       const config = yield* ServerConfig.ServerConfig;
@@ -1996,6 +2002,36 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.agentSessionsScan, agentSessionScanner.scan, {
             "rpc.aggregate": "workspace",
           }),
+        [WS_METHODS.agentSessionsImport]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.agentSessionsImport,
+            Option.match(providerSessionDirectory, {
+              onNone: () =>
+                Effect.fail(
+                  new AgentSessionScanError({
+                    operation: "read-projects",
+                    cause: new Error("Provider session storage is not available."),
+                  }),
+                ),
+              onSome: (directory) =>
+                importRecentAgentThreads(input).pipe(
+                  Effect.provideService(
+                    AgentSessionScanner.AgentSessionScanner,
+                    agentSessionScanner,
+                  ),
+                  Effect.provideService(
+                    OrchestrationEngine.OrchestrationEngineService,
+                    orchestrationEngine,
+                  ),
+                  Effect.provideService(
+                    ProviderSessionDirectory.ProviderSessionDirectory,
+                    directory,
+                  ),
+                  Effect.provideService(Crypto.Crypto, crypto),
+                ),
+            }),
+            { "rpc.aggregate": "workspace" },
+          ),
         [WS_METHODS.assetsCreateUrl]: (input) =>
           observeRpcEffect(
             WS_METHODS.assetsCreateUrl,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2009,6 +2009,11 @@ const makeWsRpcLayer = (
                 orchestrationEngine,
               ),
               Effect.provideService(
+                ProjectionSnapshotQuery.ProjectionSnapshotQuery,
+                projectionSnapshotQuery,
+              ),
+              Effect.provideService(Crypto.Crypto, crypto),
+              Effect.provideService(
                 ProviderSessionDirectory.ProviderSessionDirectory,
                 providerSessionDirectory,
               ),

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -40,7 +40,7 @@ import { resolveOnboardingTargetEnvironment } from "../../onboarding/targetEnvir
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { newProjectId, randomUUID } from "../../lib/utils";
 import { resolveDefaultProviderModelSelection } from "../../providerInstances";
-import { agentSessionScan } from "../../state/agentSessions";
+import { agentSessionImport, agentSessionScan } from "../../state/agentSessions";
 import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
@@ -884,8 +884,8 @@ function AgentInstallTerminal({
 /**
  * One-decision import (4B): a summary line with Import recent / Choose /
  * Skip. The default imports only projects touched in the last 30 days;
- * Choose expands a checklist including older ones. Projects only — thread
- * history import is a follow-up.
+ * Choose expands a checklist including older ones. Imported projects also
+ * receive Codex and Claude threads active within the last 30 days.
  */
 function ImportStep({
   mode,
@@ -908,6 +908,7 @@ function ImportStep({
     environmentId === null ? null : agentSessionScan({ environmentId, input: {} }),
   );
   const createProject = useAtomCommand(projectEnvironment.create, { reportFailure: false });
+  const importThreads = useAtomCommand(agentSessionImport, { reportFailure: false });
   const [choosing, setChoosing] = useState(false);
   const [deselected, setDeselected] = useState<ReadonlySet<string>>(new Set());
   const [isImporting, setIsImporting] = useState(false);
@@ -964,10 +965,11 @@ function ImportStep({
         return;
       }
       if (importedPaths.has(candidate.path)) continue;
+      const projectId = newProjectId();
       const result = await createProject({
         environmentId,
         input: {
-          projectId: newProjectId(),
+          projectId,
           title: candidate.title,
           workspaceRoot: candidate.path,
           createWorkspaceRootIfMissing: false,
@@ -983,6 +985,16 @@ function ImportStep({
       if (result._tag === "Success") {
         imported += 1;
         importedPaths.add(candidate.path);
+        await importThreads({
+          environmentId,
+          input: { projectId, workspaceRoot: candidate.path },
+        });
+        if (
+          importGeneration !== importGenerationRef.current ||
+          importedPaths !== importedPathsRef.current
+        ) {
+          return;
+        }
       }
     }
     setIsImporting(false);

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -3,6 +3,7 @@ import { useAtomValue } from "@effect/atom-react";
 import type {
   AgentSessionProjectCandidate,
   EnvironmentId,
+  ProjectId,
   ServerProvider,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
@@ -913,9 +914,9 @@ function ImportStep({
   const [deselected, setDeselected] = useState<ReadonlySet<string>>(new Set());
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState("");
-  // Paths that already imported this session, so a retry after a partial
-  // failure skips them instead of tripping the duplicate-root invariant.
+  // Keep created projects separate from completed imports so history failures can retry.
   const importedPathsRef = useRef(new Set<string>());
+  const createdProjectIdsRef = useRef(new Map<string, ProjectId>());
   const importGenerationRef = useRef(0);
 
   // Candidate paths are per-environment; a target switch would otherwise
@@ -926,6 +927,7 @@ function ImportStep({
     setIsImporting(false);
     setImportError("");
     importedPathsRef.current = new Set();
+    createdProjectIdsRef.current = new Map();
     return () => {
       importGenerationRef.current += 1;
     };
@@ -947,6 +949,7 @@ function ImportStep({
     setImportError("");
     const importGeneration = importGenerationRef.current;
     const importedPaths = importedPathsRef.current;
+    const createdProjectIds = createdProjectIdsRef.current;
     const defaultModelSelection = resolveDefaultProviderModelSelection(providers ?? [], null);
     // Interrupted imports are neither failures nor successes — the command was
     // superseded or the environment dropped — but they still didn't land, so
@@ -965,29 +968,18 @@ function ImportStep({
         return;
       }
       if (importedPaths.has(candidate.path)) continue;
-      const projectId = newProjectId();
-      const result = await createProject({
-        environmentId,
-        input: {
-          projectId,
-          title: candidate.title,
-          workspaceRoot: candidate.path,
-          createWorkspaceRootIfMissing: false,
-          defaultModelSelection,
-        },
-      });
-      if (
-        importGeneration !== importGenerationRef.current ||
-        importedPaths !== importedPathsRef.current
-      ) {
-        return;
-      }
-      if (result._tag === "Success") {
-        imported += 1;
-        importedPaths.add(candidate.path);
-        await importThreads({
+      let projectId = createdProjectIds.get(candidate.path);
+      if (projectId === undefined) {
+        projectId = newProjectId();
+        const result = await createProject({
           environmentId,
-          input: { projectId, workspaceRoot: candidate.path },
+          input: {
+            projectId,
+            title: candidate.title,
+            workspaceRoot: candidate.path,
+            createWorkspaceRootIfMissing: false,
+            defaultModelSelection,
+          },
         });
         if (
           importGeneration !== importGenerationRef.current ||
@@ -995,6 +987,26 @@ function ImportStep({
         ) {
           return;
         }
+        if (result._tag !== "Success") continue;
+        createdProjectIds.set(candidate.path, projectId);
+      }
+
+      const threadImportResult = await importThreads({
+        environmentId,
+        input: { projectId, workspaceRoot: candidate.path },
+      });
+      if (
+        importGeneration !== importGenerationRef.current ||
+        importedPaths !== importedPathsRef.current
+      ) {
+        return;
+      }
+      if (
+        threadImportResult._tag === "Success" &&
+        (threadImportResult.value.importedCount > 0 || threadImportResult.value.skippedCount === 0)
+      ) {
+        imported += 1;
+        importedPaths.add(candidate.path);
       }
     }
     setIsImporting(false);

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -11,7 +11,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { ThreadId } from "@t3tools/contracts";
+import { CommandId, ThreadId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 import {
   ArrowRightIcon,
@@ -32,7 +32,10 @@ import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { hasCloudPublicConfig } from "../../cloud/publicConfig";
 import { useT3ConnectAuthPrompt } from "../clerk/useT3ConnectAuthPrompt";
 import { useCompleteOnboarding } from "../../onboarding/firstRun";
-import { partitionOnboardingProjects } from "../../onboarding/projectImport.logic";
+import {
+  partitionOnboardingProjects,
+  resolveOnboardingProjectId,
+} from "../../onboarding/projectImport.logic";
 import {
   getOnboardingProviderState,
   selectOnboardingProvidersByDriver,
@@ -42,6 +45,7 @@ import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { newProjectId, randomUUID } from "../../lib/utils";
 import { resolveDefaultProviderModelSelection } from "../../providerInstances";
 import { agentSessionImport, agentSessionScan } from "../../state/agentSessions";
+import { useProjects } from "../../state/entities";
 import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
@@ -910,13 +914,18 @@ function ImportStep({
   );
   const createProject = useAtomCommand(projectEnvironment.create, { reportFailure: false });
   const importThreads = useAtomCommand(agentSessionImport, { reportFailure: false });
+  const projects = useProjects();
   const [choosing, setChoosing] = useState(false);
   const [deselected, setDeselected] = useState<ReadonlySet<string>>(new Set());
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState("");
-  // Keep created projects separate from completed imports so history failures can retry.
+  // Keep project creation attempts separate from completed history imports so both can retry.
   const importedPathsRef = useRef(new Set<string>());
-  const createdProjectIdsRef = useRef(new Map<string, ProjectId>());
+  const projectsRef = useRef(projects);
+  projectsRef.current = projects;
+  const projectAttemptsRef = useRef(
+    new Map<string, { readonly projectId: ProjectId; readonly commandId: CommandId }>(),
+  );
   const importGenerationRef = useRef(0);
 
   // Candidate paths are per-environment; a target switch would otherwise
@@ -927,17 +936,16 @@ function ImportStep({
     setIsImporting(false);
     setImportError("");
     importedPathsRef.current = new Set();
-    createdProjectIdsRef.current = new Map();
+    projectAttemptsRef.current = new Map();
     return () => {
       importGenerationRef.current += 1;
     };
   }, [environmentId]);
 
-  const {
-    available: candidates,
-    recent,
-    alreadyImportedCount,
-  } = useMemo(() => partitionOnboardingProjects(scan.data?.candidates ?? []), [scan.data]);
+  const { available: candidates, recent } = useMemo(
+    () => partitionOnboardingProjects(scan.data?.candidates ?? []),
+    [scan.data],
+  );
   const older = candidates.length - recent.length;
 
   const runImport = async (selection: ReadonlyArray<AgentSessionProjectCandidate>) => {
@@ -949,7 +957,7 @@ function ImportStep({
     setImportError("");
     const importGeneration = importGenerationRef.current;
     const importedPaths = importedPathsRef.current;
-    const createdProjectIds = createdProjectIdsRef.current;
+    const projectAttempts = projectAttemptsRef.current;
     const defaultModelSelection = resolveDefaultProviderModelSelection(providers ?? [], null);
     // Interrupted imports are neither failures nor successes — the command was
     // superseded or the environment dropped — but they still didn't land, so
@@ -968,13 +976,28 @@ function ImportStep({
         return;
       }
       if (importedPaths.has(candidate.path)) continue;
-      let projectId = createdProjectIds.get(candidate.path);
-      if (projectId === undefined) {
-        projectId = newProjectId();
+      let projectId = resolveOnboardingProjectId(
+        projectsRef.current,
+        environmentId,
+        candidate.path,
+        candidate.projectId,
+      );
+      if (projectId === null) {
+        let attempt = projectAttempts.get(candidate.path);
+        if (attempt === undefined) {
+          const nextProjectId = newProjectId();
+          attempt = {
+            projectId: nextProjectId,
+            commandId: CommandId.make(`onboarding:project:create:${nextProjectId}`),
+          };
+          projectAttempts.set(candidate.path, attempt);
+        }
+        projectId = attempt.projectId;
         const result = await createProject({
           environmentId,
           input: {
             projectId,
+            commandId: attempt.commandId,
             title: candidate.title,
             workspaceRoot: candidate.path,
             createWorkspaceRootIfMissing: false,
@@ -987,13 +1010,15 @@ function ImportStep({
         ) {
           return;
         }
-        if (result._tag !== "Success") continue;
-        createdProjectIds.set(candidate.path, projectId);
+        if (result._tag !== "Success") {
+          if (!isAtomCommandInterrupted(result)) projectAttempts.delete(candidate.path);
+          continue;
+        }
       }
 
       const threadImportResult = await importThreads({
         environmentId,
-        input: { projectId, workspaceRoot: candidate.path },
+        input: { projectId },
       });
       if (
         importGeneration !== importGenerationRef.current ||
@@ -1007,14 +1032,19 @@ function ImportStep({
       ) {
         imported += 1;
         importedPaths.add(candidate.path);
+      } else if (
+        threadImportResult._tag !== "Success" &&
+        !isAtomCommandInterrupted(threadImportResult)
+      ) {
+        projectAttempts.delete(candidate.path);
       }
     }
     setIsImporting(false);
     if (imported < selection.length) {
       setImportError(
         imported === 0
-          ? "Import failed. You can add projects manually from the command palette."
-          : `Imported ${imported} of ${selection.length} projects. The rest can be added from the command palette.`,
+          ? "Could not import thread history. Retry, or continue without it."
+          : `Imported thread history for ${imported} of ${selection.length} projects. Retry, or continue without the rest.`,
       );
       return;
     }
@@ -1044,28 +1074,32 @@ function ImportStep({
         description={
           scan.error !== null
             ? "Could not check this computer for projects."
-            : alreadyImportedCount > 0
-              ? "Your existing projects are already in T3 Code."
-              : "No existing Claude Code or Codex projects found."
+            : "No existing Claude Code or Codex projects found."
         }
         onBack={onBack}
       >
         {scan.error !== null ? (
           <p className="mt-3 text-xs text-white/50">You can add projects later.</p>
         ) : null}
-        <div className="mt-6 flex justify-end">
-          <Button onClick={onDone}>Start coding</Button>
+        <div className="mt-6 flex justify-end gap-2">
+          {scan.error !== null ? (
+            <Button variant="ghost" onClick={scan.refresh}>
+              Retry
+            </Button>
+          ) : null}
+          <Button onClick={onDone}>{scan.error !== null ? "Skip" : "Start coding"}</Button>
         </div>
       </StepShell>
     );
   }
 
   if (choosing) {
-    const selectedCount = candidates.length - deselected.size;
+    const selected = candidates.filter((candidate) => !deselected.has(candidate.path));
     return (
       <StepShell
         title="Choose your projects"
         onBack={() => setChoosing(false)}
+        backDisabled={isImporting}
         description={`${candidates.length} found on ${machineLabel}.`}
       >
         <div className="mt-6 max-h-72 overflow-x-hidden overflow-y-auto border-y border-white/12">
@@ -1104,12 +1138,10 @@ function ImportStep({
             Skip
           </Button>
           <Button
-            disabled={isImporting || selectedCount === 0}
-            onClick={() =>
-              void runImport(candidates.filter((candidate) => !deselected.has(candidate.path)))
-            }
+            disabled={isImporting || selected.length === 0}
+            onClick={() => void runImport(selected)}
           >
-            {isImporting ? "Importing..." : `Import ${selectedCount}`}
+            {isImporting ? "Importing..." : `Import ${selected.length}`}
           </Button>
         </div>
       </StepShell>
@@ -1121,6 +1153,7 @@ function ImportStep({
       title="Your recent projects"
       description={`${recent.length} ${recent.length === 1 ? "project" : "projects"} found on ${machineLabel}.${older > 0 ? ` ${older} older available.` : ""}`}
       onBack={onBack}
+      backDisabled={isImporting}
     >
       <div className="mt-6 border-y border-white/12">
         {recent.slice(0, 4).map((candidate) => (
@@ -1170,11 +1203,13 @@ function StepShell({
   title,
   description,
   onBack,
+  backDisabled = false,
   children,
 }: {
   readonly title: string;
   readonly description?: string;
   readonly onBack?: () => void;
+  readonly backDisabled?: boolean;
   readonly children?: React.ReactNode;
 }) {
   return (
@@ -1182,6 +1217,7 @@ function StepShell({
       {onBack ? (
         <Button
           className="mb-5 -ml-2 text-white/55 hover:text-white"
+          disabled={backDisabled}
           onClick={onBack}
           size="xs"
           variant="ghost-muted"

--- a/apps/web/src/onboarding/projectImport.logic.test.ts
+++ b/apps/web/src/onboarding/projectImport.logic.test.ts
@@ -1,7 +1,7 @@
-import type { AgentSessionProjectCandidate } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId, type AgentSessionProjectCandidate } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { partitionOnboardingProjects } from "./projectImport.logic";
+import { partitionOnboardingProjects, resolveOnboardingProjectId } from "./projectImport.logic";
 
 const now = Date.parse("2026-08-22T12:00:00.000Z");
 
@@ -21,28 +21,13 @@ function candidate(
 }
 
 describe("partitionOnboardingProjects", () => {
-  it("separates already imported projects from available projects", () => {
+  it("keeps existing projects available for thread history import", () => {
     const imported = candidate("/projects/current", { alreadyImported: true });
     const available = candidate("/projects/other");
 
     expect(partitionOnboardingProjects([imported, available], now)).toEqual({
-      available: [available],
-      recent: [available],
-      alreadyImportedCount: 1,
-    });
-  });
-
-  it("distinguishes an imported-only scan from a scan with no projects", () => {
-    expect(
-      partitionOnboardingProjects([candidate("/projects/current", { alreadyImported: true })], now),
-    ).toMatchObject({
-      available: [],
-      alreadyImportedCount: 1,
-    });
-
-    expect(partitionOnboardingProjects([], now)).toMatchObject({
-      available: [],
-      alreadyImportedCount: 0,
+      available: [imported, available],
+      recent: [imported, available],
     });
   });
 
@@ -55,7 +40,95 @@ describe("partitionOnboardingProjects", () => {
     expect(partitionOnboardingProjects([recent, older], now)).toEqual({
       available: [recent, older],
       recent: [recent],
-      alreadyImportedCount: 0,
     });
+  });
+});
+
+describe("resolveOnboardingProjectId", () => {
+  const localEnvironmentId = EnvironmentId.make("local");
+  const remoteEnvironmentId = EnvironmentId.make("remote");
+  const localProjectId = ProjectId.make("local-project");
+
+  it("finds an existing project by normalized root in the target environment", () => {
+    expect(
+      resolveOnboardingProjectId(
+        [
+          {
+            id: ProjectId.make("remote-project"),
+            environmentId: remoteEnvironmentId,
+            workspaceRoot: "C:\\Work\\Repo",
+          },
+          {
+            id: localProjectId,
+            environmentId: localEnvironmentId,
+            workspaceRoot: "C:\\Work\\Repo\\",
+          },
+        ],
+        localEnvironmentId,
+        "c:/work/repo",
+      ),
+    ).toBe(localProjectId);
+  });
+
+  it("does not reuse a project from another environment", () => {
+    expect(
+      resolveOnboardingProjectId(
+        [
+          {
+            id: ProjectId.make("remote-project"),
+            environmentId: remoteEnvironmentId,
+            workspaceRoot: "/projects/repo",
+          },
+        ],
+        localEnvironmentId,
+        "/projects/repo",
+      ),
+    ).toBeNull();
+  });
+
+  it("uses a live scanner project hint when the candidate path is an alias", () => {
+    expect(
+      resolveOnboardingProjectId(
+        [
+          {
+            id: localProjectId,
+            environmentId: localEnvironmentId,
+            workspaceRoot: "/real/projects/repo",
+          },
+        ],
+        localEnvironmentId,
+        "/linked/projects/repo",
+        localProjectId,
+      ),
+    ).toBe(localProjectId);
+  });
+
+  it("prefers the current root owner over a stale scanner hint", () => {
+    const recreatedProjectId = ProjectId.make("recreated-project");
+    expect(
+      resolveOnboardingProjectId(
+        [
+          {
+            id: localProjectId,
+            environmentId: localEnvironmentId,
+            workspaceRoot: "/projects/other",
+          },
+          {
+            id: recreatedProjectId,
+            environmentId: localEnvironmentId,
+            workspaceRoot: "/projects/repo",
+          },
+        ],
+        localEnvironmentId,
+        "/projects/repo",
+        localProjectId,
+      ),
+    ).toBe(recreatedProjectId);
+  });
+
+  it("ignores a scanner hint after its project was deleted", () => {
+    expect(
+      resolveOnboardingProjectId([], localEnvironmentId, "/linked/projects/repo", localProjectId),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/onboarding/projectImport.logic.ts
+++ b/apps/web/src/onboarding/projectImport.logic.ts
@@ -1,21 +1,43 @@
-import type { AgentSessionProjectCandidate } from "@t3tools/contracts";
+import { findProjectByPath } from "@t3tools/client-runtime/state/projects";
+import type { AgentSessionProjectCandidate, EnvironmentId, ProjectId } from "@t3tools/contracts";
 
 const RECENT_PROJECT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
-/** Keep imported projects visible to the empty-state decision without offering them twice. */
+/** Existing projects still need their agent history imported, so every scan candidate is offered. */
 export function partitionOnboardingProjects(
   candidates: ReadonlyArray<AgentSessionProjectCandidate>,
   now = Date.now(),
 ) {
-  const available = candidates.filter((candidate) => !candidate.alreadyImported);
   const cutoff = now - RECENT_PROJECT_WINDOW_MS;
 
   return {
-    available,
-    recent: available.filter(
+    available: candidates,
+    recent: candidates.filter(
       (candidate) =>
         candidate.lastActiveAt !== null && Date.parse(candidate.lastActiveAt) >= cutoff,
     ),
-    alreadyImportedCount: candidates.length - available.length,
   };
+}
+
+/** Resolve the active project for a scanned root. This recovers retries after a project was created. */
+export function resolveOnboardingProjectId(
+  projects: ReadonlyArray<{
+    readonly id: ProjectId;
+    readonly environmentId: EnvironmentId;
+    readonly workspaceRoot: string;
+  }>,
+  environmentId: EnvironmentId,
+  workspaceRoot: string,
+  scannedProjectId?: ProjectId,
+): ProjectId | null {
+  const environmentProjects = projects.filter((project) => project.environmentId === environmentId);
+  const currentRootMatch = findProjectByPath(environmentProjects, workspaceRoot);
+  if (currentRootMatch !== undefined) return currentRootMatch.id;
+  if (
+    scannedProjectId !== undefined &&
+    environmentProjects.some((project) => project.id === scannedProjectId)
+  ) {
+    return scannedProjectId;
+  }
+  return null;
 }

--- a/apps/web/src/state/agentSessions.ts
+++ b/apps/web/src/state/agentSessions.ts
@@ -1,5 +1,8 @@
 import { WS_METHODS } from "@t3tools/contracts";
-import { createEnvironmentRpcQueryAtomFamily } from "@t3tools/client-runtime/state/runtime";
+import {
+  createEnvironmentRpcCommand,
+  createEnvironmentRpcQueryAtomFamily,
+} from "@t3tools/client-runtime/state/runtime";
 
 import { connectionAtomRuntime } from "../connection/runtime";
 
@@ -14,4 +17,9 @@ export const agentSessionScan = createEnvironmentRpcQueryAtomFamily(connectionAt
   tag: WS_METHODS.agentSessionsScan,
   staleTimeMs: 30_000,
   idleTtlMs: 5 * 60_000,
+});
+
+export const agentSessionImport = createEnvironmentRpcCommand(connectionAtomRuntime, {
+  label: "environment-data:agent-sessions:import",
+  tag: WS_METHODS.agentSessionsImport,
 });

--- a/docs/user/welcome-wizard.md
+++ b/docs/user/welcome-wizard.md
@@ -24,5 +24,8 @@ T3 Code finds directories that Claude Code or Codex has used. The default
 selection includes projects active within the last 30 days. Select **Choose**
 to include older projects or change the selection.
 
+Imported projects include Codex and Claude conversations active within the last
+30 days. You can continue those conversations in T3 Code.
+
 You can skip agent setup and project import. Select **Back** to return to a
 previous step.

--- a/docs/user/welcome-wizard.md
+++ b/docs/user/welcome-wizard.md
@@ -29,8 +29,8 @@ Imported projects include Codex and Claude conversations active within the last
 
 Conversation import is best effort. T3 Code keeps up to 200 recent visible user
 and assistant messages. It omits tool activity, attachments, and injected setup
-context. It ignores malformed records and skips unreadable, oversized, or
-unparseable conversations.
+context. It reads one conversation at a time and skips files larger than 16 MB.
+It ignores malformed records and skips unreadable or unparseable conversations.
 
 You can skip agent setup and project import. Select **Back** to return to a
 previous step.

--- a/docs/user/welcome-wizard.md
+++ b/docs/user/welcome-wizard.md
@@ -27,5 +27,10 @@ to include older projects or change the selection.
 Imported projects include Codex and Claude conversations active within the last
 30 days. You can continue those conversations in T3 Code.
 
+Conversation import is best effort. T3 Code keeps up to 200 recent visible user
+and assistant messages. It omits tool activity, attachments, and injected setup
+context. It ignores malformed records and skips unreadable, oversized, or
+unparseable conversations.
+
 You can skip agent setup and project import. Select **Back** to return to a
 previous step.

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -848,6 +848,59 @@ describe("applyThreadDetailEvent", () => {
   });
 
   describe("thread.reverted", () => {
+    it("keeps imported history and removes the first live prompt at checkpoint zero", () => {
+      const threadWithImportedHistory: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("import:codex:session-1:000000"),
+            role: "user",
+            text: "Imported prompt",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedAt: "2026-03-01T00:00:00.000Z",
+          },
+          {
+            id: MessageId.make("import:codex:session-1:000001"),
+            role: "assistant",
+            text: "Imported answer",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-03-01T00:01:00.000Z",
+            updatedAt: "2026-03-01T00:01:00.000Z",
+          },
+          {
+            id: MessageId.make("live-user-message"),
+            role: "user",
+            text: "New work",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(threadWithImportedHistory, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T02:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: { threadId: ThreadId.make("thread-1"), turnCount: 0 },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.text)).toEqual([
+          "Imported prompt",
+          "Imported answer",
+        ]);
+      }
+    });
+
     it("filters entities to retained turns", () => {
       const threadWithData: OrchestrationThread = {
         ...baseThread,

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -12,6 +12,7 @@ import type {
   OrchestrationThreadActivity,
   TurnId,
 } from "@t3tools/contracts";
+import { isImportedAgentSessionMessageId } from "@t3tools/contracts";
 
 export type ThreadDetailReducerResult =
   | { readonly kind: "updated"; readonly thread: OrchestrationThread }
@@ -525,7 +526,11 @@ export function applyThreadDetailEvent(
       );
 
       const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(thread.messages, retainedTurnIds);
+      const messages = retainMessagesAfterRevert(
+        thread.messages,
+        retainedTurnIds,
+        event.payload.turnCount,
+      );
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -657,16 +662,41 @@ function rebindCheckpointAssistantMessage(
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
+  turnCount: number,
 ): OrchestrationMessage[] {
-  // Keep messages that belong to a retained turn, plus system messages and
-  // messages without a turn binding (pre-turn-0 user messages).
-  return Arr.filter(messages, (message) => {
-    if (message.role === "system") {
-      return true;
+  const retainedMessageIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role === "system" || isImportedAgentSessionMessageId(message.id)) {
+      retainedMessageIds.add(message.id);
+    } else if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
+      retainedMessageIds.add(message.id);
     }
-    if (message.turnId === null) {
-      return true;
+  }
+
+  for (const role of ["user", "assistant"] as const) {
+    const retainedCount = messages.filter(
+      (message) =>
+        message.role === role &&
+        !isImportedAgentSessionMessageId(message.id) &&
+        retainedMessageIds.has(message.id),
+    ).length;
+    const missingCount = Math.max(0, turnCount - retainedCount);
+    const fallbackMessages = messages
+      .filter(
+        (message) =>
+          message.role === role &&
+          !retainedMessageIds.has(message.id) &&
+          (message.turnId === null || retainedTurnIds.has(message.turnId)),
+      )
+      .toSorted(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .slice(0, missingCount);
+    for (const message of fallbackMessages) {
+      retainedMessageIds.add(message.id);
     }
-    return retainedTurnIds.has(message.turnId);
-  });
+  }
+
+  return Arr.filter(messages, (message) => retainedMessageIds.has(message.id));
 }

--- a/packages/contracts/src/agentSessions.ts
+++ b/packages/contracts/src/agentSessions.ts
@@ -5,6 +5,11 @@ import { IsoDateTime, NonNegativeInt, ProjectId, TrimmedNonEmptyString } from ".
 export const AgentSessionSource = Schema.Literals(["claudeAgent", "codex"]);
 export type AgentSessionSource = typeof AgentSessionSource.Type;
 
+/** Imported message ids retain their origin after event metadata is projected into SQLite. */
+export function isImportedAgentSessionMessageId(messageId: string): boolean {
+  return messageId.startsWith("import:");
+}
+
 /**
  * Empty for now. Kept as a struct so future scan options (source filters,
  * explicit roots) can be added without a new method.

--- a/packages/contracts/src/agentSessions.ts
+++ b/packages/contracts/src/agentSessions.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { IsoDateTime, NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { IsoDateTime, NonNegativeInt, ProjectId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 /** Coding agent home directories the scanner knows how to read. */
 export const AgentSessionSource = Schema.Literals(["claudeAgent", "codex"]);
@@ -32,6 +32,18 @@ export const AgentSessionScanResult = Schema.Struct({
   scannedAt: IsoDateTime,
 });
 export type AgentSessionScanResult = typeof AgentSessionScanResult.Type;
+
+export const AgentSessionImportInput = Schema.Struct({
+  projectId: ProjectId,
+  workspaceRoot: TrimmedNonEmptyString,
+});
+export type AgentSessionImportInput = typeof AgentSessionImportInput.Type;
+
+export const AgentSessionImportResult = Schema.Struct({
+  importedCount: NonNegativeInt,
+  skippedCount: NonNegativeInt,
+});
+export type AgentSessionImportResult = typeof AgentSessionImportResult.Type;
 
 export class AgentSessionScanError extends Schema.TaggedErrorClass<AgentSessionScanError>()(
   "AgentSessionScanError",

--- a/packages/contracts/src/agentSessions.ts
+++ b/packages/contracts/src/agentSessions.ts
@@ -25,6 +25,7 @@ export type AgentSessionScanInput = typeof AgentSessionScanInput.Type;
 export const AgentSessionProjectCandidate = Schema.Struct({
   path: TrimmedNonEmptyString,
   title: TrimmedNonEmptyString,
+  projectId: Schema.optional(ProjectId),
   sources: Schema.Array(AgentSessionSource),
   threadCount: NonNegativeInt,
   lastActiveAt: Schema.NullOr(IsoDateTime),
@@ -40,9 +41,17 @@ export type AgentSessionScanResult = typeof AgentSessionScanResult.Type;
 
 export const AgentSessionImportInput = Schema.Struct({
   projectId: ProjectId,
-  workspaceRoot: TrimmedNonEmptyString,
 });
 export type AgentSessionImportInput = typeof AgentSessionImportInput.Type;
+
+export class AgentSessionImportProjectNotFoundError extends Schema.TaggedErrorClass<AgentSessionImportProjectNotFoundError>()(
+  "AgentSessionImportProjectNotFoundError",
+  { projectId: ProjectId },
+) {
+  override get message(): string {
+    return `Project '${this.projectId}' does not exist.`;
+  }
+}
 
 export const AgentSessionImportResult = Schema.Struct({
   importedCount: NonNegativeInt,

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -1016,6 +1016,21 @@ it.effect("project favicon overrides accept only supported image files", () =>
   }),
 );
 
+it.effect("rejects thread history imports without messages", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.exit(
+      decodeOrchestrationCommand({
+        type: "thread.history.import",
+        commandId: "command-empty-history",
+        threadId: "thread-1",
+        messages: [],
+      }),
+    );
+
+    assert.strictEqual(result._tag, "Failure");
+  }),
+);
+
 it("isProviderSendTurnSupportedImageMimeType accepts raster formats and rejects svg", () => {
   assert.strictEqual(isProviderSendTurnSupportedImageMimeType("image/png"), true);
   assert.strictEqual(isProviderSendTurnSupportedImageMimeType("IMAGE/JPEG"), true);

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1025,7 +1025,7 @@ const ThreadHistoryImportCommand = Schema.Struct({
       text: Schema.String,
       createdAt: IsoDateTime,
     }),
-  ),
+  ).check(Schema.isNonEmpty()),
 });
 
 const ThreadProposedPlanUpsertCommand = Schema.Struct({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1014,6 +1014,20 @@ const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadHistoryImportCommand = Schema.Struct({
+  type: Schema.Literal("thread.history.import"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  messages: Schema.Array(
+    Schema.Struct({
+      messageId: MessageId,
+      role: Schema.Literals(["user", "assistant"]),
+      text: Schema.String,
+      createdAt: IsoDateTime,
+    }),
+  ),
+});
+
 const ThreadProposedPlanUpsertCommand = Schema.Struct({
   type: Schema.Literal("thread.proposed-plan.upsert"),
   commandId: CommandId,
@@ -1064,6 +1078,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadSessionSetCommand,
   ThreadMessageAssistantDeltaCommand,
   ThreadMessageAssistantCompleteCommand,
+  ThreadHistoryImportCommand,
   ThreadProposedPlanUpsertCommand,
   ThreadTurnDiffCompleteCommand,
   ThreadActivityAppendCommand,
@@ -1361,6 +1376,7 @@ export const OrchestrationEventMetadata = Schema.Struct({
   adapterKey: Schema.optional(TrimmedNonEmptyString),
   requestId: Schema.optional(ApprovalRequestId),
   ingestedAt: Schema.optional(IsoDateTime),
+  historyImport: Schema.optional(Schema.Boolean),
   origin: Schema.optional(OrchestrationClientOrigin),
 });
 export type OrchestrationEventMetadata = typeof OrchestrationEventMetadata.Type;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -19,6 +19,8 @@ import {
   FilesystemBrowseError,
 } from "./filesystem.ts";
 import {
+  AgentSessionImportInput,
+  AgentSessionImportResult,
   AgentSessionScanInput,
   AgentSessionScanResult,
   AgentSessionScanError,
@@ -228,6 +230,7 @@ export const WS_METHODS = {
   // Filesystem methods
   filesystemBrowse: "filesystem.browse",
   agentSessionsScan: "agentSessions.scan",
+  agentSessionsImport: "agentSessions.import",
   assetsCreateUrl: "assets.createUrl",
   attachmentsCreateUploadUrl: "attachments.createUploadUrl",
   attachmentsDelete: "attachments.delete",
@@ -689,6 +692,12 @@ export const WsAgentSessionsScanRpc = Rpc.make(WS_METHODS.agentSessionsScan, {
   error: Schema.Union([AgentSessionScanError, EnvironmentAuthorizationError]),
 });
 
+export const WsAgentSessionsImportRpc = Rpc.make(WS_METHODS.agentSessionsImport, {
+  payload: AgentSessionImportInput,
+  success: AgentSessionImportResult,
+  error: Schema.Union([AgentSessionScanError, EnvironmentAuthorizationError]),
+});
+
 export const WsAssetsCreateUrlRpc = Rpc.make(WS_METHODS.assetsCreateUrl, {
   payload: AssetCreateUrlInput,
   success: AssetCreateUrlResult,
@@ -1081,6 +1090,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
   WsAgentSessionsScanRpc,
+  WsAgentSessionsImportRpc,
   WsAssetsCreateUrlRpc,
   WsAttachmentsCreateUploadUrlRpc,
   WsAttachmentsDeleteRpc,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -20,6 +20,7 @@ import {
 } from "./filesystem.ts";
 import {
   AgentSessionImportInput,
+  AgentSessionImportProjectNotFoundError,
   AgentSessionImportResult,
   AgentSessionScanInput,
   AgentSessionScanResult,
@@ -695,7 +696,11 @@ export const WsAgentSessionsScanRpc = Rpc.make(WS_METHODS.agentSessionsScan, {
 export const WsAgentSessionsImportRpc = Rpc.make(WS_METHODS.agentSessionsImport, {
   payload: AgentSessionImportInput,
   success: AgentSessionImportResult,
-  error: Schema.Union([AgentSessionScanError, EnvironmentAuthorizationError]),
+  error: Schema.Union([
+    AgentSessionImportProjectNotFoundError,
+    AgentSessionScanError,
+    EnvironmentAuthorizationError,
+  ]),
 });
 
 export const WsAssetsCreateUrlRpc = Rpc.make(WS_METHODS.assetsCreateUrl, {


### PR DESCRIPTION
Project onboarding discovers existing Codex and Claude projects, but leaves their conversations behind.

Import threads active within the last 30 days with their visible messages and provider resume state. Malformed or oversized sessions are skipped, custom provider accounts stay matched, and imported history does not create Git checkpoints.

Focused scanner, importer, orchestration, projection, relay, onboarding, and server RPC tests passed. Scoped type checks also passed for server, web, desktop, mobile, contracts, and client-runtime. No browser or native-client verification was run.

Made by GPT-5.6 Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration commands, projections, provider runtime persistence, and onboarding import retries; mistakes could corrupt thread state or clobber live provider bindings, though idempotency and on-conflict-ignore paths are heavily tested.
> 
> **Overview**
> Onboarding and a new **`agentSessionsImport`** RPC now pull in **Codex and Claude conversations from the last 30 days**, not just project roots. The server scans JSONL transcripts (size-capped, parsed for visible user/assistant text), then **`importRecentAgentThreads`** creates or reuses threads, dispatches **`thread.history.import`**, and stores provider resume bindings without overwriting an active session.
> 
> Imported history is modeled as **`thread.message-sent`** events tagged with **`historyImport`**, followed by **`thread.settled`**. That path skips Git checkpoints, does not mark threads as queued work in projections, and is excluded from agent-awareness “settled” notifications. **`isImportedAgentSessionMessageId`** keeps imported messages across reverts and out of live turn/queue logic on server and client.
> 
> The welcome wizard **creates projects idempotently** (stable command IDs and path resolution) and runs thread import after each project; scan candidates can include **`projectId`** for already-imported workspaces so history can still be backfilled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52aeac1a90eb7a512d5ebf880fdf856e43d130fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Import recent Codex and Claude threads during onboarding
> - Scanner discovers transcripts from Claude and Codex home directories within a 30-day window, parses JSONL into normalized threads, and deduplicates by provider instance and session ID
> - `importRecentAgentThreads` creates missing orchestration threads, imports historical messages, and persists provider-session bindings; per-thread failures are logged and skipped
> - New `thread.history.import` orchestration command emits `thread.message-sent` events with `metadata.historyImport=true` then a `thread.settled` event; only allowed on active, empty threads
> - Imported messages are excluded from queued-turn detection, checkpoint creation, agent awareness relay publishing, and turn-count balancing during reverts
> - Risk: `partitionOnboardingProjects` in [projectImport.logic.ts](https://github.com/pingdotgg/t3code/pull/8066/files#diff-6ea4fcf4f3f52a6b44f0530024b2b907bbbf724a61f85150766a8bfae40923dd) no longer returns `alreadyImportedCount` and includes already-imported projects in available/recent sets; `ProviderSessionDirectory.upsert` and `ProviderSessionRuntimeRepository.upsert` gain an optional `options` parameter
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52aeac1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->