### PR TITLE
feat(mobile): add thread rename action

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -10,6 +10,7 @@ import { createStaticNavigation } from "@react-navigation/native";
 
 import { RegistryContext } from "@effect/atom-react";
 import { ConfirmDialogHost } from "./components/ConfirmDialogHost";
+import { TextInputDialogHost } from "./components/TextInputDialogHost";
 import { CloudAuthProvider } from "./features/cloud/CloudAuthProvider";
 import { prepareNativeShowcaseCapture } from "./features/showcase/nativeShowcaseScene";
 import { IncomingShareProvider } from "./features/sharing/IncomingShareProvider";
@@ -97,6 +98,7 @@ function AppContent() {
                 <Navigation linking={appLinking} theme={navigationTheme} />
               </IncomingShareProvider>
               <ConfirmDialogHost />
+              <TextInputDialogHost />
             </BlurTargetView>
             {/* Anchored-menu overlays render here — in-window, so the
                 keyboard stays up while a dropdown is open. */}

--- a/apps/mobile/src/components/TextInputDialogHost.tsx
+++ b/apps/mobile/src/components/TextInputDialogHost.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from "react";
+import { Modal, Pressable, View } from "react-native";
+
+import { AppText, AppTextInput } from "./AppText";
+import { useThemeColor } from "../lib/useThemeColor";
+
+export type TextInputDialogRequest = {
+  readonly title: string;
+  readonly initialValue: string;
+  readonly confirmText: string;
+  readonly onConfirm: (value: string) => void;
+};
+
+let presentRequest: ((request: TextInputDialogRequest) => void) | null = null;
+
+export function showTextInputDialog(request: TextInputDialogRequest): void {
+  presentRequest?.(request);
+}
+
+export function TextInputDialogHost() {
+  const [request, setRequest] = useState<TextInputDialogRequest | null>(null);
+  const [value, setValue] = useState("");
+  const pressedOverlay = useThemeColor("--color-subtle");
+
+  useEffect(() => {
+    presentRequest = (nextRequest) => {
+      setValue(nextRequest.initialValue);
+      setRequest(nextRequest);
+    };
+    return () => {
+      presentRequest = null;
+    };
+  }, []);
+
+  const handleCancel = useCallback(() => setRequest(null), []);
+  const handleConfirm = useCallback(() => {
+    request?.onConfirm(value);
+    setRequest(null);
+  }, [request, value]);
+
+  return (
+    <Modal
+      visible={request !== null}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      navigationBarTranslucent
+      onRequestClose={handleCancel}
+    >
+      {request === null ? null : (
+        <View className="flex-1 items-center justify-center bg-backdrop px-8">
+          <View className="w-full rounded-[24px] bg-card px-6 pb-4 pt-5">
+            <AppText className="text-lg font-t3-medium">{request.title}</AppText>
+            <AppTextInput
+              autoFocus
+              className="mt-4 rounded-xl bg-input px-3 py-2 text-base text-foreground"
+              enterKeyHint="done"
+              onChangeText={setValue}
+              onSubmitEditing={handleConfirm}
+              selectTextOnFocus
+              value={value}
+            />
+            <View className="mt-4 flex-row justify-end gap-1">
+              <View className="overflow-hidden rounded-full">
+                <Pressable
+                  accessibilityRole="button"
+                  className="min-h-10 items-center justify-center px-4"
+                  android_ripple={{ color: pressedOverlay }}
+                  onPress={handleCancel}
+                >
+                  <AppText className="text-base font-t3-medium">Cancel</AppText>
+                </Pressable>
+              </View>
+              <View className="overflow-hidden rounded-full">
+                <Pressable
+                  accessibilityRole="button"
+                  className="min-h-10 items-center justify-center px-4"
+                  android_ripple={{ color: pressedOverlay }}
+                  onPress={handleConfirm}
+                >
+                  <AppText className="text-base font-t3-medium">{request.confirmText}</AppText>
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        </View>
+      )}
+    </Modal>
+  );
+}

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -47,6 +47,7 @@ export function HomeRouteScreen() {
     pinThread,
     unpinThread,
     movePinnedThread,
+    renameThread,
     regenerateThreadTitle,
     unsettleThread,
   } = useThreadListActions();
@@ -195,6 +196,7 @@ export function HomeRouteScreen() {
           onPinThread={pinThread}
           onUnpinThread={unpinThread}
           onMovePinnedThread={movePinnedThread}
+          onRenameThread={renameThread}
           onRegenerateThreadTitle={regenerateThreadTitle}
           onEnvironmentChange={setSelectedEnvironmentId}
           onProjectChange={setSelectedProjectKey}

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -117,6 +117,7 @@ interface HomeScreenProps {
     thread: EnvironmentThreadShell,
     direction: "up" | "down",
   ) => Promise<boolean>;
+  readonly onRenameThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => Promise<boolean>;
   readonly onSelectPendingTask: (pendingTask: PendingNewTask) => void;
   readonly onDeletePendingTask: (pendingTask: PendingNewTask) => void;
@@ -556,6 +557,7 @@ export function HomeScreen(props: HomeScreenProps) {
     },
     [props.onRegenerateThreadTitle],
   );
+  const handleRenameThread = props.onRenameThread;
   const handleDeleteThread = props.onDeleteThread;
   const handleUnsettleThread = props.onUnsettleThread;
   // The settled tail renders in pages; expansion resets when the filter
@@ -846,6 +848,7 @@ export function HomeScreen(props: HomeScreenProps) {
           onDeleteThread={handleDeleteThread}
           onArchiveThread={props.onArchiveThread}
           onRegenerateThreadTitle={handleRegenerateThreadTitle}
+          onRenameThread={handleRenameThread}
           titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
           settlementSupported={settlementEnvironmentIds.has(thread.environmentId)}
           onSettleThread={handleSettleThread}
@@ -1007,6 +1010,7 @@ export function HomeScreen(props: HomeScreenProps) {
               onArchiveThread={props.onArchiveThread}
               onDeleteThread={props.onDeleteThread}
               onRegenerateThreadTitle={handleRegenerateThreadTitle}
+              onRenameThread={handleRenameThread}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
               onSelectThread={props.onSelectThread}
               onSwipeableClose={handleSwipeableClose}

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -6,6 +6,7 @@ import { useCallback, useRef } from "react";
 import { Alert } from "react-native";
 
 import { showConfirmDialog } from "../../components/ConfirmDialogHost";
+import { showTextInputDialog } from "../../components/TextInputDialogHost";
 import { scopedThreadKey } from "../../lib/scopedEntities";
 import { refreshArchivedThreadsForEnvironment } from "../archive/useArchivedThreadSnapshots";
 import {
@@ -237,6 +238,7 @@ export function useThreadListActions(): {
     direction: "up" | "down",
   ) => Promise<boolean>;
   readonly regenerateThreadTitle: (thread: EnvironmentThreadShell) => Promise<boolean>;
+  readonly renameThread: (thread: EnvironmentThreadShell) => void;
 } {
   const executeAction = useThreadActionExecutor();
   const snoozeMutation = useAtomCommand(threadEnvironment.snooze, { reportFailure: false });
@@ -460,6 +462,37 @@ export function useThreadListActions(): {
     },
     [updateThreadMetadata],
   );
+  const renameThread = useCallback(
+    (thread: EnvironmentThreadShell) => {
+      showTextInputDialog({
+        title: "Rename thread",
+        initialValue: thread.title,
+        confirmText: "Rename",
+        onConfirm: (title) => {
+          const trimmedTitle = title.trim();
+          if (trimmedTitle.length === 0) {
+            Alert.alert("Could not rename thread", "Thread title cannot be empty.");
+            return;
+          }
+          if (trimmedTitle === thread.title) return;
+          void updateThreadMetadata({
+            environmentId: thread.environmentId,
+            input: { threadId: thread.id, title: trimmedTitle },
+          }).then((result) => {
+            if (result._tag !== "Failure") return;
+            const error = Cause.squash(result.cause);
+            Alert.alert(
+              "Could not rename thread",
+              error instanceof Error && error.message.trim().length > 0
+                ? error.message
+                : "The thread title could not be changed.",
+            );
+          });
+        },
+      });
+    },
+    [updateThreadMetadata],
+  );
 
   // Move up / Move down for the pinned block. Computed against the CANONICAL
   // keyed pinned order (not the rendered list), so the move is valid even
@@ -553,6 +586,7 @@ export function useThreadListActions(): {
     unpinThread,
     movePinnedThread,
     regenerateThreadTitle,
+    renameThread,
   };
 }
 

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -170,6 +170,7 @@ function ThreadNavigationSidebarPane(
     pinThread,
     unpinThread,
     movePinnedThread,
+    renameThread,
     regenerateThreadTitle,
   } = useThreadListActions();
   const threadListV2Enabled = useThreadListV2Enabled();
@@ -924,6 +925,7 @@ function ThreadNavigationSidebarPane(
               onDeleteThread={confirmDeleteThread}
               onArchiveThread={archiveThread}
               onRegenerateThreadTitle={regenerateThreadTitle}
+              onRenameThread={renameThread}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
               settlementSupported={settlementEnvironmentIds.has(thread.environmentId)}
               onSettleThread={settleThread}
@@ -1045,6 +1047,7 @@ function ThreadNavigationSidebarPane(
               onArchiveThread={archiveThread}
               onDeleteThread={confirmDeleteThread}
               onRegenerateThreadTitle={regenerateThreadTitle}
+              onRenameThread={renameThread}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
               onSelectThread={handleSelectThread}
               onSwipeableClose={handleSwipeableClose}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -430,6 +430,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onArchiveThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onRenameThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly titleRegenerationSupported: boolean;
   readonly onSwipeableWillOpen: (methods: SwipeableMethods) => void;
@@ -454,8 +455,14 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const selectedBackgroundColor = useThemeColor("--color-user-bubble");
   const selectedForegroundColor = useThemeColor("--color-user-bubble-foreground");
 
-  const { thread, onSelectThread, onArchiveThread, onDeleteThread, onRegenerateThreadTitle } =
-    props;
+  const {
+    thread,
+    onSelectThread,
+    onArchiveThread,
+    onDeleteThread,
+    onRenameThread,
+    onRegenerateThreadTitle,
+  } = props;
   const status = resolveThreadStatus(thread);
   const pr = useThreadPr(thread, props.projectCwd);
   const timestamp = relativeTime(
@@ -485,9 +492,11 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
     () => onRegenerateThreadTitle(thread),
     [onRegenerateThreadTitle, thread],
   );
+  const handleRename = useCallback(() => onRenameThread(thread), [onRenameThread, thread]);
   const menuActions = useMemo<MenuAction[]>(
     () => [
       THREAD_ROW_MENU_ACTIONS[0]!,
+      { id: "rename", title: "Rename thread", image: "pencil" },
       ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
         isRegenerating: thread.titleRegeneration != null,
@@ -508,10 +517,11 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
       if (nativeEvent.event === "archive") handleArchive();
+      if (nativeEvent.event === "rename") handleRename();
       if (nativeEvent.event === "regenerate-title") handleRegenerateTitle();
       if (nativeEvent.event === "delete") handleDelete();
     },
-    [handleArchive, handleDelete, handleRegenerateTitle],
+    [handleArchive, handleDelete, handleRegenerateTitle, handleRename],
   );
 
   const statusPill = effectiveStatus ? (

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -346,6 +346,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly fullSwipeWidth?: number;
   readonly onSelectThread: (thread: EnvironmentThreadShell) => void;
   readonly onDeleteThread: (thread: EnvironmentThreadShell) => void;
+  readonly onRenameThread: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly onSettleThread: (thread: EnvironmentThreadShell) => void;
   readonly onSnoozeThread: (thread: EnvironmentThreadShell, snoozedUntil: string) => void;
@@ -392,6 +393,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     variant,
     onSelectThread,
     onDeleteThread,
+    onRenameThread,
     onRegenerateThreadTitle,
     onSettleThread,
     onSnoozeThread,
@@ -434,6 +436,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     () => onRegenerateThreadTitle(thread),
     [onRegenerateThreadTitle, thread],
   );
+  const handleRename = useCallback(() => onRenameThread(thread), [onRenameThread, thread]);
   const handleSettle = useCallback(() => onSettleThread(thread), [onSettleThread, thread]);
   const handleSnooze = useCallback(
     (snoozedUntil: string) => onSnoozeThread(thread, snoozedUntil),
@@ -532,6 +535,13 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       }),
     [props.titleRegenerationSupported, thread.titleRegeneration],
   );
+  const titleMenuItems = useMemo<MenuAction[]>(
+    () => [
+      { id: "rename", title: "Rename thread", image: "pencil" },
+      ...titleRegenerationMenuItems,
+    ],
+    [titleRegenerationMenuItems],
+  );
   const snoozableCardMenuActions = useMemo<MenuAction[]>(
     () => [
       { id: "settle", title: "Settle", image: "checkmark" },
@@ -542,36 +552,36 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         subactions: snoozePresetActions,
       },
       ...pinMenuItem,
-      ...titleRegenerationMenuItems,
+      ...titleMenuItems,
       { id: "delete", title: "Delete", image: "trash", attributes: { destructive: true } },
     ],
-    [pinMenuItem, snoozePresetActions, titleRegenerationMenuItems],
+    [pinMenuItem, snoozePresetActions, titleMenuItems],
   );
   const cardMenuActions = useMemo<MenuAction[]>(
     () => [
       CARD_MENU_ACTIONS[0]!,
       ...pinMenuItem,
-      ...titleRegenerationMenuItems,
+      ...titleMenuItems,
       ...CARD_MENU_ACTIONS.slice(1),
     ],
-    [pinMenuItem, titleRegenerationMenuItems],
+    [pinMenuItem, titleMenuItems],
   );
   const slimMenuActions = useMemo<MenuAction[]>(
     () => [
       SLIM_MENU_ACTIONS[0]!,
       ...(thread.pinnedAt != null ? pinMenuItem : []),
-      ...titleRegenerationMenuItems,
+      ...titleMenuItems,
       SLIM_MENU_ACTIONS[1]!,
     ],
-    [pinMenuItem, thread.pinnedAt, titleRegenerationMenuItems],
+    [pinMenuItem, thread.pinnedAt, titleMenuItems],
   );
   const snoozedMenuActions = useMemo<MenuAction[]>(
-    () => [SNOOZED_MENU_ACTIONS[0]!, ...titleRegenerationMenuItems, SNOOZED_MENU_ACTIONS[1]!],
-    [titleRegenerationMenuItems],
+    () => [SNOOZED_MENU_ACTIONS[0]!, ...titleMenuItems, SNOOZED_MENU_ACTIONS[1]!],
+    [titleMenuItems],
   );
   const legacyMenuActions = useMemo<MenuAction[]>(
-    () => [LEGACY_MENU_ACTIONS[0]!, ...titleRegenerationMenuItems, LEGACY_MENU_ACTIONS[1]!],
-    [titleRegenerationMenuItems],
+    () => [LEGACY_MENU_ACTIONS[0]!, ...titleMenuItems, LEGACY_MENU_ACTIONS[1]!],
+    [titleMenuItems],
   );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
@@ -583,6 +593,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       if (nativeEvent.event === "move-pin-up") handleMovePinnedUp();
       if (nativeEvent.event === "move-pin-down") handleMovePinnedDown();
       if (nativeEvent.event === "archive") handleArchive();
+      if (nativeEvent.event === "rename") handleRename();
       if (nativeEvent.event === "regenerate-title") handleRegenerateTitle();
       if (nativeEvent.event === "delete") handleDelete();
       const snoozeSelection = resolveThreadListV2SnoozeMenuSelection({
@@ -600,6 +611,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       handleArchive,
       handleDelete,
       handleRegenerateTitle,
+      handleRename,
       handleMovePinnedDown,
       handleMovePinnedUp,
       handlePin,


### PR DESCRIPTION
Mobile users could regenerate thread titles but could not set one manually, even though the server contract and web client already support manual titles.

This adds Rename thread to every active mobile thread menu, wires it through both Home and tablet navigation, and presents a shared cross-platform text input dialog. Titles are trimmed and validated before the existing thread metadata command is sent, with failures surfaced to the user.

Verification:
- `git diff --check`
- Mobile typecheck and simulator verification not run because this worktree has no Node/vp/pnpm toolchain installed.

Implemented by GPT-5.6-sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX wired to the existing metadata update path; validation is local and failures are surfaced with alerts.
> 
> **Overview**
> **Mobile users can set thread titles manually** from thread row menus (v1 grouped list and Thread List v2), on phone Home and iPad sidebar.
> 
> A new root-level **`TextInputDialogHost`** (same imperative pattern as `ConfirmDialogHost`) collects the new title. **`renameThread`** in `useThreadListActions` opens that dialog, rejects empty trimmed input, skips no-op renames, and persists via the existing **`threadEnvironment.updateMetadata`** command with user-facing alerts on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a128427698135a1e91ffe771345242892641bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread rename action to mobile thread list rows
> - Adds a global `TextInputDialogHost` mounted in `AppContent` that exposes `showTextInputDialog(request)` for presenting a themed text-input modal from anywhere
> - Implements `renameThread` in `useThreadListActions`: opens the dialog prefilled with the current title, trims and validates input, and persists via `updateThreadMetadata`; errors surface as alerts
> - Wires the rename callback through `HomeScreen`, `ThreadNavigationSidebar`, and both `ThreadListRow` and `ThreadListV2Row` menus via a new 'Rename thread' menu item (id: `'rename'`, image: `'pencil'`)
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5a12842. 8 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->