### PR TITLE
feat(server): add ZCode provider for Z.AI coding-plan models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # T3 Code
 
-T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps provider CLIs (Codex, Claude Code, Cursor, Grok, OpenCode) and serves web, desktop, and mobile clients.
+T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps provider CLIs (Codex, Claude Code, Cursor, Grok, OpenCode, ZCode) and serves web, desktop, and mobile clients.
 
 You can think of T3 Code as an open source "bring-your-own-subscription" alternative to apps like Claude Desktop, Codex App, Cursor Glass and Conductor.
 
@@ -48,7 +48,7 @@ We need to be on the same page with terminology. When communicating, use this la
 - **we, us, and maintainers** mean Theo, Julius and the people building T3 Code. These are who you are talking to now.
 - **user** means the person using T3 Code to direct coding agents.
 - **agent** means the coding agent a user runs inside T3 Code. Depending on context, that may also include you.
-- **provider** means the agent runtime or harness T3 Code talks to, such as Codex, Claude, Cursor, or OpenCode.
+- **provider** means the agent runtime or harness T3 Code talks to, such as Codex, Claude, Cursor, OpenCode, or ZCode.
 - **client** means the web, desktop, or mobile UI.
 - **environment** means one running T3 server and the machine, filesystem, provider credentials, and state it owns.
 - **project** means an environment-local workspace record rooted at a directory.
@@ -68,7 +68,7 @@ The most common defect in this repo is a change that works on the path you teste
 
 - **Entry points.** A behavior reachable from the chat view is usually also reachable from Settings, the command palette, and a keybinding. Fixing one is not fixing the feature.
 - **Clients.** Web, desktop (wraps web, adds Electron shell/IPC), and mobile (React Native, separate navigation). Shared logic lives in `packages/client-runtime`
-- **Providers.** Codex, Claude, Cursor, Grok, and OpenCode each have an adapter. Provider-shaped features need a decision per adapter, even if the decision is "not supported here".
+- **Providers.** Codex, Claude, Cursor, Grok, OpenCode, and ZCode each have an adapter. Provider-shaped features need a decision per adapter, even if the decision is "not supported here".
 - **Contracts.** Anything crossing the wire is typed in `packages/contracts`. Change the schema and the server, web, mobile, and desktop all follow.
 - **Reverse states.** If you added a way in, add the way out and the way to see it. Snooze needs unsnooze. Close needs reopen. A one-way door is a bug.
 - **Connection modes.** Local, remote/relay, and tunnel behave differently. Multi-device and multi-environment cases are real.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 T3 Code is an "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app ([iOS](https://apps.apple.com/us/app/t3-code-remote-claude-more/id6787819824), [Android](https://play.google.com/store/apps/details?id=com.t3tools.t3code)), [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
 
-Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, and OpenCode. If they're set up on your computer, T3 Code can control them.
+Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, OpenCode, and ZCode. If they're set up on your computer, T3 Code can control them.
 
 ## "Wait, what are you selling me?"
 
@@ -13,13 +13,14 @@ We wanted something performant, remote-ready, and truly open. If we ever go the 
 ## Installation
 
 > [!WARNING]
