### PR TITLE
feat(web): keybinding settings as settings rows

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -908,7 +908,8 @@ function KeybindingRowMenu({
 }) {
   const canReset = row.source === "Custom" && row.defaultKey !== null;
   const canRemove = row.source !== "Default";
-  if (!canReset && !canRemove) return null;
+  // Keep the slot occupied so shortcut pills share a right edge across rows.
+  if (!canReset && !canRemove) return <span className="size-7 shrink-0" aria-hidden />;
 
   return (
     <Menu>

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -876,12 +876,9 @@ function WhenClauseControl({
       <PopoverTrigger
         render={
           <Button
-            variant="ghost"
+            variant={expression ? "ghost" : "ghost-muted"}
             size="compact"
-            className={cn(
-              "h-6 max-w-full gap-1 px-1 font-mono font-normal text-[12px] sm:text-[12px]",
-              !expression && "text-muted-foreground",
-            )}
+            className="h-6 min-w-0 shrink gap-1 px-1 font-mono font-normal text-[12px] sm:text-[12px]"
           />
         }
         aria-label={`Edit when clause for ${label}`}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -3,7 +3,6 @@ import {
   CircleXIcon,
   EllipsisIcon,
   FileJsonIcon,
-  InfoIcon,
   MinusIcon,
   PlusIcon,
   SearchIcon,
@@ -35,7 +34,6 @@ import {
 
 import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
-import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import {
   primaryServerAvailableEditorsAtom,
@@ -44,12 +42,12 @@ import {
   serverEnvironment,
 } from "../../state/server";
 import { usePrimaryEnvironment } from "../../state/environments";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { ScrollArea } from "../ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Toggle } from "../ui/toggle";
 import { toastManager } from "../ui/toast";
@@ -69,7 +67,7 @@ import {
   unknownWhenVariables,
   whenAstToExpression,
 } from "./KeybindingsSettings.logic";
-import { SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import { SettingsPageContainer, SettingsRow, SettingsSection } from "./settingsLayout";
 import { searchableSetting } from "./settingsSearch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { useAtomCommand } from "../../state/use-atom-command";
@@ -733,32 +731,20 @@ function rowKeybindingTarget(row: KeybindingRow): ServerRemoveKeybindingInput {
   };
 }
 
-function KeybindingTableRow({
+/** Draft state and actions for editing one existing binding; layouts decide how to render it. */
+function useKeybindingRowEditor({
   row,
   allRows,
-  variables,
-  isSaving,
   onSave,
-  onReset,
-  onRemove,
 }: {
   row: KeybindingRow;
   allRows: ReadonlyArray<KeybindingRow>;
-  variables: ReadonlyArray<WhenVariableOption>;
-  isSaving: boolean;
   onSave: (input: ServerUpsertKeybindingInput) => void;
-  onReset: (row: KeybindingRow) => void;
-  onRemove: (row: KeybindingRow) => void;
 }) {
   const [draft, setDraft] = useReducer(keybindingRowDraftReducer, row, createKeybindingRowDraft);
   const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
   const whenDraftExpression = whenAstToExpression(whenDraft);
   const isDirty = keyDraft !== row.key || whenDraftExpression !== row.when;
-  const displayShortcut = formatShortcutLabel(row.binding.shortcut);
-  const canReset = row.source === "Custom" && row.defaultKey !== null;
-  const canRemove = row.source !== "Default";
-  const hasRowActions = canReset || canRemove;
-  const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
   const conflictLabels = keybindingConflictLabels(allRows, {
     rowId: row.id,
     key: keyDraft,
@@ -786,139 +772,244 @@ function KeybindingTableRow({
     setDraft({ keyDraft: next, isRecording: false });
   };
 
+  return {
+    keyDraft,
+    whenDraft,
+    isRecording,
+    isWhenDraftValid,
+    whenDraftExpression,
+    isDirty,
+    conflictLabels,
+    setDraft,
+    save,
+    captureKeybinding,
+  };
+}
+
+type KeybindingRowEditor = ReturnType<typeof useKeybindingRowEditor>;
+
+interface KeybindingRowActions {
+  allRows: ReadonlyArray<KeybindingRow>;
+  variables: ReadonlyArray<WhenVariableOption>;
+  onSave: (input: ServerUpsertKeybindingInput) => void;
+  onReset: (row: KeybindingRow) => void;
+  onRemove: (row: KeybindingRow) => void;
+}
+
+type KeybindingRowProps = KeybindingRowActions & { row: KeybindingRow; isSaving: boolean };
+
+/** Shortcut pill that turns into a capture input when clicked, plus Save once the draft changes. */
+function KeybindingKeyControl({
+  row,
+  editor,
+  isSaving,
+}: {
+  row: KeybindingRow;
+  editor: KeybindingRowEditor;
+  isSaving: boolean;
+}) {
+  const { keyDraft, isRecording, isDirty, isWhenDraftValid, setDraft, save, captureKeybinding } =
+    editor;
+  const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
+
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
-      <div className="min-w-0 pr-4">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <div
-                  aria-label={row.command}
-                  className="truncate text-[13px] font-medium text-foreground"
-                />
-              }
-            >
-              {commandLabel(row.command)}
-            </TooltipTrigger>
-            <TooltipPopup side="top">{row.command}</TooltipPopup>
-          </Tooltip>
-        </div>
-      </div>
-      <div className="flex min-w-0 items-center gap-2 pr-4">
-        {showPill ? (
-          <button
-            type="button"
-            onClick={() => setDraft({ isRecording: true })}
-            aria-label={`Edit shortcut for ${commandLabel(row.command)}`}
-            className="group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
-          >
-            <KeybindingPill value={row.key} />
-            <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/0 transition-opacity group-hover:text-muted-foreground/70 group-focus-visible:text-muted-foreground/70">
-              Edit
-            </span>
-          </button>
-        ) : (
-          <Input
-            data-keybinding-capture=""
-            autoFocus={isRecording}
-            aria-label={`Keybinding for ${commandLabel(row.command)}`}
-            value={isRecording ? "" : keyDraft}
-            placeholder={isRecording ? "Press shortcut" : "Unassigned"}
-            className={cn(
-              "h-7 w-44 rounded-md font-mono text-[12px] sm:h-7",
-              isRecording && "border-primary/70 bg-primary/5",
-            )}
-            onFocus={() => setDraft({ isRecording: true })}
-            onBlur={() => setDraft({ isRecording: false })}
-            onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
-            onKeyDown={captureKeybinding}
-          />
-        )}
-        {isDirty ? (
-          <Button
-            size="compact"
-            disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
-            onClick={save}
-          >
-            {isSaving ? "Saving" : "Save"}
-          </Button>
-        ) : null}
-      </div>
-      <div className="pr-4">
-        <Popover>
-          <PopoverTrigger
-            className={cn(
-              "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
-              !whenDraftExpression && "text-muted-foreground",
-            )}
-            aria-label={`Edit when clause for ${commandLabel(row.command)}`}
-          >
-            <span className="truncate">{whenDraftExpression || "Always"}</span>
-            <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
-          </PopoverTrigger>
-          <PopoverContent align="start" sideOffset={6}>
-            <WhenExpressionBuilder
-              value={whenDraft}
-              variables={variables}
-              onChange={(nextWhenDraft) => setDraft({ whenDraft: nextWhenDraft })}
-              onValidityChange={(nextIsValid) => setDraft({ isWhenDraftValid: nextIsValid })}
-            />
-          </PopoverContent>
-        </Popover>
-      </div>
-      <div className="flex items-center justify-end gap-1">
-        <KeybindingConflictWarning labels={conflictLabels} />
-        {hasRowActions ? (
-          <Menu>
-            <MenuTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
-                  disabled={isSaving}
-                  aria-label={`Actions for ${commandLabel(row.command)}`}
-                />
-              }
-            >
-              <EllipsisIcon className="size-3.5" />
-            </MenuTrigger>
-            <MenuPopup align="end" className="min-w-36">
-              {canReset ? (
-                <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
-                  Reset to default
-                </MenuItem>
-              ) : null}
-              {canRemove ? (
-                <MenuItem variant="destructive" disabled={isSaving} onClick={() => onRemove(row)}>
-                  Remove
-                </MenuItem>
-              ) : null}
-            </MenuPopup>
-          </Menu>
-        ) : null}
-        <span className="sr-only">{displayShortcut}</span>
-      </div>
-    </div>
+    <>
+      {showPill ? (
+        <button
+          type="button"
+          onClick={() => setDraft({ isRecording: true })}
+          aria-label={`Edit shortcut for ${commandLabel(row.command)}`}
+          className="group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
+        >
+          <KeybindingPill value={row.key} />
+          <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/0 transition-opacity group-hover:text-muted-foreground/70 group-focus-visible:text-muted-foreground/70">
+            Edit
+          </span>
+        </button>
+      ) : (
+        <Input
+          data-keybinding-capture=""
+          autoFocus={isRecording}
+          aria-label={`Keybinding for ${commandLabel(row.command)}`}
+          value={isRecording ? "" : keyDraft}
+          placeholder={isRecording ? "Press shortcut" : "Unassigned"}
+          className={cn(
+            "h-7 w-44 rounded-md font-mono text-[12px] sm:h-7",
+            isRecording && "border-primary/70 bg-primary/5",
+          )}
+          onFocus={() => setDraft({ isRecording: true })}
+          onBlur={() => setDraft({ isRecording: false })}
+          onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
+          onKeyDown={captureKeybinding}
+        />
+      )}
+      {isDirty ? (
+        <Button
+          size="compact"
+          disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
+          onClick={save}
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
+      ) : null}
+    </>
   );
 }
 
-function NewKeybindingTableRow({
-  commandOptions,
-  allRows,
+const WHEN_TRIGGER_CLASS = {
+  field:
+    "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+  inline:
+    "inline-flex h-6 max-w-full items-center gap-1 rounded-sm px-1 font-mono text-[12px] outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/24",
+} as const;
+
+/** Popover trigger showing the when clause, styled as a field or as quiet inline text. */
+function WhenClauseControl({
+  label,
+  expression,
+  value,
   variables,
-  isSaving,
-  onSave,
-  onCancel,
+  onChange,
+  onValidityChange,
+  variant = "field",
+  className,
 }: {
-  commandOptions: ReadonlyArray<KeybindingCommandOption>;
-  allRows: ReadonlyArray<KeybindingRow>;
+  label: string;
+  expression: string;
+  value: KeybindingWhenNode | undefined;
   variables: ReadonlyArray<WhenVariableOption>;
+  onChange: (value: KeybindingWhenNode | undefined) => void;
+  onValidityChange: (valid: boolean) => void;
+  variant?: keyof typeof WHEN_TRIGGER_CLASS | undefined;
+  className?: string | undefined;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        className={cn(
+          WHEN_TRIGGER_CLASS[variant],
+          !expression && "text-muted-foreground",
+          className,
+        )}
+        aria-label={`Edit when clause for ${label}`}
+      >
+        <span className="truncate">{expression || "Always"}</span>
+        <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
+      </PopoverTrigger>
+      <PopoverContent align="start" sideOffset={6}>
+        <WhenExpressionBuilder
+          value={value}
+          variables={variables}
+          onChange={onChange}
+          onValidityChange={onValidityChange}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function KeybindingRowMenu({
+  row,
+  isSaving,
+  onReset,
+  onRemove,
+}: {
+  row: KeybindingRow;
   isSaving: boolean;
+  onReset: (row: KeybindingRow) => void;
+  onRemove: (row: KeybindingRow) => void;
+}) {
+  const canReset = row.source === "Custom" && row.defaultKey !== null;
+  const canRemove = row.source !== "Default";
+  if (!canReset && !canRemove) return null;
+
+  return (
+    <Menu>
+      <MenuTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
+            disabled={isSaving}
+            aria-label={`Actions for ${commandLabel(row.command)}`}
+          />
+        }
+      >
+        <EllipsisIcon className="size-3.5" />
+      </MenuTrigger>
+      <MenuPopup align="end" className="min-w-36">
+        {canReset ? (
+          <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
+            Reset to default
+          </MenuItem>
+        ) : null}
+        {canRemove ? (
+          <MenuItem variant="destructive" disabled={isSaving} onClick={() => onRemove(row)}>
+            Remove
+          </MenuItem>
+        ) : null}
+      </MenuPopup>
+    </Menu>
+  );
+}
+
+function KeybindingSourceBadge({ source }: { source: KeybindingRow["source"] }) {
+  if (source === "Default") return null;
+  return (
+    <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
+      {source}
+    </Badge>
+  );
+}
+
+/** One binding as a standard settings row; the When clause opens the expression builder. */
+function KeybindingSettingsRow(props: KeybindingRowProps) {
+  const { row, isSaving, allRows, variables, onSave, onReset, onRemove } = props;
+  const editor = useKeybindingRowEditor({ row, allRows, onSave });
+
+  return (
+    <SettingsRow
+      className="rounded-none hover:bg-accent/30"
+      title={
+        <span className="flex items-center gap-2">
+          {commandLabel(row.command)}
+          <KeybindingSourceBadge source={row.source} />
+        </span>
+      }
+      description={
+        <span className="flex h-6 items-center gap-1.5">
+          <span className="text-[12px] leading-none text-muted-foreground/70">When</span>
+          <WhenClauseControl
+            variant="inline"
+            label={commandLabel(row.command)}
+            expression={editor.whenDraftExpression}
+            value={editor.whenDraft}
+            variables={variables}
+            onChange={(whenDraft) => editor.setDraft({ whenDraft })}
+            onValidityChange={(isWhenDraftValid) => editor.setDraft({ isWhenDraftValid })}
+          />
+        </span>
+      }
+      control={
+        <>
+          <KeybindingConflictWarning labels={editor.conflictLabels} />
+          <KeybindingKeyControl row={row} editor={editor} isSaving={isSaving} />
+          <KeybindingRowMenu row={row} isSaving={isSaving} onReset={onReset} onRemove={onRemove} />
+        </>
+      }
+    />
+  );
+}
+
+/** Draft state for a binding that does not exist yet. */
+function useNewKeybindingDraft({
+  allRows,
+  onSave,
+}: {
+  allRows: ReadonlyArray<KeybindingRow>;
   onSave: (input: ServerUpsertKeybindingInput) => void;
-  onCancel: () => void;
 }) {
   const [commandDraft, setCommandDraft] = useState<KeybindingCommand | "">("");
   const [draft, setDraft] = useReducer(keybindingRowDraftReducer, {
@@ -935,6 +1026,7 @@ function NewKeybindingTableRow({
     when: whenDraftExpression,
   });
   const commandLabelText = commandDraft ? commandLabel(commandDraft) : "new keybinding";
+  const canSave = Boolean(commandDraft) && keyDraft.trim().length > 0 && isWhenDraftValid;
 
   const save = () => {
     if (!commandDraft) return;
@@ -957,93 +1049,241 @@ function NewKeybindingTableRow({
     setDraft({ keyDraft: next, isRecording: false });
   };
 
+  return {
+    commandDraft,
+    setCommandDraft,
+    keyDraft,
+    whenDraft,
+    whenDraftExpression,
+    isRecording,
+    conflictLabels,
+    commandLabelText,
+    canSave,
+    setDraft,
+    save,
+    captureKeybinding,
+  };
+}
+
+type NewKeybindingDraft = ReturnType<typeof useNewKeybindingDraft>;
+
+interface NewKeybindingProps {
+  commandOptions: ReadonlyArray<KeybindingCommandOption>;
+  allRows: ReadonlyArray<KeybindingRow>;
+  variables: ReadonlyArray<WhenVariableOption>;
+  isSaving: boolean;
+  onSave: (input: ServerUpsertKeybindingInput) => void;
+  onCancel: () => void;
+}
+
+function NewKeybindingCommandSelect({
+  draft,
+  commandOptions,
+  className,
+}: {
+  draft: NewKeybindingDraft;
+  commandOptions: ReadonlyArray<KeybindingCommandOption>;
+  className?: string | undefined;
+}) {
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
-      <div className="min-w-0 pr-4">
-        <Select
-          value={commandDraft}
-          onValueChange={(value) => setCommandDraft(value as KeybindingCommand)}
-        >
-          <SelectTrigger size="compact" className="w-full max-w-60">
-            <SelectValue placeholder="Command" />
-          </SelectTrigger>
-          <SelectContent
-            alignItemWithTrigger={false}
-            matchTriggerWidth={false}
-            className="max-h-72 w-fit min-w-56"
-          >
-            {commandOptions.map((command) => (
-              <SelectItem key={command} value={command} className="min-h-7 w-full py-1 text-[12px]">
-                <span className="truncate">{commandLabel(command)}</span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="flex min-w-0 items-center gap-2 pr-4">
-        <Input
-          data-keybinding-capture=""
-          aria-label={`Keybinding for ${commandLabelText}`}
-          value={isRecording ? "" : keyDraft}
-          placeholder={isRecording ? "Press shortcut" : "Unassigned"}
-          size="compact"
-          className={cn("w-44 font-mono", isRecording && "border-primary/70 bg-primary/5")}
-          onFocus={() => setDraft({ isRecording: true })}
-          onBlur={() => setDraft({ isRecording: false })}
-          onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
-          onKeyDown={captureKeybinding}
+    <Select
+      value={draft.commandDraft}
+      onValueChange={(value) => draft.setCommandDraft(value as KeybindingCommand)}
+    >
+      <SelectTrigger size="compact" className={className}>
+        <SelectValue placeholder="Command" />
+      </SelectTrigger>
+      <SelectContent
+        alignItemWithTrigger={false}
+        matchTriggerWidth={false}
+        className="max-h-72 w-fit min-w-56"
+      >
+        {commandOptions.map((command) => (
+          <SelectItem key={command} value={command} className="min-h-7 w-full py-1 text-[12px]">
+            <span className="truncate">{commandLabel(command)}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function NewKeybindingKeyInput({
+  draft,
+  autoFocus = false,
+  className,
+}: {
+  draft: NewKeybindingDraft;
+  autoFocus?: boolean;
+  className?: string | undefined;
+}) {
+  return (
+    <Input
+      data-keybinding-capture=""
+      autoFocus={autoFocus}
+      aria-label={`Keybinding for ${draft.commandLabelText}`}
+      value={draft.isRecording ? "" : draft.keyDraft}
+      placeholder={draft.isRecording ? "Press shortcut" : "Unassigned"}
+      size="compact"
+      className={cn("font-mono", draft.isRecording && "border-primary/70 bg-primary/5", className)}
+      onFocus={() => draft.setDraft({ isRecording: true })}
+      onBlur={() => draft.setDraft({ isRecording: false })}
+      onChange={(event) => draft.setDraft({ keyDraft: event.currentTarget.value })}
+      onKeyDown={draft.captureKeybinding}
+    />
+  );
+}
+
+function NewKeybindingWhen({
+  draft,
+  variables,
+  variant,
+  className,
+}: {
+  draft: NewKeybindingDraft;
+  variables: ReadonlyArray<WhenVariableOption>;
+  variant?: keyof typeof WHEN_TRIGGER_CLASS | undefined;
+  className?: string | undefined;
+}) {
+  return (
+    <WhenClauseControl
+      label={draft.commandLabelText}
+      expression={draft.whenDraftExpression}
+      value={draft.whenDraft}
+      variables={variables}
+      onChange={(whenDraft) => draft.setDraft({ whenDraft })}
+      onValidityChange={(isWhenDraftValid) => draft.setDraft({ isWhenDraftValid })}
+      variant={variant}
+      className={className}
+    />
+  );
+}
+
+function NewKeybindingCancelIcon({
+  isSaving,
+  onCancel,
+}: {
+  isSaving: boolean;
+  onCancel: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="size-7 text-muted-foreground hover:text-foreground"
+            disabled={isSaving}
+            aria-label="Cancel new keybinding"
+            onClick={onCancel}
+          />
+        }
+      >
+        <XIcon className="size-3.5" />
+      </TooltipTrigger>
+      <TooltipPopup side="top">Cancel</TooltipPopup>
+    </Tooltip>
+  );
+}
+
+/** Add-binding form shaped like the binding rows below it. */
+function NewKeybindingSettingsRow(props: NewKeybindingProps) {
+  const { commandOptions, allRows, variables, isSaving, onSave, onCancel } = props;
+  const draft = useNewKeybindingDraft({ allRows, onSave });
+
+  return (
+    <SettingsRow
+      className="rounded-none bg-muted/15"
+      title={
+        <NewKeybindingCommandSelect
+          draft={draft}
+          commandOptions={commandOptions}
+          className="w-56"
         />
-        <Button
-          size="compact"
-          disabled={isSaving || !commandDraft || keyDraft.trim().length === 0 || !isWhenDraftValid}
-          onClick={save}
-        >
-          {isSaving ? "Saving" : "Save"}
-        </Button>
-      </div>
-      <div className="pr-4">
-        <Popover>
-          <PopoverTrigger
-            className={cn(
-              "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
-              !whenDraftExpression && "text-muted-foreground",
-            )}
-            aria-label={`Edit when clause for ${commandLabelText}`}
-          >
-            <span className="truncate">{whenDraftExpression || "Always"}</span>
-            <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
-          </PopoverTrigger>
-          <PopoverContent align="start" sideOffset={6}>
-            <WhenExpressionBuilder
-              value={whenDraft}
-              variables={variables}
-              onChange={(nextWhenDraft) => setDraft({ whenDraft: nextWhenDraft })}
-              onValidityChange={(nextIsValid) => setDraft({ isWhenDraftValid: nextIsValid })}
+      }
+      description={
+        <span className="flex h-6 items-center gap-1.5">
+          <span className="text-[12px] leading-none text-muted-foreground/70">When</span>
+          <NewKeybindingWhen draft={draft} variables={variables} variant="inline" />
+        </span>
+      }
+      control={
+        <>
+          <KeybindingConflictWarning labels={draft.conflictLabels} />
+          <NewKeybindingKeyInput draft={draft} className="w-44" />
+          <Button size="compact" disabled={isSaving || !draft.canSave} onClick={draft.save}>
+            {isSaving ? "Saving" : "Save"}
+          </Button>
+          <NewKeybindingCancelIcon isSaving={isSaving} onCancel={onCancel} />
+        </>
+      }
+    />
+  );
+}
+
+interface KeybindingsListProps extends KeybindingRowActions {
+  rows: ReadonlyArray<KeybindingRow>;
+  commandOptions: ReadonlyArray<KeybindingCommandOption>;
+  savingCommand: KeybindingCommand | null;
+  isAddingBinding: boolean;
+  onCancelAdd: () => void;
+}
+
+/** The add-binding row, one settings row per binding, and the empty state. */
+function KeybindingsList(props: KeybindingsListProps) {
+  const { rows, commandOptions, savingCommand, isAddingBinding, onCancelAdd, ...rowActions } =
+    props;
+  const newProps: NewKeybindingProps = {
+    commandOptions,
+    allRows: rows,
+    variables: rowActions.variables,
+    isSaving: savingCommand !== null,
+    onSave: rowActions.onSave,
+    onCancel: onCancelAdd,
+  };
+  return (
+    <div className="divide-y divide-border/50">
+      {isAddingBinding ? <NewKeybindingSettingsRow {...newProps} /> : null}
+      {rows.map((row) => (
+        <KeybindingSettingsRow
+          key={row.id}
+          row={row}
+          isSaving={savingCommand === row.command}
+          {...rowActions}
+        />
+      ))}
+      {rows.length === 0 && !isAddingBinding ? (
+        <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+          No keybindings match your search.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Shown in the browser build only; the desktop app receives every shortcut. */
+function BrowserKeybindingNotice() {
+  return (
+    <div className="flex items-center gap-1.5 px-3 pb-2 text-[12px] text-muted-foreground sm:px-4">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              tabIndex={0}
+              className="inline-flex size-4.5 items-center justify-center rounded-sm text-warning outline-none hover:bg-warning/10 focus-visible:ring-[3px] focus-visible:ring-warning/25"
             />
-          </PopoverContent>
-        </Popover>
-      </div>
-      <div className="flex items-center justify-end gap-1">
-        <KeybindingConflictWarning labels={conflictLabels} />
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className="size-7 text-muted-foreground hover:text-foreground"
-                disabled={isSaving}
-                aria-label="Cancel new keybinding"
-                onClick={onCancel}
-              />
-            }
-          >
-            <XIcon className="size-3.5" />
-          </TooltipTrigger>
-          <TooltipPopup side="top">Cancel</TooltipPopup>
-        </Tooltip>
-      </div>
+          }
+        >
+          <TriangleAlertIcon className="size-3.5" />
+        </TooltipTrigger>
+        <TooltipPopup side="top" className="max-w-72 whitespace-normal leading-relaxed">
+          Some shortcuts are claimed by the browser before T3 Code sees them. Use the desktop app
+          for better keybinding support.
+        </TooltipPopup>
+      </Tooltip>
+      <span>Browser shortcuts may take precedence.</span>
     </div>
   );
 }
@@ -1187,12 +1427,27 @@ export function KeybindingsSettingsPanel() {
     [saveKeybinding],
   );
 
+  const cancelAdd = useCallback(() => setIsAddingBinding(false), []);
+
   const bindingsCount = (
     <span className="text-[11px] text-muted-foreground">
       {rows.length + (isAddingBinding ? 1 : 0)}{" "}
       {rows.length + (isAddingBinding ? 1 : 0) === 1 ? "binding" : "bindings"}
     </span>
   );
+
+  const listProps: KeybindingsListProps = {
+    rows,
+    allRows: rows,
+    commandOptions,
+    variables: whenVariables,
+    savingCommand,
+    isAddingBinding,
+    onCancelAdd: cancelAdd,
+    onSave: saveKeybinding,
+    onReset: resetKeybinding,
+    onRemove: removeKeybinding,
+  };
 
   return (
     <SettingsPageContainer width="wide">
@@ -1244,58 +1499,9 @@ export function KeybindingsSettingsPanel() {
           </div>
         }
       >
-        {!isElectron ? (
-          <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
-            <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
-            <p>
-              Some shortcuts may be claimed by the browser before T3 Code sees them. Use the desktop
-              app for better keybinding support.
-            </p>
-          </div>
-        ) : null}
+        {!isElectron ? <BrowserKeybindingNotice /> : null}
 
-        <ScrollArea
-          chainVerticalScroll
-          scrollFade
-          hideScrollbars
-          className="w-full max-w-full rounded-none"
-        >
-          <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-            <div>Command</div>
-            <div>Keybinding</div>
-            <div>When</div>
-            <div>Status</div>
-          </div>
-          <div className="min-w-[680px] divide-y divide-border/60">
-            {isAddingBinding ? (
-              <NewKeybindingTableRow
-                commandOptions={commandOptions}
-                allRows={rows}
-                variables={whenVariables}
-                isSaving={savingCommand !== null}
-                onSave={saveKeybinding}
-                onCancel={() => setIsAddingBinding(false)}
-              />
-            ) : null}
-            {rows.map((row) => (
-              <KeybindingTableRow
-                key={row.id}
-                row={row}
-                allRows={rows}
-                variables={whenVariables}
-                isSaving={savingCommand === row.command}
-                onSave={saveKeybinding}
-                onReset={resetKeybinding}
-                onRemove={removeKeybinding}
-              />
-            ))}
-            {rows.length === 0 && !isAddingBinding ? (
-              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
-                No keybindings match your search.
-              </div>
-            ) : null}
-          </div>
-        </ScrollArea>
+        <KeybindingsList {...listProps} />
       </SettingsSection>
     </SettingsPageContainer>
   );

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -833,10 +833,8 @@ function KeybindingKeyControl({
           aria-label={`Keybinding for ${commandLabel(row.command)}`}
           value={isRecording ? "" : keyDraft}
           placeholder={isRecording ? "Press shortcut" : "Unassigned"}
-          className={cn(
-            "h-7 w-44 rounded-md font-mono text-[12px] sm:h-7",
-            isRecording && "border-primary/70 bg-primary/5",
-          )}
+          size="compact"
+          className={cn("w-44 font-mono", isRecording && "border-primary/70 bg-primary/5")}
           onFocus={() => setDraft({ isRecording: true })}
           onBlur={() => setDraft({ isRecording: false })}
           onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
@@ -856,14 +854,7 @@ function KeybindingKeyControl({
   );
 }
 
-const WHEN_TRIGGER_CLASS = {
-  field:
-    "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
-  inline:
-    "inline-flex h-6 max-w-full items-center gap-1 rounded-sm px-1 font-mono text-[12px] outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/24",
-} as const;
-
-/** Popover trigger showing the when clause, styled as a field or as quiet inline text. */
+/** Quiet inline trigger showing the when clause; opens the expression builder. */
 function WhenClauseControl({
   label,
   expression,
@@ -871,8 +862,6 @@ function WhenClauseControl({
   variables,
   onChange,
   onValidityChange,
-  variant = "field",
-  className,
 }: {
   label: string;
   expression: string;
@@ -880,16 +869,13 @@ function WhenClauseControl({
   variables: ReadonlyArray<WhenVariableOption>;
   onChange: (value: KeybindingWhenNode | undefined) => void;
   onValidityChange: (valid: boolean) => void;
-  variant?: keyof typeof WHEN_TRIGGER_CLASS | undefined;
-  className?: string | undefined;
 }) {
   return (
     <Popover>
       <PopoverTrigger
         className={cn(
-          WHEN_TRIGGER_CLASS[variant],
+          "inline-flex h-6 max-w-full items-center gap-1 rounded-sm px-1 font-mono text-[12px] outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/24",
           !expression && "text-muted-foreground",
-          className,
         )}
         aria-label={`Edit when clause for ${label}`}
       >
@@ -982,7 +968,6 @@ function KeybindingSettingsRow(props: KeybindingRowProps) {
         <span className="flex h-6 items-center gap-1.5">
           <span className="text-[12px] leading-none text-muted-foreground/70">When</span>
           <WhenClauseControl
-            variant="inline"
             label={commandLabel(row.command)}
             expression={editor.whenDraftExpression}
             value={editor.whenDraft}
@@ -1137,13 +1122,9 @@ function NewKeybindingKeyInput({
 function NewKeybindingWhen({
   draft,
   variables,
-  variant,
-  className,
 }: {
   draft: NewKeybindingDraft;
   variables: ReadonlyArray<WhenVariableOption>;
-  variant?: keyof typeof WHEN_TRIGGER_CLASS | undefined;
-  className?: string | undefined;
 }) {
   return (
     <WhenClauseControl
@@ -1153,8 +1134,6 @@ function NewKeybindingWhen({
       variables={variables}
       onChange={(whenDraft) => draft.setDraft({ whenDraft })}
       onValidityChange={(isWhenDraftValid) => draft.setDraft({ isWhenDraftValid })}
-      variant={variant}
-      className={className}
     />
   );
 }
@@ -1206,18 +1185,18 @@ function NewKeybindingSettingsRow(props: NewKeybindingProps) {
       description={
         <span className="flex h-6 items-center gap-1.5">
           <span className="text-[12px] leading-none text-muted-foreground/70">When</span>
-          <NewKeybindingWhen draft={draft} variables={variables} variant="inline" />
+          <NewKeybindingWhen draft={draft} variables={variables} />
         </span>
       }
       control={
-        <>
+        <div className="flex flex-wrap items-center gap-2">
           <KeybindingConflictWarning labels={draft.conflictLabels} />
           <NewKeybindingKeyInput draft={draft} className="w-44" />
           <Button size="compact" disabled={isSaving || !draft.canSave} onClick={draft.save}>
             {isSaving ? "Saving" : "Save"}
           </Button>
           <NewKeybindingCancelIcon isSaving={isSaving} onCancel={onCancel} />
-        </>
+        </div>
       }
     />
   );
@@ -1272,7 +1251,8 @@ function BrowserKeybindingNotice() {
           render={
             <span
               tabIndex={0}
-              className="inline-flex size-4.5 items-center justify-center rounded-sm text-warning outline-none hover:bg-warning/10 focus-visible:ring-[3px] focus-visible:ring-warning/25"
+              aria-label="Browser keybinding limitations"
+              className="inline-flex size-4.5 shrink-0 items-center justify-center rounded-sm text-warning outline-none transition-colors hover:bg-warning/10 focus-visible:ring-[3px] focus-visible:ring-warning/25"
             />
           }
         >

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -34,6 +34,7 @@ import {
 
 import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
+import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import {
   primaryServerAvailableEditorsAtom,
@@ -818,7 +819,7 @@ function KeybindingKeyControl({
         <button
           type="button"
           onClick={() => setDraft({ isRecording: true })}
-          aria-label={`Edit shortcut for ${commandLabel(row.command)}`}
+          aria-label={`Edit shortcut for ${commandLabel(row.command)}: ${formatShortcutLabel(row.binding.shortcut)}`}
           className="group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
         >
           <KeybindingPill value={row.key} />
@@ -1175,13 +1176,7 @@ function NewKeybindingSettingsRow(props: NewKeybindingProps) {
   return (
     <SettingsRow
       className="rounded-none bg-muted/15"
-      title={
-        <NewKeybindingCommandSelect
-          draft={draft}
-          commandOptions={commandOptions}
-          className="w-56"
-        />
-      }
+      title="New keybinding"
       description={
         <span className="flex h-6 items-center gap-1.5">
           <span className="text-[12px] leading-none text-muted-foreground/70">When</span>
@@ -1190,6 +1185,11 @@ function NewKeybindingSettingsRow(props: NewKeybindingProps) {
       }
       control={
         <div className="flex flex-wrap items-center gap-2">
+          <NewKeybindingCommandSelect
+            draft={draft}
+            commandOptions={commandOptions}
+            className="w-56"
+          />
           <KeybindingConflictWarning labels={draft.conflictLabels} />
           <NewKeybindingKeyInput draft={draft} className="w-44" />
           <Button size="compact" disabled={isSaving || !draft.canSave} onClick={draft.save}>

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -815,6 +815,15 @@ function KeybindingKeyControl({
 
   return (
     <>
+      {isDirty ? (
+        <Button
+          size="compact"
+          disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
+          onClick={save}
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
+      ) : null}
       {showPill ? (
         <button
           type="button"
@@ -842,15 +851,6 @@ function KeybindingKeyControl({
           onKeyDown={captureKeybinding}
         />
       )}
-      {isDirty ? (
-        <Button
-          size="compact"
-          disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
-          onClick={save}
-        >
-          {isSaving ? "Saving" : "Save"}
-        </Button>
-      ) : null}
     </>
   );
 }
@@ -874,10 +874,16 @@ function WhenClauseControl({
   return (
     <Popover>
       <PopoverTrigger
-        className={cn(
-          "inline-flex h-6 max-w-full items-center gap-1 rounded-sm px-1 font-mono text-[12px] outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/24",
-          !expression && "text-muted-foreground",
-        )}
+        render={
+          <Button
+            variant="ghost"
+            size="compact"
+            className={cn(
+              "h-6 max-w-full gap-1 px-1 font-mono font-normal text-[12px] sm:text-[12px]",
+              !expression && "text-muted-foreground",
+            )}
+          />
+        }
         aria-label={`Edit when clause for ${label}`}
       >
         <span className="truncate">{expression || "Always"}</span>


### PR DESCRIPTION
The keybindings settings page was a dense four-column table that looked nothing like the other settings pages, needed a 680px horizontal scroll on narrow windows, and led with a tinted warning banner on the web build. The add-binding row and the inline When trigger were misaligned with the rest of the page.

Each binding is now a standard settings row: command name (with a Custom/Project badge when it isn't a default), a quiet inline `When …` trigger under the title that opens the existing expression builder, and the shortcut pill, conflict warning, and actions menu on the right. Rows stack on narrow viewports instead of scrolling sideways. The browser notice is a single line with a warning glyph and the detail in a tooltip. The add-binding form has the same row shape as the bindings below it.

The two large copy-pasted row components are replaced by a shared `useKeybindingRowEditor` / `useNewKeybindingDraft` and small controls (`KeybindingKeyControl`, `WhenClauseControl`, `KeybindingRowMenu`). Capture, escape, save/replace, reset, remove, conflict detection, and When validation are unchanged and go through the same server commands.

## Before

![Keybindings table before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/b70afdf5-917e-4be9-b3dc-5ffe59d189ca/keybindings-before-list.png)

![Add-binding row before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/0544f892-c630-4cda-88ee-f33e4643ed58/keybindings-before-add.png)

## After

![Keybindings settings rows after](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/8bcd9d36-321b-4997-8291-35882970e4e9/keybindings-after-list.png)

![Add-binding form after](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/0885c31d-8bf2-49b2-9f31-7ea6465c5a0b/keybindings-after-add-v2.png)

Built with Claude Fable 5 in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only UI refactor with unchanged persistence APIs; minor accessibility risk from removing the table layout and hidden shortcut text, partly offset by updated aria-labels.
> 
> **Overview**
> The keybindings settings UI is reworked from a **four-column table inside a horizontal `ScrollArea`** into a **stacked list of `SettingsRow` entries**, matching other settings pages and avoiding the ~680px sideways scroll on narrow viewports.
> 
> Each binding row now shows the **command label** (plus an outline **Custom/Project** badge when not default), an inline **When** control in the description that opens the same expression builder via a quieter ghost trigger, and on the right the **conflict warning**, **shortcut pill/capture** (with **Save** when dirty), and **actions menu**. The **add-binding** flow uses the same row shape with command select, key input, save, and cancel.
> 
> Implementation-wise, the old monolithic table row components are split into **`useKeybindingRowEditor` / `useNewKeybindingDraft`** and small controls (`KeybindingKeyControl`, `WhenClauseControl`, `KeybindingRowMenu`, `KeybindingsList`). The web-only limitation message moves from a full-width banner to **`BrowserKeybindingNotice`** (one line + tooltip). **Upsert/remove/reset, capture, conflicts, and when validation** still go through the same server commands; the table **Status** column and **`sr-only` shortcut text** are dropped in favor of richer **aria-label** on the edit shortcut control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa02a651f84a9c99a7c93d931b97f10d2e395aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor keybindings settings panel to use `SettingsRow` layout
> Replaces the custom grid/table UI in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/8174/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) with a vertical list of `SettingsRow` entries, aligning the keybindings panel with the rest of the settings page.
> - Splits the old row components into focused pieces: `KeybindingSettingsRow`, `KeybindingKeyControl`, `WhenClauseControl`, and `KeybindingRowMenu`, with draft logic moved into `useKeybindingRowEditor`.
> - Mirrors the same composition for the add-new-binding flow via `NewKeybindingSettingsRow` and `useNewKeybindingDraft`.
> - Adds a `KeybindingSourceBadge` showing whether a binding is default or user-defined; replaces the non-Electron warning banner with a compact `BrowserKeybindingNotice`.
> - Behavioral Change: the panel no longer uses an internal `ScrollArea` or table header; keybindings now rely on page-level scrolling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4aa02a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->