### PR TITLE
fix(provider): load Claude SDK only when needed

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.lazy.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.lazy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  throw new Error("Claude SDK loaded eagerly.");
+});
+
+describe("ClaudeAdapter module loading", () => {
+  it("does not load the Claude SDK while importing the adapter", async () => {
+    await expect(import("./ClaudeAdapter.ts")).resolves.toMatchObject({
+      makeClaudeAdapter: expect.any(Function),
+    });
+  });
+});

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 import { assert, describe, it } from "@effect/vitest";
+import { vi } from "vite-plus/test";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
@@ -39,6 +40,34 @@ import { ProviderAdapterProcessError, ProviderAdapterValidationError } from "../
 import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
+
+const lazyClaudeSdk = vi.hoisted(() => {
+  let markImportStarted!: () => void;
+  let markImportFinished!: () => void;
+  let releaseImport!: () => void;
+  return {
+    importFinished: new Promise<void>((resolve) => {
+      markImportFinished = resolve;
+    }),
+    importStarted: new Promise<void>((resolve) => {
+      markImportStarted = resolve;
+    }),
+    markImportFinished: () => markImportFinished(),
+    markImportStarted: () => markImportStarted(),
+    query: vi.fn(),
+    releaseImport: () => releaseImport(),
+    waitForRelease: new Promise<void>((resolve) => {
+      releaseImport = resolve;
+    }),
+  };
+});
+
+vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
+  lazyClaudeSdk.markImportStarted();
+  await lazyClaudeSdk.waitForRelease;
+  lazyClaudeSdk.markImportFinished();
+  return { query: lazyClaudeSdk.query };
+});
 
 // Test-local service tag so the rest of the file can keep using `yield* ClaudeAdapter`.
 class ClaudeAdapter extends Context.Service<ClaudeAdapter, ClaudeAdapterShape>()(
@@ -1659,6 +1688,41 @@ describe("ClaudeAdapterLive", () => {
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not start a Claude runtime after lazy loading is interrupted", () => {
+    const layer = Layer.effect(
+      ClaudeAdapter,
+      Effect.gen(function* () {
+        const claudeConfig = decodeClaudeSettings({});
+        return yield* makeClaudeAdapter(claudeConfig);
+      }),
+    ).pipe(
+      Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const startFiber = yield* Effect.forkChild(
+        adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        }),
+      );
+
+      yield* Effect.promise(() => lazyClaudeSdk.importStarted);
+      yield* Fiber.interrupt(startFiber);
+      lazyClaudeSdk.releaseImport();
+      yield* Effect.promise(() => lazyClaudeSdk.importFinished);
+
+      assert.equal(lazyClaudeSdk.query.mock.calls.length, 0);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
     );
   });
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -6,19 +6,18 @@
  *
  * @module ClaudeAdapterLive
  */
