### PR TITLE
feat(web): filter the sidebar by several projects at once

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -17,6 +17,8 @@ import {
   isSidebarNestedLinkClick,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  pruneProjectScopeKeys,
+  toggleProjectScopeKey,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -1681,5 +1683,28 @@ describe("sortLogicalProjectsForSidebar", () => {
         (project) => project.projectKey,
       ),
     ).toEqual(["logical-newer", "logical-older"]);
+  });
+});
+
+describe("toggleProjectScopeKey", () => {
+  it("adds a key in pick order and removes it again", () => {
+    expect(toggleProjectScopeKey([], "alpha")).toEqual(["alpha"]);
+    expect(toggleProjectScopeKey(["alpha"], "beta")).toEqual(["alpha", "beta"]);
+    expect(toggleProjectScopeKey(["alpha", "beta"], "alpha")).toEqual(["beta"]);
+  });
+
+  it("returns an empty selection when the last key is toggled off", () => {
+    expect(toggleProjectScopeKey(["alpha"], "alpha")).toEqual([]);
+  });
+});
+
+describe("pruneProjectScopeKeys", () => {
+  it("drops keys whose project group disappeared", () => {
+    expect(pruneProjectScopeKeys(["alpha", "beta"], new Set(["beta"]))).toEqual(["beta"]);
+  });
+
+  it("keeps the same array when every key survives", () => {
+    const scopeKeys = ["alpha", "beta"];
+    expect(pruneProjectScopeKeys(scopeKeys, new Set(["alpha", "beta", "gamma"]))).toBe(scopeKeys);
   });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -394,6 +394,32 @@ export function resolveAdjacentThreadId<T>(input: {
   return currentIndex < threadIds.length - 1 ? (threadIds[currentIndex + 1] ?? null) : null;
 }
 
+/**
+ * The sidebar's project scope is a list of logical project keys, where an
+ * empty list means "all projects".
+ */
+export function toggleProjectScopeKey(
+  scopeKeys: readonly string[],
+  scopeKey: string,
+): readonly string[] {
+  return scopeKeys.includes(scopeKey)
+    ? scopeKeys.filter((key) => key !== scopeKey)
+    : [...scopeKeys, scopeKey];
+}
+
+/**
+ * Drops picks whose project group is gone (project removed, environment
+ * dropped, grouping mode changed). Returns the same array when nothing was
+ * dropped so callers can feed it straight back into state without a loop.
+ */
+export function pruneProjectScopeKeys(
+  scopeKeys: readonly string[],
+  availableScopeKeys: ReadonlySet<string>,
+): readonly string[] {
+  const kept = scopeKeys.filter((key) => availableScopeKeys.has(key));
+  return kept.length === scopeKeys.length ? scopeKeys : kept;
+}
+
 export function shouldNavigateAfterProjectRemoval(input: {
   routeTarget: ThreadRouteTarget | null;
   projectThreads: readonly {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -132,6 +132,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   planPinnedReorder,
+  pruneProjectScopeKeys,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
@@ -142,6 +143,7 @@ import {
   sortPinnedThreadsForSidebar,
   sortSettledThreadsForSidebar,
   sortThreadsForSidebar,
+  toggleProjectScopeKey,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
@@ -175,7 +177,7 @@ import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import { Menu, MenuCheckboxItem, MenuPopup, MenuTrigger } from "./ui/menu";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
@@ -1926,30 +1928,46 @@ export default function Sidebar() {
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
-  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
-  const scopedProjectGroup = useMemo(
+  // An empty selection means "all projects"; picking several narrows the list
+  // to their union, so two projects can be watched without the rest.
+  const [projectScopeKeys, setProjectScopeKeys] = useState<readonly string[]>([]);
+  const scopedProjectGroups = useMemo(
     () =>
-      projectScopeKey === null
-        ? null
-        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
-    [projectGroups, projectScopeKey],
+      projectScopeKeys.length === 0
+        ? []
+        : projectGroups.filter((project) => projectScopeKeys.includes(project.projectKey)),
+    [projectGroups, projectScopeKeys],
   );
+  // Trigger and empty state read like the old single-project scope whenever
+  // exactly one project is picked.
+  const soleScopedProjectGroup =
+    scopedProjectGroups.length === 1 ? (scopedProjectGroups[0] ?? null) : null;
   const scopedProjectKeys = useMemo(
     () =>
-      scopedProjectGroup === null
+      scopedProjectGroups.length === 0
         ? null
         : new Set(
-            scopedProjectGroup.memberProjectRefs.map(
-              (projectRef) => `${projectRef.environmentId}:${projectRef.projectId}`,
+            scopedProjectGroups.flatMap((group) =>
+              group.memberProjectRefs.map(
+                (projectRef) => `${projectRef.environmentId}:${projectRef.projectId}`,
+              ),
             ),
           ),
-    [scopedProjectGroup],
+    [scopedProjectGroups],
+  );
+  // Pick order says nothing about what the list shows, so resets key off the
+  // sorted selection: reordering picks must not reset paging or selection.
+  const projectScopeSelectionKey = useMemo(
+    () => (projectScopeKeys.length === 0 ? "all" : [...projectScopeKeys].toSorted().join("\u0000")),
+    [projectScopeKeys],
+  );
+  const projectGroupKeys = useMemo(
+    () => new Set(projectGroups.map((project) => project.projectKey)),
+    [projectGroups],
   );
   useEffect(() => {
-    if (projectScopeKey !== null && scopedProjectGroup === null) {
-      setProjectScopeKey(null);
-    }
-  }, [projectScopeKey, scopedProjectGroup]);
+    setProjectScopeKeys((keys) => pruneProjectScopeKeys(keys, projectGroupKeys));
+  }, [projectGroupKeys]);
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from
@@ -1980,7 +1998,7 @@ export default function Sidebar() {
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
     clearSelection();
-  }, [clearSelection, projectScopeKey]);
+  }, [clearSelection, projectScopeSelectionKey]);
 
   const handleProjectSettings = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
@@ -2148,7 +2166,7 @@ export default function Sidebar() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = projectScopeKey ?? "all";
+  const settledResetKey = projectScopeSelectionKey;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -3480,69 +3498,70 @@ export default function Sidebar() {
                       />
                     }
                   >
-                    {scopedProjectGroup ? (
+                    {soleScopedProjectGroup ? (
                       <ProjectFavicon
-                        environmentId={scopedProjectGroup.environmentId}
-                        cwd={scopedProjectGroup.workspaceRoot}
-                        faviconPath={scopedProjectGroup.faviconPath}
+                        environmentId={soleScopedProjectGroup.environmentId}
+                        cwd={soleScopedProjectGroup.workspaceRoot}
+                        faviconPath={soleScopedProjectGroup.faviconPath}
                         className="size-4 shrink-0"
                       />
                     ) : (
                       <FolderIcon className="size-4 shrink-0" />
                     )}
                     <span className="min-w-0 flex-1 truncate">
-                      {scopedProjectGroup?.displayName ?? "All projects"}
+                      {soleScopedProjectGroup
+                        ? soleScopedProjectGroup.displayName
+                        : scopedProjectGroups.length === 0
+                          ? "All projects"
+                          : `${scopedProjectGroups.length} projects`}
                     </span>
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />
                   </MenuTrigger>
                   <MenuPopup align="start" className="w-(--anchor-width)">
-                    <MenuRadioGroup
-                      value={projectScopeKey ?? "all"}
-                      onValueChange={(value) =>
-                        setProjectScopeKey(value === "all" ? null : (value as string))
-                      }
+                    <MenuCheckboxItem
+                      checked={projectScopeKeys.length === 0}
+                      onCheckedChange={() => setProjectScopeKeys([])}
+                      closeOnClick={false}
+                      className="h-8 min-h-8 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
                     >
-                      <MenuRadioItem
-                        value="all"
-                        closeOnClick
-                        className="h-8 min-h-8 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
-                      >
-                        <FolderIcon className="size-4 shrink-0" />
-                        <span className="min-w-0 truncate text-sm">All projects</span>
-                      </MenuRadioItem>
-                      {projectGroups.map((project) => {
-                        const scopeKey = project.projectKey;
-                        return (
-                          <MenuRadioItem
-                            key={scopeKey}
-                            value={scopeKey}
-                            closeOnClick
-                            className="h-8 min-h-8 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                      <FolderIcon className="size-4 shrink-0" />
+                      <span className="min-w-0 truncate text-sm">All projects</span>
+                    </MenuCheckboxItem>
+                    {projectGroups.map((project) => {
+                      const scopeKey = project.projectKey;
+                      return (
+                        <MenuCheckboxItem
+                          key={scopeKey}
+                          checked={projectScopeKeys.includes(scopeKey)}
+                          onCheckedChange={() =>
+                            setProjectScopeKeys((keys) => toggleProjectScopeKey(keys, scopeKey))
+                          }
+                          closeOnClick={false}
+                          className="h-8 min-h-8 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                        >
+                          <ProjectFavicon
+                            environmentId={project.environmentId}
+                            cwd={project.workspaceRoot}
+                            faviconPath={project.faviconPath}
+                            className="size-4 shrink-0"
+                          />
+                          <span className="min-w-0 truncate text-sm">{project.displayName}</span>
+                          <Button
+                            size="icon-xs"
+                            variant="ghost-muted"
+                            aria-label={`Project settings for ${project.displayName}`}
+                            title={`Project settings for ${project.displayName}`}
+                            className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+                            onPointerDown={(event) => event.stopPropagation()}
+                            onClick={(event) => {
+                              void handleProjectSettings(event, project);
+                            }}
                           >
-                            <ProjectFavicon
-                              environmentId={project.environmentId}
-                              cwd={project.workspaceRoot}
-                              faviconPath={project.faviconPath}
-                              className="size-4 shrink-0"
-                            />
-                            <span className="min-w-0 truncate text-sm">{project.displayName}</span>
-                            <Button
-                              size="icon-xs"
-                              variant="ghost-muted"
-                              aria-label={`Project settings for ${project.displayName}`}
-                              title={`Project settings for ${project.displayName}`}
-                              className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => {
-                                void handleProjectSettings(event, project);
-                              }}
-                            >
-                              <SettingsIcon className="size-3.5" />
-                            </Button>
-                          </MenuRadioItem>
-                        );
-                      })}
-                    </MenuRadioGroup>
+                            <SettingsIcon className="size-3.5" />
+                          </Button>
+                        </MenuCheckboxItem>
+                      );
+                    })}
                   </MenuPopup>
                 </Menu>
                 <Tooltip>
@@ -3924,8 +3943,10 @@ export default function Sidebar() {
                     Add project
                   </button>
                 </>
-              ) : scopedProjectGroup ? (
-                `No threads in ${scopedProjectGroup.displayName} yet`
+              ) : soleScopedProjectGroup ? (
+                `No threads in ${soleScopedProjectGroup.displayName} yet`
+              ) : scopedProjectGroups.length > 1 ? (
+                "No threads in the selected projects yet"
               ) : (
                 "No threads yet"
               )}


### PR DESCRIPTION
The project filter was a radio menu: all projects, or one. If you're working
in two repos at the same time you end up flipping it back and forth all day.

It's checkboxes now. 

### Before

<img width="616" height="528" alt="before" src="https://github.com/user-attachments/assets/b71094bb-40c2-43d0-b4d4-5d5f1f3863da" />

### After

<img width="588" height="514" alt="after" src="https://github.com/user-attachments/assets/478f98f0-1937-4f24-8129-ca1782bd6958" />

Tests: 4 new ones for the toggle/prune helpers, plus typecheck and lint on
the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only sidebar filter UX and local state; no auth, persistence, or API changes.
> 
> **Overview**
> The sidebar project filter moves from **single-select** to **multi-select**: an empty checkbox selection still means **all projects**, but users can check several logical projects and see the **union** of their threads without flipping the menu back and forth.
> 
> State is now `projectScopeKeys` (array) instead of one nullable key. **`toggleProjectScopeKey`** and **`pruneProjectScopeKeys`** in `Sidebar.logic` handle add/remove and drop stale keys when project groups disappear. The filter menu uses **`MenuCheckboxItem`** with **`closeOnClick={false}`** so the menu stays open while toggling; the trigger shows one project’s favicon/name when exactly one is selected, **“All projects”** when none, or **“N projects”** when several.
> 
> Pagination reset and bulk-selection clearing key off **`projectScopeSelectionKey`** (sorted set of keys, or `"all"`), so reordering picks alone does not reset settled paging or selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ba5a940a4b8707e8be630451dc249bcd9b0594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `Sidebar` to support filtering by multiple projects
> - Updates the `Sidebar` component to allow users to filter by multiple projects simultaneously instead of a single project.
> - Replaces `projectScopeKey` with `projectScopeKeys` (readonly string array) and introduces `toggleProjectScopeKey` and `pruneProjectScopeKeys` utilities to manage selection state.
> - Changes the project filter menu from a radio group to a checkbox list that remains open while toggling selections, and updates empty-state messages to handle zero, one, or multiple selections.
> - Resets pagination and clears row selection only when the effective set of scoped projects changes, using the new `projectScopeSelectionKey`.
> - Behavioral Change: The filter UI switches from single-select radio buttons to multi-select checkboxes, and stale project selections are pruned automatically when available projects change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6ba5a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->