### PR TITLE
feat(desktop): apply theme files from command line

### DIFF
--- a/apps/desktop/src/app/DesktopClerk.test.ts
+++ b/apps/desktop/src/app/DesktopClerk.test.ts
@@ -24,6 +24,7 @@ vi.mock("@clerk/electron/storage", () => ({
 
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
@@ -52,6 +53,7 @@ const makeDesktopClerkLayer = (isDevelopment = true, events: string[] = []) => {
         Layer.succeed(DesktopEnvironment.DesktopEnvironment, environment),
         Layer.succeed(ElectronApp.ElectronApp, electronApp),
         FileSystem.layerNoop({ exists: () => Effect.succeed(false) }),
+        Path.layer,
       ),
     ),
   );
@@ -173,7 +175,7 @@ describe("DesktopClerk", () => {
 
       assert.isTrue(Exit.isSuccess(exit));
       assert.equal(quit.mock.calls.length, 0);
-      assert.deepEqual(registeredEvents, ["second-instance"]);
+      assert.deepEqual(registeredEvents, ["browser-window-created", "second-instance"]);
     }).pipe(
       Effect.provide(makeDesktopClerkLayer()),
       Effect.provideService(ElectronApp.ElectronApp, electronApp),

--- a/apps/desktop/src/app/DesktopClerk.ts
+++ b/apps/desktop/src/app/DesktopClerk.ts
@@ -2,17 +2,23 @@ import { createClerkBridge } from "@clerk/electron";
 import { storage } from "@clerk/electron/storage";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import type * as Electron from "electron";
 
 import { clerkFrontendApiHostnameFromPublishableKey } from "@t3tools/shared/relayAuth";
+import * as IpcChannels from "../ipc/channels.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import { makeComponentLogger } from "./DesktopObservability.ts";
+import { readThemeFile, themeFilePathFromArguments } from "./DesktopThemeFileCommand.ts";
 
 declare const __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: string | undefined;
 
@@ -72,6 +78,8 @@ export const desktopClerkFrontendApiHostname = resolveDesktopClerkFrontendApiHos
     : __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__,
 );
 
+const { logInfo, logWarning } = makeComponentLogger("desktop-theme-file-command");
+
 export function createDesktopClerkBridge(stateDir: string, isDevelopment: boolean) {
   return createClerkBridge({
     storage: storage({ path: stateDir }),
@@ -86,6 +94,8 @@ export function createDesktopClerkBridge(stateDir: string, isDevelopment: boolea
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const electronApp = yield* ElectronApp.ElectronApp;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
 
   // Electron scopes the single-instance lock to the userData directory and
   // creates that directory when the lock is acquired. The SDK bridge takes
@@ -124,6 +134,32 @@ export const make = Effect.gen(function* () {
       const electronWindow = yield* ElectronWindow.ElectronWindow;
       const context = yield* Effect.context<ElectronWindow.ElectronWindow>();
       const runPromise = Effect.runPromiseWith(context);
+      const pendingThemePaths: string[] = [];
+
+      const readRequestedTheme = (filePath: string) =>
+        readThemeFile(filePath).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+          Effect.catchCause((cause) =>
+            logWarning("failed to read requested theme file", { filePath, cause }).pipe(
+              Effect.as(null),
+            ),
+          ),
+        );
+
+      const sendThemePath = (filePath: string) =>
+        Effect.gen(function* () {
+          const file = yield* readRequestedTheme(filePath);
+          if (file === null) return;
+          yield* logInfo("applying requested theme file", {
+            fileName: file.name,
+            fileSize: file.size,
+          });
+          yield* electronWindow.sendAll(IpcChannels.APPLY_THEME_FILE_CHANNEL, file);
+        });
+
+      const initialThemePath = themeFilePathFromArguments(process.argv);
+      if (initialThemePath) pendingThemePaths.push(initialThemePath);
 
       // The SDK bridge holds Electron's single-instance lock (acquired at
       // bridge creation) so OAuth deep-link callbacks on Windows/Linux are
@@ -135,9 +171,42 @@ export const make = Effect.gen(function* () {
         return yield* Effect.interrupt;
       }
 
-      yield* electronApp.on("second-instance", () => {
+      yield* electronApp.on(
+        "browser-window-created",
+        (_event: Electron.Event, window: Electron.BrowserWindow) => {
+          window.webContents.once("did-finish-load", () => {
+            const paths = pendingThemePaths.splice(0);
+            for (const filePath of paths) {
+              void runPromise(
+                Effect.gen(function* () {
+                  const file = yield* readRequestedTheme(filePath);
+                  if (file !== null && !window.isDestroyed()) {
+                    yield* logInfo("applying requested startup theme file", {
+                      fileName: file.name,
+                      fileSize: file.size,
+                    });
+                    window.webContents.send(IpcChannels.APPLY_THEME_FILE_CHANNEL, file);
+                  }
+                }),
+              );
+            }
+          });
+        },
+      );
+
+      yield* electronApp.on("second-instance", (_event: unknown, commandLine: unknown) => {
         void runPromise(
           Effect.gen(function* () {
+            if (Array.isArray(commandLine)) {
+              const themePath = themeFilePathFromArguments(
+                commandLine.filter((argument): argument is string => typeof argument === "string"),
+              );
+              if (themePath) {
+                const currentWindow = yield* electronWindow.currentMainOrFirst;
+                if (Option.isNone(currentWindow)) pendingThemePaths.push(themePath);
+                else yield* sendThemePath(themePath);
+              }
+            }
             const mainWindow = yield* electronWindow.currentMainOrFirst;
             if (Option.isSome(mainWindow)) {
               yield* electronWindow.reveal(mainWindow.value);

--- a/apps/desktop/src/app/DesktopThemeFileCommand.test.ts
+++ b/apps/desktop/src/app/DesktopThemeFileCommand.test.ts
@@ -1,0 +1,25 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { themeFilePathFromArguments } from "./DesktopThemeFileCommand.ts";
+
+describe("DesktopThemeFileCommand", () => {
+  it("reads a separated theme file argument", () => {
+    assert.equal(
+      themeFilePathFromArguments(["t3code", "--theme-file", "/tmp/omarchy theme.json"]),
+      "/tmp/omarchy theme.json",
+    );
+  });
+
+  it("reads an inline theme file argument", () => {
+    assert.equal(
+      themeFilePathFromArguments(["t3code", "--theme-file=/tmp/theme.json"]),
+      "/tmp/theme.json",
+    );
+  });
+
+  it("ignores missing and empty values", () => {
+    assert.isNull(themeFilePathFromArguments(["t3code", "--theme-file"]));
+    assert.isNull(themeFilePathFromArguments(["t3code", "--theme-file="]));
+    assert.isNull(themeFilePathFromArguments(["t3code", "--theme-file", "--inspect"]));
+  });
+});

--- a/apps/desktop/src/app/DesktopThemeFileCommand.ts
+++ b/apps/desktop/src/app/DesktopThemeFileCommand.ts
@@ -1,0 +1,33 @@
+import type { PickedThemeFile } from "@t3tools/contracts";
+import * as FileSystem from "effect/FileSystem";
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+
+export const THEME_FILE_ARGUMENT = "--theme-file";
+export const THEME_FILE_MAX_BYTES = 256 * 1024;
+
+export function themeFilePathFromArguments(args: readonly string[]): string | null {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]!;
+    if (argument === THEME_FILE_ARGUMENT) {
+      const value = args[index + 1];
+      return value && !value.startsWith("--") ? value : null;
+    }
+    if (argument.startsWith(`${THEME_FILE_ARGUMENT}=`)) {
+      const value = argument.slice(THEME_FILE_ARGUMENT.length + 1);
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+export const readThemeFile = Effect.fn("desktop.themeFileCommand.read")(function* (
+  filePath: string,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const info = yield* fileSystem.stat(filePath);
+  const size = Number(info.size);
+  const text = size > THEME_FILE_MAX_BYTES ? "" : yield* fileSystem.readFileString(filePath);
+  return { name: path.basename(filePath), size, text } satisfies PickedThemeFile;
+});

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -1,6 +1,7 @@
 export const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 export const PICK_PROJECT_FAVICON_CHANNEL = "desktop:pick-project-favicon";
 export const PICK_THEME_FILES_CHANNEL = "desktop:pick-theme-files";
+export const APPLY_THEME_FILE_CHANNEL = "desktop:apply-theme-file";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -3,6 +3,7 @@ import type {
   DesktopPreviewPointerEvent,
   DesktopPreviewRecordingFrame,
   DesktopPreviewTabState,
+  PickedThemeFile,
 } from "@t3tools/contracts";
 import { exposeClerkBridge } from "@clerk/electron/preload";
 import { contextBridge, ipcRenderer } from "electron";
@@ -10,6 +11,27 @@ import { contextBridge, ipcRenderer } from "electron";
 import * as IpcChannels from "./ipc/channels.ts";
 
 exposeClerkBridge({ passkeys: true });
+
+let pendingThemeFile: PickedThemeFile | null = null;
+const themeFileListeners = new Set<(file: PickedThemeFile) => void>();
+
+ipcRenderer.on(IpcChannels.APPLY_THEME_FILE_CHANNEL, (_event, file: unknown) => {
+  if (typeof file !== "object" || file === null) return;
+  const candidate = file as Partial<PickedThemeFile>;
+  if (
+    typeof candidate.name !== "string" ||
+    typeof candidate.size !== "number" ||
+    typeof candidate.text !== "string"
+  ) {
+    return;
+  }
+  const picked = candidate as PickedThemeFile;
+  if (themeFileListeners.size === 0) {
+    pendingThemeFile = picked;
+    return;
+  }
+  for (const listener of themeFileListeners) listener(picked);
+});
 
 function unwrapEnsureSshEnvironmentResult(result: unknown) {
   if (
@@ -104,6 +126,14 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   pickProjectFavicon: (initialPath) =>
     ipcRenderer.invoke(IpcChannels.PICK_PROJECT_FAVICON_CHANNEL, initialPath),
   pickThemeFiles: () => ipcRenderer.invoke(IpcChannels.PICK_THEME_FILES_CHANNEL, undefined),
+  onThemeFileApply: (listener) => {
+    themeFileListeners.add(listener);
+    if (pendingThemeFile) {
+      listener(pendingThemeFile);
+      pendingThemeFile = null;
+    }
+    return () => themeFileListeners.delete(listener);
+  },
   setTheme: (theme) => ipcRenderer.invoke(IpcChannels.SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) =>
     ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {

--- a/apps/web/src/AppRoot.tsx
+++ b/apps/web/src/AppRoot.tsx
@@ -1,6 +1,7 @@
 import { RouterProvider } from "@tanstack/react-router";
 
 import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
+import { DesktopThemeFileCommands } from "./components/DesktopThemeFileCommands";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
 import { QuitHoldOverlay } from "./components/QuitHoldOverlay";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
@@ -15,6 +16,7 @@ export function AppRoot({ router }: { readonly router: AppRouter }) {
   return (
     <AppAtomRegistryProvider>
       <RouterProvider router={router} />
+      <DesktopThemeFileCommands />
       <PreviewAutomationHosts />
       <ElectronBrowserHost />
       <QuitHoldOverlay />

--- a/apps/web/src/components/DesktopThemeFileCommands.test.ts
+++ b/apps/web/src/components/DesktopThemeFileCommands.test.ts
@@ -1,0 +1,56 @@
+import { assert } from "@effect/vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vite-plus/test";
+
+import { getCustomThemes, invalidateCustomThemes } from "../themePalette";
+import { importDesktopThemeFile } from "./DesktopThemeFileCommands";
+
+const vscodeTheme = (background: string) => ({
+  name: "Omarchy Current",
+  type: "dark",
+  colors: {
+    "editor.background": background,
+    "editor.foreground": "#cacccc",
+  },
+});
+
+describe("DesktopThemeFileCommands", () => {
+  beforeEach(() => {
+    const stored = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        clear: () => stored.clear(),
+        getItem: (key: string) => stored.get(key) ?? null,
+        removeItem: (key: string) => stored.delete(key),
+        setItem: (key: string, value: string) => stored.set(key, value),
+      },
+    });
+    invalidateCustomThemes();
+  });
+
+  afterEach(() => {
+    invalidateCustomThemes();
+    vi.unstubAllGlobals();
+  });
+
+  it("installs and updates a requested VS Code theme", () => {
+    const firstId = importDesktopThemeFile({
+      name: "vscode.json",
+      size: 100,
+      text: JSON.stringify(vscodeTheme("#101315")),
+    });
+
+    assert.equal(getCustomThemes().length, 1);
+    assert.equal(getCustomThemes()[0]?.id, firstId);
+    const firstCanvas = getCustomThemes()[0]?.colors.canvas;
+
+    const secondId = importDesktopThemeFile({
+      name: "vscode.json",
+      size: 100,
+      text: JSON.stringify(vscodeTheme("#202426")),
+    });
+
+    assert.equal(secondId, firstId);
+    assert.equal(getCustomThemes().length, 1);
+    assert.notEqual(getCustomThemes()[0]?.colors.canvas, firstCanvas);
+  });
+});

--- a/apps/web/src/components/DesktopThemeFileCommands.tsx
+++ b/apps/web/src/components/DesktopThemeFileCommands.tsx
@@ -1,0 +1,42 @@
+import type { PickedThemeFile } from "@t3tools/contracts";
+import { useEffect } from "react";
+
+import { useTheme } from "../hooks/useTheme";
+import {
+  getCustomThemes,
+  installCustomTheme,
+  parseThemeFile,
+  updateCustomTheme,
+} from "../themePalette";
+import { isVsCodeThemeFile, parseVsCodeThemeFile } from "../vscodeThemeImport";
+
+export function importDesktopThemeFile(file: PickedThemeFile): string {
+  if (!file.text) throw new Error(`Could not read theme file "${file.name}".`);
+  const value: unknown = JSON.parse(file.text);
+  const theme = isVsCodeThemeFile(value) ? parseVsCodeThemeFile(value) : parseThemeFile(value);
+  if (getCustomThemes().some((installed) => installed.id === theme.id)) {
+    updateCustomTheme(theme);
+  } else {
+    installCustomTheme(theme);
+  }
+  return theme.id;
+}
+
+export function DesktopThemeFileCommands() {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    const bridge = window.desktopBridge;
+    if (!bridge?.onThemeFileApply) return;
+    return bridge.onThemeFileApply((file) => {
+      try {
+        const themeId = importDesktopThemeFile(file);
+        if (!setTheme(themeId)) throw new Error(`Could not activate theme "${themeId}".`);
+      } catch (cause) {
+        console.error("Failed to apply desktop theme file.", { file: file.name, cause });
+      }
+    });
+  }, [setTheme]);
+
+  return null;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)
+- [Themes and desktop automation](./user/themes.md)
 - [Mobile appearance](./user/mobile-appearance.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)

--- a/docs/user/themes.md
+++ b/docs/user/themes.md
@@ -1,0 +1,38 @@
+# Themes and desktop automation
+
+Import T3 Code ThemeFile v1 or VS Code color-theme JSON files from **Settings** →
+**Appearance**. The desktop app can also import and activate a theme from the command line:
+
+```bash
+t3code --theme-file=/absolute/path/to/theme.json
+```
+
+Use the `--theme-file=<path>` form when T3 Code is already running. Reapplying a theme with the
+same ID updates the installed theme instead of creating a duplicate, which makes the command safe
+for desktop theme-manager hooks. Files larger than 256 KiB are rejected.
+
+## Omarchy
+
+Omarchy generates a complete VS Code color theme from its canonical `colors.toml` palette at
+`~/.local/state/omarchy/current/theme/vscode-theme.json`. Use that generated file rather than
+`vscode.json`, which only identifies a marketplace extension.
+
+For example, save this hook script somewhere in your home directory:
+
+```bash
+#!/bin/bash
+
+theme_file="$HOME/.local/state/omarchy/current/theme/vscode-theme.json"
+[[ -f $theme_file ]] || exit 0
+
+t3code --theme-file="$theme_file" >/dev/null 2>&1 &
+```
+
+Then install it through Omarchy's supported hook interface:
+
+```bash
+omarchy hook install theme-set /path/to/the/script
+```
+
+The command opens T3 Code if it is not already running. When it is running, Electron forwards the
+request to the existing window and exits the second process.

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1118,6 +1118,8 @@ export interface DesktopBridge {
    * web callers fall back to a plain file input.
    */
   pickThemeFiles?: () => Promise<readonly PickedThemeFile[] | null>;
+  /** Theme files requested by the local desktop command line. */
+  onThemeFileApply?: (listener: (file: PickedThemeFile) => void) => () => void;
   setTheme: (theme: DesktopTheme) => Promise<void>;
   showContextMenu: <T extends string>(
     items: readonly ContextMenuItem<T>[],


### PR DESCRIPTION
## Problem

Desktop theme managers can update the rest of a user's environment, but T3 Code themes currently require a manual import and selection. Integrations also should not need to edit T3 Code's local storage directly.

Proposal: https://github.com/pingdotgg/t3code/discussions/8079

## Fix

- Add a desktop-only `--theme-file=<path>` command-line interface.
- Accept the same ThemeFile v1 and VS Code color-theme JSON supported by the existing import UI.
- Apply files during startup and through Electron's second-instance handoff when T3 Code is already running.
- Buffer startup IPC until the renderer listener is ready.
- Update themes with an existing ID instead of creating duplicates.
- Preserve the existing 256 KiB theme-file limit.
- Document the generic interface and an Omarchy `theme-set` hook using Omarchy's generated `vscode-theme.json`.

This keeps desktop-specific integration in external hooks while giving those hooks a supported T3 Code boundary.

## Validation

- Tested end to end against the v0.0.33 release source on Omarchy: the running Electron instance received Omarchy's generated theme through a second-instance invocation, activated it, and persisted `omarchy` as the selected custom theme.
- `vp test run apps/desktop/src/app/DesktopThemeFileCommand.test.ts apps/desktop/src/app/DesktopClerk.test.ts apps/web/src/components/DesktopThemeFileCommands.test.ts` (12 tests)
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/desktop typecheck`
- Focused lint for changed TypeScript files
- `vp run --filter @t3tools/desktop --filter @t3tools/web build`

No new UI surface is introduced, so there are no before/after screenshots.

Built with GPT-5.6 Sol in T3 Code (Codex harness).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reads user-supplied local files in the Electron main process and forwards them over IPC, plus new second-instance/window-created handlers. Size-capped and renderer-validated, but still touches process-lifecycle and IPC paths.
> 
> **Overview**
> Lets desktop theme managers (e.g. Omarchy) import and activate a ThemeFile v1 or VS Code color-theme JSON via `t3code --theme-file=<path>` without touching local storage.
> 
> Main process parses argv, reads the file (256 KiB cap, same as the picker), and sends it on `desktop:apply-theme-file`. Startup requests wait for `did-finish-load`; if the app is already running, `second-instance` forwards the path and reveals the window. Preload buffers the payload until the renderer listener is ready.
> 
> The renderer installs or **updates** a custom theme by ID, then activates it. Docs cover the CLI and an Omarchy `theme-set` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51668e97b78c3c2ee996c781bffb8460325e5b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply theme files passed via `--theme-file` command-line argument in desktop app
> - Adds a `--theme-file <path>` CLI argument parsed by [DesktopThemeFileCommand.ts](https://github.com/pingdotgg/t3code/pull/8080/files#diff-a0fcd912052ad9bb4dc42e7c61e89976646602c11d4328cbfb70ea053749707f); works with both space-separated and `=` forms. The main process in [DesktopClerk.ts](https://github.com/pingdotgg/t3code/pull/8080/files#diff-6ee8f6640c664637b8e75826b581300f21ae329abd23d301a562639f3aff75e2) reads the file (capped at 256 KiB) and forwards it to renderer windows over the new `APPLY_THEME_FILE_CHANNEL` IPC channel defined in [channels.ts](https://github.com/pingdotgg/t3code/pull/8080/files#diff-f45759ad31ff5d968e71f0ff1bc8259be6c057b7bccf2325ee30419ca8300739).
> - Theme files passed to the initial process are queued and applied after the first window finishes loading; files passed to a second instance are forwarded to the existing window immediately. The preload script in [preload.ts](https://github.com/pingdotgg/t3code/pull/8080/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac) buffers payloads until a renderer listener subscribes.
> - The renderer-side [DesktopThemeFileCommands.tsx](https://github.com/pingdotgg/t3code/pull/8080/files#diff-93ab2f9efc1389fc44e07467d54c04a3bc1ef55cce974bf66cc977ded42d6d3d) auto-detects VS Code vs. native theme format, installs or updates the theme by id, and activates it. It is mounted globally in [AppRoot.tsx](https://github.com/pingdotgg/t3code/pull/8080/files#diff-21926ebb90f26239608d00b3283a87aac57ccce9e94d529a524ce198d179567b).
> - Behavioral Change: `readThemeFile` rejects files larger than 256 KiB; callers receive no file content in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 51668e9. 9 files reviewed, 4 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->