### PR TITLE
feat(git): let users choose the worktree branch prefix

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -150,6 +150,7 @@ describe("ProviderCommandReactor", () => {
     readonly requiresNewThreadForModelChange?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly worktreeBranchPrefix?: string;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly startSessionEffect?: (
@@ -426,7 +427,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.worktreeBranchPrefix === undefined
+            ? {}
+            : { worktreeBranchPrefix: input.worktreeBranchPrefix },
+        ),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -1472,59 +1479,81 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Reconnect spinner resume bug");
   });
 
-  it("generates a worktree branch name for the first turn", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  it.each([
+    {
+      prefix: undefined,
+      generated: "feature/reconnect-backoff",
+      expected: "t3code/feature/reconnect-backoff",
+    },
+    {
+      prefix: "my-team",
+      generated: "My-Team/Feature/Reconnect Backoff",
+      expected: "my-team/feature/reconnect-backoff",
+    },
+    {
+      prefix: "my-team",
+      generated: "t3code/feature/reconnect-backoff",
+      expected: "my-team/feature/reconnect-backoff",
+    },
+    {
+      prefix: "t3code/my-team",
+      generated: "t3code/my-team/feature/reconnect-backoff",
+      expected: "t3code/my-team/feature/reconnect-backoff",
+    },
+    {
+      prefix: "",
+      generated: "t3code/feature/reconnect-backoff",
+      expected: "feature/reconnect-backoff",
+    },
+  ])(
+    "generates a worktree branch with prefix $prefix for the first turn",
+    async ({ prefix, generated, expected }) => {
+      const harness = await createHarness(
+        prefix === undefined ? undefined : { worktreeBranchPrefix: prefix },
+      );
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-thread-branch"),
-        threadId: ThreadId.make("thread-1"),
-        branch: "t3code/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make("cmd-thread-branch"),
+          threadId: ThreadId.make("thread-1"),
+          branch: "t3code/1234abcd",
+          worktreePath: "/tmp/provider-project-worktree",
+        }),
+      );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
-    );
+      harness.generateBranchName.mockReturnValue(Effect.succeed({ branch: generated }));
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-branch-model"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-branch-model"),
-          role: "user",
-          text: "Add a safer reconnect backoff.",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-branch-model"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-branch-model"),
+            role: "user",
+            text: "Add a safer reconnect backoff.",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      );
 
