### PR TITLE
fix(web): keep remote icon visible on hover

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -790,13 +790,15 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               isRemoteThread ? "max-sm:min-w-24" : "max-sm:min-w-20"
             }`}
           >
-            {isRemoteThread && !isDesktopLocalThread && !isConfirmingArchive && (
+            {isRemoteThread && !isDesktopLocalThread && (
               <Tooltip>
                 <TooltipTrigger
                   render={
                     <span
                       aria-label={threadEnvironmentLabel ?? "Remote"}
-                      className="inline-flex shrink-0 items-center justify-center"
+                      className={`inline-flex shrink-0 items-center justify-center ${
+                        isConfirmingArchive ? "invisible" : ""
+                      }`}
                     />
                   }
                 >

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -790,7 +790,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               isRemoteThread ? "max-sm:min-w-24" : "max-sm:min-w-20"
             }`}
           >
-            {isRemoteThread && !isDesktopLocalThread && (
+            {isRemoteThread && !isDesktopLocalThread && !isConfirmingArchive && (
               <Tooltip>
                 <TooltipTrigger
                   render={

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -786,10 +786,25 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
             </Tooltip>
           )}
           <div
-            className={`flex min-w-12 justify-end ${
+            className={`flex min-w-12 items-center justify-end gap-1 ${
               isRemoteThread ? "max-sm:min-w-24" : "max-sm:min-w-20"
             }`}
           >
+            {isRemoteThread && !isDesktopLocalThread && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      aria-label={threadEnvironmentLabel ?? "Remote"}
+                      className="inline-flex shrink-0 items-center justify-center"
+                    />
+                  }
+                >
+                  <CloudIcon className="size-3 text-muted-foreground/40" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">{threadEnvironmentLabel}</TooltipPopup>
+              </Tooltip>
+            )}
             {isConfirmingArchive ? (
               <button
                 ref={handleConfirmArchiveRef}
@@ -843,21 +858,6 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
             ) : null}
             <span className={threadMetaClassName}>
               <span className="inline-flex items-center gap-1">
-                {isRemoteThread && !isDesktopLocalThread && (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <span
-                          aria-label={threadEnvironmentLabel ?? "Remote"}
-                          className="inline-flex items-center justify-center"
-                        />
-                      }
-                    >
-                      <CloudIcon className="size-3 text-muted-foreground/40" />
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">{threadEnvironmentLabel}</TooltipPopup>
-                  </Tooltip>
-                )}
                 {jumpLabel ? (
                   <Tooltip>
                     <TooltipTrigger


### PR DESCRIPTION
## What Changed

Keeps the remote-machine cloud icon visible when a legacy sidebar thread row is hovered. The timestamp or jump hint still fades to make room for the archive action.

## Why

The cloud icon identifies which machine owns a thread. Hiding it on hover removes useful context at the moment the user is about to act on the row. The icon now sits beside, rather than inside, the metadata block that intentionally fades on hover.

## UI Changes

Before: hovering a remote thread hides both its timestamp and cloud icon.

After: hovering hides only the timestamp or jump hint; the cloud icon remains visible beside the archive action.

The reporter supplied a before screenshot. Automated after-image capture was not available in the clean upstream worktree because it has no paired remote environment fixture.

## Validation

- `pnpm exec vp fmt --check apps/web/src/components/LegacySidebar.tsx`
- `pnpm exec vp lint --report-unused-disable-directives apps/web/src/components/LegacySidebar.tsx`
- `pnpm exec vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] Interaction behavior is described above; no animation changed

LastCode port: https://github.com/lastobelus/lastCode/pull/82

Implemented with GPT-5.6 Codex in the T3 Code harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep remote `CloudIcon` visible on hover in `SidebarThreadRow`
> Moves the remote-thread environment icon from the metadata span into the right-side control area of [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/8132/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86), where it stays visible on hover. The control container now uses `items-center` and `gap-1` for alignment. The icon is hidden during archive confirmation.
> - Risk: icon placement changes from metadata area to control group, so any layout relying on its old position may shift.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c58270.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar layout and hover styling in LegacySidebar; no auth, data, or API changes.
> 
> **Overview**
> **Moves the remote-environment cloud icon** out of the legacy sidebar thread row metadata block (timestamp / jump hint) into the right-aligned **actions** area next to the archive control.
> 
> On hover, only the metadata still fades via `threadMetaClassName`; the cloud icon **stays visible** so users still see which machine owns the thread when the archive action appears. The actions wrapper adds `items-center` and `gap-1` for alignment. During archive confirmation, the icon is **hidden** with `invisible` while the confirm button is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c58270a3ec7b0fa01c5200c04865af5531a42cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->