### PR TITLE
feat(web): add mod+t shortcut for new project

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -461,11 +461,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       if (command === "project.new") {
         event.preventDefault();
         event.stopPropagation();
-        if (state.open && state.openIntent?.kind === "add-project") {
-          setOpen(false);
-        } else {
-          openAddProject();
-        }
+        openAddProject();
         return;
       }
       const mode = overlayModeForCommand(command);
@@ -483,9 +479,6 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     openAddProject,
     previewOpen,
     resolvedTheme,
-    setOpen,
-    state.open,
-    state.openIntent?.kind,
     terminalOpen,
     theme,
     themeHalves,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -461,7 +461,11 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       if (command === "project.new") {
         event.preventDefault();
         event.stopPropagation();
-        openAddProject();
+        if (state.open && state.openIntent?.kind === "add-project") {
+          setOpen(false);
+        } else {
+          openAddProject();
+        }
         return;
       }
       const mode = overlayModeForCommand(command);
@@ -479,6 +483,9 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     openAddProject,
     previewOpen,
     resolvedTheme,
+    setOpen,
+    state.open,
+    state.openIntent?.kind,
     terminalOpen,
     theme,
     themeHalves,
@@ -1591,6 +1598,7 @@ function OpenCommandPaletteDialog(props: {
     disabled: defaultAddProjectEnvironmentId === null,
     icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
     keepOpen: true,
+    shortcutCommand: "project.new",
     run: async () => {
       openAddProjectFlow();
     },

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -458,6 +458,12 @@ export function CommandPalette({ children }: { children: ReactNode }) {
         });
         return;
       }
+      if (command === "project.new") {
+        event.preventDefault();
+        event.stopPropagation();
+        openAddProject();
+        return;
+      }
       const mode = overlayModeForCommand(command);
       if (mode === null) {
         return;
@@ -468,7 +474,16 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, previewOpen, resolvedTheme, terminalOpen, theme, themeHalves, toggleMode]);
+  }, [
+    keybindings,
+    openAddProject,
+    previewOpen,
+    resolvedTheme,
+    terminalOpen,
+    theme,
+    themeHalves,
+    toggleMode,
+  ]);
 
   useEffect(
     () =>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3387,6 +3387,7 @@ export default function Sidebar() {
     shortcutLabelForCommand(keybindings, "chat.new") ??
     (projectGroups.length <= 1 ? shortcutLabelForCommand(keybindings, "chat.newLocal") : undefined);
   const newThreadInProjectShortcutLabel = shortcutLabelForCommand(keybindings, "chat.newLocal");
+  const newProjectShortcutLabel = shortcutLabelForCommand(keybindings, "project.new");
   return (
     <>
       <SidebarChromeHeader isElectron={isElectron} />
@@ -3581,7 +3582,11 @@ export default function Sidebar() {
                       aria-hidden="true"
                     />
                   </TooltipTrigger>
-                  <TooltipPopup side="right">New project</TooltipPopup>
+                  <TooltipPopup side="right">
+                    {newProjectShortcutLabel
+                      ? `New project (${newProjectShortcutLabel})`
+                      : "New project"}
+                  </TooltipPopup>
                 </Tooltip>
               </div>
             ) : null}

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -69,6 +69,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "projectSearch.toggle",
   "themeEditor.toggle",
   "composer.stash",
+  "project.new",
   "chat.new",
   "chat.newLocal",
   "editor.openFavorite",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -39,6 +39,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+f", command: "projectSearch.toggle", when: "!terminalFocus" },
   { key: "mod+alt+shift+t", command: "themeEditor.toggle" },
   { key: "mod+s", command: "composer.stash", when: "!terminalFocus" },
+  { key: "mod+t", command: "project.new", when: "!terminalFocus" },
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },


### PR DESCRIPTION
## What Changed

Adds a new `project.new` keybinding command with the default shortcut `mod+t` (Cmd+T on macOS, Ctrl+T elsewhere). When triggered, it opens the command palette's add-project flow. This doesn't take over the browser's shortcut

## Why

There was no keyboard shortcut to add a new project. Users had to reach for the mouse and click through the sidebar. `mod+t` is the natural choice. It matches VS Code's pattern and is unused in the keybinding set.

## UI Changes

Before:
<img width="199" height="64" alt="image" src="https://github.com/user-attachments/assets/67dd141b-6704-491d-adcd-49e415312820" />

After:
<img width="274" height="78" alt="image" src="https://github.com/user-attachments/assets/10cb71e3-e10f-4237-9a06-879769365344" />

https://github.com/user-attachments/assets/386db42d-a341-4b93-8270-7437d9dafaa9

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard and tooltip wiring only; no changes to project creation, auth, or server APIs. **`mod+t`** may override the browser’s new-tab shortcut when the app has focus outside the terminal.
> 
> **Overview**
> Introduces a **`project.new`** keybinding (default **`mod+t`**, active when the terminal is not focused) so users can start adding a project from the keyboard.
> 
> The global shortcut handler in **`CommandPalette`** intercepts **`project.new`**, prevents default browser behavior, and opens the same add-project flow as the palette bus (`openAddProject`). The **Add project** command palette row is wired with **`shortcutCommand: "project.new"`** so the shortcut appears in the palette UI. The sidebar **New project** tooltip now shows the configured shortcut label when one exists.
> 
> Contracts and shared defaults register **`project.new`** in the keybinding schema and map **`mod+t`** to it alongside existing chat/new-thread bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0eef33314cc6c4e7cc9f42ffc8efcfdbebebe9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mod+t` shortcut for new project in web app
> - Registers `project.new` as a valid keybinding command and maps `mod+t` to it by default when `!terminalFocus`
> - `CommandPalette` keydown handler now opens the Add Project flow when `project.new` fires, and the 'Add project' action item carries the shortcut metadata
> - `Sidebar` New project button tooltip displays the configured shortcut when available
> - Behavioral Change: `mod+t` outside terminal focus now triggers the new project flow instead of any prior browser default
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0eef33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->