### PR TITLE
feat(mobile-ios): paste into the terminal with a long press

### DIFF
--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -132,6 +132,14 @@ private enum TerminalInputSequence {
       return input
     }
   }
+
+  /// Pasted text can carry many line endings; each must arrive as Enter, not
+  /// as the Ctrl+J a bare line feed means to a raw-mode TUI.
+  static func normalizingNewlines(_ input: String) -> String {
+    input
+      .replacingOccurrences(of: "\r\n", with: carriageReturn)
+      .replacingOccurrences(of: "\n", with: carriageReturn)
+  }
 }
 
 private final class TerminalInputField: UITextField {
@@ -409,7 +417,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate, UIEditMenuInte
     UIMenu(title: "", children: [
       UIAction(title: "Paste") { [weak self] _ in
         guard let text = UIPasteboard.general.string else { return }
-        self?.emitInput(TerminalInputSequence.normalizingReturn(text))
+        self?.emitInput(TerminalInputSequence.normalizingNewlines(text))
       },
     ])
   }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -193,7 +193,7 @@ private extension UIColor {
   }
 }
 
-public final class T3TerminalView: ExpoView, UITextFieldDelegate {
+public final class T3TerminalView: ExpoView, UITextFieldDelegate, UIEditMenuInteractionDelegate {
   private static let minimumVerticalScrollStepPoints: CGFloat = 18
   private static let verticalScrollStepMultiplier: CGFloat = 1.15
 
@@ -201,6 +201,8 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private let inputField = TerminalInputField()
   private let focusTapGesture = UITapGestureRecognizer()
   private let scrollPanGesture = UIPanGestureRecognizer()
+  private let pasteLongPressGesture = UILongPressGestureRecognizer()
+  private lazy var pasteMenuInteraction = UIEditMenuInteraction(delegate: self)
   private var lastViewportSize: CGSize = .zero
   private var lastContentScale: CGFloat = 0
   private var lastReportedGrid: (cols: Int, rows: Int)?
@@ -328,6 +330,10 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     scrollPanGesture.maximumNumberOfTouches = 1
     scrollPanGesture.cancelsTouchesInView = false
     terminalViewport.addGestureRecognizer(scrollPanGesture)
+    pasteLongPressGesture.addTarget(self, action: #selector(handleViewportLongPress(_:)))
+    pasteLongPressGesture.cancelsTouchesInView = false
+    terminalViewport.addGestureRecognizer(pasteLongPressGesture)
+    terminalViewport.addInteraction(pasteMenuInteraction)
 
     addSubview(terminalViewport)
     addSubview(inputField)
@@ -393,9 +399,38 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     return false
   }
 
+  /// Backs the Paste item of the long-press edit menu. Clipboard text is sent
+  /// through the same input path as the keyboard.
+  public func editMenuInteraction(
+    _ interaction: UIEditMenuInteraction,
+    menuFor configuration: UIEditMenuConfiguration,
+    suggestedActions: [UIMenuElement]
+  ) -> UIMenu? {
+    UIMenu(title: "", children: [
+      UIAction(title: "Paste") { [weak self] _ in
+        guard let text = UIPasteboard.general.string else { return }
+        self?.emitInput(TerminalInputSequence.normalizingReturn(text))
+      },
+    ])
+  }
+
   @objc
   private func handleViewportTap() {
     requestKeyboardFocus()
+  }
+
+  /// Offers the system edit menu where the finger landed, the way a text field does.
+  /// `hasStrings` keeps the menu away when there is nothing to paste, and reads the
+  /// clipboard only once the user taps Paste.
+  @objc
+  private func handleViewportLongPress(_ gesture: UILongPressGestureRecognizer) {
+    guard gesture.state == .began, UIPasteboard.general.hasStrings else { return }
+
+    let configuration = UIEditMenuConfiguration(
+      identifier: nil,
+      sourcePoint: gesture.location(in: terminalViewport)
+    )
+    pasteMenuInteraction.presentEditMenu(with: configuration)
   }
 
   @objc


### PR DESCRIPTION
The iOS terminal has no way to paste. The clipboard callbacks in `T3TerminalView.swift` are stubbed, so anything on the clipboard (a token, a command, a path copied from chat) has to be retyped into the terminal by hand. Android's terminal has clipboard interaction; iOS has none.

Long-pressing the terminal viewport now presents the standard iOS edit menu with a Paste action, the same affordance a text field gives. Pasting sends the clipboard string through `emitInput` wrapped in the file's existing `normalizingReturn`, i.e. exactly the path and normalization every software-keyboard route already uses; the JS boundary is untouched. The menu is deliberate rather than pasting directly on long-press: a terminal is a destructive paste target, and an accidental hold that dumps a multi-line clipboard into a live shell executes those lines. `UIEditMenuInteraction` needs no availability guard at the module's iOS 16.1 deployment target, presentation is gated on `hasStrings`, and the clipboard is read only inside the action, so the system paste notice fires once, on the actual paste.

Gesture interplay, from reading the existing recognizers: scrolling is unaffected (a pan starts moving well before the 0.5s hold, so the long press fails), and the focus tap ends long before the hold threshold. The long press sets `cancelsTouchesInView = false` to match the pan. The clipboard string goes verbatim without bracketed-paste wrapping: this view is display-only for a remote pty and cannot know whether the app enabled DECSET 2004, and wrapping unconditionally would corrupt input for apps that never did.

## Verification

This machine has no Xcode or iOS SDK, so the change is neither compiled nor device-tested; stating that plainly rather than skipping it. What did run:

- SwiftLint 0.65.1 with the repo config, strict: `Found 0 violations, 0 serious in 1 file.`
- `swiftc -parse T3TerminalView.swift`: exit 0 (syntax only, no type checking)

The diff is 36 lines in one file, and every symbol is core UIKit; two of the three already appear in this app (`UILongPressGestureRecognizer` in `T3ReviewDiffView.swift`, `UIPasteboard.general` in `T3ComposerEditorView.swift`). If anything is off in the `UIEditMenuInteraction` call sites it will surface as a compile error on the first CI or local build, not as a silent runtime bug.

Change made by Claude Opus via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pasting into a live remote PTY can execute multi-line clipboard contents; the menu gate reduces accidents, but there is no bracketed-paste wrapping.
> 
> **Overview**
> Lets users paste into the iOS terminal via a long-press system edit menu instead of retyping clipboard text.
> 
> A long-press on the viewport shows **Paste** only when the pasteboard has strings; the clipboard is read only after the user confirms. Pasted text goes through the same `emitInput` path as the keyboard, with `\r\n`/`\n` converted to `\r` so line breaks act as Enter rather than Ctrl+J. Paste is not wrapped in bracketed-paste sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918e4f8946646090767d3fd88fcb1830d0501dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add long-press paste support to iOS terminal in `T3TerminalView`
> - Adds a `UILongPressGestureRecognizer` to [T3TerminalView.swift](https://github.com/pingdotgg/t3code/pull/8095/files#diff-f62e0027105bee3eafacb6199a2218932ecbbd4b8bba7193a3a0da4f065a62ca) that shows a system edit menu with a Paste action when the clipboard contains text.
> - Pasting sends the clipboard string to the terminal via `emitInput`, using a new `TerminalInputSequence.normalizingNewlines` helper to convert CRLF and LF characters to carriage returns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 918e4f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->