### PR TITLE
fix(server): keep provider CLIs available in the macOS service

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -284,7 +284,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
         true,
       );
       expect(yield* fs.readFileString(plan.unitPath)).toContain(
-        `    <key>PATH</key>\n    <string>${macInstallerPath}</string>`,
+        `    <key>PATH</key>\n    <string>${macInstallerPath}:/usr/local/bin:/usr/sbin:/sbin</string>`,
       );
       expect(parseServiceState(yield* fs.readFileString(statePath))).toEqual({
         protocol: SERVICE_LAUNCHER_PROTOCOL,
@@ -335,6 +335,18 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
     }),
   );
 
+  it.effect("adds missing provider directories to a minimal installer PATH", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness("darwin", false, "/usr/bin:/bin");
+      const plan = yield* service.install;
+
+      expect(yield* fs.readFileString(plan.unitPath)).toContain(
+        "    <key>PATH</key>\n    <string>/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/usr/sbin:/sbin</string>",
+      );
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
   it.effect("keeps an installed launch agent current when the process PATH changes", () =>
     Effect.gen(function* () {
       const { service, makeService } = yield* makeHarness("darwin");
@@ -356,7 +368,7 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       const plist = yield* fs.readFileString(plan.unitPath);
 
       expect(plist).toContain(
-        "    <key>PATH</key>\n    <string>/opt/homebrew/bin:/usr/bin</string>",
+        "    <key>PATH</key>\n    <string>/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin:/usr/sbin:/sbin</string>",
       );
       expect(plist).not.toContain("\u0001");
       expect((yield* service.status).current).toBe(true);

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -56,17 +56,26 @@ const macPlan = {
   logPath: "/Users/theo/.t3/userdata/logs/boot-service.log",
   unitPath: "/Users/theo/Library/LaunchAgents/com.t3tools.t3code.service.plist",
 };
+const macInstallerPath =
+  "/opt/homebrew/bin:/Users/theo/.npm-global/bin:/Users/theo/.nvm/versions/node/v22.16.0/bin:/usr/bin:/bin";
+const macRenderOptions = { homeDir: "/Users/theo", environmentPath: macInstallerPath };
 
 it("keeps launchd pinned to the stable launcher rather than a versioned server", () => {
-  const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
+  const plist = BootService.renderBootServicePlist(macPlan, macRenderOptions);
 
   expect(plist).toContain("<string>/opt/homebrew/bin/node</string>");
   expect(plist).toContain("<string>/Users/theo/.t3/runtime/service-launcher.mjs</string>");
   expect(plist).not.toContain("versions/1.2.3");
 });
 
+it("preserves the installer's provider search path in the launch agent", () => {
+  const plist = BootService.renderBootServicePlist(macPlan, macRenderOptions);
+
+  expect(plist).toContain(`    <key>PATH</key>\n    <string>${macInstallerPath}</string>`);
+});
+
 it("restarts the launch agent on the systemd cadence", () => {
-  const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
+  const plist = BootService.renderBootServicePlist(macPlan, macRenderOptions);
 
   expect(plist).toContain("<key>RunAtLoad</key>\n  <true/>");
   expect(plist).toContain("<key>KeepAlive</key>\n  <true/>");
@@ -75,7 +84,7 @@ it("restarts the launch agent on the systemd cadence", () => {
 });
 
 it("appends both stdio streams to the boot service log", () => {
-  const plist = BootService.renderBootServicePlist(macPlan, { homeDir: "/Users/theo" });
+  const plist = BootService.renderBootServicePlist(macPlan, macRenderOptions);
 
   expect(plist).toContain(
     "<key>StandardOutPath</key>\n  <string>/Users/theo/.t3/userdata/logs/boot-service.log</string>",
@@ -88,15 +97,17 @@ it("appends both stdio streams to the boot service log", () => {
 it("escapes XML in host paths", () => {
   const plist = BootService.renderBootServicePlist(
     { ...macPlan, baseDir: "/Users/theo/T3 & <Co>" },
-    { homeDir: "/Users/theo" },
+    { homeDir: "/Users/theo", environmentPath: "/Users/theo/Tools & <Scripts>:/usr/bin" },
   );
 
   expect(plist).toContain("<string>/Users/theo/T3 &amp; &lt;Co&gt;</string>");
+  expect(plist).toContain("<string>/Users/theo/Tools &amp; &lt;Scripts&gt;:/usr/bin</string>");
 });
 
 const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   platform: NodeJS.Platform = "linux",
   usePinnedLauncher = false,
+  installerPath: string | undefined = macInstallerPath,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -151,7 +162,11 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
         Layer.succeed(HostProcessUserId, 501),
         Layer.succeed(HostProcessExecutablePath, "/usr/bin/node"),
         Layer.succeed(HostProcessArguments, ["/usr/bin/node", path.join(home, "bin.mjs")]),
-        ConfigProvider.layer(ConfigProvider.fromEnv({ env: { HOME: home } })),
+        ConfigProvider.layer(
+          ConfigProvider.fromEnv({
+            env: { HOME: home, ...(installerPath === "" ? {} : { PATH: installerPath }) },
+          }),
+        ),
       ),
     ),
   );
@@ -266,6 +281,9 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(plan.unitPath.endsWith("Library/LaunchAgents/com.t3tools.t3code.service.plist")).toBe(
         true,
       );
+      expect(yield* fs.readFileString(plan.unitPath)).toContain(
+        `    <key>PATH</key>\n    <string>${macInstallerPath}</string>`,
+      );
       expect(parseServiceState(yield* fs.readFileString(statePath))).toEqual({
         protocol: SERVICE_LAUNCHER_PROTOCOL,
         activeVersion: "1.2.3",
@@ -300,6 +318,18 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
         `launchctl bootstrap gui/501 ${plistPath}`,
         `launchctl bootstrap gui/501 ${plistPath}`,
       ]);
+    }),
+  );
+
+  it.effect("reconstructs a launch agent search path when the installer has no PATH", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness("darwin", false, "");
+      const plan = yield* service.install;
+
+      expect(yield* fs.readFileString(plan.unitPath)).toContain(
+        "    <key>PATH</key>\n    <string>/usr/bin:/opt/homebrew/bin:/usr/local/bin:/bin:/usr/sbin:/sbin</string>",
+      );
+      expect((yield* service.status).current).toBe(true);
     }),
   );
 

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -107,7 +107,7 @@ it("escapes XML in host paths", () => {
 const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   platform: NodeJS.Platform = "linux",
   usePinnedLauncher = false,
-  installerPath: string | undefined = macInstallerPath,
+  installerPath = macInstallerPath,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -146,31 +146,33 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
         };
       }),
   });
