### PR TITLE
fix(web): sort usage models by token count

### DIFF
--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const testState = vi.hoisted(() => ({
   useUsage: vi.fn(),
+  metric: "cost" as "cost" | "tokens",
+  breakdown: "time" as "model" | "time",
 }));
 
 vi.mock("react", async (importOriginal) => {
@@ -24,9 +26,11 @@ vi.mock("react", async (importOriginal) => {
               untilTime: "2026-08-11T12:37:00.000Z",
             },
           }
-        : initial === "model"
-          ? "time"
-          : initial,
+        : initial === "cost"
+          ? testState.metric
+          : initial === "model"
+            ? testState.breakdown
+            : initial,
       vi.fn(),
     ]),
   };
@@ -72,10 +76,40 @@ const providerTotals = (codex: number, claude: number) =>
     ["claude", { costUsd: claude, totalTokens: claude * 1_000 }],
   ] as const);
 
+const modelTotals = Object.freeze([
+  {
+    model: "expensive-model",
+    provider: "claude" as const,
+    costUsd: 10,
+    totalTokens: 100,
+    records: 1,
+    costShare: 10 / 16,
+  },
+  {
+    model: "token-heavy-model",
+    provider: "codex" as const,
+    costUsd: 5,
+    totalTokens: 1_000,
+    records: 1,
+    costShare: 5 / 16,
+  },
+  {
+    model: "token-heavy-cheaper-model",
+    provider: "codex" as const,
+    costUsd: 1,
+    totalTokens: 1_000,
+    records: 1,
+    costShare: 1 / 16,
+  },
+]);
+
 beforeEach(() => {
+  testState.metric = "cost";
+  testState.breakdown = "time";
   testState.useUsage.mockReturnValue({
     merged: {
       ...mergeUsage([], USAGE_CONTRACT_VERSION),
+      models: modelTotals,
       hourly: [
         {
           day: "2026-08-10",
@@ -109,5 +143,40 @@ describe("UsagePage hourly breakdown", () => {
     expect(body).toContain("$11.00");
     expect(body).toContain("$13.00");
     expect(body.indexOf("$11.00")).toBeLessThan(body.indexOf("$13.00"));
+  });
+
+  it("keeps chronological ordering when the token metric is selected", () => {
+    testState.metric = "tokens";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/\$11\.00.*\$13\.00/);
+  });
+});
+
+describe("UsagePage model breakdown", () => {
+  it("sorts models by cost when the cost metric is selected", () => {
+    testState.breakdown = "model";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/expensive-model.*token-heavy-model.*token-heavy-cheaper-model/);
+  });
+
+  it("sorts models by token usage when the token metric is selected", () => {
+    testState.metric = "tokens";
+    testState.breakdown = "model";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+
+    expect(body).toMatch(/token-heavy-model.*token-heavy-cheaper-model.*expensive-model/);
+    expect(modelTotals.map((model) => model.model)).toEqual([
+      "expensive-model",
+      "token-heavy-model",
+      "token-heavy-cheaper-model",
+    ]);
   });
 });

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -74,6 +74,15 @@ export function UsagePage() {
     () => (isPast24Hours ? merged.hourly : merged.daily).toReversed(),
     [isPast24Hours, merged.daily, merged.hourly],
   );
+  const breakdownModels = useMemo(
+    () =>
+      breakdown === "model" && metric === "tokens"
+        ? merged.models.toSorted(
+            (left, right) => right.totalTokens - left.totalTokens || right.costUsd - left.costUsd,
+          )
+        : merged.models,
+    [breakdown, merged.models, metric],
+  );
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
 
@@ -350,14 +359,14 @@ export function UsagePage() {
                         </tr>
                       </thead>
                       <tbody>
-                        {merged.models.length === 0 ? (
+                        {breakdownModels.length === 0 ? (
                           <tr>
                             <td colSpan={4} className="py-6 text-center text-muted-foreground">
                               No activity in this window.
                             </td>
                           </tr>
                         ) : (
-                          merged.models.map((model) => (
+                          breakdownModels.map((model) => (
                             <tr
                               key={`${model.provider}:${model.model}`}
                               className="border-b border-border/50 transition-colors hover:bg-muted/50"


### PR DESCRIPTION
Selecting Tokens on the Usage page changed the summary and chart, but the model breakdown remained ordered by cost. That made the table disagree with the selected metric.

The model breakdown now sorts by total token usage when Tokens is active. Equal token totals fall back to cost for deterministic ordering. Cost ordering is unchanged, and the day and hour breakdowns remain chronological.

Tests: 15 focused usage tests, web typecheck, targeted lint and formatting.

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only table sort on the Usage page; no data, auth, or merge-pipeline changes.
> 
> **Overview**
> The Usage model breakdown now follows the selected metric. With **Tokens** active, models are sorted by `totalTokens` (cost as a tiebreaker). Cost view still uses the existing cost order from merge, and hour/day tables stay chronological.
> 
> Tests cover cost vs token model order and confirm hourly rows stay newest-first when the token metric is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b87076dae349de0a6f5bf8f3cab063e48c48f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort usage models by descending token count when Tokens metric is selected
> - Adds a `useMemo`-derived `breakdownModels` in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/8108/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) that sorts `merged.models` by descending `totalTokens` (with descending `costUsd` as tie-breaker) when the breakdown is `model` and the metric is `tokens`.
> - Updates the Models table rendering and empty-state check to use `breakdownModels` instead of `merged.models`.
> - Adds tests in [UsagePage.test.tsx](https://github.com/pingdotgg/t3code/pull/8108/files#diff-24a2e6328dbf1f4eacc7dcde8181e27bdf71272864ee73a714563ca56a7839f5) covering token-based and cost-based model ordering, plus chronological order preservation in hourly breakdown.
> - Behavioral Change: models are now reordered by token count only under the `model` + `tokens` combination; all other breakdown/metric pairs preserve the original `merged.models` order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b87076.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->