### PR TITLE
fix(server): stop routine events from rescanning thread history

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -174,6 +174,78 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         assert.equal(row.lastAppliedSequence, 3);
       }
 
+      yield* sql`CREATE TABLE thread_shell_updates (count INTEGER NOT NULL)`;
+      yield* sql`INSERT INTO thread_shell_updates (count) VALUES (0)`;
+      yield* sql`
+        CREATE TRIGGER count_thread_shell_updates
+        AFTER UPDATE ON projection_threads
+        WHEN NEW.thread_id = 'thread-1'
+        BEGIN
+          UPDATE thread_shell_updates SET count = count + 1;
+        END;
+      `;
+
+      yield* eventStore.append({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-assistant-update"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        occurredAt: "2026-01-01T00:00:00.100Z",
+        commandId: CommandId.make("cmd-assistant-update"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-assistant-update"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("message-2"),
+          role: "assistant",
+          text: "more work",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-01-01T00:00:00.100Z",
+          updatedAt: "2026-01-01T00:00:00.100Z",
+        },
+      });
+      yield* projectionPipeline.bootstrap;
+
+      let threadShellUpdates = yield* sql<{ readonly count: number }>`
+        SELECT count FROM thread_shell_updates
+      `;
+      assert.deepEqual(threadShellUpdates, [{ count: 1 }]);
+
+      yield* sql`UPDATE thread_shell_updates SET count = 0`;
+      yield* eventStore.append({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-routine-activity"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        occurredAt: "2026-01-01T00:00:00.200Z",
+        commandId: CommandId.make("cmd-routine-activity"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-routine-activity"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          activity: {
+            id: EventId.make("activity-routine"),
+            tone: "tool",
+            kind: "tool.updated",
+            summary: "Tool made progress",
+            payload: {},
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00.200Z",
+          },
+        },
+      });
+      yield* projectionPipeline.bootstrap;
+
+      threadShellUpdates = yield* sql<{ readonly count: number }>`
+        SELECT count FROM thread_shell_updates
+      `;
+      assert.deepEqual(threadShellUpdates, [{ count: 1 }]);
+      yield* sql`DROP TRIGGER count_thread_shell_updates`;
+      yield* sql`DROP TABLE thread_shell_updates`;
+
       // Settled lifecycle through the DB pipeline: thread.settled writes the
       // override + timestamp, thread.unsettled(user) flips to the active pin.
       yield* eventStore.append({

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -130,6 +130,7 @@ function isStalePendingApprovalFailureDetail(detail: string | null): boolean {
   );
 }
 
+// A full refresh loads all thread history, so skip events that cannot change the summary.
 function shouldRefreshThreadShellSummary(event: OrchestrationEvent): boolean {
   if (event.type === "thread.message-sent") {
     return event.payload.role === "user";

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -130,6 +130,28 @@ function isStalePendingApprovalFailureDetail(detail: string | null): boolean {
   );
 }
 
+function shouldRefreshThreadShellSummary(event: OrchestrationEvent): boolean {
+  if (event.type === "thread.message-sent") {
+    return event.payload.role === "user";
+  }
+
+  if (event.type !== "thread.activity-appended") {
+    return true;
+  }
+
+  switch (event.payload.activity.kind) {
+    case "approval.requested":
+    case "approval.resolved":
+    case "provider.approval.respond.failed":
+    case "user-input.requested":
+    case "user-input.resolved":
+    case "provider.user-input.respond.failed":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function derivePendingUserInputCountFromActivities(
   activities: ReadonlyArray<ProjectionThreadActivity>,
 ): number {
@@ -865,7 +887,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             ...existingRow.value,
             updatedAt: event.occurredAt,
           });
-          yield* refreshThreadShellSummary(event.payload.threadId);
+          if (shouldRefreshThreadShellSummary(event)) {
+            yield* refreshThreadShellSummary(event.payload.threadId);
+          }
           return;
         }
 


### PR DESCRIPTION
Assistant messages and routine tool activity reload complete thread histories even when no thread summary can change. This slows both the default buffered mode and legacy streaming, and busy threads can delay other conversations.

Skip the summary refresh for assistant messages and routine activities. Keep existing refreshes for user messages, approvals, user input, plans, session changes, and reverts.

Thanks to @cheruvian for #5855, @dain for #7356, and @maria-rcks for #7486.

Fixes #4008.

Checks:
- vp test run apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
- vp run --filter t3 typecheck
- vp check apps/server/src/orchestration/Layers/ProjectionPipeline.ts apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts

Model and harness: GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when derived `projection_threads` summary columns update; anything expecting fresh counts after assistant or routine tool activity may stay stale until a user message or allowlisted event.
> 
> **Overview**
> **Stops expensive thread shell summary refreshes** on events that cannot change sidebar/summary fields (`latestUserMessageAt`, pending approval/input counts, actionable plans).
> 
> Adds **`shouldRefreshThreadShellSummary`** and uses it before **`refreshThreadShellSummary`** in the shared message/activity/plan handler. Assistant **`thread.message-sent`** events and most **`thread.activity-appended`** kinds (e.g. **`tool.updated`**) no longer trigger a full history rescan; user messages and allowlisted approval/user-input activity kinds still do. Session, revert, and proposed-plan paths are unchanged.
> 
> The projection pipeline test uses a **`projection_threads`** update trigger to assert assistant messages and routine tool activity each produce only the lightweight **`updatedAt`** upsert—not an extra summary refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7c00a5d3ebc93a513ffb63b504cbb0186231a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `refreshThreadShellSummary` call in `applyProjectsProjection` to skip routine events
> Introduces `shouldRefreshThreadShellSummary` to decide whether a given event warrants a thread shell summary refresh. It returns `true` for user messages and a specific set of activity kinds (`approval.requested`, `approval.resolved`, `provider.approval.respond.failed`, `user-input.requested`, `user-input.resolved`, `provider.user-input.respond.failed`), and `false` for assistant messages and other activity kinds.
> - Replaces the unconditional `refreshThreadShellSummary(threadId)` call in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/8150/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4) with a conditional call guarded by this function. The thread row upsert with `updatedAt` still runs on every event.
> - Adds a test in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/8150/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) using a SQL trigger to count `projection_threads` updates, verifying that a user message triggers one refresh and a subsequent `tool.updated` activity does not trigger an additional one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec7c00a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->