### PR TITLE
fix(web): stop update notices showing through the composer

### DIFF
--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -53,7 +53,7 @@ describe("ComposerBannerStack", () => {
     expect(markup).not.toContain("data-composer-banner-stack-expanded-items");
     expect(markup).toContain("chat-composer-drawer-surface");
     expect(markup).toContain("chat-composer-drawer-attached");
-    expect(markup).toContain("before:mask-none");
+    expect(markup).not.toContain("before:mask-none");
     expect(markup).toContain("text-xs");
     expect(markup).toContain('data-composer-banner-drawer="true"');
     expect(markup).toContain('data-variant="warning"');

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -199,7 +199,7 @@ function ComposerBannerStackAlert({
       variant={item.variant}
       className={cn(
         attached
-          ? "chat-composer-drawer-surface chat-composer-drawer-attached px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)_+_0.375rem)] text-xs before:mask-none sm:px-4"
+          ? "chat-composer-drawer-surface chat-composer-drawer-attached px-3 pt-2 pb-[calc(var(--chat-composer-attachment-overlap)_+_0.375rem)] text-xs sm:px-4"
           : "alert-glass rounded-[22px]",
         item.className,
       )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1021,6 +1021,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 
   .chat-composer-glass-host {
+    background: var(--chat-composer-glass-surface);
     box-shadow: 0 12px 28px -18px rgb(0 0 0 / 40%);
 
     @variant dark {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1021,7 +1021,6 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 
   .chat-composer-glass-host {
-    background: var(--chat-composer-glass-surface);
     box-shadow: 0 12px 28px -18px rgb(0 0 0 / 40%);
 
     @variant dark {


### PR DESCRIPTION
Server update notices showed through the message composer because `before:mask-none` disabled the banner's overlap mask. Remove that override so the existing mask hides the notice without changing the composer's glass, blur, or opacity.

Verified in Chrome: the 17-pixel banner overlap is masked, while the original 80% glass opacity and 16-pixel blur stay unchanged. The production web build and all four composer banner tests pass.

Made with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS class tweak on composer banner chrome only; no logic, auth, or data-path changes.
> 
> **Overview**
> Stops attached composer banners from disabling the drawer-surface `::before` mask.
> 
> `ComposerBannerStackAlert` no longer adds `before:mask-none` on attached banners, so the bottom overlap stays cut out and the composer surface can cover content behind it. The single-banner test now asserts that class is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9676863de4d50e5f127cd87f7120b0fb571f628f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `before:mask-none` from `ComposerBannerStackAlert` attached state
> Removes the `before:mask-none` utility class from the attached-state className in [ComposerBannerStack.tsx](https://github.com/pingdotgg/t3code/pull/8083/files#diff-70e682f5637e29152782d8d01713cd41d0ced0860f99ad7cefbdc07da06e364b). This stops update notices from showing through the composer overlay. The corresponding test in [ComposerBannerStack.test.tsx](https://github.com/pingdotgg/t3code/pull/8083/files#diff-42a843f261677966877e088af03bb146717f2e6ca66172f4763d8449d994a5f0) is updated to assert the class is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9676863.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->