-    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
-    await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
-    expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
-      message: "Add a safer reconnect backoff.",
-    });
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
-  });
+      await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
+      await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
+      expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
+        message: "Add a safer reconnect backoff.",
+      });
+      expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+      expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+        oldBranch: "t3code/1234abcd",
+        newBranch: expected,
+      });
+    },
+  );
 
   it("recreates a missing worktree from the thread branch before starting a turn", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1496,6 +1496,16 @@ describe("ProviderCommandReactor", () => {
       expected: "my-team/feature/reconnect-backoff",
     },
     {
+      prefix: "feature",
+      generated: "t3code/feature/reconnect-backoff",
+      expected: "feature/reconnect-backoff",
+    },
+    {
+      prefix: "teams/platform",
+      generated: "t3code/teams/platform/reconnect-backoff",
+      expected: "teams/platform/reconnect-backoff",
+    },
+    {
       prefix: "t3code/my-team",
       generated: "t3code/my-team/feature/reconnect-backoff",
       expected: "t3code/my-team/feature/reconnect-backoff",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -287,12 +287,15 @@ function buildGeneratedWorktreeBranchName(raw: string, prefix: string): string {
     .replace(/^refs\/heads\//, "")
     .replace(/['"`]/g, "");
 
+  const withoutLegacyPrefix =
+    normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`) &&
+    !(prefix.length > 0 && normalized.startsWith(`${prefix}/`))
+      ? normalized.slice(WORKTREE_BRANCH_PREFIX.length + 1)
+      : normalized;
   const withoutPrefix =
-    prefix.length > 0 && normalized.startsWith(`${prefix}/`)
-      ? normalized.slice(prefix.length + 1)
-      : normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-        ? normalized.slice(WORKTREE_BRANCH_PREFIX.length + 1)
-        : normalized;
+    prefix.length > 0 && withoutLegacyPrefix.startsWith(`${prefix}/`)
+      ? withoutLegacyPrefix.slice(prefix.length + 1)
+      : withoutLegacyPrefix;
 
   const safeFragment = sanitizeBranchFragment(withoutPrefix);
   return prefix.length > 0 ? `${prefix}/${safeFragment}` : safeFragment;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,11 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import {
+  isTemporaryWorktreeBranch,
+  sanitizeBranchFragment,
+  WORKTREE_BRANCH_PREFIX,
+} from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -276,27 +280,22 @@ function stalePendingRequestDetail(
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
 }
 
-function buildGeneratedWorktreeBranchName(raw: string): string {
+function buildGeneratedWorktreeBranchName(raw: string, prefix: string): string {
   const normalized = raw
     .trim()
     .toLowerCase()
     .replace(/^refs\/heads\//, "")
     .replace(/['"`]/g, "");
 
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
+  const withoutPrefix =
+    prefix.length > 0 && normalized.startsWith(`${prefix}/`)
+      ? normalized.slice(prefix.length + 1)
+      : normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
+        ? normalized.slice(WORKTREE_BRANCH_PREFIX.length + 1)
+        : normalized;
 
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
+  const safeFragment = sanitizeBranchFragment(withoutPrefix);
+  return prefix.length > 0 ? `${prefix}/${safeFragment}` : safeFragment;
 }
 
 const make = Effect.gen(function* () {
@@ -866,7 +865,10 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        generated.branch,
+        settings.worktreeBranchPrefix,
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -36,6 +36,7 @@ import {
   MIN_TERMINAL_FONT_SIZE,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import { sanitizeBranchFragment } from "@t3tools/shared/git";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -526,6 +527,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix
+        ? ["Worktree branch prefix"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -559,6 +563,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeBranchPrefix,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
       settings.fontFamilyCode,
@@ -667,6 +672,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2291,6 +2297,40 @@ export function GeneralSettingsPanel() {
             }
           />
         ) : null}
+
+        <SettingsRow
+          {...searchableSetting("worktree-branch-prefix")}
+          description="Prefix for generated worktree branch names. Leave blank for no prefix."
+          resetAction={
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+              <SettingResetButton
+                label="worktree branch prefix"
+                onClick={() =>
+                  updateSettings({
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              className="w-full sm:w-44"
+              value={settings.worktreeBranchPrefix}
+              placeholder="No prefix"
+              spellCheck={false}
+              aria-label="Worktree branch prefix"
+              onCommit={(value) => {
+                const worktreeBranchPrefix = /[a-z0-9]/i.test(value)
+                  ? sanitizeBranchFragment(value)
+                  : "";
+                if (worktreeBranchPrefix !== settings.worktreeBranchPrefix) {
+                  updateSettings({ worktreeBranchPrefix });
+                }
+              }}
+            />
+          }
+        />
 
         <SettingsRow
           {...searchableSetting("add-project-starts-in")}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -153,6 +153,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "new-threads",
   },
   {
+    id: "worktree-branch-prefix",
+    title: "Worktree branch prefix",
+    to: "/settings/general",
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -13,6 +13,11 @@ T3 Code works with the platforms your team already uses:
 
 ## What You Can Do
 
+### Choose a Worktree Branch Prefix
+
+New worktree branch names start with `t3code/` by default. In **Settings > General > Worktree branch
+prefix**, enter a custom prefix or clear the field to use no prefix.
+
 ### Start Projects from Anywhere
 
 **Clone repositories directly**

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -246,6 +246,26 @@ describe("ServerSettings worktree defaults", () => {
       decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
     ).toBe(false);
   });
+
+  it("defaults the worktree branch prefix for legacy configs", () => {
+    expect(decodeServerSettings({}).worktreeBranchPrefix).toBe("t3code");
+  });
+
+  it.each(["", "team", "my-team", "team/backend", "team_1"])(
+    "accepts the worktree branch prefix %j",
+    (worktreeBranchPrefix) => {
+      expect(decodeServerSettingsPatch({ worktreeBranchPrefix }).worktreeBranchPrefix).toBe(
+        worktreeBranchPrefix,
+      );
+    },
+  );
+
+  it.each(["../unsafe", "team//backend", "Team", "-team", "team-", "a".repeat(65)])(
+    "rejects the unsafe worktree branch prefix %j",
+    (worktreeBranchPrefix) => {
+      expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix })).toThrow();
+    },
+  );
 });
 
 describe("ServerSettings.sourceControlWritingStyle", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -278,6 +278,12 @@ const makeBinaryPathSetting = (fallback: string) =>
     Schema.withDecodingDefault(Effect.succeed(fallback)),
   );
 
+const WorktreeBranchPrefix = TrimmedString.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^(?:[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?)?$/),
+  Schema.makeFilter((value) => !value.includes("//") || "must not contain adjacent slashes"),
+);
+
 export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch";
 
 export interface ProviderSettingsFormAnnotation {
@@ -639,6 +645,9 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  worktreeBranchPrefix: WorktreeBranchPrefix.pipe(
+    Schema.withDecodingDefault(Effect.succeed("t3code")),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -838,6 +847,7 @@ export const ServerSettingsPatch = Schema.Struct({
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeBranchPrefix: Schema.optionalKey(WorktreeBranchPrefix),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(


### PR DESCRIPTION
Generated worktree branches always start with `t3code/`, which conflicts with personal and team branch conventions.

Add a server-owned **Worktree branch prefix** setting under **Settings > General**. It defaults to `t3code`, accepts validated custom prefixes, and can be cleared to create branches without a prefix. Temporary branches stay unchanged, and the server applies the prefix when it generates the final branch name for web, desktop, mobile, and remote clients.

Inspired by and with thanks to:
- @yasinkavakli for [#7887](https://github.com/pingdotgg/t3code/pull/7887)
- @filipgutica for [#6037](https://github.com/pingdotgg/t3code/pull/6037)
- @jssblck for [#3954](https://github.com/pingdotgg/t3code/pull/3954)
- @MrSimmmons for [#6428](https://github.com/pingdotgg/t3code/pull/6428)

Verified with 116 focused tests, targeted lint, and scoped typechecks for contracts, shared, client runtime, server, web, and mobile.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git branch naming and persisted server settings. Invalid prefixes are schema-validated, but misconfigured prefixes still change how worktrees are renamed for all clients.
> 
> **Overview**
> Users can now set a **Worktree branch prefix** in Settings > General. Generated worktree names still default to `t3code/…`, but a custom prefix (including nested paths like `teams/platform`) is applied server-side, and clearing the field creates unprefixed branches.
> 
> `buildGeneratedWorktreeBranchName` strips a leftover `t3code/` from the model output when it is not the configured prefix, then sanitizes the remainder. Temporary worktree branches are unchanged.
> 
> The new `worktreeBranchPrefix` setting is validated (lowercase, max 64, no `//` or leading/trailing separators) and wired through dirty/reset/search plus user docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5ed3f01680ba8445bb54879d389f61454711e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `worktreeBranchPrefix` setting defaulting to `t3code`
> - Adds a `worktreeBranchPrefix` field to `ServerSettings`, defaulting to `t3code` and validated by the new `WorktreeBranchPrefix` schema (max 64 chars, lowercase alphanumerics, no adjacent slashes).
> - Updates `buildGeneratedWorktreeBranchName` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/8082/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) to accept a `prefix` argument and sanitize it via `sanitizeBranchFragment`.
> - Adds a UI control in the General Settings panel to edit the prefix, with settings search indexing and restore-defaults support.
> - Behavioral Change: `buildGeneratedWorktreeBranchName` now requires a `prefix` parameter; existing callers must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e5ed3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->