-> T3 Code currently supports Codex, Claude, Cursor, Grok Build and OpenCode. Install and authenticate at least one provider before use:
+> T3 Code currently supports Codex, Claude, Cursor, Grok Build, OpenCode and ZCode. Install and authenticate at least one provider before use:
 >
 > - Codex: install [Codex CLI](https://developers.openai.com/codex/cli) and run `codex login`
 > - Claude: install [Claude Code](https://claude.com/product/claude-code) and run `claude auth login`
 > - Cursor: install [Cursor CLI](https://cursor.com/cli) and run `agent login`
 > - Grok Build: install [Grok Build CLI](https://x.ai/cli) and run `grok login`
 > - OpenCode: install [OpenCode](https://opencode.ai) and run `opencode auth login`
+> - ZCode: install [ZCode](https://zcode.z.ai) and run `zcode login`
 
 ### Try it out (install-free)
 
@@ -83,6 +84,7 @@ Full docs live in [docs/](./docs). There's no docs site yet.
 - [Keeping app and server in sync](./docs/user/updating.md)
 - [Source control integrations](./docs/user/source-control.md)
 - Multiple accounts: [Codex](./docs/user/providers-codex.md) · [Claude](./docs/user/providers-claude.md)
+- [ZCode](./docs/user/providers-zcode.md)
 - Linux: [run T3 Code as a background service](./docs/user/background-service.md)
 
 Building from source? Start at [docs/internals/overview.md](./docs/internals/overview.md).

--- a/apps/mobile/src/components/ProviderIcon.tsx
+++ b/apps/mobile/src/components/ProviderIcon.tsx
@@ -50,6 +50,17 @@ export function ProviderIcon(props: ProviderIconProps) {
     );
   }
 
+  if (props.provider === "zcode") {
+    return (
+      <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+        <Path
+          fill="#1A7AFF"
+          d="M4 5.5A1.5 1.5 0 0 1 5.5 4h13A1.5 1.5 0 0 1 20 5.5v2A1.5 1.5 0 0 1 18.5 9H9.8l8.7 8.2A1.5 1.5 0 0 1 17.4 20h-13A1.5 1.5 0 0 1 4 18.5v-2A1.5 1.5 0 0 1 5.5 15h8.7L5.5 6.8A1.5 1.5 0 0 1 4 5.5Z"
+        />
+      </Svg>
+    );
+  }
+
   if (props.provider === "opencode") {
     return (
       <Svg width={size} height={size} viewBox="0 0 32 40" fill="none">

--- a/apps/server/scripts/zcode-mock-app-server.mjs
+++ b/apps/server/scripts/zcode-mock-app-server.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import readline from "node:readline";
+
+const sessionId = "sess_mock_zcode";
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(payload) {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+function emit(type, payload = {}) {
+  send({
+    method: "session/event",
+    params: { sessionId, seq: Date.now(), type, payload },
+  });
+}
+
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let message;
+  try {
+    message = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+  if (message.result !== undefined || message.error !== undefined) {
+    return;
+  }
+  const { id, method, params } = message;
+  if (method === "session/create" || method === "session/resume") {
+    send({
+      id,
+      result: {
+        session: {
+          sessionId,
+          model: { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan" },
+          status: "idle",
+        },
+        settings: {
+          mode: { current: params?.mode ?? "yolo" },
+          model: {
+            current: { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan" },
+            available: [
+              {
+                label: "GLM-5.3",
+                ref: { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan" },
+              },
+              {
+                label: "GLM-5.2",
+                ref: { modelId: "GLM-5.2", providerId: "builtin:zai-coding-plan" },
+              },
+            ],
+          },
+        },
+      },
+    });
+    return;
+  }
+  if (
+    method === "session/subscribe" ||
+    method === "session/setModel" ||
+    method === "session/setMode"
+  ) {
+    send({ id, result: { ok: true } });
+    return;
+  }
+  if (method === "session/send") {
+    send({ id, result: { accepted: true } });
+    emit("turn.started", {});
+    emit("model.streaming", { kind: "text_delta", delta: "hello from zcode" });
+    emit("turn.completed", { resultType: "success" });
+    return;
+  }
+  if (method === "session/stop") {
+    send({ id, result: { ok: true } });
+    return;
+  }
+  if (id !== undefined) {
+    send({ id, result: {} });
+  }
+});

--- a/apps/server/src/provider/Drivers/ZCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/ZCodeDriver.ts
@@ -1,0 +1,162 @@
+import { ProviderDriverKind, type ServerProvider, ZCodeSettings } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeZcodeTextGeneration } from "../../textGeneration/ZCodeTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeZcodeAdapter } from "../Layers/ZCodeAdapter.ts";
+import {
+  buildInitialZcodeProviderSnapshot,
+  checkZcodeProviderStatus,
+  enrichZcodeSnapshot,
+} from "../Layers/ZCodeProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeZcodeSettings = Schema.decodeSync(ZCodeSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("zcode");
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+  }),
+);
+
+export type ZCodeDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const ZCodeDriver: ProviderDriver<ZCodeSettings, ZCodeDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "ZCode",
+    supportsMultipleInstances: true,
+  },
+  configSchema: ZCodeSettings,
+  defaultConfig: (): ZCodeSettings => decodeZcodeSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies ZCodeSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeZcodeAdapter(effectiveConfig, {
+        environment: processEnv,
+        instanceId,
+      });
+      const textGeneration = yield* makeZcodeTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkZcodeProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<ZCodeSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialZcodeProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichZcodeSnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            httpClient,
+          }),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build ZCode snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Drivers/ZCodeExecutable.test.ts
+++ b/apps/server/src/provider/Drivers/ZCodeExecutable.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import {
+  buildZcodeAppServerArgv,
+  isZcodeNodeBundle,
+  resolveZcodeCliPath,
+} from "./ZCodeExecutable.ts";
+
+describe("resolveZcodeCliPath", () => {
+  it("prefers an explicit zcode.cjs path", () => {
+    const dir = NodeFs.mkdtempSync(NodePath.join(NodeOs.tmpdir(), "zcode-exec-"));
+    const cjs = NodePath.join(dir, "zcode.cjs");
+    NodeFs.writeFileSync(cjs, "console.log('ok')\n");
+    expect(resolveZcodeCliPath(cjs)).toBe(cjs);
+  });
+
+  it("keeps an explicit missing path so the probe can fail clearly", () => {
+    expect(resolveZcodeCliPath("/definitely/missing/zcode")).toBe("/definitely/missing/zcode");
+  });
+
+  it("discovers the bundled CLI when the setting is the default name", () => {
+    const resolved = resolveZcodeCliPath("zcode");
+    expect(resolved.endsWith("zcode.cjs") || resolved === "zcode").toBe(true);
+  });
+
+  it("builds an app-server argv that forces the desktop surface", () => {
+    const dir = NodeFs.mkdtempSync(NodePath.join(NodeOs.tmpdir(), "zcode-exec-"));
+    const cjs = NodePath.join(dir, "zcode.cjs");
+    NodeFs.writeFileSync(cjs, "console.log('ok')\n");
+    const argv = buildZcodeAppServerArgv({ binaryPath: cjs });
+    expect(isZcodeNodeBundle(cjs)).toBe(true);
+    expect(argv.args).toEqual([cjs, "app-server", "--surface", "desktop"]);
+  });
+});

--- a/apps/server/src/provider/Drivers/ZCodeExecutable.ts
+++ b/apps/server/src/provider/Drivers/ZCodeExecutable.ts
@@ -1,0 +1,162 @@
+/**
+ * Resolve the official ZCode CLI entry (`zcode.cjs` from the desktop app).
+ *
+ * The `zcode` wrapper on PATH is often an Electron launcher. Spawning that
+ * from T3 Code opens the GUI instead of the stdio app-server, so discovery
+ * prefers the bundled `zcode.cjs` and only falls back to a PATH binary when
+ * it is actually a Node CLI.
+ *
+ * @module provider/Drivers/ZCodeExecutable
+ */
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+const ZCODE_CJS_BASENAME = "zcode.cjs";
+
+function existingFile(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  try {
+    return NodeFs.statSync(path).isFile() ? path : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function looksLikeElectronLauncher(path: string): boolean {
+  try {
+    const head = NodeFs.readFileSync(path, { encoding: "utf8" }).slice(0, 8_192);
+    return (
+      head.includes("electron") || head.includes("ELECTRON_IS_DEV") || head.includes("app.asar")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function siblingCjsFromLauncher(launcherPath: string): string | undefined {
+  const resolved = NodeFs.realpathSync.native(launcherPath);
+  const dir = NodePath.dirname(resolved);
+  const candidates = [
+    NodePath.join(dir, "..", "lib", "zcode", "glm", ZCODE_CJS_BASENAME),
+    NodePath.join(dir, "..", "lib", "ZCode", "glm", ZCODE_CJS_BASENAME),
+    NodePath.join(dir, "glm", ZCODE_CJS_BASENAME),
+    NodePath.join(dir, "..", "resources", "glm", ZCODE_CJS_BASENAME),
+    NodePath.join(dir, "..", "..", "resources", "glm", ZCODE_CJS_BASENAME),
+  ];
+  for (const candidate of candidates) {
+    const found = existingFile(NodePath.resolve(candidate));
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function wellKnownCjsPaths(): ReadonlyArray<string> {
+  const home = NodeOs.homedir();
+  const localAppData = process.env.LOCALAPPDATA?.trim();
+  return [
+    "/usr/lib/zcode/glm/zcode.cjs",
+    "/usr/lib/ZCode/glm/zcode.cjs",
+    "/opt/ZCode/resources/glm/zcode.cjs",
+    "/opt/zcode/resources/glm/zcode.cjs",
+    "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+    ...(localAppData
+      ? [NodePath.join(localAppData, "Programs", "ZCode", "resources", "glm", ZCODE_CJS_BASENAME)]
+      : []),
+    NodePath.join(
+      home,
+      "Applications",
+      "ZCode.app",
+      "Contents",
+      "Resources",
+      "glm",
+      ZCODE_CJS_BASENAME,
+    ),
+  ];
+}
+
+function whichOnPath(binary: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const pathEnv = env.PATH ?? env.Path;
+  if (!pathEnv) return undefined;
+  const extensions = process.platform === "win32" ? ["", ".cmd", ".exe", ".bat"] : [""];
+  for (const dir of pathEnv.split(NodePath.delimiter)) {
+    for (const extension of extensions) {
+      const found = existingFile(NodePath.join(dir, `${binary}${extension}`));
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a spawnable ZCode CLI path. Prefer the desktop-bundled `zcode.cjs`
+ * so sessions use the same OAuth coding-plan path as the ZCode app.
+ */
+export function resolveZcodeCliPath(
+  binaryPath: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const requested = binaryPath?.trim() || "zcode";
+  const requestedFile = existingFile(requested);
+  if (requestedFile) {
+    if (
+      requestedFile.endsWith(".cjs") ||
+      requestedFile.endsWith(".js") ||
+      requestedFile.endsWith(".mjs")
+    ) {
+      return requestedFile;
+    }
+    if (looksLikeElectronLauncher(requestedFile)) {
+      return siblingCjsFromLauncher(requestedFile) ?? requestedFile;
+    }
+    return requestedFile;
+  }
+
+  const isDefaultName =
+    requested === "zcode" || requested === "zcode.exe" || requested === "zcode.cmd";
+  if (!isDefaultName) {
+    return requested;
+  }
+
+  for (const candidate of wellKnownCjsPaths()) {
+    const found = existingFile(candidate);
+    if (found) return found;
+  }
+
+  const fromPath = whichOnPath(requested === "zcode" ? "zcode" : requested, env);
+  if (fromPath) {
+    if (looksLikeElectronLauncher(fromPath)) {
+      return siblingCjsFromLauncher(fromPath) ?? fromPath;
+    }
+    return fromPath;
+  }
+
+  return requested;
+}
+
+export function isZcodeNodeBundle(path: string): boolean {
+  return path.endsWith(".cjs") || path.endsWith(".js") || path.endsWith(".mjs");
+}
+
+export function resolveZcodeNodeBinary(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.ZCODE_NODE?.trim();
+  if (explicit) return explicit;
+  return process.execPath;
+}
+
+export function buildZcodeAppServerArgv(input: {
+  readonly binaryPath: string | null | undefined;
+  readonly env?: NodeJS.ProcessEnv;
+}): { readonly command: string; readonly args: ReadonlyArray<string> } {
+  const cliPath = resolveZcodeCliPath(input.binaryPath, input.env);
+  if (isZcodeNodeBundle(cliPath)) {
+    return {
+      command: resolveZcodeNodeBinary(input.env),
+      args: [cliPath, "app-server", "--surface", "desktop"],
+    };
+  }
+  return {
+    command: cliPath,
+    args: ["app-server", "--surface", "desktop"],
+  };
+}

--- a/apps/server/src/provider/Layers/ZCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ZCodeAdapter.test.ts
@@ -1,0 +1,91 @@
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+  ZCodeSettings,
+} from "@t3tools/contracts";
+
+import { ServerConfig } from "../../config.ts";
+import { makeZcodeAdapter } from "./ZCodeAdapter.ts";
+
+const decodeZcodeSettings = Schema.decodeSync(ZCodeSettings);
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockAgentPath = NodePath.join(__dirname, "../../../scripts/zcode-mock-app-server.mjs");
+
+const zcodeAdapterTestLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-zcode-adapter-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+it.layer(zcodeAdapterTestLayer)("ZCodeAdapterLive", (it) => {
+  it.effect("starts a session and maps mock ZCode events to runtime events", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("zcode-mock-thread");
+      const adapter = yield* makeZcodeAdapter(
+        decodeZcodeSettings({ binaryPath: mockAgentPath, enabled: true }),
+      );
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "turn.completed"
+              ? Deferred.succeed(turnCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("zcode"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("zcode"), model: "GLM-5.3" },
+      });
+
+      assert.equal(session.provider, "zcode");
+      assert.equal(session.model, "GLM-5.3");
+      assert.deepStrictEqual(session.resumeCursor, {
+        schemaVersion: 1,
+        sessionId: "sess_mock_zcode",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "hello zcode",
+        attachments: [],
+      });
+
+      yield* Deferred.await(turnCompleted);
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      const types = runtimeEvents.map((event) => event.type);
+
+      assert.includeMembers(types, [
+        "session.started",
+        "session.state.changed",
+        "thread.started",
+        "turn.started",
+        "content.delta",
+        "turn.completed",
+      ] as const);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/ZCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/ZCodeAdapter.ts
@@ -1,0 +1,860 @@
+import {
+  ApprovalRequestId,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeItemId,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+  type UserInputQuestion,
+  type ZCodeSettings,
+} from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { type ZCodeAdapterShape } from "../Services/ZCodeAdapter.ts";
+import {
+  handleBuiltinZcodeServerRequest,
+  mapRuntimeModeToZcodeMode,
+  startZcodeProtocolClient,
+  zcodeCreateSession,
+  zcodeResumeSession,
+  type ZcodeProtocolClient,
+  type ZcodeServerRequest,
+  type ZcodeSessionEvent,
+} from "../zcodeRuntime.ts";
+import { readZcodeDesktopPlan } from "../zcodeDesktopAuth.ts";
+
+const PROVIDER = ProviderDriverKind.make("zcode");
+const ZCODE_RESUME_VERSION = 1 as const;
+
+export interface ZCodeAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly instanceId?: ProviderInstanceId;
+}
+
+interface PendingApproval {
+  readonly zcodeRequestId: number | string;
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly options: ReadonlyArray<{ readonly optionId: string; readonly kind: string }>;
+}
+
+interface PendingUserInput {
+  readonly zcodeRequestId: number | string;
+  readonly resolution: Deferred.Deferred<
+    | { readonly _tag: "answered"; readonly answers: ProviderUserInputAnswers }
+    | { readonly _tag: "cancelled" }
+  >;
+}
+
+interface ZcodeSessionContext {
+  readonly threadId: ThreadId;
+  readonly zcodeSessionId: string;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly client: ZcodeProtocolClient;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
+  turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  activeTurnId: TurnId | undefined;
+  interruptedTurnIds: Set<TurnId>;
+  currentModelId: string | undefined;
+  currentProviderId: string | undefined;
+  assistantItemStarted: boolean;
+  stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseZcodeResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== ZCODE_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+export function resolveZcodeModelId(model: string | null | undefined): string {
+  const trimmed = model?.trim();
+  const base = trimmed && trimmed.length > 0 ? trimmed : "GLM-5.3";
+  const slash = base.lastIndexOf("/");
+  const modelId = slash >= 0 ? base.slice(slash + 1) : base;
+  return normalizeModelSlug(modelId, PROVIDER) ?? "GLM-5.3";
+}
+
+function toolItemType(
+  toolName: string | undefined,
+): "command_execution" | "file_change" | "dynamic_tool_call" {
+  const name = toolName?.toLowerCase() ?? "";
+  if (name.includes("bash") || name.includes("shell") || name.includes("exec")) {
+    return "command_execution";
+  }
+  if (name.includes("edit") || name.includes("write") || name.includes("apply")) {
+    return "file_change";
+  }
+  return "dynamic_tool_call";
+}
+
+function permissionOptions(
+  params: unknown,
+): ReadonlyArray<{ readonly optionId: string; readonly kind: string }> {
+  if (!isRecord(params) || !Array.isArray(params.options)) return [];
+  return params.options.flatMap((option) => {
+    if (!isRecord(option) || typeof option.optionId !== "string") return [];
+    return [{ optionId: option.optionId, kind: String(option.kind ?? "") }];
+  });
+}
+
+function selectPermissionOptionId(
+  options: ReadonlyArray<{ readonly optionId: string; readonly kind: string }>,
+  decision: Exclude<ProviderApprovalDecision, "cancel">,
+): string | undefined {
+  const kind =
+    decision === "acceptForSession"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  return (
+    options.find((option) => option.kind === kind)?.optionId ??
+    options.find((option) =>
+      decision === "reject"
+        ? option.kind.includes("deny") || option.kind.includes("reject")
+        : option.kind.includes("allow"),
+    )?.optionId ??
+    options[0]?.optionId
+  );
+}
+
+function userInputQuestions(params: unknown): ReadonlyArray<UserInputQuestion> {
+  if (!isRecord(params)) return [];
+  if (Array.isArray(params.questions)) {
+    return params.questions.flatMap((question, index) => {
+      if (!isRecord(question) || typeof question.question !== "string") return [];
+      const options = Array.isArray(question.options)
+        ? question.options.flatMap((option) => {
+            if (!isRecord(option)) return [];
+            const label =
+              typeof option.label === "string" ? option.label : String(option.value ?? "OK");
+            return [
+              {
+                label,
+                description: typeof option.description === "string" ? option.description : label,
+              },
+            ];
+          })
+        : [{ label: "OK", description: "Continue" }];
+      return [
+        {
+          id: `q_${index}`,
+          header: "Question",
+          question: question.question,
+          multiSelect: question.multiSelect === true,
+          options: options.length > 0 ? options : [{ label: "OK", description: "Continue" }],
+        } satisfies UserInputQuestion,
+      ];
+    });
+  }
+  if (isRecord(params.schema) && params.schema.interaction === "plan_approval") {
+    const plan =
+      isRecord(params.input) && typeof params.input.plan === "string"
+        ? params.input.plan
+        : "Approve this plan?";
+    return [
+      {
+        id: "plan",
+        header: "Plan",
+        question: plan,
+        multiSelect: false,
+        options: [
+          { label: "Approve", description: "Approve this plan" },
+          { label: "Reject", description: "Reject this plan" },
+        ],
+      },
+    ];
+  }
+  return [];
+}
+
+export function makeZcodeAdapter(zcodeSettings: ZCodeSettings, options?: ZCodeAdapterLiveOptions) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("zcode");
+    const crypto = yield* Crypto.Crypto;
+    const sessions = new Map<ThreadId, ZcodeSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const runtimeContext = yield* Effect.context<Crypto.Crypto | Clock.Clock>();
+    const runFork = Effect.runForkWith(runtimeContext);
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate ZCode runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing = Option.fromNullishOr(current.get(threadId));
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const requireSession = (threadId: ThreadId) => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const handleZcodeEvent = (ctx: ZcodeSessionContext, event: ZcodeSessionEvent) =>
+      Effect.gen(function* () {
+        if (event.sessionId !== ctx.zcodeSessionId) return;
+        const turnId = ctx.activeTurnId;
+        if (turnId !== undefined && ctx.interruptedTurnIds.has(turnId)) return;
+        const stamp = yield* makeEventStamp();
+        const payload = isRecord(event.payload) ? event.payload : {};
+
+        switch (event.type) {
+          case "turn.started":
+            return;
+          case "model.streaming": {
+            if (!turnId) return;
+            const kind = typeof payload.kind === "string" ? payload.kind : "";
+            const delta = typeof payload.delta === "string" ? payload.delta : "";
+            if (kind === "reasoning_delta" && delta) {
+              yield* offerRuntimeEvent({
+                type: "content.delta",
+                ...stamp,
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                turnId,
+                payload: { streamKind: "reasoning_text", delta },
+                raw: { source: "zcode.protocol.event", method: event.type, payload: event.payload },
+              });
+              return;
+            }
+            if ((kind === "text_delta" || kind === "") && delta) {
+              if (!ctx.assistantItemStarted) {
+                ctx.assistantItemStarted = true;
+                yield* offerRuntimeEvent({
+                  type: "item.started",
+                  ...stamp,
+                  provider: PROVIDER,
+                  threadId: ctx.threadId,
+                  turnId,
+                  itemId: RuntimeItemId.make(`assistant-${turnId}`),
+                  payload: { itemType: "assistant_message", status: "inProgress" },
+                });
+              }
+              yield* offerRuntimeEvent({
+                type: "content.delta",
+                ...stamp,
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                turnId,
+                itemId: RuntimeItemId.make(`assistant-${turnId}`),
+                payload: { streamKind: "assistant_text", delta },
+                raw: { source: "zcode.protocol.event", method: event.type, payload: event.payload },
+              });
+            }
+            return;
+          }
+          case "tool.updated": {
+            if (!turnId) return;
+            const toolCallId =
+              typeof payload.toolCallId === "string" ? payload.toolCallId : yield* randomUUIDv4;
+            const toolName = typeof payload.toolName === "string" ? payload.toolName : "tool";
+            const kind = typeof payload.kind === "string" ? payload.kind : "started";
+            const completed = kind === "result" || kind === "error" || kind === "batch";
+            yield* offerRuntimeEvent({
+              type: completed
+                ? "item.completed"
+                : kind === "scheduled"
+                  ? "item.started"
+                  : "item.updated",
+              ...stamp,
+              provider: PROVIDER,
+              threadId: ctx.threadId,
+              turnId,
+              itemId: RuntimeItemId.make(toolCallId),
+              payload: {
+                itemType: toolItemType(toolName),
+                status: kind === "error" ? "failed" : completed ? "completed" : "inProgress",
+                title: toolName,
+                ...(isRecord(payload.input) ? { data: payload.input } : {}),
+              },
+              raw: { source: "zcode.protocol.event", method: event.type, payload: event.payload },
+            });
+            return;
+          }
+          case "turn.completed":
+          case "turn.failed":
+          case "turn.terminal": {
+            if (!turnId) return;
+            const failed = event.type === "turn.failed";
+            const { activeTurnId: _done, ...readySession } = ctx.session;
+            ctx.activeTurnId = undefined;
+            ctx.assistantItemStarted = false;
+            ctx.session = {
+              ...readySession,
+              status: "ready",
+              updatedAt: yield* nowIso,
+            };
+            yield* offerRuntimeEvent({
+              type: "turn.completed",
+              ...stamp,
+              provider: PROVIDER,
+              threadId: ctx.threadId,
+              turnId,
+              payload: {
+                state: failed ? "failed" : "completed",
+                ...(failed
+                  ? {
+                      errorMessage:
+                        isRecord(payload.error) && typeof payload.error.message === "string"
+                          ? payload.error.message
+                          : "ZCode turn failed.",
+                    }
+                  : {}),
+              },
+              raw: { source: "zcode.protocol.event", method: event.type, payload: event.payload },
+            });
+            return;
+          }
+          default:
+            return;
+        }
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to process ZCode session event.", { cause, type: event.type }),
+        ),
+      );
+
+    const handleServerRequest = (ctx: ZcodeSessionContext, request: ZcodeServerRequest) =>
+      Effect.gen(function* () {
+        if (handleBuiltinZcodeServerRequest(ctx.client, request)) {
+          return;
+        }
+        if (request.method === "interaction/requestPermission") {
+          const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+          const runtimeRequestId = RuntimeRequestId.make(requestId);
+          const decision = yield* Deferred.make<ProviderApprovalDecision>();
+          const options = permissionOptions(request.params);
+          ctx.pendingApprovals.set(requestId, {
+            zcodeRequestId: request.id,
+            decision,
+            options,
+          });
+          const params = isRecord(request.params) ? request.params : {};
+          yield* offerRuntimeEvent({
+            type: "request.opened",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            requestId: runtimeRequestId,
+            payload: {
+              requestType: "exec_command_approval",
+              detail:
+                typeof params.reason === "string"
+                  ? params.reason
+                  : String(params.toolName ?? "tool"),
+              args: params.input ?? params,
+            },
+            raw: {
+              source: "zcode.protocol.event",
+              method: request.method,
+              payload: request.params,
+            },
+          });
+          return;
+        }
+        if (request.method === "interaction/requestUserInput") {
+          const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+          const runtimeRequestId = RuntimeRequestId.make(requestId);
+          const resolution = yield* Deferred.make<
+            | { readonly _tag: "answered"; readonly answers: ProviderUserInputAnswers }
+            | { readonly _tag: "cancelled" }
+          >();
+          ctx.pendingUserInputs.set(requestId, {
+            zcodeRequestId: request.id,
+            resolution,
+          });
+          yield* offerRuntimeEvent({
+            type: "user-input.requested",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            requestId: runtimeRequestId,
+            payload: { questions: userInputQuestions(request.params) },
+            raw: {
+              source: "zcode.protocol.event",
+              method: request.method,
+              payload: request.params,
+            },
+          });
+          return;
+        }
+        ctx.client.reply(request.id, {});
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to handle ZCode server request.", {
+            cause,
+            method: request.method,
+          }),
+        ),
+      );
+
+    const stopSessionInternal = (ctx: ZcodeSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        for (const pending of ctx.pendingApprovals.values()) {
+          yield* Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore);
+        }
+        for (const pending of ctx.pendingUserInputs.values()) {
+          yield* Deferred.succeed(pending.resolution, { _tag: "cancelled" }).pipe(Effect.ignore);
+        }
+        sessions.delete(ctx.threadId);
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach([...sessions.values()], stopSessionInternal, {
+        concurrency: "unbounded",
+        discard: true,
+      }),
+    );
+
+    const startSession: ZCodeAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+          const cwd = input.cwd.trim();
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+
+          const client = yield* startZcodeProtocolClient({
+            binaryPath: zcodeSettings.binaryPath,
+            cwd,
+            environment: options?.environment,
+          }).pipe(
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const ctxHolder: { current: ZcodeSessionContext | undefined } = { current: undefined };
+          client.setEventHandler((event) => {
+            const ctx = ctxHolder.current;
+            if (!ctx) return;
+            runFork(handleZcodeEvent(ctx, event));
+          });
+          client.setServerRequestHandler((request) => {
+            const ctx = ctxHolder.current;
+            if (!ctx) {
+              handleBuiltinZcodeServerRequest(client, request);
+              return;
+            }
+            if (handleBuiltinZcodeServerRequest(client, request)) return;
+            runFork(handleServerRequest(ctx, request));
+          });
+
+          const desktopPlan = readZcodeDesktopPlan(options?.environment);
+          const requestedModel = resolveZcodeModelId(input.modelSelection?.model);
+          const resumeSessionId = parseZcodeResume(input.resumeCursor)?.sessionId;
+          const created = yield* (
+            resumeSessionId
+              ? zcodeResumeSession(client, { cwd, sessionId: resumeSessionId })
+              : zcodeCreateSession(client, {
+                  cwd,
+                  mode: mapRuntimeModeToZcodeMode(input.runtimeMode, undefined),
+                  modelId: requestedModel,
+                  providerId: desktopPlan?.providerId,
+                })
+          ).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          if (created.modelId && created.modelId !== requestedModel) {
+            yield* Effect.tryPromise({
+              try: () =>
+                client.request("session/setModel", {
+                  sessionId: created.sessionId,
+                  model: {
+                    modelId: requestedModel,
+                    ...(desktopPlan?.providerId ? { providerId: desktopPlan.providerId } : {}),
+                  },
+                }),
+              catch: (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/setModel",
+                  detail: cause instanceof Error ? cause.message : String(cause),
+                  cause,
+                }),
+            }).pipe(Effect.ignore);
+          }
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: created.modelId ?? requestedModel,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: ZCODE_RESUME_VERSION,
+              sessionId: created.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+          const ctx: ZcodeSessionContext = {
+            threadId: input.threadId,
+            zcodeSessionId: created.sessionId,
+            session,
+            scope: sessionScope,
+            client,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            activeTurnId: undefined,
+            interruptedTurnIds: new Set(),
+            currentModelId: created.modelId ?? requestedModel,
+            currentProviderId: created.providerId ?? desktopPlan?.providerId,
+            assistantItemStarted: false,
+            stopped: false,
+          };
+          ctxHolder.current = ctx;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: created.raw },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "ZCode session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: created.sessionId },
+          });
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: ZCodeAdapterShape["sendTurn"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(input.threadId);
+          const turnId = ctx.activeTurnId ?? TurnId.make(yield* randomUUIDv4);
+          ctx.activeTurnId = turnId;
+          ctx.assistantItemStarted = false;
+          ctx.session = {
+            ...ctx.session,
+            status: "running",
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+          };
+          if (input.interactionMode === "plan") {
+            yield* Effect.tryPromise({
+              try: () =>
+                ctx.client.request("session/setMode", {
+                  sessionId: ctx.zcodeSessionId,
+                  mode: "plan",
+                }),
+              catch: (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/setMode",
+                  detail: cause instanceof Error ? cause.message : String(cause),
+                  cause,
+                }),
+            }).pipe(Effect.ignore);
+          }
+          const requestedModel = input.modelSelection?.model
+            ? resolveZcodeModelId(input.modelSelection.model)
+            : undefined;
+          if (requestedModel && requestedModel !== ctx.currentModelId) {
+            yield* Effect.tryPromise({
+              try: () =>
+                ctx.client.request("session/setModel", {
+                  sessionId: ctx.zcodeSessionId,
+                  model: {
+                    modelId: requestedModel,
+                    ...(ctx.currentProviderId ? { providerId: ctx.currentProviderId } : {}),
+                  },
+                }),
+              catch: (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/setModel",
+                  detail: cause instanceof Error ? cause.message : String(cause),
+                  cause,
+                }),
+            }).pipe(Effect.ignore);
+            ctx.currentModelId = requestedModel;
+            ctx.session = { ...ctx.session, model: requestedModel };
+          }
+
+          yield* offerRuntimeEvent({
+            type: "turn.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            turnId,
+            payload: ctx.currentModelId ? { model: ctx.currentModelId } : {},
+          });
+
+          yield* Effect.tryPromise({
+            try: () =>
+              ctx.client.request("session/send", {
+                sessionId: ctx.zcodeSessionId,
+                content: input.input ?? "",
+              }),
+            catch: (cause) =>
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/send",
+                detail: cause instanceof Error ? cause.message : String(cause),
+                cause,
+              }),
+          });
+
+          ctx.turns = [...ctx.turns, { id: turnId, items: [{ prompt: input.input }] }];
+          return {
+            threadId: input.threadId,
+            turnId,
+            resumeCursor: ctx.session.resumeCursor,
+          };
+        }),
+      );
+
+    const interruptTurn: ZCodeAdapterShape["interruptTurn"] = (threadId, turnId) =>
+      Effect.gen(function* () {
+        const ctx = sessions.get(threadId);
+        if (!ctx || ctx.stopped) return;
+        const activeTurnId = ctx.activeTurnId ?? ctx.session.activeTurnId;
+        if (turnId !== undefined && activeTurnId !== undefined && activeTurnId !== turnId) {
+          return;
+        }
+        const interruptedTurnId = turnId ?? activeTurnId;
+        if (interruptedTurnId !== undefined) {
+          ctx.interruptedTurnIds.add(interruptedTurnId);
+        }
+        ctx.client.notify("session/stop", { sessionId: ctx.zcodeSessionId });
+        if (interruptedTurnId) {
+          const { activeTurnId: _cleared, ...readySession } = ctx.session;
+          ctx.activeTurnId = undefined;
+          ctx.session = { ...readySession, status: "ready", updatedAt: yield* nowIso };
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId,
+            turnId: interruptedTurnId,
+            payload: { state: "cancelled" },
+          });
+        }
+      });
+
+    const respondToRequest: ZCodeAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) return;
+        ctx.pendingApprovals.delete(requestId);
+        yield* Deferred.succeed(pending.decision, decision).pipe(Effect.ignore);
+        if (decision === "cancel") {
+          ctx.client.reply(pending.zcodeRequestId, {
+            outcome: { outcome: "cancelled" },
+          });
+        } else {
+          const optionId = selectPermissionOptionId(pending.options, decision);
+          ctx.client.reply(pending.zcodeRequestId, {
+            outcome: optionId ? { outcome: "selected", optionId } : { outcome: "cancelled" },
+          });
+        }
+        yield* offerRuntimeEvent({
+          type: "request.resolved",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId,
+          turnId: ctx.activeTurnId,
+          requestId: RuntimeRequestId.make(requestId),
+          payload: { requestType: "exec_command_approval", decision },
+        });
+      });
+
+    const respondToUserInput: ZCodeAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingUserInputs.get(requestId);
+        if (!pending) return;
+        ctx.pendingUserInputs.delete(requestId);
+        yield* Deferred.succeed(pending.resolution, { _tag: "answered", answers }).pipe(
+          Effect.ignore,
+        );
+        ctx.client.reply(pending.zcodeRequestId, { answers });
+        yield* offerRuntimeEvent({
+          type: "user-input.resolved",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId,
+          turnId: ctx.activeTurnId,
+          requestId: RuntimeRequestId.make(requestId),
+          payload: { answers },
+        });
+      });
+
+    const stopSession: ZCodeAdapterShape["stopSession"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = sessions.get(threadId);
+        if (!ctx) return;
+        yield* stopSessionInternal(ctx);
+      });
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions: () => Effect.sync(() => [...sessions.values()].map((ctx) => ctx.session)),
+      hasSession: (threadId) => Effect.sync(() => sessions.has(threadId)),
+      readThread: (threadId) =>
+        requireSession(threadId).pipe(Effect.map((ctx) => ({ threadId, turns: ctx.turns }))),
+      rollbackThread: (threadId) =>
+        requireSession(threadId).pipe(Effect.map((ctx) => ({ threadId, turns: ctx.turns }))),
+      stopAll: () =>
+        Effect.forEach([...sessions.values()], stopSessionInternal, {
+          concurrency: "unbounded",
+          discard: true,
+        }),
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    } satisfies ZCodeAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/ZCodeProvider.ts
+++ b/apps/server/src/provider/Layers/ZCodeProvider.ts
@@ -1,0 +1,271 @@
+import {
+  type ModelCapabilities,
+  type ServerProvider,
+  type ServerProviderModel,
+  type ZCodeSettings,
+} from "@t3tools/contracts";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import {
+  buildZcodeAppServerArgv,
+  isZcodeNodeBundle,
+  resolveZcodeCliPath,
+} from "../Drivers/ZCodeExecutable.ts";
+import { readZcodeDesktopPlan } from "../zcodeDesktopAuth.ts";
+
+const ZCODE_PRESENTATION = {
+  displayName: "ZCode",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: true,
+  requiresNewThreadForModelChange: false,
+} as const;
+
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+
+const ZCODE_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  { slug: "GLM-5.3", name: "GLM-5.3", isCustom: false, capabilities: EMPTY_CAPABILITIES },
+  { slug: "GLM-5.2", name: "GLM-5.2", isCustom: false, capabilities: EMPTY_CAPABILITIES },
+  { slug: "GLM-5-Turbo", name: "GLM-5-Turbo", isCustom: false, capabilities: EMPTY_CAPABILITIES },
+];
+
+export function buildInitialZcodeProviderSnapshot(
+  zcodeSettings: ZCodeSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = zcodeModelsFromSettings(zcodeSettings.customModels);
+
+    if (!zcodeSettings.enabled) {
+      return buildServerProvider({
+        presentation: ZCODE_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "ZCode is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: ZCODE_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking ZCode CLI availability...",
+      },
+    });
+  });
+}
+
+function zcodeModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = ZCODE_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+}
+
+const runZcodeVersionCommand = (
+  zcodeSettings: ZCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const argv = buildZcodeAppServerArgv({
+      binaryPath: zcodeSettings.binaryPath,
+      env: environment,
+    });
+    const versionArgs =
+      argv.args[0] && isZcodeNodeBundle(argv.args[0]) ? [argv.args[0], "--version"] : ["--version"];
+    const spawnCommand = yield* resolveSpawnCommand(argv.command, versionArgs, {
+      env: environment,
+    });
+    return yield* spawnAndCollect(
+      argv.command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+      }),
+    );
+  });
+
+export const checkZcodeProviderStatus = Effect.fn("checkZcodeProviderStatus")(function* (
+  zcodeSettings: ZCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const desktopPlan = readZcodeDesktopPlan(environment);
+  const discoveredModels = desktopPlan
+    ? desktopPlan.modelIds.map(
+        (slug): ServerProviderModel => ({
+          slug,
+          name: slug,
+          isCustom: false,
+          capabilities: EMPTY_CAPABILITIES,
+        }),
+      )
+    : ZCODE_BUILT_IN_MODELS;
+  const fallbackModels = zcodeModelsFromSettings(zcodeSettings.customModels, discoveredModels);
+
+  if (!zcodeSettings.enabled) {
+    return buildServerProvider({
+      presentation: ZCODE_PRESENTATION,
+      enabled: false,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "ZCode is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  const cliPath = resolveZcodeCliPath(zcodeSettings.binaryPath, environment);
+  const versionResult = yield* runZcodeVersionCommand(zcodeSettings, environment).pipe(
+    Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(versionResult)) {
+    const error = versionResult.failure;
+    yield* Effect.logWarning("ZCode CLI health check failed.", {
+      errorTag: error._tag,
+    });
+    return buildServerProvider({
+      presentation: ZCODE_PRESENTATION,
+      enabled: zcodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: !isCommandMissingCause(error),
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: isCommandMissingCause(error)
+          ? "ZCode CLI is not installed. Install the ZCode desktop app from https://zcode.z.ai."
+          : "Failed to execute ZCode CLI health check.",
+      },
+    });
+  }
+
+  if (Option.isNone(versionResult.success)) {
+    return buildServerProvider({
+      presentation: ZCODE_PRESENTATION,
+      enabled: zcodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "ZCode CLI is installed but timed out while reporting its version.",
+      },
+    });
+  }
+
+  const versionOutput = versionResult.success.value;
+  const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+
+  if (versionOutput.code !== 0 && !cliPath.endsWith(".cjs")) {
+    return buildServerProvider({
+      presentation: ZCODE_PRESENTATION,
+      enabled: zcodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: false,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message:
+          "ZCode CLI is not installed. Install the ZCode desktop app from https://zcode.z.ai.",
+      },
+    });
+  }
+
+  if (!desktopPlan?.authenticated) {
+    return buildServerProvider({
+      presentation: ZCODE_PRESENTATION,
+      enabled: zcodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "warning",
+        auth: { status: "unauthenticated" },
+        message:
+          "Sign in with the ZCode app (or `zcode login`) so T3 Code can use your Z.AI coding plan.",
+      },
+    });
+  }
+
+  return buildServerProvider({
+    presentation: ZCODE_PRESENTATION,
+    enabled: zcodeSettings.enabled,
+    checkedAt,
+    models: fallbackModels,
+    probe: {
+      installed: true,
+      version,
+      status: "ready",
+      auth: { status: "authenticated" },
+    },
+  });
+});
+
+export const enrichZcodeSnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> =>
+  enrichProviderSnapshotWithVersionAdvisory(input.snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => input.publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("ZCode version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );

--- a/apps/server/src/provider/Services/ZCodeAdapter.ts
+++ b/apps/server/src/provider/Services/ZCodeAdapter.ts
@@ -1,0 +1,9 @@
+/**
+ * ZCodeAdapter — shape type for the ZCode provider adapter.
+ *
+ * @module ZCodeAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+export interface ZCodeAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -25,6 +25,7 @@ import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
+import { ZCodeDriver, type ZCodeDriverEnv } from "./Drivers/ZCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
 /**
@@ -37,7 +38,8 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | ZCodeDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -50,4 +52,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,
+  ZCodeDriver,
 ];

--- a/apps/server/src/provider/zcodeDesktopAuth.ts
+++ b/apps/server/src/provider/zcodeDesktopAuth.ts
@@ -1,0 +1,129 @@
+/**
+ * Read the ZCode desktop app's coding-plan selection so T3 sessions use the
+ * same Z.AI quota as the app, not a third-party API-key client like Pi.
+ *
+ * @module provider/zcodeDesktopAuth
+ */
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+const DEFAULT_MODEL_ID = "GLM-5.3";
+const PREFERRED_PROVIDER_IDS = [
+  "builtin:zai-coding-plan",
+  "builtin:zai",
+  "builtin:bigmodel-coding-plan",
+] as const;
+
+export interface ZcodeDesktopPlan {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly baseUrl: string | undefined;
+  readonly modelIds: ReadonlyArray<string>;
+  readonly authenticated: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJsonFile(path: string): unknown {
+  try {
+    return JSON.parse(NodeFs.readFileSync(path, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function zcodeHome(env: NodeJS.ProcessEnv = process.env): string {
+  const storage = env.ZCODE_STORAGE_DIR?.trim();
+  if (storage) return storage;
+  return NodePath.join(NodeOs.homedir(), ".zcode");
+}
+
+function modelIdsFromProvider(provider: Record<string, unknown>): string[] {
+  const models = provider.models;
+  if (!isRecord(models)) return [];
+  return Object.keys(models).filter((key) => key.trim().length > 0);
+}
+
+function pickPreferredModel(modelIds: ReadonlyArray<string>): string {
+  if (modelIds.includes(DEFAULT_MODEL_ID)) return DEFAULT_MODEL_ID;
+  return modelIds[0] ?? DEFAULT_MODEL_ID;
+}
+
+function providerEnabled(provider: Record<string, unknown>): boolean {
+  return provider.enabled !== false;
+}
+
+export function readZcodeDesktopPlan(
+  env: NodeJS.ProcessEnv = process.env,
+): ZcodeDesktopPlan | null {
+  const home = zcodeHome(env);
+  const config = readJsonFile(NodePath.join(home, "v2", "config.json"));
+  if (!isRecord(config) || !isRecord(config.provider)) {
+    return null;
+  }
+
+  const providers = config.provider;
+  const orderedIds = [
+    ...PREFERRED_PROVIDER_IDS.filter((id) => id in providers),
+    ...Object.keys(providers).filter(
+      (id) => !(PREFERRED_PROVIDER_IDS as ReadonlyArray<string>).includes(id),
+    ),
+  ];
+
+  let selected: { readonly id: string; readonly provider: Record<string, unknown> } | undefined;
+  for (const id of orderedIds) {
+    const provider = providers[id];
+    if (!isRecord(provider) || !providerEnabled(provider)) continue;
+    selected = { id, provider };
+    if (id.startsWith("builtin:") && id.includes("coding-plan")) {
+      break;
+    }
+  }
+  if (!selected) return null;
+
+  const options = isRecord(selected.provider.options) ? selected.provider.options : {};
+  const baseUrl = typeof options.baseURL === "string" ? options.baseURL.trim() : "";
+  const modelIds = modelIdsFromProvider(selected.provider);
+  const credentials = readJsonFile(NodePath.join(home, "v2", "credentials.json"));
+  const authenticated = isRecord(credentials)
+    ? Object.keys(credentials).some(
+        (key) =>
+          key.startsWith("oauth:") ||
+          key === "zcodejwttoken" ||
+          key.toLowerCase().includes("token"),
+      )
+    : false;
+
+  return {
+    providerId: selected.id,
+    modelId: pickPreferredModel(modelIds),
+    baseUrl: baseUrl.length > 0 ? baseUrl : undefined,
+    modelIds: modelIds.length > 0 ? modelIds : [DEFAULT_MODEL_ID],
+    authenticated,
+  };
+}
+
+export function zcodeModelEnvValue(plan: ZcodeDesktopPlan): string {
+  return `${plan.providerId}/${plan.modelId}`;
+}
+
+export function buildZcodeDesktopSpawnEnv(
+  environment: NodeJS.ProcessEnv,
+  plan: ZcodeDesktopPlan | null,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...environment,
+    ZCODE_TELEMETRY_RUNTIME_SURFACE: "desktop",
+    ZCODE_TELEMETRY_RUNTIME_DISTRIBUTION: "desktop",
+  };
+  if (plan) {
+    env.ZCODE_MODEL = zcodeModelEnvValue(plan);
+    if (plan.baseUrl) {
+      env.ZCODE_BASE_URL = plan.baseUrl;
+    }
+  }
+  return env;
+}

--- a/apps/server/src/provider/zcodeRuntime.test.ts
+++ b/apps/server/src/provider/zcodeRuntime.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mapRuntimeModeToZcodeMode,
+  parseZcodeCreateResult,
+  parseZcodeSessionEvent,
+} from "./zcodeRuntime.ts";
+
+describe("mapRuntimeModeToZcodeMode", () => {
+  it("maps T3 runtime modes onto ZCode permission modes", () => {
+    expect(mapRuntimeModeToZcodeMode("full-access", undefined)).toBe("yolo");
+    expect(mapRuntimeModeToZcodeMode("auto-accept-edits", undefined)).toBe("edit");
+    expect(mapRuntimeModeToZcodeMode("approval-required", undefined)).toBe("build");
+    expect(mapRuntimeModeToZcodeMode("full-access", "plan")).toBe("plan");
+  });
+});
+
+describe("parseZcodeCreateResult", () => {
+  it("reads sessionId and available models from a create response", () => {
+    const parsed = parseZcodeCreateResult({
+      session: {
+        sessionId: "sess_1",
+        model: { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan" },
+      },
+      settings: {
+        model: {
+          current: { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan" },
+          available: [
+            {
+              label: "GLM-5.3",
+              ref: { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan" },
+            },
+          ],
+        },
+      },
+    });
+    expect(parsed.sessionId).toBe("sess_1");
+    expect(parsed.modelId).toBe("GLM-5.3");
+    expect(parsed.availableModels).toEqual([
+      { modelId: "GLM-5.3", providerId: "builtin:zai-coding-plan", label: "GLM-5.3" },
+    ]);
+  });
+});
+
+describe("parseZcodeSessionEvent", () => {
+  it("ignores malformed events", () => {
+    expect(parseZcodeSessionEvent(null)).toBeUndefined();
+    expect(parseZcodeSessionEvent({ type: "turn.started" })).toBeUndefined();
+  });
+
+  it("parses a session event", () => {
+    expect(
+      parseZcodeSessionEvent({
+        sessionId: "sess_1",
+        seq: 3,
+        type: "model.streaming",
+        payload: { kind: "text_delta", delta: "hi" },
+      }),
+    ).toEqual({
+      sessionId: "sess_1",
+      seq: 3,
+      type: "model.streaming",
+      payload: { kind: "text_delta", delta: "hi" },
+    });
+  });
+});

--- a/apps/server/src/provider/zcodeRuntime.ts
+++ b/apps/server/src/provider/zcodeRuntime.ts
@@ -1,0 +1,401 @@
+/**
+ * ZCode Protocol client: spawn `zcode.cjs app-server --surface desktop` and
+ * speak line-delimited JSON (JSON-RPC without the `jsonrpc` field).
+ *
+ * @module provider/zcodeRuntime
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+
+import * as Effect from "effect/Effect";
+import * as Scope from "effect/Scope";
+
+import { buildZcodeAppServerArgv } from "./Drivers/ZCodeExecutable.ts";
+import { buildZcodeDesktopSpawnEnv, readZcodeDesktopPlan } from "./zcodeDesktopAuth.ts";
+
+export type ZcodeJson = Record<string, unknown>;
+
+export interface ZcodeInboundMessage {
+  readonly id?: number | string;
+  readonly method?: string;
+  readonly params?: unknown;
+  readonly result?: unknown;
+  readonly error?: { readonly code?: number; readonly message?: string; readonly data?: unknown };
+}
+
+export interface ZcodeServerRequest {
+  readonly id: number | string;
+  readonly method: string;
+  readonly params: unknown;
+}
+
+export interface ZcodeSessionEvent {
+  readonly sessionId: string;
+  readonly seq: number;
+  readonly type: string;
+  readonly payload: unknown;
+}
+
+export interface ZcodeCreateSessionResult {
+  readonly sessionId: string;
+  readonly modelId: string | undefined;
+  readonly providerId: string | undefined;
+  readonly availableModels: ReadonlyArray<{
+    readonly modelId: string;
+    readonly providerId: string | undefined;
+    readonly label: string | undefined;
+  }>;
+  readonly raw: unknown;
+}
+
+export type ZcodeServerRequestHandler = (request: ZcodeServerRequest) => Effect.Effect<unknown>;
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function mapRuntimeModeToZcodeMode(
+  runtimeMode: string | undefined,
+  interactionMode: string | undefined,
+): "yolo" | "build" | "edit" | "plan" {
+  if (interactionMode === "plan") return "plan";
+  switch (runtimeMode) {
+    case "full-access":
+      return "yolo";
+    case "auto-accept-edits":
+      return "edit";
+    default:
+      return "build";
+  }
+}
+
+function parseAvailableModels(settings: unknown): ZcodeCreateSessionResult["availableModels"] {
+  if (!isRecord(settings) || !isRecord(settings.model)) return [];
+  const available = settings.model.available;
+  if (!Array.isArray(available)) return [];
+  const models: Array<ZcodeCreateSessionResult["availableModels"][number]> = [];
+  for (const entry of available) {
+    if (!isRecord(entry)) continue;
+    const ref = isRecord(entry.ref) ? entry.ref : entry;
+    const modelId = asString(ref.modelId) ?? asString(entry.label);
+    if (!modelId) continue;
+    models.push({
+      modelId,
+      providerId: asString(ref.providerId),
+      label: asString(entry.label) ?? modelId,
+    });
+  }
+  return models;
+}
+
+export function parseZcodeCreateResult(raw: unknown): ZcodeCreateSessionResult {
+  const record = isRecord(raw) ? raw : {};
+  const session = isRecord(record.session) ? record.session : record;
+  const settings = record.settings;
+  const model = isRecord(session.model) ? session.model : undefined;
+  const current =
+    isRecord(settings) && isRecord(settings.model) && isRecord(settings.model.current)
+      ? settings.model.current
+      : model;
+  const sessionId = asString(session.sessionId) ?? asString(record.sessionId) ?? "";
+  return {
+    sessionId,
+    modelId: current ? asString(current.modelId) : undefined,
+    providerId: current ? asString(current.providerId) : undefined,
+    availableModels: parseAvailableModels(settings),
+    raw,
+  };
+}
+
+export function parseZcodeSessionEvent(params: unknown): ZcodeSessionEvent | undefined {
+  if (!isRecord(params)) return undefined;
+  const sessionId = asString(params.sessionId);
+  const type = asString(params.type);
+  if (!sessionId || !type) return undefined;
+  return {
+    sessionId,
+    seq: typeof params.seq === "number" ? params.seq : 0,
+    type,
+    payload: params.payload,
+  };
+}
+
+interface PendingRequest {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: Error) => void;
+  readonly timer: ReturnType<typeof setTimeout>;
+}
+
+export class ZcodeProtocolClient {
+  private readonly proc: ChildProcessWithoutNullStreams;
+  private readonly reader: ReadlineInterface;
+  private readonly pending = new Map<string, PendingRequest>();
+  private nextId = 1;
+  private closed = false;
+  private eventHandler: ((event: ZcodeSessionEvent) => void) | undefined;
+  private serverRequestHandler: ((request: ZcodeServerRequest) => void) | undefined;
+
+  constructor(proc: ChildProcessWithoutNullStreams) {
+    this.proc = proc;
+    this.reader = createInterface({ input: proc.stdout });
+    this.reader.on("line", (line) => this.onLine(line));
+    this.reader.on("close", () => this.failAll(new Error("ZCode app-server stdout closed.")));
+    proc.on("exit", (code, signal) => {
+      this.failAll(
+        new Error(
+          `ZCode app-server exited${code !== null ? ` with code ${code}` : ""}${
+            signal ? ` (${signal})` : ""
+          }.`,
+        ),
+      );
+    });
+    proc.stdin.on("error", () => {
+      this.closed = true;
+    });
+  }
+
+  setEventHandler(handler: (event: ZcodeSessionEvent) => void): void {
+    this.eventHandler = handler;
+  }
+
+  setServerRequestHandler(handler: (request: ZcodeServerRequest) => void): void {
+    this.serverRequestHandler = handler;
+  }
+
+  request(
+    method: string,
+    params?: unknown,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(new Error("ZCode app-server is closed."));
+    }
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(String(id));
+        reject(new Error(`ZCode request timed out: ${method}`));
+      }, timeoutMs);
+      this.pending.set(String(id), { resolve, reject, timer });
+      this.write({ id, method, params: params ?? {} });
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.write({ method, params: params ?? {} });
+  }
+
+  reply(id: number | string, result: unknown): void {
+    this.write({ id, result });
+  }
+
+  replyError(id: number | string, message: string, code = -32000): void {
+    this.write({ id, error: { code, message } });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.failAll(new Error("ZCode app-server closed."));
+    this.reader.close();
+    const pid = this.proc.pid;
+    if (pid) {
+      try {
+        process.kill(-pid, "SIGTERM");
+      } catch {
+        this.proc.kill("SIGTERM");
+      }
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        try {
+          if (pid) process.kill(-pid, "SIGKILL");
+        } catch {
+          this.proc.kill("SIGKILL");
+        }
+        resolve();
+      }, 2_000);
+      this.proc.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  private write(payload: unknown): void {
+    if (this.closed || this.proc.stdin.destroyed) return;
+    this.proc.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  private onLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let message: ZcodeInboundMessage;
+    try {
+      message = JSON.parse(trimmed) as ZcodeInboundMessage;
+    } catch {
+      return;
+    }
+    const id = message.id;
+    const method = message.method;
+    if (id !== undefined && method === undefined) {
+      const pending = this.pending.get(String(id));
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(String(id));
+      if (message.error) {
+        pending.reject(
+          new Error(
+            message.error.message ?? `ZCode request failed (${message.error.code ?? "?"}).`,
+          ),
+        );
+        return;
+      }
+      pending.resolve(message.result);
+      return;
+    }
+    if (id !== undefined && method !== undefined) {
+      if (this.pending.has(String(id))) {
+        const pending = this.pending.get(String(id));
+        if (pending) {
+          clearTimeout(pending.timer);
+          this.pending.delete(String(id));
+          pending.resolve(message.result);
+        }
+        return;
+      }
+      this.serverRequestHandler?.({ id, method, params: message.params });
+      return;
+    }
+    if (method === "session/event") {
+      const event = parseZcodeSessionEvent(message.params);
+      if (event) this.eventHandler?.(event);
+    }
+  }
+
+  private failAll(error: Error): void {
+    this.closed = true;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export const startZcodeProtocolClient = (input: {
+  readonly binaryPath: string | null | undefined;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}): Effect.Effect<ZcodeProtocolClient, Error, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.try({
+      try: () => {
+        const argv = buildZcodeAppServerArgv({
+          binaryPath: input.binaryPath,
+          env: input.environment,
+        });
+        const plan = readZcodeDesktopPlan(input.environment);
+        const env = buildZcodeDesktopSpawnEnv(input.environment ?? process.env, plan);
+        const proc = spawn(argv.command, [...argv.args], {
+          cwd: input.cwd,
+          env,
+          stdio: ["pipe", "pipe", "pipe"],
+          detached: process.platform !== "win32",
+        }) as ChildProcessWithoutNullStreams;
+        return new ZcodeProtocolClient(proc);
+      },
+      catch: (cause) =>
+        cause instanceof Error
+          ? cause
+          : new Error(`Failed to start ZCode app-server: ${String(cause)}`),
+    }),
+    (client) => Effect.promise(() => client.close()),
+  );
+
+export const handleBuiltinZcodeServerRequest = (
+  client: ZcodeProtocolClient,
+  request: ZcodeServerRequest,
+): boolean => {
+  if (request.method === "session/requestRuntimePreferences") {
+    client.reply(request.id, {
+      nativeSearchEnhancementsEnabled: false,
+      memoryEnabled: false,
+      askUserQuestionAutoResolutionEnabled: false,
+    });
+    return true;
+  }
+  if (request.method === "interaction/requestProviderRuntimeHeaders") {
+    client.reply(request.id, {});
+    return true;
+  }
+  return false;
+};
+
+export const zcodeCreateSession = (
+  client: ZcodeProtocolClient,
+  input: {
+    readonly cwd: string;
+    readonly mode: "yolo" | "build" | "edit" | "plan";
+    readonly modelId?: string;
+    readonly providerId?: string;
+  },
+): Effect.Effect<ZcodeCreateSessionResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const params: ZcodeJson = {
+        workspace: { workspacePath: input.cwd, workspaceKey: input.cwd },
+        mode: input.mode,
+      };
+      if (input.modelId) {
+        params.model = {
+          modelId: input.modelId,
+          ...(input.providerId ? { providerId: input.providerId } : {}),
+        };
+      }
+      const raw = await client.request("session/create", params);
+      const created = parseZcodeCreateResult(raw);
+      if (!created.sessionId) {
+        throw new Error("ZCode session/create did not return a sessionId.");
+      }
+      await client.request("session/subscribe", {
+        sessionId: created.sessionId,
+        deliveryKind: "desktop-continuous",
+        includeSnapshot: true,
+        afterSeq: 0,
+      });
+      return created;
+    },
+    catch: (cause) =>
+      cause instanceof Error ? cause : new Error(`ZCode session/create failed: ${String(cause)}`),
+  });
+
+export const zcodeResumeSession = (
+  client: ZcodeProtocolClient,
+  input: { readonly cwd: string; readonly sessionId: string },
+): Effect.Effect<ZcodeCreateSessionResult, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const raw = await client.request("session/resume", {
+        sessionId: input.sessionId,
+        workspace: { workspacePath: input.cwd, workspaceKey: input.cwd },
+      });
+      const resumed = parseZcodeCreateResult(raw);
+      const sessionId = resumed.sessionId || input.sessionId;
+      await client.request("session/subscribe", {
+        sessionId,
+        deliveryKind: "desktop-continuous",
+        includeSnapshot: true,
+        afterSeq: 0,
+      });
+      return { ...resumed, sessionId };
+    },
+    catch: (cause) =>
+      cause instanceof Error ? cause : new Error(`ZCode session/resume failed: ${String(cause)}`),
+  });

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -8,7 +8,13 @@ import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstance
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import type { TextGenerationPolicy } from "./TextGenerationPolicy.ts";
 
-export type TextGenerationProvider = "codex" | "claudeAgent" | "cursor" | "grok" | "opencode";
+export type TextGenerationProvider =
+  | "codex"
+  | "claudeAgent"
+  | "cursor"
+  | "grok"
+  | "opencode"
+  | "zcode";
 
 export interface CommitMessageGenerationInput {
   cwd: string;

--- a/apps/server/src/textGeneration/ZCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ZCodeTextGeneration.ts
@@ -1,0 +1,251 @@
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { TextGenerationError, type ModelSelection, type ZCodeSettings } from "@t3tools/contracts";
+import { sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import { resolveZcodeModelId } from "../provider/Layers/ZCodeAdapter.ts";
+import {
+  handleBuiltinZcodeServerRequest,
+  startZcodeProtocolClient,
+  zcodeCreateSession,
+} from "../provider/zcodeRuntime.ts";
+import { readZcodeDesktopPlan } from "../provider/zcodeDesktopAuth.ts";
+
+const ZCODE_TIMEOUT_MS = 180_000;
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+export const makeZcodeTextGeneration = Effect.fn("makeZcodeTextGeneration")(function* (
+  zcodeSettings: ZCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const runZcodeJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      let output = "";
+      let resolveDone: (() => void) | undefined;
+      const donePromise = new Promise<void>((resolve) => {
+        resolveDone = resolve;
+      });
+      const client = yield* startZcodeProtocolClient({
+        binaryPath: zcodeSettings.binaryPath,
+        cwd,
+        environment,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TextGenerationError({
+              operation,
+              detail: cause.message,
+              cause,
+            }),
+        ),
+      );
+
+      client.setServerRequestHandler((request) => {
+        handleBuiltinZcodeServerRequest(client, request);
+      });
+      client.setEventHandler((event) => {
+        if (event.type === "model.streaming") {
+          const payload =
+            event.payload && typeof event.payload === "object"
+              ? (event.payload as Record<string, unknown>)
+              : {};
+          if (payload.kind === "text_delta" && typeof payload.delta === "string") {
+            output += payload.delta;
+          }
+        }
+        if (
+          event.type === "turn.completed" ||
+          event.type === "turn.failed" ||
+          event.type === "turn.terminal"
+        ) {
+          resolveDone?.();
+        }
+      });
+
+      const plan = readZcodeDesktopPlan(environment);
+      const created = yield* zcodeCreateSession(client, {
+        cwd,
+        mode: "yolo",
+        modelId: resolveZcodeModelId(modelSelection.model),
+        providerId: plan?.providerId,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TextGenerationError({
+              operation,
+              detail: cause.message,
+              cause,
+            }),
+        ),
+      );
+
+      yield* Effect.tryPromise({
+        try: () =>
+          client.request("session/send", {
+            sessionId: created.sessionId,
+            content: `${prompt}\n\nReturn only JSON.`,
+          }),
+        catch: (cause) =>
+          new TextGenerationError({
+            operation,
+            detail: cause instanceof Error ? cause.message : String(cause),
+            cause,
+          }),
+      });
+
+      yield* Effect.promise(() => donePromise).pipe(
+        Effect.timeoutOption(ZCODE_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({ operation, detail: "ZCode text generation timed out." }),
+              ),
+            onSome: () => Effect.void,
+          }),
+        ),
+      );
+
+      const trimmed = output.trim();
+      if (!trimmed) {
+        return yield* new TextGenerationError({
+          operation,
+          detail: "ZCode returned empty output.",
+        });
+      }
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(trimmed)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "ZCode returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "ZCode text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  return {
+    generateCommitMessage: Effect.fn("ZCodeTextGeneration.generateCommitMessage")(
+      function* (input) {
+        const { prompt, outputSchema } = buildCommitMessagePrompt({
+          branch: input.branch,
+          stagedSummary: input.stagedSummary,
+          stagedPatch: input.stagedPatch,
+          includeBranch: input.includeBranch === true,
+          policy: input.policy,
+        });
+        const generated = yield* runZcodeJson({
+          operation: "generateCommitMessage",
+          cwd: input.cwd,
+          prompt,
+          outputSchemaJson: outputSchema,
+          modelSelection: input.modelSelection,
+        });
+        return {
+          subject: sanitizeCommitSubject(generated.subject),
+          body: generated.body,
+          ...("branch" in generated && typeof generated.branch === "string"
+            ? { branch: sanitizeFeatureBranchName(generated.branch) }
+            : {}),
+        };
+      },
+    ),
+    generatePrContent: Effect.fn("ZCodeTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+        changeRequestTemplate: input.changeRequestTemplate,
+        policy: input.policy,
+      });
+      const generated = yield* runZcodeJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body,
+      };
+    }),
+    generateBranchName: Effect.fn("ZCodeTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+      const generated = yield* runZcodeJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+      return { branch: sanitizeFeatureBranchName(generated.branch) };
+    }),
+    generateThreadTitle: Effect.fn("ZCodeTextGeneration.generateThreadTitle")(function* (input) {
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        previousTitle: input.previousTitle,
+        attachments: input.attachments,
+      });
+      const generated = yield* runZcodeJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+      return { title: sanitizeThreadTitle(generated.title) };
+    }),
+  } satisfies TextGeneration.TextGeneration["Service"];
+});

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -214,6 +214,17 @@ export const GrokIcon: Icon = ({ className, ...props }) => (
   </svg>
 );
 
+export const ZCodeIcon: Icon = ({ className, ...props }) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    className={cn("fill-[#1A7AFF] dark:fill-[#6BA6FF]", className)}
+  >
+    <path d="M4 5.5A1.5 1.5 0 0 1 5.5 4h13A1.5 1.5 0 0 1 20 5.5v2A1.5 1.5 0 0 1 18.5 9H9.8l8.7 8.2A1.5 1.5 0 0 1 17.4 20h-13A1.5 1.5 0 0 1 4 18.5v-2A1.5 1.5 0 0 1 5.5 15h8.7L5.5 6.8A1.5 1.5 0 0 1 4 5.5Z" />
+  </svg>
+);
+
 export const TraeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 24 24" fill="currentColor">
     {/* Back rectangle: left strip + bottom strip drawn separately — empty bottom-left corner is the gap between them */}

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon, ZCodeIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +8,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("zcode")]: ZCodeIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -5,9 +5,18 @@ import {
   GrokSettings,
   OpenCodeSettings,
   ProviderDriverKind,
+  ZCodeSettings,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+  ZCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -66,6 +75,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("zcode"),
+    label: "ZCode",
+    icon: ZCodeIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: ZCodeSettings,
   },
 ];
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -55,6 +55,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("zcode"),
+    label: "ZCode",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -94,7 +94,7 @@ The live backend agent implementation and its event stream. The main service is 
 
 #### Provider
 
-The backend agent runtime that actually performs work. Five drivers ship built in: Codex, Claude, Cursor, Grok, and OpenCode. See [ProviderService.ts][14], [ProviderAdapter.ts][15], and [CodexAdapter.ts][17] as a representative adapter.
+The backend agent runtime that actually performs work. Six drivers ship built in: Codex, Claude, Cursor, Grok, OpenCode, and ZCode. See [ProviderService.ts][14], [ProviderAdapter.ts][15], and [CodexAdapter.ts][17] as a representative adapter.
 
 #### Session
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -18,13 +18,13 @@ there, never in the client.
 ┌──────────────────▼─────────────────────────────┐
 │ apps/server                                    │
 │  orchestration engine (event-sourced)          │
-│  provider driver registry (5 built-in drivers) │
+│  provider driver registry (6 built-in drivers) │
 │  checkpointing, VCS, terminals, filesystem     │
 └──────────────────┬─────────────────────────────┘
                    │ per-driver transport
 ┌──────────────────▼─────────────────────────────┐
 │ Agent CLIs: Codex, Claude, Cursor, Grok,       │
-│ OpenCode                                       │
+│ OpenCode, ZCode                                │
 └────────────────────────────────────────────────┘
 ```
 
@@ -106,8 +106,8 @@ build production behavior on receipts.
 
 ## Provider drivers
 
-Five drivers ship built in, registered in [`builtInDrivers.ts`][drivers] as `BUILT_IN_DRIVERS`:
-Codex, Claude, Cursor, Grok, and OpenCode. A driver declares its kind and config schema and creates a
+Six drivers ship built in, registered in [`builtInDrivers.ts`][drivers] as `BUILT_IN_DRIVERS`:
+Codex, Claude, Cursor, Grok, OpenCode, and ZCode. A driver declares its kind and config schema and creates a
 scoped adapter; `ProviderInstanceRegistry` owns live instances and `ProviderAdapterRegistry` resolves
 an instance to its adapter, so `ProviderService` routes session and turn operations without knowing
 which agent is behind them. See [providers.md](./providers.md).

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -7,7 +7,7 @@ orchestration layer does not know which one is behind a thread.
 
 ## Built-in drivers
 
-[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with five entries:
+[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with six entries:
 
 | Driver kind   | Driver source                           |
 | ------------- | --------------------------------------- |
@@ -16,6 +16,7 @@ orchestration layer does not know which one is behind a thread.
 | `cursor`      | [`Drivers/CursorDriver.ts`][cursor]     |
 | `grok`        | [`Drivers/GrokDriver.ts`][grok]         |
 | `opencode`    | [`Drivers/OpenCodeDriver.ts`][opencode] |
+| `zcode`       | [`Drivers/ZCodeDriver.ts`][zcode]       |
 
 Each driver declares its `driverKind`, a `configSchema`, and a `create` function that builds an
 adapter in a child scope. Adapter implementations live beside them in
@@ -81,6 +82,7 @@ when a request opens (approval) or user input is requested, via
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts
 [opencode]: ../../apps/server/src/provider/Drivers/OpenCodeDriver.ts
+[zcode]: ../../apps/server/src/provider/Drivers/ZCodeDriver.ts
 [adapter]: ../../apps/server/src/provider/Services/ProviderAdapter.ts
 [instances]: ../../apps/server/src/provider/Services/ProviderInstanceRegistry.ts
 [registry]: ../../apps/server/src/provider/Services/ProviderAdapterRegistry.ts

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -61,8 +61,9 @@ to use, then authenticate it.
 | Cursor     | [Cursor CLI](https://cursor.com/cli)                  | `cursor-agent` | `agent login`         |
 | Grok Build | [Grok Build CLI](https://x.ai/cli)                    | `grok`         | `grok login`          |
 | OpenCode   | [OpenCode](https://opencode.ai)                       | `opencode`     | `opencode auth login` |
+| ZCode      | [ZCode](https://zcode.z.ai)                           | `zcode`        | `zcode login`         |
 
-Codex and Claude are on by default. Cursor, Grok Build, and OpenCode are off by default; turn
+Codex and Claude are on by default. Cursor, Grok Build, OpenCode, and ZCode are off by default; turn
 them on in **Settings** → the provider's card when you want to use them.
 
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
@@ -86,6 +87,7 @@ authenticated shows its status in **Settings** and fails at session start with t
 to run.
 
 For multi-account setups, see [Codex](./providers-codex.md) and [Claude](./providers-claude.md).
+For ZCode coding-plan login and quota, see [ZCode](./providers-zcode.md).
 
 ## Next Steps
 

--- a/docs/user/providers-zcode.md
+++ b/docs/user/providers-zcode.md
@@ -1,0 +1,17 @@
+# ZCode
+
+ZCode is Z.ai's coding agent. T3 Code drives the CLI that ships inside the ZCode desktop app, using the same Z.AI coding-plan login as the app itself.
+
+## Install
+
+Install the [ZCode desktop app](https://zcode.z.ai) and sign in there, or run `zcode login` on the machine that hosts T3 Code.
+
+Turn the provider on in **Settings** → **ZCode**. T3 Code looks for the bundled CLI (`zcode.cjs`) next to the app; set **Binary path** only if yours lives somewhere unusual.
+
+Do not point Binary path at the Electron wrapper named `zcode` on Linux package installs. That launches the GUI. The CLI entry is the `zcode.cjs` file inside the app bundle.
+
+## Quota
+
+ZCode's coding-plan quota is tied to the official app identity. T3 Code starts that CLI with the desktop surface and your existing ZCode login, so usage is counted like the ZCode app — not like a third-party client that only has an API key.
+
+If Settings shows ZCode as installed but unauthenticated, sign in with the ZCode app (or `zcode login`) and refresh the provider.

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ZCODE_DRIVER_KIND = ProviderDriverKind.make("zcode");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -153,6 +154,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ZCODE_DRIVER_KIND]: "GLM-5.3",
 };
 
 /** Per-provider text generation model defaults. */
@@ -163,6 +165,7 @@ export const DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ZCODE_DRIVER_KIND]: "GLM-5-Turbo",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -212,6 +215,13 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [ZCODE_DRIVER_KIND]: {
+    glm: "GLM-5.3",
+    "glm-5.3": "GLM-5.3",
+    "glm-5.2": "GLM-5.2",
+    "glm-5-turbo": "GLM-5-Turbo",
+    turbo: "GLM-5-Turbo",
+  },
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -222,4 +232,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ZCODE_DRIVER_KIND]: "ZCode",
 };

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -27,6 +27,7 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("claude.sdk.permission"),
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
+  Schema.Literal("zcode.protocol.event"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -203,12 +203,14 @@ describe("provider enabled defaults", () => {
     expect(decoded.providers.cursor.enabled).toBe(true);
     expect(decoded.providers.grok.enabled).toBe(false);
     expect(decoded.providers.opencode.enabled).toBe(false);
+    expect(decoded.providers.zcode.enabled).toBe(false);
   });
 
   it("derives per-driver defaults from the settings schemas", () => {
     expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(true);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("zcode"))).toBe(false);
     // Unknown fork drivers stay enabled; their own build decides otherwise.
     expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
   });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -479,6 +479,32 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const ZCodeSettings = makeProviderSettingsSchema(
+  {
+    // Off by default: probe the installed ZCode app/CLI only when opted in.
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("zcode").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description:
+          "Path to the ZCode CLI (`zcode.cjs` from the desktop app). Leave blank to auto-discover the app bundle.",
+        providerSettingsForm: { placeholder: "zcode", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type ZCodeSettings = typeof ZCodeSettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     // Off by default (like Cursor and Grok): the binding is not yet stable
@@ -673,6 +699,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    zcode: ZCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -812,6 +839,12 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const ZCodeSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -861,6 +894,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      zcode: Schema.optionalKey(ZCodeSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
## Problem

T3 Code can control Codex, Claude, Cursor, Grok, and OpenCode, but not ZCode. People with a Z.AI coding-plan subscription have to leave T3, and calling GLM through a third-party client (Pi, raw API keys) uses a smaller quota than the official ZCode app.

## Change

Add a `zcode` driver that:

- finds the CLI bundled in the ZCode desktop app (`zcode.cjs`), not the Electron wrapper
- starts `app-server --surface desktop` with the existing coding-plan login
- maps ZCode Protocol sessions, streaming, tools, and permissions into T3
- exposes GLM-5.3 / GLM-5.2 / GLM-5-Turbo in the model picker (off by default, same as Grok)

Focused tests cover CLI discovery, protocol parsing, settings defaults, and a mock session/turn.

## Notes

ZCode is off until you enable it in Settings. Install the [ZCode app](https://zcode.z.ai) and sign in there, or run `zcode login`.

Made with Grok Build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new provider surface (child processes, local credential reads, permission bridging) with broad contract and UI touchpoints; behavior is mostly isolated behind the adapter pattern but subprocess and auth edge cases can affect session reliability.
> 
> **Overview**
> Adds **ZCode** as a sixth built-in provider so T3 can drive the Z.ai desktop agent from web, mobile, and settings like the other CLIs.
> 
> On the server, a new `zcode` driver spawns the bundled **`zcode.cjs`** entry (not the Electron `zcode` launcher) as `app-server --surface desktop`, speaks line-delimited ZCode Protocol JSON, and maps sessions, streaming, tools, permissions, and user-input/plan prompts into T3 runtime events. **Desktop auth** is read from `~/.zcode` so sessions use the same Z.AI coding-plan OAuth as the official app. Provider health checks probe CLI install/version and login state; **ZCodeTextGeneration** reuses the protocol for commit/PR/title helpers.
> 
> **Contracts** add `ZCodeSettings` (off by default), GLM model defaults/aliases, and `zcode.protocol.event` as a raw runtime source. **Web and mobile** wire ZCode into the provider picker, settings cards, and icons. User docs cover install, binary path, and quota behavior; a mock app-server supports adapter tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adf4064e2590234ed0d9d72bb61c29a4083dfee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ZCode provider for Z.AI coding-plan models
> - Introduces a full ZCode provider: a stdio JSON-RPC protocol client in [zcodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/8116/files#diff-a0a8ba1f9bbbc901c42621ddd13e34d5a0e371ca9d94e735c23e5ed10098c7b1), an adapter translating ZCode events to runtime events in [ZCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/8116/files#diff-947469694fe6b92f7136abf7dba73e51d54643585beae9d66ee519ab5c34a828), and a provider driver in [ZCodeDriver.ts](https://github.com/pingdotgg/t3code/pull/8116/files#diff-b375693ce88446e29b988bb9af86c7fc45cab8577caaab14ed8b17aa38064820).
> - Adds `ZCodeSettings` schema (enabled `false` by default, `binaryPath`, `customModels`) and contracts constants mapping `ZCODE_DRIVER_KIND` to default models `GLM-5.3` and `GLM-5-Turbo`.
> - Registers `ZCodeDriver` in `BUILT_IN_DRIVERS` and adds ZCode to the web and mobile UI provider pickers with dedicated icons.
> - Implements `makeZcodeTextGeneration` in [ZCodeTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/8116/files#diff-fe4b8a75374d9dc0286558b3e9f5e91188ce9997e0609a4b26bcdee2e3a1aed0) to fulfill text generation requests using a local ZCode runtime with a 180s timeout.
> - Risk: `ZcodeProtocolClient` spawns a detached ZCode app-server child process; verify `close()` terminates the process group cleanly on non-Windows platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6adf406. 26 files reviewed, 28 issues evaluated, 8 issues filtered, 15 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Drivers/ZCodeExecutable.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 84](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/Drivers/ZCodeExecutable.ts#L84): `whichOnPath` treats any regular file as a usable PATH command and returns it without checking executable permission. On Unix, a non-executable file named `zcode` in an earlier PATH directory therefore shadows a valid executable in a later directory; the returned path is then spawned directly and fails with `EACCES` instead of discovering the working CLI. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/ZCodeAdapter.ts — 6 comments posted, 7 evaluated, 1 filtered</summary>
>
> - [line 755](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/Layers/ZCodeAdapter.ts#L755): Every interrupted turn is added to `ctx.interruptedTurnIds`, but no path ever removes IDs from this set. A long-lived session that repeatedly interrupts turns accumulates one permanent entry per interruption, causing unbounded memory growth until the whole session is stopped. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/zcodeRuntime.ts — 2 comments posted, 13 evaluated, 6 filtered</summary>
>
> - [line 144](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/zcodeRuntime.ts#L144): `ZcodeProtocolClient` never registers an `error` listener on `proc`. `spawn()` reports failures such as a missing configured binary or nonexistent `cwd` asynchronously via the child process `error` event, so the surrounding `Effect.try` cannot catch them; an unhandled EventEmitter `error` then terminates the server instead of returning a provider startup error. <b>[ Out of scope ]</b>
> - [line 148](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/zcodeRuntime.ts#L148): The readline `close` callback calls `failAll`, which sets `closed = true`. If the child closes stdout without exiting, subsequent scope cleanup calls `close()` and returns immediately at its `closed` guard, so the detached ZCode process is never sent `SIGTERM`/`SIGKILL` and can leak indefinitely. <b>[ Already posted ]</b>
> - [line 149](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/zcodeRuntime.ts#L149): `ZcodeProtocolClient` never registers an `error` listener on `proc`. Node emits this event when `spawn` cannot start the command (for example, the configured ZCode binary or `cwd` no longer exists), and `spawn()` returns before that asynchronous failure, so the surrounding `Effect.try` cannot catch it. The unhandled `error` event can terminate the entire server instead of returning a provider startup error. <b>[ Already posted ]</b>
> - [line 241](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/zcodeRuntime.ts#L241): `onLine` trusts any successfully parsed JSON as a `ZcodeInboundMessage` and immediately reads `message.id`. A valid JSON line such as `null` causes a `TypeError` in the readline event callback, which is uncaught and can crash the server. The parsed value should be validated as a non-null object before property access. <b>[ Exceeded comment limit ]</b>
> - [line 264](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/zcodeRuntime.ts#L264): Inbound messages containing both `id` and `method` are server requests, but this branch treats one as a response whenever its ID matches an outstanding client request. Client and server request ID namespaces can overlap (for example, both sides may begin at `1`), so a runtime-preferences/permission request can incorrectly resolve `session/create` with `undefined` and is never delivered or replied to, breaking the session. <b>[ Out of scope ]</b>
> - [line 264](https://github.com/pingdotgg/t3code/blob/6adf4064e2590234ed0d9d72bb61c29a4083dfee/apps/server/src/provider/zcodeRuntime.ts#L264): Inbound messages containing both `id` and `method` are server requests, but this branch reclassifies them as responses whenever the server-chosen ID happens to match a client request in `pending`. Bidirectional RPC peers have independent request-ID namespaces, so a normal collision (for example both sides using ID `1`) resolves the unrelated client request with `undefined` and silently drops the server request instead of invoking `serverRequestHandler`. <b>[ Exceeded comment limit ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->