### PR TITLE
fix(web): dialogs and palettes no longer render under the composer slash menu

### DIFF
--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ function AlertDialogViewport({ className, ...props }: AlertDialogPrimitive.Viewp
   return (
     <AlertDialogPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 grid grid-rows-[1fr_auto_1fr] justify-items-center p-4",
+        "fixed inset-0 z-[80] grid grid-rows-[1fr_auto_1fr] justify-items-center p-4",
         className,
       )}
       data-slot="alert-dialog-viewport"

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ function CommandDialogViewport({ className, ...props }: CommandDialogPrimitive.V
   return (
     <CommandDialogPrimitive.Viewport
       className={cn(
-        "pointer-events-none fixed inset-0 z-50 flex flex-col items-center px-4 py-[max(--spacing(4),4vh)] sm:py-[10vh]",
+        "pointer-events-none fixed inset-0 z-[80] flex flex-col items-center px-4 py-[max(--spacing(4),4vh)] sm:py-[10vh]",
         className,
       )}
       data-slot="command-dialog-viewport"

--- a/apps/web/src/components/ui/dialog-styles.ts
+++ b/apps/web/src/components/ui/dialog-styles.ts
@@ -1,5 +1,5 @@
 const DIALOG_BACKDROP_CLASS =
-  "dialog-backdrop fixed inset-0 z-50 transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0";
+  "dialog-backdrop fixed inset-0 z-[80] transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0";
 
 const DIALOG_POPUP_CLASS =
   "dialog-glass -translate-y-[calc(1.25rem*var(--nested-dialogs))] relative flex min-h-0 w-full min-w-0 scale-[calc(1-0.1*var(--nested-dialogs))] flex-col rounded-2xl border opacity-[calc(1-0.1*var(--nested-dialogs))] outline-none transition-[scale,opacity,translate] duration-200 ease-in-out will-change-transform data-nested:data-ending-style:translate-y-8 data-nested:data-starting-style:translate-y-8 data-nested-dialog-open:origin-top data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0";

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -40,7 +40,7 @@ function DialogViewport({ className, ...props }: DialogPrimitive.Viewport.Props)
   return (
     <DialogPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 grid grid-rows-[1fr_auto_1fr] justify-items-center p-4",
+        "fixed inset-0 z-[80] grid grid-rows-[1fr_auto_1fr] justify-items-center p-4",
         className,
       )}
       data-slot="dialog-viewport"

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -22,7 +22,7 @@ function SheetBackdrop({ className, ...props }: SheetPrimitive.Backdrop.Props) {
   return (
     <SheetPrimitive.Backdrop
       className={cn(
-        "fixed inset-0 z-50 bg-background/60 backdrop-blur-xs transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed inset-0 z-[80] bg-background/60 backdrop-blur-xs transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
         className,
       )}
       data-slot="sheet-backdrop"
@@ -43,7 +43,7 @@ function SheetViewport({
   return (
     <SheetPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 grid",
+        "fixed inset-0 z-[80] grid",
         side === "bottom" && "grid grid-rows-[1fr_auto] pt-12",
         side === "top" && "grid grid-rows-[auto_1fr] pb-12",
         side === "left" && "flex justify-start",


### PR DESCRIPTION
## What Changed

Raised the modal overlay layer (dialog, alert dialog, command palette, sheet — backdrops and viewports) from `z-50` to `z-[80]`. Six class strings across five files in `apps/web/src/components/ui/`; no logic changes.

## Why

The composer's `/` and `$` menus portal to `document.body` at `z-[70]` (added in #4365 so they win over page content). Modal overlays sat at `z-50`, so opening one while a slash menu was up — for example clicking **New thread** or **Add project** in the sidebar — drew the modal underneath the menu.

Moving the modal layer to 80 slots it above the composer drawer (70) and below toasts (100) and popups/menus/selects (130), so the only relationship that changes is the broken one. Lowering the drawer instead would have re-exposed the page-content stacking bug that 70 was picked to fix.

Reproduced and verified in the web app; the desktop app wraps the same UI.

## UI Changes

Slash menu open, then sidebar → New project:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/shaneeilia-bridgit/t3code/pr-assets-slash-menu-z/before.png) | ![after](https://raw.githubusercontent.com/shaneeilia-bridgit/t3code/pr-assets-slash-menu-z/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable — static stacking fix)

Verified with `tsgo --noEmit`, `vp lint` + `vp fmt --check` on the changed files, and `vp test run apps/web/src/components/ui/command.test.tsx`.

Implemented by Claude Fable 5 running in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind z-index-only changes in shared UI primitives; no auth, data, or runtime logic.
> 
> **Overview**
> Fixes modals and palettes rendering **under** the composer `/` and `$` menus when both are open (e.g. slash menu up, then **New thread** / **Add project** from the sidebar).
> 
> Modal overlay stacking is bumped from `z-50` to `z-[80]` on shared dialog backdrops (`dialog-styles.ts`) and on viewports/backdrops for **dialog**, **alert-dialog**, **command** palette, and **sheet** — six class strings, no behavior changes. That puts overlays above the composer menu layer at `z-[70]` while staying below toasts (`100`) and popover-style UI (`130`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054501874109ddb2c864e4fc65251bc25308c0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise z-index of dialogs, sheets, and command palettes from `z-50` to `z-[80]`
> Updates the `z-index` utility class across the dialog, alert dialog, command palette, and sheet viewports and backdrops so they stack above the composer slash menu. Changes span [dialog.tsx](https://github.com/pingdotgg/t3code/pull/8152/files#diff-95914fee92dbf96a6ab95e18ff8b1ebbdd79effdd428c3ff5047344a94c944fa), [alert-dialog.tsx](https://github.com/pingdotgg/t3code/pull/8152/files#diff-33c02a6236d51f1905be1d3e723565707bd844a3db7d57fee3e13f7d383f0fb6), [command.tsx](https://github.com/pingdotgg/t3code/pull/8152/files#diff-a7353b0e68c4fef64c878ccbcb5e69b63cd9ba3f09da247a83c582f8647e1bf4), [sheet.tsx](https://github.com/pingdotgg/t3code/pull/8152/files#diff-469f4e28330102561cbb81c44ce503ac1f3ed554bc0ddf338ff352bfbe714bd8), and [dialog-styles.ts](https://github.com/pingdotgg/t3code/pull/8152/files#diff-8b7a027b6f0f350a8b79799cda38ec4b73d9dc8b8f2f102b792c94785e397237).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0545018.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->