### PR TITLE
fix: open agent file links in the file viewer

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/markdownLinks.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/markdownLinks.ts
@@ -3,8 +3,10 @@ import type { MARKDOWN_FILE_ICON_SOURCES } from "./markdownFileIcons.generated";
 const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\/;
 const RELATIVE_PATH_PREFIX_PATTERN = /^(~\/|\.{1,2}\/)/;
-const RELATIVE_FILE_PATH_PATTERN = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}$/;
-const RELATIVE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]+\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
+const RELATIVE_FILE_PATH_PATTERN =
+  /^(?:[A-Za-z0-9._-]+(?: +[A-Za-z0-9._-]+)*\/)+[A-Za-z0-9._-]+(?: +[A-Za-z0-9._-]+)*(?::\d+){0,2}$/;
+const RELATIVE_FILE_NAME_PATTERN =
+  /^[A-Za-z0-9._-]+(?: +[A-Za-z0-9._-]+)*\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
 const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 const POSIX_FILE_ROOT_PREFIXES = [
   "/Users/",

--- a/apps/mobile/src/lib/markdownLinks.test.ts
+++ b/apps/mobile/src/lib/markdownLinks.test.ts
@@ -50,6 +50,24 @@ describe("resolveMarkdownLinkPresentation", () => {
     });
   });
 
+  it.each(["md", "html", "xml"])("recognizes a bare spaced .%s filename", (extension) => {
+    expect(
+      resolveMarkdownLinkPresentation(`Updated%20cutover%20checklist.${extension}`),
+    ).toMatchObject({
+      kind: "file",
+      path: `Updated cutover checklist.${extension}`,
+      label: `Updated cutover checklist.${extension}`,
+    });
+  });
+
+  it("recognizes spaced relative paths", () => {
+    expect(resolveMarkdownLinkPresentation("docs/My%20Folder/checklist.xml")).toMatchObject({
+      kind: "file",
+      path: "docs/My Folder/checklist.xml",
+      label: "checklist.xml",
+    });
+  });
+
   it("extracts line fragments from relative file links", () => {
     expect(resolveMarkdownLinkPresentation("src/main.ts#L18C2")).toMatchObject({
       kind: "file",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -80,6 +80,7 @@ import {
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
+  shouldOpenMarkdownFileLinkInBrowserByDefault,
   shouldOpenMarkdownFileLinkInEditor,
   type MarkdownFileLinkMeta,
 } from "../markdown-links";
@@ -1394,7 +1395,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
                 handleOpenInEditor();
                 return;
               }
-              if (onOpenInBrowser) {
+              if (onOpenInBrowser && shouldOpenMarkdownFileLinkInBrowserByDefault(iconPath)) {
                 handleOpenInBrowser();
                 return;
               }

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -9,6 +9,7 @@ import {
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
+  shouldOpenMarkdownFileLinkInBrowserByDefault,
   shouldOpenMarkdownFileLinkInEditor,
 } from "./markdown-links";
 
@@ -66,6 +67,15 @@ describe("shouldOpenMarkdownFileLinkInEditor", () => {
     expect(
       shouldOpenMarkdownFileLinkInEditor({ metaKey: true, ctrlKey: false }, "Linux x86_64"),
     ).toBe(false);
+  });
+});
+
+describe("shouldOpenMarkdownFileLinkInBrowserByDefault", () => {
+  it("keeps PDFs browser-first while source files open in the file viewer", () => {
+    expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.pdf")).toBe(true);
+    expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.PDF?download=1")).toBe(true);
+    expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.html")).toBe(false);
+    expect(shouldOpenMarkdownFileLinkInBrowserByDefault("report.xml")).toBe(false);
   });
 });
 
@@ -197,6 +207,20 @@ describe("resolveMarkdownFileLinkTarget", () => {
       basename: "My Folder",
     });
   });