-  const service = yield* BootService.make({
-    baseDir,
-    logsDir: path.join(baseDir, "userdata", "logs"),
-    cliVersion: "1.2.3",
-    host: {
-      execPath: "/usr/bin/node",
-      ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
-    },
-  }).pipe(
-    Effect.provideService(ProcessRunner.ProcessRunner, runner),
-    Effect.provide(
-      Layer.mergeAll(
-        Layer.succeed(HostProcessPlatform, platform),
-        Layer.succeed(HostProcessUserId, 501),
-        Layer.succeed(HostProcessExecutablePath, "/usr/bin/node"),
-        Layer.succeed(HostProcessArguments, ["/usr/bin/node", path.join(home, "bin.mjs")]),
-        ConfigProvider.layer(
-          ConfigProvider.fromEnv({
-            env: { HOME: home, ...(installerPath === "" ? {} : { PATH: installerPath }) },
-          }),
+  const makeService = (environmentPath = installerPath) =>
+    BootService.make({
+      baseDir,
+      logsDir: path.join(baseDir, "userdata", "logs"),
+      cliVersion: "1.2.3",
+      host: {
+        execPath: "/usr/bin/node",
+        ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
+      },
+    }).pipe(
+      Effect.provideService(ProcessRunner.ProcessRunner, runner),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(HostProcessPlatform, platform),
+          Layer.succeed(HostProcessUserId, 501),
+          Layer.succeed(HostProcessExecutablePath, "/usr/bin/node"),
+          Layer.succeed(HostProcessArguments, ["/usr/bin/node", path.join(home, "bin.mjs")]),
+          ConfigProvider.layer(
+            ConfigProvider.fromEnv({
+              env: { HOME: home, ...(environmentPath === "" ? {} : { PATH: environmentPath }) },
+            }),
+          ),
         ),
       ),
-    ),
-  );
-  return { service, fs, statePath, commands, timeouts, control };
+    );
+  const service = yield* makeService();
+  return { service, makeService, fs, statePath, commands, timeouts, control };
 });
 
 it.layer(NodeServices.layer)("boot service install", (it) => {
@@ -329,6 +331,34 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       expect(yield* fs.readFileString(plan.unitPath)).toContain(
         "    <key>PATH</key>\n    <string>/usr/bin:/opt/homebrew/bin:/usr/local/bin:/bin:/usr/sbin:/sbin</string>",
       );
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
+  it.effect("keeps an installed launch agent current when the process PATH changes", () =>
+    Effect.gen(function* () {
+      const { service, makeService } = yield* makeHarness("darwin");
+      yield* service.install;
+
+      const restartedService = yield* makeService("/usr/local/bin:/usr/bin:/bin");
+      expect((yield* restartedService.status).current).toBe(true);
+    }),
+  );
+
+  it.effect("drops PATH directories that cannot be represented in a launch agent plist", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness(
+        "darwin",
+        false,
+        "/opt/homebrew/bin:/Users/theo/\u0001invalid:/usr/bin",
+      );
+      const plan = yield* service.install;
+      const plist = yield* fs.readFileString(plan.unitPath);
+
+      expect(plist).toContain(
+        "    <key>PATH</key>\n    <string>/opt/homebrew/bin:/usr/bin</string>",
+      );
+      expect(plist).not.toContain("\u0001");
       expect((yield* service.status).current).toBe(true);
     }),
   );

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -459,28 +459,26 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
   const host = input.host ?? { execPath: hostExecPath };
