### PR TITLE
feat(clients): sync working thread messages in background

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -37,6 +37,7 @@ const clientSettings: ClientSettings = {
   glassOpacity: 80,
   planModeEnabled: false,
   showSkillsInSlashMenu: false,
+  syncWorkingThreadMessages: true,
   providerModelPreferences: {},
   sidebarAutoSettleAfterDays: 3,
   sidebarAutoSettleOnMerge: true,

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -73,6 +73,7 @@ import { NATIVE_LIQUID_GLASS_SUPPORTED } from "./native/native-glass";
 import { nativeHeaderScrollEdgeEffects } from "./native/StackHeader";
 import { FORM_SHEET_PRESENTATION_OPTIONS } from "./native/sheet-surface";
 import { useThreadOutboxDrain } from "./state/use-thread-outbox-drain";
+import { BackgroundThreadSync } from "./state/background-thread-sync";
 
 const HEADER_SCROLL_EDGE_EFFECTS = nativeHeaderScrollEdgeEffects(Platform.OS, Platform.Version);
 
@@ -394,6 +395,7 @@ function RootStackLayout(props: {
   return (
     <HardwareKeyboardCommandProvider pathname={pathname}>
       <ThreadOutboxDrainWorker />
+      <BackgroundThreadSync />
       <ShowcaseCaptureCoordinator pathname={pathname} />
       <ExistingThreadSettingsRouteProvider>
         <AdaptiveWorkspaceLayout pathname={workspacePathname}>

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -533,10 +533,19 @@ function GeneralSettingsSection() {
   const autoSettleOnMerge =
     !AsyncResult.isSuccess(preferencesResult) ||
     preferencesResult.value.autoSettleOnMerge !== false;
+  const syncWorkingThreadMessages =
+    AsyncResult.isSuccess(preferencesResult) &&
+    preferencesResult.value.syncWorkingThreadMessages === true;
 
   return (
     <SettingsSection title="General">
       <SettingsRow icon="folder" label="Project Grouping" target="SettingsProjectGrouping" />
+      <SettingsSwitchRow
+        icon="arrow.triangle.2.circlepath"
+        label="Sync Working Threads"
+        value={syncWorkingThreadMessages}
+        onValueChange={(value) => savePreferences({ syncWorkingThreadMessages: value })}
+      />
       <SettingsSwitchRow
         icon="arrow.triangle.branch"
         label="Auto-settle merged threads"

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -42,6 +42,7 @@ export interface Preferences {
   readonly legacyThreadListEnabled?: boolean;
   /** Device-local counterpart of desktop's `planModeEnabled` legacy flag. */
   readonly planModeEnabled?: boolean;
+  readonly syncWorkingThreadMessages?: boolean;
   /** Undefined preserves the default expanded Settled shelf. */
   readonly threadListV2SettledShelfExpanded?: boolean;
   /** Undefined preserves the default collapsed Snoozed shelf. */
@@ -104,6 +105,7 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     autoSettleOnMerge?: boolean;
     legacyThreadListEnabled?: boolean;
     planModeEnabled?: boolean;
+    syncWorkingThreadMessages?: boolean;
     threadListV2SettledShelfExpanded?: boolean;
     threadListV2SnoozedShelfExpanded?: boolean;
   } = {};
@@ -175,6 +177,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
   }
   if (typeof parsed.planModeEnabled === "boolean") {
     preferences.planModeEnabled = parsed.planModeEnabled;
+  }
+  if (typeof parsed.syncWorkingThreadMessages === "boolean") {
+    preferences.syncWorkingThreadMessages = parsed.syncWorkingThreadMessages;
   }
   if (typeof parsed.threadListV2SettledShelfExpanded === "boolean") {
     preferences.threadListV2SettledShelfExpanded = parsed.threadListV2SettledShelfExpanded;

--- a/apps/mobile/src/state/background-thread-sync.tsx
+++ b/apps/mobile/src/state/background-thread-sync.tsx
@@ -1,0 +1,39 @@
+import { useAtomValue } from "@effect/atom-react";
+import { hasLiveThreadWork } from "@t3tools/client-runtime/state/thread-settled";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { useEffect, useMemo } from "react";
+
+import { mobilePreferencesAtom } from "./preferences";
+import { appAtomRegistry } from "./atom-registry";
+import { useThreadShells } from "./entities";
+import { environmentThreadDetails } from "./threads";
+
+/** Keeps message windows warm only while their threads have live work. */
+export function BackgroundThreadSync() {
+  const preferences = useAtomValue(mobilePreferencesAtom);
+  const enabled =
+    AsyncResult.isSuccess(preferences) && preferences.value.syncWorkingThreadMessages === true;
+  const threadShells = useThreadShells();
+  const workingThreads = useMemo(() => threadShells.filter(hasLiveThreadWork), [threadShells]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const unsubscribes = workingThreads.map((thread) =>
+      appAtomRegistry.subscribe(
+        environmentThreadDetails.detailAtom({
+          environmentId: thread.environmentId,
+          threadId: thread.id,
+        }),
+        () => {},
+      ),
+    );
+    return () => {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe();
+      }
+    };
+  }, [enabled, workingThreads]);
+
+  return null;
+}

--- a/apps/web/src/backgroundThreadSync.tsx
+++ b/apps/web/src/backgroundThreadSync.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useMemo } from "react";
+import { hasLiveThreadWork } from "@t3tools/client-runtime/state/thread-settled";
+
+import { useClientSettings } from "./hooks/useSettings";
+import { appAtomRegistry } from "./rpc/atomRegistry";
+import { useThreadShells } from "./state/entities";
+import { environmentThreadDetails } from "./state/threads";
+
+/** Keeps message windows warm only while their threads have live work. */
+export function BackgroundThreadSync() {
+  const enabled = useClientSettings((settings) => settings.syncWorkingThreadMessages);
+  const threadShells = useThreadShells();
+  const workingThreads = useMemo(() => threadShells.filter(hasLiveThreadWork), [threadShells]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const unsubscribes = workingThreads.map((thread) =>
+      appAtomRegistry.subscribe(
+        environmentThreadDetails.detailAtom({
+          environmentId: thread.environmentId,
+          threadId: thread.id,
+        }),
+        () => {},
+      ),
+    );
+    return () => {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe();
+      }
+    };
+  }, [enabled, workingThreads]);
+
+  return null;
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1910,6 +1910,32 @@ export function GeneralSettingsPanel() {
     <SettingsPageContainer>
       <SettingsSection title="General">
         <SettingsRow
+          {...searchableSetting("sync-working-thread-messages")}
+          description="Keep messages from actively working threads synced while this app is open."
+          resetAction={
+            settings.syncWorkingThreadMessages !==
+            DEFAULT_UNIFIED_SETTINGS.syncWorkingThreadMessages ? (
+              <SettingResetButton
+                label="sync working thread messages"
+                onClick={() =>
+                  updateSettings({
+                    syncWorkingThreadMessages: DEFAULT_UNIFIED_SETTINGS.syncWorkingThreadMessages,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.syncWorkingThreadMessages}
+              onCheckedChange={(checked) =>
+                updateSettings({ syncWorkingThreadMessages: Boolean(checked) })
+              }
+              aria-label="Sync working threads"
+            />
+          }
+        />
+        <SettingsRow
           {...searchableSetting("project-grouping")}
           description="Combine matching repositories across environments."
           resetAction={

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -112,6 +112,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "sync-working-thread-messages",
+    title: "Sync working threads",
+    to: "/settings/general",
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -33,6 +33,7 @@ import { applyAppearanceFontVariables } from "~/appearanceFonts";
 import { applyAppearanceContrast } from "~/appearanceContrast";
 import { useClientSettings } from "../hooks/useSettings";
 import { PlanAgentSelectionHeal } from "../planAgentSelectionHeal";
+import { BackgroundThreadSync } from "../backgroundThreadSync";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -142,6 +143,7 @@ function RootRouteView() {
         <ConfirmDialogHost />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
+        <BackgroundThreadSync />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <PlanAgentSelectionHeal /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -15,6 +15,12 @@ If reordering is unavailable for one environment, update the T3 Code server runn
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
 
+## Faster thread opening
+
+Turn on **Sync working threads** in **Settings → General** to keep messages from threads with live
+foreground or background work up to date while that client is open. Threads without live work are
+not synced in the background. The setting is local to each web, desktop, or mobile client.
+
 ## Environment artwork
 
 Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in

--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -11,10 +11,30 @@ import {
   canSettle,
   changeRequestAutoSettles,
   effectiveSettled,
+  hasLiveThreadWork,
   hasQueuedTurnStart,
   threadLastActivityAt,
   type ChangeRequestStateLike,
 } from "./threadSettled.ts";
+
+describe("hasLiveThreadWork", () => {
+  it("excludes quiet threads", () => {
+    expect(hasLiveThreadWork({ session: null, backgroundLiveness: null })).toBe(false);
+  });
+
+  it.each(["starting", "running"] as const)("includes %s foreground sessions", (status) => {
+    expect(
+      hasLiveThreadWork({
+        session: { status } as NonNullable<OrchestrationThreadShell["session"]>,
+        backgroundLiveness: null,
+      }),
+    ).toBe(true);
+  });
+
+  it.each(["working", "monitoring"] as const)("includes %s background work", (liveness) => {
+    expect(hasLiveThreadWork({ session: null, backgroundLiveness: liveness })).toBe(true);
+  });
+});
 
 const NOW = "2026-04-10T00:00:00.000Z";
 const FRESH = "2026-04-09T00:00:00.000Z";

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -3,6 +3,17 @@ import type { OrchestrationThreadShell } from "@t3tools/contracts";
 
 export type ChangeRequestStateLike = "open" | "closed" | "merged";
 
+export function hasLiveThreadWork(
+  shell: Pick<OrchestrationThreadShell, "session" | "backgroundLiveness">,
+): boolean {
+  return (
+    shell.session?.status === "starting" ||
+    shell.session?.status === "running" ||
+    shell.backgroundLiveness === "working" ||
+    shell.backgroundLiveness === "monitoring"
+  );
+}
+
 /**
  * The slice of a change request the settle rules need. `updatedAt` is the
  * provider's last-activity timestamp; for a merged/closed request it bounds

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -18,6 +18,15 @@ const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 
+describe("ClientSettings background thread sync", () => {
+  it("defaults to off and preserves an explicit opt-in", () => {
+    expect(decodeClientSettings({}).syncWorkingThreadMessages).toBe(false);
+    expect(
+      decodeClientSettings({ syncWorkingThreadMessages: true }).syncWorkingThreadMessages,
+    ).toBe(true);
+  });
+});
+
 describe("ClientSettings word wrap", () => {
   it("defaults word wrap on", () => {
     expect(decodeClientSettings({}).wordWrap).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -226,6 +226,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // commands) for users who still rely on the old workflow.
   planModeEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  syncWorkingThreadMessages: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
   // (was `sidebarV2Enabled` + `sidebarV2ConfiguredByUser`): decoding drops the
   // old keys, so everyone, including prior beta opt-outs, resets to the new
@@ -915,6 +916,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
+  syncWorkingThreadMessages: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarAutoSettleOnMerge: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
Threads with live agent work can accumulate messages while another thread is open, making them feel stale when the user returns.

Add an opt-in Sync working threads setting on web, desktop, and mobile. While enabled, each client retains detail subscriptions only for threads with a starting/running foreground session or live background working/monitoring activity. Quiet threads remain unsubscribed, and shell updates automatically add or remove subscriptions as work starts and stops. The preference is device-local, searchable on web, documented, and covered by shared classification and settings contract tests.

Verification:
- Web typecheck
- Mobile typecheck
- Desktop typecheck
- Contracts typecheck
- Contracts settings tests (44 passed)
- Client-runtime thread settlement tests (196 passed)
- Focused formatting check
- git diff --check

Visual evidence was not captured because browser/computer-use verification was not authorized for this run.

Implemented with GPT-5.6-sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in, scoped background subscriptions with no auth or data-model changes; main impact is extra RPC/sync load when many threads are actively working with the setting enabled.
> 
> **Overview**
> Adds an opt-in **Sync working threads** preference (defaults **off**, device-local) so clients can keep message data fresh for threads that still have live work while the app stays open.
> 
> When enabled, new `BackgroundThreadSync` workers on **web** and **mobile** subscribe to thread detail atoms only for shells classified by shared `hasLiveThreadWork` (foreground `starting`/`running`, or background `working`/`monitoring`). Quiet threads stay unsubscribed; subscriptions follow shell changes as work starts and stops. **Web/desktop** wire the toggle through unified client settings (General panel + search); **mobile** persists it in device preferences with a matching switch. Contracts, client-runtime classification tests, and user docs for “faster thread opening” are updated; desktop test fixtures include the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c567a665e10e4a25302114a850cafcec45caa746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `syncWorkingThreadMessages` setting and background sync for working threads across clients
> - Adds `syncWorkingThreadMessages` (boolean, default false) to `ClientSettingsSchema` and `ClientSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/8122/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), plus the equivalent optional field in mobile preferences in [mobile-preferences.ts](https://github.com/pingdotgg/t3code/pull/8122/files#diff-3aa27c7cc6d8de9ee5cea2957f2ae3f02d47323310fab6293827508e890b7be7)
> - Introduces `hasLiveThreadWork` in [threadSettled.ts](https://github.com/pingdotgg/t3code/pull/8122/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c) which returns true when a thread has a foreground session in `starting`/`running` or `backgroundLiveness` of `working`/`monitoring`
> - Adds `BackgroundThreadSync` components for [web](https://github.com/pingdotgg/t3code/pull/8122/files#diff-fc184de51f84093b8fa45bf9bc5c01bc9eaa48f6397a451a8de328b216cea6a0) and [mobile](https://github.com/pingdotgg/t3code/pull/8122/files#diff-215b4cf53e00f3c7f8bec800e71075ecb38df3b147919d3f3b9ab7a4a9a02a68) that, when the setting is enabled, subscribe to `environmentThreadDetails.detailAtom` for each working thread and keep their message windows synced in the background
> - Renders the sync component in [web root route](https://github.com/pingdotgg/t3code/pull/8122/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) and [mobile Stack](https://github.com/pingdotgg/t3code/pull/8122/files#diff-6c445d1d9bb762a38688d21c21790ec36c9a0b882fd17c04888c694ba76736ab), and adds toggle UI in web [SettingsPanels](https://github.com/pingdotgg/t3code/pull/8122/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) and mobile [SettingsRouteScreen](https://github.com/pingdotgg/t3code/pull/8122/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e)
> - Risk: when enabled, the app holds active subscriptions to `environmentThreadDetails.detailAtom` for every working thread while open, increasing network and memory usage proportional to the number of live threads
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c567a66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->