### PR TITLE
feat(mobile): customizable sent message colors

### DIFF
--- a/apps/mobile/src/features/settings/SettingsAppearanceRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAppearanceRouteScreen.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { CodeAppearanceSection } from "./appearance/sections/CodeAppearanceSection";
+import { MessageAppearanceSection } from "./appearance/sections/MessageAppearanceSection";
 import { TerminalAppearanceSection } from "./appearance/sections/TerminalAppearanceSection";
 import { TextAppearanceSection } from "./appearance/sections/TextAppearanceSection";
 import { ThemeAppearanceSection } from "./appearance/sections/ThemeAppearanceSection";
@@ -31,6 +32,7 @@ export function SettingsAppearanceRouteScreen() {
         }}
       >
         <ThemeAppearanceSection />
+        <MessageAppearanceSection />
         <TextAppearanceSection />
         <TerminalAppearanceSection />
         <CodeAppearanceSection />

--- a/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
+++ b/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
@@ -17,8 +17,10 @@ import type { Preferences } from "../../../persistence/mobile-preferences";
 import {
   createMobileThemePairPatch,
   createMobileThemeSelectionPatch,
+  createUserBubbleOverrides,
   getMobileThemeVariables,
   normalizeMobileThemeMode,
+  normalizeUserBubbleColor,
   resolveMobileThemeIds,
   type MobileThemeAppearance,
   type MobileThemeId,
@@ -34,6 +36,10 @@ interface AppearancePreferencesContextValue {
   readonly themeIds: MobileThemeIds;
   readonly themeMode: MobileThemeMode;
   readonly themeAppearance: MobileThemeAppearance;
+  /** Custom sent-message bubble color; null follows the theme. */
+  readonly userBubbleColor: string | null;
+  /** Custom sent-message text color; null derives from the bubble. */
+  readonly userBubbleTextColor: string | null;
   readonly isReady: boolean;
   readonly setThemeIdForAppearance: (
     appearance: MobileThemeAppearance,
@@ -47,6 +53,10 @@ interface AppearancePreferencesContextValue {
   /** Pass null to clear the override and follow the base font size. */
   readonly setCodeFontSize: (value: number | null) => void;
   readonly setCodeWordBreak: (value: boolean) => void;
+  /** Pass null to clear the override and follow the theme. */
+  readonly setUserBubbleColor: (value: string | null) => void;
+  /** Pass null to clear the override and derive from the bubble color. */
+  readonly setUserBubbleTextColor: (value: string | null) => void;
 }
 
 const AppearancePreferencesContext = createContext<AppearancePreferencesContextValue | null>(null);
@@ -55,23 +65,33 @@ const AppearancePreferencesContext = createContext<AppearancePreferencesContextV
  * Injects palette and text-scale variables into both adaptive stylesheets.
  * Updating the active sheet last lets the visible app settle in one pass.
  */
-function applyAppearanceVariables(baseFontSize: number, themeIds: MobileThemeIds) {
+function applyAppearanceVariables(
+  baseFontSize: number,
+  themeIds: MobileThemeIds,
+  userBubbleColor: string | null,
+  userBubbleTextColor: string | null,
+) {
   const textVariables = resolveTextScaleVariables(baseFontSize);
   const currentTheme = Uniwind.currentTheme;
   const activeAppearance =
     currentTheme === "light" || currentTheme === "dark" ? currentTheme : null;
 
+  const variablesFor = (theme: MobileThemeAppearance) => {
+    const base = getMobileThemeVariables(themeIds[theme], theme);
+    return {
+      ...base,
+      ...createUserBubbleOverrides(base, userBubbleColor, userBubbleTextColor),
+      ...textVariables,
+    };
+  };
+
   for (const theme of ["light", "dark"] as const) {
-    const variables = { ...getMobileThemeVariables(themeIds[theme], theme), ...textVariables };
     if (theme !== activeAppearance) {
-      Uniwind.updateCSSVariables(theme, variables);
+      Uniwind.updateCSSVariables(theme, variablesFor(theme));
     }
   }
   if (activeAppearance !== null) {
-    Uniwind.updateCSSVariables(activeAppearance, {
-      ...getMobileThemeVariables(themeIds[activeAppearance], activeAppearance),
-      ...textVariables,
-    });
+    Uniwind.updateCSSVariables(activeAppearance, variablesFor(activeAppearance));
   }
 }
 
@@ -93,13 +113,20 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
     [storedPreferences],
   );
   const themeId = themeIds[themeAppearance];
+  const userBubbleColor = normalizeUserBubbleColor(storedPreferences?.userBubbleColor);
+  const userBubbleTextColor = normalizeUserBubbleColor(storedPreferences?.userBubbleTextColor);
   const isReady = AsyncResult.isSuccess(preferencesResult) && !preferencesResult.waiting;
 
   useLayoutEffect(() => {
-    applyAppearanceVariables(preferences.baseFontSize, themeIds);
+    applyAppearanceVariables(
+      preferences.baseFontSize,
+      themeIds,
+      userBubbleColor,
+      userBubbleTextColor,
+    );
     Uniwind.setTheme(themeMode);
     cacheTerminalFontSize(resolveAppearance(preferences).terminalFontSize);
-  }, [preferences, themeIds, themeMode]);
+  }, [preferences, themeIds, themeMode, userBubbleColor, userBubbleTextColor]);
 
   const updatePreferences = useCallback(
     (patch: Partial<Preferences>) => {
@@ -159,6 +186,20 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
     [updatePreferences],
   );
 
+  const setUserBubbleColor = useCallback(
+    (value: string | null) => {
+      updatePreferences({ userBubbleColor: value });
+    },
+    [updatePreferences],
+  );
+
+  const setUserBubbleTextColor = useCallback(
+    (value: string | null) => {
+      updatePreferences({ userBubbleTextColor: value });
+    },
+    [updatePreferences],
+  );
+
   const value = useMemo(
     (): AppearancePreferencesContextValue => ({
       appearance: resolveAppearance(preferences),
@@ -166,6 +207,8 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       themeIds,
       themeMode,
       themeAppearance,
+      userBubbleColor,
+      userBubbleTextColor,
       isReady,
       setThemeIdForAppearance,
       setThemeIdForBothAppearances,
@@ -174,6 +217,8 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       setTerminalFontSize,
       setCodeFontSize,
       setCodeWordBreak,
+      setUserBubbleColor,
+      setUserBubbleTextColor,
     }),
     [
       preferences,
@@ -181,6 +226,8 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       themeIds,
       themeMode,
       themeAppearance,
+      userBubbleColor,
+      userBubbleTextColor,
       isReady,
       setThemeIdForAppearance,
       setThemeIdForBothAppearances,
@@ -189,6 +236,8 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       setTerminalFontSize,
       setCodeFontSize,
       setCodeWordBreak,
+      setUserBubbleColor,
+      setUserBubbleTextColor,
     ],
   );
 

--- a/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
@@ -1,6 +1,7 @@
-import { useId, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue } from "react-native-reanimated";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 
 import { hexToHsv, hsvToHex, type HsvColor } from "../../../../lib/mobileTheme";
@@ -17,6 +18,7 @@ const HUE_STOPS: ReadonlyArray<{ readonly offset: number; readonly color: string
 ];
 
 function clamp01(value: number): number {
+  "worklet";
   return Math.min(1, Math.max(0, value));
 }
 
@@ -29,8 +31,9 @@ function quantize(color: HsvColor): HsvColor {
 }
 
 /**
- * Saturation/brightness pad plus hue slider. The thumb tracks while dragging;
- * the color is committed once on release so a drag writes preferences once.
+ * Saturation/brightness pad plus hue slider. Thumbs track on the UI thread
+ * via shared values; the color is committed to React state and preferences
+ * once on release, so dragging never re-renders the SVG surfaces.
  */
 export function HsvColorPicker(props: {
   readonly disabled?: boolean;
@@ -42,8 +45,6 @@ export function HsvColorPicker(props: {
     () => hexToHsv(props.value) ?? { h: 210, s: 0.8, v: 0.9 },
   );
   const [syncedValue, setSyncedValue] = useState(props.value);
-  const [padSize, setPadSize] = useState({ height: 0, width: 0 });
-  const [hueWidth, setHueWidth] = useState(0);
 
   // Adopt external changes (hex field, preset then custom) without fighting
   // our own commits, which round-trip to the same hex.
@@ -53,55 +54,95 @@ export function HsvColorPicker(props: {
     if (parsed !== null && hsvToHex(hsv) !== props.value) setHsv(quantize(parsed));
   }
 
-  const latest = useRef({ hsv, hueWidth, onChange: props.onChange, padSize });
-  latest.current = { hsv, hueWidth, onChange: props.onChange, padSize };
+  const saturation = useSharedValue(hsv.s);
+  const brightness = useSharedValue(hsv.v);
+  const huePosition = useSharedValue(hsv.h / 360);
+  const padWidth = useSharedValue(0);
+  const padHeight = useSharedValue(0);
+  const hueWidth = useSharedValue(0);
+
+  useEffect(() => {
+    saturation.value = hsv.s;
+    brightness.value = hsv.v;
+    huePosition.value = hsv.h / 360;
+  }, [brightness, hsv, huePosition, saturation]);
+
+  const latest = useRef({ hsv, onChange: props.onChange });
+  latest.current = { hsv, onChange: props.onChange };
+
+  const commitPad = (s: number, v: number) => {
+    const next = quantize({ h: latest.current.hsv.h, s, v });
+    setHsv(next);
+    latest.current.onChange(hsvToHex(next));
+  };
+  const commitHue = (position: number) => {
+    const next = quantize({ ...latest.current.hsv, h: position * 360 });
+    setHsv(next);
+    latest.current.onChange(hsvToHex(next));
+  };
+  const commitPadRef = useRef(commitPad);
+  commitPadRef.current = commitPad;
+  const commitHueRef = useRef(commitHue);
+  commitHueRef.current = commitHue;
+
+  const runCommitPad = useMemo(() => (s: number, v: number) => commitPadRef.current(s, v), []);
+  const runCommitHue = useMemo(() => (position: number) => commitHueRef.current(position), []);
 
   const padGesture = useMemo(() => {
-    const apply = (x: number, y: number, commit: boolean) => {
-      const { padSize: size, hsv: current, onChange } = latest.current;
-      if (size.width <= 0 || size.height <= 0) return;
-      const next = quantize({
-        h: current.h,
-        s: clamp01(x / size.width),
-        v: clamp01(1 - y / size.height),
-      });
-      setHsv(next);
-      if (commit) onChange(hsvToHex(next));
+    const track = (x: number, y: number) => {
+      "worklet";
+      if (padWidth.value <= 0 || padHeight.value <= 0) return;
+      saturation.value = clamp01(x / padWidth.value);
+      brightness.value = clamp01(1 - y / padHeight.value);
     };
     const pan = Gesture.Pan()
       .enabled(!props.disabled)
-      .runOnJS(true)
       .activeOffsetX([-6, 6])
-      .onUpdate((event) => apply(event.x, event.y, false))
-      .onEnd((event) => apply(event.x, event.y, true));
+      .onUpdate((event) => track(event.x, event.y))
+      .onEnd(() => {
+        runOnJS(runCommitPad)(saturation.value, brightness.value);
+      });
     const tap = Gesture.Tap()
       .enabled(!props.disabled)
-      .runOnJS(true)
-      .onEnd((event) => apply(event.x, event.y, true));
+      .onEnd((event) => {
+        track(event.x, event.y);
+        runOnJS(runCommitPad)(saturation.value, brightness.value);
+      });
     return Gesture.Race(pan, tap);
-  }, [props.disabled]);
+  }, [brightness, padHeight, padWidth, props.disabled, runCommitPad, saturation]);
 
   const hueGesture = useMemo(() => {
-    const apply = (x: number, commit: boolean) => {
-      const { hueWidth: width, hsv: current, onChange } = latest.current;
-      if (width <= 0) return;
-      const next = quantize({ ...current, h: clamp01(x / width) * 360 });
-      setHsv(next);
-      if (commit) onChange(hsvToHex(next));
+    const track = (x: number) => {
+      "worklet";
+      if (hueWidth.value <= 0) return;
+      huePosition.value = clamp01(x / hueWidth.value);
     };
     const pan = Gesture.Pan()
       .enabled(!props.disabled)
-      .runOnJS(true)
       .activeOffsetX([-6, 6])
       .failOffsetY([-12, 12])
-      .onUpdate((event) => apply(event.x, false))
-      .onEnd((event) => apply(event.x, true));
+      .onUpdate((event) => track(event.x))
+      .onEnd(() => {
+        runOnJS(runCommitHue)(huePosition.value);
+      });
     const tap = Gesture.Tap()
       .enabled(!props.disabled)
-      .runOnJS(true)
-      .onEnd((event) => apply(event.x, true));
+      .onEnd((event) => {
+        track(event.x);
+        runOnJS(runCommitHue)(huePosition.value);
+      });
     return Gesture.Race(pan, tap);
-  }, [props.disabled]);
+  }, [hueWidth, huePosition, props.disabled, runCommitHue]);
+
+  const padThumbStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: saturation.value * padWidth.value - THUMB_SIZE / 2 },
+      { translateY: (1 - brightness.value) * padHeight.value - THUMB_SIZE / 2 },
+    ],
+  }));
+  const hueThumbStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: huePosition.value * hueWidth.value - THUMB_SIZE / 2 }],
+  }));
 
   const hueColor = hsvToHex({ h: hsv.h, s: 1, v: 1 });
   const currentColor = hsvToHex(hsv);