-  const xmlSafeInstallerPath = installerPath
-    .split(":")
-    .filter((directory) =>
+  const xmlSafeInstallerDirectories = installerPath.split(":").filter(
+    (directory) =>
+      directory.length > 0 &&
       Array.from(directory).every((character) => {
         const code = character.charCodeAt(0);
         return code >= 0x20 || code === 0x09 || code === 0x0a || code === 0x0d;
       }),
-    )
-    .join(":");
-  const environmentPath =
-    xmlSafeInstallerPath ||
-    Array.from(
-      new Set([
-        path.dirname(host.execPath),
-        "/opt/homebrew/bin",
-        "/usr/local/bin",
-        "/usr/bin",
-        "/bin",
-        "/usr/sbin",
-        "/sbin",
-      ]),
-    ).join(":");
+  );
+  const environmentPath = Array.from(
+    new Set([
+      ...xmlSafeInstallerDirectories,
+      path.dirname(host.execPath),
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]),
+  ).join(":");
 
   const detectedManager = selectBootServiceManager({
     platform,

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -99,7 +99,7 @@ export function escapeXmlText(value: string): string {
 /** Pure renderer: launch agents cannot rely on the user's shell or PATH. */
 export function renderBootServicePlist(
   plan: BootServicePlan,
-  options: { readonly homeDir: string },
+  options: { readonly homeDir: string; readonly environmentPath: string },
 ): string {
   // KeepAlive + ThrottleInterval mirror Restart=always + RestartSec=5. launchd
   // has no StartLimitBurst analog; a hard crash loop respawns every 5s forever.
@@ -127,6 +127,8 @@ export function renderBootServicePlist(
     `  </array>`,
     `  <key>EnvironmentVariables</key>`,
     `  <dict>`,
+    `    <key>PATH</key>`,
+    `    <string>${escapeXmlText(options.environmentPath)}</string>`,
     `    <key>T3CODE_HOME</key>`,
     `    <string>${escapeXmlText(plan.baseDir)}</string>`,
     `    <key>${BOOT_SERVICE_UNIT_ENV}</key>`,
@@ -268,6 +270,7 @@ export function launchdManager(input: {
   readonly path: Path.Path;
   readonly homeDir: string;
   readonly uid: number;
+  readonly environmentPath: string;
 }): BootServiceManager {
   const unitPath = input.path.join(
     input.homeDir,
@@ -287,7 +290,11 @@ export function launchdManager(input: {
   return {
     kind: "launchd",
     unitPath,
-    render: (plan) => renderBootServicePlist(plan, { homeDir: input.homeDir }),
+    render: (plan) =>
+      renderBootServicePlist(plan, {
+        homeDir: input.homeDir,
+        environmentPath: input.environmentPath,
+      }),
     // Without --wait, bootout returns in milliseconds while the job drains
     // for up to ExitTimeOut, and a bootstrap during the drain fails EIO.
     // --wait (present on modern macOS, absent from the man page) blocks until
@@ -346,6 +353,7 @@ export function selectBootServiceManager(input: {
   readonly homeDir: string;
   readonly uid: number | undefined;
   readonly path: Path.Path;
+  readonly environmentPath: string;
 }): BootServiceManager | undefined {
   if (input.homeDir === "") {
     return undefined;
@@ -354,7 +362,12 @@ export function selectBootServiceManager(input: {
     return systemdManager({ path: input.path, homeDir: input.homeDir });
   }
   if (input.platform === "darwin" && input.uid !== undefined) {
-    return launchdManager({ path: input.path, homeDir: input.homeDir, uid: input.uid });
+    return launchdManager({
+      path: input.path,
+      homeDir: input.homeDir,
+      uid: input.uid,
+      environmentPath: input.environmentPath,
+    });
   }
   return undefined;
 }
@@ -441,12 +454,32 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const platform = yield* HostProcessPlatform;
   const uid = yield* HostProcessUserId;
   const homeDir = yield* Config.string("HOME").pipe(Config.withDefault(""));
+  const installerPath = yield* Config.string("PATH").pipe(Config.withDefault(""));
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
   const host = input.host ?? { execPath: hostExecPath };
+  const environmentPath =
+    installerPath ||
+    Array.from(
+      new Set([
+        path.dirname(host.execPath),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+      ]),
+    ).join(":");
 
-  const detectedManager = selectBootServiceManager({ platform, homeDir, uid, path });
+  const detectedManager = selectBootServiceManager({
+    platform,
+    homeDir,
+    uid,
+    path,
+    environmentPath,
+  });
   const unitPath = detectedManager?.unitPath ?? "";
   const logPath = path.join(input.logsDir, "boot-service.log");
   const launcherPath = path.join(input.baseDir, "runtime", SERVICE_LAUNCHER_FILE);

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -459,8 +459,17 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
   const host = input.host ?? { execPath: hostExecPath };
+  const xmlSafeInstallerPath = installerPath
+    .split(":")
+    .filter((directory) =>
+      Array.from(directory).every((character) => {
+        const code = character.charCodeAt(0);
+        return code >= 0x20 || code === 0x09 || code === 0x0a || code === 0x0d;
+      }),
+    )
+    .join(":");
   const environmentPath =
-    installerPath ||
+    xmlSafeInstallerPath ||
     Array.from(
       new Set([
         path.dirname(host.execPath),
@@ -697,11 +706,15 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
         fs.readFileString(statePath).pipe(Effect.option),
       ]);
     const state = Option.isSome(stateText) ? parseServiceState(stateText.value) : undefined;
+    const normalizeUnit = (contents: string) =>
+      detectedManager.kind === "launchd"
+        ? contents.replace(/(<key>PATH<\/key>\n\s*<string>)[^<]*(<\/string>)/, "$1$2")
+        : contents;
     return {
       supported: true,
       installed: true,
       current:
-        unit === detectedManager.render(plan) &&
+        normalizeUnit(unit) === normalizeUnit(detectedManager.render(plan)) &&
         launcherExists &&
         runtimeEntryExists &&
         Option.isSome(runtimeSentinel) &&


### PR DESCRIPTION
The macOS background service starts with launchd's limited PATH, so Codex, Claude, and other provider CLIs disappear if login-shell PATH recovery fails.

Save the installer's PATH in the LaunchAgent, and fall back to the Node directory plus standard macOS binary directories when PATH is missing. Focused tests cover installation, XML escaping, fallback paths, and existing service restarts.

Built by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS service install and health-check behavior for a critical background daemon; incorrect PATH could break provider CLIs or mask real plist drift via normalization.
> 
> **Overview**
> The macOS LaunchAgent plist now sets **`PATH`** in `EnvironmentVariables`, built from the installer’s `PATH` (with non–XML-safe segments removed), plus the Node binary directory and standard macOS tool locations when entries are missing.
> 
> **`renderBootServicePlist`** and the launchd wiring take a new `environmentPath` argument. **`status.current`** compares plist content with the `PATH` value blanked out so a different shell `PATH` at check time does not force a reinstall.
> 
> Tests cover preserved installer paths, empty/minimal `PATH` fallbacks, XML escaping for `PATH`, invalid path segments, and unchanged “current” status when only process `PATH` differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e1de2c51032b5b5280e0977f101b82dbb2024a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PATH` environment variable to macOS LaunchAgent plist in `bootService`
> - The macOS LaunchAgent plist now includes a `PATH` built from the installer's `PATH`, the host executable directory, and a fixed set of provider/system directories (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`)
> - Invalid `PATH` segments containing disallowed XML control characters are dropped, and duplicate directories are de-duplicated
> - `renderBootServicePlist` and `launchdManager` accept a new `environmentPath` option that flows through from `make`
> - `BootService.status` now strips the `PATH` value from both on-disk and freshly rendered plists before comparing, so a changed `PATH` alone does not mark the installed unit as stale
> - Behavioral Change: `selectBootServiceManager` and `launchdManager` now require `environmentPath`; callers that do not supply it will produce a plist without a `PATH` entry
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2e1de2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->