### PR TITLE
feat(connect): raise device limit to five

### DIFF
--- a/infra/relay/src/environments/ManagedTunnelLimits.test.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.test.ts
@@ -59,9 +59,9 @@ describe("ManagedTunnelLimits", () => {
     }).pipe(Effect.provide(layerWithDb(fakeDb)));
   });
 
-  it.effect("rejects provisioning at the default limit of 3", () => {
+  it.effect("rejects provisioning at the default limit of 5", () => {
     const fakeDb = makeFakeDb({
-      countRows: Effect.succeed([{ activeTunnels: 3 }]),
+      countRows: Effect.succeed([{ activeTunnels: 5 }]),
     });
 
     return Effect.gen(function* () {
@@ -74,8 +74,8 @@ describe("ManagedTunnelLimits", () => {
         _tag: "ManagedTunnelLimitExceeded",
         userId: "user-1",
         environmentId: "environment-1",
-        maxTunnels: 3,
-        activeTunnels: 3,
+        maxTunnels: 5,
+        activeTunnels: 5,
       });
     }).pipe(Effect.provide(layerWithDb(fakeDb)));
   });

--- a/infra/relay/src/environments/ManagedTunnelLimits.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.ts
@@ -15,7 +15,7 @@ import {
  * Managed tunnels a user may hold at once unless a row in
  * `relay_managed_tunnel_limits` overrides it for that user.
  */
-export const DEFAULT_MANAGED_TUNNEL_LIMIT = 3;
+export const DEFAULT_MANAGED_TUNNEL_LIMIT = 5;
 
 export class ManagedTunnelLimitPersistenceError extends Schema.TaggedErrorClass<ManagedTunnelLimitPersistenceError>()(
   "ManagedTunnelLimitPersistenceError",


### PR DESCRIPTION
T3 Connect accounts currently allow only three devices.

Raise the default limit to five and update the existing limit test. Per-account overrides are unchanged.

Made with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change with matching tests; per-user overrides and limit-check logic are unchanged, only the default provisioning ceiling increases.
> 
> **Overview**
> Raises the default concurrent **managed tunnel** cap for Connect users from **3 to 5** by changing `DEFAULT_MANAGED_TUNNEL_LIMIT` in relay’s `ManagedTunnelLimits` service. `ensureCapacity` still uses per-user rows in `relay_managed_tunnel_limits` when present; only accounts without an override get the higher ceiling.
> 
> The unit test that asserts rejection at the default cap is updated so expectations match **5** active tunnels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd7ca0021a7c30576ef998c5a55950452aa11b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `DEFAULT_MANAGED_TUNNEL_LIMIT` from 3 to 5
> Increases the default managed tunnel capacity for users without an override. Updates the corresponding test in [ManagedTunnelLimits.test.ts](https://github.com/pingdotgg/t3code/pull/8127/files#diff-30d897bb930e4470e803fd995cd86f0e4f60ad12460d8f6bfe23824aaa206443) to assert rejection at the new limit of 5.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dd7ca0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->