### PR TITLE
fix(mobile): open linked pull requests from thread menus

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -25,6 +25,7 @@ import { useThreadPr, type ThreadPr } from "../../state/use-thread-pr";
 import type { HomeGroupDisplayAction } from "../home/homeListItems";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
 import { buildThreadTitleRegenerationMenuItems } from "./thread-title-regeneration-menu";
+import { buildThreadPullRequestMenuItems, openThreadPullRequest } from "./thread-pull-request-menu";
 import { resolveThreadStatus } from "./threadPresentation";
 import { ThreadSearchMatchExcerpt } from "./thread-search-match";
 
@@ -487,6 +488,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
   const menuActions = useMemo<MenuAction[]>(
     () => [
+      ...buildThreadPullRequestMenuItems(pr),
       THREAD_ROW_MENU_ACTIONS[0]!,
       ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
@@ -494,7 +496,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
       }),
       THREAD_ROW_MENU_ACTIONS[1]!,
     ],
-    [props.titleRegenerationSupported, thread.titleRegeneration],
+    [pr, props.titleRegenerationSupported, thread.titleRegeneration],
   );
   const primaryAction = useMemo(
     () => ({
@@ -507,11 +509,12 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "open-pull-request") void openThreadPullRequest(pr);
       if (nativeEvent.event === "archive") handleArchive();
       if (nativeEvent.event === "regenerate-title") handleRegenerateTitle();
       if (nativeEvent.event === "delete") handleDelete();
     },
-    [handleArchive, handleDelete, handleRegenerateTitle],
+    [handleArchive, handleDelete, handleRegenerateTitle, pr],
   );
 
   const statusPill = effectiveStatus ? (

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -22,6 +22,7 @@ import { useThreadPr } from "../../state/use-thread-pr";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { buildThreadTitleRegenerationMenuItems } from "./thread-title-regeneration-menu";
+import { buildThreadPullRequestMenuItems, openThreadPullRequest } from "./thread-pull-request-menu";
 import {
   resolveThreadListV2ChangeRequestState,
   resolveThreadListV2SnoozeMenuSelection,
@@ -574,8 +575,35 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     () => [LEGACY_MENU_ACTIONS[0]!, ...titleRegenerationMenuItems, LEGACY_MENU_ACTIONS[1]!],
     [titleRegenerationMenuItems],
   );
+  const menuActions = useMemo<MenuAction[]>(
+    () => [
+      ...buildThreadPullRequestMenuItems(pr),
+      ...(snoozedRow
+        ? snoozedMenuActions
+        : !props.settlementSupported
+          ? legacyMenuActions
+          : canUnsettle
+            ? slimMenuActions
+            : swipeActions.secondary === "snooze"
+              ? snoozableCardMenuActions
+              : cardMenuActions),
+    ],
+    [
+      canUnsettle,
+      cardMenuActions,
+      legacyMenuActions,
+      pr,
+      props.settlementSupported,
+      slimMenuActions,
+      snoozableCardMenuActions,
+      snoozedMenuActions,
+      snoozedRow,
+      swipeActions.secondary,
+    ],
+  );
   const handleMenuAction = useCallback(
     ({ nativeEvent }: { readonly nativeEvent: { readonly event: string } }) => {
+      if (nativeEvent.event === "open-pull-request") void openThreadPullRequest(pr);
       if (nativeEvent.event === "settle") handleSettle();
       if (nativeEvent.event === "unsettle") handleUnsettle();
       if (nativeEvent.event === "unsnooze") handleUnsnooze();
@@ -609,6 +637,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       handleUnpin,
       handleUnsettle,
       handleUnsnooze,
+      pr,
       snoozePresets,
     ],
   );
@@ -942,17 +971,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
       >
         {(close) => (
           <ControlPillMenu
-            actions={
-              snoozedRow
-                ? snoozedMenuActions
-                : !props.settlementSupported
-                  ? legacyMenuActions
-                  : canUnsettle
-                    ? slimMenuActions
-                    : swipeActions.secondary === "snooze"
-                      ? snoozableCardMenuActions
-                      : cardMenuActions
-            }
+            actions={menuActions}
             onPressAction={handleMenuAction}
             shouldOpenOnLongPress
           >

--- a/apps/mobile/src/features/threads/thread-pull-request-menu.test.ts
+++ b/apps/mobile/src/features/threads/thread-pull-request-menu.test.ts
@@ -1,0 +1,90 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+import { Alert } from "react-native";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
+import { presentThreadPr } from "../../state/thread-pr-presentation";
+import { buildThreadPullRequestMenuItems, openThreadPullRequest } from "./thread-pull-request-menu";
+
+vi.mock("react-native", () => ({
+  Alert: { alert: vi.fn() },
+}));
+
+vi.mock("../../lib/openExternalUrl", () => ({
+  tryOpenExternalUrl: vi.fn(),
+}));
+
+const pullRequest: NonNullable<VcsStatusResult["pr"]> = {
+  number: 42,
+  title: "Linked pull request",
+  url: "https://github.com/pingdotgg/t3code/pull/42",
+  baseRef: "main",
+  headRef: "another-branch",
+  state: "open",
+};
+
+const openExternalUrl = vi.mocked(tryOpenExternalUrl);
+const showAlert = vi.mocked(Alert.alert);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildThreadPullRequestMenuItems", () => {
+  it("hides the action when the thread has no pull request", () => {
+    expect(buildThreadPullRequestMenuItems(null)).toEqual([]);
+  });
+
+  it.each(["open", "merged", "closed"] as const)(
+    "offers the browser action for a %s pull request",
+    (state) => {
+      expect(
+        buildThreadPullRequestMenuItems(presentThreadPr({ ...pullRequest, state }, null)),
+      ).toEqual([
+        {
+          id: "open-pull-request",
+          title: "Open pull request #42",
+          image: "arrow.up.right",
+        },
+      ]);
+    },
+  );
+
+  it("uses merge request terminology for GitLab", () => {
+    const mergeRequest = presentThreadPr(pullRequest, {
+      kind: "gitlab",
+      name: "GitLab",
+      baseUrl: "https://gitlab.com",
+    });
+
+    expect(buildThreadPullRequestMenuItems(mergeRequest)).toEqual([
+      {
+        id: "open-pull-request",
+        title: "Open merge request #42",
+        image: "arrow.up.right",
+      },
+    ]);
+  });
+});
+
+describe("openThreadPullRequest", () => {
+  it("opens the URL from the linked pull request", async () => {
+    openExternalUrl.mockResolvedValue(true);
+
+    await openThreadPullRequest(presentThreadPr(pullRequest, null));
+
+    expect(openExternalUrl).toHaveBeenCalledWith(pullRequest.url, "pull-request");
+    expect(showAlert).not.toHaveBeenCalled();
+  });
+
+  it("reports a browser failure", async () => {
+    openExternalUrl.mockResolvedValue(false);
+
+    await openThreadPullRequest(presentThreadPr(pullRequest, null));
+
+    expect(showAlert).toHaveBeenCalledWith(
+      "Unable to open pull request",
+      "The pull request could not be opened.",
+    );
+  });
+});

--- a/apps/mobile/src/features/threads/thread-pull-request-menu.ts
+++ b/apps/mobile/src/features/threads/thread-pull-request-menu.ts
@@ -1,0 +1,32 @@
+import type { MenuAction } from "@react-native-menu/menu";
+import { Alert } from "react-native";
+
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
+import type { ThreadPrPresentation } from "../../state/thread-pr-presentation";
+
+export function buildThreadPullRequestMenuItems(
+  pullRequest: ThreadPrPresentation | null,
+): MenuAction[] {
+  if (pullRequest === null) return [];
+
+  return [
+    {
+      id: "open-pull-request",
+      title: `Open ${pullRequest.longName} #${pullRequest.number}`,
+      image: "arrow.up.right",
+    },
+  ];
+}
+
+export async function openThreadPullRequest(
+  pullRequest: ThreadPrPresentation | null,
+): Promise<void> {
+  if (pullRequest === null) return;
+
+  if (!(await tryOpenExternalUrl(pullRequest.url, "pull-request"))) {
+    Alert.alert(
+      `Unable to open ${pullRequest.longName}`,
+      `The ${pullRequest.longName} could not be opened.`,
+    );
+  }
+}

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -11,6 +11,7 @@ export interface ThreadPrPresentation {
   readonly url: string;
   /** Compact pull request number label, e.g. "3774". */
   readonly label: string;
+  readonly longName: string;
   /** Full, provider-aware label for assistive technologies. */
   readonly accessibilityLabel: string;
   readonly textClassName: string;
@@ -33,6 +34,7 @@ export function presentThreadPr(
     updatedAt: pr.updatedAt ?? null,
     url: pr.url,
     label: String(pr.number),
+    longName: presentation.longName,
     accessibilityLabel: `#${pr.number} ${presentation.longName} ${pr.state}`,
     textClassName: PR_STATE_TEXT_CLASS[pr.state],
   };

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -16,6 +16,7 @@ describe("presentThreadPr", () => {
   it("uses the compact pull request number label without a hash prefix", () => {
     expect(presentThreadPr(pullRequest, undefined)).toMatchObject({
       label: "3774",
+      longName: "pull request",
       accessibilityLabel: "#3774 pull request merged",
       textClassName: "text-violet-600 dark:text-violet-400",
     });
@@ -30,6 +31,7 @@ describe("presentThreadPr", () => {
       }),
     ).toMatchObject({
       label: "3774",
+      longName: "merge request",
       accessibilityLabel: "#3774 merge request merged",
     });
   });

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -1,6 +1,8 @@
 # Source Control Integrations
 
-T3 Code connects to your Git hosting provider so you can create pull requests, review code, and manage repositories without leaving the app.
+T3 Code connects to your Git hosting provider so you can create pull requests and manage
+repositories. On web and desktop, you can review pull requests without leaving the app. On mobile,
+you can open a thread's pull request in your browser.
 
 ## Supported Providers
 
@@ -38,17 +40,20 @@ T3 Code works with the platforms your team already uses:
 **Stay on top of open reviews**
 
 - See if your current branch already has an open PR/MR
-- Open several reviews from the **Pull requests** page as tabs in the right panel
-- While working in a thread, open linked reviews in the same compact right-panel tabs without
-  leaving the conversation
+- On web and desktop, open several reviews from the **Pull requests** page as tabs in the right
+  panel
+- On web and desktop, open a thread's linked review in the right panel without leaving the
+  conversation
+- On mobile, press and hold a thread and choose **Open pull request #42** to open its linked or
+  current-branch pull request in your browser. GitLab uses **Open merge request #42**.
 - Open the review directly in your browser with one click
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
 
 **Fix what you wrote, in place**
 
-- Rewrite a pull request's title and description from the review itself, in Markdown, with a
-  preview before you save
+- On web and desktop, rewrite a pull request's title and description from the review itself, in
+  Markdown, with a preview before you save
 - Rewrite your own comments the same way, wherever they are shown
 - Works on GitHub, GitLab, and Bitbucket. Azure DevOps takes a new title and description; its
   comments stay read-only here, as they already were

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -7,9 +7,13 @@ one environment.
 Pinned threads still move to **Settled** when they become inactive. They also move when their pull
 request merges if **Auto-settle merged threads** is enabled.
 
-Right-click a pull request link in a thread and choose **Link to thread** to show that pull request
-in the sidebar. The thread settles when the linked pull request merges if **Auto-settle merged
-threads** is enabled. Right-click the same link and choose **Unlink from thread** to remove it.
+On web and desktop, right-click a pull request link in a thread and choose **Link to thread** to
+show that pull request in the sidebar. The thread settles when the linked pull request merges if
+**Auto-settle merged threads** is enabled. Right-click the same link and choose **Unlink from
+thread** to remove it.
+
+On mobile, press and hold a thread with a pull request and choose **Open pull request #42** to open
+it in your browser. GitLab uses **Open merge request #42**.
 
 On web and desktop, drag a pinned thread to change its position. On mobile, open the thread's menu
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your


### PR DESCRIPTION
Mobile showed linked pull requests on threads but could only open the current branch's pull request. A pull request linked from another branch had no way to open on mobile.

Add a browser action to both thread menus, with GitLab terminology and support for open, closed, and merged requests. Clarify that the full pull request workspace is available on web and desktop.

Verified with 60 focused tests, the mobile type check, and targeted lint.

Made with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile UI and external URL opening with tests; no auth, server, or data-model changes.
> 
> **Overview**
> Mobile thread long-press menus now include **Open pull request #N** (or **Open merge request #N** on GitLab) when the row has a PR, and the action opens that URL in the browser via `tryOpenExternalUrl`, with an alert if opening fails. The item is omitted when there is no PR.
> 
> The same wiring is applied to both **v1** (`thread-list-items`) and **v2** (`thread-list-v2-items`) list rows; v2 consolidates menu actions in a `menuActions` memo so PR items are prepended consistently across snoozed, legacy, slim, and card menus.
> 
> `ThreadPrPresentation` gains **`longName`** (provider-aware “pull request” / “merge request”) for menu titles and error text. New unit tests cover menu building and open behavior for open, merged, and closed states.
> 
> User docs clarify that in-app PR review and editing stay on **web/desktop**, while **mobile** opens the thread’s linked or current-branch PR in the browser from the thread menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749d6b755eae1ce2fffbde7177eba4cfb4aeaac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Open pull request" action to mobile thread context menus
> - Adds `buildThreadPullRequestMenuItems` and `openThreadPullRequest` utilities in [thread-pull-request-menu.ts](https://github.com/pingdotgg/t3code/pull/8178/files#diff-36de8bd1fb2b64ddddfc802ded6bc12b6f407c0cff3279814295e8b752f52415); the menu item is provider-aware ("pull request" vs "merge request") and opens the PR URL in the browser, alerting on failure.
> - Wires these items into both `ThreadListRow` and `ThreadListV2Row` via the `"open-pull-request"` action handler.
> - Adds a required `longName` field to `ThreadPrPresentation` in [thread-pr-presentation.ts](https://github.com/pingdotgg/t3code/pull/8178/files#diff-befc8c3b6d8c70a55eaf17f748347c0e6796e91fda062e99ccd9da596395c595), populated by `presentThreadPr` from `resolveChangeRequestPresentation`.
> - Updates [source-control.md](https://github.com/pingdotgg/t3code/pull/8178/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05) and [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/8178/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a) to document mobile browser-opening behavior versus in-app reviews on web/desktop.
> - Risk: `ThreadPrPresentation.longName` is now required; any out-of-tree consumers constructing this type directly must set the new field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 749d6b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->