### PR TITLE
fix(web): include images when copying prompts

### DIFF
--- a/apps/web/src/components/chat/MessageCopyButton.tsx
+++ b/apps/web/src/components/chat/MessageCopyButton.tsx
@@ -1,10 +1,11 @@
-import { memo, useRef } from "react";
+import { memo, useCallback, useRef } from "react";
 import { CopyIcon, CheckIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { cn } from "~/lib/utils";
 import { anchoredToastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { type MessageClipboardImage, writeMessageToClipboard } from "../../messageClipboard";
 
 const ANCHORED_TOAST_TIMEOUT_MS = 1000;
 const onCopy = (ref: React.RefObject<HTMLButtonElement | null>) => {
@@ -43,14 +44,18 @@ export const MessageCopyButton = memo(function MessageCopyButton({
   size = "xs",
   variant = "outline",
   className,
+  image,
 }: {
   text: string;
   size?: "xs" | "icon-xs";
   variant?: "outline" | "ghost";
   className?: string;
+  image?: MessageClipboardImage;
 }) {
   const ref = useRef<HTMLButtonElement>(null);
+  const write = useCallback((value: string) => writeMessageToClipboard(value, image), [image]);
   const { copyToClipboard, isCopied } = useCopyToClipboard<void>({
+    ...(image ? { write } : {}),
     onCopy: () => onCopy(ref),
     onError: (error: Error) => onCopyError(ref, error),
     timeout: ANCHORED_TOAST_TIMEOUT_MS,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1005,6 +1005,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   ];
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
+  const clipboardImage = userImages.find((image) => image.previewUrl);
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
 
   return (
@@ -1080,7 +1081,11 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
           <div className="flex items-center gap-0.5">
             {canRevertAgentWork && <RevertUserMessageButton messageId={row.message.id} />}
             {displayedUserMessage.copyText && (
-              <MessageCopyButton text={displayedUserMessage.copyText} variant="ghost" />
+              <MessageCopyButton
+                text={displayedUserMessage.copyText}
+                variant="ghost"
+                {...(clipboardImage ? { image: clipboardImage } : {})}
+              />
             )}
           </div>
         </div>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1005,7 +1005,9 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   ];
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
-  const clipboardImage = userImages.find((image) => image.previewUrl);
+  const clipboardImage =
+    regularImages.find((image) => image.previewUrl) ??
+    previewImages.find((image) => image.previewUrl);
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
 
   return (

--- a/apps/web/src/hooks/useCopyToClipboard.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.ts
@@ -95,11 +95,13 @@ export async function readTextFromClipboard(target = "text"): Promise<string> {
 export function useCopyToClipboard<TContext = void>({
   timeout = 2000,
   target = "text",
+  write,
   onCopy,
   onError,
 }: {
   timeout?: number;
   target?: string;
+  write?: (value: string, ctx: TContext) => Promise<boolean>;
   onCopy?: (ctx: TContext) => void;
   onError?: (error: Error, ctx: TContext) => void;
 } = {}): { copyToClipboard: (value: string, ctx: TContext) => void; isCopied: boolean } {
@@ -107,16 +109,21 @@ export function useCopyToClipboard<TContext = void>({
   const timeoutIdRef = React.useRef<NodeJS.Timeout | null>(null);
   const onCopyRef = React.useRef(onCopy);
   const onErrorRef = React.useRef(onError);
+  const writeRef = React.useRef(write);
   const targetRef = React.useRef(target);
   const timeoutRef = React.useRef(timeout);
 
   onCopyRef.current = onCopy;
   onErrorRef.current = onError;
+  writeRef.current = write;
   targetRef.current = target;
   timeoutRef.current = timeout;
 
   const copyToClipboard = React.useCallback((value: string, ctx: TContext): void => {
-    void writeTextToClipboard(value, targetRef.current).then(
+    const writeValue = writeRef.current;
+    void (
+      writeValue ? writeValue(value, ctx) : writeTextToClipboard(value, targetRef.current)
+    ).then(
       (didCopy) => {
         if (!didCopy) return;
         if (timeoutIdRef.current) {

--- a/apps/web/src/messageClipboard.test.ts
+++ b/apps/web/src/messageClipboard.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { writeMessageToClipboard } from "./messageClipboard";
+
+class TestClipboardItem {
+  constructor(readonly data: Record<string, Blob | PromiseLike<Blob>>) {}
+}
+
+describe("message clipboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("writes prompt text and a PNG as one clipboard item", async () => {
+    const write = vi.fn(async (items: TestClipboardItem[]) => {
+      await Promise.all(Object.values(items[0]!.data));
+    });
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { clipboard: { write, writeText: vi.fn() } });
+    vi.stubGlobal("ClipboardItem", TestClipboardItem);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }), {
+          status: 200,
+        }),
+      ),
+    );
+
+    await expect(
+      writeMessageToClipboard("Describe this screenshot", {
+        mimeType: "image/png",
+        previewUrl: "blob:screenshot",
+      }),
+    ).resolves.toBe(true);
+
+    expect(write).toHaveBeenCalledOnce();
+    const item = write.mock.calls[0]![0][0]!;
+    expect(Object.keys(item.data)).toEqual(["text/plain", "image/png"]);
+    await expect(Promise.resolve(item.data["text/plain"])).resolves.toMatchObject({
+      type: "text/plain",
+    });
+    await expect(Promise.resolve(item.data["image/png"])).resolves.toMatchObject({
+      type: "image/png",
+      size: 3,
+    });
+  });
+
+  it("falls back to text copy without a usable image", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await expect(writeMessageToClipboard("Text only", undefined)).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("Text only");
+  });
+});

--- a/apps/web/src/messageClipboard.test.ts
+++ b/apps/web/src/messageClipboard.test.ts
@@ -9,6 +9,7 @@ class TestClipboardItem {
 describe("message clipboard", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("writes prompt text and a PNG as one clipboard item", async () => {
@@ -53,5 +54,36 @@ describe("message clipboard", () => {
 
     await expect(writeMessageToClipboard("Text only", undefined)).resolves.toBe(true);
     expect(writeText).toHaveBeenCalledWith("Text only");
+  });
+
+  it("still copies the text when the rich clipboard write fails", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        write: vi.fn().mockRejectedValue(new Error("rich clipboard rejected")),
+        writeText,
+      },
+    });
+    vi.stubGlobal("ClipboardItem", TestClipboardItem);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(new Blob([new Uint8Array([1])], { type: "image/png" }), { status: 200 }),
+        ),
+    );
+
+    await expect(
+      writeMessageToClipboard("Keep this text", {
+        mimeType: "image/png",
+        previewUrl: "blob:stale-image",
+      }),
+    ).resolves.toBe(true);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith("Keep this text");
   });
 });

--- a/apps/web/src/messageClipboard.ts
+++ b/apps/web/src/messageClipboard.ts
@@ -1,0 +1,99 @@
+import { ClipboardWriteError, writeTextToClipboard } from "./hooks/useCopyToClipboard";
+
+export interface MessageClipboardImage {
+  readonly mimeType: string;
+  readonly previewUrl?: string;
+}
+
+function imageBlobAsPng(blob: Blob): Promise<Blob> {
+  if (blob.type.toLowerCase() === "image/png") {
+    return Promise.resolve(blob);
+  }
+
+  return new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(blob);
+    const image = new Image();
+    image.addEventListener(
+      "load",
+      () => {
+        try {
+          const canvas = document.createElement("canvas");
+          canvas.width = image.naturalWidth;
+          canvas.height = image.naturalHeight;
+          const context = canvas.getContext("2d");
+          if (!context) {
+            reject(new Error("Could not prepare the copied image."));
+            return;
+          }
+          context.drawImage(image, 0, 0);
+          canvas.toBlob((png) => {
+            if (png) {
+              resolve(png);
+            } else {
+              reject(new Error("Could not encode the copied image."));
+            }
+          }, "image/png");
+        } catch (cause) {
+          reject(cause);
+        } finally {
+          URL.revokeObjectURL(objectUrl);
+        }
+      },
+      { once: true },
+    );
+    image.addEventListener(
+      "error",
+      () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error("Could not read the copied image."));
+      },
+      { once: true },
+    );
+    image.src = objectUrl;
+  });
+}
+
+async function fetchClipboardImageAsPng(previewUrl: string, mimeType: string): Promise<Blob> {
+  const response = await fetch(previewUrl);
+  if (!response.ok) {
+    throw new Error("Could not load the copied image.");
+  }
+  const blob = await response.blob();
+  if (blob.size === 0) {
+    throw new Error("The copied image is empty.");
+  }
+  const typedBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: mimeType });
+  return imageBlobAsPng(typedBlob);
+}
+
+/** Writes text plus one image as a single clipboard item so both paste together. */
+export async function writeMessageToClipboard(
+  value: string,
+  image: MessageClipboardImage | undefined,
+): Promise<boolean> {
+  if (!value) return false;
+
+  if (
+    !image?.previewUrl ||
+    typeof window === "undefined" ||
+    typeof navigator === "undefined" ||
+    typeof ClipboardItem === "undefined" ||
+    typeof navigator.clipboard?.write !== "function"
+  ) {
+    return writeTextToClipboard(value, "message");
+  }
+
+  try {
+    const item = new ClipboardItem({
+      "text/plain": new Blob([value], { type: "text/plain" }),
+      "image/png": fetchClipboardImageAsPng(image.previewUrl, image.mimeType),
+    });
+    await navigator.clipboard.write([item]);
+    return true;
+  } catch (cause) {
+    throw new ClipboardWriteError({
+      target: "message with image",
+      cause,
+    });
+  }
+}

