### PR TITLE
feat(mobile): rename a thread from the thread list menu

### DIFF
--- a/apps/mobile/src/components/ConfirmDialogHost.tsx
+++ b/apps/mobile/src/components/ConfirmDialogHost.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Modal, Pressable, View } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 
 import { useThemeColor } from "../lib/useThemeColor";
 import { cn } from "../lib/cn";
-import { AppText } from "./AppText";
+import { AppText, AppTextInput as TextInput } from "./AppText";
 
 export type ConfirmDialogRequest = {
   readonly title: string;
@@ -15,7 +16,24 @@ export type ConfirmDialogRequest = {
   readonly onCancel?: () => void;
 };
 
-let presentRequest: ((request: ConfirmDialogRequest) => void) | null = null;
+export type PromptDialogRequest = {
+  readonly title: string;
+  readonly message?: string;
+  readonly placeholder?: string;
+  /** Prefills the field and is selected on open, so typing replaces it. */
+  readonly initialValue?: string;
+  readonly cancelText?: string;
+  readonly confirmText: string;
+  /** Receives the raw field text; the caller owns trimming and no-op rules. */
+  readonly onConfirm: (value: string) => void;
+  readonly onCancel?: () => void;
+};
+
+type DialogRequest =
+  | { readonly kind: "confirm"; readonly request: ConfirmDialogRequest }
+  | { readonly kind: "prompt"; readonly request: PromptDialogRequest };
+
+let presentDialog: ((dialog: DialogRequest) => void) | null = null;
 
 /**
  * Imperative confirm dialog, Alert.alert-shaped. Native iOS alerts already
@@ -24,7 +42,16 @@ let presentRequest: ((request: ConfirmDialogRequest) => void) | null = null;
  * once. Requires ConfirmDialogHost to be mounted at the app root.
  */
 export function showConfirmDialog(request: ConfirmDialogRequest): void {
-  presentRequest?.(request);
+  presentDialog?.({ kind: "confirm", request });
+}
+
+/**
+ * Imperative single-field text prompt. Unlike showConfirmDialog this is the
+ * only option on both platforms: Alert.prompt is iOS-only. Confirm stays
+ * disabled while the field is blank. Requires ConfirmDialogHost at the root.
+ */
+export function showPromptDialog(request: PromptDialogRequest): void {
+  presentDialog?.({ kind: "prompt", request });
 }
 
 /**
@@ -34,77 +61,108 @@ export function showConfirmDialog(request: ConfirmDialogRequest): void {
  * button color and a dimmer message than the title.
  */
 export function ConfirmDialogHost() {
-  const [request, setRequest] = useState<ConfirmDialogRequest | null>(null);
+  const [dialog, setDialog] = useState<DialogRequest | null>(null);
+  const [draft, setDraft] = useState("");
   const pressedOverlay = useThemeColor("--color-subtle");
 
   useEffect(() => {
-    presentRequest = setRequest;
+    presentDialog = (next) => {
+      setDialog(next);
+      setDraft(next.kind === "prompt" ? (next.request.initialValue ?? "") : "");
+    };
     return () => {
-      presentRequest = null;
+      presentDialog = null;
     };
   }, []);
 
   const handleCancel = useCallback(() => {
-    request?.onCancel?.();
-    setRequest(null);
-  }, [request]);
+    dialog?.request.onCancel?.();
+    setDialog(null);
+  }, [dialog]);
+
+  const confirmDisabled = dialog?.kind === "prompt" && draft.trim().length === 0;
 
   const handleConfirm = useCallback(() => {
-    request?.onConfirm();
-    setRequest(null);
-  }, [request]);
+    if (dialog === null) return;
+    if (dialog.kind === "prompt") {
+      if (draft.trim().length === 0) return;
+      dialog.request.onConfirm(draft);
+    } else {
+      dialog.request.onConfirm();
+    }
+    setDialog(null);
+  }, [dialog, draft]);
 
   return (
     <Modal
-      visible={request !== null}
+      visible={dialog !== null}
       transparent
       animationType="fade"
       statusBarTranslucent
       navigationBarTranslucent
       onRequestClose={handleCancel}
     >
-      {request === null ? null : (
-        <View className="flex-1 items-center justify-center bg-backdrop px-8">
-          <View className="w-full rounded-[24px] bg-card px-6 pb-4 pt-5">
-            <AppText className="text-lg font-t3-medium">{request.title}</AppText>
-            {request.message === undefined ? null : (
-              <AppText className="mt-2 text-sm text-foreground-secondary">
-                {request.message}
-              </AppText>
-            )}
-            <View className="mt-5 flex-row justify-end gap-1">
-              <View className="overflow-hidden rounded-full">
-                <Pressable
-                  accessibilityRole="button"
-                  className="min-h-10 items-center justify-center px-4"
-                  android_ripple={{ color: pressedOverlay }}
-                  onPress={handleCancel}
-                >
-                  <AppText className="text-base font-t3-medium">
-                    {request.cancelText ?? "Cancel"}
-                  </AppText>
-                </Pressable>
-              </View>
-              <View className="overflow-hidden rounded-full">
-                <Pressable
-                  accessibilityRole="button"
-                  className="min-h-10 items-center justify-center px-4"
-                  android_ripple={{ color: pressedOverlay }}
-                  onPress={handleConfirm}
-                >
-                  <AppText
-                    className={cn(
-                      "text-base font-t3-medium",
-                      request.destructive && "text-danger-foreground",
-                    )}
+      {dialog === null ? null : (
+        <KeyboardAvoidingView automaticOffset behavior="padding" style={{ flex: 1 }}>
+          <View className="flex-1 items-center justify-center bg-backdrop px-8">
+            <View className="w-full rounded-[24px] bg-card px-6 pb-4 pt-5">
+              <AppText className="text-lg font-t3-medium">{dialog.request.title}</AppText>
+              {dialog.request.message === undefined ? null : (
+                <AppText className="mt-2 text-sm text-foreground-secondary">
+                  {dialog.request.message}
+                </AppText>
+              )}
+              {dialog.kind === "prompt" ? (
+                <TextInput
+                  autoFocus
+                  className="mt-4"
+                  onChangeText={setDraft}
+                  onSubmitEditing={handleConfirm}
+                  placeholder={dialog.request.placeholder}
+                  returnKeyType="done"
+                  selectTextOnFocus
+                  value={draft}
+                />
+              ) : null}
+              <View className="mt-5 flex-row justify-end gap-1">
+                <View className="overflow-hidden rounded-full">
+                  <Pressable
+                    accessibilityRole="button"
+                    className="min-h-10 items-center justify-center px-4"
+                    android_ripple={{ color: pressedOverlay }}
+                    onPress={handleCancel}
                   >
-                    {request.confirmText}
-                  </AppText>
-                </Pressable>
+                    <AppText className="text-base font-t3-medium">
+                      {dialog.request.cancelText ?? "Cancel"}
+                    </AppText>
+                  </Pressable>
+                </View>
+                <View className="overflow-hidden rounded-full">
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityState={{ disabled: confirmDisabled }}
+                    className="min-h-10 items-center justify-center px-4"
+                    android_ripple={{ color: pressedOverlay }}
+                    disabled={confirmDisabled}
+                    onPress={handleConfirm}
+                  >
+                    <AppText
+                      className={cn(
+                        "text-base font-t3-medium",
+                        dialog.kind === "confirm" &&
+                          dialog.request.destructive &&
+                          "text-danger-foreground",
+                        confirmDisabled && "text-foreground-muted",
+                      )}
+                    >
+                      {dialog.request.confirmText}
+                    </AppText>
+                  </Pressable>
+                </View>
               </View>
             </View>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       )}
     </Modal>
   );

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -47,6 +47,7 @@ export function HomeRouteScreen() {
     pinThread,
     unpinThread,
     movePinnedThread,
+    renameThread,
     regenerateThreadTitle,
     unsettleThread,
   } = useThreadListActions();
@@ -195,6 +196,7 @@ export function HomeRouteScreen() {
           onPinThread={pinThread}
           onUnpinThread={unpinThread}
           onMovePinnedThread={movePinnedThread}
+          onRenameThread={renameThread}
           onRegenerateThreadTitle={regenerateThreadTitle}
           onEnvironmentChange={setSelectedEnvironmentId}
           onProjectChange={setSelectedProjectKey}

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -117,6 +117,7 @@ interface HomeScreenProps {
     thread: EnvironmentThreadShell,
     direction: "up" | "down",
   ) => Promise<boolean>;
+  readonly onRenameThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => Promise<boolean>;
   readonly onSelectPendingTask: (pendingTask: PendingNewTask) => void;
   readonly onDeletePendingTask: (pendingTask: PendingNewTask) => void;
@@ -845,6 +846,7 @@ export function HomeScreen(props: HomeScreenProps) {
           onSelectThread={props.onSelectThread}
           onDeleteThread={handleDeleteThread}
           onArchiveThread={props.onArchiveThread}
+          onRenameThread={props.onRenameThread}
           onRegenerateThreadTitle={handleRegenerateThreadTitle}
           titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
           settlementSupported={settlementEnvironmentIds.has(thread.environmentId)}
@@ -1006,6 +1008,7 @@ export function HomeScreen(props: HomeScreenProps) {
               searchQuery={props.searchQuery}
               onArchiveThread={props.onArchiveThread}
               onDeleteThread={props.onDeleteThread}
+              onRenameThread={props.onRenameThread}
               onRegenerateThreadTitle={handleRegenerateThreadTitle}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
               onSelectThread={props.onSelectThread}

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -5,7 +5,7 @@ import * as Haptics from "expo-haptics";
 import { useCallback, useRef } from "react";
 import { Alert } from "react-native";
 
-import { showConfirmDialog } from "../../components/ConfirmDialogHost";
+import { showConfirmDialog, showPromptDialog } from "../../components/ConfirmDialogHost";
 import { scopedThreadKey } from "../../lib/scopedEntities";
 import { refreshArchivedThreadsForEnvironment } from "../archive/useArchivedThreadSnapshots";
 import {
@@ -236,6 +236,7 @@ export function useThreadListActions(): {
     thread: EnvironmentThreadShell,
     direction: "up" | "down",
   ) => Promise<boolean>;
+  readonly renameThread: (thread: EnvironmentThreadShell) => void;
   readonly regenerateThreadTitle: (thread: EnvironmentThreadShell) => Promise<boolean>;
 } {
   const executeAction = useThreadActionExecutor();
@@ -419,6 +420,45 @@ export function useThreadListActions(): {
     },
     [unpinMutation],
   );
+  /** Same commit rule as web's resolveRenameCommit: trim, drop an empty
+      title, and skip the write when nothing changed. */
+  const commitRename = useCallback(
+    async (thread: EnvironmentThreadShell, title: string) => {
+      const trimmed = title.trim();
+      if (trimmed.length === 0 || trimmed === thread.title) return;
+      selectionHaptic();
+      const result = await updateThreadMetadata({
+        environmentId: thread.environmentId,
+        input: { threadId: thread.id, title: trimmed },
+      });
+      if (result._tag === "Failure") {
+        const error = Cause.squash(result.cause);
+        Alert.alert(
+          "Could not rename thread",
+          error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : "The thread could not be renamed.",
+        );
+      }
+    },
+    [updateThreadMetadata],
+  );
+  /** Prompts for a new title, then writes it. Not capability-gated: every
+      server that accepts thread.meta.update accepts a manual title. */
+  const renameThread = useCallback(
+    (thread: EnvironmentThreadShell) => {
+      showPromptDialog({
+        title: "Rename thread",
+        confirmText: "Rename",
+        initialValue: thread.title,
+        placeholder: "Thread title",
+        onConfirm: (value) => {
+          void commitRename(thread, value);
+        },
+      });
+    },
+    [commitRename],
+  );
   const regenerateThreadTitle = useCallback(
     async (thread: EnvironmentThreadShell) => {
       const key = scopedThreadKey(thread.environmentId, thread.id);
@@ -552,6 +592,7 @@ export function useThreadListActions(): {
     pinThread,
     unpinThread,
     movePinnedThread,
+    renameThread,
     regenerateThreadTitle,
   };
 }

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -170,6 +170,7 @@ function ThreadNavigationSidebarPane(
     pinThread,
     unpinThread,
     movePinnedThread,
+    renameThread,
     regenerateThreadTitle,
   } = useThreadListActions();
   const threadListV2Enabled = useThreadListV2Enabled();
@@ -923,6 +924,7 @@ function ThreadNavigationSidebarPane(
               onSelectThread={handleSelectThread}
               onDeleteThread={confirmDeleteThread}
               onArchiveThread={archiveThread}
+              onRenameThread={renameThread}
               onRegenerateThreadTitle={regenerateThreadTitle}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
               settlementSupported={settlementEnvironmentIds.has(thread.environmentId)}
@@ -1044,6 +1046,7 @@ function ThreadNavigationSidebarPane(
               fullSwipeWidth={props.width - 20}
               onArchiveThread={archiveThread}
               onDeleteThread={confirmDeleteThread}
+              onRenameThread={renameThread}
               onRegenerateThreadTitle={regenerateThreadTitle}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
               onSelectThread={handleSelectThread}
@@ -1083,6 +1086,7 @@ function ThreadNavigationSidebarPane(
       projectCwdByKey,
       projectTitleByProjectKey,
       regenerateThreadTitle,
+      renameThread,
       props.onNewThreadInProject,
       props.searchQuery,
       props.selectedThreadKey,

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -415,6 +415,8 @@ const THREAD_ROW_MENU_ACTIONS: MenuAction[] = [
   { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
 ];
 
+const RENAME_MENU_ACTION = { id: "rename", title: "Rename", image: "pencil" } satisfies MenuAction;
+
 export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly variant: ThreadListVariant;
   readonly thread: EnvironmentThreadShell;
@@ -430,6 +432,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onArchiveThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onRenameThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly titleRegenerationSupported: boolean;
   readonly onSwipeableWillOpen: (methods: SwipeableMethods) => void;
@@ -454,8 +457,14 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const selectedBackgroundColor = useThemeColor("--color-user-bubble");
   const selectedForegroundColor = useThemeColor("--color-user-bubble-foreground");
 
-  const { thread, onSelectThread, onArchiveThread, onDeleteThread, onRegenerateThreadTitle } =
-    props;
+  const {
+    thread,
+    onSelectThread,
+    onArchiveThread,
+    onDeleteThread,
+    onRenameThread,
+    onRegenerateThreadTitle,
+  } = props;
   const status = resolveThreadStatus(thread);
   const pr = useThreadPr(thread, props.projectCwd);
   const timestamp = relativeTime(
@@ -481,6 +490,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
 
   const handleDelete = useCallback(() => onDeleteThread(thread), [onDeleteThread, thread]);
   const handleArchive = useCallback(() => onArchiveThread(thread), [onArchiveThread, thread]);
+  const handleRename = useCallback(() => onRenameThread(thread), [onRenameThread, thread]);
   const handleRegenerateTitle = useCallback(
     () => onRegenerateThreadTitle(thread),
     [onRegenerateThreadTitle, thread],
@@ -488,6 +498,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const menuActions = useMemo<MenuAction[]>(
     () => [
       THREAD_ROW_MENU_ACTIONS[0]!,
+      RENAME_MENU_ACTION,
       ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
         isRegenerating: thread.titleRegeneration != null,
@@ -508,10 +519,11 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
       if (nativeEvent.event === "archive") handleArchive();
+      if (nativeEvent.event === "rename") handleRename();
       if (nativeEvent.event === "regenerate-title") handleRegenerateTitle();
       if (nativeEvent.event === "delete") handleDelete();
     },
-    [handleArchive, handleDelete, handleRegenerateTitle],
+    [handleArchive, handleDelete, handleRegenerateTitle, handleRename],
   );
 
   const statusPill = effectiveStatus ? (

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -64,7 +64,9 @@ function threadTimeLabel(thread: EnvironmentThreadShell): string {
   return relativeTime(thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt);
 }
 
-// Menus keep lifecycle and title regeneration together. Archive keeps its
+const RENAME_MENU_ACTION = { id: "rename", title: "Rename", image: "pencil" } satisfies MenuAction;
+
+// Menus keep lifecycle and title actions together. Archive keeps its
 // own surface (thread screen / settings) rather than crowding v2 rows.
 const CARD_MENU_ACTIONS: MenuAction[] = [
   { id: "settle", title: "Settle", image: "checkmark" },
@@ -346,6 +348,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly fullSwipeWidth?: number;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onRenameThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly onSettleThread: (thread: EnvironmentThreadShell) => void;
   readonly onSnoozeThread: (thread: EnvironmentThreadShell, snoozedUntil: string) => void;
@@ -392,6 +395,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     variant,
     onSelectThread,
     onDeleteThread,
+    onRenameThread,
     onRegenerateThreadTitle,
     onSettleThread,
     onSnoozeThread,
@@ -430,6 +434,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   const timeLabel = threadTimeLabel(thread);
 
   const handleDelete = useCallback(() => onDeleteThread(thread), [onDeleteThread, thread]);
+  const handleRename = useCallback(() => onRenameThread(thread), [onRenameThread, thread]);
   const handleRegenerateTitle = useCallback(
     () => onRegenerateThreadTitle(thread),
     [onRegenerateThreadTitle, thread],
@@ -524,12 +529,16 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       thread.pinnedAt,
     ],
   );
-  const titleRegenerationMenuItems = useMemo<MenuAction[]>(
-    () =>
-      buildThreadTitleRegenerationMenuItems({
+  // Manual rename rides along with the title items so every menu that offers
+  // regeneration also offers it. Rename is never capability-gated.
+  const titleMenuItems = useMemo<MenuAction[]>(
+    () => [
+      RENAME_MENU_ACTION,
+      ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
         isRegenerating: thread.titleRegeneration != null,
       }),
+    ],
     [props.titleRegenerationSupported, thread.titleRegeneration],
   );
   const snoozableCardMenuActions = useMemo<MenuAction[]>(
@@ -542,36 +551,31 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         subactions: snoozePresetActions,
       },
       ...pinMenuItem,
-      ...titleRegenerationMenuItems,
+      ...titleMenuItems,
       { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
     ],
-    [pinMenuItem, snoozePresetActions, titleRegenerationMenuItems],
+    [pinMenuItem, snoozePresetActions, titleMenuItems],
   );
   const cardMenuActions = useMemo<MenuAction[]>(
-    () => [
-      CARD_MENU_ACTIONS[0]!,
-      ...pinMenuItem,
-      ...titleRegenerationMenuItems,
-      ...CARD_MENU_ACTIONS.slice(1),
-    ],
-    [pinMenuItem, titleRegenerationMenuItems],
+    () => [CARD_MENU_ACTIONS[0]!, ...pinMenuItem, ...titleMenuItems, ...CARD_MENU_ACTIONS.slice(1)],
+    [pinMenuItem, titleMenuItems],
   );
   const slimMenuActions = useMemo<MenuAction[]>(
     () => [
       SLIM_MENU_ACTIONS[0]!,
       ...(thread.pinnedAt != null ? pinMenuItem : []),
-      ...titleRegenerationMenuItems,
+      ...titleMenuItems,
       SLIM_MENU_ACTIONS[1]!,
     ],
-    [pinMenuItem, thread.pinnedAt, titleRegenerationMenuItems],
+    [pinMenuItem, thread.pinnedAt, titleMenuItems],
   );
   const snoozedMenuActions = useMemo<MenuAction[]>(
-    () => [SNOOZED_MENU_ACTIONS[0]!, ...titleRegenerationMenuItems, SNOOZED_MENU_ACTIONS[1]!],
-    [titleRegenerationMenuItems],
+    () => [SNOOZED_MENU_ACTIONS[0]!, ...titleMenuItems, SNOOZED_MENU_ACTIONS[1]!],
+    [titleMenuItems],
   );
   const legacyMenuActions = useMemo<MenuAction[]>(
-    () => [LEGACY_MENU_ACTIONS[0]!, ...titleRegenerationMenuItems, LEGACY_MENU_ACTIONS[1]!],
-    [titleRegenerationMenuItems],
+    () => [LEGACY_MENU_ACTIONS[0]!, ...titleMenuItems, LEGACY_MENU_ACTIONS[1]!],
+    [titleMenuItems],
   );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
@@ -583,6 +587,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       if (nativeEvent.event === "move-pin-up") handleMovePinnedUp();
       if (nativeEvent.event === "move-pin-down") handleMovePinnedDown();
       if (nativeEvent.event === "archive") handleArchive();
+      if (nativeEvent.event === "rename") handleRename();
       if (nativeEvent.event === "regenerate-title") handleRegenerateTitle();
       if (nativeEvent.event === "delete") handleDelete();
       const snoozeSelection = resolveThreadListV2SnoozeMenuSelection({
@@ -599,6 +604,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     [
       handleArchive,
       handleDelete,
+      handleRename,
       handleRegenerateTitle,
       handleMovePinnedDown,
       handleMovePinnedUp,


### PR DESCRIPTION
Renaming a thread to a chosen title works on web (sidebar row menu and chat header) but is unreachable on mobile, where the row menu only offers automatic title regeneration. The command side needs nothing: `thread.meta.update` already accepts a manual `title` (not capability-gated, unlike `regenerateTitle`), the decider already cancels an in-flight regeneration when a manual title arrives, and mobile already instantiates the exact `updateMetadata` mutation for regeneration. The gap is UI only.

This follows #5648, which proposed the same thing and was closed as already added. I went looking for where it landed before writing this and could not find it: on current main, `git grep -i rename apps/mobile/src` matches only file-diff rename notices, the v1 row menu composes Archive / Regenerate title / Delete, the v2 menus compose their settle/snooze/pin/archive/delete sets plus Regenerate title, and neither the thread settings sheet nor the thread header offers a title edit. If it did land somewhere I missed, happy to close this too.

The change mirrors the regenerate-title pattern: a `renameThread` action in `useThreadListActions` (the prompt lives in the hook, same as `useConfirmDeleteThread`, so the rows stay dumb), a "Rename" item in both the v1 and v2 row menus next to Regenerate title, on both the Home list and the iPad sidebar. Since the codebase has no text-prompt primitive (`Alert.prompt` is iOS-only and unused), `ConfirmDialogHost` gains a prompt variant: same imperative style, same theming, field prefilled with the current title, confirm disabled while the field trims to empty. Committing an unchanged title is a no-op; the commit rules (trim, reject empty) are ported from web's `resolveRenameCommit`.

## Verification

- `tsgo --noEmit` in `apps/mobile`: error output identical to the origin/main baseline (all pre-existing react-navigation typing noise; zero errors in touched files, verified by diffing against a stashed baseline run)
- `vp lint` and `vp fmt --check` on all seven touched files: clean
- `vp test run src/features/threads/thread-title-regeneration-menu.test.ts`: 3 passed, as a no-regression check on the adjacent menu logic

## Screenshots

I could not produce simulator captures for this one (no iOS or Android toolchain on this machine); describing the two states instead. Long-pressing a thread row shows the existing context menu with "Rename" between the pin/archive items and "Regenerate title". Selecting it opens a modal titled "Rename thread" with the current title prefilled and selected, Cancel and Rename buttons, Rename disabled while the field is empty. The dialog is the same custom in-app modal on both platforms, styled by the existing `ConfirmDialogHost`. I can add real captures if wanted.

Change made by Claude Opus via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only thread metadata update via an existing mutation; no auth or new backend surface. Dialog host is a small shared primitive with empty-title guards.
> 
> **Overview**
> Lets users rename a thread from the Home and iPad sidebar row menus (v1 and v2), matching web’s manual title edit.
> 
> A **Rename** item sits next to regenerate-title. It opens a new cross-platform `showPromptDialog` on `ConfirmDialogHost` (keyboard-aware, prefilled/selected title, confirm disabled when blank). Commit uses existing `updateMetadata` with web’s trim / empty / no-op rules; failures surface via `Alert`. Rename is not capability-gated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1bed6bed2c04a535db6b21fbf5a22377eb5d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Rename` action to mobile thread list menus
> - Refactors [ConfirmDialogHost.tsx](https://github.com/pingdotgg/t3code/pull/8074/files#diff-5718b6c7964c04d97b304214a792e8e6775ed6fc1a585f471708eff7dfecc3f6) to render single-field prompt dialogs alongside confirm dialogs using a new `presentDialog` dispatcher and `DialogRequest` union type.
> - Adds `renameThread` to [useThreadListActions.ts](https://github.com/pingdotgg/t3code/pull/8074/files#diff-306460b1de597bc9d164b691fb0e4075061f7eb9246d316db687209ac8dec787) to open a prompt, trim the input, ignore no-ops, and call `updateMetadata` with the new title.
> - Wires `onRenameThread` through [HomeScreen.tsx](https://github.com/pingdotgg/t3code/pull/8074/files#diff-b6e075b3065ae370669290cbaa8476a852399968002468571cd914d06a32fd40) and the v1/v2 thread list row components to surface the `RENAME_MENU_ACTION`.
> - Behavioral Change: `ConfirmDialogHost` replaces the `presentRequest` singleton with `presentDialog`, wraps content in `KeyboardAvoidingView`, and disables the confirm button when prompt input is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0e1bed6. 7 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/mobile/src/features/home/HomeScreen.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 849](https://github.com/pingdotgg/t3code/blob/0e1bed6bed2c04a535db6b21fbf5a22377eb5d42/apps/mobile/src/features/home/HomeScreen.tsx#L849): The newly captured `props.onRenameThread` is missing from the dependency arrays of both `renderV2Item` and `renderItem`. If the parent supplies a new rename callback (for example after one of that callback's hook dependencies changes), these memoized renderers continue passing the old callback to rows, so Rename can execute against stale mutation/dialog state until some other listed dependency changes. Add `props.onRenameThread` to both callback dependency arrays. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->