### PR TITLE
fix(server): support Cygwin Git on Windows

### DIFF
--- a/apps/server/src/git/GitEnvironment.test.ts
+++ b/apps/server/src/git/GitEnvironment.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { gitProcessEnvironment } from "./GitEnvironment.ts";
+
+describe("gitProcessEnvironment", () => {
+  it("disables Cygwin globbing on Windows", () => {
+    expect(gitProcessEnvironment(["status"], "win32", undefined, {})).toEqual({
+      CYGWIN: "noglob",
+    });
+  });
+
+  it("preserves existing Cygwin options", () => {
+    expect(
+      gitProcessEnvironment(
+        ["status"],
+        "win32",
+        { GIT_CONFIG_COUNT: "0" },
+        {
+          CYGWIN: "winsymlinks:native",
+        },
+      ),
+    ).toEqual({
+      GIT_CONFIG_COUNT: "0",
+      CYGWIN: "winsymlinks:native noglob",
+    });
+  });
+
+  it("prefers explicitly supplied Cygwin options", () => {
+    expect(
+      gitProcessEnvironment(
+        ["status"],
+        "win32",
+        { CYGWIN: "glob:ignorecase" },
+        {
+          CYGWIN: "winsymlinks:native",
+        },
+      ),
+    ).toEqual({ CYGWIN: "glob:ignorecase noglob" });
+  });
+
+  it("leaves non-Windows environments unchanged", () => {
+    const env = { GIT_CONFIG_COUNT: "0" };
+    expect(gitProcessEnvironment(["status"], "linux", env, {})).toBe(env);
+  });
+
+  it("retains Cygwin's normal parsing for arguments containing double quotes", () => {
+    const env = { LC_ALL: "zh_CN.UTF-8" };
+    expect(
+      gitProcessEnvironment(
+        ["-c", 'alias.print-locale=!printf "%s" "$LC_ALL"', "print-locale"],
+        "win32",
+        env,
+        {},
+      ),
+    ).toBe(env);
+  });
+});

--- a/apps/server/src/git/GitEnvironment.ts
+++ b/apps/server/src/git/GitEnvironment.ts
@@ -1,0 +1,27 @@
+// When a Cygwin executable is launched by a native Windows process, Cygwin
+// by default glob-expands braces and brackets.
+// <https://cygwin.com/cygwin-ug-net/using-cygwinenv.html>
+// T3 Code uses these characters in Git refs (such as `HEAD^{commit}`)
+// and literal path names.
+// Setting `CYGWIN=noglob` preserves those arguments, but Cygwin mishandles
+// literal double quotes in this mode, converting them to backslashes.
+// <https://cygwin.com/pipermail/cygwin/2016-May/227720.html>
+// T3 Code can pass such quotes in Git commit messages, for example.
+// Therefore, we set `CYGWIN=noglob` only for commands without double quotes.
+// This workaround does not handle commands containing both braces/brackets and
+// double quotes, but it's difficult to do so cleanly until Cygwin changes.
+
+export function gitProcessEnvironment(
+  args: ReadonlyArray<string>,
+  platform: NodeJS.Platform,
+  env?: NodeJS.ProcessEnv,
+  inheritedEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv | undefined {
+  if (platform !== "win32" || args.some((arg) => arg.includes('"'))) return env;
+
+  const cygwinOptions = (env?.CYGWIN ?? inheritedEnv.CYGWIN)?.trim();
+  return {
+    ...env,
+    CYGWIN: cygwinOptions ? `${cygwinOptions} noglob` : "noglob",
+  };
+}

--- a/apps/server/src/git/GitPath.test.ts
+++ b/apps/server/src/git/GitPath.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeGitPathForHost } from "./GitPath.ts";
+
+describe("normalizeGitPathForHost", () => {
+  it("converts Git for Windows/MSYS2, Cygwin, and WSL drive paths on Windows", () => {
+    expect(normalizeGitPathForHost("/c/Users/example/repo", "win32")).toBe("C:/Users/example/repo");
+    expect(normalizeGitPathForHost("/cygdrive/c/Users/example/repo", "win32")).toBe(
+      "C:/Users/example/repo",
+    );
+    expect(normalizeGitPathForHost("/mnt/c/Users/example/repo", "win32")).toBe(
+      "C:/Users/example/repo",
+    );
+    expect(normalizeGitPathForHost("/cygdrive/d", "win32")).toBe("D:/");
+  });
+
+  it("leaves other paths unchanged", () => {
+    expect(normalizeGitPathForHost("C:/Users/example/repo", "win32")).toBe("C:/Users/example/repo");
+    expect(normalizeGitPathForHost("C:\\Users\\example\\repo", "win32")).toBe(
+      "C:\\Users\\example\\repo",
+    );
+    expect(normalizeGitPathForHost("//server/share/repo", "win32")).toBe("//server/share/repo");
+    expect(normalizeGitPathForHost("/mnt/projects/repo", "win32")).toBe("/mnt/projects/repo");
+    expect(normalizeGitPathForHost("/cygdrive/projects/repo", "win32")).toBe(
+      "/cygdrive/projects/repo",
+    );
+    expect(normalizeGitPathForHost("/cygdrive/c/Users/example/repo", "linux")).toBe(
+      "/cygdrive/c/Users/example/repo",
+    );
+  });
+});

