### PR TITLE
fix(server): keep previously used providers working after upgrades

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -143,7 +143,10 @@ const PtyAdapterLive = Layer.unwrap(
   }),
 );
 
-const ServerSettingsLayerLive = ServerSettings.layer.pipe(Layer.provide(ServerSecretStore.layer));
+const ServerSettingsLayerLive = ServerSettings.layer.pipe(
+  Layer.provide(ServerSecretStore.layer),
+  Layer.provideMerge(SqlitePersistenceLayerLive),
+);
 
 const NativeTelemetryLayerLive = NativeTelemetryClient.layer.pipe(
   Layer.provide(ResourceMonitorBinary.layer),

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -528,7 +528,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.isFalse(settings.providers.grok.enabled);
       assert.isTrue(settings.providers.opencode.enabled);
-      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providers.cursor.enabled);
       assert.equal(settings.providers.opencode.serverUrl, "http://127.0.0.1:4096");
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
@@ -540,13 +540,16 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
       yield* fileSystem.writeFileString(
         serverConfig.settingsPath,
-        '{"providerInstances":{"grok":{"driver":"grok","config":{}},"opencode_work":{"driver":"opencode","config":{"serverUrl":"http://127.0.0.1:4096"}},"opencode_unused":{"driver":"opencode","config":{}}}}',
+        '{"providerInstances":{"cursor_work":{"driver":"cursor","config":{}},"grok":{"driver":"grok","config":{}},"opencode_work":{"driver":"opencode","config":{"serverUrl":"http://127.0.0.1:4096"}},"opencode_unused":{"driver":"opencode","config":{}}}}',
       );
+      yield* recordProviderUsage("cursor", "cursor_work");
       yield* recordProviderUsage("grok", null);
       yield* recordProviderUsage("opencode", "opencode_work");
 
       const settings = yield* serverSettings.getSettings;
 
+      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("cursor_work")]?.enabled);
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("opencode_work")]?.enabled);
       const unused = settings.providerInstances[ProviderInstanceId.make("opencode_unused")];
@@ -590,7 +593,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.isFalse(settings.providers.grok.enabled);
       assert.isFalse(settings.providers.opencode.enabled);
-      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providers.cursor.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -603,7 +606,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.isTrue(settings.providers.grok.enabled);
       assert.isFalse(settings.providers.opencode.enabled);
-      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providers.cursor.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -634,7 +637,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.isFalse(settings.providers.grok.enabled);
       assert.isTrue(settings.providers.opencode.enabled);
-      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providers.cursor.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -667,7 +670,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const initial = yield* serverSettings.getSettings;
       assert.isFalse(initial.providers.grok.enabled);
       assert.isFalse(initial.providers.opencode.enabled);
