### PR TITLE
fix(web): block type-to-focus behind open dialogs

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -493,6 +493,7 @@ const TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR = [
   '[data-slot="command-dialog-popup"][data-open]',
   '[data-slot="dialog-popup"][data-open]',
   '[data-slot="sheet-popup"][data-open]',
+  '[data-slot="sidebar"][data-mobile="true"][data-open]',
   '[data-slot="menu-popup"]',
   '[data-slot="select-popup"]',
   '[data-slot="popover-popup"]',

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -489,7 +489,10 @@ const TYPE_TO_FOCUS_INTERACTIVE_SELECTOR = [
   '[role="tab"]',
 ].join(",");
 const TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR = [
-  '[data-slot="dialog"]',
+  '[data-slot="alert-dialog-popup"][data-open]',
+  '[data-slot="command-dialog-popup"][data-open]',
+  '[data-slot="dialog-popup"][data-open]',
+  '[data-slot="sheet-popup"][data-open]',
   '[data-slot="menu-popup"]',
   '[data-slot="select-popup"]',
   '[data-slot="popover-popup"]',

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -489,11 +489,11 @@ const TYPE_TO_FOCUS_INTERACTIVE_SELECTOR = [
   '[role="tab"]',
 ].join(",");
 const TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR = [
-  '[data-slot="alert-dialog-popup"][data-open]',
-  '[data-slot="command-dialog-popup"][data-open]',
-  '[data-slot="dialog-popup"][data-open]',
-  '[data-slot="sheet-popup"][data-open]',
-  '[data-slot="sidebar"][data-mobile="true"][data-open]',
+  '[data-slot="alert-dialog-popup"]:is([data-open],[data-ending-style])',
+  '[data-slot="command-dialog-popup"]:is([data-open],[data-ending-style])',
+  '[data-slot="dialog-popup"]:is([data-open],[data-ending-style])',
+  '[data-slot="sheet-popup"]:is([data-open],[data-ending-style])',
+  '[data-slot="sidebar"][data-mobile="true"]:is([data-open],[data-ending-style])',
   '[data-slot="menu-popup"]',
   '[data-slot="select-popup"]',
   '[data-slot="popover-popup"]',


### PR DESCRIPTION
## Problem

The chat type-to-focus guard checks for `[data-slot="dialog"]`, but the app's dialog primitives render popup slots such as `dialog-popup` and `alert-dialog-popup`. A printable key can therefore be redirected into the composer behind an open dialog.

## Fix

Match the actual dialog, alert-dialog, command-dialog, and sheet popup slots, including the mobile sidebar's overridden sheet slot. The selectors cover Base UI's open and ending-style states, preserving the guard through exit transitions without matching fully closed keep-mounted popups.

No visual styling changes.

## Verification

- `vp test run apps/web/src/components/RightPanelTabs.test.tsx apps/web/src/components/ChatView.logic.test.ts` (65 passed)
- `pnpm typecheck` in `apps/web`
- `vp lint apps/web/src/components/ChatView.tsx`
- `react-doctor --verbose --scope changed --base upstream/main` (no issues)

Built with GPT-5.6 Sol via pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, chat keyboard-guard change with no auth or data impact; risk is mainly if something still relied on the old generic `dialog` slot match.
> 
> **Overview**
> Fixes a bug where **printable keys could still focus the chat composer** while a modal was open, because the guard looked for `[data-slot="dialog"]` instead of the real popup elements.
> 
> **`TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR`** in `ChatView.tsx` now targets open floating layers: `dialog-popup`, `alert-dialog-popup`, `command-dialog-popup`, `sheet-popup`, and the mobile sidebar sheet. Selectors require Base UI **`data-open`** or **`data-ending-style`** so keep-mounted closed sheets do not block type-to-focus. Existing menu, select, popover, combobox, and autocomplete popup selectors are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7ed48de08c4ec8b4a32b7bc496a061b0ad7d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block type-to-focus behind open dialogs in `ChatView`
> - Updates `ChatView.TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8139/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) with selectors for `alert-dialog`, `command-dialog`, `dialog`, `sheet`, and the mobile sidebar.
> - Constrains all popup selectors to match only elements in an `open` or `ending` state, replacing the generic dialog slot selector.
> - Behavioral Change: Type-to-focus logic now only reacts to open or ending popups and dialogs, and includes the newly added component types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c7ed48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->