### PR TITLE
fix(client-runtime): retry queries after connection interruption

### DIFF
--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../connection/model.ts";
 import * as EnvironmentRegistry from "../connection/registry.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
+import { EnvironmentRpcUnavailableError } from "../rpc/client.ts";
 import type * as RpcSession from "../rpc/session.ts";
 import {
   environmentRpcKey,
@@ -45,6 +46,8 @@ const QUERY_ENVIRONMENT = new PrimaryConnectionTarget({
   httpBaseUrl: "https://query.example.test",
   wsBaseUrl: "wss://query.example.test",
 });
+
+const QUERY_RPC_SESSION = {} as RpcSession.RpcSession;
 
 class TestQueryError extends Schema.TaggedErrorClass<TestQueryError>()("TestQueryError", {
   message: Schema.String,
@@ -78,10 +81,11 @@ const makeEnvironmentQueryHarness = Effect.fn("TestEnvironmentQuery.makeHarness"
   execute: Effect.Effect<A, E>,
 ) {
   const supervisorState = yield* SubscriptionRef.make(queryConnectionState());
+  const supervisorSession = yield* SubscriptionRef.make(Option.some(QUERY_RPC_SESSION));
   const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
     target: QUERY_ENVIRONMENT,
     state: supervisorState,
-    session: yield* SubscriptionRef.make<Option.Option<RpcSession.RpcSession>>(Option.none()),
+    session: supervisorSession,
     prepared: yield* SubscriptionRef.make<Option.Option<PreparedConnection>>(Option.none()),
     connect: Effect.void,
     disconnect: Effect.void,
@@ -89,8 +93,13 @@ const makeEnvironmentQueryHarness = Effect.fn("TestEnvironmentQuery.makeHarness"
   } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
   const run: EnvironmentRegistry.EnvironmentRegistry["Service"]["run"] = (_environmentId, effect) =>
     Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+  const followStream: EnvironmentRegistry.EnvironmentRegistry["Service"]["followStream"] = (
+    _environmentId,
+    stream,
+  ) => Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
   const environmentRegistry = EnvironmentRegistry.EnvironmentRegistry.of({
     run,
+    followStream,
     stateChanges: () => SubscriptionRef.changes(supervisorState),
   } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
   const runtime = Atom.runtime(
@@ -104,6 +113,7 @@ const makeEnvironmentQueryHarness = Effect.fn("TestEnvironmentQuery.makeHarness"
 
   return {
     atom: family({ environmentId: QUERY_ENVIRONMENT.environmentId, input: undefined }),
+    supervisorSession,
     supervisorState,
   };
 });
@@ -268,8 +278,12 @@ describe("environment query lifecycle", () => {
       Effect.scoped(
         Effect.gen(function* () {
           const firstStarted = Latch.makeUnsafe();
-          const interruptFirst = Latch.makeUnsafe();
+          const failFirst = Latch.makeUnsafe();
           const firstSettled = Latch.makeUnsafe();
+          const unavailable = new EnvironmentRpcUnavailableError({
+            environmentId: QUERY_ENVIRONMENT.environmentId,
+            message: "Query environment is not connected.",
+          });
           let executions = 0;
           const execute = Effect.suspend(() => {
             executions += 1;
@@ -277,8 +291,8 @@ describe("environment query lifecycle", () => {
               return Effect.succeed("recovered");
             }
             firstStarted.openUnsafe();
-            return interruptFirst.await.pipe(
-              Effect.andThen(Effect.interrupt),
+            return failFirst.await.pipe(
+              Effect.andThen(Effect.fail(unavailable)),
               Effect.ensuring(
                 Effect.sync(() => {
                   firstSettled.openUnsafe();
@@ -304,6 +318,14 @@ describe("environment query lifecycle", () => {
           );
 
           yield* firstStarted.await;
+          yield* SubscriptionRef.set(harness.supervisorSession, Option.none());
+          yield* Effect.yieldNow;
+          failFirst.openUnsafe();
+          yield* firstSettled.await;
+          yield* Effect.yieldNow;
+
+          expect(observed.some(AsyncResult.isFailure)).toBe(false);
+
           yield* SubscriptionRef.set(
             harness.supervisorState,
             queryConnectionState({ phase: "connecting", stage: "preparing" }),
@@ -322,12 +344,8 @@ describe("environment query lifecycle", () => {
             }),
           );
           yield* Effect.yieldNow;
-          interruptFirst.openUnsafe();
-          yield* firstSettled.await;
-          yield* Effect.yieldNow;
 
-          expect(observed.some(AsyncResult.isFailure)).toBe(false);
-
+          yield* SubscriptionRef.set(harness.supervisorSession, Option.some(QUERY_RPC_SESSION));
           yield* SubscriptionRef.set(
             harness.supervisorState,
             queryConnectionState({ generation: 2 }),

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -6,12 +6,27 @@ import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Latch from "effect/Latch";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import {
+  AVAILABLE_CONNECTION_STATE,
+  ConnectionBlockedError,
+  ConnectionTransientError,
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
+import * as EnvironmentRegistry from "../connection/registry.ts";
+import * as EnvironmentSupervisor from "../connection/supervisor.ts";
+import type * as RpcSession from "../rpc/session.ts";
+import {
   environmentRpcKey,
   createAtomCommandScheduler,
+  createEnvironmentQueryAtomFamily,
   createRuntimeCommand,
   scheduleAtomCommandEffect,
   executeAtomCommand,
@@ -23,6 +38,79 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "./runtime.ts";
+
+const QUERY_ENVIRONMENT = new PrimaryConnectionTarget({
+  environmentId: EnvironmentId.make("query-environment"),
+  label: "Query environment",
+  httpBaseUrl: "https://query.example.test",
+  wsBaseUrl: "wss://query.example.test",
+});
+
+class TestQueryError extends Schema.TaggedErrorClass<TestQueryError>()("TestQueryError", {
+  message: Schema.String,
+}) {}
+
+function queryConnectionState(
+  overrides: Partial<SupervisorConnectionState> = {},
+): SupervisorConnectionState {
+  return {
+    ...AVAILABLE_CONNECTION_STATE,
+    desired: true,
+    network: "online",
+    phase: "connected",
+    attempt: 1,
+    generation: 1,
+    ...overrides,
+  };
+}
+
+const makeEnvironmentQueryHarness = Effect.fn("TestEnvironmentQuery.makeHarness")(function* <A, E>(
+  execute: Effect.Effect<A, E>,
+) {
+  const supervisorState = yield* SubscriptionRef.make(queryConnectionState());
+  const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+    target: QUERY_ENVIRONMENT,
+    state: supervisorState,
+    session: yield* SubscriptionRef.make<Option.Option<RpcSession.RpcSession>>(Option.none()),
+    prepared: yield* SubscriptionRef.make<Option.Option<PreparedConnection>>(Option.none()),
+    connect: Effect.void,
+    disconnect: Effect.void,
+    retryNow: Effect.void,
+  } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+  const run: EnvironmentRegistry.EnvironmentRegistry["Service"]["run"] = (_environmentId, effect) =>
+    Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+  const environmentRegistry = EnvironmentRegistry.EnvironmentRegistry.of({
+    run,
+    stateChanges: () => SubscriptionRef.changes(supervisorState),
+  } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]);
+  const runtime = Atom.runtime(
+    Layer.succeed(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+  );
+  const family = createEnvironmentQueryAtomFamily(runtime, {
+    label: "test.environment-query",
+    staleTimeMs: 60_000,
+    execute: () => execute,
+  });
+
+  return {
+    atom: family({ environmentId: QUERY_ENVIRONMENT.environmentId, input: undefined }),
+    supervisorState,
+  };
+});
+
+const mountEnvironmentQuery = Effect.fn("TestEnvironmentQuery.mount")(function* <A, E>(
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+) {
+  const registry = AtomRegistry.make();
+  const unmount = registry.mount(atom);
+  yield* Effect.addFinalizer(() =>
+    Effect.sync(() => {
+      unmount();
+      registry.dispose();
+    }),
+  );
+  return registry;
+});
 
 describe("settleAsyncResult", () => {
   it("preserves successful values and typed failures", async () => {
@@ -161,6 +249,267 @@ describe("environmentRpcKey", () => {
       }),
     ).not.toBe(environmentRpcKey(originalTarget));
   });
+});
+
+describe("environment query lifecycle", () => {
+  it.effect(
+    "retries an interrupted query without exposing a failure during session replacement",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const firstStarted = Latch.makeUnsafe();
+          const interruptFirst = Latch.makeUnsafe();
+          const firstSettled = Latch.makeUnsafe();
+          let executions = 0;
+          const execute = Effect.suspend(() => {
+            executions += 1;
+            if (executions > 1) {
+              return Effect.succeed("recovered");
+            }
+            firstStarted.openUnsafe();
+            return interruptFirst.await.pipe(
+              Effect.andThen(Effect.interrupt),
+              Effect.ensuring(
+                Effect.sync(() => {
+                  firstSettled.openUnsafe();
+                }),
+              ),
+            );
+          });
+          const harness = yield* makeEnvironmentQueryHarness(execute);
+          const registry = AtomRegistry.make();
+          const observed: Array<AsyncResult.AsyncResult<string, unknown>> = [];
+          const unsubscribe = registry.subscribe(
+            harness.atom,
+            (result) => {
+              observed.push(result);
+            },
+            { immediate: true },
+          );
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              unsubscribe();
+              registry.dispose();
+            }),
+          );
+
+          yield* firstStarted.await;
+          yield* SubscriptionRef.set(
+            harness.supervisorState,
+            queryConnectionState({ phase: "connecting", stage: "preparing" }),
+          );
+          yield* Effect.yieldNow;
+          yield* SubscriptionRef.set(
+            harness.supervisorState,
+            queryConnectionState({
+              phase: "backoff",
+              stage: null,
+              lastFailure: new ConnectionTransientError({
+                reason: "transport",
+                detail: "Relay session is reconnecting.",
+              }),
+              retryAt: 1,
+            }),
+          );
+          yield* Effect.yieldNow;
+          interruptFirst.openUnsafe();
+          yield* firstSettled.await;
+          yield* Effect.yieldNow;
+
+          expect(observed.some(AsyncResult.isFailure)).toBe(false);
+
+          yield* SubscriptionRef.set(
+            harness.supervisorState,
+            queryConnectionState({ generation: 2 }),
+          );
+          expect(
+            yield* AtomRegistry.getResult(registry, harness.atom, {
+              suspendOnWaiting: true,
+            }),
+          ).toBe("recovered");
+        }),
+      ),
+  );
+
+  it.effect.each([
+    {
+      condition: "after a manual disconnect",
+      state: queryConnectionState({
+        desired: false,
+        phase: "available",
+        stage: null,
+        attempt: 0,
+      }),
+    },
+    {
+      condition: "while the environment is offline",
+      state: queryConnectionState({ network: "offline", phase: "offline", stage: null }),
+    },
+    {
+      condition: "when connection recovery is blocked",
+      state: queryConnectionState({
+        phase: "blocked",
+        stage: null,
+        lastFailure: new ConnectionBlockedError({
+          reason: "permission",
+          detail: "Access denied.",
+        }),
+      }),
+    },
+  ] as const)("settles as unavailable $condition", ({ state }) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeEnvironmentQueryHarness(Effect.succeed("connected"));
+        const registry = yield* mountEnvironmentQuery(harness.atom);
+
+        expect(
+          yield* AtomRegistry.getResult(registry, harness.atom, {
+            suspendOnWaiting: true,
+          }),
+        ).toBe("connected");
+
+        yield* SubscriptionRef.set(harness.supervisorState, state);
+        yield* Effect.yieldNow;
+
+        const result = registry.get(harness.atom);
+        expect(AsyncResult.isFailure(result)).toBe(true);
+        expect(result.waiting).toBe(false);
+      }),
+    ),
+  );
+
+  it.effect("keeps a genuine query failure settled while reconnecting", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const expectedFailure = new TestQueryError({ message: "Query failed." });
+        const firstStarted = Latch.makeUnsafe();
+        const failFirst = Latch.makeUnsafe();
+        const refreshStarted = Latch.makeUnsafe();
+        const finishRefresh = Latch.makeUnsafe();
+        let executions = 0;
+        const execute = Effect.suspend(() => {
+          executions += 1;
+          if (executions === 1) {
+            firstStarted.openUnsafe();
+            return failFirst.await.pipe(Effect.andThen(Effect.fail(expectedFailure)));
+          }
+          refreshStarted.openUnsafe();
+          return finishRefresh.await.pipe(Effect.as("recovered"));
+        });
+        const harness = yield* makeEnvironmentQueryHarness(execute);
+        const registry = yield* mountEnvironmentQuery(harness.atom);
+
+        yield* firstStarted.await;
+        failFirst.openUnsafe();
+        const initial = yield* AtomRegistry.getResult(registry, harness.atom, {
+          suspendOnWaiting: true,
+        }).pipe(Effect.exit);
+        expect(Exit.isFailure(initial)).toBe(true);
+        if (Exit.isFailure(initial)) {
+          expect(Cause.squash(initial.cause)).toBe(expectedFailure);
+        }
+
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ phase: "connecting", stage: "opening" }),
+        );
+        yield* Effect.yieldNow;
+
+        const refreshing = registry.get(harness.atom);
+        expect(AsyncResult.isFailure(refreshing)).toBe(true);
+        expect(refreshing.waiting).toBe(true);
+        if (AsyncResult.isFailure(refreshing)) {
+          expect(Cause.squash(refreshing.cause)).toBe(expectedFailure);
+        }
+
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ generation: 2 }),
+        );
+        yield* refreshStarted.await;
+        finishRefresh.openUnsafe();
+        expect(
+          yield* AtomRegistry.getResult(registry, harness.atom, {
+            suspendOnWaiting: true,
+          }),
+        ).toBe("recovered");
+      }),
+    ),
+  );
+
+  it.effect("retains the last successful value while reconnecting", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const refreshStarted = Latch.makeUnsafe();
+        const finishRefresh = Latch.makeUnsafe();
+        let executions = 0;
+        const execute = Effect.suspend(() => {
+          executions += 1;
+          if (executions === 1) {
+            return Effect.succeed("cached");
+          }
+          refreshStarted.openUnsafe();
+          return finishRefresh.await.pipe(Effect.as("updated"));
+        });
+        const harness = yield* makeEnvironmentQueryHarness(execute);
+        const registry = yield* mountEnvironmentQuery(harness.atom);
+
+        expect(
+          yield* AtomRegistry.getResult(registry, harness.atom, {
+            suspendOnWaiting: true,
+          }),
+        ).toBe("cached");
+
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ phase: "connecting", stage: "opening" }),
+        );
+        yield* Effect.yieldNow;
+        expect(registry.get(harness.atom)).toMatchObject({
+          _tag: "Success",
+          value: "cached",
+          waiting: true,
+        });
+
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({
+            phase: "backoff",
+            stage: null,
+            lastFailure: new ConnectionTransientError({
+              reason: "transport",
+              detail: "Retrying.",
+            }),
+            retryAt: 1,
+          }),
+        );
+        yield* Effect.yieldNow;
+        expect(registry.get(harness.atom)).toMatchObject({
+          _tag: "Success",
+          value: "cached",
+          waiting: true,
+        });
+
+        yield* SubscriptionRef.set(
+          harness.supervisorState,
+          queryConnectionState({ generation: 2 }),
+        );
+        yield* refreshStarted.await;
+        expect(registry.get(harness.atom)).toMatchObject({
+          _tag: "Success",
+          value: "cached",
+          waiting: true,
+        });
+
+        finishRefresh.openUnsafe();
+        expect(
+          yield* AtomRegistry.getResult(registry, harness.atom, {
+            suspendOnWaiting: true,
+          }),
+        ).toBe("updated");
+      }),
+    ),
+  );
 });
 
 describe("Atom.fn mutation semantics", () => {

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -50,6 +50,16 @@ class TestQueryError extends Schema.TaggedErrorClass<TestQueryError>()("TestQuer
   message: Schema.String,
 }) {}
 
+const OFFLINE_QUERY_FAILURE = new ConnectionTransientError({
+  reason: "transport",
+  detail: "Relay is unavailable.",
+});
+
+const BLOCKED_QUERY_FAILURE = new ConnectionBlockedError({
+  reason: "permission",
+  detail: "Access denied.",
+});
+
 function queryConnectionState(
   overrides: Partial<SupervisorConnectionState> = {},
 ): SupervisorConnectionState {
@@ -340,23 +350,28 @@ describe("environment query lifecycle", () => {
         stage: null,
         attempt: 0,
       }),
+      expectedFailure: null,
     },
     {
       condition: "while the environment is offline",
-      state: queryConnectionState({ network: "offline", phase: "offline", stage: null }),
+      state: queryConnectionState({
+        network: "offline",
+        phase: "offline",
+        stage: null,
+        lastFailure: OFFLINE_QUERY_FAILURE,
+      }),
+      expectedFailure: OFFLINE_QUERY_FAILURE,
     },
     {
       condition: "when connection recovery is blocked",
       state: queryConnectionState({
         phase: "blocked",
         stage: null,
-        lastFailure: new ConnectionBlockedError({
-          reason: "permission",
-          detail: "Access denied.",
-        }),
+        lastFailure: BLOCKED_QUERY_FAILURE,
       }),
+      expectedFailure: BLOCKED_QUERY_FAILURE,
     },
-  ] as const)("settles as unavailable $condition", ({ state }) =>
+  ] as const)("settles as unavailable $condition", ({ state, expectedFailure }) =>
     Effect.scoped(
       Effect.gen(function* () {
         const harness = yield* makeEnvironmentQueryHarness(Effect.succeed("connected"));
@@ -374,6 +389,9 @@ describe("environment query lifecycle", () => {
         const result = registry.get(harness.atom);
         expect(AsyncResult.isFailure(result)).toBe(true);
         expect(result.waiting).toBe(false);
+        if (AsyncResult.isFailure(result) && expectedFailure !== null) {
+          expect(Cause.squash(result.cause)).toBe(expectedFailure);
+        }
       }),
     ),
   );

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -3,9 +3,7 @@ import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
-import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
-import * as SubscriptionRef from "effect/SubscriptionRef";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import { EnvironmentNotRegisteredError, EnvironmentRegistry } from "../connection/registry.ts";
@@ -16,6 +14,7 @@ import {
   type EnvironmentStreamCommandRpcTag,
   type EnvironmentSubscriptionRpcTag,
   type EnvironmentUnaryRpcTag,
+  EnvironmentRpcUnavailableError,
   request,
   runStream,
   subscribe,
@@ -484,22 +483,11 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
   readonly environmentId: EnvironmentIdType;
   readonly input: Input;
 }) => Atom.Atom<AsyncResult.AsyncResult<A, E | ER | Error>> {
-  const rpcGenerationAtom = Atom.family((environmentId: EnvironmentIdType) =>
+  const connectionStateAtom = Atom.family((environmentId: EnvironmentIdType) =>
     runtime.atom(
-      followStreamInEnvironment(
-        environmentId,
-        Stream.unwrap(
-          EnvironmentSupervisor.pipe(
-            Effect.map((supervisor) =>
-              SubscriptionRef.changes(supervisor.state).pipe(
-                Stream.filterMap((state) =>
-                  state.phase === "connected" ? Result.succeed(state.generation) : Result.failVoid,
-                ),
-                Stream.changes,
-                Stream.map<number, number | null>((generation) => generation),
-              ),
-            ),
-          ),
+      Stream.unwrap(
+        EnvironmentRegistry.pipe(
+          Effect.map((registry) => registry.stateChanges(environmentId).pipe(Stream.changes)),
         ),
       ),
       { initialValue: null },
@@ -509,14 +497,29 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
     const target = parseEnvironmentRpcKey<Input>(key);
     const idleTtlMs = options.idleTtlMs ?? 5 * 60_000;
     const queryAtom = runtime
-      .atom((get) => {
-        const generation = Option.getOrNull(
-          AsyncResult.value(get(rpcGenerationAtom(target.environmentId))),
+      .atom<A, E | EnvironmentNotRegisteredError | EnvironmentRpcUnavailableError>((get) => {
+        const connectionState = Option.getOrNull(
+          AsyncResult.value(get(connectionStateAtom(target.environmentId))),
         );
-        if (generation === null) {
+        if (connectionState === null) {
           return Effect.never;
         }
-        return runInEnvironment(target.environmentId, options.execute(target.input));
+        switch (connectionState.phase) {
+          case "connected":
+            return runInEnvironment(target.environmentId, options.execute(target.input));
+          case "connecting":
+          case "backoff":
+            return Effect.never;
+          case "available":
+          case "offline":
+          case "blocked":
+            return Effect.fail(
+              new EnvironmentRpcUnavailableError({
+                environmentId: target.environmentId,
+                message: `Environment ${target.environmentId} is not connected.`,
+              }),
+            );
+        }
       })
       .pipe(
         Atom.swr({

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -6,6 +6,7 @@ import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
+import type { ConnectionAttemptError } from "../connection/model.ts";
 import { EnvironmentNotRegisteredError, EnvironmentRegistry } from "../connection/registry.ts";
 import {
   type EnvironmentRpcInput,
@@ -497,7 +498,10 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
     const target = parseEnvironmentRpcKey<Input>(key);
     const idleTtlMs = options.idleTtlMs ?? 5 * 60_000;
     const queryAtom = runtime
-      .atom<A, E | EnvironmentNotRegisteredError | EnvironmentRpcUnavailableError>((get) => {
+      .atom<
+        A,
+        E | ConnectionAttemptError | EnvironmentNotRegisteredError | EnvironmentRpcUnavailableError
+      >((get) => {
         const connectionState = Option.getOrNull(
           AsyncResult.value(get(connectionStateAtom(target.environmentId))),
         );
@@ -513,10 +517,15 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
           case "available":
           case "offline":
           case "blocked":
+            if (connectionState.lastFailure !== null) {
+              return Effect.fail(connectionState.lastFailure);
+            }
             return Effect.fail(
               new EnvironmentRpcUnavailableError({
                 environmentId: target.environmentId,
-                message: `Environment ${target.environmentId} is not connected.`,
+                message: `Environment ${target.environmentId} is ${
+                  connectionState.phase === "available" ? "not connected" : connectionState.phase
+                }.`,
               }),
             );
         }

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import type { ConnectionAttemptError } from "../connection/model.ts";
@@ -484,11 +485,18 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
   readonly environmentId: EnvironmentIdType;
   readonly input: Input;
 }) => Atom.Atom<AsyncResult.AsyncResult<A, E | ER | Error>> {
-  const connectionStateAtom = Atom.family((environmentId: EnvironmentIdType) =>
+  const connectionAtom = Atom.family((environmentId: EnvironmentIdType) =>
     runtime.atom(
-      Stream.unwrap(
-        EnvironmentRegistry.pipe(
-          Effect.map((registry) => registry.stateChanges(environmentId).pipe(Stream.changes)),
+      followStreamInEnvironment(
+        environmentId,
+        Stream.unwrap(
+          EnvironmentSupervisor.pipe(
+            Effect.map((supervisor) =>
+              SubscriptionRef.changes(supervisor.state).pipe(
+                Stream.zipLatest(SubscriptionRef.changes(supervisor.session)),
+              ),
+            ),
+          ),
         ),
       ),
       { initialValue: null },
@@ -502,15 +510,18 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
         A,
         E | ConnectionAttemptError | EnvironmentNotRegisteredError | EnvironmentRpcUnavailableError
       >((get) => {
-        const connectionState = Option.getOrNull(
-          AsyncResult.value(get(connectionStateAtom(target.environmentId))),
+        const connection = Option.getOrNull(
+          AsyncResult.value(get(connectionAtom(target.environmentId))),
         );
-        if (connectionState === null) {
+        if (connection === null) {
           return Effect.never;
         }
+        const [connectionState, session] = connection;
         switch (connectionState.phase) {
           case "connected":
-            return runInEnvironment(target.environmentId, options.execute(target.input));
+            return Option.isSome(session)
+              ? runInEnvironment(target.environmentId, options.execute(target.input))
+              : Effect.never;
           case "connecting":
           case "backoff":
             return Effect.never;


### PR DESCRIPTION
## What Changed

- Make environment queries observe the full connection lifecycle instead of connected generations only.
- Keep queries pending or revalidating while a connection is recovering, and settle them as unavailable for manual disconnect, offline, or blocked states.
- Add focused regression coverage for session replacement, terminal connection states, retained failures, and stale-while-revalidate values.

## Why

A hard refresh of Usage through T3 Connect could briefly surface “This environment could not report usage.” Relay credential reconciliation interrupted the in-flight query before the replacement session retried it, allowing an interrupt-only failure to reach consumers. Handling recovery at the shared environment-query seam fixes every caller without teaching Usage about Effect interruption causes or supervisor phases.

## UI Changes

None. This changes shared client-runtime lifecycle behavior; no rendered UI, layout, or motion code changed.

## Verification

- `vp test run packages/client-runtime/src/state/runtime.test.ts` (25 tests)
- `vp run --filter @t3tools/client-runtime typecheck`
- targeted lint and formatting for the changed files
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because no UI code changed
- [x] Video is not applicable because no animation or interaction code changed

Generated with GPT-5.6 in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared client-runtime query lifecycle affects all environment-query callers; error unions now include connection attempt and unavailable errors, so consumers that narrow failures may need updates.
> 
> **Overview**
> **Environment query atoms** in `createEnvironmentQueryAtomFamily` no longer gate execution on connected **generation** only. They subscribe to paired **supervisor state and session** and branch on `connectionState.phase`.
> 
> During **connecting** and **backoff**, queries stay pending (`Effect.never`) so SWR can keep the last value or failure with a **waiting** flag instead of surfacing interrupt-only failures when the RPC session is replaced. When **connected**, execution runs only if a session is present; otherwise it stays pending. For **available**, **offline**, and **blocked**, queries fail immediately—using `lastFailure` when set, otherwise `EnvironmentRpcUnavailableError`.
> 
> Adds regression tests for session replacement retry, terminal disconnect/offline/blocked settling, retaining real query failures across reconnect, and stale-while-revalidate success values during recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b76e36076a6a5cc58371e99ad4c267c5fa2d424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `createEnvironmentQueryAtomFamily` to retry queries after connection interruption
> Reworks the query trigger signal from a generation-only stream to a combined connection state + session stream using `Stream.zipLatest` over `supervisor.state` and `supervisor.session` changes. Query atoms now execute only when the environment is `connected` with a concrete session, remain idle during `connecting`/`backoff`, and fail immediately in `available`/`offline`/`blocked` phases using `lastFailure` or `EnvironmentRpcUnavailableError`.
> - Adds test coverage for interrupted-query retry during session replacement, unavailable settlement on disconnect/offline/blocked, and last-successful-value retention during reconnection in [runtime.test.ts](https://github.com/pingdotgg/t3code/pull/8117/files#diff-a5c5109a4b9f0728aa26f51d6945846b1177efdebf84aed03e0778f7d135e937)
> - Expands the atom's error type to include `ConnectionAttemptError` and `EnvironmentRpcUnavailableError`
> - Behavioral Change: queries that previously retried silently during `available`/`offline`/`blocked` phases now fail immediately — consumers must handle the new error types in `createEnvironmentQueryAtomFamily`'s error union
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b76e36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->