--- a/apps/server/src/git/GitPath.test.ts
+++ b/apps/server/src/git/GitPath.test.ts
@@ -3,18 +3,19 @@ import { describe, expect, it } from "vite-plus/test";
 import { normalizeGitPathForHost } from "./GitPath.ts";
 
 describe("normalizeGitPathForHost", () => {
-  it("converts Git for Windows/MSYS2, Cygwin, and WSL drive paths on Windows", () => {
-    expect(normalizeGitPathForHost("/c/Users/example/repo", "win32")).toBe("C:/Users/example/repo");
+  it("converts Cygwin drive paths on Windows", () => {
     expect(normalizeGitPathForHost("/cygdrive/c/Users/example/repo", "win32")).toBe(
-      "C:/Users/example/repo",
-    );
-    expect(normalizeGitPathForHost("/mnt/c/Users/example/repo", "win32")).toBe(
       "C:/Users/example/repo",
     );
     expect(normalizeGitPathForHost("/cygdrive/d", "win32")).toBe("D:/");
   });
 
   it("leaves other paths unchanged", () => {
+    expect(normalizeGitPathForHost("/c/Users/example/repo", "win32")).toBe("/c/Users/example/repo");
+    expect(normalizeGitPathForHost("/d/project", "win32")).toBe("/d/project");
+    expect(normalizeGitPathForHost("/mnt/c/Users/example/repo", "win32")).toBe(
+      "/mnt/c/Users/example/repo",
+    );
     expect(normalizeGitPathForHost("C:/Users/example/repo", "win32")).toBe("C:/Users/example/repo");
     expect(normalizeGitPathForHost("C:\\Users\\example\\repo", "win32")).toBe(
       "C:\\Users\\example\\repo",

--- a/apps/server/src/git/GitPath.ts
+++ b/apps/server/src/git/GitPath.ts
@@ -1,0 +1,12 @@
+// Git for Windows/MSYS2 normally uses /c. Cygwin and WSL default to
+// /cygdrive/c and /mnt/c, respectively.
+// <https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#known-issues>
+// <https://cygwin.com/cygwin-ug-net/using.html#cygdrive>
+// <https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-settings>
+const POSIX_WINDOWS_DRIVE_PATH = /^\/(?:(?:cygdrive|mnt)\/)?([a-zA-Z])(?:\/|$)/;
+const normalizeWindowsDrive = (_match: string, drive: string) => `${drive.toUpperCase()}:/`;
+
+export function normalizeGitPathForHost(value: string, platform: NodeJS.Platform): string {
+  if (platform !== "win32") return value;
+  return value.replace(POSIX_WINDOWS_DRIVE_PATH, normalizeWindowsDrive);
+}

--- a/apps/server/src/git/GitPath.ts
+++ b/apps/server/src/git/GitPath.ts
@@ -1,12 +1,9 @@
-// Git for Windows/MSYS2 normally uses /c. Cygwin and WSL default to
-// /cygdrive/c and /mnt/c, respectively.
-// <https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#known-issues>
+// Cygwin's default cygdrive prefix exposes Windows drives as /cygdrive/c.
 // <https://cygwin.com/cygwin-ug-net/using.html#cygdrive>
-// <https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-settings>
-const POSIX_WINDOWS_DRIVE_PATH = /^\/(?:(?:cygdrive|mnt)\/)?([a-zA-Z])(?:\/|$)/;
+const CYGWIN_DRIVE_PATH = /^\/cygdrive\/([a-zA-Z])(?:\/|$)/;
 const normalizeWindowsDrive = (_match: string, drive: string) => `${drive.toUpperCase()}:/`;
 
 export function normalizeGitPathForHost(value: string, platform: NodeJS.Platform): string {
   if (platform !== "win32") return value;
-  return value.replace(POSIX_WINDOWS_DRIVE_PATH, normalizeWindowsDrive);
+  return value.replace(CYGWIN_DRIVE_PATH, normalizeWindowsDrive);
 }

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -3,6 +3,7 @@ import {
   detectSourceControlProviderFromGitRemoteUrl,
   normalizeGitRemoteUrl,
 } from "@t3tools/shared/git";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -10,6 +11,8 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 
+import { gitProcessEnvironment } from "../git/GitEnvironment.ts";
+import { normalizeGitPathForHost } from "../git/GitPath.ts";
 import * as ProcessRunner from "../processRunner.ts";
 
 const DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY = 512;
@@ -90,6 +93,9 @@ function buildRepositoryIdentity(input: {
 const resolveRepositoryIdentityCacheKey = Effect.fn("RepositoryIdentityResolver.resolveCacheKey")(
   function* (cwd: string) {
     const processRunner = yield* ProcessRunner.ProcessRunner;
+    const hostPlatform = yield* HostProcessPlatform;
+    const args = ["-C", cwd, "rev-parse", "--show-toplevel"];
+    const env = gitProcessEnvironment(args, hostPlatform);
     let cacheKey = cwd;
 
     // git is a real executable on every platform — no cmd.exe shell mode, which
@@ -97,7 +103,8 @@ const resolveRepositoryIdentityCacheKey = Effect.fn("RepositoryIdentityResolver.
     const topLevelResult = yield* processRunner
       .run({
         command: "git",
-        args: ["-C", cwd, "rev-parse", "--show-toplevel"],
+        args,
+        ...(env === undefined ? {} : { env }),
         timeoutBehavior: "timedOutResult",
       })
       .pipe(Effect.option);
@@ -105,7 +112,7 @@ const resolveRepositoryIdentityCacheKey = Effect.fn("RepositoryIdentityResolver.
       return cacheKey;
     }
 
-    const candidate = topLevelResult.value.stdout.trim();
+    const candidate = normalizeGitPathForHost(topLevelResult.value.stdout.trim(), hostPlatform);
     if (candidate.length > 0) {
       cacheKey = candidate;
     }
@@ -120,10 +127,14 @@ const resolveRepositoryIdentityFromCacheKey = Effect.fn(
   cacheKey: string,
 ): Effect.fn.Return<RepositoryIdentity | null, never, ProcessRunner.ProcessRunner> {
   const processRunner = yield* ProcessRunner.ProcessRunner;
+  const hostPlatform = yield* HostProcessPlatform;
+  const args = ["-C", cacheKey, "remote", "-v"];
+  const env = gitProcessEnvironment(args, hostPlatform);
   const remoteResult = yield* processRunner
     .run({
       command: "git",
-      args: ["-C", cacheKey, "remote", "-v"],
+      args,
+      ...(env === undefined ? {} : { env }),
       timeoutBehavior: "timedOutResult",
     })
     .pipe(Effect.option);

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -1,3 +1,4 @@
+import * as NodePath from "@effect/platform-node/NodePath";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -7,7 +8,8 @@ import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { assert, it } from "@effect/vitest";
 
-import { GitCommandError } from "@t3tools/contracts";
+import { CheckpointRef, GitCommandError } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -87,6 +89,7 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
     });
     assert.strictEqual(observedAppendTruncationMarker, true);
   }).pipe(
+    Effect.provideService(HostProcessPlatform, "linux"),
     Effect.provide(
       Layer.mergeAll(
         NodeServices.layer,
@@ -98,6 +101,159 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
               return {
                 exitCode: ChildProcessSpawner.ExitCode(0),
                 stdout: "",
+                stderr: "",
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("GitVcsDriver disables Cygwin globbing on Windows", () => {
+  let observedEnv: NodeJS.ProcessEnv | undefined;
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    yield* driver.execute({
+      operation: "GitVcsDriver.test.cygwinEnv",
+      cwd: "C:/repo",
+      args: ["status"],
+    });
+
+    assert.deepStrictEqual(observedEnv, { CYGWIN: "noglob" });
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              observedEnv = input.env;
+              return {
+                exitCode: ChildProcessSpawner.ExitCode(0),
+                stdout: "",
+                stderr: "",
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("GitVcsDriver retains Cygwin quote parsing for quoted arguments", () => {
+  let observedEnv: NodeJS.ProcessEnv | undefined;
+  const env = { LC_ALL: "zh_CN.UTF-8" };
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    yield* driver.execute({
+      operation: "GitVcsDriver.test.cygwinQuotedArgs",
+      cwd: "C:/repo",
+      args: ["-c", 'alias.print-locale=!printf "%s" "$LC_ALL"', "print-locale"],
+      env,
+    });
+
+    assert.strictEqual(observedEnv, env);
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              observedEnv = input.env;
+              return {
+                exitCode: ChildProcessSpawner.ExitCode(0),
+                stdout: "",
+                stderr: "",
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("normalizes Cygwin repository paths on Windows", () =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    const repository = yield* driver.detectRepository("C:/repo");
+
+    assert.deepInclude(repository, {
+      rootPath: "C:/repo",
+      metadataPath: "C:/repo/.git",
+    });
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.succeed({
+              exitCode: ChildProcessSpawner.ExitCode(0),
+              stdout: input.args.includes("--is-inside-work-tree")
+                ? "true\n"
+                : input.args.includes("--show-toplevel")
+                  ? "/cygdrive/c/repo\n"
+                  : "/cygdrive/c/repo/.git\n",
+              stderr: "",
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  ),
+);
+
+it.effect("uses a Windows path for Cygwin Git checkpoint indexes", () => {
+  const observedIndexPaths: Array<string> = [];
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    yield* driver.checkpoints.captureCheckpoint({
+      cwd: "C:/repo",
+      checkpointRef: CheckpointRef.make("refs/t3/checkpoints/test"),
+    });
+
+    assert.isNotEmpty(observedIndexPaths);
+    for (const indexPath of observedIndexPaths) {
+      assert.match(indexPath, /^C:\\repo\\\.git\\t3-checkpoint-index-/);
+    }
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        NodePath.layerWin32,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              if (input.env?.GIT_INDEX_FILE) {
+                observedIndexPaths.push(input.env.GIT_INDEX_FILE);
+              }
+              const isHeadCheck =
+                input.args.includes("HEAD^{commit}") && input.args.includes("--verify");
+              return {
+                exitCode: ChildProcessSpawner.ExitCode(isHeadCheck ? 1 : 0),
+                stdout: input.args.includes("--git-common-dir")
+                  ? "/cygdrive/c/repo/.git\n"
+                  : input.args.includes("write-tree")
+                    ? "tree-oid\n"
+                    : input.args.includes("commit-tree")
+                      ? "commit-oid\n"
+                      : "",
                 stderr: "",
                 stdoutTruncated: false,
                 stderrTruncated: false,

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -30,6 +30,9 @@ import {
   type VcsStatusInput,
   type VcsStatusResult,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { gitProcessEnvironment } from "../git/GitEnvironment.ts";
+import { normalizeGitPathForHost } from "../git/GitPath.ts";
 import { makeGitVcsDriverCore } from "./GitVcsDriverCore.ts";
 import * as VcsDriver from "./VcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -416,42 +419,49 @@ function parseGitRemoteVerboseOutput(
   return remotes;
 }
 
-const gitCommand = (
-  process: VcsProcess.VcsProcess["Service"],
-  operation: string,
-  cwd: string,
-  args: ReadonlyArray<string>,
-  options?: {
-    readonly stdin?: string;
-    readonly env?: NodeJS.ProcessEnv;
-    readonly allowNonZeroExit?: boolean;
-    readonly timeoutMs?: number;
-    readonly maxOutputBytes?: number;
-    readonly appendTruncationMarker?: boolean;
-  },
-) =>
-  process.run({
-    operation,
-    command: "git",
-    args: ["-C", cwd, ...args],
-    cwd,
-    spawnCwd: globalThis.process.cwd(),
-    ...(options?.stdin !== undefined ? { stdin: options.stdin } : {}),
-    ...(options?.env !== undefined ? { env: options.env } : {}),
-    ...(options?.allowNonZeroExit !== undefined
-      ? { allowNonZeroExit: options.allowNonZeroExit }
-      : {}),
-    ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-    ...(options?.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
-    ...(options?.appendTruncationMarker !== undefined
-      ? { appendTruncationMarker: options.appendTruncationMarker }
-      : {}),
-  });
+const makeGitCommand =
+  (hostPlatform: NodeJS.Platform) =>
+  (
+    process: VcsProcess.VcsProcess["Service"],
+    operation: string,
+    cwd: string,
+    args: ReadonlyArray<string>,
+    options?: {
+      readonly stdin?: string;
+      readonly env?: NodeJS.ProcessEnv;
+      readonly allowNonZeroExit?: boolean;
+      readonly timeoutMs?: number;
+      readonly maxOutputBytes?: number;
+      readonly appendTruncationMarker?: boolean;
+    },
+  ) => {
+    const commandArgs = ["-C", cwd, ...args];
+    const env = gitProcessEnvironment(commandArgs, hostPlatform, options?.env);
+    return process.run({
+      operation,
+      command: "git",
+      args: commandArgs,
+      cwd,
+      spawnCwd: globalThis.process.cwd(),
+      ...(options?.stdin !== undefined ? { stdin: options.stdin } : {}),
+      ...(env !== undefined ? { env } : {}),
+      ...(options?.allowNonZeroExit !== undefined
+        ? { allowNonZeroExit: options.allowNonZeroExit }
+        : {}),
+      ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+      ...(options?.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
+      ...(options?.appendTruncationMarker !== undefined
+        ? { appendTruncationMarker: options.appendTruncationMarker }
+        : {}),
+    });
+  };
 
 export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const vcsProcess = yield* VcsProcess.VcsProcess;
+  const hostPlatform = yield* HostProcessPlatform;
+  const gitCommand = makeGitCommand(hostPlatform);
   const capabilities = {
     kind: "git" as const,
     supportsWorktrees: true,
@@ -506,8 +516,10 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
 
     return {
       kind: "git" as const,
-      rootPath: root.stdout.trim(),
-      metadataPath: gitCommonDir?.stdout.trim() || null,
+      rootPath: normalizeGitPathForHost(root.stdout.trim(), hostPlatform),
+      metadataPath: gitCommonDir
+        ? normalizeGitPathForHost(gitCommonDir.stdout.trim(), hostPlatform) || null
+        : null,
       freshness: yield* nowFreshness(),
     };
   });
@@ -700,7 +712,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         cwd,
         args: ["rev-parse", "--git-common-dir"],
       });
-      const gitCommonDir = result.stdout.trim();
+      const gitCommonDir = normalizeGitPathForHost(result.stdout.trim(), hostPlatform);
       return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
     });
 

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -27,8 +27,11 @@ import {
   type VcsRef,
 } from "@t3tools/contracts";
 import { dedupeRemoteBranchesWithLocalMatches, normalizeGitRemoteUrl } from "@t3tools/shared/git";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { compactTraceAttributes } from "@t3tools/shared/observability";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
+import { gitProcessEnvironment } from "../git/GitEnvironment.ts";
+import { normalizeGitPathForHost } from "../git/GitPath.ts";
 import { gitCommandDuration, gitCommandsTotal, withMetrics } from "../observability/Metrics.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import {
@@ -710,6 +713,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const { worktreesDir } = yield* ServerConfig;
   const crypto = yield* Crypto.Crypto;
+  const hostPlatform = yield* HostProcessPlatform;
 
   const executeRaw: GitVcsDriver.GitVcsDriver["Service"]["execute"] = Effect.fnUntraced(
     function* (input) {
@@ -738,11 +742,11 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           .spawn(
             ChildProcess.make("git", commandInput.args, {
               cwd: commandInput.cwd,
-              env: {
+              env: gitProcessEnvironment(commandInput.args, hostPlatform, {
                 ...process.env,
                 ...input.env,
                 ...trace2Monitor.env,
-              },
+              }),
             }),
           )
           .pipe(
@@ -1048,7 +1052,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       });
     }
 
-    const commonDirOutput = commonDirResult.stdout.trim();
+    const commonDirOutput = normalizeGitPathForHost(commonDirResult.stdout.trim(), hostPlatform);
     const resolvedGitCommonDir = path.isAbsolute(commonDirOutput)
       ? path.normalize(commonDirOutput)
       : path.resolve(cwd, commonDirOutput);
@@ -1078,7 +1082,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       ],
       { concurrency: 2 },
     );
-    const worktreeRootOutput = worktreeRootResult.stdout.trim();
+    const worktreeRootOutput = normalizeGitPathForHost(
+      worktreeRootResult.stdout.trim(),
+      hostPlatform,
+    );
     const worktreeRoot =
       worktreeRootResult.exitCode === 0 && worktreeRootOutput.length > 0
         ? path.normalize(
@@ -2408,7 +2415,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         "GitVcsDriver.getReviewDiffFileContents.repositoryRoot",
         input.cwd,
         ["rev-parse", "--show-toplevel"],
-      ).pipe(Effect.map((value) => value.trim()));
+      ).pipe(Effect.map((value) => normalizeGitPathForHost(value.trim(), hostPlatform)));
       if (repositoryRoot.length === 0) {
         return yield* reviewDiffFileError(input, "Could not resolve the Git repository root.");
       }
@@ -2523,8 +2530,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const parsedWorktreeEntries =
       worktreeListResult.exitCode === 0
         ? [...parseWorktreeBranchPaths(worktreeListResult.stdout)].map(
-            ([branchName, worktreePath]) =>
-              [branchName, path.normalize(path.resolve(worktreePath))] as const,
+            ([branchName, worktreePath]) => {
+              const hostPath = normalizeGitPathForHost(worktreePath, hostPlatform);
+              return [branchName, path.normalize(path.resolve(hostPath))] as const;
+            },
           )
         : [];
     const existingWorktreeEntries = yield* Effect.filter(


### PR DESCRIPTION
## What Changed

- Normalize ~~the default POSIX drive formats emitted by Git for Windows/MSYS2, Cygwin, and WSL (`/c`, `/cygdrive/c`, and `/mnt/c`)~~ Cygwin's default POSIX drive format (`/cygdrive/c`) before passing those paths to native Windows APIs.
- Apply that normalization to repository roots, Git metadata directories, checkpoint paths, review-diff roots, repository identity caching, and worktree associations.
- Set `CYGWIN=noglob` for Windows Git commands so Cygwin does not expand braces in refs such as `HEAD^{commit}` or brackets in literal filenames.
- Retain Cygwin's normal parsing for commands containing literal double quotes, because Cygwin mishandles those quotes in `noglob` mode.
- Preserve caller-provided environments and existing `CYGWIN` options.

## Why

Windows support is hard because different people use different systems for Git, and most of them are weird. I'm one of the weirdos still using [Cygwin](https://cygwin.com/), because it is often a nice balance between "feeling like UNIX" and "fully integrated into Windows" (no separate mounts like WSL). But it also has its quirks, which this fairly small PR aims to fix in the context of T3 Code.

Specifically: When T3 Code runs as a native Windows Node process but resolves `git` to Cygwin Git, the command crosses two incompatible boundaries:

1. Cygwin applies glob expansion while reconstructing argv from a native Windows command line. That can change T3 Code's Git refs and selected-file paths before Git receives them. Cygwin documents this behavior through the [`CYGWIN` `glob`/`noglob` option](https://cygwin.com/cygwin-ug-net/using-cygwinenv.html); its [`noglob` quote behavior](https://cygwin.com/pipermail/cygwin/2016-May/227720.html) requires the conditional handling used here.

2. ~~Many Git implementations (including Git for Windows/MSYS2, Cygwin, and WSL) usually report Windows drives using POSIX syntax, and they do so in a way that's inconsistent and~~ Cygwin reports Windows drives using its default `/cygdrive/<drive>` syntax, which is incompatible with native Windows path APIs. This leads to incorrect repository roots, checkpoint indexes, review diffs, and worktree associations.

The conversion in this PR applies only on Windows and leaves native drive paths, UNC paths, unrelated POSIX paths, and non-Windows hosts unchanged. It deliberately leaves bare `/c` and WSL `/mnt/c` paths unchanged. So it shouldn't impact anyone else, while improving the lives of us Windows folks.

## Verification

- `vp test run apps/server/src/git/GitEnvironment.test.ts apps/server/src/git/GitPath.test.ts apps/server/src/project/RepositoryIdentityResolver.test.ts apps/server/src/vcs/GitVcsDriver.test.ts`
  - 4 files passed, 25 tests passed
- Focused `GitVcsDriverCore.test.ts` coverage for the real Cygwin caller-locale and bracketed-filename cases
  - 2 tests passed
- Server TypeScript typecheck
- Server bundle build
- Targeted lint and formatting
- `git diff --check`
- Manually verified latest-turn diffs with Cygwin Git through `dev:desktop`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots and video are not applicable

Implemented with GPT-5.6 Sol in T3 Code + Codex.

## Annotated Diff

Lately I've been into getting the LLM to generate an annotated diff that orders/groups changes nicely, as well as explaining *why* it made the changes it makes. (From your videos, I gather CodeRabbit does some or all of this.) In case it's helpful, here's that diff:

<details>
<summary>Annotated Diff</summary>

# Annotated diff: Windows Git interoperability

## Comparison

- Base: `origin/main` at `30be3119` (`fix(server): fall back to the remote default branch instead of assuming main (#7078)`)
- Scope: commit `2254cf11` (`fix(server): support POSIX-style Git on Windows`), containing eight server files
- Excluded: this explanatory document (`diff.md`)

The change makes T3 Code tolerate Git executables that use a POSIX compatibility layer while the server itself runs as a native Windows Node process. It addresses two independent boundary mismatches:

1. Cygwin may glob arguments received from a non-Cygwin parent, even though Node passed Git a structured argument array.
2. Git for Windows/MSYS2, Cygwin, and WSL may print Windows locations using POSIX drive syntax that native Windows path APIs do not recognize.

The fixes remain at Git process and output boundaries; internal VCS operations continue to use native host paths and structured Git arguments.

## 1. Keep Git arguments literal when Windows launches Cygwin Git

### Shared environment policy

Cygwin's startup layer can rewrite arguments passed by a native Windows process. T3 Code invokes Git with revision expressions containing braces, such as `HEAD^{commit}`, when resolving checkpoints. It also passes literal selected-file paths that can contain brackets, such as `selected[1].txt`, when constructing scoped diffs. If Cygwin rewrites either argument, Git receives a different revision or path and the corresponding checkpoint or diff operation fails.

The new helper normally appends Cygwin's documented `noglob` option to the `CYGWIN` environment variable passed to Git subprocesses on Windows. It preserves the rest of the caller-provided environment, prefers an explicitly supplied `CYGWIN` value over the inherited value, and appends `noglob` last so it wins over an earlier `glob` option.

Cygwin's no-glob parser also has a narrower incompatibility relevant to T3 Code: literal double quotes in an argument are converted to backslashes. T3 Code uses quote-bearing arguments for commands such as the locale-preservation test's Git alias, and commit messages may contain quotes. The helper therefore inspects the exact Git argv and retains Cygwin's normal parsing when any argument contains a double quote. This prioritizes literal braces and brackets for the ordinary checkpoint and selected-file commands without globally rewriting those characters or damaging quote-bearing commands. Non-Windows callers retain their original environment unchanged. See the [Cygwin `CYGWIN` options documentation](https://cygwin.com/cygwin-ug-net/using-cygwinenv.html) and the [Cygwin mailing-list reproduction using a native `CreateProcess` caller](https://cygwin.com/pipermail/cygwin/2016-May/227720.html).

**`apps/server/src/git/GitEnvironment.ts`**

```diff
new file mode 100644
+// When a Cygwin executable is launched by a native Windows process, Cygwin
+// by default glob-expands braces and brackets.
+// <https://cygwin.com/cygwin-ug-net/using-cygwinenv.html>
+// T3 Code uses these characters in Git refs (such as `HEAD^{commit}`)
+// and literal path names.
+// Setting `CYGWIN=noglob` preserves those arguments, but Cygwin mishandles
+// literal double quotes in this mode, converting them to backslashes.
+// <https://cygwin.com/pipermail/cygwin/2016-May/227720.html>
+// T3 Code can pass such quotes in Git commit messages, for example.
+// Therefore, we set `CYGWIN=noglob` only for commands without double quotes.
+// This workaround does not handle commands containing both braces/brackets and
+// double quotes, but it's difficult to do so cleanly until Cygwin changes.
+
+export function gitProcessEnvironment(
+  args: ReadonlyArray<string>,
+  platform: NodeJS.Platform,
+  env?: NodeJS.ProcessEnv,
+  inheritedEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv | undefined {
+  if (platform !== "win32" || args.some((arg) => arg.includes('"'))) return env;
+
+  const cygwinOptions = (env?.CYGWIN ?? inheritedEnv.CYGWIN)?.trim();
+  return {
+    ...env,
+    CYGWIN: cygwinOptions ? `${cygwinOptions} noglob` : "noglob",
+  };
+}
```

The helper has focused tests for the Windows default, inherited option preservation, explicit override precedence, the non-Windows no-op invariant, and the quote-bearing argv exception.

**`apps/server/src/git/GitEnvironment.test.ts`**

```diff
new file mode 100644
+import { describe, expect, it } from "vite-plus/test";
+
+import { gitProcessEnvironment } from "./GitEnvironment.ts";
+
+describe("gitProcessEnvironment", () => {
+  it("disables Cygwin globbing on Windows", () => {
+    expect(gitProcessEnvironment(["status"], "win32", undefined, {})).toEqual({
+      CYGWIN: "noglob",
+    });
+  });
+
+  it("preserves existing Cygwin options", () => {
+    expect(
+      gitProcessEnvironment(
+        ["status"],
+        "win32",
+        { GIT_CONFIG_COUNT: "0" },
+        {
+          CYGWIN: "winsymlinks:native",
+        },
+      ),
+    ).toEqual({
+      GIT_CONFIG_COUNT: "0",
+      CYGWIN: "winsymlinks:native noglob",
+    });
+  });
+
+  it("prefers explicitly supplied Cygwin options", () => {
+    expect(
+      gitProcessEnvironment(
+        ["status"],
+        "win32",
+        { CYGWIN: "glob:ignorecase" },
+        {
+          CYGWIN: "winsymlinks:native",
+        },
+      ),
+    ).toEqual({ CYGWIN: "glob:ignorecase noglob" });
+  });
+
+  it("leaves non-Windows environments unchanged", () => {
+    const env = { GIT_CONFIG_COUNT: "0" };
+    expect(gitProcessEnvironment(["status"], "linux", env, {})).toBe(env);
+  });
+
+  it("retains Cygwin's normal parsing for arguments containing double quotes", () => {
+    const env = { LC_ALL: "zh_CN.UTF-8" };
+    expect(
+      gitProcessEnvironment(
+        ["-c", 'alias.print-locale=!printf "%s" "$LC_ALL"', "print-locale"],
+        "win32",
+        env,
+        {},
+      ),
+    ).toBe(env);
+  });
+});
```

### Apply the policy at every affected Git execution boundary

`GitVcsDriver` already centralizes its command construction. The helper is now a small factory: `makeGitCommand(hostPlatform)` returns a closure that captures the host platform and applies the shared environment policy to each command. The returned function still takes `vcsProcess` explicitly at every call site, so the service itself is not wrapped or replaced.

**`apps/server/src/vcs/GitVcsDriver.ts`**

```diff
-const gitCommand = (
+const makeGitCommand =
+  (hostPlatform: NodeJS.Platform) =>
+  (
 ...
-) =>
-  process.run({
+  ) => {
+    const commandArgs = ["-C", cwd, ...args];
+    const env = gitProcessEnvironment(commandArgs, hostPlatform, options?.env);
+    return process.run({
 ...
-      args: ["-C", cwd, ...args],
+      args: commandArgs,
 ...
-    ...(options?.env !== undefined ? { env: options.env } : {}),
+      ...(env !== undefined ? { env } : {}),
 ...
-  });
+    });
+  };
```

The biggest change here is reindentation.

**`apps/server/src/vcs/GitVcsDriver.ts`**

```diff
 const vcsProcess = yield* VcsProcess.VcsProcess;
+const hostPlatform = yield* HostProcessPlatform;
+const gitCommand = makeGitCommand(hostPlatform);
```

`GitVcsDriverCore` has a separate low-level spawn path for Git tracing and metrics. Applying the same helper there is essential for checkpoint, diff, ref, and branch operations that bypass `VcsProcess`.

**`apps/server/src/vcs/GitVcsDriverCore.ts`**

```diff
 const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
 const { worktreesDir } = yield* ServerConfig;
 const crypto = yield* Crypto.Crypto;
+const hostPlatform = yield* HostProcessPlatform;
```

```diff
 ChildProcess.make("git", commandInput.args, {
   cwd: commandInput.cwd,
-  env: {
+  env: gitProcessEnvironment(commandInput.args, hostPlatform, {
     ...process.env,
     ...input.env,
     ...trace2Monitor.env,
-  },
+  }),
 })
```

Repository identity resolution invokes `ProcessRunner` directly rather than either VCS driver. Both its top-level lookup and remote lookup receive the same environment policy, so a Cygwin Git executable behaves consistently during cache-key and remote discovery.

**`apps/server/src/project/RepositoryIdentityResolver.ts`**

```diff
 const processRunner = yield* ProcessRunner.ProcessRunner;
+const hostPlatform = yield* HostProcessPlatform;
+const args = ["-C", cwd, "rev-parse", "--show-toplevel"];
+const env = gitProcessEnvironment(args, hostPlatform);
 let cacheKey = cwd;
 ...
 const topLevelResult = yield* processRunner
   .run({
     command: "git",
-    args: ["-C", cwd, "rev-parse", "--show-toplevel"],
+    args,
+    ...(env === undefined ? {} : { env }),
     timeoutBehavior: "timedOutResult",
   })
```

```diff
 const processRunner = yield* ProcessRunner.ProcessRunner;
+const hostPlatform = yield* HostProcessPlatform;
+const args = ["-C", cacheKey, "remote", "-v"];
+const env = gitProcessEnvironment(args, hostPlatform);
 const remoteResult = yield* processRunner
   .run({
     command: "git",
-    args: ["-C", cacheKey, "remote", "-v"],
+    args,
+    ...(env === undefined ? {} : { env }),
     timeoutBehavior: "timedOutResult",
   })
```

The existing execute-environment test remains focused on forwarding caller-provided options and is pinned to a non-Windows platform. Separate Windows integration tests verify both sides of the policy: ordinary argv receives `CYGWIN=noglob`, while quote-bearing argv forwards the caller's environment unchanged. The repeated mocked-process setup is omitted from the second excerpt.

**`apps/server/src/vcs/GitVcsDriver.test.ts`**

```diff
   }).pipe(
+    Effect.provideService(HostProcessPlatform, "linux"),
     Effect.provide(
```

```diff
+it.effect("GitVcsDriver disables Cygwin globbing on Windows", () => {
+  let observedEnv: NodeJS.ProcessEnv | undefined;
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    yield* driver.execute({
+      operation: "GitVcsDriver.test.cygwinEnv",
+      cwd: "C:/repo",
+      args: ["status"],
+    });
+
+    assert.deepStrictEqual(observedEnv, { CYGWIN: "noglob" });
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              observedEnv = input.env;
+              return {
+                exitCode: ChildProcessSpawner.ExitCode(0),
+                stdout: "",
+                stderr: "",
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    ),
+  );
+});
```

```diff
+it.effect("GitVcsDriver retains Cygwin quote parsing for quoted arguments", () => {
+  let observedEnv: NodeJS.ProcessEnv | undefined;
+  const env = { LC_ALL: "zh_CN.UTF-8" };
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    yield* driver.execute({
+      operation: "GitVcsDriver.test.cygwinQuotedArgs",
+      cwd: "C:/repo",
+      args: ["-c", 'alias.print-locale=!printf "%s" "$LC_ALL"', "print-locale"],
+      env,
+    });
+
+    assert.strictEqual(observedEnv, env);
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
     ...
+  );
+});
```

## 2. Convert POSIX drive paths before using native Windows path APIs

### Windows path-normalization helper

Git implementations can print the same Windows drive in several POSIX forms: Git for Windows/MSYS2 uses `/c/...`, Cygwin commonly uses `/cygdrive/c/...`, and WSL uses `/mnt/c/...`. Native Windows path handling does not consider those strings absolute Windows paths, which can produce incorrect repository roots, checkpoint index locations, diff file resolution, and branch worktree associations.

The recognized forms are the normal Git for Windows/MSYS2 drive path (`/c`), Cygwin's default cygdrive prefix (`/cygdrive/c`), and WSL's default automount root (`/mnt/c`). Cygwin and WSL allow those defaults to be reconfigured; this helper intentionally covers their standard forms rather than arbitrary mount points. It recognizes only a drive marker at the start of a path and only rewrites it when the Node host is Windows. Native drive paths, UNC paths, ordinary POSIX paths, and non-Windows hosts remain unchanged. See the [Git for Windows release notes](https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md), [Cygwin path-prefix documentation](https://cygwin.com/cygwin-ug-net/using.html#cygdrive), and [WSL automount settings](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-settings).

**`apps/server/src/git/GitPath.ts`**

```diff
new file mode 100644
+// Git for Windows/MSYS2 normally uses /c. Cygwin and WSL default to
+// /cygdrive/c and /mnt/c, respectively.
+// <https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#known-issues>
+// <https://cygwin.com/cygwin-ug-net/using.html#cygdrive>
+// <https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-settings>
+const POSIX_WINDOWS_DRIVE_PATH = /^\/(?:(?:cygdrive|mnt)\/)?([a-zA-Z])(?:\/|$)/;
+const normalizeWindowsDrive = (_match: string, drive: string) => `${drive.toUpperCase()}:/`;
+
+export function normalizeGitPathForHost(value: string, platform: NodeJS.Platform): string {
+  if (platform !== "win32") return value;
+  return value.replace(POSIX_WINDOWS_DRIVE_PATH, normalizeWindowsDrive);
+}
```

The tests cover all three supported POSIX drive forms, a drive root, native slash and backslash paths, UNC paths, lookalikes without a drive letter, and the non-Windows no-op behavior.

**`apps/server/src/git/GitPath.test.ts`**

```diff
new file mode 100644
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeGitPathForHost } from "./GitPath.ts";
+
+describe("normalizeGitPathForHost", () => {
+  it("converts Git for Windows/MSYS2, Cygwin, and WSL drive paths on Windows", () => {
+    expect(normalizeGitPathForHost("/c/Users/example/repo", "win32")).toBe("C:/Users/example/repo");
+    expect(normalizeGitPathForHost("/cygdrive/c/Users/example/repo", "win32")).toBe(
+      "C:/Users/example/repo",
+    );
+    expect(normalizeGitPathForHost("/mnt/c/Users/example/repo", "win32")).toBe(
+      "C:/Users/example/repo",
+    );
+    expect(normalizeGitPathForHost("/cygdrive/d", "win32")).toBe("D:/");
+  });
+
+  it("leaves other paths unchanged", () => {
+    expect(normalizeGitPathForHost("C:/Users/example/repo", "win32")).toBe("C:/Users/example/repo");
+    expect(normalizeGitPathForHost("C:\\Users\\example\\repo", "win32")).toBe(
+      "C:\\Users\\example\\repo",
+    );
+    expect(normalizeGitPathForHost("//server/share/repo", "win32")).toBe("//server/share/repo");
+    expect(normalizeGitPathForHost("/mnt/projects/repo", "win32")).toBe("/mnt/projects/repo");
+    expect(normalizeGitPathForHost("/cygdrive/projects/repo", "win32")).toBe(
+      "/cygdrive/projects/repo",
+    );
+    expect(normalizeGitPathForHost("/cygdrive/c/Users/example/repo", "linux")).toBe(
+      "/cygdrive/c/Users/example/repo",
+    );
+  });
+});
```

### Normalize repository and metadata roots

The higher-level driver converts `--show-toplevel` and `--git-common-dir` results before returning repository metadata. Checkpoint capture also converts the common directory before `path.join` creates its temporary index path; this prevents a POSIX-looking Cygwin path from being resolved relative to the native Windows working directory.

**`apps/server/src/vcs/GitVcsDriver.ts`**

```diff
 return {
   kind: "git" as const,
-  rootPath: root.stdout.trim(),
-  metadataPath: gitCommonDir?.stdout.trim() || null,
+  rootPath: normalizeGitPathForHost(root.stdout.trim(), hostPlatform),
+  metadataPath: gitCommonDir
+    ? normalizeGitPathForHost(gitCommonDir.stdout.trim(), hostPlatform) || null
+    : null,
   freshness: yield* nowFreshness(),
 };
```

```diff
 const result = yield* execute({
   operation: "GitVcsDriver.checkpoints.resolveGitCommonDir",
   cwd,
   args: ["rev-parse", "--git-common-dir"],
 });
-const gitCommonDir = result.stdout.trim();
+const gitCommonDir = normalizeGitPathForHost(result.stdout.trim(), hostPlatform);
 return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
```

Two integration tests make these downstream effects concrete. One checks the repository metadata returned for Cygwin output. The other checks that checkpoint temporary indexes are created under the native Windows `.git` directory.

**`apps/server/src/vcs/GitVcsDriver.test.ts`**

```diff
+it.effect("normalizes Cygwin repository paths on Windows", () =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    const repository = yield* driver.detectRepository("C:/repo");
+
+    assert.deepInclude(repository, {
+      rootPath: "C:/repo",
+      metadataPath: "C:/repo/.git",
+    });
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.succeed({
+              exitCode: ChildProcessSpawner.ExitCode(0),
+              stdout: input.args.includes("--is-inside-work-tree")
+                ? "true\n"
+                : input.args.includes("--show-toplevel")
+                  ? "/cygdrive/c/repo\n"
+                  : "/cygdrive/c/repo/.git\n",
+              stderr: "",
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  ),
+);
```

```diff
+it.effect("uses a Windows path for Cygwin Git checkpoint indexes", () => {
+  const observedIndexPaths: Array<string> = [];
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    yield* driver.checkpoints.captureCheckpoint({
+      cwd: "C:/repo",
+      checkpointRef: CheckpointRef.make("refs/t3/checkpoints/test"),
+    });
+
+    assert.isNotEmpty(observedIndexPaths);
+    for (const indexPath of observedIndexPaths) {
+      assert.match(indexPath, /^C:\\repo\\\.git\\t3-checkpoint-index-/);
+    }
+  }).pipe(
+    Effect.provideService(HostProcessPlatform, "win32"),
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        NodePath.layerWin32,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              if (input.env?.GIT_INDEX_FILE) {
+                observedIndexPaths.push(input.env.GIT_INDEX_FILE);
+              }
+              const isHeadCheck =
+                input.args.includes("HEAD^{commit}") && input.args.includes("--verify");
+              return {
+                exitCode: ChildProcessSpawner.ExitCode(isHeadCheck ? 1 : 0),
+                stdout: input.args.includes("--git-common-dir")
+                  ? "/cygdrive/c/repo/.git\n"
+                  : input.args.includes("write-tree")
+                    ? "tree-oid\n"
+                    : input.args.includes("commit-tree")
+                      ? "commit-oid\n"
+                      : "",
+                stderr: "",
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    ),
+  );
+});
```

The import additions for `NodePath`, `CheckpointRef`, and `HostProcessPlatform` support these tests and their Windows-specific path service.

### Normalize paths used by diffs, checkpoints, and branch worktrees

The core driver consumes Git paths in several independent workflows. Each value is converted immediately after reading Git output, before Effect's native `Path` and `FileSystem` services inspect it.

Repository-path resolution now normalizes both the common Git directory and the worktree root. These values feed status refresh, diff/checkpoint operations, and repository caching.

**`apps/server/src/vcs/GitVcsDriverCore.ts`**

```diff
-const commonDirOutput = commonDirResult.stdout.trim();
+const commonDirOutput = normalizeGitPathForHost(commonDirResult.stdout.trim(), hostPlatform);
 const resolvedGitCommonDir = path.isAbsolute(commonDirOutput)
   ? path.normalize(commonDirOutput)
   : path.resolve(cwd, commonDirOutput);
```

```diff
-const worktreeRootOutput = worktreeRootResult.stdout.trim();
+const worktreeRootOutput = normalizeGitPathForHost(
+  worktreeRootResult.stdout.trim(),
+  hostPlatform,
+);
 const worktreeRoot =
   worktreeRootResult.exitCode === 0 && worktreeRootOutput.length > 0
     ? path.normalize(
```

Working-tree diff expansion uses the normalized repository root for containment checks and reading the new file from disk. Without this conversion, a Cygwin top-level path is not a valid absolute Windows root.

**`apps/server/src/vcs/GitVcsDriverCore.ts`**

```diff
 const repositoryRoot = yield* runGitStdout(
   "GitVcsDriver.getReviewDiffFileContents.repositoryRoot",
   input.cwd,
   ["rev-parse", "--show-toplevel"],
-).pipe(Effect.map((value) => value.trim()));
+).pipe(Effect.map((value) => normalizeGitPathForHost(value.trim(), hostPlatform)));
```

Branch enumeration reads worktree paths from `git worktree list --porcelain`. Converting those paths before statting and indexing them restores correct worktree associations in the branch list.

**`apps/server/src/vcs/GitVcsDriverCore.ts`**

```diff
 const parsedWorktreeEntries =
   worktreeListResult.exitCode === 0
     ? [...parseWorktreeBranchPaths(worktreeListResult.stdout)].map(
-        ([branchName, worktreePath]) =>
-          [branchName, path.normalize(path.resolve(worktreePath))] as const,
+        ([branchName, worktreePath]) => {
+          const hostPath = normalizeGitPathForHost(worktreePath, hostPlatform);
+          return [branchName, path.normalize(path.resolve(hostPath))] as const;
+        },
       )
     : [];
```

Finally, repository identity caching uses the normalized top-level path. That keeps identity lookups keyed to the same native path used elsewhere and ensures the subsequent `git -C` remote lookup receives a usable Windows directory.

**`apps/server/src/project/RepositoryIdentityResolver.ts`**

```diff
-const candidate = topLevelResult.value.stdout.trim();
+const candidate = normalizeGitPathForHost(topLevelResult.value.stdout.trim(), hostPlatform);
 if (candidate.length > 0) {
   cacheKey = candidate;
 }
```

The `HostProcessPlatform`, `gitProcessEnvironment`, and `normalizeGitPathForHost` imports added to the driver, core driver, and identity resolver are mechanical support for the behavior shown above.

## Verification

The final workspace was checked with focused server tests and static checks:

- `apps/server/src/git/GitEnvironment.test.ts`
- `apps/server/src/git/GitPath.test.ts`
- `apps/server/src/vcs/GitVcsDriver.test.ts`
- `apps/server/src/project/RepositoryIdentityResolver.test.ts`
- Two focused `GitVcsDriverCore.test.ts` cases covering the real Cygwin caller-locale command and a selected path containing brackets
- Server TypeScript typecheck and bundle build
- Repository formatter and `git diff --check`

The focused suites passed. Typechecking completed with pre-existing Effect suggestions in unrelated orchestration and GitLab pull-request files.

## Complete change inventory

| File                                                    | Purpose                                                                                               |
| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| `apps/server/src/git/GitEnvironment.ts`                 | Defines the shared Windows/Cygwin Git environment policy, including the quote-bearing argv exception. |
| `apps/server/src/git/GitEnvironment.test.ts`            | Tests option precedence, non-Windows preservation, and quote handling.                                |
| `apps/server/src/git/GitPath.ts`                        | Converts supported POSIX drive forms to native Windows drive paths.                                   |
| `apps/server/src/git/GitPath.test.ts`                   | Tests conversions and unchanged path classes.                                                         |
| `apps/server/src/vcs/GitVcsDriver.ts`                   | Applies environment policy and normalizes repository/checkpoint paths.                                |
| `apps/server/src/vcs/GitVcsDriver.test.ts`              | Verifies environment merging, conditional Cygwin parsing, and Cygwin repository/checkpoint paths.     |
| `apps/server/src/vcs/GitVcsDriverCore.ts`               | Applies policy to low-level Git spawns and normalizes core diff/ref/worktree paths.                   |
| `apps/server/src/project/RepositoryIdentityResolver.ts` | Applies policy and native path normalization during identity discovery.                               |


</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every Windows Git subprocess env and path normalization across core VCS flows; behavior changes for Cygwin users (noglob) but is scoped to win32 and Cygwin-style paths.
> 
> **Overview**
> When the server runs as native Windows Node but invokes **Cygwin Git**, this PR adds two boundary helpers and threads them through repository identity resolution and the Git VCS driver.
> 
> **`gitProcessEnvironment`** appends **`CYGWIN=noglob`** on Windows so Cygwin does not glob-expand braces/brackets in refs like `HEAD^{commit}` or literal paths. It skips that when any argument contains a double quote (Cygwin breaks quotes in `noglob` mode) and leaves non-Windows env unchanged.
> 
> **`normalizeGitPathForHost`** rewrites Cygwin **`/cygdrive/<letter>/...`** output to native **`C:/...`** on Windows only; other POSIX forms and non-Windows hosts are untouched.
> 
> Those utilities are applied wherever Git is spawned (`GitVcsDriver`, `GitVcsDriverCore`, `RepositoryIdentityResolver`) and wherever Git stdout paths feed Windows path APIs—repo roots, `.git` dirs, checkpoint index files, review-diff roots, and worktree paths—with focused unit and driver tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da620a2b0b727a58b631c815b39340a548da38b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support Cygwin Git on Windows with `CYGWIN=noglob` env and `/cygdrive` path normalization
> - Adds `gitProcessEnvironment` which sets `CYGWIN` to include `noglob` on Windows when no args contain double quotes; preserves and appends to existing `CYGWIN` values
> - Adds `normalizeGitPathForHost` to convert Cygwin `/cygdrive/<drive>/...` paths to Windows `<DRIVE>:/...` form on `win32`, returning input unchanged elsewhere
> - Integrates both utilities across [GitVcsDriver.ts](https://github.com/pingdotgg/t3code/pull/8123/files#diff-51125f02a750f476d151ebf951da622dc9738e642dc72b99dc8bfccf689a1483), [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/8123/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8), and [RepositoryIdentityResolver.ts](https://github.com/pingdotgg/t3code/pull/8123/files#diff-150725a1a7c2fad32a2af878e610161760c1d30b61e1fc4e4aaba35d01587171) so all Git invocations and stdout paths are handled correctly on Windows
> - Risk: when args contain double quotes, `gitProcessEnvironment` returns the env unchanged (no `noglob`), which may cause glob expansion in Cygwin Git for those commands; reviewers should check quoted-arg call sites in `makeGitCommand` and `executeRaw`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da620a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->