### PR TITLE
fix(web,mobile): keep substantive assistant prose outside the settled-turn fold

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -620,6 +620,77 @@ describe("buildThreadFeed", () => {
     ]);
   });
 
+  it("keeps a multi-paragraph mid-turn message visible while its work still folds", () => {
+    const turnId = TurnId.make("turn-1");
+    const thread = makeThread({
+      id: ThreadId.make("thread-substantive-middle"),
+      projectId: ProjectId.make("project-1"),
+      title: "Substantive narration",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:08.000Z",
+        assistantMessageId: MessageId.make("assistant-final"),
+      },
+      messages: [
+        {
+          id: MessageId.make("assistant-first"),
+          role: "assistant",
+          text: "Looking around first.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:01.000Z",
+          updatedAt: "2026-04-01T00:00:02.000Z",
+        },
+        {
+          id: MessageId.make("assistant-analysis"),
+          role: "assistant",
+          text: "The projector rebuilds the read model on every event.\n\nThat is why the timeline lags behind the socket by one frame.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:04.000Z",
+          updatedAt: "2026-04-01T00:00:05.000Z",
+        },
+        {
+          id: MessageId.make("assistant-final"),
+          role: "assistant",
+          text: "Done.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:07.000Z",
+          updatedAt: "2026-04-01T00:00:08.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read files",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId,
+          payload: {
+            title: "Read files",
+            itemType: "file_read",
+            status: "completed",
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const collapsed = deriveThreadFeedPresentation(feed, thread.latestTurn, new Set());
+
+    expect(collapsed.map((entry) => entry.id)).toEqual([
+      "assistant-first",
+      "turn-fold:turn-1",
+      "assistant-analysis",
+      "assistant-final",
+    ]);
+  });
+
   it("measures a steer-superseded turn from its user boundary through trailing work", () => {
     const firstTurnId = TurnId.make("turn-1");
     const secondTurnId = TurnId.make("turn-2");

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -12,6 +12,7 @@ import type {
   TurnId,
   UserInputQuestion,
 } from "@t3tools/contracts";
+import { isFoldableAssistantNarration } from "@t3tools/client-runtime/state/turn-fold";
 import { formatDuration } from "@t3tools/shared/orchestrationTiming";
 
 import * as Arr from "effect/Array";
@@ -1215,10 +1216,14 @@ function deriveThreadFeedTurnFolds(
     const terminalAssistantMessageId = terminalAssistantMessageIdByTurn.get(turnId);
     const hiddenEntryIds = new Set(
       entries
-        .filter(
-          (entry) =>
-            entry.id !== firstAssistantMessageId && entry.id !== terminalAssistantMessageId,
-        )
+        .filter((entry) => {
+          if (entry.id === firstAssistantMessageId || entry.id === terminalAssistantMessageId) {
+            return false;
+          }
+          // Mid-turn messages are stream segments of one reply, so anything
+          // longer than narration is answer text and must not fold away.
+          return entry.type !== "message" || isFoldableAssistantNarration(entry.message.text);
+        })
         .map((entry) => entry.id),
     );
     if (hiddenEntryIds.size === 0) {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -615,6 +615,92 @@ describe("deriveMessagesTimelineRows", () => {
     ]);
   });
 
+  it("keeps a multi-paragraph mid-turn message visible while its work still folds", () => {
+    const timelineEntries = [
+      {
+        id: "assistant-first-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:01Z",
+        message: {
+          id: "assistant-first" as never,
+          role: "assistant" as const,
+          text: "Looking around first.",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:01Z",
+          updatedAt: "2026-01-01T00:00:02Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "work-entry-1",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:03Z",
+        entry: {
+          id: "work-1",
+          createdAt: "2026-01-01T00:00:03Z",
+          turnId: "turn-1" as never,
+          label: "Ran command",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "assistant-analysis-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:04Z",
+        message: {
+          id: "assistant-analysis" as never,
+          role: "assistant" as const,
+          text: "The projector rebuilds the read model on every event.\n\nThat is why the timeline lags behind the socket by one frame.",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:04Z",
+          updatedAt: "2026-01-01T00:00:05Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "work-entry-2",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:06Z",
+        entry: {
+          id: "work-2",
+          createdAt: "2026-01-01T00:00:06Z",
+          turnId: "turn-1" as never,
+          label: "Read files",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "assistant-final-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:07Z",
+        message: {
+          id: "assistant-final" as never,
+          role: "assistant" as const,
+          text: "Done.",
+          turnId: "turn-1" as never,
+          createdAt: "2026-01-01T00:00:07Z",
+          updatedAt: "2026-01-01T00:00:08Z",
+          streaming: false,
+        },
+      },
+    ];
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "assistant-first-entry",
+      "turn-fold:turn-1",
+      "assistant-analysis-entry",
+      "assistant-final-entry",
+    ]);
+  });
+
   it("derives a sane duration for a steer-superseded turn with one instant commentary message", () => {
     // A steer ends the previous turn early: its only message completes the
     // instant it is created, and trailing work entries land after it. The

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -10,6 +10,7 @@ import {
 } from "../../session-logic";
 import { type ChatMessage, type ProposedPlan, type TurnDiffSummary } from "../../types";
 import { type MessageId, type OrchestrationLatestTurn, type TurnId } from "@t3tools/contracts";
+import { isFoldableAssistantNarration } from "@t3tools/client-runtime/state/turn-fold";
 
 export const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
 export const TIMELINE_MINIMAP_ITEM_SPACING = 8;
@@ -521,10 +522,11 @@ function timelineEntryTurnId(entry: TimelineEntry): TurnId | null {
 }
 
 /**
- * Settled turns keep their first and terminal assistant messages visible.
- * Everything between them folds behind a "Worked for ..." row anchored at
- * the first hidden entry. Keeping both ends prevents a short follow-up from
- * hiding a substantive opening response while still bounding noisy turns.
+ * Settled turns keep their first and terminal assistant messages visible, plus
+ * any message between them that is too long to be narration. Everything else
+ * folds behind a "Worked for ..." row anchored at the first hidden entry.
+ * Keeping both ends prevents a short follow-up from hiding a substantive
+ * opening response while still bounding noisy turns.
  */
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
@@ -606,6 +608,11 @@ function deriveTurnFolds(input: {
       // turn (dynamic spawns, background execution), and folding the CTA
       // when the turn settles makes a still-running fleet invisible.
       if (entry.kind === "work" && entry.entry.agentSpawn !== undefined) {
+        continue;
+      }
+      // Mid-turn messages are stream segments of one reply, so anything longer
+      // than narration is answer text and must not fold away.
+      if (entry.kind === "message" && !isFoldableAssistantNarration(entry.message.text)) {
         continue;
       }
       hiddenEntryIds.add(entry.id);

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -151,6 +151,10 @@
       "types": "./src/state/threadSearch.ts",
       "default": "./src/state/threadSearch.ts"
     },
+    "./state/turn-fold": {
+      "types": "./src/state/turnFold.ts",
+      "default": "./src/state/turnFold.ts"
+    },
     "./state/vcs": {
       "types": "./src/state/vcs.ts",
       "default": "./src/state/vcs.ts"

--- a/packages/client-runtime/src/state/turnFold.test.ts
+++ b/packages/client-runtime/src/state/turnFold.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { FOLDABLE_NARRATION_MAX_CHARS, isFoldableAssistantNarration } from "./turnFold.ts";
+
+describe("isFoldableAssistantNarration", () => {
+  it("folds a short single block", () => {
+    expect(isFoldableAssistantNarration("Looking around first.")).toBe(true);
+  });
+
+  it("folds text exactly at the length limit but not one character past it", () => {
+    expect(isFoldableAssistantNarration("a".repeat(FOLDABLE_NARRATION_MAX_CHARS))).toBe(true);
+    expect(isFoldableAssistantNarration("a".repeat(FOLDABLE_NARRATION_MAX_CHARS + 1))).toBe(false);
+  });
+
+  it("measures the trimmed text, so surrounding whitespace does not push it over", () => {
+    expect(
+      isFoldableAssistantNarration(`\n\n  ${"a".repeat(FOLDABLE_NARRATION_MAX_CHARS)}  \n`),
+    ).toBe(true);
+  });
+
+  it("keeps multi-paragraph text visible even when it is short", () => {
+    expect(isFoldableAssistantNarration("First point.\n\nSecond point.")).toBe(false);
+    expect(isFoldableAssistantNarration("First point.\n \t \nSecond point.")).toBe(false);
+  });
+
+  it("folds a single block that wraps across lines", () => {
+    expect(isFoldableAssistantNarration("Checking the config.\nThen the tests.")).toBe(true);
+  });
+
+  it("folds whitespace-only text", () => {
+    expect(isFoldableAssistantNarration("   \n\n  ")).toBe(true);
+  });
+});

--- a/packages/client-runtime/src/state/turnFold.ts
+++ b/packages/client-runtime/src/state/turnFold.ts
@@ -1,0 +1,20 @@
+/**
+ * Longest assistant message the settled-turn fold treats as narration.
+ *
+ * A reply is minted as one message per provider stream segment, and a segment
+ * closes on every tool call, so one answer routinely arrives as several
+ * messages with tool activity between them. Position alone therefore cannot
+ * separate narration ("Looking around first.") from a mid-reply chunk of the
+ * answer itself — folding every non-terminal message hides most of the reply.
+ */
+export const FOLDABLE_NARRATION_MAX_CHARS = 240;
+
+/**
+ * Whether an assistant message reads as narration the settled-turn fold may
+ * hide: one short block with no paragraph break. Longer or multi-paragraph
+ * text is part of the reply and stays visible outside the fold.
+ */
+export function isFoldableAssistantNarration(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.length <= FOLDABLE_NARRATION_MAX_CHARS && !/\n[^\S\n]*\n/.test(trimmed);
+}


### PR DESCRIPTION
When a settled turn folds behind the "Worked for ..." row, every assistant message between the first and the terminal one is hidden, regardless of what it contains. The server mints a separate message per assistant stream segment (segments close at tool boundaries), so a model that interleaves real prose with tool calls gets the substance of its reply folded: write three paragraphs of analysis, run a tool, close with "Done", and the analysis is invisible until the fold is clicked. With reasoning-heavy models this happens on most turns, and users report the majority of a reply routinely hidden.

The middle of a turn is only sometimes narration. "Looking around first." should fold; a multi-paragraph explanation of the root cause should not. Since nothing in the data model distinguishes the two, this adds a small shared predicate, `isFoldableAssistantNarration` in `@t3tools/client-runtime/state/turn-fold`: a mid-turn assistant message folds only when it is a single block (no blank-line paragraph break) of at most 240 characters. Web and mobile both apply it, so the two surfaces keep agreeing on what a fold contains. Everything else is unchanged: tool and work rows still fold, the first and terminal messages stay visible as today, agent-spawn rows keep their escape, and the running turn is never folded.

One boundary I left alone: the copy button still appears only on the terminal message, because `showAssistantMeta` doubles as the row-spacing signal in the timeline and decoupling them is a layout change of its own.

## Verification

- `vp test run src/state/turnFold.test.ts` in `packages/client-runtime`: 6 passed (boundary at 240, paragraph breaks, whitespace-only)
- `vp test run src/components/chat/MessagesTimeline.logic.test.ts` in `apps/web`: 46 passed, including a new case asserting a long mid-turn message stays visible while tool rows still fold; the new case fails on main
- `vp test run src/lib/threadActivity.test.ts` in `apps/mobile`: 20 passed, same new case for the mobile fold; also fails on main
- `tsgo --noEmit`: clean in `apps/web` and `packages/client-runtime`; `apps/mobile` output byte-identical to the main baseline (pre-existing react-navigation noise only)
- No existing test expectation changed; the short narration fixtures in the current fold tests still fold

## Screenshots

Same seeded thread, identical crops, collapsed state in both (the fold was never expanded). The turn is: "Looking around first." / tool run / two-paragraph analysis / tool run / "Done. The fix is batching the rebuild."

Before, the analysis is inside the fold:

![before](https://raw.githubusercontent.com/spiky02plateau/t3code/pr-assets-fold/fold-before.png)

After, the analysis renders; the tool rows are still behind "Worked for 18s":

![after](https://raw.githubusercontent.com/spiky02plateau/t3code/pr-assets-fold/fold-after.png)

Change made by Claude Opus via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only fold heuristic on web and mobile; no auth, data, or protocol changes. Heuristic may still hide some mid-length single-paragraph answer text.
> 
> **Overview**
> Stops the settled-turn “Worked for …” fold from hiding real mid-turn answer text. Stream segments close at tool calls, so one reply is often several messages; previously everything between the first and last assistant message was folded.
> 
> Web and mobile now share `isFoldableAssistantNarration`: a mid-turn assistant message folds only if it is a single block of at most 240 characters. Longer or multi-paragraph chunks stay visible; tool/work rows, first/terminal messages, and running turns are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57238e2092da608d490b10b47adf1d439cb3faf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep substantive mid-turn assistant messages visible in settled-turn folds
> - Adds `isFoldableAssistantNarration` in [turnFold.ts](https://github.com/pingdotgg/t3code/pull/8075/files#diff-a8ccd3561591eedf1a1dce6506524342cffb94a0a9f0c49906d6dbffc0511c8b): an assistant message is foldable only if it is under 240 chars and contains no blank-line paragraph break.
> - Exposes this utility via the new `./state/turn-fold` subpath export in [package.json](https://github.com/pingdotgg/t3code/pull/8075/files#diff-6e89e5cdd29d27c6871a007cebd586b99715fcdf8b711ff74f5d0b4f8e691db1).
> - Updates `deriveThreadFeedTurnFolds` ([threadActivity.ts](https://github.com/pingdotgg/t3code/pull/8075/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5)) and `deriveTurnFolds` ([MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/8075/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe)) so mid-turn assistant messages that are not foldable narration stay visible instead of being hidden with other work entries.
> - Risk: any mid-turn assistant message shorter than `FOLDABLE_NARRATION_MAX_CHARS` with no paragraph break will still be folded; content that previously collapsed may now appear inline and change timeline scroll height.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57238e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->