### PR TITLE
fix(web): make Windows file links clickable in chat

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -88,6 +88,23 @@ describe("ChatMarkdown Windows file links", () => {
     expect(html).toContain("chat-markdown-file-link");
   });
 
+  it.each([true, false])(
+    "distinguishes same-named backslash paths with parseRawHtml=%s",
+    (parseRawHtml) => {
+      const html = renderToStaticMarkup(
+        <ChatMarkdown
+          cwd="C:/Users/shawn/project"
+          text={String.raw`[Source](C:\Users\shawn\project\src\index.ts) and [Test](C:\Users\shawn\project\test\index.ts)`}
+          lineBreaks={!parseRawHtml}
+          parseRawHtml={parseRawHtml}
+        />,
+      );
+
+      expect(html).toContain("index.ts · project/src");
+      expect(html).toContain("index.ts · project/test");
+    },
+  );
+
   it.each([true, false])("preserves reference links with parseRawHtml=%s", (parseRawHtml) => {
     const html = renderToStaticMarkup(
       <ChatMarkdown

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -105,6 +105,24 @@ describe("ChatMarkdown Windows file links", () => {
     },
   );
 
+  it.each([true, false])(
+    "does not disambiguate the same file in links and inline code with parseRawHtml=%s",
+    (parseRawHtml) => {
+      const path = String.raw`C:\Users\shawn\project\src\main.ts`;
+      const html = renderToStaticMarkup(
+        <ChatMarkdown
+          cwd="C:/Users/shawn/project"
+          text={`[Source](${path}) and \`${path}\``}
+          lineBreaks={!parseRawHtml}
+          parseRawHtml={parseRawHtml}
+        />,
+      );
+
+      expect(html.match(/chat-markdown-file-link/g)).toHaveLength(2);
+      expect(html).not.toContain("main.ts ·");
+    },
+  );
+
   it.each([true, false])("preserves reference links with parseRawHtml=%s", (parseRawHtml) => {
     const html = renderToStaticMarkup(
       <ChatMarkdown

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -1,6 +1,22 @@
-import { describe, expect, it } from "vite-plus/test";
+import { EnvironmentId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
 
-import { orderedListGutterStyle } from "./ChatMarkdown";
+vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
+vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+vi.mock("../state/use-atom-query-runner", () => ({ useAtomQueryRunner: () => vi.fn() }));
+vi.mock("../state/use-atom-command", () => ({ useAtomCommand: () => vi.fn() }));
+vi.mock("../state/session", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../state/session")>()),
+  usePreparedConnection: () => ({ _tag: "Loading" }),
+}));
+vi.mock("../state/entities", () => ({
+  useActiveEnvironmentId: () => EnvironmentId.make("env-windows"),
+}));
+vi.mock("../editorPreferences", () => ({ useOpenInPreferredEditor: () => vi.fn() }));
+vi.mock("~/lib/openPullRequestLink", () => ({ useOpenChangeRequestLink: () => vi.fn() }));
+
+import ChatMarkdown, { orderedListGutterStyle } from "./ChatMarkdown";
 
 describe("orderedListGutterStyle", () => {
   it("leaves the default gutter alone for single-digit lists", () => {
@@ -40,5 +56,64 @@ describe("orderedListGutterStyle", () => {
   it("treats a missing/zero item count as a single item", () => {
     expect(orderedListGutterStyle(0, undefined)).toBeUndefined();
     expect(orderedListGutterStyle(0, 100)).toEqual({ "--list-gutter": "4ch" });
+  });
+});
+
+describe("ChatMarkdown Windows file links", () => {
+  it.each([true, false])("preserves drive paths with parseRawHtml=%s", (parseRawHtml) => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="C:/Users/shawn/project"
+        text="[Open](C:/Users/shawn/project/src/main.ts)"
+        lineBreaks={!parseRawHtml}
+        parseRawHtml={parseRawHtml}
+      />,
+    );
+
+    expect(html).toContain('href="C:/Users/shawn/project/src/main.ts"');
+    expect(html).toContain("chat-markdown-file-link");
+  });
+
+  it.each([true, false])("normalizes backslashes with parseRawHtml=%s", (parseRawHtml) => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="C:/Users/shawn/project"
+        text={String.raw`[Open](C:\Users\shawn\project\src\main.ts)`}
+        lineBreaks={!parseRawHtml}
+        parseRawHtml={parseRawHtml}
+      />,
+    );
+
+    expect(html).toContain('href="C:/Users/shawn/project/src/main.ts"');
+    expect(html).toContain("chat-markdown-file-link");
+  });
+
+  it.each([true, false])("preserves reference links with parseRawHtml=%s", (parseRawHtml) => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="C:/Users/shawn/project"
+        text={"[Open][source]\n\n[source]: C:/Users/shawn/project/src/main.ts"}
+        lineBreaks={!parseRawHtml}
+        parseRawHtml={parseRawHtml}
+      />,
+    );
+
+    expect(html).toContain('href="C:/Users/shawn/project/src/main.ts"');
+    expect(html).toContain("chat-markdown-file-link");
+  });
+
+  it.each([true, false])("still rejects unsafe schemes with parseRawHtml=%s", (parseRawHtml) => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="C:/Users/shawn/project"
+        text="[unsafe](javascript:alert(1)) and [unknown](d:alert(1))"
+        lineBreaks={!parseRawHtml}
+        parseRawHtml={parseRawHtml}
+      />,
+    );
+
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain("d:alert");
+    expect(html).not.toContain("chat-markdown-file-link");
   });
 });

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -128,6 +128,7 @@ interface ChatMarkdownProps {
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
 
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
+const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
 const MAX_HIGHLIGHT_CACHE_MEMORY_BYTES = 50 * 1024 * 1024;
 
@@ -197,7 +198,7 @@ function rehypeNormalizeWindowsImageSrc() {
         node.type === "element" &&
         node.tagName === "img" &&
         typeof src === "string" &&
-        /^[A-Za-z]:[\\/]/.test(src)
+        WINDOWS_DRIVE_PATH_REGEX.test(src)
       ) {
         node.properties = {
           ...node.properties,
@@ -231,7 +232,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
   remarkPreserveCodeMeta,
-  remarkTagInlineCode,
+  remarkNormalizeLinksAndTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 
 const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
@@ -240,7 +241,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkNormalizeListItemIndentation,
   remarkBreaks,
   remarkPreserveCodeMeta,
-  remarkTagInlineCode,
+  remarkNormalizeLinksAndTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
@@ -326,6 +327,7 @@ function extractPreCodeMeta(node: unknown): string | undefined {
 type MarkdownAstNode = {
   type?: string;
   meta?: unknown;
+  url?: string;
   data?: {
     hProperties?: Record<string, unknown>;
   };
@@ -352,15 +354,20 @@ function remarkPreserveCodeMeta() {
 }
 
 /**
- * Fenced code also lands on the `code` component, and inline vs block is no
- * longer distinguishable there once both render `<code>` — so inline spans are
- * tagged on the mdast, where the distinction still exists. Code inside a link
- * label stays untagged: linkifying it would nest an anchor inside the link's
- * anchor and steal its clicks.
+ * Preserve Windows drive links as allowed `file:` URLs before sanitization.
+ * The same traversal tags inline code while it can still be distinguished
+ * from fenced code. Code inside links stays untagged to avoid nested anchors.
  */
-function remarkTagInlineCode() {
+function remarkNormalizeLinksAndTagInlineCode() {
   return (tree: MarkdownAstNode) => {
     const visit = (node: MarkdownAstNode, insideLink: boolean) => {
+      if (
+        (node.type === "link" || node.type === "definition") &&
+        typeof node.url === "string" &&
+        WINDOWS_DRIVE_PATH_REGEX.test(node.url)
+      ) {
+        node.url = `file:///${node.url.replaceAll("\\", "/")}`;
+      }
       if (node.type === "inlineCode" && !insideLink) {
         node.data = {
           ...node.data,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -950,7 +950,10 @@ function extractInlineCodeSpans(text: string): string[] {
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
   const normalizedHref = normalizeMarkdownLinkDestination(href);
-  return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
+  const rewrittenHref = rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
+  return WINDOWS_DRIVE_PATH_REGEX.test(rewrittenHref)
+    ? rewrittenHref.replaceAll("\\", "/")
+    : rewrittenHref;
 }
 
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -882,14 +882,12 @@ function pathParentSegments(path: string): string[] {
 function buildFileLinkParentSuffixByPath(filePaths: ReadonlyArray<string>): Map<string, string> {
   const groups = new Map<string, Set<string>>();
   for (const filePath of filePaths) {
-    const pathSegments = filePath
-      .replaceAll("\\", "/")
-      .split("/")
-      .filter((segment) => segment.length > 0);
+    const normalizedPath = filePath.replaceAll("\\", "/");
+    const pathSegments = normalizedPath.split("/").filter((segment) => segment.length > 0);
     const basename = pathSegments[pathSegments.length - 1];
     if (!basename) continue;
     const group = groups.get(basename) ?? new Set<string>();
-    group.add(filePath);
+    group.add(normalizedPath);
     groups.set(basename, group);
   }
 
@@ -1615,7 +1613,9 @@ function ChatMarkdown({
       copyMarkdown: string,
       className?: string,
     ) => {
-      const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
+      const parentSuffix = fileLinkParentSuffixByPath.get(
+        fileLinkMeta.filePath.replaceAll("\\", "/"),
+      );
       const labelParts = [fileLinkMeta.basename];
       if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
         labelParts.push(parentSuffix);


### PR DESCRIPTION
Windows file links such as `C:/Users/shawn/project/src/main.ts` were not clickable in chat because Markdown sanitization treated the drive letter as an unsafe URL scheme.

Normalize Windows drive paths to already-allowed `file:` URLs during the existing Markdown tree traversal. Assistant and user messages, backslash paths, and reference links now open correctly without changing the sanitizer or adding another tree pass.

Thanks to @peculiarnewbie ([#6237](https://github.com/pingdotgg/t3code/pull/6237)), @thiscallnet ([#5283](https://github.com/pingdotgg/t3code/pull/5283)), @maslinedwin ([#7182](https://github.com/pingdotgg/t3code/pull/7182)), and @CDVolvik ([#7189](https://github.com/pingdotgg/t3code/pull/7189)) for their work and the implementations that informed this fix.

Verified with 69 focused tests, web typecheck, and targeted lint and formatting checks.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Markdown URL sanitization and link rewriting. Tests still reject javascript: and unknown schemes, but this is security-adjacent rendering.
> 
> **Overview**
> Makes Windows drive-letter file links in chat Markdown clickable. Sanitization previously treated `C:` as an unsafe scheme, so those hrefs were stripped.
> 
> The existing remark pass now rewrites matching `link` and `definition` URLs to `file:///` with forward slashes before sanitize, covering assistant/user messages, backslash paths, and reference links. File-link disambiguation keys also normalize slashes so `src\index.ts` and `test\index.ts` still get distinct labels.
> 
> Unsafe schemes such as `javascript:` remain rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c458380a88bcbeb063b28ba27add5e879c1ee4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows file links in `ChatMarkdown` chat rendering
> - Adds `WINDOWS_DRIVE_PATH_REGEX` and rewrites markdown link, definition, and `<img>` src values that start with a Windows drive path to `file:///` form with forward slashes via the renamed `remarkNormalizeLinksAndTagInlineCode` and `rehypeNormalizeWindowsImageSrc` plugins
> - Normalizes backslashes to forward slashes in `buildFileLinkParentSuffixByPath`, `normalizeMarkdownLinkHrefKey`, and the `fileLinkChip` helper so disambiguation suffixes and link keys match regardless of slash style
> - Preserves existing inline-code tagging behavior; code inside links is now skipped for tagging
> - Behavioral Change: markdown links and images with Windows drive paths are now rewritten to `file:///C:/...` before sanitization; out-of-tree consumers of `CHAT_MARKDOWN_REMARK_PLUGINS` will see the renamed/merged plugin replacing `remarkTagInlineCode`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c458380.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->