### PR TITLE
fix(mobile): publish missed updates after native builds finish

### DIFF
--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -69,11 +69,10 @@ on:
   schedule:
     - cron: "17,47 * * * *"
 
-# Serialize runs so OTAs publish in merge order. GitHub keeps at most one
-# queued run per group, so a burst of merges collapses into one run of the
-# newest commit — intermediate commits don't need their own OTA.
+# Serialize push releases so OTAs publish in merge order. Scheduled retries
+# use a separate group and cannot replace a queued push that must start builds.
 concurrency:
-  group: mobile-eas-production
+  group: mobile-eas-production-${{ github.event_name == 'schedule' && 'scheduled' || 'release' }}
   cancel-in-progress: false
 
 jobs:
@@ -277,9 +276,16 @@ jobs:
             matching="$(eas build:list --platform "$platform" --build-profile production --status finished --fingerprint-hash "$hash" --limit 1 --json --non-interactive | jq 'length')"
             if [ "$matching" -gt 0 ]; then
               if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-                group="$(eas update:list --branch production --platform "$platform" --runtime-version "$hash" --limit 1 --json --non-interactive | jq -r '.currentPage[0].group // empty')"
+                updates="$(eas update:list --branch production --platform "$platform" --runtime-version "$hash" --limit 2 --json --non-interactive)"
+                group="$(jq -r '.currentPage[0].group // empty' <<< "$updates")"
                 if [ -n "$group" ]; then
-                  published_commit="$(eas update:view "$group" --json | jq -r --arg platform "$platform" '.[] | select(.platform == $platform) | .gitCommitHash // empty')"
+                  update="$(eas update:view "$group" --json | jq -c --arg platform "$platform" 'map(select(.platform == $platform)) | .[0] // {}')"
+                  if [ "$(jq -r '.isRollBackToEmbedded // false' <<< "$update")" = "true" ]; then
+                    echo "$platform: preserving production rollback to the embedded update"
+                    continue
+                  fi
+
+                  published_commit="$(jq -r '.gitCommitHash // empty' <<< "$update")"
                   if [ -n "$published_commit" ] &&
                     git cat-file -e "$published_commit^{commit}" 2>/dev/null &&
                     git -C "$(git rev-parse --show-toplevel)" diff --quiet "$published_commit" HEAD -- \
@@ -295,6 +301,18 @@ jobs:
                       .github/workflows/mobile-eas-production.yml; then
                     echo "$platform: production OTA already contains the latest mobile changes"
                     continue
+                  fi
+
+                  previous_group="$(jq -r '.currentPage[1].group // empty' <<< "$updates")"
+                  if [ -n "$published_commit" ] && [ -n "$previous_group" ]; then
+                    previous_commit="$(eas update:view "$previous_group" --json | jq -r --arg platform "$platform" '.[] | select(.platform == $platform) | .gitCommitHash // empty')"
+                    if [ -n "$previous_commit" ] &&
+                      [ "$published_commit" != "$previous_commit" ] &&
+                      git cat-file -e "$previous_commit^{commit}" 2>/dev/null &&
+                      git merge-base --is-ancestor "$published_commit" "$previous_commit"; then
+                      echo "$platform: preserving production rollback to an earlier update"
+                      continue
+                    fi
                   fi
                 fi
               fi

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -22,6 +22,7 @@ name: Mobile EAS Production
 #      it too. When native drift means no binary could install the update,
 #      it is skipped and flagged in the job summary instead of published
 #      into the void.
+# Scheduled runs retry skipped updates after asynchronous builds finish.
 # workflow_dispatch remains as a manual override for both modes (e.g. to
 # retry an errored build or force an OTA).
 on:
@@ -65,6 +66,8 @@ on:
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
       - .github/workflows/mobile-eas-production.yml
+  schedule:
+    - cron: "17,47 * * * *"
 
 # Serialize runs so OTAs publish in merge order. GitHub keeps at most one
 # queued run per group, so a burst of merges collapses into one run of the