@@ -123,8 +164,8 @@ export function HsvColorPicker(props: {
           accessibilityLabel="Saturation and brightness"
           className="h-40 overflow-hidden rounded-2xl border border-border"
           onLayout={(event) => {
-            const { height, width } = event.nativeEvent.layout;
-            setPadSize({ height, width });
+            padWidth.value = event.nativeEvent.layout.width;
+            padHeight.value = event.nativeEvent.layout.height;
           }}
         >
           <Svg height="100%" width="100%">
@@ -142,15 +183,10 @@ export function HsvColorPicker(props: {
             <Rect fill={`url(#${idPrefix}-s)`} height="100%" width="100%" />
             <Rect fill={`url(#${idPrefix}-v)`} height="100%" width="100%" />
           </Svg>
-          <View
-            className="absolute rounded-full"
+          <Animated.View
+            className="absolute left-0 top-0 rounded-full"
             pointerEvents="none"
-            style={{
-              ...thumbStyle,
-              backgroundColor: currentColor,
-              left: hsv.s * padSize.width - THUMB_SIZE / 2,
-              top: (1 - hsv.v) * padSize.height - THUMB_SIZE / 2,
-            }}
+            style={[{ ...thumbStyle, backgroundColor: currentColor }, padThumbStyle]}
           />
         </View>
       </GestureDetector>
@@ -158,7 +194,9 @@ export function HsvColorPicker(props: {
         <View
           accessibilityLabel="Hue"
           className="h-11 justify-center"
-          onLayout={(event) => setHueWidth(event.nativeEvent.layout.width)}
+          onLayout={(event) => {
+            hueWidth.value = event.nativeEvent.layout.width;
+          }}
         >
           <View className="h-3 overflow-hidden rounded-full">
             <Svg height="100%" width="100%">
@@ -172,16 +210,10 @@ export function HsvColorPicker(props: {
               <Rect fill={`url(#${idPrefix}-hue)`} height="100%" width="100%" />
             </Svg>
           </View>
-          <View
-            className="absolute rounded-full"
+          <Animated.View
+            className="absolute left-0 rounded-full"
             pointerEvents="none"
-            style={{
-              ...thumbStyle,
-              backgroundColor: hueColor,
-              left: (hsv.h / 360) * hueWidth - THUMB_SIZE / 2,
-              top: "50%",
-              marginTop: -THUMB_SIZE / 2,
-            }}
+            style={[{ ...thumbStyle, backgroundColor: hueColor }, hueThumbStyle]}
           />
         </View>
       </GestureDetector>

--- a/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
@@ -1,0 +1,190 @@
+import { useId, useMemo, useRef, useState } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
+
+import { hexToHsv, hsvToHex, type HsvColor } from "../../../../lib/mobileTheme";
+
+const THUMB_SIZE = 24;
+const HUE_STOPS: ReadonlyArray<{ readonly offset: number; readonly color: string }> = [
+  { offset: 0, color: "#ff0000" },
+  { offset: 1 / 6, color: "#ffff00" },
+  { offset: 2 / 6, color: "#00ff00" },
+  { offset: 3 / 6, color: "#00ffff" },
+  { offset: 4 / 6, color: "#0000ff" },
+  { offset: 5 / 6, color: "#ff00ff" },
+  { offset: 1, color: "#ff0000" },
+];
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function quantize(color: HsvColor): HsvColor {
+  return {
+    h: Math.round(color.h),
+    s: Math.round(color.s * 100) / 100,
+    v: Math.round(color.v * 100) / 100,
+  };
+}
+
+/**
+ * Saturation/brightness pad plus hue slider. The thumb tracks while dragging;
+ * the color is committed once on release so a drag writes preferences once.
+ */
+export function HsvColorPicker(props: {
+  readonly disabled?: boolean;
+  readonly value: string;
+  readonly onChange: (hex: string) => void;
+}) {
+  const idPrefix = useId().replaceAll(":", "");
+  const [hsv, setHsv] = useState<HsvColor>(
+    () => hexToHsv(props.value) ?? { h: 210, s: 0.8, v: 0.9 },
+  );
+  const [syncedValue, setSyncedValue] = useState(props.value);
+  const [padSize, setPadSize] = useState({ height: 0, width: 0 });
+  const [hueWidth, setHueWidth] = useState(0);
+
+  // Adopt external changes (hex field, preset then custom) without fighting
+  // our own commits, which round-trip to the same hex.
+  if (props.value !== syncedValue) {
+    setSyncedValue(props.value);
+    const parsed = hexToHsv(props.value);
+    if (parsed !== null && hsvToHex(hsv) !== props.value) setHsv(quantize(parsed));
+  }
+
+  const latest = useRef({ hsv, hueWidth, onChange: props.onChange, padSize });
+  latest.current = { hsv, hueWidth, onChange: props.onChange, padSize };
+
+  const padGesture = useMemo(() => {
+    const apply = (x: number, y: number, commit: boolean) => {
+      const { padSize: size, hsv: current, onChange } = latest.current;
+      if (size.width <= 0 || size.height <= 0) return;
+      const next = quantize({
+        h: current.h,
+        s: clamp01(x / size.width),
+        v: clamp01(1 - y / size.height),
+      });
+      setHsv(next);
+      if (commit) onChange(hsvToHex(next));
+    };
+    const pan = Gesture.Pan()
+      .enabled(!props.disabled)
+      .runOnJS(true)
+      .activeOffsetX([-6, 6])
+      .onUpdate((event) => apply(event.x, event.y, false))
+      .onEnd((event) => apply(event.x, event.y, true));
+    const tap = Gesture.Tap()
+      .enabled(!props.disabled)
+      .runOnJS(true)
+      .onEnd((event) => apply(event.x, event.y, true));
+    return Gesture.Race(pan, tap);
+  }, [props.disabled]);
+
+  const hueGesture = useMemo(() => {
+    const apply = (x: number, commit: boolean) => {
+      const { hueWidth: width, hsv: current, onChange } = latest.current;
+      if (width <= 0) return;
+      const next = quantize({ ...current, h: clamp01(x / width) * 360 });
+      setHsv(next);
+      if (commit) onChange(hsvToHex(next));
+    };
+    const pan = Gesture.Pan()
+      .enabled(!props.disabled)
+      .runOnJS(true)
+      .activeOffsetX([-6, 6])
+      .failOffsetY([-12, 12])
+      .onUpdate((event) => apply(event.x, false))
+      .onEnd((event) => apply(event.x, true));
+    const tap = Gesture.Tap()
+      .enabled(!props.disabled)
+      .runOnJS(true)
+      .onEnd((event) => apply(event.x, true));
+    return Gesture.Race(pan, tap);
+  }, [props.disabled]);
+
+  const hueColor = hsvToHex({ h: hsv.h, s: 1, v: 1 });
+  const currentColor = hsvToHex(hsv);
+  const thumbStyle = {
+    borderColor: "#ffffff",
+    borderWidth: 2,
+    height: THUMB_SIZE,
+    shadowColor: "#000000",
+    shadowOffset: { height: 1, width: 0 },
+    shadowOpacity: 0.25,
+    shadowRadius: 2,
+    width: THUMB_SIZE,
+  } as const;
+
+  return (
+    <View className={props.disabled ? "gap-3 opacity-[0.45]" : "gap-3"}>
+      <GestureDetector gesture={padGesture}>
+        <View
+          accessibilityLabel="Saturation and brightness"
+          className="h-40 overflow-hidden rounded-2xl border border-border"
+          onLayout={(event) => {
+            const { height, width } = event.nativeEvent.layout;
+            setPadSize({ height, width });
+          }}
+        >
+          <Svg height="100%" width="100%">
+            <Defs>
+              <LinearGradient id={`${idPrefix}-s`} x1="0" x2="1" y1="0" y2="0">
+                <Stop offset="0" stopColor="#ffffff" stopOpacity={1} />
+                <Stop offset="1" stopColor="#ffffff" stopOpacity={0} />
+              </LinearGradient>
+              <LinearGradient id={`${idPrefix}-v`} x1="0" x2="0" y1="0" y2="1">
+                <Stop offset="0" stopColor="#000000" stopOpacity={0} />
+                <Stop offset="1" stopColor="#000000" stopOpacity={1} />
+              </LinearGradient>
+            </Defs>
+            <Rect fill={hueColor} height="100%" width="100%" />
+            <Rect fill={`url(#${idPrefix}-s)`} height="100%" width="100%" />
+            <Rect fill={`url(#${idPrefix}-v)`} height="100%" width="100%" />
+          </Svg>
+          <View
+            className="absolute rounded-full"
+            pointerEvents="none"
+            style={{
+              ...thumbStyle,
+              backgroundColor: currentColor,
+              left: hsv.s * padSize.width - THUMB_SIZE / 2,
+              top: (1 - hsv.v) * padSize.height - THUMB_SIZE / 2,
+            }}
+          />
+        </View>
+      </GestureDetector>
+      <GestureDetector gesture={hueGesture}>
+        <View
+          accessibilityLabel="Hue"
+          className="h-11 justify-center"
+          onLayout={(event) => setHueWidth(event.nativeEvent.layout.width)}
+        >
+          <View className="h-3 overflow-hidden rounded-full">
+            <Svg height="100%" width="100%">
+              <Defs>
+                <LinearGradient id={`${idPrefix}-hue`} x1="0" x2="1" y1="0" y2="0">
+                  {HUE_STOPS.map((stop) => (
+                    <Stop key={stop.offset} offset={stop.offset} stopColor={stop.color} />
+                  ))}
+                </LinearGradient>
+              </Defs>
+              <Rect fill={`url(#${idPrefix}-hue)`} height="100%" width="100%" />
+            </Svg>
+          </View>
+          <View
+            className="absolute rounded-full"
+            pointerEvents="none"
+            style={{
+              ...thumbStyle,
+              backgroundColor: hueColor,
+              left: (hsv.h / 360) * hueWidth - THUMB_SIZE / 2,
+              top: "50%",
+              marginTop: -THUMB_SIZE / 2,
+            }}
+          />
+        </View>
+      </GestureDetector>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
@@ -47,11 +47,12 @@ export function HsvColorPicker(props: {
   const [syncedValue, setSyncedValue] = useState(props.value);
 
   // Adopt external changes (hex field, preset then custom) without fighting
-  // our own commits, which round-trip to the same hex.
+  // our own commits, which round-trip to the same hex. Adopt the parsed HSV
+  // exactly — quantizing here would drift the color off the typed hex.
   if (props.value !== syncedValue) {
     setSyncedValue(props.value);
     const parsed = hexToHsv(props.value);
-    if (parsed !== null && hsvToHex(hsv) !== props.value) setHsv(quantize(parsed));
+    if (parsed !== null && hsvToHex(hsv) !== props.value) setHsv(parsed);
   }
 
   const saturation = useSharedValue(hsv.s);

--- a/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
@@ -95,9 +95,11 @@ export function HsvColorPicker(props: {
       saturation.value = clamp01(x / padWidth.value);
       brightness.value = clamp01(1 - y / padHeight.value);
     };
+    // Axis-independent activation: brightness-only drags are vertical, so the
+    // pad must win over the surrounding ScrollView in both directions.
     const pan = Gesture.Pan()
       .enabled(!props.disabled)
-      .activeOffsetX([-6, 6])
+      .minDistance(6)
       .onUpdate((event) => track(event.x, event.y))
       .onEnd(() => {
         runOnJS(runCommitPad)(saturation.value, brightness.value);

--- a/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/HsvColorPicker.tsx
@@ -68,26 +68,22 @@ export function HsvColorPicker(props: {
     huePosition.value = hsv.h / 360;
   }, [brightness, hsv, huePosition, saturation]);
 
-  const latest = useRef({ hsv, onChange: props.onChange });
-  latest.current = { hsv, onChange: props.onChange };
+  const latest = useRef({ onChange: props.onChange });
+  latest.current = { onChange: props.onChange };
 
-  const commitPad = (s: number, v: number) => {
-    const next = quantize({ h: latest.current.hsv.h, s, v });
+  // Commits carry a full HSV snapshot taken from the shared values at gesture
+  // time, so a queued callback cannot mix stale state with newer selections.
+  const commitColor = (huePos: number, s: number, v: number) => {
+    const next = quantize({ h: huePos * 360, s, v });
     setHsv(next);
     latest.current.onChange(hsvToHex(next));
   };
-  const commitHue = (position: number) => {
-    const next = quantize({ ...latest.current.hsv, h: position * 360 });
-    setHsv(next);
-    latest.current.onChange(hsvToHex(next));
-  };
-  const commitPadRef = useRef(commitPad);
-  commitPadRef.current = commitPad;
-  const commitHueRef = useRef(commitHue);
-  commitHueRef.current = commitHue;
-
-  const runCommitPad = useMemo(() => (s: number, v: number) => commitPadRef.current(s, v), []);
-  const runCommitHue = useMemo(() => (position: number) => commitHueRef.current(position), []);
+  const commitRef = useRef(commitColor);
+  commitRef.current = commitColor;
+  const runCommit = useMemo(
+    () => (huePos: number, s: number, v: number) => commitRef.current(huePos, s, v),
+    [],
+  );
 
   const padGesture = useMemo(() => {
     const track = (x: number, y: number) => {
@@ -103,16 +99,16 @@ export function HsvColorPicker(props: {
       .minDistance(6)
       .onUpdate((event) => track(event.x, event.y))
       .onEnd(() => {
-        runOnJS(runCommitPad)(saturation.value, brightness.value);
+        runOnJS(runCommit)(huePosition.value, saturation.value, brightness.value);
       });
     const tap = Gesture.Tap()
       .enabled(!props.disabled)
       .onEnd((event) => {
         track(event.x, event.y);
-        runOnJS(runCommitPad)(saturation.value, brightness.value);
+        runOnJS(runCommit)(huePosition.value, saturation.value, brightness.value);
       });
     return Gesture.Race(pan, tap);
-  }, [brightness, padHeight, padWidth, props.disabled, runCommitPad, saturation]);
+  }, [brightness, huePosition, padHeight, padWidth, props.disabled, runCommit, saturation]);
 
   const hueGesture = useMemo(() => {
     const track = (x: number) => {
@@ -126,16 +122,16 @@ export function HsvColorPicker(props: {
       .failOffsetY([-12, 12])
       .onUpdate((event) => track(event.x))
       .onEnd(() => {
-        runOnJS(runCommitHue)(huePosition.value);
+        runOnJS(runCommit)(huePosition.value, saturation.value, brightness.value);
       });
     const tap = Gesture.Tap()
       .enabled(!props.disabled)
       .onEnd((event) => {
         track(event.x);
-        runOnJS(runCommitHue)(huePosition.value);
+        runOnJS(runCommit)(huePosition.value, saturation.value, brightness.value);
       });
     return Gesture.Race(pan, tap);
-  }, [hueWidth, huePosition, props.disabled, runCommitHue]);
+  }, [brightness, hueWidth, huePosition, props.disabled, runCommit, saturation]);
 
   const padThumbStyle = useAnimatedStyle(() => ({
     transform: [

--- a/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
@@ -1,0 +1,214 @@
+import type { ComponentProps } from "react";
+import { Pressable, View } from "react-native";
+
+import { SymbolView } from "../../../../components/AppSymbol";
+import { AppText as Text, AppTextInput } from "../../../../components/AppText";
+import {
+  createUserBubbleOverrides,
+  getMobileThemeVariables,
+  normalizeUserBubbleColor,
+} from "../../../../lib/mobileTheme";
+import { useThemeColor } from "../../../../lib/useThemeColor";
+import { SettingsSection } from "../../components/SettingsSection";
+import { useAppearancePreferences } from "../AppearancePreferencesProvider";
+import { AppearancePreviewSeparator } from "../components/AppearancePreviews";
+
+type SymbolName = ComponentProps<typeof SymbolView>["name"];
+
+const BUBBLE_COLOR_PRESETS = ["#34c759", "#af52de", "#ff9500"] as const;
+const TEXT_COLOR_PRESETS = ["#ffffff", "#000000"] as const;
+
+/** Live sample of a sent message using the effective bubble and text colors. */
+function SentMessagePreview() {
+  const bubbleColor = useThemeColor("--color-user-bubble");
+  const textColor = useThemeColor("--color-user-bubble-foreground");
+
+  return (
+    <View className="items-end p-4">
+      <View
+        className="max-w-[85%] rounded-[20px] px-3.5 py-2.5"
+        style={{ backgroundColor: bubbleColor }}
+      >
+        <Text className="text-base" style={{ color: String(textColor) }}>
+          Make the sidebar remember its width.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function ColorSwatch(props: {
+  readonly color: string;
+  readonly disabled: boolean;
+  readonly label: string;
+  readonly onPress: () => void;
+  readonly selected: boolean;
+  readonly icon?: SymbolName;
+  readonly iconColor?: string;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={props.label}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: props.selected, disabled: props.disabled }}
+      className={
+        props.selected
+          ? "size-11 items-center justify-center rounded-full border-[3px] border-primary"
+          : "size-11 items-center justify-center rounded-full border-[3px] border-transparent"
+      }
+      disabled={props.disabled}
+      onPress={props.onPress}
+    >
+      <View
+        className="size-8 items-center justify-center rounded-full border border-border"
+        style={{ backgroundColor: props.color }}
+      >
+        {props.icon ? (
+          <SymbolView
+            name={props.icon}
+            size={14}
+            tintColor={props.iconColor}
+            type="monochrome"
+            weight="medium"
+          />
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+/**
+ * Default swatch + presets + custom, in the same circular style as the theme
+ * pickers. Selecting custom seeds it with the current effective color and
+ * reveals a hex field.
+ */
+function ColorSwatchRow(props: {
+  readonly defaultColor: string;
+  readonly defaultLabel: string;
+  readonly disabled: boolean;
+  readonly icon: SymbolName;
+  readonly label: string;
+  readonly onChange: (value: string | null) => void;
+  readonly presets: readonly string[];
+  readonly value: string | null;
+}) {
+  const iconColor = useThemeColor("--color-icon");
+  const subtleIconColor = String(useThemeColor("--color-icon-muted"));
+  const customSurface = String(useThemeColor("--color-subtle"));
+  const isCustom = props.value !== null && !props.presets.includes(props.value);
+
+  const commitCustom = (text: string) => {
+    const normalized = normalizeUserBubbleColor(text);
+    if (normalized !== null) props.onChange(normalized);
+  };
+
+  return (
+    <View className={props.disabled ? "gap-3 p-4 opacity-[0.45]" : "gap-3 p-4"}>
+      <View className="flex-row items-center gap-4">
+        <SymbolView
+          name={props.icon}
+          size={22}
+          tintColor={iconColor}
+          type="monochrome"
+          weight="regular"
+        />
+        <Text className="flex-1 text-lg text-foreground">{props.label}</Text>
+        <Text className="text-base font-t3-medium text-foreground-muted">
+          {props.value === null ? props.defaultLabel : props.value.toUpperCase()}
+        </Text>
+      </View>
+      <View accessibilityRole="radiogroup" className="flex-row items-center gap-2 pl-[38px]">
+        <ColorSwatch
+          color={props.defaultColor}
+          disabled={props.disabled}
+          label={`${props.defaultLabel} ${props.label.toLowerCase()}`}
+          onPress={() => props.onChange(null)}
+          selected={props.value === null}
+        />
+        {props.presets.map((preset) => (
+          <ColorSwatch
+            color={preset}
+            disabled={props.disabled}
+            key={preset}
+            label={`${props.label} ${preset}`}
+            onPress={() => props.onChange(preset)}
+            selected={props.value === preset}
+          />
+        ))}
+        <ColorSwatch
+          color={isCustom && props.value !== null ? props.value : customSurface}
+          disabled={props.disabled}
+          icon={isCustom ? undefined : "plus"}
+          iconColor={subtleIconColor}
+          label={`Custom ${props.label.toLowerCase()}`}
+          onPress={() => props.onChange(isCustom ? props.value : props.defaultColor)}
+          selected={isCustom}
+        />
+      </View>
+      {isCustom ? (
+        <View className="pl-[38px]">
+          <AppTextInput
+            accessibilityLabel={`Custom ${props.label.toLowerCase()} hex value`}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect={false}
+            defaultValue={props.value ?? ""}
+            key={props.value}
+            maxLength={7}
+            onEndEditing={(event) => commitCustom(event.nativeEvent.text)}
+            onSubmitEditing={(event) => commitCustom(event.nativeEvent.text)}
+            placeholder="#4F46E5"
+            returnKeyType="done"
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export function MessageAppearanceSection() {
+  const {
+    isReady,
+    setUserBubbleColor,
+    setUserBubbleTextColor,
+    themeAppearance,
+    themeId,
+    userBubbleColor,
+    userBubbleTextColor,
+  } = useAppearancePreferences();
+
+  const base = getMobileThemeVariables(themeId, themeAppearance);
+  const themeBubbleColor = base["--color-user-bubble"];
+  // What the text falls back to when unset: the theme foreground on a themed
+  // bubble, or black/white by contrast on a custom one.
+  const autoTextColor =
+    createUserBubbleOverrides(base, userBubbleColor, null)?.["--color-user-bubble-foreground"] ??
+    base["--color-user-bubble-foreground"];
+
+  return (
+    <SettingsSection card title="Sent messages">
+      <SentMessagePreview />
+      <AppearancePreviewSeparator />
+      <ColorSwatchRow
+        defaultColor={themeBubbleColor}
+        defaultLabel="Theme"
+        disabled={!isReady}
+        icon="paintbrush"
+        label="Bubble color"
+        onChange={setUserBubbleColor}
+        presets={BUBBLE_COLOR_PRESETS}
+        value={userBubbleColor}
+      />
+      <ColorSwatchRow
+        defaultColor={autoTextColor}
+        defaultLabel="Auto"
+        disabled={!isReady}
+        icon="textformat.size"
+        label="Text color"
+        onChange={setUserBubbleTextColor}
+        presets={TEXT_COLOR_PRESETS}
+        value={userBubbleTextColor}
+      />
+    </SettingsSection>
+  );
+}

--- a/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from "react";
+import { useState, type ComponentProps } from "react";
 import { Pressable, View } from "react-native";
 
 import { SymbolView } from "../../../../components/AppSymbol";
@@ -79,8 +79,9 @@ function ColorSwatch(props: {
 
 /**
  * Default swatch + presets + custom, in the same circular style as the theme
- * pickers. Selecting custom seeds it with the current effective color and
- * reveals a hex field.
+ * pickers. Selecting custom reveals a hex field without changing the stored
+ * color until a valid value is typed, so it stays reachable even when the
+ * current color matches a preset.
  */
 function ColorSwatchRow(props: {
   readonly defaultColor: string;
@@ -95,7 +96,9 @@ function ColorSwatchRow(props: {
   const iconColor = useThemeColor("--color-icon");
   const subtleIconColor = String(useThemeColor("--color-icon-muted"));
   const customSurface = String(useThemeColor("--color-subtle"));
-  const isCustom = props.value !== null && !props.presets.includes(props.value);
+  const [customSelected, setCustomSelected] = useState(false);
+  const isCustomValue = props.value !== null && !props.presets.includes(props.value);
+  const isCustom = customSelected || isCustomValue;
 
   const commitCustom = (text: string) => {
     const normalized = normalizeUserBubbleColor(text);
@@ -117,13 +120,16 @@ function ColorSwatchRow(props: {
           {props.value === null ? props.defaultLabel : props.value.toUpperCase()}
         </Text>
       </View>
-      <View accessibilityRole="radiogroup" className="flex-row items-center gap-2 pl-[38px]">
+      <View accessibilityRole="radiogroup" className="flex-row flex-wrap items-center gap-2">
         <ColorSwatch
           color={props.defaultColor}
           disabled={props.disabled}
           label={`${props.defaultLabel} ${props.label.toLowerCase()}`}
-          onPress={() => props.onChange(null)}
-          selected={props.value === null}
+          onPress={() => {
+            setCustomSelected(false);
+            props.onChange(null);
+          }}
+          selected={props.value === null && !customSelected}
         />
         {props.presets.map((preset) => (
           <ColorSwatch
@@ -131,36 +137,37 @@ function ColorSwatchRow(props: {
             disabled={props.disabled}
             key={preset}
             label={`${props.label} ${preset}`}
-            onPress={() => props.onChange(preset)}
-            selected={props.value === preset}
+            onPress={() => {
+              setCustomSelected(false);
+              props.onChange(preset);
+            }}
+            selected={props.value === preset && !customSelected}
           />
         ))}
         <ColorSwatch
-          color={isCustom && props.value !== null ? props.value : customSurface}
+          color={isCustomValue && props.value !== null ? props.value : customSurface}
           disabled={props.disabled}
-          icon={isCustom ? undefined : "plus"}
+          icon={isCustomValue ? undefined : "plus"}
           iconColor={subtleIconColor}
           label={`Custom ${props.label.toLowerCase()}`}
-          onPress={() => props.onChange(isCustom ? props.value : props.defaultColor)}
+          onPress={() => setCustomSelected(true)}
           selected={isCustom}
         />
       </View>
       {isCustom ? (
-        <View className="pl-[38px]">
-          <AppTextInput
-            accessibilityLabel={`Custom ${props.label.toLowerCase()} hex value`}
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect={false}
-            defaultValue={props.value ?? ""}
-            key={props.value}
-            maxLength={7}
-            onEndEditing={(event) => commitCustom(event.nativeEvent.text)}
-            onSubmitEditing={(event) => commitCustom(event.nativeEvent.text)}
-            placeholder="#4F46E5"
-            returnKeyType="done"
-          />
-        </View>
+        <AppTextInput
+          accessibilityLabel={`Custom ${props.label.toLowerCase()} hex value`}
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect={false}
+          defaultValue={props.value ?? ""}
+          key={props.value}
+          maxLength={7}
+          onEndEditing={(event) => commitCustom(event.nativeEvent.text)}
+          onSubmitEditing={(event) => commitCustom(event.nativeEvent.text)}
+          placeholder="#4F46E5"
+          returnKeyType="done"
+        />
       ) : null}
     </View>
   );

--- a/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
@@ -12,6 +12,7 @@ import { useThemeColor } from "../../../../lib/useThemeColor";
 import { SettingsSection } from "../../components/SettingsSection";
 import { useAppearancePreferences } from "../AppearancePreferencesProvider";
 import { AppearancePreviewSeparator } from "../components/AppearancePreviews";
+import { HsvColorPicker } from "../components/HsvColorPicker";
 
 type SymbolName = ComponentProps<typeof SymbolView>["name"];
 
@@ -155,18 +156,25 @@ function ColorSwatchRow(props: {
         />
       </View>
       {isCustom ? (
-        <AppTextInput
-          accessibilityLabel={`Custom ${props.label.toLowerCase()} hex value`}
-          autoCapitalize="none"
-          autoComplete="off"
-          autoCorrect={false}
-          defaultValue={props.value ?? ""}
-          key={props.value}
-          onEndEditing={(event) => commitCustom(event.nativeEvent.text)}
-          onSubmitEditing={(event) => commitCustom(event.nativeEvent.text)}
-          placeholder="#4F46E5"
-          returnKeyType="done"
-        />
+        <View className="gap-3">
+          <HsvColorPicker
+            disabled={props.disabled}
+            onChange={props.onChange}
+            value={props.value ?? props.defaultColor}
+          />
+          <AppTextInput
+            accessibilityLabel={`Custom ${props.label.toLowerCase()} hex value`}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect={false}
+            defaultValue={props.value ?? ""}
+            key={props.value}
+            onEndEditing={(event) => commitCustom(event.nativeEvent.text)}
+            onSubmitEditing={(event) => commitCustom(event.nativeEvent.text)}
+            placeholder="#4F46E5"
+            returnKeyType="done"
+          />
+        </View>
       ) : null}
     </View>
   );

--- a/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/MessageAppearanceSection.tsx
@@ -162,7 +162,6 @@ function ColorSwatchRow(props: {
           autoCorrect={false}
           defaultValue={props.value ?? ""}
           key={props.value}
-          maxLength={7}
           onEndEditing={(event) => commitCustom(event.nativeEvent.text)}
           onSubmitEditing={(event) => commitCustom(event.nativeEvent.text)}
           placeholder="#4F46E5"

--- a/apps/mobile/src/lib/mobileTheme.test.ts
+++ b/apps/mobile/src/lib/mobileTheme.test.ts
@@ -272,6 +272,17 @@ describe("mobile themes", () => {
     expect(overrides["--color-md-user-fence-text"]).toBe("#000000");
   });
 
+  it("keeps fenced code readable on custom bubbles", () => {
+    const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "dark");
+    for (const bubble of ["#34c759", "#af52de", "#ff9500", "#ffe066", "#1c1c1e", "#808080"]) {
+      const overrides = createUserBubbleOverrides(base, bubble, null)!;
+      const fenceSurface = compositeOver(overrides["--color-md-user-fence-bg"]!, bubble);
+      expect(
+        contrastRatio(overrides["--color-md-user-fence-text"]!, fenceSurface),
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
   it("prefers an explicit text color over the derived one", () => {
     const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "light");
     const overrides = createUserBubbleOverrides(base, "#ffe066", "#ffffff")!;

--- a/apps/mobile/src/lib/mobileTheme.test.ts
+++ b/apps/mobile/src/lib/mobileTheme.test.ts
@@ -12,6 +12,8 @@ import {
   DEFAULT_MOBILE_THEME_ID,
   getMobileThemePreviewColors,
   getMobileThemeVariables,
+  hexToHsv,
+  hsvToHex,
   MOBILE_THEME_IDS,
   normalizeMobileThemeId,
   normalizeMobileThemeMode,
@@ -274,5 +276,20 @@ describe("mobile themes", () => {
     const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "light");
     const overrides = createUserBubbleOverrides(base, "#ffe066", "#ffffff")!;
     expect(overrides["--color-user-bubble-foreground"]).toBe("#ffffff");
+  });
+
+  it("converts between hex and HSV for the color picker", () => {
+    expect(hsvToHex({ h: 0, s: 1, v: 1 })).toBe("#ff0000");
+    expect(hsvToHex({ h: 120, s: 1, v: 1 })).toBe("#00ff00");
+    expect(hsvToHex({ h: 240, s: 1, v: 1 })).toBe("#0000ff");
+    expect(hsvToHex({ h: 300, s: 0, v: 1 })).toBe("#ffffff");
+    expect(hsvToHex({ h: 45, s: 0.6, v: 0 })).toBe("#000000");
+
+    expect(hexToHsv("#ff0000")).toEqual({ h: 0, s: 1, v: 1 });
+    expect(hexToHsv("not-a-color")).toBe(null);
+
+    for (const hex of ["#34c759", "#af52de", "#ff9500", "#007aff", "#123456"]) {
+      expect(hsvToHex(hexToHsv(hex)!)).toBe(hex);
+    }
   });
 });

--- a/apps/mobile/src/lib/mobileTheme.test.ts
+++ b/apps/mobile/src/lib/mobileTheme.test.ts
@@ -8,12 +8,14 @@ import {
   createMobileThemePairPatch,
   createMobileThemeSelectionPatch,
   createMobileThemeVariables,
+  createUserBubbleOverrides,
   DEFAULT_MOBILE_THEME_ID,
   getMobileThemePreviewColors,
   getMobileThemeVariables,
   MOBILE_THEME_IDS,
   normalizeMobileThemeId,
   normalizeMobileThemeMode,
+  normalizeUserBubbleColor,
   resolveMobileThemeIds,
   themeColorWithAlpha,
   themeColorToNativeColor,
@@ -227,5 +229,50 @@ describe("mobile themes", () => {
         ).toBeGreaterThanOrEqual(4.5);
       }
     }
+  });
+
+  it("normalizes persisted sent-message colors to six-digit hex or null", () => {
+    expect(normalizeUserBubbleColor("#34C759")).toBe("#34c759");
+    expect(normalizeUserBubbleColor(" #abc ")).toBe("#aabbcc");
+    expect(normalizeUserBubbleColor("34c759")).toBe(null);
+    expect(normalizeUserBubbleColor("#34c7")).toBe(null);
+    expect(normalizeUserBubbleColor("#gggggg")).toBe(null);
+    expect(normalizeUserBubbleColor(null)).toBe(null);
+    expect(normalizeUserBubbleColor(42)).toBe(null);
+  });
+
+  it("returns no sent-message overrides when both colors follow the theme", () => {
+    const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "dark");
+    expect(createUserBubbleOverrides(base, null, null)).toBe(null);
+  });
+
+  it("derives readable text and layered tokens for a custom bubble color", () => {
+    const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "dark");
+
+    const onLightBubble = createUserBubbleOverrides(base, "#ffe066", null)!;
+    expect(onLightBubble["--color-user-bubble"]).toBe("#ffe066");
+    expect(onLightBubble["--color-user-bubble-foreground"]).toBe("#000000");
+    expect(onLightBubble["--color-user-bubble-foreground-muted"]).toBe("rgba(0, 0, 0, 0.78)");
+    expect(onLightBubble["--color-md-user-code-text"]).toBe("#000000");
+    expect(
+      contrastRatio(onLightBubble["--color-user-bubble-skill-foreground"]!, "#ffe066"),
+    ).toBeGreaterThanOrEqual(4.5);
+
+    const onDarkBubble = createUserBubbleOverrides(base, "#1c1c1e", null)!;
+    expect(onDarkBubble["--color-user-bubble-foreground"]).toBe("#ffffff");
+  });
+
+  it("keeps the theme bubble when only the text color is custom", () => {
+    const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "light");
+    const overrides = createUserBubbleOverrides(base, null, "#000000")!;
+    expect(overrides["--color-user-bubble"]).toBe(base["--color-user-bubble"]);
+    expect(overrides["--color-user-bubble-foreground"]).toBe("#000000");
+    expect(overrides["--color-md-user-fence-text"]).toBe("#000000");
+  });
+
+  it("prefers an explicit text color over the derived one", () => {
+    const base = getMobileThemeVariables(DEFAULT_MOBILE_THEME_ID, "light");
+    const overrides = createUserBubbleOverrides(base, "#ffe066", "#ffffff")!;
+    expect(overrides["--color-user-bubble-foreground"]).toBe("#ffffff");
   });
 });

--- a/apps/mobile/src/lib/mobileTheme.ts
+++ b/apps/mobile/src/lib/mobileTheme.ts
@@ -196,6 +196,61 @@ function readableMessageAccent(accent: string, surface: string): string {
   return `#${readable.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
 }
 
+const HEX_COLOR_PATTERN = /^#(?:[\da-f]{3}|[\da-f]{6})$/i;
+
+/**
+ * Stored sent-message colors are user-typed; anything that is not a hex color
+ * falls back to null, meaning "follow the theme".
+ */
+export function normalizeUserBubbleColor(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const color = value.trim().toLowerCase();
+  if (!HEX_COLOR_PATTERN.test(color)) return null;
+  return color.length === 4
+    ? `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}`
+    : color;
+}
+
+/** Black or white, whichever reads better on the given surface. */
+export function readableForegroundFor(surface: string): string {
+  const surfaceChannels = rgbChannels(surface);
+  if (!surfaceChannels) return "#ffffff";
+  return contrastRatio([0, 0, 0], surfaceChannels) >=
+    contrastRatio([255, 255, 255], surfaceChannels)
+    ? "#000000"
+    : "#ffffff";
+}
+
+/**
+ * Variable overrides for a custom sent-message bubble and/or text color.
+ * Derived tokens (muted text, inline code, skill mentions) follow the chosen
+ * colors so custom bubbles keep the same layering as themed ones. A custom
+ * bubble without a custom text color gets black or white text by contrast.
+ */
+export function createUserBubbleOverrides(
+  base: MobileThemeVariables,
+  bubbleColor: string | null,
+  textColor: string | null,
+): Partial<MobileThemeVariables> | null {
+  if (bubbleColor === null && textColor === null) return null;
+  const bubble = bubbleColor ?? base["--color-user-bubble"];
+  const text =
+    textColor ??
+    (bubbleColor === null ? base["--color-user-bubble-foreground"] : readableForegroundFor(bubble));
+  return {
+    "--color-user-bubble": bubble,
+    "--color-user-bubble-foreground": text,
+    "--color-user-bubble-foreground-muted": withAlpha(text, 0.78),
+    "--color-user-bubble-skill-foreground": readableMessageAccent(
+      base["--color-user-bubble-skill-foreground"],
+      bubble,
+    ),
+    "--color-md-user-code-bg": withAlpha(text, 0.18),
+    "--color-md-user-code-text": text,
+    "--color-md-user-fence-text": text,
+  };
+}
+
 export function themeColorWithAlpha(color: string, alpha: number): string {
   const hex = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(color);
   if (hex) {

--- a/apps/mobile/src/lib/mobileTheme.ts
+++ b/apps/mobile/src/lib/mobileTheme.ts
@@ -288,6 +288,9 @@ export function createUserBubbleOverrides(
   const text =
     textColor ??
     (bubbleColor === null ? base["--color-user-bubble-foreground"] : readableForegroundFor(bubble));
+  // Fence surfaces shift the bubble away from the text's pole (dark text gets
+  // a lightening overlay and vice versa), so composited contrast only improves.
+  const fenceOverlay = readableForegroundFor(text);
   return {
     "--color-user-bubble": bubble,
     "--color-user-bubble-foreground": text,
@@ -298,6 +301,7 @@ export function createUserBubbleOverrides(
     ),
     "--color-md-user-code-bg": withAlpha(text, 0.18),
     "--color-md-user-code-text": text,
+    "--color-md-user-fence-bg": withAlpha(fenceOverlay, 0.22),
     "--color-md-user-fence-text": text,
   };
 }

--- a/apps/mobile/src/lib/mobileTheme.ts
+++ b/apps/mobile/src/lib/mobileTheme.ts
@@ -196,6 +196,57 @@ function readableMessageAccent(accent: string, surface: string): string {
   return `#${readable.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
 }
 
+export interface HsvColor {
+  readonly h: number;
+  readonly s: number;
+  readonly v: number;
+}
+
+/** Parses a #rrggbb color into HSV (h in degrees, s and v in 0..1). */
+export function hexToHsv(color: string): HsvColor | null {
+  const channels = rgbChannels(color);
+  if (!channels) return null;
+  const [red, green, blue] = channels.map((channel) => channel / 255) as [number, number, number];
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+  let h = 0;
+  if (delta !== 0) {
+    if (max === red) h = ((green - blue) / delta) % 6;
+    else if (max === green) h = (blue - red) / delta + 2;
+    else h = (red - green) / delta + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  return { h, s: max === 0 ? 0 : delta / max, v: max };
+}
+
+export function hsvToHex(color: HsvColor): string {
+  const h = ((color.h % 360) + 360) % 360;
+  const s = Math.min(1, Math.max(0, color.s));
+  const v = Math.min(1, Math.max(0, color.v));
+  const chroma = v * s;
+  const x = chroma * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = v - chroma;
+  const [red, green, blue] =
+    h < 60
+      ? [chroma, x, 0]
+      : h < 120
+        ? [x, chroma, 0]
+        : h < 180
+          ? [0, chroma, x]
+          : h < 240
+            ? [0, x, chroma]
+            : h < 300
+              ? [x, 0, chroma]
+              : [chroma, 0, x];
+  const channel = (value: number) =>
+    Math.round((value + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${channel(red)}${channel(green)}${channel(blue)}`;
+}
+
 const HEX_COLOR_PATTERN = /^#(?:[\da-f]{3}|[\da-f]{6})$/i;
 
 /**

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -6,7 +6,12 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import type { SidebarProjectGroupingMode } from "@t3tools/contracts";
-import { MOBILE_THEME_IDS, type MobileThemeId, type MobileThemeMode } from "../lib/mobileTheme";
+import {
+  MOBILE_THEME_IDS,
+  normalizeUserBubbleColor,
+  type MobileThemeId,
+  type MobileThemeMode,
+} from "../lib/mobileTheme";
 
 import * as MobileDatabase from "./mobile-database";
 import * as MobileSecureStorage from "./mobile-secure-storage";
@@ -26,6 +31,10 @@ export interface Preferences {
   readonly markdownFontSize?: number;
   readonly codeFontSize?: number | null;
   readonly codeWordBreak?: boolean;
+  /** Sent-message bubble color as a hex string; null/absent follows the theme. */
+  readonly userBubbleColor?: string | null;
+  /** Sent-message text color as a hex string; null/absent derives from the bubble. */
+  readonly userBubbleTextColor?: string | null;
   readonly connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
   readonly collapsedProjectGroups?: readonly string[];
   /** @deprecated Kept temporarily so older OTA bundles retain the selected mode. */
@@ -93,6 +102,8 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     markdownFontSize?: number;
     codeFontSize?: number | null;
     codeWordBreak?: boolean;
+    userBubbleColor?: string;
+    userBubbleTextColor?: string;
     connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
     collapsedProjectGroups?: readonly string[];
     projectGroupingEnabled?: boolean;
@@ -141,6 +152,10 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     preferences.codeFontSize = parsed.codeFontSize;
   }
   if (typeof parsed.codeWordBreak === "boolean") preferences.codeWordBreak = parsed.codeWordBreak;
+  const userBubbleColor = normalizeUserBubbleColor(parsed.userBubbleColor);
+  if (userBubbleColor !== null) preferences.userBubbleColor = userBubbleColor;
+  const userBubbleTextColor = normalizeUserBubbleColor(parsed.userBubbleTextColor);
+  if (userBubbleTextColor !== null) preferences.userBubbleTextColor = userBubbleTextColor;
   if (Array.isArray(parsed.connectOnboardingOptOutAccounts)) {
     preferences.connectOnboardingOptOutAccounts = parsed.connectOnboardingOptOutAccounts.filter(
       (account): account is string => typeof account === "string",

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -102,8 +102,8 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     markdownFontSize?: number;
     codeFontSize?: number | null;
     codeWordBreak?: boolean;
-    userBubbleColor?: string;
-    userBubbleTextColor?: string;
+    userBubbleColor?: string | null;
+    userBubbleTextColor?: string | null;
     connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
     collapsedProjectGroups?: readonly string[];
     projectGroupingEnabled?: boolean;
@@ -152,10 +152,15 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     preferences.codeFontSize = parsed.codeFontSize;
   }
   if (typeof parsed.codeWordBreak === "boolean") preferences.codeWordBreak = parsed.codeWordBreak;
+  // Explicit null (cleared back to theme/auto) must survive sanitizing, or the
+  // session's initial stored snapshot bleeds the old color back through the
+  // optimistic-merge in state/preferences until the next app restart.
   const userBubbleColor = normalizeUserBubbleColor(parsed.userBubbleColor);
   if (userBubbleColor !== null) preferences.userBubbleColor = userBubbleColor;
+  else if (parsed.userBubbleColor === null) preferences.userBubbleColor = null;
   const userBubbleTextColor = normalizeUserBubbleColor(parsed.userBubbleTextColor);
   if (userBubbleTextColor !== null) preferences.userBubbleTextColor = userBubbleTextColor;
+  else if (parsed.userBubbleTextColor === null) preferences.userBubbleTextColor = null;
   if (Array.isArray(parsed.connectOnboardingOptOutAccounts)) {
     preferences.connectOnboardingOptOutAccounts = parsed.connectOnboardingOptOutAccounts.filter(
       (account): account is string => typeof account === "string",

--- a/docs/user/mobile-appearance.md
+++ b/docs/user/mobile-appearance.md
@@ -13,3 +13,10 @@ To change themes:
 
 **System** follows the device appearance automatically. Theme, text, code, and terminal appearance
 preferences are stored on the device.
+
+## Sent message colors
+
+The **Sent messages** section lets you recolor your own message bubbles. Pick a bubble color from
+the theme default, a preset, or a custom hex value, and do the same for the text color. Text set to
+**Auto** stays readable on whatever bubble color you choose. Both colors apply in light and dark
+appearance and are stored on the device.


### PR DESCRIPTION
Sent messages on mobile were always the theme's blue with no way to change them.

This adds a **Sent messages** section to mobile Settings → Appearance: bubble color and text color, each with the theme default, a few presets, or a custom color via an HSV picker and hex field. Auto text picks black or white by contrast on custom bubbles, and derived tokens (muted text, inline code, skill mentions) follow the chosen colors. Mobile only; preferences are device-local.

| Before | After | After (custom color) |
| --- | --- | --- |
| <img src="https://github.com/abcdmku/t3libre-paid/releases/download/pr-8155-assets/before-appearance-main.jpg" width="250" alt="Appearance settings on main: themes go straight to Text, no message color options" /> | <img src="https://github.com/abcdmku/t3libre-paid/releases/download/pr-8155-assets/after-sent-messages-default.jpg" width="250" alt="Sent messages section with theme default bubble and auto text selected" /> | <img src="https://github.com/abcdmku/t3libre-paid/releases/download/pr-8155-assets/after-sent-messages-picker.jpg" width="250" alt="Sent messages section with a custom bubble color selected in the HSV picker" /> |

Built with Claude Fable 5 on Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Device-local appearance preferences and theme CSS overrides only; no auth or network paths. Main risk is contrast/readability regressions on custom colors, which tests partially guard.
> 
> **Overview**
> Adds a **Sent messages** block to mobile Settings → Appearance with a live preview, theme/preset swatches, an HSV picker, and hex input for bubble and text colors.
> 
> **`userBubbleColor`** and **`userBubbleTextColor`** are stored in device preferences (null means theme default or auto text). **`AppearancePreferencesProvider`** merges **`createUserBubbleOverrides`** into Uniwind CSS variables for both light and dark sheets so chat bubbles pick up the same tokens (muted text, code blocks, fences, skill accents). **`normalizeUserBubbleColor`** and explicit **`null`** handling in **`sanitizePreferences`** avoid stale colors after clearing overrides.
> 
> **`mobileTheme`** adds contrast-based derivation and hex/HSV helpers; tests cover normalization, overrides, and fence readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d02613334249ee4e4ed869eb07a160341006858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add customizable sent message bubble and text colors to mobile appearance settings
> - Adds a "Sent messages" section to the Appearance screen with a live preview and color swatch controls for bubble and text colors.
> - Users pick theme default, presets, or a custom color via the new `HsvColorPicker` or hex input; text color can be set to auto (derived for readability), white, black, or custom.
> - `AppearancePreferencesProvider` exposes `userBubbleColor` and `userBubbleTextColor` with setters; changes update theme variables immediately without a reload.
> - `createUserBubbleOverrides` in [mobileTheme.ts](apps/mobile/src/lib/mobileTheme.ts) generates coherent CSS variable overrides for the bubble, text, and related tokens like inline code and mentions.
> - Risk: `sanitizePreferences` in [mobile-preferences.ts](apps/mobile/src/persistence/mobile-preferences.ts) now sanitizes new color fields and preserves explicit `null`; out-of-tree callers that merge preferences without sanitization may see stale bubble colors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d02613.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->