### PR TITLE
fix(server): optimize transcript body construction for performance

### DIFF
--- a/apps/web/src/historyBootstrap.ts
+++ b/apps/web/src/historyBootstrap.ts
@@ -91,20 +91,35 @@ export function buildBootstrapInput(
   }
 
   // Include a contiguous suffix from newest to oldest, then reverse to chronological.
-  let includedNewestFirst: string[] = [];
+  // Joined-string length doesn't depend on block order, so the fitting count can be
+  // found with running totals instead of rebuilding the array and rejoining the full
+  // string on every block (which was O(n^2) on long transcripts).
+  const fixedLength =
+    BOOTSTRAP_PREAMBLE.length +
+    2 +
+    TRANSCRIPT_HEADER.length +
+    1 +
+    2 +
+    LATEST_PROMPT_HEADER.length +
+    1 +
+    latestPrompt.length;
+  let includedCount = 0;
+  let joinedLength = 0;
   for (const block of newestFirstBlocks) {
-    const nextNewestFirst = [...includedNewestFirst, block];
-    const nextChronological = nextNewestFirst.toReversed();
-    const omittedCount = newestFirstBlocks.length - nextChronological.length;
-    const transcriptBody =
+    const candidateJoinedLength = joinedLength + (includedCount > 0 ? 2 : 0) + block.length;
+    const candidateCount = includedCount + 1;
+    const omittedCount = newestFirstBlocks.length - candidateCount;
+    const bodyLength =
       omittedCount > 0
-        ? `${OMITTED_SUMMARY(omittedCount)}\n\n${nextChronological.join("\n\n")}`
-        : nextChronological.join("\n\n");
-    if (!finalizeWithPrompt(transcriptBody, latestPrompt, budget)) {
+        ? OMITTED_SUMMARY(omittedCount).length + 2 + candidateJoinedLength
+        : candidateJoinedLength;
+    if (fixedLength + bodyLength > budget) {
       break;
     }
-    includedNewestFirst = nextNewestFirst;
+    includedCount = candidateCount;
+    joinedLength = candidateJoinedLength;
   }
+  const includedNewestFirst = newestFirstBlocks.slice(0, includedCount);
 
   let includedChronological = includedNewestFirst.toReversed();
   while (true) {


### PR DESCRIPTION
## What Changed

PERFORMANCE 

Rewrote `buildBootstrapInput` in `apps/web/src/historyBootstrap.ts` to find the largest fitting suffix of transcript blocks using running length totals instead of rebuilding the array and rejoining the full string on every iteration.

## Why

The original loop was O(n²): each of the n messages triggered a full array copy, reverse, and string join just to check the candidate length against the budget. On a long thread (thousands of messages), this scaled badly, measured ~33s for a 20,000-message history vs ~4ms after the fix. Since joined-string length doesn't depend on block order, the fitting count can be computed with O(1) work per block, then the actual string is built once at the end. Verified against the original implementation with 20,000 randomized trials (varying block count/content, prompt length, and budget, including edge cases), output is byte-identical in every case.

## UI Changes

N/A pure logic change, no UI surface currently calls this function.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal string-budget algorithm only; intended byte-identical output with no API or security surface change.
> 
> **Overview**
> **`buildBootstrapInput`** in `historyBootstrap.ts` now picks how many newest transcript blocks fit under the char budget without rebuilding arrays and rejoining the full transcript on every block.
> 
> The inclusion loop precomputes **`fixedLength`** (preamble, headers, latest prompt) and tracks **`joinedLength`** / **`includedCount`** so each step only adds block length and omitted-summary length to the running total. After the loop, it **`slice`s** once to get the included blocks; the existing **`while`** path still builds the final transcript string and calls **`finalizeWithPrompt`**.
> 
> Same fitting logic as before (joined length is order-independent for the count step), aimed at avoiding **O(n²)** work on very long histories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7579aadab373016412ced2f2f07ca3cc34fdb8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize `buildBootstrapInput` transcript body construction to avoid O(n²) array rebuilds
> Reworks the block-inclusion loop in [historyBootstrap.ts](https://github.com/pingdotgg/t3code/pull/8109/files#diff-7263f6dec2c9a7d82746ca91930f0ea8dc806fafcbe75d490aa4cf78c65e2e60) to precompute constant header and prompt sizes (`fixedLength`) and use a running `joinedLength` accumulator with `includedCount` to determine how many newest-first blocks fit within the budget. This replaces repeated array rebuilds and full-string joins on each iteration with a single slice of `newestFirstBlocks` after the count is computed. The subsequent transcript body construction loop remains unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7579aad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->