### PR TITLE
fix(web): detect outdated nightly servers

### DIFF
--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -50,6 +50,25 @@ describe("versionSkew", () => {
     expect(resolveVersionMismatch("0.0.34")).toBeNull();
   });
 
+  it.each(["0.0.34-nightly.20260823.1124", "0.0.34-nightly.20260824.1124"])(
+    "warns when nightly server %s is behind a nightly client on the same release",
+    (serverVersion) => {
+      branding.APP_VERSION = "0.0.34-nightly.20260824.1125";
+
+      expect(resolveVersionMismatch(serverVersion)).toEqual({
+        clientVersion: "0.0.34-nightly.20260824.1125",
+        serverVersion,
+        hint: MISMATCH_HINT,
+      });
+    },
+  );
+
+  it("does not warn when a nightly server is ahead on the same release", () => {
+    branding.APP_VERSION = "0.0.34-nightly.20260824.1125";
+
+    expect(resolveVersionMismatch("0.0.34-nightly.20260824.1126")).toBeNull();
+  });
+
   it("treats a nightly server built past the client as ahead, not skew", () => {
     expect(resolveVersionMismatch("0.0.35-nightly.20260818.1124")).toBeNull();
   });

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -33,13 +33,11 @@ function versionCore(version: string): string {
  * The skew a user can act on: the connected server runs an older T3 Code than
  * this client, so the server is the side that needs updating.
  *
- * Versions compare as semver on their core `major.minor.patch` only. Nightlies
- * are `<core>-nightly.<date>.<run>` builds of the release they precede, so a
- * stable client on a nightly server (or the reverse, at the same core) shares a
- * wire contract and is not skew. A server *ahead* of the client is not skew
- * either: the client is the stale side, and every consumer of this result tells
- * the user to update their server. Versions that do not parse as semver fall
- * back to plain string inequality.
+ * Two nightly builds compare their full versions, including the date and run.
+ * Other combinations compare their core `major.minor.patch` only, so a stable
+ * build and a nightly build with the same core do not cause an update warning.
+ * A server ahead of the client does not need an update. Versions that do not
+ * parse as semver fall back to plain string inequality.
  */
 export function resolveVersionMismatch(
   serverVersion: string | null | undefined,
@@ -52,9 +50,15 @@ export function resolveVersionMismatch(
 
   const clientCore = versionCore(normalizedClientVersion);
   const serverCore = versionCore(normalizedServerVersion);
+  const compareNightlyBuilds =
+    parseSemver(normalizedClientVersion)?.prerelease[0] === "nightly" &&
+    parseSemver(normalizedServerVersion)?.prerelease[0] === "nightly";
   const serverIsBehind =
     parseSemver(clientCore) && parseSemver(serverCore)
-      ? compareSemverVersions(serverCore, clientCore) < 0
+      ? compareSemverVersions(
+          compareNightlyBuilds ? normalizedServerVersion : serverCore,
+          compareNightlyBuilds ? normalizedClientVersion : clientCore,
+        ) < 0
       : normalizedServerVersion !== normalizedClientVersion;
   if (!serverIsBehind) {
     return null;


### PR DESCRIPTION
Nightly clients stopped detecting older nightly servers after the version check discarded nightly build dates and run numbers.

Compare full semver versions when both builds are nightly. Keep the existing release-only comparison for stable and nightly combinations.

Tests: `vp test run apps/web/src/versionSkew.test.ts packages/shared/src/semver.test.ts`; `vp run --filter @t3tools/web typecheck`.

Made by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to client-side version mismatch logic and tests; no auth, data, or server contract changes beyond more accurate nightly warnings.
> 
> **Overview**
> **Nightly-to-nightly version skew** now compares the **full** semver string (date and run), so an older nightly server on the same `major.minor.patch` is flagged again instead of being treated as a match.
> 
> **Stable ↔ nightly** behavior is unchanged: comparisons still use core `major.minor.patch` only, so mixed stable/nightly pairs on the same release do not warn. A server ahead of the client still does not trigger a mismatch.
> 
> Tests cover behind/ahead nightly pairs on the same release and the existing stable/nightly cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938586739b1bb9956f8460a76964b88b87fa5818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix outdated nightly server detection in `resolveVersionMismatch`
> - `resolveVersionMismatch` now checks if both client and server are nightly builds by inspecting the prerelease tag. When both are nightly, it compares full normalized versions (including nightly date/run) instead of only core semantic versions.
> - A warning is shown when the server nightly is behind the client nightly on the same core release; no warning when the server nightly is ahead. Stable-vs-nightly comparisons on the same core remain unchanged.
> - Behavioral Change: nightly-to-nightly comparisons now use the full version string, so a server nightly that previously appeared equal (same core version) now warns if it is older than the client nightly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9385867.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->