### PR TITLE
feat(mobile): track device models and OS versions

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -81,6 +81,7 @@
     "expo-constants": "~56.0.18",
     "expo-crypto": "~56.0.4",
     "expo-dev-client": "~56.0.20",
+    "expo-device": "~56.0.4",
     "expo-file-system": "~56.0.8",
     "expo-font": "~56.0.7",
     "expo-glass-effect": "~56.0.4",

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -33,6 +33,11 @@ vi.mock("expo-constants", () => ({
   },
 }));
 
+vi.mock("expo-device", () => ({
+  osVersion: "18.4.1",
+  modelName: "iPhone 15 Pro",
+}));
+
 vi.mock("react-native", () => ({
   Platform: {
     OS: "ios",

--- a/apps/mobile/src/lib/authClientMetadata.ts
+++ b/apps/mobile/src/lib/authClientMetadata.ts
@@ -1,11 +1,17 @@
 import type { AuthClientPresentationMetadata } from "@t3tools/contracts";
+import * as Device from "expo-device";
 import { Platform } from "react-native";
 
 export function authClientMetadata(appVersion?: string): AuthClientPresentationMetadata {
+  const osMajorVersion = Number.parseInt(Device.osVersion?.split(".")[0] ?? "", 10);
+  const deviceModel = Device.modelName?.trim();
+
   return {
     label: "T3 Code Mobile",
     deviceType: "mobile",
     ...(Platform.OS === "ios" ? { os: "iOS" } : Platform.OS === "android" ? { os: "Android" } : {}),
+    ...(Number.isFinite(osMajorVersion) && osMajorVersion > 0 ? { osMajorVersion } : {}),
+    ...(deviceModel ? { deviceModel } : {}),
     surface: "mobile",
     ...(appVersion ? { appVersion } : {}),
   };

--- a/apps/mobile/src/lib/connection.test.ts
+++ b/apps/mobile/src/lib/connection.test.ts
@@ -3,10 +3,10 @@ import { EnvironmentId } from "@t3tools/contracts";
 
 import {
   isRelayManagedConnection,
-  authClientMetadata,
   redactPairingCredential,
   toStableSavedRemoteConnection,
 } from "./connection";
+import { authClientMetadata } from "./authClientMetadata";
 
 const mobilePlatform = vi.hoisted(() => ({ OS: "ios" as "ios" | "android" }));
 const mobileDevice = vi.hoisted(() => ({

--- a/apps/mobile/src/lib/connection.test.ts
+++ b/apps/mobile/src/lib/connection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId } from "@t3tools/contracts";
 
 import {
@@ -8,6 +8,12 @@ import {
   toStableSavedRemoteConnection,
 } from "./connection";
 
+const mobilePlatform = vi.hoisted(() => ({ OS: "ios" as "ios" | "android" }));
+const mobileDevice = vi.hoisted(() => ({
+  osVersion: "18.4.1",
+  modelName: "iPhone 15 Pro",
+}));
+
 vi.mock("./runtime", () => ({
   runtime: {
     runPromise: vi.fn(),
@@ -15,18 +21,38 @@ vi.mock("./runtime", () => ({
 }));
 
 vi.mock("react-native", () => ({
-  Platform: {
-    OS: "ios",
-  },
+  Platform: mobilePlatform,
 }));
 
+vi.mock("expo-device", () => mobileDevice);
+
 describe("mobile remote connection records", () => {
+  afterEach(() => {
+    mobilePlatform.OS = "ios";
+    mobileDevice.osVersion = "18.4.1";
+    mobileDevice.modelName = "iPhone 15 Pro";
+  });
+
   it("identifies mobile token exchanges for authorized-client presentation", () => {
     expect(authClientMetadata()).toEqual({
       label: "T3 Code Mobile",
       deviceType: "mobile",
       os: "iOS",
+      osMajorVersion: 18,
+      deviceModel: "iPhone 15 Pro",
       surface: "mobile",
+    });
+  });
+
+  it("includes only the Android major version and hardware model", () => {
+    mobilePlatform.OS = "android";
+    mobileDevice.osVersion = "15.2.1";
+    mobileDevice.modelName = "Pixel 9";
+
+    expect(authClientMetadata()).toMatchObject({
+      os: "Android",
+      osMajorVersion: 15,
+      deviceModel: "Pixel 9",
     });
   });
 

--- a/apps/mobile/src/lib/connection.ts
+++ b/apps/mobile/src/lib/connection.ts
@@ -2,8 +2,6 @@ import { EnvironmentId } from "@t3tools/contracts";
 import { stripPairingTokenFromUrl } from "@t3tools/shared/remote";
 import { type EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 
-export { authClientMetadata } from "./authClientMetadata";
-
 export interface SavedRemoteConnection {
   readonly environmentId: EnvironmentId;
   readonly environmentLabel: string;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5209,7 +5209,9 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           createdAt: "2026-01-01T00:00:00.000Z",
         }) as const;
 
-      const wsUrl = yield* getWsServerUrl("/ws?clientSurface=mobile&clientAppVersion=1.2.3");
+      const wsUrl = yield* getWsServerUrl(
+        "/ws?clientSurface=mobile&clientAppVersion=1.2.3&clientOs=iOS&clientOsMajorVersion=18&clientDeviceModel=iPhone+15+Pro",
+      );
       yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
           Effect.gen(function* () {
@@ -5242,7 +5244,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         "analytics:client.thread.started",
       ]);
       assert.deepEqual(analyticsProperties, [
-        { surface: "mobile", appVersion: "1.2.3" },
+        {
+          surface: "mobile",
+          appVersion: "1.2.3",
+          os: "iOS",
+          osMajorVersion: 18,
+          deviceModel: "iPhone 15 Pro",
+        },
         { surface: "mobile", appVersion: "1.2.3" },
       ]);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -360,6 +360,7 @@ function toAuthAccessStreamEvent(
 
 const isClientSurface = Schema.is(ClientSurface);
 const MAX_CLIENT_APP_VERSION_LENGTH = 64;
+const MAX_CLIENT_DEVICE_MODEL_LENGTH = 80;
 
 // Optional client identity announced on the /ws upgrade URL next to wsTicket.
 // Lenient by design: absent or malformed values degrade to {} so a connection
@@ -385,6 +386,28 @@ const clientOriginAnalyticsProps = (origin: OrchestrationClientOrigin) => ({
   ...(origin.surface !== undefined ? { surface: origin.surface } : {}),
   ...(origin.appVersion !== undefined ? { appVersion: origin.appVersion } : {}),
 });
+
+function readMobileDeviceAnalyticsProps(request: HttpServerRequest.HttpServerRequest) {
+  const url = HttpServerRequest.toURL(request);
+  if (Option.isNone(url) || url.value.searchParams.get("clientSurface") !== "mobile") {
+    return {};
+  }
+
+  const os = url.value.searchParams.get("clientOs");
+  const rawOsMajorVersion = url.value.searchParams.get("clientOsMajorVersion") ?? "";
+  const osMajorVersion = Number(rawOsMajorVersion);
+  const deviceModel = url.value.searchParams.get("clientDeviceModel")?.trim() ?? "";
+
+  return {
+    ...(os === "iOS" || os === "Android" ? { os } : {}),
+    ...(rawOsMajorVersion !== "" && Number.isInteger(osMajorVersion) && osMajorVersion > 0
+      ? { osMajorVersion }
+      : {}),
+    ...(deviceModel !== "" && deviceModel.length <= MAX_CLIENT_DEVICE_MODEL_LENGTH
+      ? { deviceModel }
+      : {}),
+  };
+}
 
 const makeWsRpcLayer = (
   currentSession: EnvironmentAuth.AuthenticatedSession,
@@ -2434,7 +2457,10 @@ export const websocketRpcRouteLayer = Layer.unwrap(
         );
         const clientOrigin = readClientConnectionOrigin(request);
         yield* sessions.recordClientConnection(session.sessionId, clientOrigin);
-        yield* analytics.record("client.connected", clientOriginAnalyticsProps(clientOrigin));
+        yield* analytics.record("client.connected", {
+          ...clientOriginAnalyticsProps(clientOrigin),
+          ...readMobileDeviceAnalyticsProps(request),
+        });
         const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
           disableTracing: true,
         }).pipe(

--- a/packages/client-runtime/src/authorization/remote.test.ts
+++ b/packages/client-runtime/src/authorization/remote.test.ts
@@ -467,9 +467,18 @@ describe("remote environment authorization", () => {
         wsBaseUrl: "wss://remote.example.com/",
         httpBaseUrl: "https://remote.example.com/",
         bearerToken: "bearer-token",
+        clientMetadata: {
+          surface: "mobile",
+          appVersion: "1.2.3",
+          os: "Android",
+          osMajorVersion: 15,
+          deviceModel: "Pixel 9",
+        },
       }).pipe(provideRemoteHttp(fetch.fetchFn));
 
-      expect(url).toBe("wss://remote.example.com/ws?wsTicket=ws-ticket");
+      expect(url).toBe(
+        "wss://remote.example.com/ws?wsTicket=ws-ticket&clientSurface=mobile&clientAppVersion=1.2.3&clientOs=Android&clientOsMajorVersion=15&clientDeviceModel=Pixel+9",
+      );
     }),
   );
 });

--- a/packages/client-runtime/src/authorization/remote.ts
+++ b/packages/client-runtime/src/authorization/remote.ts
@@ -44,6 +44,17 @@ export const appendClientConnectionParams = (
   if (clientMetadata?.appVersion) {
     url.searchParams.set("clientAppVersion", clientMetadata.appVersion);
   }
+  if (clientMetadata?.surface === "mobile") {
+    if (clientMetadata.os) {
+      url.searchParams.set("clientOs", clientMetadata.os);
+    }
+    if (clientMetadata.osMajorVersion !== undefined) {
+      url.searchParams.set("clientOsMajorVersion", String(clientMetadata.osMajorVersion));
+    }
+    if (clientMetadata.deviceModel) {
+      url.searchParams.set("clientDeviceModel", clientMetadata.deviceModel);
+    }
+  }
 };
 
 export const exchangeRemoteDpopAccessToken = Effect.fn(

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -169,6 +169,8 @@ export const AuthClientPresentationMetadata = Schema.Struct({
   label: Schema.optionalKey(TrimmedNonEmptyString),
   deviceType: Schema.optionalKey(AuthClientMetadataDeviceType),
   os: Schema.optionalKey(TrimmedNonEmptyString),
+  osMajorVersion: Schema.optionalKey(Schema.Int),
+  deviceModel: Schema.optionalKey(TrimmedNonEmptyString),
   surface: Schema.optionalKey(ClientSurface),
   appVersion: Schema.optionalKey(TrimmedNonEmptyString),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       expo-dev-client:
         specifier: ~56.0.20
         version: 56.0.20(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+      expo-device:
+        specifier: ~56.0.4
+        version: 56.0.4(expo@56.0.12)
       expo-file-system:
         specifier: ~56.0.8
         version: 56.0.8(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
@@ -6586,6 +6589,11 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-device@56.0.4:
+    resolution: {integrity: sha512-ucVcGPkvBrl2QHuy7XcYex2Y6BETvJ6TREutZrwLGUDnlvbpKS8KfQoNZOpvkyo5Nmm9RrasYQ0CrXmBHho2mg==}
+    peerDependencies:
+      expo: '*'
+
   expo-eas-client@56.0.1:
     resolution: {integrity: sha512-r8h0ZIExacCrSRgY+ARfhMvFqosLHLJt1L7jyhvabfr1DN/ZDKDsYbovss2tzkpEUZGxZ3BPcB5epCwUsBBdOA==}
 
@@ -9855,6 +9863,10 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-parser-js@0.7.41:
+    resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
     hasBin: true
 
   ufo@1.6.4:
@@ -16867,6 +16879,11 @@ snapshots:
       expo-dev-menu-interface: 56.0.1(expo@56.0.12)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
+  expo-device@56.0.4(expo@56.0.12):
+    dependencies:
+      expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
+      ua-parser-js: 0.7.41
+
   expo-eas-client@56.0.1: {}
 
   expo-file-system@56.0.8(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
@@ -21103,6 +21120,8 @@ snapshots:
       semver: 7.8.5
 
   typescript@6.0.3: {}
+
+  ua-parser-js@0.7.41: {}
 
   ufo@1.6.4: {}
 


### PR DESCRIPTION
We do not know which phones or operating system versions our mobile users have, so it is hard to choose which hardware to support.

Record the OS name, OS major version, and hardware model on existing mobile connection events. Do not collect device names, device IDs, or precise OS versions.

Model: GPT-5.6 Sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional analytics metadata with lenient server parsing; WebSocket connections are not rejected on bad values, and auth paths are unchanged.
> 
> **Overview**
> Adds **optional mobile device attribution** so connection analytics can include OS name, **OS major version only**, and hardware model—without device IDs or full OS strings.
> 
> The mobile app depends on **`expo-device`** and extends `authClientMetadata` to populate `osMajorVersion` and `deviceModel` on `AuthClientPresentationMetadata`. `appendClientConnectionParams` appends `clientOs`, `clientOsMajorVersion`, and `clientDeviceModel` to the WebSocket upgrade URL when `surface === "mobile"`. The server reads those query params in **`readMobileDeviceAnalyticsProps`** (iOS/Android only, positive integer major version, model capped at 80 chars) and merges them into the **`client.connected`** analytics payload. Contracts, client-runtime, server WS handling, and mobile tests are updated accordingly; `connection.ts` stops re-exporting `authClientMetadata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41b1f3431956714bda3da3754df6231082149e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track device models and OS versions for mobile clients in analytics
> - Adds `expo-device` dependency and reads `Device.osVersion` and `Device.modelName` in `authClientMetadata` to populate `osMajorVersion` and `deviceModel` for mobile clients.
> - Extends `AuthClientPresentationMetadata` schema with optional `osMajorVersion` and `deviceModel` fields, and appends them as WebSocket query params (`clientOs`, `clientOsMajorVersion`, `clientDeviceModel`) when `surface` is mobile.
> - Server validates these params in `readMobileDeviceAnalyticsProps` (os must be `iOS` or `Android`, version must be positive integer, model length ≤ 80) and merges them into `client.connected` analytics.
> - Risk: out-of-tree consumers of `AuthClientPresentationMetadata` that do strict validation may reject the new optional `osMajorVersion` and `deviceModel` fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d41b1f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->