### PR TITLE
fix(marketing): stop automatic Vercel deployments on pull requests

### DIFF
--- a/apps/marketing/vercel.ts
+++ b/apps/marketing/vercel.ts
@@ -1,6 +1,9 @@
 import type { VercelConfig } from "@vercel/config/v1";
 
 export const config: VercelConfig = {
+  git: {
+    deploymentEnabled: false,
+  },
   installCommand: "npm install -g vite-plus && vp install --filter '@t3tools/marketing...'",
   buildCommand: "vp run --filter @t3tools/marketing build",
   outputDirectory: "dist",


### PR DESCRIPTION
Vercel marks pull requests as failed when it tries to deploy the marketing site, even when those changes do not need a marketing deployment.

Disable automatic Git deployments for the marketing project, matching the existing hosted web configuration. Manual deployments still work.

Model: GPT-5.6 Sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line Vercel config change with no application, auth, or data-handling impact. Manual deploys remain available.
> 
> **Overview**
> Turns off automatic Git-triggered Vercel deploys for the marketing site so unrelated PRs no longer fail when Vercel tries to build it.
> 
> Sets `git.deploymentEnabled: false` in `apps/marketing/vercel.ts`, matching the hosted web project. Manual deployments still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec102c37fcb46f90f74864cf276682d0dd63f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable automatic Vercel deployments on pull requests in `marketing`
> Adds a `git.deploymentEnabled: false` field to the exported `VercelConfig` in [vercel.ts](https://github.com/pingdotgg/t3code/pull/8070/files#diff-435ec5ba13a75287fc98a303dc901dfc678232099ac7aa4abc66f0056d53b06f). This stops Vercel from auto-deploying preview builds for Git events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ec102c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->