-import {
-  type CanUseTool,
-  query,
-  type Options as ClaudeQueryOptions,
-  type PermissionMode,
-  type PermissionResult,
-  type PermissionUpdate,
-  type SDKMessage,
-  type SDKControlGetContextUsageResponse,
-  type SDKResultMessage,
-  type SettingSource,
-  type SDKUserMessage,
-  type ModelUsage,
+import type {
+  CanUseTool,
+  Options as ClaudeQueryOptions,
+  PermissionMode,
+  PermissionResult,
+  PermissionUpdate,
+  SDKMessage,
+  SDKControlGetContextUsageResponse,
+  SDKResultMessage,
+  SettingSource,
+  SDKUserMessage,
+  ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import {
@@ -1706,16 +1705,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   const managedNativeEventLogger =
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
 
-  const createQuery =
-    options?.createQuery ??
-    ((input: {
-      readonly prompt: AsyncIterable<SDKUserMessage>;
-      readonly options: ClaudeQueryOptions;
-    }) =>
-      query({
-        prompt: input.prompt,
-        options: input.options,
-      }) as ClaudeQueryRuntime);
+  const createQuery = options?.createQuery;
 
   const sessions = new Map<ThreadId, ClaudeSessionContext>();
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
@@ -4271,12 +4261,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         "claude.query.path_to_executable": claudeBinaryPath,
       });
 
-      const queryRuntime = yield* Effect.try({
-        try: () =>
-          createQuery({
-            prompt,
-            options: queryOptions,
-          }),
+      const queryRuntime = yield* Effect.tryPromise({
+        try: async () =>
+          createQuery
+            ? createQuery({
+                prompt,
+                options: queryOptions,
+              })
+            : ((await import(/* @vite-ignore */ "@anthropic-ai/claude-agent-sdk")).query({
+                prompt,
+                options: queryOptions,
+              }) as ClaudeQueryRuntime),
         catch: (cause) =>
           new ProviderAdapterProcessError({
             provider: PROVIDER,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4262,16 +4262,32 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
 
       const queryRuntime = yield* Effect.tryPromise({
-        try: async () =>
-          createQuery
-            ? createQuery({
-                prompt,
-                options: queryOptions,
-              })
-            : ((await import(/* @vite-ignore */ "@anthropic-ai/claude-agent-sdk")).query({
-                prompt,
-                options: queryOptions,
-              }) as ClaudeQueryRuntime),
+        try: async (signal) => {
+          const query =
+            createQuery ??
+            (await import(/* @vite-ignore */ "@anthropic-ai/claude-agent-sdk")).query;
+          signal.throwIfAborted();
+          const runtime = query({
+            prompt,
+            options: queryOptions,
+          }) as ClaudeQueryRuntime;
+          let closed = false;
+          const close = () => {
+            if (closed) return;
+            closed = true;
+            try {
+              runtime.close();
+            } catch {
+              // Interruption remains authoritative when late runtime cleanup fails.
+            }
+          };
+          signal.addEventListener("abort", close, { once: true });
+          if (signal.aborted) {
+            close();
+            signal.throwIfAborted();
+          }
+          return runtime;
+        },
         catch: (cause) =>
           new ProviderAdapterProcessError({
             provider: PROVIDER,

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -20,12 +20,11 @@ import {
 } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { compareSemverVersions } from "@t3tools/shared/semver";
-import {
-  query as claudeQuery,
-  type Options as ClaudeQueryOptions,
-  type SlashCommand as ClaudeSlashCommand,
-  type SDKUserMessage,
-  type SettingSource,
+import type {
+  Options as ClaudeQueryOptions,
+  SlashCommand as ClaudeSlashCommand,
+  SDKUserMessage,
+  SettingSource,
 } from "@anthropic-ai/claude-agent-sdk";
 
 import {
@@ -742,6 +741,9 @@ const probeClaudeCapabilities = (
       claudeEnvironment,
     );
     return yield* Effect.tryPromise(async () => {
+      const { query: claudeQuery } = await import(
+        /* @vite-ignore */ "@anthropic-ai/claude-agent-sdk"
+      );
       const q = claudeQuery({
         // Never yield — we only need initialization data, not a conversation.
         // This prevents any prompt from reaching the Anthropic API.


### PR DESCRIPTION
## What Changed

Changed the Claude adapter and capability probe to import SDK runtime values only when they start Claude work. Type imports remain static, and the existing injected query path is unchanged.

Added a regression test that makes the Claude SDK throw if importing the adapter evaluates it. Focused adapter and capability-probe tests pass with 78 tests, the server typecheck passes, and the production server bundle contains only deferred Claude SDK imports.

## Why

T3 currently evaluates `@anthropic-ai/claude-agent-sdk` during server startup even when the active provider is Codex, Cursor, Grok, or OpenCode. Provider-specific runtime code should load at the point where T3 starts a Claude query or SDK capability probe. This keeps unrelated provider startup isolated while preserving the existing Claude behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Created with the Codex harness using gpt-5.6-sol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude session startup and capability probing, including abort-during-import cleanup. Behavior is otherwise unchanged, but SDK failures now appear later than module load.
> 
> **Overview**
> Stops evaluating `@anthropic-ai/claude-agent-sdk` when Claude adapter/provider modules load. Type imports stay static; `query` is dynamic-imported only when starting a session or probing capabilities.
> 
> Session start now uses `Effect.tryPromise` with abort handling so an interrupted lazy import does not call `query`. Injected `createQuery` is unchanged.
> 
> Adds a module-load regression test and an interrupt test covering the abort path. SDK load failures now surface at first Claude use instead of import time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ebbc412af467614aea27a77549a6447f9feace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer loading `@anthropic-ai/claude-agent-sdk` until session start in `ClaudeAdapter`
> - Changes `ClaudeAdapter` and `ClaudeProvider` to import only types from the Claude SDK at module load, and dynamically `import()` the `query` value inside `Effect.tryPromise` when a session starts or capabilities are probed.
> - Starting a Claude session now checks the abort signal before and after the dynamic import, and closes the runtime exactly once if interrupted during loading.
> - Adds tests asserting the adapter module imports without touching the SDK, and that interrupting `startSession` mid-import prevents `query` from being called.
> - Risk: `createQuery` is no longer passed the statically imported `query` as a default; callers that relied on the old default in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/8104/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) must supply it via options or rely on the new dynamic import path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20ebbc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->