### PR TITLE
fix(server): stop probing Cursor until enabled

### DIFF
--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1660,7 +1660,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
       );
 
       it.effect(
-        "keeps cursor disabled and skips probing when the provider setting is disabled",
+        "keeps Cursor disabled and skips provider probing when settings use their defaults",
         () =>
           Effect.gen(function* () {
             const serverSettings = yield* makeMutableServerSettingsService(
@@ -1668,9 +1668,6 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 deepMerge(encodedDefaultServerSettings, {
                   providers: {
                     codex: {
-                      enabled: false,
-                    },
-                    cursor: {
                       enabled: false,
                     },
                     grok: {

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -200,17 +200,31 @@ describe("provider enabled defaults", () => {
     const decoded = decodeServerSettings({});
     expect(decoded.providers.codex.enabled).toBe(true);
     expect(decoded.providers.claudeAgent.enabled).toBe(true);
-    expect(decoded.providers.cursor.enabled).toBe(true);
+    expect(decoded.providers.cursor.enabled).toBe(false);
     expect(decoded.providers.grok.enabled).toBe(false);
     expect(decoded.providers.opencode.enabled).toBe(false);
   });
 
   it("derives per-driver defaults from the settings schemas", () => {
     expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
-    expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(true);
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(false);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
     // Unknown fork drivers stay enabled; their own build decides otherwise.
     expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
+  });
+
+  it("keeps Cursor enabled when an existing user explicitly opted in", () => {
+    const cursor = ProviderDriverKind.make("cursor");
+    const cursorId = ProviderInstanceId.make("cursor");
+    const decoded = decodeServerSettings({
+      providers: { cursor: { enabled: true } },
+      providerInstances: {
+        [cursorId]: { driver: cursor, enabled: true, config: {} },
+      },
+    });
+
+    expect(decoded.providers.cursor.enabled).toBe(true);
+    expect(resolveProviderInstanceEnabled(decoded.providerInstances[cursorId]!)).toBe(true);
   });
 
   it("resolves instance enabled state with explicit false winning", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -419,9 +419,9 @@ export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const CursorSettings = makeProviderSettingsSchema(
   {
-    // Enabled by default alongside Codex and Claude Agent.
+    // Off by default like Grok and OpenCode. Users opt in from Settings.
     enabled: Schema.Boolean.pipe(
-      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.withDecodingDefault(Effect.succeed(false)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
     binaryPath: makeBinaryPathSetting("cursor-agent").pipe(


### PR DESCRIPTION
Cursor was turned back on by #7089 after #7459 made optional providers opt-in. Every installation then tried to launch `cursor-agent` at startup and during provider health checks, although the installation guide says Cursor is off by default.

Restore the Cursor opt-in default and verify that untouched installations skip Cursor probes. Saved Cursor opt-ins still work.

Made by GPT-5.6 Sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-only configuration change with regression tests; explicit Cursor opt-in paths are preserved and probing already short-circuits when disabled.
> 
> **Overview**
> **Cursor is off by default again**, matching Grok/OpenCode and the documented install behavior, so fresh or default server settings no longer spawn `cursor-agent` during startup or health checks.
> 
> The change is in **`CursorSettings`**: the schema decoding default for `enabled` goes from `true` to `false`, which flows through `defaultEnabledForDriver` and `DEFAULT_SERVER_SETTINGS`. **Explicit opt-in is unchanged**—settings that set `providers.cursor.enabled: true` (and matching instance flags) still decode as enabled.
> 
> Tests were updated to assert the new defaults, cover preserved opt-in, and confirm the provider registry leaves Cursor **disabled** and **does not probe** when only other providers are toggled off (without forcing `cursor.enabled: false` in the fixture).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ab1c7a247662584d9d374808799d852e63696c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `CursorSettings.enabled` default to `false`
> - Changes the `enabled` default in `CursorSettings` from `true` to `false` via `Schema.withDecodingDefault(Effect.succeed(false))` in [settings.ts](https://github.com/pingdotgg/t3code/pull/8175/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), so Cursor is off unless the user opts in.
> - Updates tests in [settings.test.ts](https://github.com/pingdotgg/t3code/pull/8175/files#diff-fd1303724b757882ea800308c3e9f426c66a71a81c2c80fae2b7f125749a4012) and [ProviderRegistry.test.ts](https://github.com/pingdotgg/t3code/pull/8175/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f) to assert Cursor is disabled by default and that probing is skipped under default settings.
> - Risk: existing configs that relied on Cursor being enabled by default must now set `providers.cursor.enabled = true` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4ab1c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->