### PR TITLE
fix(desktop): require passkey signing material only when Clerk is configured

### DIFF
--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2869,10 +2869,14 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const stageProdResourcesDir = path.join(stageAppDir, "apps/desktop/prod-resources");
   yield* fs.copy(stageResourcesDir, stageProdResourcesDir);
 
+  const repoEnvForSigning = loadRepoEnv({ repoRoot });
   const configuredMacPasskeySigning =
-    options.platform === "mac" && options.signed
+    options.platform === "mac" &&
+    options.signed &&
+    (repoEnvForSigning.T3CODE_CLERK_PUBLISHABLE_KEY ||
+      repoEnvForSigning.T3CODE_CLERK_PASSKEY_RP_DOMAINS)
       ? yield* Effect.try({
-          try: () => resolveMacPasskeySigningConfiguration(loadRepoEnv({ repoRoot })),
+          try: () => resolveMacPasskeySigningConfiguration(repoEnvForSigning),
           catch: MacPasskeySigningConfigurationResolutionError.fromCause,
         })
       : undefined;


### PR DESCRIPTION
A signed macOS build resolves the passkey signing configuration unconditionally, so it demands `T3CODE_MACOS_PROVISIONING_PROFILE` and either `T3CODE_CLERK_PASSKEY_RP_DOMAINS` or `T3CODE_CLERK_PUBLISHABLE_KEY`. All three serve passkey sign-in, which serves T3 Connect. With cloud features off there is no domain for the Associated Domains entitlement to claim, but the build still refuses.

`.env.example` says the cloud identifiers are optional and that removing them builds with cloud features disabled. That holds for unsigned builds only, and a signed build is the only kind that can auto-update. The failure names a provisioning profile and mentions neither Clerk nor T3 Connect, so it does not lead anywhere useful.

The fix gates the passkey configuration on `T3CODE_CLERK_PUBLISHABLE_KEY`. That key is the root of the chain, and `resolveMacPasskeySigningConfiguration` already derives the RP domain from it. With a key present nothing changes.

## Testing

Built a signed macOS artifact from this branch with only `T3CODE_APPLE_TEAM_ID` set. It completes, the app is signed by a Developer ID identity, and `codesign -d --entitlements` shows no `associated-domains` entry. Before the change the same build threw `MissingMacPasskeyProvisioningProfileError` immediately after staging.

`vp run --filter scripts typecheck` is clean. `vp test run scripts/build-desktop-artifact.test.ts` gives 48 passed and 1 failed; that one failure, "skips the primary native probe for cross-architecture Windows payloads", also fails on an unmodified checkout of `main`, so it is not from this change.

Written by Claude Fable 5.0 running as an agent in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when signed mac builds apply passkey entitlements; misconfigured CI (signed mac + Clerk expected but env vars missing) would skip Associated Domains signing instead of failing loudly.
> 
> **Overview**
> **Signed macOS desktop builds** no longer always resolve passkey signing (Associated Domains provisioning profile + Clerk RP domains). In `buildDesktopArtifact`, passkey setup now runs only when the build is mac, signing is enabled, and **`T3CODE_CLERK_PUBLISHABLE_KEY` or `T3CODE_CLERK_PASSKEY_RP_DOMAINS`** is set in repo env.
> 
> Repo env is loaded once as **`repoEnvForSigning`** and passed into **`resolveMacPasskeySigningConfiguration`** instead of calling **`loadRepoEnv`** inside the resolver path. Signed mac builds without Clerk/T3 Connect config can complete with Developer ID signing and **without** passkey entitlements, matching optional cloud identifiers in `.env.example`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9eadb53646b44bb9f49996c52c7099ee58f34f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require passkey signing material only when Clerk env vars are set in `buildDesktopArtifact`
> Updates the mac signed build path so `resolveMacPasskeySigningConfiguration` runs only when `T3CODE_CLERK_PUBLISHABLE_KEY` or `T3CODE_CLERK_PASSKEY_RP_DOMAINS` is present. Repo environment variables are loaded once into `repoEnvForSigning` and reused for both the configuration check and the resolution call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d9eadb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->