### PR TITLE
feat(web): settle and restore threads with a keyboard shortcut

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -195,6 +195,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
+      assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+s");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -204,6 +204,7 @@ import {
 } from "../hooks/useSettings";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { confirmTerminalClose, isTerminalCloseConfirmPending } from "../lib/terminalCloseConfirm";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
@@ -1257,6 +1258,7 @@ function ChatViewContent(props: ChatViewProps) {
   const threadSyncPhase = routeKind === "server" ? (props.threadSyncPhase ?? null) : null;
   const threadDetailLoading = threadSyncPhase === "loading";
   const handleNewThread = useNewThreadHandler();
+  const { settleThread } = useThreadActions();
   const routeThreadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
@@ -4928,6 +4930,29 @@ function ChatViewContent(props: ChatViewProps) {
       });
       if (!command) return;
 
+      if (command === "thread.settle") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!isServerThread || !activeThreadRef || !supportsSettlement) return;
+        if (activeThreadSettled) {
+          void handleUnsettleActiveThread();
+          return;
+        }
+
+        void settleThread(activeThreadRef).then((result) => {
+          if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to settle thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        });
+        return;
+      }
+
       if (command === "terminal.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -5031,6 +5056,8 @@ function ChatViewContent(props: ChatViewProps) {
     activeProject,
     activeRightPanelSurface,
     addTerminalSurface,
+    activeThreadRef,
+    activeThreadSettled,
     terminalUiState.terminalOpen,
     terminalUiState.activeTerminalId,
     activeThreadId,
@@ -5042,7 +5069,11 @@ function ChatViewContent(props: ChatViewProps) {
     splitTerminal,
     splitPanelTerminal,
     keybindings,
+    handleUnsettleActiveThread,
+    isServerThread,
     onToggleDiff,
+    settleThread,
+    supportsSettlement,
     toggleRightPanel,
     toggleRightPanelMaximized,
     toggleTerminalVisibility,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -142,6 +142,11 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
+  {
+    shortcut: modShortcut("s", { shiftKey: true }),
+    command: "thread.settle",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
   { shortcut: modShortcut("1"), command: "thread.jump.1" },
   { shortcut: modShortcut("2"), command: "thread.jump.2" },
   { shortcut: modShortcut("3"), command: "thread.jump.3" },
@@ -180,6 +185,27 @@ describe("isTerminalToggleShortcut", () => {
   it("matches Ctrl+J on non-macOS while terminalFocus is true", () => {
     assert.isTrue(
       isTerminalToggleShortcut(event({ ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+        context: { terminalFocus: true },
+      }),
+    );
+  });
+});
+
+describe("settle thread shortcut", () => {
+  it("resolves outside the terminal", () => {
+    assert.equal(
+      resolveShortcutCommand(event({ key: "s", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "thread.settle",
+    );
+  });
+
+  it("does not intercept the terminal", () => {
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "s", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
         platform: "Win32",
         context: { terminalFocus: true },
       }),

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo } from "react";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
-import { readThreadShell, useProjects } from "../state/entities";
+import { readEnvironmentSupportsSettlement, readThreadShell, useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
@@ -124,6 +124,7 @@ function ChatRouteGlobalShortcuts() {
         event.preventDefault();
         event.stopPropagation();
         if (!routeThreadRef) return;
+        if (!readEnvironmentSupportsSettlement(routeThreadRef.environmentId)) return;
 
         const thread = readThreadShell(routeThreadRef);
         if (!thread) return;

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,16 +1,23 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
 import { useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
-import { useProjects } from "../state/entities";
+import { readThreadShell, useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -19,6 +26,8 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { threadChangeRequestSnapshotsAtom } from "../components/ThreadStatusIndicators";
+import { appAtomRegistry } from "../rpc/atomRegistry";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 
@@ -27,9 +36,12 @@ function ChatRouteGlobalShortcuts() {
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
+  const { settleThread, unsettleThread } = useThreadActions();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const legacySidebarEnabled = useLegacySidebarEnabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
+  const autoSettleOnMerge = useClientSettings((settings) => settings.sidebarAutoSettleOnMerge);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const projectGroupCount = useMemo(
@@ -108,6 +120,44 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
+      if (command === "thread.settle") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!routeThreadRef) return;
+
+        const thread = readThreadShell(routeThreadRef);
+        if (!thread) return;
+
+        const snapshot = appAtomRegistry
+          .get(threadChangeRequestSnapshotsAtom)
+          .get(scopedThreadKey(routeThreadRef));
+        const changeRequest =
+          snapshot != null && (thread.worktreePath === null || snapshot.branch === thread.branch)
+            ? snapshot.pr
+            : null;
+        const settled = effectiveSettled(thread, {
+          now: `${new Date().toISOString().slice(0, 16)}:00.000Z`,
+          autoSettleAfterDays,
+          autoSettleOnMerge,
+          changeRequest,
+        });
+
+        void (settled ? unsettleThread(routeThreadRef) : settleThread(routeThreadRef)).then(
+          (result) => {
+            if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: settled ? "Failed to un-settle thread" : "Failed to settle thread",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          },
+        );
+        return;
+      }
+
       if (command === "preview.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -159,6 +209,8 @@ function ChatRouteGlobalShortcuts() {
   }, [
     activeDraftThread,
     activeThread,
+    autoSettleAfterDays,
+    autoSettleOnMerge,
     clearSelection,
     handleNewThread,
     keybindings,
@@ -167,8 +219,10 @@ function ChatRouteGlobalShortcuts() {
     projectGroupCount,
     routeThreadRef,
     selectedThreadKeysSize,
+    settleThread,
     legacySidebarEnabled,
     terminalOpen,
+    unsettleThread,
   ]);
 
   return null;

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,23 +1,16 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
-import { scopedThreadKey } from "@t3tools/client-runtime/environment";
-import {
-  isAtomCommandInterrupted,
-  squashAtomCommandFailure,
-} from "@t3tools/client-runtime/state/runtime";
-import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
 import { useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
-import { readEnvironmentSupportsSettlement, readThreadShell, useProjects } from "../state/entities";
+import { useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { useThreadActions } from "../hooks/useThreadActions";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -26,8 +19,6 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
-import { threadChangeRequestSnapshotsAtom } from "../components/ThreadStatusIndicators";
-import { appAtomRegistry } from "../rpc/atomRegistry";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 
@@ -36,12 +27,9 @@ function ChatRouteGlobalShortcuts() {
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
-  const { settleThread, unsettleThread } = useThreadActions();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const legacySidebarEnabled = useLegacySidebarEnabled();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
-  const autoSettleOnMerge = useClientSettings((settings) => settings.sidebarAutoSettleOnMerge);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const projectGroupCount = useMemo(
@@ -120,45 +108,6 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      if (command === "thread.settle") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!routeThreadRef) return;
-        if (!readEnvironmentSupportsSettlement(routeThreadRef.environmentId)) return;
-
-        const thread = readThreadShell(routeThreadRef);
-        if (!thread) return;
-
-        const snapshot = appAtomRegistry
-          .get(threadChangeRequestSnapshotsAtom)
-          .get(scopedThreadKey(routeThreadRef));
-        const changeRequest =
-          snapshot != null && (thread.worktreePath === null || snapshot.branch === thread.branch)
-            ? snapshot.pr
-            : null;
-        const settled = effectiveSettled(thread, {
-          now: `${new Date().toISOString().slice(0, 16)}:00.000Z`,
-          autoSettleAfterDays,
-          autoSettleOnMerge,
-          changeRequest,
-        });
-
-        void (settled ? unsettleThread(routeThreadRef) : settleThread(routeThreadRef)).then(
-          (result) => {
-            if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
-            const error = squashAtomCommandFailure(result);
-            toastManager.add(
-              stackedThreadToast({
-                type: "error",
-                title: settled ? "Failed to un-settle thread" : "Failed to settle thread",
-                description: error instanceof Error ? error.message : "An error occurred.",
-              }),
-            );
-          },
-        );
-        return;
-      }
-
       if (command === "preview.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -210,8 +159,6 @@ function ChatRouteGlobalShortcuts() {
   }, [
     activeDraftThread,
     activeThread,
-    autoSettleAfterDays,
-    autoSettleOnMerge,
     clearSelection,
     handleNewThread,
     keybindings,
@@ -220,10 +167,8 @@ function ChatRouteGlobalShortcuts() {
     projectGroupCount,
     routeThreadRef,
     selectedThreadKeysSize,
-    settleThread,
     legacySidebarEnabled,
     terminalOpen,
-    unsettleThread,
   ]);
 
   return null;

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -52,6 +52,9 @@ successful pick; its hover glow and badge preview the element and color family t
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.
 
+`thread.settle` settles the active thread or restores it when it is already settled. Its default
+shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -107,6 +107,13 @@ it.effect("parses keybinding rules", () =>
       command: "thread.previous",
     });
     assert.strictEqual(parsedThreadPrevious.command, "thread.previous");
+
+    const parsedThreadSettle = yield* decode(KeybindingRule, {
+      key: "mod+shift+s",
+      command: "thread.settle",
+      when: "!terminalFocus",
+    });
+    assert.strictEqual(parsedThreadSettle.command, "thread.settle");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.settle",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,6 +46,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "mod+shift+s", command: "thread.settle", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
Settling the active thread required pointer-driven sidebar or header actions, and settled threads had no matching keyboard path back.

Add `thread.settle` with the default shortcut `mod+shift+s`. The same shortcut settles an active thread or restores a settled thread, respects existing settlement rules, and never intercepts keys while the terminal has focus. The shortcut is configurable through the existing keybinding settings.

Inspired by and with thanks to:
- @effektsvk for [#6446](https://github.com/pingdotgg/t3code/pull/6446)
- @jackmhny for [#5940](https://github.com/pingdotgg/t3code/pull/5940)
- @UtkarshUsername for [#7881](https://github.com/pingdotgg/t3code/pull/7881)
- @colonelpanic8 for [#4277](https://github.com/pingdotgg/t3code/pull/4277)
- @jbmcguire for [#4876](https://github.com/pingdotgg/t3code/pull/4876)

Verified with 83 focused contract, server, and web tests, targeted lint and formatting, plus scoped typechecks for contracts, shared, client runtime, server, and web.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard-only wiring to existing thread settlement APIs with the same guards as pointer actions; no new auth or data paths.
> 
> **Overview**
> Adds a **`thread.settle`** keybinding (`mod+shift+s`, disabled when the terminal has focus) across contracts, shared defaults, and server default tests.
> 
> **ChatView** global shortcuts now handle that command: on a settle-capable server thread they call existing **settle** / **unsettle** flows (same rules as UI), with an error toast if settle fails.
> 
> Web and contracts tests cover resolution and the `!terminalFocus` guard; user docs describe the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f0c37195d39b6f167a35dc3d2fbb0e511a41de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mod+shift+s` keyboard shortcut to settle and restore threads
> - Adds the `thread.settle` command to `THREAD_KEYBINDING_COMMANDS` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/8089/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6) and maps `mod+shift+s` to it in the default keybinding set in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/8089/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06)
> - Wires the shortcut into `ChatViewContent` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8089/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e): when pressed on an active server thread that supports settlement, it calls `settleThread` or `handleUnsettleActiveThread` if already settled, showing a toast on failure
> - The shortcut is gated on `!terminalFocus` so it does not fire inside the terminal
> - Documents the new shortcut in [keybindings.md](https://github.com/pingdotgg/t3code/pull/8089/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43)
> - Risk: the new global keydown branch in `ChatViewContent` calls `preventDefault` on `mod+shift+s` outside the terminal, which could shadow existing browser or app shortcuts bound to that combination
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e4f0c37. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 4933](https://github.com/pingdotgg/t3code/blob/e4f0c37195d39b6f167a35dc3d2fbb0e511a41de/apps/web/src/components/ChatView.tsx#L4933): The new `thread.settle` branch does not enforce the terminal-focus exclusion itself. `resolveShortcutCommand` accepts bindings with no `whenAst` (and users can configure a custom binding without `!terminalFocus`), so when such a binding matches while a terminal owns focus this branch still calls `settleThread`/`handleUnsettleActiveThread` after only checking the server/thread guards. This lets a terminal keystroke unexpectedly settle or restore the active thread, contrary to the shortcut's terminal-focus behavior. <b>[ Filtered as negative feedback ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->