--- a/apps/web/src/messageClipboard.ts
+++ b/apps/web/src/messageClipboard.ts
@@ -91,9 +91,12 @@ export async function writeMessageToClipboard(
     await navigator.clipboard.write([item]);
     return true;
   } catch (cause) {
-    throw new ClipboardWriteError({
-      target: "message with image",
-      cause,
-    });
+    console.warn(
+      new ClipboardWriteError({
+        target: "message with image",
+        cause,
+      }),
+    );
+    return writeTextToClipboard(value, "message");
   }
 }


### PR DESCRIPTION
Copying a user prompt with an attached image only placed the text on the clipboard, so pasting into a new thread dropped the image.

The copy action now writes the prompt and first available attachment as one clipboard item. Images are normalized to PNG for browser clipboard support, while unsupported browsers keep the existing text-only fallback.

## Proof

![Playwright proof of copying a prompt and image into a new thread](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/a3686d1d-d65c-4185-8f3e-03771877bef0/copy-prompt-with-image.gif)

## Testing

- `vp test run` on the message clipboard, copy hook, and message timeline tests
- Web package typecheck
- Targeted lint for the changed files
- Playwright copy and paste round trip in an isolated T3 environment

Implemented with GPT-5.6-Sol in the Codex harness inside T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only clipboard write with a text fallback. No auth, persistence, or server changes.
> 
> **Overview**
> Copying a user prompt with an attachment now writes **text and one image as a single clipboard item**, so pasting into a new thread keeps the image.
> 
> `writeMessageToClipboard` fetches the preview, normalizes it to PNG, and uses `navigator.clipboard.write`. If there is no image, the browser lacks composite clipboard support, or the rich write fails, it still copies text.
> 
> The copy hook accepts an optional `write` override. User timeline copy uses the first attachment with a `previewUrl` (regular images first, then preview annotations). Assistant copy is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025f7ff08afa037e165338a9fbeefe9622359a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include images when copying chat prompts via `MessageCopyButton`
> - Adds `writeMessageToClipboard` in [messageClipboard.ts](https://github.com/pingdotgg/t3code/pull/8099/files#diff-b702be439c09e30e465c4eed9a08cd266ebdfb576030a31c2e4a7dbdb4040c71) to write text plus a PNG image as a single `ClipboardItem`, falling back to text-only when unsupported or on error.
> - Extends `useCopyToClipboard` in [useCopyToClipboard.ts](https://github.com/pingdotgg/t3code/pull/8099/files#diff-974e1dc0bd8d7dd8989de9b385c2299f9bfe38c29926aaad1b80d22f942b9db8) with an optional `write` override so callers can perform rich clipboard writes while keeping the hook's copied-state and callbacks.
> - Passes a selected image (first regular image with a `previewUrl`, else first preview-annotation image) from `UserTimelineRow` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/8099/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) into `MessageCopyButton`, which uses the new path when an image is present.
> - Risk: `fetchClipboardImageAsPng` relies on `fetch` + offscreen canvas conversion; if the preview URL is cross-origin without CORS headers, the canvas taints and the write fails, silently degrading to text-only copy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 025f7ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->