### PR TITLE
fix(web): stop thread shortcut hints from getting stuck

### DIFF
--- a/apps/web/src/shortcutModifierState.test.ts
+++ b/apps/web/src/shortcutModifierState.test.ts
@@ -1,10 +1,28 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   areShortcutModifierStatesEqual,
   shortcutModifierStateAfterKeyboardEvent,
   type ShortcutModifierState,
+  useShortcutModifierState,
 } from "./shortcutModifierState";
+import { reactHookHarness } from "./test/reactHookHarness";
+
+const effectCleanups = vi.hoisted(() => [] as Array<() => void>);
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  const { reactHookHarness } = await import("./test/reactHookHarness");
+
+  return {
+    ...actual,
+    useState: reactHookHarness.useState,
+    useEffect: (effect: () => void | (() => void)) => {
+      const cleanup = effect();
+      if (cleanup) effectCleanups.push(cleanup);
+    },
+  };
+});
 
 const emptyState = (): ShortcutModifierState => ({
   metaKey: false,
@@ -24,6 +42,46 @@ function keyboardEventLike(type: "keydown" | "keyup", init: Partial<KeyboardEven
     ...init,
   } as KeyboardEvent;
 }
+
+function installShortcutModifierHook() {
+  const browserWindow = new EventTarget();
+  const browserDocument = new EventTarget();
+  vi.stubGlobal("window", browserWindow);
+  vi.stubGlobal("document", browserDocument);
+
+  reactHookHarness.beginRender();
+  useShortcutModifierState();
+
+  return { window: browserWindow, document: browserDocument };
+}
+
+function dispatchModifierEvent(
+  target: EventTarget,
+  type: "keydown" | "keyup" | "pointerdown",
+  init: Partial<KeyboardEvent>,
+) {
+  const event = new Event(type);
+  Object.assign(event, {
+    key: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...init,
+  });
+  target.dispatchEvent(event);
+}
+
+function currentModifierState() {
+  reactHookHarness.beginRender();
+  return reactHookHarness.useState(emptyState())[0];
+}
+
+afterEach(() => {
+  for (const cleanup of effectCleanups.splice(0)) cleanup();
+  reactHookHarness.reset();
+  vi.unstubAllGlobals();
+});
 
 describe("shortcutModifierState", () => {
   it("compares modifier states by value", () => {
@@ -110,4 +168,74 @@ describe("shortcutModifierState", () => {
       shiftKey: false,
     });
   });
+
+  it("does not activate Command when a function-key release reports a stale modifier", () => {
+    const state = shortcutModifierStateAfterKeyboardEvent(
+      emptyState(),
+      keyboardEventLike("keyup", {
+        key: "Fn",
+        metaKey: true,
+      }),
+    );
+
+    expect(state).toEqual(emptyState());
+  });
+
+  it("clears a missed Command release when another modifier is pressed", () => {
+    const state = shortcutModifierStateAfterKeyboardEvent(
+      { ...emptyState(), metaKey: true },
+      keyboardEventLike("keydown", {
+        key: "Shift",
+        metaKey: false,
+        shiftKey: false,
+      }),
+    );
+
+    expect(state).toEqual({ ...emptyState(), shiftKey: true });
+  });
+
+  it.each(["blur", "focus"])("clears stuck modifiers on window %s", (eventType) => {
+    const { window } = installShortcutModifierHook();
+    dispatchModifierEvent(window, "keydown", { key: "Meta", metaKey: true });
+    expect(currentModifierState().metaKey).toBe(true);
+
+    window.dispatchEvent(new Event(eventType));
+
+    expect(currentModifierState()).toEqual(emptyState());
+  });
+
+  it("clears stuck modifiers when page visibility changes", () => {
+    const { window, document } = installShortcutModifierHook();
+    dispatchModifierEvent(window, "keydown", { key: "Meta", metaKey: true });
+    expect(currentModifierState().metaKey).toBe(true);
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(currentModifierState()).toEqual(emptyState());
+  });
+
+  it("clears stuck modifiers when a pointer press does not include them", () => {
+    const { window } = installShortcutModifierHook();
+    dispatchModifierEvent(window, "keydown", { key: "Meta", metaKey: true });
+    expect(currentModifierState().metaKey).toBe(true);
+
+    dispatchModifierEvent(window, "pointerdown", { metaKey: false });
+
+    expect(currentModifierState()).toEqual(emptyState());
+  });
+
+  it.each(["paste", "input"])(
+    "clears a synthetic Command press when dictated text triggers %s",
+    (eventType) => {
+      const { window } = installShortcutModifierHook();
+      dispatchModifierEvent(window, "keydown", { key: "Meta", metaKey: true });
+      dispatchModifierEvent(window, "keydown", { key: "v", metaKey: true });
+      expect(currentModifierState().metaKey).toBe(true);
+
+      window.dispatchEvent(new Event(eventType));
+      dispatchModifierEvent(window, "keyup", { key: "v", metaKey: true });
+
+      expect(currentModifierState()).toEqual(emptyState());
+    },
+  );
 });

--- a/apps/web/src/shortcutModifierState.test.ts
+++ b/apps/web/src/shortcutModifierState.test.ts
@@ -224,6 +224,17 @@ describe("shortcutModifierState", () => {
     expect(currentModifierState()).toEqual(emptyState());
   });
 
+  it("restores held modifiers from a pointer press after focus returns", () => {
+    const { window } = installShortcutModifierHook();
+    dispatchModifierEvent(window, "keydown", { key: "Meta", metaKey: true });
+    window.dispatchEvent(new Event("focus"));
+    expect(currentModifierState()).toEqual(emptyState());
+
+    dispatchModifierEvent(window, "pointerdown", { metaKey: true });
+
+    expect(currentModifierState()).toEqual({ ...emptyState(), metaKey: true });
+  });
+
   it.each(["paste", "input"])(
     "clears a synthetic Command press when dictated text triggers %s",
     (eventType) => {
@@ -238,4 +249,15 @@ describe("shortcutModifierState", () => {
       expect(currentModifierState()).toEqual(emptyState());
     },
   );
+
+  it("keeps Shift active when ordinary text input inserts an uppercase character", () => {
+    const { window } = installShortcutModifierHook();
+    dispatchModifierEvent(window, "keydown", { key: "Shift", shiftKey: true });
+    dispatchModifierEvent(window, "keydown", { key: "A", shiftKey: true });
+
+    window.dispatchEvent(new Event("input"));
+    dispatchModifierEvent(window, "keyup", { key: "A", shiftKey: true });
+
+    expect(currentModifierState()).toEqual({ ...emptyState(), shiftKey: true });
+  });
 });

--- a/apps/web/src/shortcutModifierState.ts
+++ b/apps/web/src/shortcutModifierState.ts
@@ -36,14 +36,21 @@ export function useShortcutModifierState(): ShortcutModifierState {
     const onPointerDown = (event: PointerEvent) => {
       setState((current) => {
         const nextState = {
-          metaKey: current.metaKey && event.metaKey,
-          ctrlKey: current.ctrlKey && event.ctrlKey,
-          altKey: current.altKey && event.altKey,
-          shiftKey: current.shiftKey && event.shiftKey,
+          metaKey: event.metaKey,
+          ctrlKey: event.ctrlKey,
+          altKey: event.altKey,
+          shiftKey: event.shiftKey,
         };
 
         return areShortcutModifierStatesEqual(current, nextState) ? current : nextState;
       });
+    };
+    const onTextInput = () => {
+      setState((current) =>
+        current.metaKey || current.ctrlKey
+          ? { ...current, metaKey: false, ctrlKey: false }
+          : current,
+      );
     };
     const resetModifierState = () => {
       setState((current) =>
@@ -56,8 +63,8 @@ export function useShortcutModifierState(): ShortcutModifierState {
     window.addEventListener("keydown", onKeyboardEvent, true);
     window.addEventListener("keyup", onKeyboardEvent, true);
     window.addEventListener("pointerdown", onPointerDown, true);
-    window.addEventListener("paste", resetModifierState, true);
-    window.addEventListener("input", resetModifierState, true);
+    window.addEventListener("paste", onTextInput, true);
+    window.addEventListener("input", onTextInput, true);
     window.addEventListener("blur", resetModifierState);
     window.addEventListener("focus", resetModifierState);
     document.addEventListener("visibilitychange", resetModifierState);
@@ -65,8 +72,8 @@ export function useShortcutModifierState(): ShortcutModifierState {
       window.removeEventListener("keydown", onKeyboardEvent, true);
       window.removeEventListener("keyup", onKeyboardEvent, true);
       window.removeEventListener("pointerdown", onPointerDown, true);
-      window.removeEventListener("paste", resetModifierState, true);
-      window.removeEventListener("input", resetModifierState, true);
+      window.removeEventListener("paste", onTextInput, true);
+      window.removeEventListener("input", onTextInput, true);
       window.removeEventListener("blur", resetModifierState);
       window.removeEventListener("focus", resetModifierState);
       document.removeEventListener("visibilitychange", resetModifierState);

--- a/apps/web/src/shortcutModifierState.ts
+++ b/apps/web/src/shortcutModifierState.ts
@@ -33,7 +33,19 @@ export function useShortcutModifierState(): ShortcutModifierState {
     const onKeyboardEvent = (event: KeyboardEvent) => {
       setState((current) => shortcutModifierStateAfterKeyboardEvent(current, event));
     };
-    const onWindowBlur = () => {
+    const onPointerDown = (event: PointerEvent) => {
+      setState((current) => {
+        const nextState = {
+          metaKey: current.metaKey && event.metaKey,
+          ctrlKey: current.ctrlKey && event.ctrlKey,
+          altKey: current.altKey && event.altKey,
+          shiftKey: current.shiftKey && event.shiftKey,
+        };
+
+        return areShortcutModifierStatesEqual(current, nextState) ? current : nextState;
+      });
+    };
+    const resetModifierState = () => {
       setState((current) =>
         areShortcutModifierStatesEqual(current, EMPTY_SHORTCUT_MODIFIER_STATE)
           ? current
@@ -43,11 +55,21 @@ export function useShortcutModifierState(): ShortcutModifierState {
 
     window.addEventListener("keydown", onKeyboardEvent, true);
     window.addEventListener("keyup", onKeyboardEvent, true);
-    window.addEventListener("blur", onWindowBlur);
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("paste", resetModifierState, true);
+    window.addEventListener("input", resetModifierState, true);
+    window.addEventListener("blur", resetModifierState);
+    window.addEventListener("focus", resetModifierState);
+    document.addEventListener("visibilitychange", resetModifierState);
     return () => {
       window.removeEventListener("keydown", onKeyboardEvent, true);
       window.removeEventListener("keyup", onKeyboardEvent, true);
-      window.removeEventListener("blur", onWindowBlur);
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("paste", resetModifierState, true);
+      window.removeEventListener("input", resetModifierState, true);
+      window.removeEventListener("blur", resetModifierState);
+      window.removeEventListener("focus", resetModifierState);
+      document.removeEventListener("visibilitychange", resetModifierState);
     };
   }, []);
 
@@ -77,19 +99,16 @@ export function shortcutModifierStateAfterKeyboardEvent(
   event: KeyboardEvent,
 ): ShortcutModifierState {
   const normalizedModifierKey = normalizeModifierKey(event.key);
-  let nextState: ShortcutModifierState;
+  const isKeyDown = event.type === "keydown";
+  const nextState: ShortcutModifierState = {
+    metaKey: event.metaKey && (isKeyDown || currentState.metaKey),
+    ctrlKey: event.ctrlKey && (isKeyDown || currentState.ctrlKey),
+    altKey: event.altKey && (isKeyDown || currentState.altKey),
+    shiftKey: event.shiftKey && (isKeyDown || currentState.shiftKey),
+  };
+
   if (normalizedModifierKey) {
-    nextState = {
-      ...currentState,
-      [normalizedModifierKey]: event.type === "keydown",
-    };
-  } else {
-    nextState = {
-      metaKey: event.metaKey,
-      ctrlKey: event.ctrlKey,
-      altKey: event.altKey,
-      shiftKey: event.shiftKey,
-    };
+    nextState[normalizedModifierKey] = isKeyDown;
   }
 
   return areShortcutModifierStatesEqual(currentState, nextState) ? currentState : nextState;


### PR DESCRIPTION
Thread shortcut hints stayed visible after app switches or after Wispr Flow inserted dictated text. Synthetic keyboard events could mark Command as pressed without a matching key release.

Clear stale modifier state when focus changes, text is inserted, or a click shows that Command is up. Prevent key releases from creating new pressed modifiers.

Made with GPT-5.6 Sol using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds capture-phase global listeners that can clear or resync modifier state; incorrect OS modifier reporting could briefly affect shortcut hint visibility, but scope is UI-only.
> 
> **Overview**
> Fixes **thread shortcut hints** staying visible when modifiers never get a clean key release (app switches, dictation paste, synthetic keyboard events).
> 
> **`shortcutModifierStateAfterKeyboardEvent`** now treats modifier flags on **keyup** as authoritative only for modifiers already held, so a release like Fn with a stale `metaKey` no longer turns Command on. Pressing another modifier while Command is stuck can clear the missed release.
> 
> **`useShortcutModifierState`** resets all modifiers on window **blur/focus** and **visibilitychange**, syncs state from **`pointerdown`** modifier flags (clear or restore after focus), and clears **meta/ctrl** on **paste/input** when those look like a synthetic Command press—while leaving Shift alone for normal uppercase typing.
> 
> Tests add a React hook harness and cover these recovery paths end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec1dfee6a7d903300bf599f83cbb2b2c695433c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stuck thread shortcut modifier hints in `useShortcutModifierState`
> - `shortcutModifierStateAfterKeyboardEvent` now gates modifier truthiness by event type so keyup events with stale modifier flags no longer set a modifier true; pressing another modifier clears previously stuck modifiers while preserving those actually held.
> - `useShortcutModifierState` adds pointerdown syncing, clears synthetic Command/Control on paste/input (but keeps Shift for normal uppercase text), and resets all modifiers on window blur/focus and document visibilitychange.
> - Adds unit tests for the hook using a mocked React harness that captures `useEffect` cleanups, plus edge-case coverage for stale Fn-key release, missed Command release, and pointer/visibility resets.
> - Behavioral Change: `onTextInput` clears `metaKey`/`ctrlKey` on paste or input when either is active; reviewers should verify ordinary typing that relies on synthetic input events is not affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fec1dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->