### PR TITLE
fix(web): stop draft hero banners overlapping the composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6780,7 +6780,8 @@ function ChatViewContent(props: ChatViewProps) {
                         />
                       </div>
                       <ComposerBannerStack
-                        className="relative z-0 chat-composer-drawer-detached"
+                        className="relative z-0"
+                        detached
                         items={composerBannerItems}
                       />
                     </div>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6779,7 +6779,10 @@ function ChatViewContent(props: ChatViewProps) {
                           activeProjectTitle={activeProject?.title ?? null}
                         />
                       </div>
-                      <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
+                      <ComposerBannerStack
+                        className="relative z-0 [--chat-composer-attachment-overlap:0px]"
+                        items={composerBannerItems}
+                      />
                     </div>
                   ) : (
                     <ComposerBannerStack className="relative z-0" items={composerBannerItems} />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6780,7 +6780,7 @@ function ChatViewContent(props: ChatViewProps) {
                         />
                       </div>
                       <ComposerBannerStack
-                        className="relative z-0 [--chat-composer-attachment-overlap:0px]"
+                        className="relative z-0 chat-composer-drawer-detached"
                         items={composerBannerItems}
                       />
                     </div>

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -53,8 +53,9 @@ interface ComposerBannerStackProps {
   readonly className?: string;
   readonly items: ReadonlyArray<ComposerBannerStackItem>;
   // Hero layout floats the stack above the composer instead of docking onto
-  // it: the front banner renders with the detached glass treatment and the
-  // slot drops its attached negative margin.
+  // it: the slot drops its attached negative margin and the front banner
+  // keeps its surface but reads the overlap as zero, so it sits flush on
+  // the composer without the seam pull-down.
   readonly detached?: boolean;
 }
 
@@ -145,7 +146,7 @@ export function ComposerBannerStack({
         >
           <ComposerBannerStackAlert
             item={frontItem}
-            attached={!detached}
+            attached
             exiting={exitingItemId === frontItem.id}
             onDismissRequest={() => requestDismiss(frontItem)}
           />

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -52,9 +52,17 @@ export interface ComposerBannerStackItem {
 interface ComposerBannerStackProps {
   readonly className?: string;
   readonly items: ReadonlyArray<ComposerBannerStackItem>;
+  // Hero layout floats the stack above the composer instead of docking onto
+  // it: the front banner renders with the detached glass treatment and the
+  // slot drops its attached negative margin.
+  readonly detached?: boolean;
 }
 
-export function ComposerBannerStack({ className, items }: ComposerBannerStackProps) {
+export function ComposerBannerStack({
+  className,
+  items,
+  detached = false,
+}: ComposerBannerStackProps) {
   const [requestedExitingItemId, setExitingItemId] = useState<string | null>(null);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const exitingItemId =
@@ -99,7 +107,11 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
 
   return (
     <div
-      className={cn("group/banner-stack chat-composer-drawer-slot", className)}
+      className={cn(
+        "group/banner-stack chat-composer-drawer-slot",
+        detached && "chat-composer-drawer-detached",
+        className,
+      )}
       data-composer-banner-drawer="true"
     >
       <div
@@ -133,7 +145,7 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
         >
           <ComposerBannerStackAlert
             item={frontItem}
-            attached
+            attached={!detached}
             exiting={exitingItemId === frontItem.id}
             onDismissRequest={() => requestDismiss(frontItem)}
           />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -884,6 +884,15 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     margin-bottom: calc(-1 * var(--chat-composer-attachment-overlap));
   }
 
+  /* Detached drawers (draft hero banners) float above the composer instead of
+     merging with it, so the attachment overlap must read as zero everywhere:
+     on the slot for its negative margin and on the drawer surface, which
+     re-declares the variable for its seam padding and glass. */
+  .chat-composer-drawer-detached,
+  .chat-composer-drawer-detached .chat-composer-drawer-surface {
+    --chat-composer-attachment-overlap: 0px;
+  }
+
   :is(.chat-composer-drawer-surface, .chat-composer-top-drawer)::before {
     pointer-events: none;
     position: absolute;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -884,9 +884,12 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     margin-bottom: calc(-1 * var(--chat-composer-attachment-overlap));
   }
 
-  /* Detached drawers (draft hero banners) float above the composer instead of
-     merging with it, so the slot must drop its attached negative margin. */
-  .chat-composer-drawer-detached {
+  /* Detached drawers (draft hero banners) sit flush on the composer instead
+     of being pulled into it, so the attachment overlap must read as zero
+     everywhere: on the slot for its negative margin and on the drawer
+     surface, which re-declares the variable for its seam padding. */
+  .chat-composer-drawer-detached,
+  .chat-composer-drawer-detached .chat-composer-drawer-surface {
     --chat-composer-attachment-overlap: 0px;
   }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -885,11 +885,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 
   /* Detached drawers (draft hero banners) float above the composer instead of
-     merging with it, so the attachment overlap must read as zero everywhere:
-     on the slot for its negative margin and on the drawer surface, which
-     re-declares the variable for its seam padding and glass. */
-  .chat-composer-drawer-detached,
-  .chat-composer-drawer-detached .chat-composer-drawer-surface {
+     merging with it, so the slot must drop its attached negative margin. */
+  .chat-composer-drawer-detached {
     --chat-composer-attachment-overlap: 0px;
   }
 


### PR DESCRIPTION
## Problem

In the draft hero layout (new thread, no messages yet), the composer banner stack floats above the composer instead of sitting directly on it. It still carried the drawer attachment styles, whose negative bottom margin derived from `--chat-composer-attachment-overlap` pulled the banner 17px down into the composer input, so banners collided with the input instead of stacking cleanly above it.

## Solution

Express detachment as a `detached` prop on `ComposerBannerStack`. The detached slot gets a `chat-composer-drawer-detached` class whose CSS rule zeroes `--chat-composer-attachment-overlap` for both the slot and its drawer surface (the surface re-declares the variable for its seam padding). The banner keeps the attached surface styling and sits flush on the composer — reading as part of the composer field rather than a floating card — but without the 17px pull-down or dead seam padding. The docked banner stack is untouched.

## Before

![Before: the composer overlaps the bottom of the hero banner](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/2b25631e-d6bf-40b2-83f6-865516da115d/before-seam.png)

## After

![After: the hero banner sits flush on the composer with no overlap](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/b5e44368-ec32-4b31-aada-cfaac7f91821/after-seam.png)

Side by side:

![Before and after side by side](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/bf2a8fd6-14ab-4ea5-8d97-0afdf9eba24e/before-after.png)

Captured in a real client (draft hero view with a live "Server update available" composer banner): before shows the banner 17px inside the composer with its seam padding doubled; after shows 0px overlap, normal padding, and the banner flush on the composer. The flush attached look is intentional maintainer preference.

Made by ox-alpha (stealth/ox-alpha via OpenRouter) in T3 Code.