### PR TITLE
docs(release): verify remote updates with database migrations

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -188,10 +188,12 @@ the **Update server** action targeting a package version that does not exist yet
 
 For a release smoke test, confirm `npm view t3@<version> version` returns the expected version, then
 connect the new client to a server on the previous version and verify that the update action
-reconnects to the matching server. Use releases with identical migration manifests for the
-automatic path. When the manifest changed, verify that the remote action stops before restart and
-shows the exact local `npx t3@<version> service update` command. Also test the manual or
-desktop-managed guidance when those environments are available.
+reconnects to the matching server. When the release adds database migrations, verify that the
+remote update applies them and reconnects. A failed trial must restore the database snapshot and
+restart the previous server. If the installed launcher does not support the target protocol,
+verify that the update stops before restart and run `npx t3@<version> service update` once on the
+server machine. Also test the manual or desktop-managed guidance when those environments are
+available.
 
 ## Desktop auto-update notes
 


### PR DESCRIPTION
The release checklist says database migrations require a local service update. Stable v0.0.33 already has the launcher protocol that snapshots SQLite, applies migrations 41 and 42 remotely, and restores the old database if the candidate fails.

Update the checklist to require remote migration and rollback checks. Reserve the local service update for an incompatible launcher protocol.

Verified with the published v0.0.33 launcher and disposable databases, plus 11 focused launcher, preflight, and migration tests.

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the release checklist; no runtime or workflow behavior is modified.
> 
> **Overview**
> Updates the **release smoke test** section in `docs/operations/release.md` so migration checks match how connected servers actually update.
> 
> Previously the checklist treated **changed migration manifests** as a reason to stop remotely and rely on local `npx t3@<version> service update`, and used **identical manifests** for the automatic path. It now requires that when a release **adds database migrations**, the remote update **applies them and reconnects**, and that a **failed trial restores the database snapshot** and restarts the previous server.
> 
> Local `npx t3@<version> service update` on the server machine is documented only when the **installed launcher does not support the target protocol** (update should stop before restart). Manual and desktop-managed guidance remains part of the smoke test when those environments are available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797b23e1d8ae7cfa6d63cff76406af68a482ff9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite release smoke test docs to cover database migrations and fallback paths
> Updates [release.md](https://github.com/pingdotgg/t3code/pull/8177/files#diff-a426703c462dd239e12f4c991868c2b2bcc70f5ff28e0b2fed4c76c2b545874b) so release smoke tests require verifying that remote updates apply database migrations and reconnect, and that failed trials restore the database snapshot and restart the previous server. Clarifies the fallback when the installed launcher lacks target protocol support: stop the update before restart and run `npx t3@<version> service update` on the server machine.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 797b23e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->