@@ -75,7 +78,7 @@ concurrency:
 
 jobs:
   production:
-    name: EAS Production ${{ github.event_name == 'push' && 'auto' || inputs.mode }}
+    name: EAS Production ${{ github.event_name != 'workflow_dispatch' && 'auto' || inputs.mode }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -261,7 +264,7 @@ jobs:
           exit "$failed"
 
       - name: Publish fingerprint-gated OTA
-        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'push'
+        if: steps.expo-token.outputs.present == 'true' && (github.event_name == 'push' || github.event_name == 'schedule')
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -273,6 +276,29 @@ jobs:
             hash="$(eas fingerprint:generate --platform "$platform" --environment production --json --non-interactive | sed -n '/^{/,$p' | jq -er '.hash | select(type == "string" and length > 0)')"
             matching="$(eas build:list --platform "$platform" --build-profile production --status finished --fingerprint-hash "$hash" --limit 1 --json --non-interactive | jq 'length')"
             if [ "$matching" -gt 0 ]; then
+              if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+                group="$(eas update:list --branch production --platform "$platform" --runtime-version "$hash" --limit 1 --json --non-interactive | jq -r '.currentPage[0].group // empty')"
+                if [ -n "$group" ]; then
+                  published_commit="$(eas update:view "$group" --json | jq -r --arg platform "$platform" '.[] | select(.platform == $platform) | .gitCommitHash // empty')"
+                  if [ -n "$published_commit" ] &&
+                    git cat-file -e "$published_commit^{commit}" 2>/dev/null &&
+                    git -C "$(git rev-parse --show-toplevel)" diff --quiet "$published_commit" HEAD -- \
+                      apps/mobile \
+                      packages/client-runtime \
+                      packages/contracts \
+                      packages/shared \
+                      assets \
+                      scripts \
+                      patches \
+                      pnpm-lock.yaml \
+                      pnpm-workspace.yaml \
+                      .github/workflows/mobile-eas-production.yml; then
+                    echo "$platform: production OTA already contains the latest mobile changes"
+                    continue
+                  fi
+                fi
+              fi
+
               eas update \
                 --channel production \
                 --environment production \

--- a/scripts/mobile-eas-production.test.ts
+++ b/scripts/mobile-eas-production.test.ts
@@ -10,6 +10,7 @@ const Workflow = Schema.Struct({
   on: Schema.Struct({
     schedule: Schema.optional(Schema.Array(Schema.Struct({ cron: Schema.String }))),
   }),
+  concurrency: Schema.Struct({ group: Schema.String }),
   jobs: Schema.Struct({
     production: Schema.Struct({
       steps: Schema.Array(
@@ -42,7 +43,10 @@ function workflowStep(name: string) {
 function runPublishStep(options: {
   readonly finishedPlatforms: ReadonlyArray<"ios" | "android">;
   readonly publishedCommit?: string;
+  readonly previousCommit?: string;
   readonly mobileFilesChanged?: boolean;
+  readonly rollbackToEmbedded?: boolean;
+  readonly rollbackToPrevious?: boolean;
 }) {
   const step = workflowStep("Publish fingerprint-gated OTA");
   const fixture = `
@@ -50,7 +54,10 @@ function runPublishStep(options: {
     export GITHUB_STEP_SUMMARY=/dev/null
     MOCK_FINISHED_PLATFORMS='${options.finishedPlatforms.join(" ")}'
     MOCK_PUBLISHED_COMMIT='${options.publishedCommit ?? ""}'
+    MOCK_PREVIOUS_COMMIT='${options.previousCommit ?? ""}'
     MOCK_MOBILE_FILES_CHANGED='${options.mobileFilesChanged ? "true" : "false"}'
+    MOCK_ROLLBACK_TO_EMBEDDED='${options.rollbackToEmbedded ? "true" : "false"}'
+    MOCK_ROLLBACK_TO_PREVIOUS='${options.rollbackToPrevious ? "true" : "false"}'
 
     eas() {
       local command="$1"
@@ -76,15 +83,23 @@ function runPublishStep(options: {
           fi
           ;;
         update:list)
-          if [ -n "$MOCK_PUBLISHED_COMMIT" ]; then
+          if [ -n "$MOCK_PREVIOUS_COMMIT" ]; then
+            printf '{"currentPage":[{"group":"published-group"},{"group":"previous-group"}]}\\n'
+          elif [ -n "$MOCK_PUBLISHED_COMMIT" ] || [ "$MOCK_ROLLBACK_TO_EMBEDDED" = "true" ]; then
             printf '{"currentPage":[{"group":"published-group"}]}\\n'
           else
             printf '{"currentPage":[]}\\n'
           fi
           ;;
         update:view)
-          printf '[{"platform":"ios","gitCommitHash":"%s"},{"platform":"android","gitCommitHash":"%s"}]\\n' \\
-            "$MOCK_PUBLISHED_COMMIT" "$MOCK_PUBLISHED_COMMIT"
+          local commit="$MOCK_PUBLISHED_COMMIT"
+          local rollback="$MOCK_ROLLBACK_TO_EMBEDDED"
+          if [ "$1" = "previous-group" ]; then
+            commit="$MOCK_PREVIOUS_COMMIT"
+            rollback=false
+          fi
+          printf '[{"platform":"ios","gitCommitHash":"%s","isRollBackToEmbedded":%s},{"platform":"android","gitCommitHash":"%s","isRollBackToEmbedded":%s}]\\n' \\
+            "$commit" "$rollback" "$commit" "$rollback"
           ;;
         update)
           printf 'published:%s\\n' "$platform"
@@ -113,6 +128,12 @@ function runPublishStep(options: {
         cat-file)
           return 0
           ;;
+        merge-base)
+          if [ "$MOCK_ROLLBACK_TO_PREVIOUS" = "true" ]; then
+            return 0
+          fi
+          return 1
+          ;;
         -C)
           if [ "$MOCK_MOBILE_FILES_CHANGED" = "true" ]; then
             return 1
@@ -137,6 +158,7 @@ function runPublishStep(options: {
 describe("mobile EAS production workflow", () => {
   it("retries finished native builds on a schedule without scheduling store builds", () => {
     expect(workflow.on.schedule).toEqual([{ cron: "17,47 * * * *" }]);
+    expect(workflow.concurrency.group).toContain("github.event_name == 'schedule'");
     expect(workflowStep("Publish fingerprint-gated OTA").if).toContain(
       "github.event_name == 'schedule'",
     );
@@ -167,5 +189,26 @@ describe("mobile EAS production workflow", () => {
         mobileFilesChanged: true,
       }),
     ).toContain("published:ios");
+  });
+
+  it("preserves an intentional rollback to the embedded update", () => {
+    expect(
+      runPublishStep({
+        finishedPlatforms: ["ios"],
+        rollbackToEmbedded: true,
+      }),
+    ).not.toContain("published:");
+  });
+
+  it("preserves an intentional rollback to an earlier update", () => {
+    expect(
+      runPublishStep({
+        finishedPlatforms: ["ios"],
+        publishedCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        previousCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        mobileFilesChanged: true,
+        rollbackToPrevious: true,
+      }),
+    ).not.toContain("published:");
   });
 });

--- a/scripts/mobile-eas-production.test.ts
+++ b/scripts/mobile-eas-production.test.ts
@@ -1,0 +1,171 @@
+// @effect-diagnostics nodeBuiltinImport:off - Execute the committed workflow shell against mocked CLIs.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+import { parse } from "yaml";
+
+const Workflow = Schema.Struct({
+  on: Schema.Struct({
+    schedule: Schema.optional(Schema.Array(Schema.Struct({ cron: Schema.String }))),
+  }),
+  jobs: Schema.Struct({
+    production: Schema.Struct({
+      steps: Schema.Array(
+        Schema.Struct({
+          name: Schema.optional(Schema.String),
+          if: Schema.optional(Schema.String),
+          run: Schema.optional(Schema.String),
+        }),
+      ),
+    }),
+  }),
+});
+
+const workflowSource = NodeFS.readFileSync(
+  new URL("../.github/workflows/mobile-eas-production.yml", import.meta.url),
+  "utf8",
+);
+const parsedWorkflow: unknown = parse(workflowSource);
+const workflow = Schema.decodeUnknownSync(Workflow)(parsedWorkflow);
+const latestCommit = "123456789abcdef123456789abcdef123456789ab";
+
+function workflowStep(name: string) {
+  const step = workflow.jobs.production.steps.find((candidate) => candidate.name === name);
+  if (!step?.run) {
+    throw new Error(`Expected a runnable workflow step named '${name}'.`);
+  }
+  return { ...step, run: step.run };
+}
+
+function runPublishStep(options: {
+  readonly finishedPlatforms: ReadonlyArray<"ios" | "android">;
+  readonly publishedCommit?: string;
+  readonly mobileFilesChanged?: boolean;
+}) {
+  const step = workflowStep("Publish fingerprint-gated OTA");
+  const fixture = `
+    export GITHUB_EVENT_NAME=schedule
+    export GITHUB_STEP_SUMMARY=/dev/null
+    MOCK_FINISHED_PLATFORMS='${options.finishedPlatforms.join(" ")}'
+    MOCK_PUBLISHED_COMMIT='${options.publishedCommit ?? ""}'
+    MOCK_MOBILE_FILES_CHANGED='${options.mobileFilesChanged ? "true" : "false"}'
+
+    eas() {
+      local command="$1"
+      shift
+      local platform=""
+      local previous=""
+      for argument in "$@"; do
+        if [ "$previous" = "--platform" ]; then
+          platform="$argument"
+        fi
+        previous="$argument"
+      done
+
+      case "$command" in
+        fingerprint:generate)
+          printf '{"hash":"native-%s"}\\n' "$platform"
+          ;;
+        build:list)
+          if [[ " $MOCK_FINISHED_PLATFORMS " == *" $platform "* ]]; then
+            printf '[{"id":"finished-build"}]\\n'
+          else
+            printf '[]\\n'
+          fi
+          ;;
+        update:list)
+          if [ -n "$MOCK_PUBLISHED_COMMIT" ]; then
+            printf '{"currentPage":[{"group":"published-group"}]}\\n'
+          else
+            printf '{"currentPage":[]}\\n'
+          fi
+          ;;
+        update:view)
+          printf '[{"platform":"ios","gitCommitHash":"%s"},{"platform":"android","gitCommitHash":"%s"}]\\n' \\
+            "$MOCK_PUBLISHED_COMMIT" "$MOCK_PUBLISHED_COMMIT"
+          ;;
+        update)
+          printf 'published:%s\\n' "$platform"
+          ;;
+        *)
+          printf 'Unexpected EAS command: %s\\n' "$command" >&2
+          return 1
+          ;;
+      esac
+    }
+
+    git() {
+      case "$1" in
+        log)
+          printf 'Latest mobile change\\n'
+          ;;
+        rev-parse)
+          if [ "$2" = "--short=9" ]; then
+            printf '123456789\\n'
+          elif [ "$2" = "--show-toplevel" ]; then
+            printf '/mock-repository\\n'
+          else
+            printf '${latestCommit}\\n'
+          fi
+          ;;
+        cat-file)
+          return 0
+          ;;
+        -C)
+          if [ "$MOCK_MOBILE_FILES_CHANGED" = "true" ]; then
+            return 1
+          fi
+          return 0
+          ;;
+        *)
+          printf 'Unexpected Git command: %s\\n' "$1" >&2
+          return 1
+          ;;
+      esac
+    }
+  `;
+
+  const result = NodeChildProcess.spawnSync("bash", ["-e", "-c", `${fixture}\n${step.run}`], {
+    encoding: "utf8",
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout;
+}
+
+describe("mobile EAS production workflow", () => {
+  it("retries finished native builds on a schedule without scheduling store builds", () => {
+    expect(workflow.on.schedule).toEqual([{ cron: "17,47 * * * *" }]);
+    expect(workflowStep("Publish fingerprint-gated OTA").if).toContain(
+      "github.event_name == 'schedule'",
+    );
+    expect(workflowStep("Ensure store builds exist for the current app version").if).toContain(
+      "github.event_name == 'push'",
+    );
+  });
+
+  it("publishes the latest compatible update after its native build finishes", () => {
+    expect(runPublishStep({ finishedPlatforms: ["ios"] })).toContain("published:ios");
+    expect(runPublishStep({ finishedPlatforms: ["android"] })).toContain("published:android");
+  });
+
+  it("does not republish updates when the mobile files already match production", () => {
+    expect(
+      runPublishStep({
+        finishedPlatforms: ["ios", "android"],
+        publishedCommit: "abcdef123456789abcdef123456789abcdef1234",
+      }),
+    ).not.toContain("published:");
+  });
+
+  it("publishes again when newer commits change mobile files", () => {
+    expect(
+      runPublishStep({
+        finishedPlatforms: ["ios"],
+        publishedCommit: "abcdef123456789abcdef123456789abcdef1234",
+        mobileFilesChanged: true,
+      }),
+    ).toContain("published:ios");
+  });
+});


### PR DESCRIPTION
Native production builds run asynchronously, so mobile changes can miss their OTA update while a matching build is still in progress. Once the build finishes, nothing retries the skipped update.

Recheck production builds every 30 minutes and publish the latest compatible mobile update after a matching build finishes. Scheduled runs never start store builds or republish unchanged mobile files.

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production OTA publishing automation and git/EAS CLI branching in CI; mistakes could skip needed updates or republish when rollbacks should be preserved, but scope is limited to the mobile EAS workflow and is covered by new tests.
> 
> **Overview**
> Production mobile OTAs can be skipped on merge when no **finished** native build matches the current fingerprint; nothing retried them once async store builds completed.
> 
> This PR adds a **cron schedule** (`17,47 * * * *`) so the fingerprint-gated OTA step also runs on `schedule`, while **store builds stay push-only**. Scheduled runs use a separate **concurrency group** (`scheduled` vs `release`) so retries do not replace queued merge releases.
> 
> On scheduled runs, before calling `eas update`, the workflow inspects the latest production updates for that runtime fingerprint and **skips publishing** when production already matches HEAD for mobile-related paths, when the channel is rolled back to embedded, or when an intentional rollback to an earlier update is detected. Push-triggered behavior is unchanged aside from the broader job naming (`auto` for any non-dispatch event).
> 
> Adds **`scripts/mobile-eas-production.test.ts`**, which parses the committed workflow YAML and executes the OTA publish shell against mocked `eas`/`git` to lock in schedule wiring and skip/republish behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11cfa29cd04fdf07014f67c996b53d9aafd710c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish missed OTA updates on schedule in mobile EAS production workflow
> - Adds a cron trigger (`17,47 * * * *`) to the Mobile EAS Production pipeline and splits concurrency groups so scheduled runs do not cancel queued release runs.
> - During scheduled runs, the OTA publish step inspects the most recent production update groups and preserves intentional rollbacks (to the embedded update or an earlier group) instead of republishing.
> - Skips republishing when production already contains the latest mobile changes, determined by comparing the published commit to HEAD over mobile-related paths.
> - Adds [scripts/mobile-eas-production.test.ts](https://github.com/pingdotgg/t3code/pull/8179/files#diff-f422025cd89938fd80ff420f19c8f5395fca004308d7956093b6dc2ff398ed02) to validate the workflow YAML, OTA publish step shell logic, rollback preservation, and skip/republish conditions.
> - Behavioral Change: the `Publish fingerprint-gated OTA` step now runs on both `push` and `schedule` events; the job display name uses `auto` for any non-`workflow_dispatch` event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a11cfa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->