+
+  it.each(["md", "html", "xml"])(
+    "resolves a bare spaced .%s filename from the markdown renderer",
+    (extension) => {
+      const href = renderMarkdownLinkHref(`[checklist](<Updated cutover checklist.${extension}>)`);
+
+      expect(href).toBe(`Updated%20cutover%20checklist.${extension}`);
+      expect(resolveMarkdownFileLinkMeta(href, "/repo/project")).toMatchObject({
+        targetPath: `/repo/project/Updated cutover checklist.${extension}`,
+        workspaceRelativePath: `Updated cutover checklist.${extension}`,
+        basename: `Updated cutover checklist.${extension}`,
+      });
+    },
+  );
 
   it("formats tooltip display paths relative to the cwd for slash-prefixed windows paths", () => {
     expect(

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -11,7 +11,8 @@ const EXTERNAL_SCHEME_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]*):(.*)$/;
 const RELATIVE_PATH_PREFIX_PATTERN = /^(~\/|\.{1,2}\/)/;
 const RELATIVE_FILE_PATH_PATTERN =
   /^(?:[A-Za-z0-9._-]+(?: +[A-Za-z0-9._-]+)*\/)+[A-Za-z0-9._-]+(?: +[A-Za-z0-9._-]+)*(?::\d+){0,2}$/;
-const RELATIVE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]+\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
+const RELATIVE_FILE_NAME_PATTERN =
+  /^[A-Za-z0-9._-]+(?: +[A-Za-z0-9._-]+)*\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
 const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 const POSITION_ONLY_PATTERN = /^\d+(?::\d+)?$/;
 // Standard OS and dev-container roots; deliberately excludes app-route-ish
@@ -69,6 +70,10 @@ export function shouldOpenMarkdownFileLinkInEditor(
   platform?: string,
 ): boolean {
   return isTerminalLinkActivation(event, platform);
+}
+
+export function shouldOpenMarkdownFileLinkInBrowserByDefault(path: string): boolean {
+  return /\.pdf$/i.test(path.split(/[?#]/, 1)[0] ?? "");
 }
 
 function safeDecode(value: string): string {


### PR DESCRIPTION
Agent-authored links to filenames with spaces rendered as ordinary web links, so clicks never reached the integrated file viewer. Recognized HTML links opened the browser directly instead of the source viewer.

This accepts spaced relative file paths on web and mobile, then routes normal HTML and XML link clicks through the file viewer. PDFs remain browser-first, modifier clicks still open the preferred editor, and the integrated browser remains available as a secondary action.

## Before

A fresh paired web client rendered the agent-authored filenames with spaces as file links. This is the state before the click.

![Agent file links before click](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/f50cbc5e-8185-4128-91e8-c8ea58e07b1e/pr-8098-file-link-before.png)

## After

Playwright clicked `getByRole('link', { name: 'Updated cutover checklist.html' })`. The integrated right-panel file viewer opened, selected that file, and exposed `HTML file opened in the integrated file viewer.` in its accessibility tree.

![Integrated file viewer after click](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/2d924115-839a-42ba-a28e-2e2a0608c862/pr-8098-file-link-after.png)

## Testing

- 98 focused web, mobile, and right-panel tests
- Targeted lint for the five changed files
- Web TypeScript check
- Mobile TypeScript check

Implemented by `gpt-5.6-sol` in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Link-detection regex and click routing for markdown file chips only. No auth, data, or security-sensitive changes.
> 
> **Overview**
> Agent markdown links to filenames with spaces (and HTML/XML files) now resolve as workspace files and open in the integrated file viewer instead of as ordinary web links.
> 
> Relative path/name matchers on web and mobile now allow spaces in path segments, so encoded names like `Updated cutover checklist.md` and `docs/My Folder/checklist.xml` are recognized as files.
> 
> Plain clicks on HTML/XML still go to the file preview. Only PDFs stay browser-first via `shouldOpenMarkdownFileLinkInBrowserByDefault`. Modifier-click still opens the preferred editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fefdd0987a852a3f068cd3b220cf6a21780f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown file links to open in the file viewer and support spaces in paths
> - Expands `RELATIVE_FILE_PATH_PATTERN` and `RELATIVE_FILE_NAME_PATTERN` in both web and mobile markdown link modules to match filenames and relative paths that contain spaces.
> - Adds `shouldOpenMarkdownFileLinkInBrowserByDefault` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/8098/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) which returns true only for PDF paths, and updates the `MarkdownFileLink` onClick handler in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8098/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to gate browser navigation on this predicate.
> - Adds tests covering percent-encoded spaces in bare filenames and relative paths, and PDF-vs-HTML/XML browser routing.
> - Behavioral Change: file-link clicks now open in the in-app file viewer for non-PDF files instead of always opening in the browser; `MarkdownFileLink.onClick` requires `shouldOpenMarkdownFileLinkInBrowserByDefault` to return true before calling `onOpenInBrowser`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57fefdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->