### PR TITLE
feat(claude): compact old threads before they burn through usage

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -413,6 +413,25 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("passes the configured auto-compaction window to Claude", () => {
+    const harness = makeHarness({ claudeConfig: { autoCompactWindow: "300000" } });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const options = harness.getLastCreateQueryInput()?.options;
+      assert.deepEqual(options?.settings, { autoCompactWindow: 300000 });
+      assert.deepEqual(options?.supportedDialogKinds, ["resume_return"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("forwards claude effort levels into query options", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -4393,6 +4412,62 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(proposedEvent.value.payload.planMarkdown, "# Final plan\n\n- capture it");
       assert.deepEqual(proposedEvent.value.providerRefs, {
         providerItemId: ProviderItemId.make("tool-exit-2"),
+      });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("routes Claude resume compaction through the shared user-input UI", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: RESUME_THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        resumeCursor: { resume: "550e8400-e29b-41d4-a716-446655440000" },
+        runtimeMode: "full-access",
+      });
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      const onUserDialog = harness.getLastCreateQueryInput()?.options.onUserDialog;
+      assert.equal(typeof onUserDialog, "function");
+      if (!onUserDialog) return;
+
+      const dialogPromise = onUserDialog(
+        {
+          dialogKind: "resume_return",
+          payload: { sessionAgeMinutes: 145, estimatedTokens: 275123 },
+        },
+        { signal: new AbortController().signal },
+      );
+
+      const requested = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(requested._tag, "Some");
+      if (requested._tag !== "Some" || requested.value.type !== "user-input.requested") return;
+      const question = requested.value.payload.questions[0];
+      assert.equal(question?.header, "Resume session");
+      assert.match(question?.question ?? "", /2h 25m/);
+      assert.match(question?.question ?? "", /275,123 tokens/);
+      assert.deepEqual(
+        question?.options.map((option) => option.label),
+        ["Compact and continue", "Keep full history", "Don't ask again"],
+      );
+      if (!question || !requested.value.requestId) return;
+
+      yield* adapter.respondToUserInput(
+        session.threadId,
+        ApprovalRequestId.make(requested.value.requestId),
+        { [question.id]: "Compact and continue" },
+      );
+
+      const resolved = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(resolved._tag, "Some");
+      if (resolved._tag === "Some") assert.equal(resolved.value.type, "user-input.resolved");
+      assert.deepEqual(yield* Effect.promise(() => dialogPromise), {
+        behavior: "completed",
+        result: "compact",
       });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -4797,6 +4797,73 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("denies AskUserQuestion when the signal aborted before the listener registered", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "approval-required",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 2).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      // Abort before the call so the adapter's listener registration can
+      // never observe the abort event, only the recheck can.
+      const controller = new AbortController();
+      controller.abort();
+      const permissionPromise = canUseTool(
+        "AskUserQuestion",
+        {
+          questions: [
+            {
+              question: "Continue?",
+              header: "Continue",
+              options: [{ label: "Yes", description: "Proceed" }],
+              multiSelect: false,
+            },
+          ],
+        },
+        {
+          signal: controller.signal,
+          toolUseID: "tool-ask-pre-aborted",
+        },
+      );
+
+      const permissionResult = yield* Effect.promise(() => permissionPromise);
+      assert.deepEqual(permissionResult, {
+        behavior: "deny",
+        message: "User cancelled tool execution.",
+      } satisfies PermissionResult);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        ["user-input.requested", "user-input.resolved"],
+      );
+      const resolvedEvent = runtimeEvents[1];
+      if (resolvedEvent?.type === "user-input.resolved") {
+        assert.deepEqual(resolvedEvent.payload.answers, {});
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("stopping a session settles pending user-input waits", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -749,6 +749,39 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("keeps compact commands intact when ultrathink is selected", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const modelSelection = createModelSelection(
+        ProviderInstanceId.make("claudeAgent"),
+        "claude-sonnet-4-6",
+        [{ id: "effort", value: "ultrathink" }],
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection,
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "/compact",
+        attachments: [],
+        modelSelection,
+      });
+
+      const promptText = yield* Effect.promise(() =>
+        readFirstPromptText(harness.getLastCreateQueryInput()),
+      );
+      assert.equal(promptText, "/compact");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("embeds image attachments in Claude user messages", () => {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-attachments-"));
     const harness = makeHarness({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -543,6 +543,7 @@ function makeClaudeTokenUsageSnapshot(input: {
   readonly totalProcessedTokens?: number;
   readonly lastUsedTokens?: number;
   readonly compactsAutomatically?: boolean;
+  readonly autoCompactThreshold?: number;
 }): ThreadTokenUsageSnapshot | undefined {
   const activeTokens = finiteNonNegativeInteger(input.activeTokens);
   if (activeTokens === undefined || activeTokens <= 0) {
@@ -569,6 +570,9 @@ function makeClaudeTokenUsageSnapshot(input: {
     ...(maxTokens !== undefined ? { maxTokens } : {}),
     ...(input.compactsAutomatically !== undefined
       ? { compactsAutomatically: input.compactsAutomatically }
+      : {}),
+    ...(input.autoCompactThreshold !== undefined
+      ? { autoCompactThreshold: input.autoCompactThreshold }
       : {}),
   };
 }
@@ -604,11 +608,13 @@ function normalizeClaudeContextUsageApiSnapshot(
   value: SDKControlGetContextUsageResponse,
   totalProcessedTokens?: number,
 ): ThreadTokenUsageSnapshot | undefined {
+  const autoCompactThreshold = finitePositiveInteger(value.autoCompactThreshold);
   return makeClaudeTokenUsageSnapshot({
     activeTokens: value.totalTokens,
     contextWindow: value.maxTokens,
     ...(totalProcessedTokens !== undefined ? { totalProcessedTokens } : {}),
     compactsAutomatically: value.isAutoCompactEnabled,
+    ...(autoCompactThreshold !== undefined ? { autoCompactThreshold } : {}),
   });
 }
 
@@ -4001,6 +4007,76 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         } satisfies PermissionResult;
       });
 
+      const handleResumeDialog = Effect.fn("handleResumeDialog")(function* (
+        request: Parameters<NonNullable<ClaudeQueryOptions["onUserDialog"]>>[0],
+        callbackOptions: Parameters<NonNullable<ClaudeQueryOptions["onUserDialog"]>>[1],
+      ) {
+        if (request.dialogKind !== "resume_return") {
+          return { behavior: "cancelled" as const };
+        }
+
+        const context = yield* Ref.get(contextRef);
+        if (!context) {
+          return { behavior: "cancelled" as const };
+        }
+
+        const estimatedTokens = finiteNonNegativeInteger(request.payload.estimatedTokens) ?? 0;
+        const ageMinutes = finiteNonNegativeInteger(request.payload.sessionAgeMinutes) ?? 0;
+        const ageLabel =
+          ageMinutes >= 60
+            ? `${Math.floor(ageMinutes / 60)}h ${ageMinutes % 60}m`
+            : `${ageMinutes}m`;
+        const question = `This session is ${ageLabel} old and uses ${estimatedTokens.toLocaleString("en-US")} tokens. Compact it before continuing?`;
+        const result = yield* handleAskUserQuestion(
+          context,
+          {
+            questions: [
+              {
+                header: "Resume session",
+                question,
+                options: [
+                  {
+                    label: "Compact and continue",
+                    description: "Resume with a summary and use fewer tokens.",
+                  },
+                  {
+                    label: "Keep full history",
+                    description: "Resume without changing the conversation.",
+                  },
+                  {
+                    label: "Don't ask again",
+                    description: "Keep full history and skip future resume prompts.",
+                  },
+                ],
+                multiSelect: false,
+              },
+            ],
+          },
+          {
+            signal: callbackOptions.signal,
+            ...(request.toolUseID ? { toolUseID: request.toolUseID } : {}),
+          },
+        );
+
+        if (result.behavior !== "allow") {
+          return { behavior: "cancelled" as const };
+        }
+
+        const answers = result.updatedInput.answers;
+        const selection =
+          answers && typeof answers === "object" && !Array.isArray(answers)
+            ? (answers as Record<string, unknown>)[question]
+            : undefined;
+        const action =
+          selection === "Compact and continue"
+            ? "compact"
+            : selection === "Don't ask again"
+              ? "never"
+              : "continue";
+
+        return { behavior: "completed" as const, result: action };
+      });
+
       const canUseToolEffect = Effect.fn("canUseTool")(function* (
         toolName: Parameters<CanUseTool>[0],
         toolInput: Parameters<CanUseTool>[1],
@@ -4161,6 +4237,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const canUseTool: CanUseTool = (toolName, toolInput, callbackOptions) =>
         runPromise(canUseToolEffect(toolName, toolInput, callbackOptions));
+      const onUserDialog: NonNullable<ClaudeQueryOptions["onUserDialog"]> = (
+        request,
+        callbackOptions,
+      ) => runPromise(handleResumeDialog(request, callbackOptions));
 
       const claudeBinaryPath = claudeSdkExecutablePath;
       const extraArgs = parseCliArgs(claudeSettings.launchArgs).flags;
@@ -4196,6 +4276,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
         ...(fastMode ? { fastMode: true } : {}),
         ...(ultracode ? { ultracode: true } : {}),
+        ...(claudeSettings.autoCompactWindow
+          ? { autoCompactWindow: Number(claudeSettings.autoCompactWindow) }
+          : {}),
       };
       const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
       // The attachments dir grant lets the agent Read/copy pasted images at
@@ -4228,6 +4311,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(newSessionId ? { sessionId: newSessionId } : {}),
         includePartialMessages: true,
         canUseTool,
+        onUserDialog,
+        supportedDialogKinds: ["resume_return"],
         env: claudeEnvironment,
         additionalDirectories,
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -57,6 +57,10 @@ import {
   getProviderOptionDescriptors,
   resolvePromptInjectedEffort,
 } from "@t3tools/shared/model";
+import {
+  CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
+  formatClaudeResumeCompactionQuestion,
+} from "@t3tools/shared/claudeCompaction";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
@@ -3959,6 +3963,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         callbackOptions.signal.addEventListener("abort", onAbort, {
           once: true,
         });
+        // The signal may have aborted during the awaited event emissions
+        // above, before the listener existed; settle now so the dialog
+        // cannot hang with a lingering pending question.
+        if (callbackOptions.signal.aborted) {
+          yield* settleAsAborted;
+        }
 
         // Block until the user provides answers.
         const answers = yield* Deferred.await(answersDeferred);
@@ -4020,13 +4030,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           return { behavior: "cancelled" as const };
         }
 
-        const estimatedTokens = finiteNonNegativeInteger(request.payload.estimatedTokens) ?? 0;
-        const ageMinutes = finiteNonNegativeInteger(request.payload.sessionAgeMinutes) ?? 0;
-        const ageLabel =
-          ageMinutes >= 60
-            ? `${Math.floor(ageMinutes / 60)}h ${ageMinutes % 60}m`
-            : `${ageMinutes}m`;
-        const question = `This session is ${ageLabel} old and uses ${estimatedTokens.toLocaleString("en-US")} tokens. Compact it before continuing?`;
+        // The question copy lives in @t3tools/shared/claudeCompaction because
+        // the web client recognizes this exact text (and the "never" answer)
+        // to mirror a permanent dismissal.
+        const question = formatClaudeResumeCompactionQuestion({
+          ageMinutes: finiteNonNegativeInteger(request.payload.sessionAgeMinutes) ?? 0,
+          estimatedTokens: finiteNonNegativeInteger(request.payload.estimatedTokens) ?? 0,
+        });
         const result = yield* handleAskUserQuestion(
           context,
           {
@@ -4044,7 +4054,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                     description: "Resume without changing the conversation.",
                   },
                   {
-                    label: "Don't ask again",
+                    label: CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
                     description: "Keep full history and skip future resume prompts.",
                   },
                 ],
@@ -4070,7 +4080,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         const action =
           selection === "Compact and continue"
             ? "compact"
-            : selection === "Don't ask again"
+            : selection === CLAUDE_RESUME_COMPACTION_NEVER_ANSWER
               ? "never"
               : "continue";
 
@@ -4182,6 +4192,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         callbackOptions.signal.addEventListener("abort", onAbort, {
           once: true,
         });
+        // Same late-listener race as handleAskUserQuestion: the signal may
+        // have aborted while the request event emissions were awaited.
+        if (callbackOptions.signal.aborted) {
+          onAbort();
+        }
 
         const decision = yield* Deferred.await(decisionDeferred);
         pendingApprovals.delete(requestId);

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -927,7 +927,13 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
   const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
-  const slashCommands = capabilities?.slashCommands ?? [];
+  const slashCommands = [
+    {
+      name: "compact",
+      description: "Summarize the conversation and reduce context usage",
+    },
+    ...(capabilities?.slashCommands ?? []),
+  ];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
   if (!capabilities) {

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -106,6 +106,7 @@ const makeClaudeConfig = (overrides: Partial<ClaudeSettings>): ClaudeSettings =>
   homePath: "",
   customModels: [],
   launchArgs: "",
+  autoCompactWindow: "",
   ...overrides,
 });
 

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2155,6 +2155,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
           assert.deepStrictEqual(status.slashCommands, [
             {
+              name: "compact",
+              description: "Summarize the conversation and reduce context usage",
+            },
+            {
               name: "review",
               description: "Review a pull request",
               input: { hint: "pr-or-branch" },
@@ -2197,6 +2201,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           );
 
           assert.deepStrictEqual(status.slashCommands, [
+            {
+              name: "compact",
+              description: "Summarize the conversation and reduce context usage",
+            },
             {
               name: "ui",
               description: "Explore and refine UI",

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -190,6 +190,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         homePath: "",
         customModels: ["claude-custom"],
         launchArgs: "",
+        autoCompactWindow: "",
       });
       assert.deepEqual(
         next.textGenerationModelSelection,
@@ -581,6 +582,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         homePath: "",
         customModels: [],
         launchArgs: "",
+        autoCompactWindow: "",
       });
       assert.deepEqual(next.providers.opencode, {
         // OpenCode is disabled by default; this update only touches paths.

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4778,6 +4778,8 @@ function ChatViewContent(props: ChatViewProps) {
     !activeThread ||
     !isServerThread ||
     selectedProvider !== "claudeAgent" ||
+    !activeProviderStatus?.enabled ||
+    activeProviderStatus.availability === "unavailable" ||
     phase === "running" ||
     isSendBusy ||
     isConnecting ||

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -198,7 +198,12 @@ import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { useBrowserHistoryStore } from "~/browserHistoryStore";
 import { registerFaviconProjectForThread } from "~/browserFaviconStore";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
-import { NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
+import {
+  applyProviderInstanceSettings,
+  deriveProviderInstanceEntries,
+  NO_PROVIDER_MODEL_SELECTION,
+  resolveSelectableProviderInstanceEntry,
+} from "../providerInstances";
 import {
   useClientSettings,
   useClientSettingsHydrated,
@@ -2782,6 +2787,19 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread?.modelSelection.instanceId ??
     activeProject?.defaultModelSelection?.instanceId ??
     null;
+  const compactionProviderAvailable = useMemo(() => {
+    const claudeProviders = applyProviderInstanceSettings(
+      deriveProviderInstanceEntries(providerStatuses),
+      settings,
+    ).filter((provider) => provider.driverKind === "claudeAgent");
+
+    return (
+      resolveSelectableProviderInstanceEntry(
+        claudeProviders,
+        activeProviderInstanceId ?? undefined,
+      ) !== undefined
+    );
+  }, [activeProviderInstanceId, providerStatuses, settings]);
   const activeProviderStatus = useMemo(() => {
     if (activeProviderInstanceId) {
       return (
@@ -4776,10 +4794,10 @@ function ChatViewContent(props: ChatViewProps) {
       : null;
   const compactDisabled =
     !activeThread ||
+    !activeProject ||
     !isServerThread ||
     selectedProvider !== "claudeAgent" ||
-    !activeProviderStatus?.enabled ||
-    activeProviderStatus.availability === "unavailable" ||
+    !compactionProviderAvailable ||
     isWorking ||
     threadDetailLoading ||
     isPreparingWorktree ||
@@ -4789,6 +4807,15 @@ function ChatViewContent(props: ChatViewProps) {
     pendingUserInputs.length > 0 ||
     showPlanFollowUpPrompt ||
     composerHasUnsentContent;
+  const compactDisabledReason = compactDisabled
+    ? composerHasUnsentContent
+      ? "Send or clear your draft before compacting"
+      : !activeProject
+        ? "Choose a project before compacting"
+        : !compactionProviderAvailable
+          ? "Enable a Claude provider before compacting"
+          : "Compacting is unavailable right now"
+    : null;
   const resumeCompactionBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
     if (
       !activeThread ||
@@ -4821,6 +4848,7 @@ function ChatViewContent(props: ChatViewProps) {
           size="xs"
           variant="outline"
           disabled={compactDisabled}
+          aria-label={compactDisabledReason ?? "Compact"}
           onClick={() => {
             if (compactDisabled) return;
             composerRef.current?.compactContext();
@@ -4836,6 +4864,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeContextWindow,
     activeThread,
     compactDisabled,
+    compactDisabledReason,
     composerRef,
     dismissedResumeCompactionKey,
     nativeResumeCompactionDismissed,
@@ -6982,6 +7011,7 @@ function ChatViewContent(props: ChatViewProps) {
                             activeThreadModelSelection={activeThread?.modelSelection}
                             activeContextWindow={activeContextWindow}
                             compactDisabled={compactDisabled}
+                            compactDisabledReason={compactDisabledReason}
                             resolvedTheme={resolvedTheme}
                             settings={settings}
                             keybindings={keybindings}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4819,11 +4819,11 @@ function ChatViewContent(props: ChatViewProps) {
       actions: (
         <Button
           size="xs"
+          variant="outline"
           disabled={compactDisabled}
           onClick={() => {
             if (compactDisabled) return;
             composerRef.current?.compactContext();
-            dismiss();
           }}
         >
           Compact

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4780,9 +4780,7 @@ function ChatViewContent(props: ChatViewProps) {
     selectedProvider !== "claudeAgent" ||
     !activeProviderStatus?.enabled ||
     activeProviderStatus.availability === "unavailable" ||
-    phase === "running" ||
-    isSendBusy ||
-    isConnecting ||
+    isWorking ||
     threadDetailLoading ||
     isPreparingWorktree ||
     activeEnvironmentUnavailable ||

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -82,6 +82,7 @@ import {
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
 import * as Cause from "effect/Cause";
+import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { isElectron } from "../env";
 import { readLocalApi } from "../localApi";
@@ -179,6 +180,7 @@ import {
   CheckCircle2Icon,
   ChevronDownIcon,
   GitBranchIcon,
+  Minimize2Icon,
   PaperclipIcon,
   WifiOffIcon,
 } from "lucide-react";
@@ -303,6 +305,11 @@ import {
   threadChangeRequestSnapshotsAtom,
 } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import {
+  hasDismissedResumeCompaction,
+  shouldOfferResumeCompaction,
+} from "./chat/ContextWindowMeter.logic";
+import { deriveLatestContextWindowSnapshot, formatContextWindowTokens } from "../lib/contextWindow";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -1364,6 +1371,18 @@ function ChatViewContent(props: ChatViewProps) {
   const composerActiveProvider = useComposerDraftStore(
     (store) => store.getComposerDraft(composerDraftTarget)?.activeProvider ?? null,
   );
+  const composerHasUnsentContent = useComposerDraftStore((store) => {
+    const draft = store.getComposerDraft(composerDraftTarget);
+    return Boolean(
+      draft &&
+      (draft.prompt.trim().length > 0 ||
+        draft.images.length > 0 ||
+        draft.terminalContexts.length > 0 ||
+        draft.elementContexts.length > 0 ||
+        draft.previewAnnotations.length > 0 ||
+        draft.reviewComments.length > 0),
+    );
+  });
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
   const setComposerDraftTerminalContexts = useComposerDraftStore(
@@ -2296,6 +2315,10 @@ function ChatViewContent(props: ChatViewProps) {
   const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
   const phase = derivePhase(activeThread?.session ?? null);
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const activeContextWindow = useMemo(
+    () => deriveLatestContextWindowSnapshot(threadActivities),
+    [threadActivities],
+  );
   const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
   const turnPlans = useMemo(() => deriveTurnPlans(threadActivities), [threadActivities]);
   // Native subagent fold: memoized by activity-list identity, shared by the
@@ -2768,6 +2791,25 @@ function ChatViewContent(props: ChatViewProps) {
     const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
+  const [resumeCompactionPermanentlyDismissed, setResumeCompactionPermanentlyDismissed] =
+    useLocalStorage(
+      `t3code:resume-compaction-dismissed:${environmentId}:${activeProviderInstanceId ?? "claudeAgent"}`,
+      false,
+      Schema.Boolean,
+    );
+  const nativeResumeCompactionDismissed = useMemo(
+    () => hasDismissedResumeCompaction(threadActivities),
+    [threadActivities],
+  );
+  useEffect(() => {
+    if (nativeResumeCompactionDismissed && !resumeCompactionPermanentlyDismissed) {
+      setResumeCompactionPermanentlyDismissed(true);
+    }
+  }, [
+    nativeResumeCompactionDismissed,
+    resumeCompactionPermanentlyDismissed,
+    setResumeCompactionPermanentlyDismissed,
+  ]);
   const providerStatusBannerKey = getProviderStatusBannerKey(activeProviderStatus);
   const [dismissedProviderStatusBannerKey, setDismissedProviderStatusBannerKey] = useState<
     string | null
@@ -4725,6 +4767,85 @@ function ChatViewContent(props: ChatViewProps) {
     isUnsnoozing,
     isUnsettling,
   ]);
+  const [dismissedResumeCompactionKey, setDismissedResumeCompactionKey] = useState<string | null>(
+    null,
+  );
+  const resumeCompactionKey =
+    activeThread && activeContextWindow
+      ? `${activeThread.id}:${activeContextWindow.updatedAt}`
+      : null;
+  const compactDisabled =
+    !activeThread ||
+    !isServerThread ||
+    selectedProvider !== "claudeAgent" ||
+    phase === "running" ||
+    isSendBusy ||
+    isConnecting ||
+    threadDetailLoading ||
+    isPreparingWorktree ||
+    activeEnvironmentUnavailable ||
+    feedbackUploading ||
+    pendingApprovals.length > 0 ||
+    pendingUserInputs.length > 0 ||
+    showPlanFollowUpPrompt ||
+    composerHasUnsentContent;
+  const resumeCompactionBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
+    if (
+      !activeThread ||
+      !activeContextWindow ||
+      resumeCompactionKey === null ||
+      dismissedResumeCompactionKey === resumeCompactionKey ||
+      resumeCompactionPermanentlyDismissed ||
+      nativeResumeCompactionDismissed ||
+      pendingUserInputs.length > 0 ||
+      phase === "running" ||
+      !shouldOfferResumeCompaction({
+        provider: selectedProvider,
+        usedTokens: activeContextWindow.usedTokens,
+        updatedAt: activeContextWindow.updatedAt,
+        now: `${nowMinute}:00.000Z`,
+      })
+    ) {
+      return null;
+    }
+
+    const dismiss = () => setDismissedResumeCompactionKey(resumeCompactionKey);
+    return {
+      id: `resume-compaction:${resumeCompactionKey}`,
+      variant: "info",
+      icon: <Minimize2Icon />,
+      title: "Resume with less context",
+      description: `${formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from an older session`,
+      actions: (
+        <Button
+          size="xs"
+          disabled={compactDisabled}
+          onClick={() => {
+            if (compactDisabled) return;
+            composerRef.current?.compactContext();
+            dismiss();
+          }}
+        >
+          Compact
+        </Button>
+      ),
+      dismissLabel: "Keep full history",
+      onDismiss: dismiss,
+    };
+  }, [
+    activeContextWindow,
+    activeThread,
+    compactDisabled,
+    composerRef,
+    dismissedResumeCompactionKey,
+    nativeResumeCompactionDismissed,
+    nowMinute,
+    pendingUserInputs.length,
+    phase,
+    resumeCompactionKey,
+    resumeCompactionPermanentlyDismissed,
+    selectedProvider,
+  ]);
   const handleRestoreThreadBranch = useCallback(() => {
     if (gitStatusQuery.data?.hasWorkingTreeChanges) {
       setBranchRestoreConfirmOpen(true);
@@ -4739,6 +4860,8 @@ function ChatViewContent(props: ChatViewProps) {
     const calmSystemItems = systemComposerBannerItems.filter((item) => !isUrgentSystemItem(item));
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
+    const resumeCompactionItems =
+      resumeCompactionBannerItem === null ? [] : [resumeCompactionBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
@@ -4746,6 +4869,7 @@ function ChatViewContent(props: ChatViewProps) {
         ...urgentSystemItems,
         ...backgroundLivenessItems,
         ...calmSystemItems,
+        ...resumeCompactionItems,
         ...wokeThreadItems,
         ...parkedThreadItems,
       ];
@@ -4754,6 +4878,7 @@ function ChatViewContent(props: ChatViewProps) {
       ...urgentSystemItems,
       ...backgroundLivenessItems,
       ...calmSystemItems,
+      ...resumeCompactionItems,
       ...wokeThreadItems,
       {
         id: `branch-mismatch:${activeBranchMismatchKey}`,
@@ -4803,6 +4928,7 @@ function ChatViewContent(props: ChatViewProps) {
     isRestoringThreadBranch,
     localCheckoutBranchMismatch,
     parkedThreadBannerItem,
+    resumeCompactionBannerItem,
     showBranchMismatchBanner,
     systemComposerBannerItems,
     wokeThreadBannerItem,
@@ -6854,7 +6980,8 @@ function ChatViewContent(props: ChatViewProps) {
                               activeProject?.defaultModelSelection
                             }
                             activeThreadModelSelection={activeThread?.modelSelection}
-                            activeThreadActivities={activeThread?.activities}
+                            activeContextWindow={activeContextWindow}
+                            compactDisabled={compactDisabled}
                             resolvedTheme={resolvedTheme}
                             settings={settings}
                             keybindings={keybindings}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -229,6 +229,7 @@ import { buildDraftThreadRouteParams, buildThreadRouteParams } from "../threadRo
 import {
   beginBackgroundDraftSubmissionByRef,
   clearBackgroundDraftSubmissionByRef,
+  composerDraftHasUserContent,
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
   finalizePromotedDraftThreadByRef,
@@ -1376,18 +1377,9 @@ function ChatViewContent(props: ChatViewProps) {
   const composerActiveProvider = useComposerDraftStore(
     (store) => store.getComposerDraft(composerDraftTarget)?.activeProvider ?? null,
   );
-  const composerHasUnsentContent = useComposerDraftStore((store) => {
-    const draft = store.getComposerDraft(composerDraftTarget);
-    return Boolean(
-      draft &&
-      (draft.prompt.trim().length > 0 ||
-        draft.images.length > 0 ||
-        draft.terminalContexts.length > 0 ||
-        draft.elementContexts.length > 0 ||
-        draft.previewAnnotations.length > 0 ||
-        draft.reviewComments.length > 0),
-    );
-  });
+  const composerHasUnsentContent = useComposerDraftStore((store) =>
+    composerDraftHasUserContent(store.getComposerDraft(composerDraftTarget)),
+  );
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
   const setComposerDraftTerminalContexts = useComposerDraftStore(
@@ -4542,18 +4534,6 @@ function ChatViewContent(props: ChatViewProps) {
   // Dismissal lives in a module-level set (survives remounts); this tick just
   // forces a re-render so the banner leaves immediately.
   const [, setBranchMismatchDismissTick] = useState(0);
-  const composerHasDraftContent = useComposerDraftStore((store) => {
-    const draft = store.getComposerDraft(composerDraftTarget);
-    return Boolean(
-      draft &&
-      (draft.prompt.trim().length > 0 ||
-        draft.images.length > 0 ||
-        draft.terminalContexts.length > 0 ||
-        draft.elementContexts.length > 0 ||
-        draft.previewAnnotations.length > 0 ||
-        draft.reviewComments.length > 0),
-    );
-  });
   const activeBranchMismatchKey = branchMismatchKey(
     activeThread?.id ?? null,
     localCheckoutBranchMismatch,
@@ -4561,7 +4541,7 @@ function ChatViewContent(props: ChatViewProps) {
   const showBranchMismatchBanner = shouldShowBranchMismatchBanner({
     hasMismatch: localCheckoutBranchMismatch !== null,
     isDismissed: isBranchMismatchDismissedForSession(activeBranchMismatchKey),
-    composerHasContent: composerHasDraftContent,
+    composerHasContent: composerHasUnsentContent,
     wasShownForCurrentMismatch:
       revealedBranchMismatchKey !== null && revealedBranchMismatchKey === activeBranchMismatchKey,
   });
@@ -4837,25 +4817,32 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     const dismiss = () => setDismissedResumeCompactionKey(resumeCompactionKey);
+    const compactAction = (
+      <Button
+        size="xs"
+        variant="outline"
+        disabled={compactDisabled}
+        onClick={() => {
+          if (compactDisabled) return;
+          composerRef.current?.compactContext();
+        }}
+      >
+        Compact
+      </Button>
+    );
     return {
       id: `resume-compaction:${resumeCompactionKey}`,
       variant: "info",
       icon: <Minimize2Icon />,
       title: "Resume with less context",
       description: `${formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from an older session`,
-      actions: (
-        <Button
-          size="xs"
-          variant="outline"
-          disabled={compactDisabled}
-          aria-label={compactDisabledReason ?? "Compact"}
-          onClick={() => {
-            if (compactDisabled) return;
-            composerRef.current?.compactContext();
-          }}
-        >
-          Compact
-        </Button>
+      actions: compactDisabledReason ? (
+        <Tooltip>
+          <TooltipTrigger render={<span className="inline-flex">{compactAction}</span>} />
+          <TooltipPopup side="top">{compactDisabledReason}</TooltipPopup>
+        </Tooltip>
+      ) : (
+        compactAction
       ),
       dismissLabel: "Keep full history",
       onDismiss: dismiss,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -202,7 +202,6 @@ import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
   NO_PROVIDER_MODEL_SELECTION,
-  resolveSelectableProviderInstanceEntry,
 } from "../providerInstances";
 import {
   useClientSettings,
@@ -312,6 +311,7 @@ import {
 } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
 import {
+  hasAvailableClaudeCompactionProvider,
   hasDismissedResumeCompaction,
   shouldOfferResumeCompaction,
 } from "./chat/ContextWindowMeter.logic";
@@ -2779,19 +2779,29 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread?.modelSelection.instanceId ??
     activeProject?.defaultModelSelection?.instanceId ??
     null;
-  const compactionProviderAvailable = useMemo(() => {
-    const claudeProviders = applyProviderInstanceSettings(
-      deriveProviderInstanceEntries(providerStatuses),
+  const compactionProviderAvailable = useMemo(
+    () =>
+      hasAvailableClaudeCompactionProvider({
+        providers: applyProviderInstanceSettings(
+          deriveProviderInstanceEntries(providerStatuses),
+          settings,
+        ),
+        instanceId: activeProviderInstanceId,
+        lockedInstanceId: lockedProvider
+          ? (activeThread?.session?.providerInstanceId ??
+            activeThread?.modelSelection.instanceId ??
+            null)
+          : null,
+      }),
+    [
+      activeProviderInstanceId,
+      activeThread?.modelSelection.instanceId,
+      activeThread?.session?.providerInstanceId,
+      lockedProvider,
+      providerStatuses,
       settings,
-    ).filter((provider) => provider.driverKind === "claudeAgent");
-
-    return (
-      resolveSelectableProviderInstanceEntry(
-        claudeProviders,
-        activeProviderInstanceId ?? undefined,
-      ) !== undefined
-    );
-  }, [activeProviderInstanceId, providerStatuses, settings]);
+    ],
+  );
   const activeProviderStatus = useMemo(() => {
     if (activeProviderInstanceId) {
       return (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4775,9 +4775,12 @@ function ChatViewContent(props: ChatViewProps) {
     isUnsnoozing,
     isUnsettling,
   ]);
-  const [dismissedResumeCompactionKey, setDismissedResumeCompactionKey] = useState<string | null>(
-    null,
-  );
+  // Session-scoped dismissals, one key per (thread, snapshot). A set rather
+  // than a single slot so dismissing the banner on one thread does not
+  // resurface it on another thread dismissed earlier.
+  const [dismissedResumeCompactionKeys, setDismissedResumeCompactionKeys] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const resumeCompactionKey =
     activeThread && activeContextWindow
       ? `${activeThread.id}:${activeContextWindow.updatedAt}`
@@ -4811,7 +4814,7 @@ function ChatViewContent(props: ChatViewProps) {
       !activeThread ||
       !activeContextWindow ||
       resumeCompactionKey === null ||
-      dismissedResumeCompactionKey === resumeCompactionKey ||
+      dismissedResumeCompactionKeys.has(resumeCompactionKey) ||
       resumeCompactionPermanentlyDismissed ||
       nativeResumeCompactionDismissed ||
       pendingUserInputs.length > 0 ||
@@ -4826,7 +4829,8 @@ function ChatViewContent(props: ChatViewProps) {
       return null;
     }
 
-    const dismiss = () => setDismissedResumeCompactionKey(resumeCompactionKey);
+    const dismiss = () =>
+      setDismissedResumeCompactionKeys((keys) => new Set(keys).add(resumeCompactionKey));
     const compactAction = (
       <Button
         size="xs"
@@ -4863,7 +4867,7 @@ function ChatViewContent(props: ChatViewProps) {
     compactDisabled,
     compactDisabledReason,
     composerRef,
-    dismissedResumeCompactionKey,
+    dismissedResumeCompactionKeys,
     nativeResumeCompactionDismissed,
     nowMinute,
     pendingUserInputs.length,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1988,6 +1988,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const compactThreadContext = useCallback(() => {
     if (
       compactDisabled ||
+      noProviderAvailable ||
       composerSendState.hasSendableContent ||
       activePendingApproval !== null ||
       pendingUserInputs.length > 0 ||
@@ -2010,6 +2011,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     composerSendState.hasSendableContent,
     isConnecting,
     isSendBusy,
+    noProviderAvailable,
     onSend,
     pendingUserInputs.length,
     phase,
@@ -3543,7 +3545,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
                     onInterrupt={handleInterruptPrimaryAction}
                     onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
-                    compactDisabled={compactDisabled}
+                    compactDisabled={compactDisabled || noProviderAvailable}
                     {...(selectedProvider === "claudeAgent"
                       ? { onCompactContext: compactThreadContext }
                       : {})}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -459,6 +459,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   onImplementPlanInNewThread: () => void;
   onCompactContext?: (() => void) | undefined;
   compactDisabled: boolean;
+  compactDisabledReason: string | null;
 }) {
   return (
     <>
@@ -468,6 +469,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
           modelDisplayName={props.activeThreadModelDisplayName}
           onCompact={props.onCompactContext}
           compactDisabled={props.compactDisabled}
+          compactDisabledReason={props.compactDisabledReason}
         />
       ) : null}
       {props.isPreparingWorktree ? (
@@ -612,6 +614,7 @@ export interface ChatComposerProps {
   // Context window
   activeContextWindow: ContextWindowSnapshot | null;
   compactDisabled: boolean;
+  compactDisabledReason: string | null;
 
   // Misc
   resolvedTheme: "light" | "dark";
@@ -705,6 +708,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThreadModelSelection,
     activeContextWindow,
     compactDisabled,
+    compactDisabledReason,
     resolvedTheme,
     settings,
     keybindings,
@@ -917,6 +921,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [providerInstanceEntries, selectedInstanceId],
   );
   const noProviderAvailable = selectedProviderEntry === undefined;
+  const resolvedCompactDisabledReason =
+    compactDisabledReason ?? (noProviderAvailable ? "Compacting is unavailable right now" : null);
   // The driver kind follows the instance that will actually run the turn,
   // which can differ from the persisted selection when that selection is
   // disabled.
@@ -1072,8 +1078,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   /**
    * Count of pasted images still being compressed, per thread. Reserved
    * against the attachment limit so concurrent pastes can't overshoot it,
-   * and checked by `submitComposer` so a send can't race an image into the
-   * next draft.
+   * and checked before sending or compacting so an image cannot move into
+   * the next draft.
    */
   const pendingImageCompressionsRef = useRef<Map<ThreadId, number>>(new Map());
 
@@ -1995,14 +2001,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       phase === "running" ||
       isSendBusy ||
       isConnecting ||
-      !activeThreadId
+      !activeThreadId ||
+      (pendingImageCompressionsRef.current.get(activeThreadId) ?? 0) > 0
     ) {
       return;
     }
 
     promptRef.current = "/compact";
     setComposerDraftPrompt(composerDraftTarget, "/compact");
-    onSend();
+    submitComposer();
   }, [
     activePendingApproval,
     activeThreadId,
@@ -2012,11 +2019,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isConnecting,
     isSendBusy,
     noProviderAvailable,
-    onSend,
     pendingUserInputs.length,
     phase,
     promptRef,
     setComposerDraftPrompt,
+    submitComposer,
   ]);
   const expandMobileComposer = useCallback(() => {
     if (composerBlurFrameRef.current !== null) {
@@ -3546,6 +3553,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onInterrupt={handleInterruptPrimaryAction}
                     onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
                     compactDisabled={compactDisabled || noProviderAvailable}
+                    compactDisabledReason={resolvedCompactDisabledReason}
                     {...(selectedProvider === "claudeAgent"
                       ? { onCompactContext: compactThreadContext }
                       : {})}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -122,12 +122,7 @@ import {
   renderProviderTraitsPicker,
 } from "./composerProviderState";
 import { ContextWindowMeter } from "./ContextWindowMeter";
-import {
-  resolveContextWindowModelDisplayName,
-  shouldOfferResumeCompaction,
-} from "./ContextWindowMeter.logic";
-import { formatContextWindowTokens } from "~/lib/contextWindow";
-import { useNowMinute } from "../../hooks/useNowMinute";
+import { resolveContextWindowModelDisplayName } from "./ContextWindowMeter.logic";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
@@ -267,7 +262,7 @@ import type { UnifiedSettings } from "@t3tools/contracts/settings";
 import type { SessionPhase, Thread } from "../../types";
 import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
 import type { PendingApproval, PendingUserInput } from "../../session-logic";
-import { deriveLatestContextWindowSnapshot } from "../../lib/contextWindow";
+import type { ContextWindowSnapshot } from "../../lib/contextWindow";
 import {
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
@@ -439,7 +434,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
 
 const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(props: {
   compact: boolean;
-  activeContextWindow: ReturnType<typeof deriveLatestContextWindowSnapshot>;
+  activeContextWindow: ContextWindowSnapshot | null;
   activeThreadModelDisplayName: string | null;
   isPreparingWorktree: boolean;
   pendingAction: {
@@ -463,6 +458,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   onInterrupt: () => void;
   onImplementPlanInNewThread: () => void;
   onCompactContext?: (() => void) | undefined;
+  compactDisabled: boolean;
 }) {
   return (
     <>
@@ -471,7 +467,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
           usage={props.activeContextWindow}
           modelDisplayName={props.activeThreadModelDisplayName}
           onCompact={props.onCompactContext}
-          compactDisabled={props.isRunning || props.isSendBusy || props.isConnecting}
+          compactDisabled={props.compactDisabled}
         />
       ) : null}
       {props.isPreparingWorktree ? (
@@ -511,6 +507,7 @@ export interface ChatComposerHandle {
   openModelPicker: () => void;
   toggleModelPicker: () => void;
   isModelPickerOpen: () => boolean;
+  compactContext: () => void;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -613,7 +610,8 @@ export interface ChatComposerProps {
   activeThreadModelSelection: ModelSelection | null | undefined;
 
   // Context window
-  activeThreadActivities: Thread["activities"] | undefined;
+  activeContextWindow: ContextWindowSnapshot | null;
+  compactDisabled: boolean;
 
   // Misc
   resolvedTheme: "light" | "dark";
@@ -705,7 +703,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     providerStatuses,
     activeProjectDefaultModelSelection,
     activeThreadModelSelection,
-    activeThreadActivities,
+    activeContextWindow,
+    compactDisabled,
     resolvedTheme,
     settings,
     keybindings,
@@ -1008,33 +1007,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Context window
   // ------------------------------------------------------------------
-  const activeContextWindow = useMemo(
-    () => deriveLatestContextWindowSnapshot(activeThreadActivities ?? []),
-    [activeThreadActivities],
-  );
   const activeThreadModelDisplayName = useMemo(
     () => resolveContextWindowModelDisplayName(activeThreadModelSelection, modelOptionsByInstance),
     [activeThreadModelSelection, modelOptionsByInstance],
   );
-  const nowMinute = useNowMinute();
-  const resumeCompactionNoticeKey =
-    activeThreadId && activeContextWindow
-      ? `${activeThreadId}:${activeContextWindow.updatedAt}`
-      : null;
-  const [dismissedResumeCompactionNoticeKey, setDismissedResumeCompactionNoticeKey] = useState<
-    string | null
-  >(null);
-  const showResumeCompactionNotice =
-    phase !== "running" &&
-    pendingUserInputs.length === 0 &&
-    resumeCompactionNoticeKey !== null &&
-    dismissedResumeCompactionNoticeKey !== resumeCompactionNoticeKey &&
-    shouldOfferResumeCompaction({
-      provider: selectedProvider,
-      usedTokens: activeContextWindow?.usedTokens,
-      updatedAt: activeContextWindow?.updatedAt,
-      now: `${nowMinute}:00.000Z`,
-    });
 
   // ------------------------------------------------------------------
   // Composer-local state
@@ -2010,25 +1986,34 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ],
   );
   const compactThreadContext = useCallback(() => {
-    if (phase === "running" || isSendBusy || isConnecting || !activeThreadId) {
+    if (
+      compactDisabled ||
+      composerSendState.hasSendableContent ||
+      activePendingApproval !== null ||
+      pendingUserInputs.length > 0 ||
+      phase === "running" ||
+      isSendBusy ||
+      isConnecting ||
+      !activeThreadId
+    ) {
       return;
     }
 
-    if (resumeCompactionNoticeKey) {
-      setDismissedResumeCompactionNoticeKey(resumeCompactionNoticeKey);
-    }
     promptRef.current = "/compact";
     setComposerDraftPrompt(composerDraftTarget, "/compact");
     onSend();
   }, [
+    activePendingApproval,
     activeThreadId,
+    compactDisabled,
     composerDraftTarget,
+    composerSendState.hasSendableContent,
     isConnecting,
     isSendBusy,
     onSend,
+    pendingUserInputs.length,
     phase,
     promptRef,
-    resumeCompactionNoticeKey,
     setComposerDraftPrompt,
   ]);
   const expandMobileComposer = useCallback(() => {
@@ -2803,6 +2788,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       toggleModelPicker: () => {
         setIsComposerModelPickerOpen((open) => !open);
       },
+      compactContext: compactThreadContext,
       isModelPickerOpen: () => isComposerModelPickerOpen,
       readSnapshot: () => {
         return readComposerSnapshot();
@@ -2914,6 +2900,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       selectedPromptEffort,
       selectedProvider,
       selectedProviderModels,
+      compactThreadContext,
     ],
   );
 
@@ -2948,32 +2935,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       className={cn("mx-auto w-full min-w-0 max-w-3xl", hasShoulderTab && "pt-7")}
       data-chat-composer-form="true"
     >
-      {showResumeCompactionNotice && activeContextWindow ? (
-        <div
-          className="mb-2 flex items-start justify-between gap-3 border-l-2 border-primary/60 px-3 py-2"
-          data-chat-composer-compaction-notice="true"
-        >
-          <div className="min-w-0">
-            <div className="text-sm font-medium text-foreground">Resume with less context</div>
-            <div className="text-xs text-muted-foreground">
-              {formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from an older
-              session
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <Button
-              size="xs"
-              variant="ghost-muted"
-              onClick={() => setDismissedResumeCompactionNoticeKey(resumeCompactionNoticeKey)}
-            >
-              Keep
-            </Button>
-            <Button size="xs" onClick={compactThreadContext}>
-              Compact
-            </Button>
-          </div>
-        </div>
-      ) : null}
       {showComposerTopDrawer && (!isTasksDrawerOpen || hasBlockingComposerTopDrawer) ? (
         <div
           className="chat-composer-top-drawer"
@@ -3582,6 +3543,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
                     onInterrupt={handleInterruptPrimaryAction}
                     onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
+                    compactDisabled={compactDisabled}
                     {...(selectedProvider === "claudeAgent"
                       ? { onCompactContext: compactThreadContext }
                       : {})}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -122,7 +122,12 @@ import {
   renderProviderTraitsPicker,
 } from "./composerProviderState";
 import { ContextWindowMeter } from "./ContextWindowMeter";
-import { resolveContextWindowModelDisplayName } from "./ContextWindowMeter.logic";
+import {
+  resolveContextWindowModelDisplayName,
+  shouldOfferResumeCompaction,
+} from "./ContextWindowMeter.logic";
+import { formatContextWindowTokens } from "~/lib/contextWindow";
+import { useNowMinute } from "../../hooks/useNowMinute";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
@@ -457,6 +462,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   onPreviousPendingQuestion: () => void;
   onInterrupt: () => void;
   onImplementPlanInNewThread: () => void;
+  onCompactContext?: (() => void) | undefined;
 }) {
   return (
     <>
@@ -464,6 +470,8 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
         <ContextWindowMeter
           usage={props.activeContextWindow}
           modelDisplayName={props.activeThreadModelDisplayName}
+          onCompact={props.onCompactContext}
+          compactDisabled={props.isRunning || props.isSendBusy || props.isConnecting}
         />
       ) : null}
       {props.isPreparingWorktree ? (
@@ -1008,6 +1016,25 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => resolveContextWindowModelDisplayName(activeThreadModelSelection, modelOptionsByInstance),
     [activeThreadModelSelection, modelOptionsByInstance],
   );
+  const nowMinute = useNowMinute();
+  const resumeCompactionNoticeKey =
+    activeThreadId && activeContextWindow
+      ? `${activeThreadId}:${activeContextWindow.updatedAt}`
+      : null;
+  const [dismissedResumeCompactionNoticeKey, setDismissedResumeCompactionNoticeKey] = useState<
+    string | null
+  >(null);
+  const showResumeCompactionNotice =
+    phase !== "running" &&
+    pendingUserInputs.length === 0 &&
+    resumeCompactionNoticeKey !== null &&
+    dismissedResumeCompactionNoticeKey !== resumeCompactionNoticeKey &&
+    shouldOfferResumeCompaction({
+      provider: selectedProvider,
+      usedTokens: activeContextWindow?.usedTokens,
+      updatedAt: activeContextWindow?.updatedAt,
+      now: `${nowMinute}:00.000Z`,
+    });
 
   // ------------------------------------------------------------------
   // Composer-local state
@@ -1982,6 +2009,28 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       shouldBlurMobileComposerOnSubmit,
     ],
   );
+  const compactThreadContext = useCallback(() => {
+    if (phase === "running" || isSendBusy || isConnecting || !activeThreadId) {
+      return;
+    }
+
+    if (resumeCompactionNoticeKey) {
+      setDismissedResumeCompactionNoticeKey(resumeCompactionNoticeKey);
+    }
+    promptRef.current = "/compact";
+    setComposerDraftPrompt(composerDraftTarget, "/compact");
+    onSend();
+  }, [
+    activeThreadId,
+    composerDraftTarget,
+    isConnecting,
+    isSendBusy,
+    onSend,
+    phase,
+    promptRef,
+    resumeCompactionNoticeKey,
+    setComposerDraftPrompt,
+  ]);
   const expandMobileComposer = useCallback(() => {
     if (composerBlurFrameRef.current !== null) {
       window.cancelAnimationFrame(composerBlurFrameRef.current);
@@ -2899,6 +2948,32 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       className={cn("mx-auto w-full min-w-0 max-w-3xl", hasShoulderTab && "pt-7")}
       data-chat-composer-form="true"
     >
+      {showResumeCompactionNotice && activeContextWindow ? (
+        <div
+          className="mb-2 flex items-start justify-between gap-3 border-l-2 border-primary/60 px-3 py-2"
+          data-chat-composer-compaction-notice="true"
+        >
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-foreground">Resume with less context</div>
+            <div className="text-xs text-muted-foreground">
+              {formatContextWindowTokens(activeContextWindow.usedTokens)} tokens from an older
+              session
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              size="xs"
+              variant="ghost-muted"
+              onClick={() => setDismissedResumeCompactionNoticeKey(resumeCompactionNoticeKey)}
+            >
+              Keep
+            </Button>
+            <Button size="xs" onClick={compactThreadContext}>
+              Compact
+            </Button>
+          </div>
+        </div>
+      ) : null}
       {showComposerTopDrawer && (!isTasksDrawerOpen || hasBlockingComposerTopDrawer) ? (
         <div
           className="chat-composer-top-drawer"
@@ -3507,6 +3582,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
                     onInterrupt={handleInterruptPrimaryAction}
                     onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
+                    {...(selectedProvider === "claudeAgent"
+                      ? { onCompactContext: compactThreadContext }
+                      : {})}
                   />
                 </div>
               </div>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3570,7 +3570,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
                     onInterrupt={handleInterruptPrimaryAction}
                     onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
-                    compactDisabled={compactDisabled || noProviderAvailable}
+                    compactDisabled={
+                      compactDisabled || noProviderAvailable || isSendBusy || isConnecting
+                    }
                     compactDisabledReason={resolvedCompactDisabledReason}
                     {...(selectedProvider === "claudeAgent"
                       ? { onCompactContext: compactThreadContext }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2001,15 +2001,33 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       phase === "running" ||
       isSendBusy ||
       isConnecting ||
-      !activeThreadId ||
-      (pendingImageCompressionsRef.current.get(activeThreadId) ?? 0) > 0
+      !activeThreadId
     ) {
+      return;
+    }
+    // The compact buttons cannot see the compression counter (it lives in
+    // a ref), so they render enabled during a paste; toast instead of
+    // silently ignoring the click.
+    if ((pendingImageCompressionsRef.current.get(activeThreadId) ?? 0) > 0) {
+      toastManager.add({
+        type: "info",
+        title: "Still compressing a pasted image.",
+        description: "Compact again once its thumbnail appears.",
+      });
       return;
     }
 
     promptRef.current = "/compact";
     setComposerDraftPrompt(composerDraftTarget, "/compact");
     submitComposer();
+    // A blocked dispatch (busy send ref, provider preflight rejection)
+    // would leave the injected "/compact" behind as if the user typed it.
+    // Clearing here is safe even when the send did dispatch: the send
+    // snapshots its prompt synchronously and clears the draft itself.
+    if (promptRef.current === "/compact") {
+      promptRef.current = "";
+      setComposerDraftPrompt(composerDraftTarget, "");
+    }
   }, [
     activePendingApproval,
     activeThreadId,

--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -77,4 +77,32 @@ describe("ComposerBannerStack", () => {
     expect(markup).toContain("branch-surface");
     expect(markup).toContain("branch-actions");
   });
+
+  it("renders a disabled compaction action on the shared accessible banner surface", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerBannerStack
+        items={[
+          {
+            id: "resume-compaction",
+            variant: "info",
+            icon: <span aria-hidden="true">!</span>,
+            title: "Resume with less context",
+            description: "250k tokens from an older session",
+            actions: (
+              <button type="button" disabled>
+                Compact
+              </button>
+            ),
+            dismissLabel: "Keep full history",
+            onDismiss: () => {},
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("chat-composer-drawer-attached");
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('aria-label="Keep full history"');
+  });
 });

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
@@ -118,7 +118,7 @@ describe("hasDismissedResumeCompaction", () => {
           kind: "user-input.resolved",
           payload: {
             answers: {
-              "This session is 2h old and uses 250,000 tokens. Compact it before continuing?":
+              "This session is 2h 0m old and uses 250,000 tokens. Compact it before continuing?":
                 "Don't ask again",
             },
           },
@@ -133,6 +133,21 @@ describe("hasDismissedResumeCompaction", () => {
         {
           kind: "user-input.resolved",
           payload: { answers: { "Show this setup reminder?": "Don't ask again" } },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("ignores unrelated questions that end with Claude's compaction prompt", () => {
+    expect(
+      hasDismissedResumeCompaction([
+        {
+          kind: "user-input.resolved",
+          payload: {
+            answers: {
+              "The build cache is large. Compact it before continuing?": "Don't ask again",
+            },
+          },
         },
       ]),
     ).toBe(false);

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
@@ -2,6 +2,7 @@ import { ProviderInstanceId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
   formatContextWindowCompactionMessage,
+  hasDismissedResumeCompaction,
   resolveContextWindowModelDisplayName,
   shouldOfferResumeCompaction,
 } from "./ContextWindowMeter.logic";
@@ -105,6 +106,45 @@ describe("shouldOfferResumeCompaction", () => {
         updatedAt: "2026-08-24T09:00:00.000Z",
         now,
       }),
+    ).toBe(false);
+  });
+});
+
+describe("hasDismissedResumeCompaction", () => {
+  it("recognizes the native resume dialog's permanent dismissal", () => {
+    expect(
+      hasDismissedResumeCompaction([
+        {
+          kind: "user-input.resolved",
+          payload: {
+            answers: {
+              "This session is 2h old and uses 250,000 tokens. Compact it before continuing?":
+                "Don't ask again",
+            },
+          },
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it("ignores the same answer on an unrelated question", () => {
+    expect(
+      hasDismissedResumeCompaction([
+        {
+          kind: "user-input.resolved",
+          payload: { answers: { "Show this setup reminder?": "Don't ask again" } },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("ignores pending questions and malformed resolved payloads", () => {
+    expect(
+      hasDismissedResumeCompaction([
+        { kind: "user-input.requested", payload: { answers: { question: "Don't ask again" } } },
+        { kind: "user-input.resolved", payload: null },
+        { kind: "user-input.resolved", payload: { answers: ["Don't ask again"] } },
+      ]),
     ).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   formatContextWindowCompactionMessage,
   resolveContextWindowModelDisplayName,
+  shouldOfferResumeCompaction,
 } from "./ContextWindowMeter.logic";
 
 describe("resolveContextWindowModelDisplayName", () => {
@@ -54,5 +55,56 @@ describe("formatContextWindowCompactionMessage", () => {
     expect(formatContextWindowCompactionMessage(null)).toBe(
       "Context compacts automatically when needed.",
     );
+  });
+
+  it("shows the configured auto-compaction threshold", () => {
+    expect(formatContextWindowCompactionMessage("Claude Sonnet 5", 300_000)).toBe(
+      "Compacts automatically at 300,000 tokens.",
+    );
+  });
+});
+
+describe("shouldOfferResumeCompaction", () => {
+  const now = "2026-08-24T12:00:00.000Z";
+
+  it("matches Claude's old-session age and context thresholds", () => {
+    expect(
+      shouldOfferResumeCompaction({
+        provider: "claudeAgent",
+        usedTokens: 100_000,
+        updatedAt: "2026-08-24T10:50:00.000Z",
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not prompt for recent or smaller sessions", () => {
+    expect(
+      shouldOfferResumeCompaction({
+        provider: "claudeAgent",
+        usedTokens: 99_999,
+        updatedAt: "2026-08-24T10:00:00.000Z",
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOfferResumeCompaction({
+        provider: "claudeAgent",
+        usedTokens: 200_000,
+        updatedAt: "2026-08-24T10:51:00.000Z",
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not show Claude's resume prompt for another provider", () => {
+    expect(
+      shouldOfferResumeCompaction({
+        provider: "codex",
+        usedTokens: 300_000,
+        updatedAt: "2026-08-24T09:00:00.000Z",
+        now,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.test.ts
@@ -1,11 +1,82 @@
-import { ProviderInstanceId } from "@t3tools/contracts";
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
+import { deriveProviderInstanceEntries } from "../../providerInstances";
 import {
   formatContextWindowCompactionMessage,
+  hasAvailableClaudeCompactionProvider,
   hasDismissedResumeCompaction,
   resolveContextWindowModelDisplayName,
   shouldOfferResumeCompaction,
 } from "./ContextWindowMeter.logic";
+
+function claudeProvider(input: {
+  instanceId: string;
+  continuationGroupKey: string;
+  enabled?: boolean;
+}): ServerProvider {
+  return {
+    instanceId: ProviderInstanceId.make(input.instanceId),
+    driver: ProviderDriverKind.make("claudeAgent"),
+    continuation: { groupKey: input.continuationGroupKey },
+    enabled: input.enabled ?? true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-08-24T12:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+  };
+}
+
+describe("hasAvailableClaudeCompactionProvider", () => {
+  const originalInstanceId = ProviderInstanceId.make("claude_original");
+
+  it("rejects a fallback in a different locked continuation group", () => {
+    const providers = deriveProviderInstanceEntries([
+      claudeProvider({
+        instanceId: originalInstanceId,
+        continuationGroupKey: "claude:home:/original",
+        enabled: false,
+      }),
+      claudeProvider({
+        instanceId: "claude_other",
+        continuationGroupKey: "claude:home:/other",
+      }),
+    ]);
+
+    expect(
+      hasAvailableClaudeCompactionProvider({
+        providers,
+        instanceId: originalInstanceId,
+        lockedInstanceId: originalInstanceId,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts an enabled fallback in the locked continuation group", () => {
+    const providers = deriveProviderInstanceEntries([
+      claudeProvider({
+        instanceId: originalInstanceId,
+        continuationGroupKey: "claude:home:/original",
+        enabled: false,
+      }),
+      claudeProvider({
+        instanceId: "claude_fallback",
+        continuationGroupKey: "claude:home:/original",
+      }),
+    ]);
+
+    expect(
+      hasAvailableClaudeCompactionProvider({
+        providers,
+        instanceId: originalInstanceId,
+        lockedInstanceId: originalInstanceId,
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("resolveContextWindowModelDisplayName", () => {
   it("uses the selected model from the exact provider instance", () => {

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -3,6 +3,25 @@ import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils
 
 export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
 export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
+export const CLAUDE_RESUME_COMPACTION_NEVER_ANSWER = "Don't ask again";
+
+export function hasDismissedResumeCompaction(
+  activities: ReadonlyArray<{ readonly kind: string; readonly payload: unknown }>,
+): boolean {
+  return activities.some((activity) => {
+    if (activity.kind !== "user-input.resolved") return false;
+    const payload = activity.payload;
+    if (!payload || typeof payload !== "object") return false;
+    const answers = (payload as { readonly answers?: unknown }).answers;
+    if (!answers || typeof answers !== "object" || Array.isArray(answers)) return false;
+
+    return Object.entries(answers).some(
+      ([question, answer]) =>
+        question.endsWith("Compact it before continuing?") &&
+        answer === CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
+    );
+  });
+}
 
 export function shouldOfferResumeCompaction(input: {
   readonly provider: string | null | undefined;

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -4,6 +4,8 @@ import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils
 export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
 export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
 export const CLAUDE_RESUME_COMPACTION_NEVER_ANSWER = "Don't ask again";
+const CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN =
+  /^This session is (?:\d+h \d+m|\d+m) old and uses \d{1,3}(?:,\d{3})* tokens\. Compact it before continuing\?$/u;
 
 export function hasDismissedResumeCompaction(
   activities: ReadonlyArray<{ readonly kind: string; readonly payload: unknown }>,
@@ -17,7 +19,7 @@ export function hasDismissedResumeCompaction(
 
     return Object.entries(answers).some(
       ([question, answer]) =>
-        question.endsWith("Compact it before continuing?") &&
+        CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN.test(question) &&
         answer === CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
     );
   });

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -1,6 +1,31 @@
 import type { ModelSelection, ProviderInstanceId } from "@t3tools/contracts";
 import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils";
 
+export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
+export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
+
+export function shouldOfferResumeCompaction(input: {
+  readonly provider: string | null | undefined;
+  readonly usedTokens: number | null | undefined;
+  readonly updatedAt: string | null | undefined;
+  readonly now: string;
+}): boolean {
+  if (
+    input.provider !== "claudeAgent" ||
+    (input.usedTokens ?? 0) < CLAUDE_RESUME_COMPACTION_TOKENS
+  ) {
+    return false;
+  }
+
+  const updatedAt = Date.parse(input.updatedAt ?? "");
+  const now = Date.parse(input.now);
+  return (
+    Number.isFinite(updatedAt) &&
+    Number.isFinite(now) &&
+    now - updatedAt >= CLAUDE_RESUME_COMPACTION_MINUTES * 60_000
+  );
+}
+
 export function resolveContextWindowModelDisplayName(
   selection: ModelSelection | null | undefined,
   modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>,
@@ -18,7 +43,11 @@ export function resolveContextWindowModelDisplayName(
 
 export function formatContextWindowCompactionMessage(
   modelDisplayName: string | null | undefined,
+  autoCompactThreshold?: number | null,
 ): string {
+  if (typeof autoCompactThreshold === "number" && autoCompactThreshold > 0) {
+    return `Compacts automatically at ${autoCompactThreshold.toLocaleString("en-US")} tokens.`;
+  }
   return modelDisplayName
     ? `Context for ${modelDisplayName} compacts automatically when needed.`
     : "Context compacts automatically when needed.";

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -1,5 +1,9 @@
 import type { ModelSelection, ProviderInstanceId } from "@t3tools/contracts";
 import {
+  CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
+  isClaudeResumeCompactionQuestion,
+} from "@t3tools/shared/claudeCompaction";
+import {
   resolveSelectableProviderInstanceEntry,
   type ProviderInstanceEntry,
 } from "../../providerInstances";
@@ -7,9 +11,6 @@ import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils
 
 export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
 export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
-export const CLAUDE_RESUME_COMPACTION_NEVER_ANSWER = "Don't ask again";
-const CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN =
-  /^This session is (?:\d+h \d+m|\d+m) old and uses \d{1,3}(?:,\d{3})* tokens\. Compact it before continuing\?$/u;
 
 export function hasAvailableClaudeCompactionProvider(input: {
   readonly providers: ReadonlyArray<ProviderInstanceEntry>;
@@ -47,7 +48,7 @@ export function hasDismissedResumeCompaction(
 
     return Object.entries(answers).some(
       ([question, answer]) =>
-        CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN.test(question) &&
+        isClaudeResumeCompactionQuestion(question) &&
         answer === CLAUDE_RESUME_COMPACTION_NEVER_ANSWER,
     );
   });

--- a/apps/web/src/components/chat/ContextWindowMeter.logic.ts
+++ b/apps/web/src/components/chat/ContextWindowMeter.logic.ts
@@ -1,4 +1,8 @@
 import type { ModelSelection, ProviderInstanceId } from "@t3tools/contracts";
+import {
+  resolveSelectableProviderInstanceEntry,
+  type ProviderInstanceEntry,
+} from "../../providerInstances";
 import { getTriggerDisplayModelName, type ModelEsque } from "./providerIconUtils";
 
 export const CLAUDE_RESUME_COMPACTION_MINUTES = 70;
@@ -6,6 +10,30 @@ export const CLAUDE_RESUME_COMPACTION_TOKENS = 100_000;
 export const CLAUDE_RESUME_COMPACTION_NEVER_ANSWER = "Don't ask again";
 const CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN =
   /^This session is (?:\d+h \d+m|\d+m) old and uses \d{1,3}(?:,\d{3})* tokens\. Compact it before continuing\?$/u;
+
+export function hasAvailableClaudeCompactionProvider(input: {
+  readonly providers: ReadonlyArray<ProviderInstanceEntry>;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly lockedInstanceId: ProviderInstanceId | null;
+}): boolean {
+  const claudeProviders = input.providers.filter(
+    (provider) => provider.driverKind === "claudeAgent",
+  );
+  const lockedContinuationGroupKey = input.lockedInstanceId
+    ? claudeProviders.find((provider) => provider.instanceId === input.lockedInstanceId)
+        ?.continuationGroupKey
+    : undefined;
+  const compatibleProviders = lockedContinuationGroupKey
+    ? claudeProviders.filter(
+        (provider) => provider.continuationGroupKey === lockedContinuationGroupKey,
+      )
+    : claudeProviders;
+
+  return (
+    resolveSelectableProviderInstanceEntry(compatibleProviders, input.instanceId ?? undefined) !==
+    undefined
+  );
+}
 
 export function hasDismissedResumeCompaction(
   activities: ReadonlyArray<{ readonly kind: string; readonly payload: unknown }>,

--- a/apps/web/src/components/chat/ContextWindowMeter.test.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.test.tsx
@@ -44,4 +44,18 @@ describe("ContextWindowMeter", () => {
     expect(markup).toContain('data-close-delay="0"');
     expect(markup).not.toContain("Compact context");
   });
+
+  it("explains why the compact action is disabled", () => {
+    const markup = renderToStaticMarkup(
+      <ContextWindowMeter
+        usage={usage}
+        onCompact={() => {}}
+        compactDisabled
+        compactDisabledReason="Send or clear your draft before compacting"
+      />,
+    );
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('aria-label="Send or clear your draft before compacting"');
+  });
 });

--- a/apps/web/src/components/chat/ContextWindowMeter.test.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.test.tsx
@@ -1,0 +1,47 @@
+import { EventId, TurnId } from "@t3tools/contracts";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { deriveLatestContextWindowSnapshot } from "~/lib/contextWindow";
+import { ContextWindowMeter } from "./ContextWindowMeter";
+
+vi.mock("../ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => children,
+  PopoverPopup: ({ children }: { children: ReactNode }) => children,
+  PopoverTrigger: ({ closeDelay, render }: { closeDelay: number; render: ReactNode }) => (
+    <div data-close-delay={closeDelay}>{render}</div>
+  ),
+}));
+
+const usage = deriveLatestContextWindowSnapshot([
+  {
+    id: EventId.make("activity-1"),
+    tone: "info",
+    kind: "context-window.updated",
+    summary: "Context updated",
+    payload: { usedTokens: 100_000, maxTokens: 1_000_000 },
+    turnId: TurnId.make("turn-1"),
+    createdAt: "2026-08-24T12:00:00.000Z",
+  },
+]);
+
+if (!usage) {
+  throw new Error("The context window test fixture did not produce a snapshot.");
+}
+
+describe("ContextWindowMeter", () => {
+  it("keeps the hover popover open while the pointer moves to the compact button", () => {
+    const markup = renderToStaticMarkup(<ContextWindowMeter usage={usage} onCompact={() => {}} />);
+
+    expect(markup).toContain('data-close-delay="150"');
+    expect(markup).toContain("Compact context");
+  });
+
+  it("closes an informational hover popover without delay", () => {
+    const markup = renderToStaticMarkup(<ContextWindowMeter usage={usage} />);
+
+    expect(markup).toContain('data-close-delay="0"');
+    expect(markup).not.toContain("Compact context");
+  });
+});

--- a/apps/web/src/components/chat/ContextWindowMeter.test.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.test.tsx
@@ -56,6 +56,7 @@ describe("ContextWindowMeter", () => {
     );
 
     expect(markup).toContain('disabled=""');
-    expect(markup).toContain('aria-label="Send or clear your draft before compacting"');
+    expect(markup).toContain(">Send or clear your draft before compacting<");
+    expect(markup).not.toContain('aria-label="Send or clear your draft before compacting"');
   });
 });

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -38,7 +38,7 @@ export function ContextWindowMeter(props: {
       <PopoverTrigger
         openOnHover
         delay={150}
-        closeDelay={0}
+        closeDelay={onCompact ? 150 : 0}
         render={
           <Button
             size="icon-sm"

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -2,6 +2,7 @@ import { Button } from "../ui/button";
 import { type ContextWindowSnapshot, formatContextWindowTokens } from "~/lib/contextWindow";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { formatContextWindowCompactionMessage } from "./ContextWindowMeter.logic";
+import { Minimize2Icon } from "lucide-react";
 
 function formatPercentage(value: number | null): string | null {
   if (value === null || !Number.isFinite(value)) {
@@ -16,8 +17,10 @@ function formatPercentage(value: number | null): string | null {
 export function ContextWindowMeter(props: {
   usage: ContextWindowSnapshot;
   modelDisplayName?: string | null;
+  onCompact?: (() => void) | undefined;
+  compactDisabled?: boolean | undefined;
 }) {
-  const { usage, modelDisplayName } = props;
+  const { usage, modelDisplayName, onCompact, compactDisabled } = props;
   const usedPercentage = formatPercentage(usage.usedPercentage);
   const normalizedPercentage = Math.max(0, Math.min(100, usage.usedPercentage ?? 0));
   const radius = 9.75;
@@ -128,8 +131,20 @@ export function ContextWindowMeter(props: {
           ) : null}
           {usage.compactsAutomatically ? (
             <div className="mt-1 text-pretty text-secondary-label text-[11px] font-medium">
-              {formatContextWindowCompactionMessage(modelDisplayName)}
+              {formatContextWindowCompactionMessage(modelDisplayName, usage.autoCompactThreshold)}
             </div>
+          ) : null}
+          {onCompact ? (
+            <Button
+              size="xs"
+              variant="outline"
+              className="mt-1 w-full justify-center"
+              disabled={compactDisabled}
+              onClick={onCompact}
+            >
+              <Minimize2Icon aria-hidden="true" />
+              Compact context
+            </Button>
           ) : null}
         </div>
       </PopoverPopup>

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -19,8 +19,9 @@ export function ContextWindowMeter(props: {
   modelDisplayName?: string | null;
   onCompact?: (() => void) | undefined;
   compactDisabled?: boolean | undefined;
+  compactDisabledReason?: string | null | undefined;
 }) {
-  const { usage, modelDisplayName, onCompact, compactDisabled } = props;
+  const { usage, modelDisplayName, onCompact, compactDisabled, compactDisabledReason } = props;
   const usedPercentage = formatPercentage(usage.usedPercentage);
   const normalizedPercentage = Math.max(0, Math.min(100, usage.usedPercentage ?? 0));
   const radius = 9.75;
@@ -140,6 +141,7 @@ export function ContextWindowMeter(props: {
               variant="outline"
               className="mt-1 w-full justify-center"
               disabled={compactDisabled}
+              aria-label={compactDisabledReason ?? "Compact context"}
               onClick={onCompact}
             >
               <Minimize2Icon aria-hidden="true" />

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -136,17 +136,23 @@ export function ContextWindowMeter(props: {
             </div>
           ) : null}
           {onCompact ? (
-            <Button
-              size="xs"
-              variant="outline"
-              className="mt-1 w-full justify-center"
-              disabled={compactDisabled}
-              aria-label={compactDisabledReason ?? "Compact context"}
-              onClick={onCompact}
-            >
-              <Minimize2Icon aria-hidden="true" />
-              Compact context
-            </Button>
+            <>
+              <Button
+                size="xs"
+                variant="outline"
+                className="mt-1 w-full justify-center"
+                disabled={compactDisabled}
+                onClick={onCompact}
+              >
+                <Minimize2Icon aria-hidden="true" />
+                Compact context
+              </Button>
+              {compactDisabled && compactDisabledReason ? (
+                <div className="text-pretty text-secondary-label text-[11px]">
+                  {compactDisabledReason}
+                </div>
+              ) : null}
+            </>
           ) : null}
         </div>
       </PopoverPopup>

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -37,6 +37,18 @@ describe("ProviderSettingsForm helpers", () => {
     });
   });
 
+  it("shows the auto-compaction threshold for Claude providers", () => {
+    const claude = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("claudeAgent")];
+    expect(claude).toBeDefined();
+
+    expect(deriveProviderSettingsFields(claude!).map((field) => field.key)).toEqual([
+      "binaryPath",
+      "homePath",
+      "autoCompactWindow",
+      "launchArgs",
+    ]);
+  });
+
   it("preserves unknown config keys while omitting empty configurable fields", () => {
     const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
     expect(opencode).toBeDefined();

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -26,6 +26,7 @@ describe("contextWindow", () => {
         usedTokens: 14_000,
         maxTokens: 258_000,
         compactsAutomatically: true,
+        autoCompactThreshold: 200_000,
       }),
     ]);
 
@@ -34,6 +35,7 @@ describe("contextWindow", () => {
     expect(snapshot?.totalProcessedTokens).toBeNull();
     expect(snapshot?.maxTokens).toBe(258_000);
     expect(snapshot?.compactsAutomatically).toBe(true);
+    expect(snapshot?.autoCompactThreshold).toBe(200_000);
   });
 
   it("ignores malformed payloads", () => {

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -88,6 +88,7 @@ export function deriveLatestContextWindowSnapshot(
       toolUses: asFiniteNumber(payload?.toolUses),
       durationMs: asFiniteNumber(payload?.durationMs),
       compactsAutomatically: asBoolean(payload?.compactsAutomatically) ?? false,
+      autoCompactThreshold: asFiniteNumber(payload?.autoCompactThreshold),
       updatedAt: activity.createdAt,
     };
   }

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -34,6 +34,17 @@ When you set this field, T3 Code points Claude Code at that directory with the
 `CLAUDE_CONFIG_DIR` environment variable. It does not change `HOME`, so your system keychain and
 the rest of your environment stay as they are.
 
+## Reduce Context Usage
+
+In Settings, open your Claude provider and set **Auto-compact after** to a token count between
+`100000` and `1000000`. For example, `300000` keeps the full model context window available but
+summarizes older messages once the conversation reaches about 300,000 tokens. Leave the field
+empty to keep Claude Code's default behavior.
+
+When you return to an older Claude thread with a large context, T3 Code offers to compact the
+conversation before you continue. You can also select **Compact context** from the context meter
+or enter `/compact` in the message composer.
+
 ## Where Claude Skills Are Loaded
 
 T3 Code looks for Claude skills in the Claude config directory's `skills` folder, then

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -37,8 +37,8 @@ the rest of your environment stay as they are.
 ## Reduce Context Usage
 
 In Settings, open your Claude provider and set **Auto-compact after** to a token count between
-`100000` and `1000000`. For example, `300000` keeps the full model context window available but
-summarizes older messages once the conversation reaches about 300,000 tokens. Leave the field
+`100000` and `1000000`. For example, `300000` compacts the conversation into a summary once it
+reaches about 300,000 tokens, without changing the model's context window. Leave the field
 empty to keep Claude Code's default behavior.
 
 On web and desktop, when you return to an older Claude thread with a large context, T3 Code

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -41,9 +41,10 @@ In Settings, open your Claude provider and set **Auto-compact after** to a token
 summarizes older messages once the conversation reaches about 300,000 tokens. Leave the field
 empty to keep Claude Code's default behavior.
 
-When you return to an older Claude thread with a large context, T3 Code offers to compact the
-conversation before you continue. You can also select **Compact context** from the context meter
-or enter `/compact` in the message composer.
+On web and desktop, when you return to an older Claude thread with a large context, T3 Code
+offers to compact the conversation before you continue. You can also select **Compact context**
+from the context meter. On every client, you can enter `/compact` in the message composer, and
+Claude can show its own resume prompt when you continue an old session.
 
 ## Where Claude Skills Are Loaded
 

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -324,6 +324,7 @@ export const ThreadTokenUsageSnapshot = Schema.Struct({
   toolUses: Schema.optional(NonNegativeInt),
   durationMs: Schema.optional(NonNegativeInt),
   compactsAutomatically: Schema.optional(Schema.Boolean),
+  autoCompactThreshold: Schema.optional(PositiveInt),
 });
 export type ThreadTokenUsageSnapshot = typeof ThreadTokenUsageSnapshot.Type;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -5,6 +5,7 @@ import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
   ClientSettingsPatch,
+  ClaudeSettings,
   DEFAULT_SERVER_SETTINGS,
   defaultEnabledForDriver,
   resolveProviderInstanceEnabled,
@@ -17,6 +18,27 @@ const decodeClientSettingsPatch = Schema.decodeUnknownSync(ClientSettingsPatch);
 const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
+const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
+
+describe("ClaudeSettings auto-compaction", () => {
+  it("uses Claude's default threshold when no override is configured", () => {
+    expect(decodeClaudeSettings({}).autoCompactWindow).toBe("");
+  });
+
+  it.each(["100000", "300000", "1000000"])(
+    "accepts a supported auto-compaction threshold: %s",
+    (value) => {
+      expect(decodeClaudeSettings({ autoCompactWindow: value }).autoCompactWindow).toBe(value);
+    },
+  );
+
+  it.each(["99999", "1000001", "300k", "invalid"])(
+    "rejects an unsupported auto-compaction threshold: %s",
+    (value) => {
+      expect(() => decodeClaudeSettings({ autoCompactWindow: value })).toThrow();
+    },
+  );
+});
 
 describe("ClientSettings word wrap", () => {
   it("defaults word wrap on", () => {

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -38,6 +38,15 @@ describe("ClaudeSettings auto-compaction", () => {
       expect(() => decodeClaudeSettings({ autoCompactWindow: value })).toThrow();
     },
   );
+
+  it("rejects an unsupported threshold at the settings patch boundary", () => {
+    expect(() =>
+      decodeServerSettingsPatch({ providers: { claudeAgent: { autoCompactWindow: "300k" } } }),
+    ).toThrow();
+    expect(
+      decodeServerSettingsPatch({ providers: { claudeAgent: { autoCompactWindow: "300000" } } }),
+    ).toBeDefined();
+  });
 });
 
 describe("ClientSettings word wrap", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -410,9 +410,21 @@ export const ClaudeSettings = makeProviderSettingsSchema(
         },
       }),
     ),
+    autoCompactWindow: TrimmedString.check(Schema.isPattern(/^(?:|[1-9]\d{5}|1000000)$/)).pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Auto-compact after",
+        description:
+          "Compact after 100,000 to 1,000,000 tokens. Leave empty to use Claude's default.",
+        providerSettingsForm: {
+          placeholder: "e.g. 300000",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
   },
   {
-    order: ["binaryPath", "homePath", "launchArgs"],
+    order: ["binaryPath", "homePath", "autoCompactWindow", "launchArgs"],
   },
 );
 export type ClaudeSettings = typeof ClaudeSettings.Type;
@@ -797,6 +809,7 @@ const ClaudeSettingsPatch = Schema.Struct({
   homePath: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
   launchArgs: Schema.optionalKey(TrimmedString),
+  autoCompactWindow: Schema.optionalKey(TrimmedString),
 });
 
 const CursorSettingsPatch = Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -373,6 +373,11 @@ export const CodexSettings = makeProviderSettingsSchema(
 );
 export type CodexSettings = typeof CodexSettings.Type;
 
+// Empty, or an integer from 100,000 to 1,000,000. Shared by the full
+// Claude settings schema and its patch so an out-of-range value fails at
+// the update that introduced it.
+const CLAUDE_AUTO_COMPACT_WINDOW_PATTERN = /^(?:|[1-9]\d{5}|1000000)$/;
+
 export const ClaudeSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -410,7 +415,9 @@ export const ClaudeSettings = makeProviderSettingsSchema(
         },
       }),
     ),
-    autoCompactWindow: TrimmedString.check(Schema.isPattern(/^(?:|[1-9]\d{5}|1000000)$/)).pipe(
+    autoCompactWindow: TrimmedString.check(
+      Schema.isPattern(CLAUDE_AUTO_COMPACT_WINDOW_PATTERN),
+    ).pipe(
       Schema.withDecodingDefault(Effect.succeed("")),
       Schema.annotateKey({
         title: "Auto-compact after",
@@ -809,7 +816,11 @@ const ClaudeSettingsPatch = Schema.Struct({
   homePath: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
   launchArgs: Schema.optionalKey(TrimmedString),
-  autoCompactWindow: Schema.optionalKey(TrimmedString),
+  // Validated at the patch boundary so a typo fails the one update with a
+  // schema error instead of a generic whole-settings failure.
+  autoCompactWindow: Schema.optionalKey(
+    TrimmedString.check(Schema.isPattern(CLAUDE_AUTO_COMPACT_WINDOW_PATTERN)),
+  ),
 });
 
 const CursorSettingsPatch = Schema.Struct({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -226,6 +226,10 @@
     "./usageFormat": {
       "types": "./src/usageFormat.ts",
       "import": "./src/usageFormat.ts"
+    },
+    "./claudeCompaction": {
+      "types": "./src/claudeCompaction.ts",
+      "import": "./src/claudeCompaction.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/claudeCompaction.test.ts
+++ b/packages/shared/src/claudeCompaction.test.ts
@@ -29,9 +29,7 @@ describe("claude resume compaction copy", () => {
 
   it("does not match unrelated questions", () => {
     expect(
-      isClaudeResumeCompactionQuestion(
-        "The build cache is large. Compact it before continuing?",
-      ),
+      isClaudeResumeCompactionQuestion("The build cache is large. Compact it before continuing?"),
     ).toBe(false);
   });
 });

--- a/packages/shared/src/claudeCompaction.test.ts
+++ b/packages/shared/src/claudeCompaction.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  formatClaudeResumeCompactionQuestion,
+  isClaudeResumeCompactionQuestion,
+} from "./claudeCompaction.ts";
+
+describe("claude resume compaction copy", () => {
+  // The matcher must recognize every question the formatter can produce.
+  // This is the drift guard: rewording one side fails here.
+  it.each([
+    { ageMinutes: 145, estimatedTokens: 275_123 },
+    { ageMinutes: 70, estimatedTokens: 100_000 },
+    { ageMinutes: 59, estimatedTokens: 1_234_567 },
+    { ageMinutes: 0, estimatedTokens: 0 },
+  ])("matches its own formatted question (%o)", (input) => {
+    const question = formatClaudeResumeCompactionQuestion(input);
+    expect(isClaudeResumeCompactionQuestion(question)).toBe(true);
+  });
+
+  it("formats ages above and below one hour", () => {
+    expect(
+      formatClaudeResumeCompactionQuestion({ ageMinutes: 145, estimatedTokens: 275_123 }),
+    ).toBe("This session is 2h 25m old and uses 275,123 tokens. Compact it before continuing?");
+    expect(formatClaudeResumeCompactionQuestion({ ageMinutes: 45, estimatedTokens: 1_000 })).toBe(
+      "This session is 45m old and uses 1,000 tokens. Compact it before continuing?",
+    );
+  });
+
+  it("does not match unrelated questions", () => {
+    expect(
+      isClaudeResumeCompactionQuestion(
+        "The build cache is large. Compact it before continuing?",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/claudeCompaction.ts
+++ b/packages/shared/src/claudeCompaction.ts
@@ -1,0 +1,26 @@
+/**
+ * Copy for Claude's resume compaction dialog, shared by the server adapter
+ * (which asks the question) and the web client (which recognizes the
+ * question and its "never" answer in resolved user-input activities to
+ * mirror the dismissal). Both sides must agree on these strings, so they
+ * live here: reword the question or the answer label in this file only.
+ */
+export const CLAUDE_RESUME_COMPACTION_NEVER_ANSWER = "Don't ask again";
+
+export function formatClaudeResumeCompactionQuestion(input: {
+  readonly ageMinutes: number;
+  readonly estimatedTokens: number;
+}): string {
+  const ageLabel =
+    input.ageMinutes >= 60
+      ? `${Math.floor(input.ageMinutes / 60)}h ${input.ageMinutes % 60}m`
+      : `${input.ageMinutes}m`;
+  return `This session is ${ageLabel} old and uses ${input.estimatedTokens.toLocaleString("en-US")} tokens. Compact it before continuing?`;
+}
+
+const CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN =
+  /^This session is (?:\d+h \d+m|\d+m) old and uses \d{1,3}(?:,\d{3})* tokens\. Compact it before continuing\?$/u;
+
+export function isClaudeResumeCompactionQuestion(question: string): boolean {
+  return CLAUDE_RESUME_COMPACTION_QUESTION_PATTERN.test(question);
+}

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -172,6 +172,9 @@ describe("applyClaudePromptEffortPrefix", () => {
     expect(applyClaudePromptEffortPrefix("/plugin:skill run", "ultrathink")).toBe(
       "/plugin:skill run",
     );
+    expect(applyClaudePromptEffortPrefix("/deploy.prod to staging", "ultrathink")).toBe(
+      "/deploy.prod to staging",
+    );
   });
 
   it("still adds the ultrathink prefix to ordinary prompts", () => {

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -166,11 +166,20 @@ describe("applyClaudePromptEffortPrefix", () => {
     expect(applyClaudePromptEffortPrefix(" /review src/model.ts ", "ultrathink")).toBe(
       "/review src/model.ts",
     );
+    expect(applyClaudePromptEffortPrefix("/security-review", "ultrathink")).toBe(
+      "/security-review",
+    );
+    expect(applyClaudePromptEffortPrefix("/plugin:skill run", "ultrathink")).toBe(
+      "/plugin:skill run",
+    );
   });
 
   it("still adds the ultrathink prefix to ordinary prompts", () => {
     expect(applyClaudePromptEffortPrefix("Investigate this failure", "ultrathink")).toBe(
       "Ultrathink:\nInvestigate this failure",
+    );
+    expect(applyClaudePromptEffortPrefix("/home/theo/app.ts crashed on load", "ultrathink")).toBe(
+      "Ultrathink:\n/home/theo/app.ts crashed on load",
     );
   });
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { ProviderDriverKind, ProviderInstanceId, type ModelCapabilities } from "@t3tools/contracts";
 
 import {
+  applyClaudePromptEffortPrefix,
   buildProviderOptionSelectionsFromDescriptors,
   createModelCapabilities,
   createModelSelection,
@@ -153,5 +154,20 @@ describe("model slug normalization", () => {
 
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
+  });
+});
+
+describe("applyClaudePromptEffortPrefix", () => {
+  it("keeps compact commands intact when ultrathink is selected", () => {
+    expect(applyClaudePromptEffortPrefix("/compact", "ultrathink")).toBe("/compact");
+    expect(applyClaudePromptEffortPrefix(" /compact keep recent errors ", "ultrathink")).toBe(
+      "/compact keep recent errors",
+    );
+  });
+
+  it("still adds the ultrathink prefix to ordinary prompts", () => {
+    expect(applyClaudePromptEffortPrefix("Investigate this failure", "ultrathink")).toBe(
+      "Ultrathink:\nInvestigate this failure",
+    );
   });
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -158,10 +158,13 @@ describe("model slug normalization", () => {
 });
 
 describe("applyClaudePromptEffortPrefix", () => {
-  it("keeps compact commands intact when ultrathink is selected", () => {
+  it("keeps slash commands intact when ultrathink is selected", () => {
     expect(applyClaudePromptEffortPrefix("/compact", "ultrathink")).toBe("/compact");
     expect(applyClaudePromptEffortPrefix(" /compact keep recent errors ", "ultrathink")).toBe(
       "/compact keep recent errors",
+    );
+    expect(applyClaudePromptEffortPrefix(" /review src/model.ts ", "ultrathink")).toBe(
+      "/review src/model.ts",
     );
   });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -363,10 +363,10 @@ export function applyClaudePromptEffortPrefix(
     return trimmed;
   }
   // Prefixing a slash command turns it into plain prose, so Claude never
-  // runs it. The pattern matches command-shaped first tokens ("/compact",
-  // "/security-review", "/plugin:skill args") without catching absolute
-  // paths like "/home/theo/app.ts", whose first token has more slashes.
-  if (effort !== "ultrathink" || /^\/[a-z0-9][\w:-]*(?:\s|$)/iu.test(trimmed)) {
+  // runs it. Command names come from arbitrary file names ("/deploy.prod",
+  // "/plugin:skill"), so accept any first token without a second slash;
+  // absolute paths like "/home/theo/app.ts" keep the prefix.
+  if (effort !== "ultrathink" || /^\/[^\s/]+(?:\s|$)/u.test(trimmed)) {
     return trimmed;
   }
   if (trimmed.startsWith("Ultrathink:")) {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -362,7 +362,7 @@ export function applyClaudePromptEffortPrefix(
   if (!trimmed) {
     return trimmed;
   }
-  if (effort !== "ultrathink") {
+  if (effort !== "ultrathink" || /^\/compact(?:\s|$)/u.test(trimmed)) {
     return trimmed;
   }
   if (trimmed.startsWith("Ultrathink:")) {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -362,7 +362,7 @@ export function applyClaudePromptEffortPrefix(
   if (!trimmed) {
     return trimmed;
   }
-  if (effort !== "ultrathink" || /^\/compact(?:\s|$)/u.test(trimmed)) {
+  if (effort !== "ultrathink" || trimmed.startsWith("/")) {
     return trimmed;
   }
   if (trimmed.startsWith("Ultrathink:")) {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -362,7 +362,11 @@ export function applyClaudePromptEffortPrefix(
   if (!trimmed) {
     return trimmed;
   }
-  if (effort !== "ultrathink" || trimmed.startsWith("/")) {
+  // Prefixing a slash command turns it into plain prose, so Claude never
+  // runs it. The pattern matches command-shaped first tokens ("/compact",
+  // "/security-review", "/plugin:skill args") without catching absolute
+  // paths like "/home/theo/app.ts", whose first token has more slashes.
+  if (effort !== "ultrathink" || /^\/[a-z0-9][\w:-]*(?:\s|$)/iu.test(trimmed)) {
     return trimmed;
   }
   if (trimmed.startsWith("Ultrathink:")) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5148,10 +5148,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}


### PR DESCRIPTION
Claude threads can resume with hundreds of thousands of old context tokens and burn through usage before the user realizes it. T3 also did not show Claude Code's resume summary prompt or expose an easy compaction control.

This change matches Claude Code's 70-minute and 100,000-token resume conditions, supports its native resume dialog on web and mobile, adds `/compact` to provider command menus, and puts a compact action in the context meter. Claude provider settings can now set an earlier auto-compaction threshold without shrinking the 1M context window.

## Before

![Claude thread without an old-context warning](https://files.tslop.org/2026/08/claude-compaction-before-55ae318a.png)

## After

![Claude thread with an old-context compaction prompt](https://files.tslop.org/2026/08/claude-resume-compaction-999e903a.png)

![Claude's native resume summary choices](https://files.tslop.org/2026/08/claude-native-resume-prompt-e29ba8b4.png)

![Claude provider auto-compaction setting](https://files.tslop.org/2026/08/claude-compaction-settings-b87e3c85.png)

Verified with 142 server tests, 61 contract tests, 26 web tests, and scoped type checks for server, web, mobile, desktop, contracts, and client runtime. Screenshots use synthetic Sonnet 5 conversations and contain no personal thread data.

Built by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude session start, resume dialogs, and user-input/approval cancellation paths; incorrect abort handling or compaction gating could affect live threads, but changes are covered by extensive adapter and UI tests.
> 
> **Overview**
> Adds **Claude context compaction** end to end: a configurable **Auto-compact after** threshold (`100000`–`1000000` tokens) on Claude provider settings, forwarded to the SDK as `autoCompactWindow` and reflected in thread usage as `autoCompactThreshold`.
> 
> The **server Claude adapter** wires Claude’s `resume_return` dialog through `onUserDialog` and the existing user-input flow (compact / keep history / don’t ask again), registers `/compact` in slash commands, and **fixes abort races** by settling `AskUserQuestion` and tool approval waits when the signal was already aborted before listeners attach. **Ultrathink** no longer prefixes single-token slash commands like `/compact`.
> 
> The **web composer** gains **Compact context** on the context meter and a **“Resume with less context”** banner when an old Claude session exceeds ~70 minutes and 100k tokens, with gating for drafts, busy state, and compatible Claude instances. Shared copy in `@t3tools/shared/claudeCompaction` keeps server prompts and client dismissal detection aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc39e204f31f70eb81573e5060d9ed651a31a5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude context compaction UI, `autoCompactWindow` setting, and resume dialog support
> - Adds a 'Compact context' action to the context window meter and a 'Resume with less context' banner in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8144/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e); clicking either injects `/compact` into the composer via the new `ChatComposerHandle.compactContext()` method
> - Wires `autoCompactWindow` (100000–1000000 tokens) through [settings.ts](https://github.com/pingdotgg/t3code/pull/8144/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) → [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/8144/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) → Claude query settings, and surfaces the threshold in `ThreadTokenUsageSnapshot.autoCompactThreshold` so the UI can display it
> - The Claude adapter now handles `resume_return` dialogs through the shared `AskUserQuestion` flow, returning `compact` | `continue` | `never`; the 'never' answer is shared via `CLAUDE_RESUME_COMPACTION_NEVER_ANSWER` in [claudeCompaction.ts](https://github.com/pingdotgg/t3code/pull/8144/files#diff-f231fb3701b6ff7422bbb74557b7ad1f06eb8410beeac9cd7c03c7a1e299e6d9)
> - Registers a built-in `/compact` slash command in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/8144/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) and fixes [model.ts](https://github.com/pingdotgg/t3code/pull/8144/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) so `ultrathink` effort no longer prefixes slash commands like `/compact`, which would break them
> - Behavioral Change: `AskUserQuestion` and tool-approval flows in `makeClaudeAdapter` now immediately resolve as cancelled if the abort signal was already aborted before listener registration, preventing hangs; `ChatComposerProps` replaces `activeThreadActivities` with `activeContextWindow` — existing consumers must update
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc39e20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->