### PR TITLE
fix(web): align usage page skeleton layout

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -212,7 +212,7 @@ export function UsagePage() {
                   staleEnvironments={merged.staleEnvironments}
                 />
 
-                <section className="grid gap-6 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)]">
+                <section className="grid gap-6 lg:grid-cols-[minmax(0,18rem)_minmax(0,1fr)]">
                   <div className="flex min-w-0 flex-col gap-5">
                     <div className="flex flex-col gap-1">
                       <span className="text-4xl font-semibold text-foreground tabular-nums">
@@ -582,7 +582,7 @@ function UsageDeviceStrip({
 function UsageSkeleton() {
   return (
     <>
-      <section className="grid gap-6 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)]">
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,18rem)_minmax(0,1fr)]">
         <div className="flex flex-col gap-5">
           <div className="flex flex-col gap-1">
             <div className="h-10 w-36 rounded-sm bg-muted" />
@@ -592,12 +592,8 @@ function UsageSkeleton() {
             <div key={provider} className="flex flex-col gap-1">
               <div className="flex min-h-5 items-center justify-between gap-4">
                 <span className="flex items-center gap-2">
-                  <span
-                    aria-hidden
-                    className="size-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: PROVIDER_PRESENTATION[provider].color }}
-                  />
-                  <ProviderMark provider={provider} className="size-4" />
+                  <span className="size-2 shrink-0 rounded-full bg-muted" />
+                  <span className="size-4 shrink-0 rounded-full bg-muted" />
                   <div className="h-3.5 w-20 rounded-sm bg-muted" />
                 </span>
                 <div className="h-3.5 w-14 rounded-sm bg-muted" />
@@ -611,7 +607,7 @@ function UsageSkeleton() {
           <div className="h-5 w-24 rounded-sm bg-muted" />
           <div className="flex flex-col gap-1">
             <div className="ml-16 h-56 rounded-sm bg-muted/35" />
-            <div className="ml-16 h-3 rounded-sm bg-muted/35" />
+            <div className="ml-16 h-4 rounded-sm bg-muted/35" />
           </div>
         </div>
       </section>
@@ -623,11 +619,19 @@ function UsageSkeleton() {
             (label) => (
               <div key={label} className="flex flex-col gap-0.5">
                 <span className="text-xs text-muted-foreground">{label}</span>
-                <div className="my-0.5 h-4 w-16 rounded-sm bg-muted" />
+                <div className="h-6 w-16 rounded-sm bg-muted" />
               </div>
             ),
           )}
         </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-sm font-medium text-foreground">Breakdown</h2>
+          <div className="h-7 w-28 rounded-lg bg-input/40" />
+        </div>
+        <div className="h-44 rounded-sm bg-muted/35" />
       </section>
     </>
   );


### PR DESCRIPTION
## What Changed

The usage-page skeleton now mirrors the loaded layout: it reserves space for the breakdown section, matches the chart-label and total-value heights, uses provider-neutral placeholders, and gives provider labels enough room beside their session counts.

## Why

The skeleton had drifted from the loaded page, causing visible layout shift as usage data arrived. The provider summary column could also truncate short provider names when the session count and total were present.

## UI Changes

### Before

<img width="1507" height="962" alt="Screenshot_2026-08-24_16-19-45" src="https://github.com/user-attachments/assets/5794d7ee-ca84-427c-b5bd-2620b095dfc1" />
<img width="332" height="65" alt="Screenshot_2026-08-24_16-26-21" src="https://github.com/user-attachments/assets/7a7ee61c-e014-4699-a336-6019edab7870" />

### After

<img width="2505" height="1068" alt="Screenshot_2026-08-24_15-52-59" src="https://github.com/user-attachments/assets/687eccaa-4560-437b-a536-e946ae3177ac" />
<img width="330" height="73" alt="image" src="https://github.com/user-attachments/assets/aa612325-e10d-41ab-819a-5a6bfef40b9d" />

## Verification

- `vp lint apps/web/src/components/usage/UsagePage.tsx`
- `vp test run apps/web/src/components/usage/UsageProviderChart.test.ts`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes — not applicable; no motion changes

Created with GPT-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Loading-state UI and Tailwind layout only; no data fetching, auth, or business logic changes in this diff.
> 
> **Overview**
> **Aligns the usage loading skeleton with the loaded page** to cut layout shift while usage data is still settling.
> 
> Widens the main `lg` grid’s left column from `16rem` to `18rem` on both the live summary and `UsageSkeleton`, giving provider labels and session counts more horizontal room.
> 
> Updates skeleton placeholders: provider-colored dots and brand marks become neutral `bg-muted` circles; chart axis and totals value bars are slightly taller; and a new **Breakdown** block (heading, toggle stub, table area) mirrors the section that appears after load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f4cdad73946ccdfdd758e8868ff03dba0b0ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align usage page skeleton with 18rem left column and breakdown section
> Updates the loading skeleton in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/8111/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) to match the actual page layout. The left grid column widens from 16rem to 18rem on both the page and the skeleton, and the skeleton now uses neutral circles for provider indicators, taller placeholder bars, and a new Breakdown section placeholder.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7f4cda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->