### PR TITLE
fix(web): add back button to project settings

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -151,11 +151,13 @@ export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
     select: (location) =>
       /^\/settings(?:\/|$)/.test(location.pathname)
         ? "settings"
-        : location.pathname === "/usage"
-          ? "usage"
-          : location.pathname === "/pull-requests"
-            ? "pull-requests"
-            : null,
+        : /^\/projects\/[^/]+\/?$/.test(location.pathname)
+          ? "project-settings"
+          : location.pathname === "/usage"
+            ? "usage"
+            : location.pathname === "/pull-requests"
+              ? "pull-requests"
+              : null,
   });
   const { environments } = useEnvironments();
   // The page reads every connected server, so one of them offering pull requests is enough for


### PR DESCRIPTION
Project settings leaves the sidebar footer on the normal utility actions, so it has no visible way back. Usage and the other full-page views already replace those actions with Back.

Treat the project settings route as a full-page sidebar destination. It now uses the existing Back control and keeps the same history navigation with a home fallback.

Verification:
- `pnpm exec vp lint apps/web/src/components/sidebar/SidebarChrome.tsx`
- `pnpm --filter @t3tools/web typecheck`
- Visual pass in an isolated public web environment at 1440x900: Back appears in Project settings and returns to the previous page

## Before

![Project settings without Back](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/64c5c3ba-1ed0-4df6-810d-031cd92b1e40/project-settings-back-before.png)

## After

![Project settings with Back](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c257d07b-86cc-4d39-8a59-cb965cc18a28/project-settings-back-after.png)

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in sidebar footer routing with no auth, data, or API impact.
> 
> **Overview**
> **Project settings** (`/projects/:key`) is now treated like other full-page sidebar destinations (settings, usage, pull requests), so the footer swaps utility icons for the existing **Back** control instead of leaving users with no obvious way out.
> 
> The change extends `currentFooterPage` in `SidebarUtilityMenu` with a path match for `/projects/[projectKey]`; Back behavior is unchanged (history when available, otherwise home).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b27340846274a9472ca798b28dcfb8752b9464d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Map project root paths to 'project-settings' in `SidebarUtilityMenu`
> Updates [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/8168/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11) so `currentFooterPage` is set to `'project-settings'` when the path matches `/projects/<id>`. Adds a regex check for project root paths (with optional trailing slash) before the existing `/usage` and `/pull-requests` checks. This enables the back button to appear on the project settings page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b27340.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->