### PR TITLE
fix(server): stop clone URLs being parsed as git options

### DIFF
--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -176,9 +176,45 @@ it.effect("clones a looked-up repository into the requested destination", () =>
       assert.deepStrictEqual(cloneCalls, [
         {
           cwd: parent,
-          args: ["clone", CLONE_URLS.url, "t3code"],
+          args: ["clone", "--", CLONE_URLS.url, "t3code"],
         },
       ]);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          git: {
+            execute: (input) =>
+              Effect.sync(() => {
+                cloneCalls.push({ cwd: input.cwd, args: input.args });
+                return processOutput();
+              }),
+          },
+        }),
+      ),
+    );
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("passes dash-prefixed remote urls as positional arguments, not git options", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const parent = yield* fs.makeTempDirectoryScoped({
+      prefix: "t3-source-control-clone-parent-",
+    });
+    const injectionUrl = "--upload-pack=touch /tmp/pwned";
+    const cloneCalls: Array<{ cwd: string; args: ReadonlyArray<string> }> = [];
+
+    yield* Effect.gen(function* () {
+      const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      const result = yield* service.cloneRepository({
+        remoteUrl: injectionUrl,
+        destinationPath: `${parent}/repo`,
+      });
+
+      assert.deepStrictEqual(cloneCalls, [
+        { cwd: parent, args: ["clone", "--", injectionUrl, "repo"] },
+      ]);
+      assert.strictEqual(result.remoteUrl, injectionUrl);
     }).pipe(
       Effect.provide(
         makeLayer({

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -203,10 +203,12 @@ export const make = Effect.gen(function* () {
       });
     }
 
+    // The end-of-options marker keeps remoteUrl and directoryName from being
+    // parsed as git options when they start with "-" (e.g. --upload-pack=...).
     yield* git.execute({
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
-      args: ["clone", remoteUrl, preparedDestination.directoryName],
+      args: ["clone", "--", remoteUrl, preparedDestination.directoryName],
       timeoutMs: 120_000,
       maxOutputBytes: 256 * 1024,
     });


### PR DESCRIPTION
User-provided clone URLs were passed to `git clone` before an end-of-options marker. A URL beginning with `-` could therefore be parsed as a Git option instead of a repository value.

Add `--` before the remote URL and destination so both remain positional arguments, and add focused regression coverage for normal and dash-prefixed clone inputs.

Tests:
- `vp test run apps/server/src/sourceControl/SourceControlRepositoryService.test.ts`
- `vp run --filter t3 typecheck`
- Targeted lint and format checks for both changed files

Model: `openai/gpt-5.6-sol` via OpenCode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how clone commands are built for untrusted URLs; scope is narrow but touches security-sensitive shell/git invocation.
> 
> **Overview**
> **Fixes a command-injection class issue** where user-supplied clone URLs passed directly to `git clone` could be interpreted as Git flags when they start with `-` (e.g. `--upload-pack=...`).
> 
> `cloneRepository` now inserts Git’s end-of-options marker (`--`) before the remote URL and destination directory name so both are always treated as positional arguments. Existing clone expectations were updated, and a regression test asserts dash-prefixed URLs are forwarded safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 368ecef24032b37ce7b6e2a9c1665931fde17758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `--` before clone URL and directory in `SourceControlRepositoryService.cloneRepository`
> Inserts an end-of-options marker (`--`) into the git clone args in [SourceControlRepositoryService.ts](https://github.com/pingdotgg/t3code/pull/8121/files#diff-ee6247891e4a01ae6615258135b417c8454fe770eae597f3591b677b32c7aa0b) so dash-prefixed `remoteUrl` or `directoryName` values are treated as positional arguments instead of git options. Adds a test for dash-prefixed remote URLs and updates an existing test to assert the new args.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 368ecef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository cloning reliability for remote URLs and destination paths that begin with a dash.
  - Prevented option-like values from being misinterpreted as command-line flags.
  - Added regression coverage to verify these URLs are preserved correctly during cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->