### PR TITLE
fix(web): sidebar follows a worktree thread's live branch

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -19,6 +19,7 @@ import {
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
+  resolveSidebarThreadBranchLabel,
   resolveThreadRowClassName,
   resolveSidebarThreadStatus,
   resolveThreadStatusPill,
@@ -690,6 +691,60 @@ describe("isContextMenuPointerDown", () => {
         isMac: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveSidebarThreadBranchLabel", () => {
+  it("follows the worktree's live ref when the agent switched branches inside it", () => {
+    expect(
+      resolveSidebarThreadBranchLabel({
+        worktreePath: "/tmp/wt/thread-1",
+        threadBranch: "seth/original",
+        currentGitBranch: "seth/switched",
+      }),
+    ).toBe("seth/switched");
+  });
+
+  it("keeps the stamped branch for a worktree in detached HEAD", () => {
+    expect(
+      resolveSidebarThreadBranchLabel({
+        worktreePath: "/tmp/wt/thread-1",
+        threadBranch: "seth/original",
+        currentGitBranch: null,
+      }),
+    ).toBe("seth/original");
+  });
+
+  it("labels a worktree that was never stamped with its live ref", () => {
+    expect(
+      resolveSidebarThreadBranchLabel({
+        worktreePath: "/tmp/wt/thread-1",
+        threadBranch: null,
+        currentGitBranch: "seth/switched",
+      }),
+    ).toBe("seth/switched");
+  });
+
+  it("keeps the branch of record on the shared local checkout", () => {
+    // The checkout's ref belongs to whichever thread last switched it, so
+    // adopting it here would relabel every row in the project at once.
+    expect(
+      resolveSidebarThreadBranchLabel({
+        worktreePath: null,
+        threadBranch: "seth/original",
+        currentGitBranch: "someone-elses-branch",
+      }),
+    ).toBe("seth/original");
+  });
+
+  it("returns null when a local thread has no branch at all", () => {
+    expect(
+      resolveSidebarThreadBranchLabel({
+        worktreePath: null,
+        threadBranch: null,
+        currentGitBranch: null,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -459,6 +459,23 @@ export function resolveThreadRowClassName(input: {
   );
 }
 
+// A worktree belongs to exactly one thread, so whichever ref is checked out
+// there is that thread's branch — an agent switching branches mid-run makes the
+// stamped `branch` stale, it does not make the checkout wrong. The shared local
+// checkout is the opposite: its ref is whatever any thread last switched it to,
+// so those rows keep the branch of record and let the mismatch warning explain
+// the difference. Detached HEAD reports no ref, so the stamp stays the fallback.
+export function resolveSidebarThreadBranchLabel(input: {
+  worktreePath: string | null;
+  threadBranch: string | null;
+  currentGitBranch: string | null;
+}): string | null {
+  if (input.worktreePath === null) {
+    return input.threadBranch;
+  }
+  return input.currentGitBranch ?? input.threadBranch;
+}
+
 // ── Sidebar thread status model ─────────────────────────────────────
 // Five visual states, three colors: color is reserved for "act now"
 // (approval), "in motion" (working), and "broken" (failed). Ready is the

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -134,6 +134,7 @@ import {
   planPinnedReorder,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
+  resolveSidebarThreadBranchLabel,
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
   shouldCreateNewThreadInCurrentProject,
@@ -264,6 +265,7 @@ function SidebarThreadTooltip({
   showInstanceBadge,
   modelInstanceId,
   modelLabel,
+  branchLabel,
   branchMismatch,
   terminalStatus,
   terminalProcessCount,
@@ -277,6 +279,7 @@ function SidebarThreadTooltip({
   showInstanceBadge: boolean;
   modelInstanceId: string;
   modelLabel: string;
+  branchLabel: string | null;
   branchMismatch: {
     threadBranch: string;
     currentBranch: string;
@@ -315,10 +318,10 @@ function SidebarThreadTooltip({
               <div className="min-w-0 truncate text-foreground/75">{environmentLabel}</div>
             </div>
           ) : null}
-          {thread.branch ? (
+          {branchLabel ? (
             <div className="flex min-w-0 items-center gap-2">
               <GitBranchIcon className="size-3 shrink-0 stroke-muted-foreground" />
-              <div className="min-w-0 truncate text-foreground/75">{thread.branch}</div>
+              <div className="min-w-0 truncate text-foreground/75">{branchLabel}</div>
             </div>
           ) : null}
           {branchMismatch ? (
@@ -896,6 +899,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     activeThreadBranch: thread.branch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
+  const branchLabel = resolveSidebarThreadBranchLabel({
+    worktreePath: thread.worktreePath,
+    threadBranch: thread.branch,
+    currentGitBranch: gitStatus.data?.refName ?? null,
+  });
   const prProvider = resolveDisplayedThreadPrProvider({
     threadBranch: thread.branch,
     gitStatus: gitStatus.data,
@@ -949,6 +957,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       showInstanceBadge={showInstanceBadge}
       modelInstanceId={modelInstanceId}
       modelLabel={modelLabel}
+      branchLabel={branchLabel}
       branchMismatch={branchMismatch}
       terminalStatus={terminalStatus}
       terminalProcessCount={terminalProcessCount}
@@ -1538,10 +1547,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               {/* Always the branch. The plan step used to take this slot while
                   working, but it truncated to a half-sentence and dropped the
                   branch, so the row lost its most stable identifier. */}
-              {thread.branch ? (
+              {branchLabel ? (
                 <>
                   <ThreadWorktreeIndicator thread={thread} />
-                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{branchLabel}</span>
                 </>
               ) : (
                 <span className="flex-1" />
@@ -1631,6 +1640,11 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
     activeThreadBranch: thread.branch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
+  const branchLabel = resolveSidebarThreadBranchLabel({
+    worktreePath: thread.worktreePath,
+    threadBranch: thread.branch,
+    currentGitBranch: gitStatus.data?.refName ?? null,
+  });
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
   const showInstanceBadge =
@@ -1697,6 +1711,7 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
           showInstanceBadge={showInstanceBadge}
           modelInstanceId={modelInstanceId}
           modelLabel={modelLabel}
+          branchLabel={branchLabel}
           branchMismatch={branchMismatch}
           terminalStatus={terminalStatus}
           terminalProcessCount={runningTerminalIds.length}


### PR DESCRIPTION
## What Changed

Sidebar rows resolve their branch label through a new `resolveSidebarThreadBranchLabel`, which adopts the live `gitStatus.refName` for **worktree** threads and falls back to the stamped `thread.branch` on detached HEAD. Local-checkout rows are unchanged.

Applied to the three places that previously read `thread.branch` directly: the thread row label, the hover tooltip, and the search-result row (which shares that tooltip).

+91 / −4 across three files, one of them the test.

## Why

> **Correction (under revision).** An earlier version of this description claimed nothing reconciles `thread.branch` against git. That is wrong. `followWorktreeBranchDrift` (`apps/server/src/orchestration/Layers/CheckpointReactor.ts:566`) already adopts the checked-out branch at turn end, skipping detached HEAD, temporary branches and shared worktrees. See Deviations — this PR is being reworked and should not be reviewed yet.

Sidebar rows render the persisted `thread.branch`. The thread view resolves the same value through `resolveBranchToolbarValue`, which prefers the live `gitStatus.refName`. Because the server only follows drift at turn completion, the two disagree in the window between a mid-turn `git checkout` and the end of that turn, and indefinitely for a checkout never followed by a turn.

So the moment a worktree's checked-out branch diverges from the stamp, the two views disagree: the toolbar follows reality while the sidebar keeps showing a branch the thread has already left.

A worktree belongs to exactly one thread, so whichever ref is checked out there **is** that thread's branch. The shared local checkout is the opposite — its ref belongs to whichever thread last switched it — so those rows keep the branch of record and let the existing mismatch warning explain the difference.

The rows already subscribe to `vcsEnvironment.status` for that warning (`Sidebar.tsx:792` and `:1622`), so reading the live ref costs no additional query.

## Scope and non-goals

In scope: the web sidebar's branch **display** for worktree threads.

Explicit non-goals:

- **Does not persist anything.** `thread.branch` stays stale in `projection_threads`, so mobile's thread list (`apps/mobile/src/features/threads/thread-list-items.tsx:465`) and PR matching still read the old value. Fixing that needs a server-side branch-update event, which #4831 noted does not exist.
- **Does not make anything refresh faster.** There is no `.git` watcher in `apps/server/src`; local status is only re-read on an in-app git action, an explicit `vcsRefreshStatus`, or the end-of-turn `CheckpointReactor`. The 30s loop refreshes remote status only. This PR makes the sidebar *agree* with the thread view, not update sooner — so it does **not** fix #7409, whose repro is a bare `git checkout` in the terminal panel.
- **Does not touch local-checkout rows.**

## Related work

- #4831 (closed) described this exact root cause: nothing writes a worktree's new HEAD back to `projection_threads.branch`.
- #5407 (open) covers overlapping ground in these files. If that supersedes this, close this one — it is deliberately small enough to be cheap to discard.
- #4926 (open) touches `Sidebar.logic.ts` for a different problem and predates the `SidebarV2.tsx` → `Sidebar.tsx` rename.

## Decisions

- **Display-only rather than server-side reconciliation.** Persisting the live ref would fix every surface at once, but it needs a new event and a rule for the shared-checkout case. Kept small on purpose, per CONTRIBUTING.
- **Worktree threads only.** Adopting live `refName` on the shared local checkout would relabel every row in a project whenever one thread switched branches.
- **Fall back to the stamp, never to nothing.** Detached HEAD reports a null ref; the row keeps its last known branch instead of going blank.

## Implementation checklist

- [x] Add `resolveSidebarThreadBranchLabel` with worktree/local split and detached-HEAD fallback
- [x] Use it for the thread row label, the tooltip, and the search-result row
- [x] Unit tests for all five branches of the resolution
- [x] Before/after screenshots

## Verification

- [x] `vp test run apps/web/src/components/Sidebar.logic.test.ts` — 110 passed, 5 new
- [x] `tsgo --noEmit` on `apps/web` — clean
- [x] `vp lint --report-unused-disable-directives` on the three changed files — clean
- [x] `vp fmt --check` on the three changed files — clean
- [x] Visual confirmation in a running client — isolated dev server against a seeded fixture; server logs confirm the status subscription resolving `branch: agent/renamed-during-run` for the worktree thread and `branch: main` for the local one

## UI Changes

A worktree thread stamped `t3code/rework-branch-toolbar` whose worktree was switched to `agent/renamed-during-run`, next to a local-checkout thread on `main` as a control. Same fixture, same viewport; only the build differs.

| Before | After |
| --- | --- |
| ![sidebar before](https://raw.githubusercontent.com/sethwebster/t3code/a0ffa151850ae1cbe48f1198a058f192a1060996/pr-assets/8126/before.png) | ![sidebar after](https://raw.githubusercontent.com/sethwebster/t3code/a0ffa151850ae1cbe48f1198a058f192a1060996/pr-assets/8126/after.png) |

Before, the worktree row shows the stale stamp. After, it shows the branch the worktree is actually on. The local-checkout row reads `main` in both, confirming shared checkouts are untouched.

## Security and compatibility

No contract, schema, or server change; no new network calls; no auth or trust-boundary surface. Purely which of two already-present client values is rendered. Fully backward compatible — a client without this change simply keeps showing the stamped branch.

## Deviations

Adversarial review found three defects in this change as written. Recorded here rather than silently amended:

1. **False premise.** `resolveSidebarThreadBranchLabel`'s comment claims a worktree belongs to exactly one thread. It does not — `new-thread-on-branch` (`Sidebar.tsx:3109`) carries `worktreePath` into a second thread and `useHandleNewThread.ts:403` persists it. The server guards this with an explicit `worktreeIsShared` check; this change has no equivalent, so two threads sharing a worktree would both be relabeled from one thread's checkout.
2. **Missing temporary-branch guard.** The server skips `isTemporaryWorktreeBranch` (`packages/shared/src/git.ts:107`) so it does not race the first-turn auto-rename. This change adopts any non-null ref, so a row can briefly render a `t3/<hex>` placeholder.
3. **Row incoherence.** Only the label follows the live ref. The PR badge, worktree tooltip, `copy-branch`, and `new-thread-on-branch` still key off `thread.branch`. Worse, `resolveDisplayedThreadPr` requires `refName === thread.branch`, so a drifted row now prints branch B while hiding branch B's PR badge.

Scope is being reconsidered in light of the existing server-side drift-follow.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes — n/a, no motion

Made with Claude Opus 5 in the Claude Code harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar to show a worktree thread's live branch instead of stamped branch
> - Adds `resolveSidebarThreadBranchLabel` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/8126/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to compute the displayed branch label. For dedicated worktrees it uses the current git ref (`gitStatus.refName`) when available, falling back to the stamped `thread.branch`; for shared local checkouts it uses `thread.branch`.
> - Updates [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/8126/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) so `SidebarThreadRow`, `SidebarSearchResultRow`, and `SidebarThreadTooltip` render the computed `branchLabel` instead of always using `thread.branch`. The tooltip hides the branch row when the label is null.
> - Adds tests in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/8126/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a) covering worktree with switched branch, detached HEAD, no stamped branch, shared checkout with differing ref, and no branch.
> - Risk: threads in a dedicated worktree whose live ref differs from the stamped branch now show the live ref; any code expecting the sidebar to always display `thread.branch` will see the new value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dca192.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