-      assert.isTrue(initial.providers.cursor.enabled);
+      assert.isFalse(initial.providers.cursor.enabled);
 
       const next = yield* serverSettings.updateSettings({
         addProjectBaseDirectory: "~/Development",
@@ -681,7 +684,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.isFalse(next.providers.grok.enabled);
       assert.isFalse(next.providers.opencode.enabled);
-      assert.isTrue(next.providers.cursor.enabled);
+      assert.isFalse(next.providers.cursor.enabled);
       const grok = next.providerInstances[ProviderInstanceId.make("grok")];
       assert.isDefined(grok);
       assert.isFalse(resolveProviderInstanceEnabled(grok));
@@ -689,6 +692,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       const persisted = JSON.parse(raw);
+      assert.isFalse(persisted.providers.cursor.enabled);
       assert.isFalse(persisted.providers.grok.enabled);
       assert.isFalse(persisted.providers.opencode.enabled);
       assert.isUndefined(persisted.providerInstances.grok.enabled);
@@ -877,6 +881,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         providers: {
           codex: {
             binaryPath: "/opt/homebrew/bin/codex",
+          },
+          cursor: {
+            enabled: false,
           },
           grok: {
             enabled: false,

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_SERVER_SETTINGS,
   ProviderDriverKind,
   ProviderInstanceId,
+  resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsPatch,
 } from "@t3tools/contracts";
@@ -16,8 +17,10 @@ import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as ServerConfig from "./config.ts";
+import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import * as ServerSettingsModule from "./serverSettings.ts";
 
 const decodeSettingsPatch = Schema.decodeUnknownEffect(ServerSettingsPatch);
@@ -26,6 +29,7 @@ const decodeServerSettings = Schema.decodeUnknownEffect(ServerSettings);
 const makeServerSettingsLayer = () =>
   ServerSettingsModule.layer.pipe(
     Layer.provide(ServerSecretStore.layer),
+    Layer.provideMerge(Layer.fresh(SqlitePersistenceMemory)),
     Layer.provideMerge(
       Layer.fresh(
         ServerConfig.layerTest(process.cwd(), {
@@ -47,6 +51,27 @@ const makeFailingSecretStoreLayer = (cause: ServerSecretStore.SecretStoreError) 
     }),
   );
 
+const recordProviderUsage = (provider: string, instanceId: string | null = provider) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`
+      INSERT INTO projection_thread_sessions (
+        thread_id,
+        status,
+        provider_name,
+        provider_instance_id,
+        updated_at
+      )
+      VALUES (
+        ${`thread-${instanceId ?? provider}`},
+        ${"ready"},
+        ${provider},
+        ${instanceId},
+        ${"2026-08-25T00:00:00.000Z"}
+      )
+    `;
+  });
+
 it.layer(NodeServices.layer)("server settings", (it) => {
   it.effect("preserves context when reading a provider environment secret fails", () => {
     const platformCause = PlatformError.systemError({
@@ -67,6 +92,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     );
     const settingsLayer = ServerSettingsModule.layer.pipe(
       Layer.provide(makeFailingSecretStoreLayer(cause)),
+      Layer.provideMerge(Layer.fresh(SqlitePersistenceMemory)),
       Layer.provideMerge(configLayer),
     );
 
@@ -487,7 +513,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
-  it.effect("preserves previously enabled providers from sparse settings files", () =>
+  it.effect("enables previously used providers from sparse settings files", () =>
     Effect.gen(function* () {
       const serverConfig = yield* ServerConfig.ServerConfig;
       const fileSystem = yield* FileSystem.FileSystem;
@@ -496,11 +522,13 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         serverConfig.settingsPath,
         '{"providers":{"opencode":{"serverUrl":"http://127.0.0.1:4096"}}}',
       );
+      yield* recordProviderUsage("opencode");
 
       const settings = yield* serverSettings.getSettings;
 
-      assert.isTrue(settings.providers.grok.enabled);
+      assert.isFalse(settings.providers.grok.enabled);
       assert.isTrue(settings.providers.opencode.enabled);
+      assert.isTrue(settings.providers.cursor.enabled);
       assert.equal(settings.providers.opencode.serverUrl, "http://127.0.0.1:4096");
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
@@ -512,13 +540,18 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
       yield* fileSystem.writeFileString(
         serverConfig.settingsPath,
-        '{"providerInstances":{"grok":{"driver":"grok","config":{}},"opencode_work":{"driver":"opencode","config":{"serverUrl":"http://127.0.0.1:4096"}}}}',
+        '{"providerInstances":{"grok":{"driver":"grok","config":{}},"opencode_work":{"driver":"opencode","config":{"serverUrl":"http://127.0.0.1:4096"}},"opencode_unused":{"driver":"opencode","config":{}}}}',
       );
+      yield* recordProviderUsage("grok", null);
+      yield* recordProviderUsage("opencode", "opencode_work");
 
       const settings = yield* serverSettings.getSettings;
 
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
       assert.isTrue(settings.providerInstances[ProviderInstanceId.make("opencode_work")]?.enabled);
+      const unused = settings.providerInstances[ProviderInstanceId.make("opencode_unused")];
+      assert.isDefined(unused);
+      assert.isFalse(resolveProviderInstanceEnabled(unused));
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -529,15 +562,99 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
       yield* fileSystem.writeFileString(
         serverConfig.settingsPath,
-        '{"providers":{"grok":{"enabled":false},"opencode":{"enabled":false}},"providerInstances":{"grok":{"driver":"grok","enabled":false,"config":{}},"opencode":{"driver":"opencode","config":{"enabled":false}}}}',
+        '{"providers":{"grok":{"enabled":false},"opencode":{"enabled":false},"cursor":{"enabled":false}},"providerInstances":{"grok":{"driver":"grok","enabled":false,"config":{}},"opencode":{"driver":"opencode","config":{"enabled":false}},"cursor":{"driver":"cursor","enabled":false,"config":{}}}}',
       );
+      yield* recordProviderUsage("grok");
+      yield* recordProviderUsage("opencode");
+      yield* recordProviderUsage("cursor");
 
       const settings = yield* serverSettings.getSettings;
 
       assert.isFalse(settings.providers.grok.enabled);
       assert.isFalse(settings.providers.opencode.enabled);
+      assert.isFalse(settings.providers.cursor.enabled);
       assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
       assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("cursor")]?.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("keeps unused providers disabled in existing sparse settings files", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* fileSystem.writeFileString(serverConfig.settingsPath, "{}");
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isFalse(settings.providers.grok.enabled);
+      assert.isFalse(settings.providers.opencode.enabled);
+      assert.isTrue(settings.providers.cursor.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("preserves provider history when no settings file exists", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* recordProviderUsage("grok");
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isTrue(settings.providers.grok.enabled);
+      assert.isFalse(settings.providers.opencode.enabled);
+      assert.isTrue(settings.providers.cursor.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("restores providers from persisted runtime sessions", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        INSERT INTO provider_session_runtime (
+          thread_id,
+          provider_name,
+          provider_instance_id,
+          adapter_key,
+          status,
+          last_seen_at
+        )
+        VALUES (
+          ${"thread-opencode-runtime"},
+          ${"opencode"},
+          ${"opencode"},
+          ${"opencode"},
+          ${"ready"},
+          ${"2026-08-25T00:00:00.000Z"}
+        )
+      `;
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isFalse(settings.providers.grok.enabled);
+      assert.isTrue(settings.providers.opencode.enabled);
+      assert.isTrue(settings.providers.cursor.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("persists explicit disables after a provider has been used", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* recordProviderUsage("grok");
+
+      assert.isTrue((yield* serverSettings.getSettings).providers.grok.enabled);
+
+      const settings = yield* serverSettings.updateSettings({
+        providers: { grok: { enabled: false } },
+      });
+      assert.isFalse(settings.providers.grok.enabled);
+
+      const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      assert.isFalse(JSON.parse(raw).providers.grok.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
@@ -550,6 +667,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const initial = yield* serverSettings.getSettings;
       assert.isFalse(initial.providers.grok.enabled);
       assert.isFalse(initial.providers.opencode.enabled);
+      assert.isTrue(initial.providers.cursor.enabled);
 
       const next = yield* serverSettings.updateSettings({
         addProjectBaseDirectory: "~/Development",
@@ -563,14 +681,17 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.isFalse(next.providers.grok.enabled);
       assert.isFalse(next.providers.opencode.enabled);
-      assert.isFalse(next.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isTrue(next.providers.cursor.enabled);
+      const grok = next.providerInstances[ProviderInstanceId.make("grok")];
+      assert.isDefined(grok);
+      assert.isFalse(resolveProviderInstanceEnabled(grok));
 
       const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       const persisted = JSON.parse(raw);
       assert.isFalse(persisted.providers.grok.enabled);
       assert.isFalse(persisted.providers.opencode.enabled);
-      assert.isFalse(persisted.providerInstances.grok.enabled);
+      assert.isUndefined(persisted.providerInstances.grok.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -487,6 +487,93 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("preserves previously enabled providers from sparse settings files", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providers":{"opencode":{"serverUrl":"http://127.0.0.1:4096"}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isTrue(settings.providers.grok.enabled);
+      assert.isTrue(settings.providers.opencode.enabled);
+      assert.equal(settings.providers.opencode.serverUrl, "http://127.0.0.1:4096");
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("preserves existing provider instances without explicit enabled flags", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providerInstances":{"grok":{"driver":"grok","config":{}},"opencode_work":{"driver":"opencode","config":{"serverUrl":"http://127.0.0.1:4096"}}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isTrue(settings.providerInstances[ProviderInstanceId.make("opencode_work")]?.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("preserves explicit provider disables in existing settings files", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providers":{"grok":{"enabled":false},"opencode":{"enabled":false}},"providerInstances":{"grok":{"driver":"grok","enabled":false,"config":{}},"opencode":{"driver":"opencode","config":{"enabled":false}}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isFalse(settings.providers.grok.enabled);
+      assert.isFalse(settings.providers.opencode.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+      assert.isFalse(settings.providerInstances[ProviderInstanceId.make("opencode")]?.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("keeps optional providers disabled after a new installation writes settings", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      const initial = yield* serverSettings.getSettings;
+      assert.isFalse(initial.providers.grok.enabled);
+      assert.isFalse(initial.providers.opencode.enabled);
+
+      const next = yield* serverSettings.updateSettings({
+        addProjectBaseDirectory: "~/Development",
+        providerInstances: {
+          [ProviderInstanceId.make("grok")]: {
+            driver: ProviderDriverKind.make("grok"),
+            config: {},
+          },
+        },
+      });
+
+      assert.isFalse(next.providers.grok.enabled);
+      assert.isFalse(next.providers.opencode.enabled);
+      assert.isFalse(next.providerInstances[ProviderInstanceId.make("grok")]?.enabled);
+
+      const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const persisted = JSON.parse(raw);
+      assert.isFalse(persisted.providers.grok.enabled);
+      assert.isFalse(persisted.providers.opencode.enabled);
+      assert.isFalse(persisted.providerInstances.grok.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("folds a legacy in-config enabled flag into the envelope on load", () =>
     Effect.gen(function* () {
       const serverConfig = yield* ServerConfig.ServerConfig;
@@ -633,7 +720,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
-  it.effect("writes only non-default server settings to disk", () =>
+  it.effect("writes non-default settings and explicit optional provider defaults to disk", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
       const serverConfig = yield* ServerConfig.ServerConfig;
@@ -670,7 +757,11 @@ it.layer(NodeServices.layer)("server settings", (it) => {
           codex: {
             binaryPath: "/opt/homebrew/bin/codex",
           },
+          grok: {
+            enabled: false,
+          },
           opencode: {
+            enabled: false,
             serverUrl: "http://127.0.0.1:4096",
             serverPassword: "secret-password",
           },

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -118,6 +118,23 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(settingsLayer));
   });
 
+  it.effect("identifies provider history query failures", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`DROP TABLE projection_thread_sessions`;
+
+      const error = yield* Effect.flip(serverSettings.getSettings);
+
+      assert.deepInclude(error, {
+        _tag: "ServerSettingsError",
+        operation: "read-provider-history",
+        settingsPath: serverConfig.settingsPath,
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("decodes nested settings patches", () =>
     Effect.gen(function* () {
       assert.deepEqual(

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -627,6 +627,22 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("preserves provider history when the settings file is invalid", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* fileSystem.writeFileString(serverConfig.settingsPath, "{invalid json");
+      yield* recordProviderUsage("cursor");
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isTrue(settings.providers.cursor.enabled);
+      assert.isFalse(settings.providers.grok.enabled);
+      assert.isFalse(settings.providers.opencode.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("restores providers from persisted runtime sessions", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -643,6 +643,25 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("preserves valid provider flags when another settings field is invalid", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"addProjectBaseDirectory":42,"providers":{"cursor":{"enabled":false},"grok":{"enabled":true}}}',
+      );
+      yield* recordProviderUsage("cursor");
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.isFalse(settings.providers.cursor.enabled);
+      assert.isTrue(settings.providers.grok.enabled);
+      assert.isFalse(settings.providers.opencode.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("restores providers from persisted runtime sessions", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
@@ -691,6 +710,30 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       assert.isFalse(JSON.parse(raw).providers.grok.enabled);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("persists explicit provider enables before their first use", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      yield* serverSettings.updateSettings({
+        providers: {
+          cursor: { enabled: true },
+          grok: { enabled: true },
+          opencode: { enabled: true },
+        },
+      });
+      yield* serverSettings.updateSettings({ addProjectBaseDirectory: "~/Development" });
+
+      const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const persisted = JSON.parse(raw);
+      assert.isTrue(persisted.providers.cursor.enabled);
+      assert.isTrue(persisted.providers.grok.enabled);
+      assert.isTrue(persisted.providers.opencode.enabled);
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -42,6 +42,7 @@ import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { writeFileStringAtomically } from "./atomicWrite.ts";
 import * as ServerConfig from "./config.ts";
 import { type DeepPartial, deepMerge } from "@t3tools/shared/Struct";
@@ -83,15 +84,7 @@ const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSetti
       Array.isArray(config) ||
       typeof (config as { readonly enabled?: unknown }).enabled !== "boolean"
     ) {
-      if (
-        instance.enabled === undefined &&
-        (instance.driver === "grok" || instance.driver === "opencode")
-      ) {
-        changed = true;
-        providerInstances[instanceId] = { ...instance, enabled: false };
-      } else {
-        providerInstances[instanceId] = instance;
-      }
+      providerInstances[instanceId] = instance;
       continue;
     }
     const { enabled: configEnabled, ...restConfig } = config as Record<string, unknown> & {
@@ -250,15 +243,26 @@ const decodePersistedOptionalProviderSettingsJsonExit = Schema.decodeUnknownExit
   fromLenientJson(PersistedOptionalProviderSettings),
 );
 
-function restoreLegacyProviderDefaults(
+function restoreUsedProviders(
   settings: ServerSettings,
   persisted: typeof PersistedOptionalProviderSettings.Type,
+  providerHistory: ReadonlyArray<{
+    readonly providerName: string;
+    readonly providerInstanceId: string | null;
+  }>,
 ): ServerSettings {
+  const usedProviders = new Set(providerHistory.map(({ providerName }) => providerName));
+  const usedProviderInstances = new Set(
+    providerHistory.map(
+      ({ providerName, providerInstanceId }) => providerInstanceId ?? providerName,
+    ),
+  );
   const providerInstances = Object.fromEntries(
     Object.entries(settings.providerInstances).map(([instanceId, instance]) => [
       instanceId,
       instance.enabled === undefined &&
-      (instance.driver === "grok" || instance.driver === "opencode")
+      (instance.driver === "grok" || instance.driver === "opencode") &&
+      usedProviderInstances.has(instanceId)
         ? { ...instance, enabled: true }
         : instance,
     ]),
@@ -270,11 +274,11 @@ function restoreLegacyProviderDefaults(
       ...settings.providers,
       grok: {
         ...settings.providers.grok,
-        enabled: persisted.providers?.grok?.enabled ?? true,
+        enabled: persisted.providers?.grok?.enabled ?? usedProviders.has("grok"),
       },
       opencode: {
         ...settings.providers.opencode,
-        enabled: persisted.providers?.opencode?.enabled ?? true,
+        enabled: persisted.providers?.opencode?.enabled ?? usedProviders.has("opencode"),
       },
     },
     providerInstances,
@@ -315,7 +319,7 @@ const ATOMIC_SETTINGS_KEYS: ReadonlySet<string> = new Set([
   "textGenerationModelSelection",
 ]);
 
-// Keep disabled optional providers explicit so new settings files do not look like old ones.
+// Preserve explicit disables because provider history can restore an omitted enabled flag.
 const PERSISTED_SERVER_SETTINGS_DEFAULTS: ServerSettings = {
   ...DEFAULT_SERVER_SETTINGS,
   providers: {
@@ -364,6 +368,7 @@ const make = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
   const secretStore = yield* ServerSecretStore.ServerSecretStore;
+  const sql = yield* SqlClient.SqlClient;
   const writeSemaphore = yield* Semaphore.make(1);
   const cacheKey = "settings" as const;
   const changesPubSub = yield* PubSub.unbounded<ServerSettings>();
@@ -398,26 +403,56 @@ const make = Effect.gen(function* () {
   );
 
   const loadSettingsFromDisk = Effect.gen(function* () {
-    if (!(yield* readConfigExists)) {
-      return DEFAULT_SERVER_SETTINGS;
+    let settings = DEFAULT_SERVER_SETTINGS;
+    let persisted: typeof PersistedOptionalProviderSettings.Type = {};
+
+    if (yield* readConfigExists) {
+      const raw = yield* readRawConfig;
+      const decoded = decodeServerSettingsJsonExit(raw);
+      const persistedSettings = decodePersistedOptionalProviderSettingsJsonExit(raw);
+      if (decoded._tag === "Failure" || persistedSettings._tag === "Failure") {
+        const failure = decoded._tag === "Failure" ? decoded : persistedSettings;
+        if (failure._tag === "Failure") {
+          yield* Effect.logWarning("failed to parse settings.json, using defaults", {
+            path: settingsPath,
+            issues: Cause.pretty(failure.cause),
+            cause: failure.cause,
+          });
+        }
+        return DEFAULT_SERVER_SETTINGS;
+      }
+      settings = decoded.value;
+      persisted = persistedSettings.value;
     }
 
-    const raw = yield* readRawConfig;
-    const decoded = decodeServerSettingsJsonExit(raw);
-    const persisted = decodePersistedOptionalProviderSettingsJsonExit(raw);
-    if (decoded._tag === "Failure" || persisted._tag === "Failure") {
-      const failure = decoded._tag === "Failure" ? decoded : persisted;
-      if (failure._tag === "Failure") {
-        yield* Effect.logWarning("failed to parse settings.json, using defaults", {
-          path: settingsPath,
-          issues: Cause.pretty(failure.cause),
-          cause: failure.cause,
-        });
-      }
-      return DEFAULT_SERVER_SETTINGS;
-    }
+    const providerHistory = yield* sql<{
+      readonly providerName: string;
+      readonly providerInstanceId: string | null;
+    }>`
+      SELECT DISTINCT
+        provider_name AS "providerName",
+        provider_instance_id AS "providerInstanceId"
+      FROM projection_thread_sessions
+      WHERE provider_name IN ('grok', 'opencode')
+      UNION
+      SELECT DISTINCT
+        provider_name AS "providerName",
+        provider_instance_id AS "providerInstanceId"
+      FROM provider_session_runtime
+      WHERE provider_name IN ('grok', 'opencode')
+    `.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerSettingsError({
+            settingsPath,
+            operation: "read-file",
+            cause,
+          }),
+      ),
+    );
+
     return foldProviderInstanceEnabledFlags(
-      restoreLegacyProviderDefaults(decoded.value, persisted.value),
+      restoreUsedProviders(settings, persisted, providerHistory),
     );
   });
 

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -83,7 +83,15 @@ const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSetti
       Array.isArray(config) ||
       typeof (config as { readonly enabled?: unknown }).enabled !== "boolean"
     ) {
-      providerInstances[instanceId] = instance;
+      if (
+        instance.enabled === undefined &&
+        (instance.driver === "grok" || instance.driver === "opencode")
+      ) {
+        changed = true;
+        providerInstances[instanceId] = { ...instance, enabled: false };
+      } else {
+        providerInstances[instanceId] = instance;
+      }
       continue;
     }
     const { enabled: configEnabled, ...restConfig } = config as Record<string, unknown> & {
@@ -230,6 +238,48 @@ export const layerTest = (overrides: DeepPartial<ServerSettings> = {}) =>
 
 const ServerSettingsJson = fromLenientJson(ServerSettings);
 const decodeServerSettingsJsonExit = Schema.decodeUnknownExit(ServerSettingsJson);
+const PersistedOptionalProviderSettings = Schema.Struct({
+  providers: Schema.optionalKey(
+    Schema.Struct({
+      grok: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
+      opencode: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
+    }),
+  ),
+});
+const decodePersistedOptionalProviderSettingsJsonExit = Schema.decodeUnknownExit(
+  fromLenientJson(PersistedOptionalProviderSettings),
+);
+
+function restoreLegacyProviderDefaults(
+  settings: ServerSettings,
+  persisted: typeof PersistedOptionalProviderSettings.Type,
+): ServerSettings {
+  const providerInstances = Object.fromEntries(
+    Object.entries(settings.providerInstances).map(([instanceId, instance]) => [
+      instanceId,
+      instance.enabled === undefined &&
+      (instance.driver === "grok" || instance.driver === "opencode")
+        ? { ...instance, enabled: true }
+        : instance,
+    ]),
+  );
+
+  return {
+    ...settings,
+    providers: {
+      ...settings.providers,
+      grok: {
+        ...settings.providers.grok,
+        enabled: persisted.providers?.grok?.enabled ?? true,
+      },
+      opencode: {
+        ...settings.providers.opencode,
+        enabled: persisted.providers?.opencode?.enabled ?? true,
+      },
+    },
+    providerInstances,
+  };
+}
 
 function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings {
   return isModelSelectionProviderEnabled(settings, settings.textGenerationModelSelection)
@@ -264,6 +314,16 @@ const ATOMIC_SETTINGS_KEYS: ReadonlySet<string> = new Set([
   "sourceControlWriterModelSelection",
   "textGenerationModelSelection",
 ]);
+
+// Keep disabled optional providers explicit so new settings files do not look like old ones.
+const PERSISTED_SERVER_SETTINGS_DEFAULTS: ServerSettings = {
+  ...DEFAULT_SERVER_SETTINGS,
+  providers: {
+    ...DEFAULT_SERVER_SETTINGS.providers,
+    grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: true },
+    opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: true },
+  },
+};
 
 function stripDefaultServerSettings(current: unknown, defaults: unknown): unknown | undefined {
   if (Array.isArray(current) || Array.isArray(defaults)) {
@@ -344,15 +404,21 @@ const make = Effect.gen(function* () {
 
     const raw = yield* readRawConfig;
     const decoded = decodeServerSettingsJsonExit(raw);
-    if (decoded._tag === "Failure") {
-      yield* Effect.logWarning("failed to parse settings.json, using defaults", {
-        path: settingsPath,
-        issues: Cause.pretty(decoded.cause),
-        cause: decoded.cause,
-      });
+    const persisted = decodePersistedOptionalProviderSettingsJsonExit(raw);
+    if (decoded._tag === "Failure" || persisted._tag === "Failure") {
+      const failure = decoded._tag === "Failure" ? decoded : persisted;
+      if (failure._tag === "Failure") {
+        yield* Effect.logWarning("failed to parse settings.json, using defaults", {
+          path: settingsPath,
+          issues: Cause.pretty(failure.cause),
+          cause: failure.cause,
+        });
+      }
       return DEFAULT_SERVER_SETTINGS;
     }
-    return foldProviderInstanceEnabledFlags(decoded.value);
+    return foldProviderInstanceEnabledFlags(
+      restoreLegacyProviderDefaults(decoded.value, persisted.value),
+    );
   });
 
   const settingsCache = yield* Cache.make<typeof cacheKey, ServerSettings, ServerSettingsError>({
@@ -528,7 +594,7 @@ const make = Effect.gen(function* () {
   const writeSettingsAtomically = Effect.fnUntraced(
     function* (settings: ServerSettings) {
       const sparseSettingsJson = yield* encodeServerSettingsJson(
-        stripDefaultServerSettings(settings, DEFAULT_SERVER_SETTINGS) ?? {},
+        stripDefaultServerSettings(settings, PERSISTED_SERVER_SETTINGS_DEFAULTS) ?? {},
       );
 
       return yield* writeFileStringAtomically({

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -234,6 +234,7 @@ const decodeServerSettingsJsonExit = Schema.decodeUnknownExit(ServerSettingsJson
 const PersistedOptionalProviderSettings = Schema.Struct({
   providers: Schema.optionalKey(
     Schema.Struct({
+      cursor: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       grok: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       opencode: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
     }),
@@ -261,7 +262,9 @@ function restoreUsedProviders(
     Object.entries(settings.providerInstances).map(([instanceId, instance]) => [
       instanceId,
       instance.enabled === undefined &&
-      (instance.driver === "grok" || instance.driver === "opencode") &&
+      (instance.driver === "cursor" ||
+        instance.driver === "grok" ||
+        instance.driver === "opencode") &&
       usedProviderInstances.has(instanceId)
         ? { ...instance, enabled: true }
         : instance,
@@ -272,6 +275,10 @@ function restoreUsedProviders(
     ...settings,
     providers: {
       ...settings.providers,
+      cursor: {
+        ...settings.providers.cursor,
+        enabled: persisted.providers?.cursor?.enabled ?? usedProviders.has("cursor"),
+      },
       grok: {
         ...settings.providers.grok,
         enabled: persisted.providers?.grok?.enabled ?? usedProviders.has("grok"),
@@ -324,6 +331,7 @@ const PERSISTED_SERVER_SETTINGS_DEFAULTS: ServerSettings = {
   ...DEFAULT_SERVER_SETTINGS,
   providers: {
     ...DEFAULT_SERVER_SETTINGS.providers,
+    cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: true },
     grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: true },
     opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: true },
   },
@@ -433,13 +441,13 @@ const make = Effect.gen(function* () {
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM projection_thread_sessions
-      WHERE provider_name IN ('grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'opencode')
       UNION
       SELECT DISTINCT
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM provider_session_runtime
-      WHERE provider_name IN ('grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'opencode')
     `.pipe(
       Effect.mapError(
         (cause) =>

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -453,7 +453,7 @@ const make = Effect.gen(function* () {
         (cause) =>
           new ServerSettingsError({
             settingsPath,
-            operation: "read-file",
+            operation: "read-provider-history",
             cause,
           }),
       ),

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -427,10 +427,10 @@ const make = Effect.gen(function* () {
             cause: failure.cause,
           });
         }
-        return DEFAULT_SERVER_SETTINGS;
+      } else {
+        settings = decoded.value;
+        persisted = persistedSettings.value;
       }
-      settings = decoded.value;
-      persisted = persistedSettings.value;
     }
 
     const providerHistory = yield* sql<{

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -326,14 +326,14 @@ const ATOMIC_SETTINGS_KEYS: ReadonlySet<string> = new Set([
   "textGenerationModelSelection",
 ]);
 
-// Preserve explicit disables because provider history can restore an omitted enabled flag.
-const PERSISTED_SERVER_SETTINGS_DEFAULTS: ServerSettings = {
+// Preserve both enabled states because provider history cannot recover a new opt-in.
+const PERSISTED_SERVER_SETTINGS_DEFAULTS = {
   ...DEFAULT_SERVER_SETTINGS,
   providers: {
     ...DEFAULT_SERVER_SETTINGS.providers,
-    cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: true },
-    grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: true },
-    opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: true },
+    cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: undefined },
+    grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: undefined },
+    opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: undefined },
   },
 };
 
@@ -418,6 +418,9 @@ const make = Effect.gen(function* () {
       const raw = yield* readRawConfig;
       const decoded = decodeServerSettingsJsonExit(raw);
       const persistedSettings = decodePersistedOptionalProviderSettingsJsonExit(raw);
+      if (persistedSettings._tag === "Success") {
+        persisted = persistedSettings.value;
+      }
       if (decoded._tag === "Failure" || persistedSettings._tag === "Failure") {
         const failure = decoded._tag === "Failure" ? decoded : persistedSettings;
         if (failure._tag === "Failure") {
@@ -429,7 +432,6 @@ const make = Effect.gen(function* () {
         }
       } else {
         settings = decoded.value;
-        persisted = persistedSettings.value;
       }
     }
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -736,6 +736,7 @@ export const ServerSettingsOperation = Schema.Literals([
   "normalize",
   "check-exists",
   "read-file",
+  "read-provider-history",
   "read-secret",
   "remove-secret",
   "remove-stale-secret",


### PR DESCRIPTION
Provider defaults changed, but stable releases omitted default `enabled` values from saved settings. Existing Cursor, Grok, and OpenCode threads could stop working after an upgrade.

Read persisted thread sessions and provider runtime sessions before loading provider settings. Restore only providers and provider instances that have real usage history, keep unused providers disabled, preserve explicit enables and disables across restarts, and restore used providers even when settings are invalid.

Verified with 87 focused settings, provider contract, provider registry, and startup tests, two integrated server startup tests, and server and contracts type checking.

Made by GPT-5.6 Sol through the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore previously used optional providers (`cursor`, `grok`, `opencode`) on settings load
> - `loadSettingsFromDisk` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/8176/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e) now queries provider usage history from `projection_thread_sessions` and `provider_session_runtime`, then enables optional providers and their instances that were previously used but lack explicit `enabled` flags.
> - Adds `PersistedOptionalProviderSettings` schema for lenient decoding of just the optional provider enabled flags, so valid flags survive even when other settings fields are invalid JSON.
> - `writeSettingsAtomically` now uses `PERSISTED_SERVER_SETTINGS_DEFAULTS` (with optional provider `enabled` set to `undefined`) so explicit `enabled:false` entries are retained in the persisted sparse JSON.
> - `ServerSettingsLayerLive` in [server.ts](https://github.com/pingdotgg/t3code/pull/8176/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) is now wired with `SqlitePersistenceLayerLive` to support the history queries.
> - Risk: `getSettings` now fails with `ServerSettingsError(operation="read-provider-history")` if the provider history SQL query fails; callers handling `ServerSettingsError` should account for this new operation literal added in [settings.ts](https://github.com/pingdotgg/t3code/pull/8176/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7252980.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->