### PR TITLE
fix(mobile): stop image attachments from dropping connections

### DIFF
--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -1,0 +1,170 @@
+import {
+  EnvironmentId,
+  type AttachmentCreateUploadUrlInput,
+  type AttachmentCreateUploadUrlResult,
+  type UploadChatImageAttachment,
+} from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  files: new Map<string, { base64: string; deleted: boolean }>(),
+  upload: vi.fn(),
+}));
+
+vi.mock("expo-file-system", () => ({
+  Paths: { cache: "file:///cache" },
+  File: class {
+    readonly uri: string;
+
+    constructor(directory: string, name: string) {
+      this.uri = `${directory}/${name}`;
+    }
+
+    get exists(): boolean {
+      return mocks.files.get(this.uri)?.deleted === false;
+    }
+
+    write(base64: string, options: { readonly encoding: string }): void {
+      expect(options.encoding).toBe("base64");
+      mocks.files.set(this.uri, { base64, deleted: false });
+    }
+
+    upload(url: string, options: unknown): Promise<{ readonly status: number }> {
+      return mocks.upload(url, options, this.uri);
+    }
+
+    delete(): void {
+      const file = mocks.files.get(this.uri);
+      if (file) {
+        file.deleted = true;
+      }
+    }
+  },
+}));
+
+import { prepareMobileTurnAttachments } from "./attachmentUpload";
+
+const environmentId = EnvironmentId.make("environment-1");
+
+function image(name: string): UploadChatImageAttachment {
+  return {
+    type: "image",
+    name,
+    mimeType: "image/png",
+    sizeBytes: 3,
+    dataUrl: "data:image/png;base64,YWJj",
+  };
+}
+
+function uploadDependencies() {
+  let nextAttachmentId = 0;
+  return {
+    createUploadUrl: vi.fn(
+      async (_input: AttachmentCreateUploadUrlInput): Promise<AttachmentCreateUploadUrlResult> => {
+        const attachmentId = `pending-${++nextAttachmentId}`;
+        return {
+          attachmentId,
+          relativeUrl: `/api/attachments/upload/${attachmentId}`,
+          expiresAt: Date.now() + 60_000,
+        };
+      },
+    ),
+    deleteUpload: vi.fn(async (_attachmentId: string) => undefined),
+  };
+}
+
+describe("prepareMobileTurnAttachments", () => {
+  beforeEach(() => {
+    mocks.files.clear();
+    mocks.upload.mockReset();
+    mocks.upload.mockResolvedValue({ status: 204 });
+  });
+
+  it("uploads image bytes to the paired remote environment and sends attachment references", async () => {
+    const dependencies = uploadDependencies();
+    const images = [image("first.png"), image("second.png")];
+
+    const prepared = await prepareMobileTurnAttachments({
+      environmentId,
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: images,
+      ...dependencies,
+    });
+
+    expect(dependencies.createUploadUrl).toHaveBeenCalledWith({
+      name: "first.png",
+      mimeType: "image/png",
+      sizeBytes: 3,
+    });
+    expect(mocks.upload).toHaveBeenNthCalledWith(
+      1,
+      "https://remote.example.test/api/attachments/upload/pending-1",
+      { httpMethod: "POST", headers: { "Content-Type": "image/png" } },
+      expect.stringMatching(/^file:\/\/\/cache\/t3-attachment-/),
+    );
+    expect(prepared.attachments).toEqual([
+      { type: "image", id: "pending-1", name: "first.png", mimeType: "image/png", sizeBytes: 3 },
+      { type: "image", id: "pending-2", name: "second.png", mimeType: "image/png", sizeBytes: 3 },
+    ]);
+    expect(JSON.stringify(prepared.attachments)).not.toContain("data:image");
+    expect(images[0]?.dataUrl).toBe("data:image/png;base64,YWJj");
+    expect([...mocks.files.values()]).toEqual([
+      { base64: "YWJj", deleted: true },
+      { base64: "YWJj", deleted: true },
+    ]);
+
+    await prepared.release();
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
+  });
+
+  it("keeps inline attachments for environments without HTTP upload support", async () => {
+    const dependencies = uploadDependencies();
+    const images = [image("legacy.png")];
+
+    const prepared = await prepareMobileTurnAttachments({
+      environmentId,
+      httpBaseUrl: "https://older.example.test/",
+      supportsUploads: false,
+      attachments: images,
+      ...dependencies,
+    });
+
+    expect(prepared.attachments).toEqual(images);
+    expect(dependencies.createUploadUrl).not.toHaveBeenCalled();
+    expect(mocks.upload).not.toHaveBeenCalled();
+  });
+
+  it("removes pending uploads after a failed request and can retry the original images", async () => {
+    const dependencies = uploadDependencies();
+    const images = [image("first.png"), image("retry.png")];
+    mocks.upload.mockResolvedValueOnce({ status: 204 }).mockResolvedValueOnce({ status: 503 });
+
+    await expect(
+      prepareMobileTurnAttachments({
+        environmentId,
+        httpBaseUrl: "https://remote.example.test/",
+        supportsUploads: true,
+        attachments: images,
+        ...dependencies,
+      }),
+    ).rejects.toMatchObject({
+      _tag: "ConnectionTransientError",
+      message: "Could not upload 'retry.png': upload rejected (503).",
+    });
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
+
+    mocks.upload.mockResolvedValue({ status: 204 });
+    const retry = await prepareMobileTurnAttachments({
+      environmentId,
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: images,
+      ...dependencies,
+    });
+
+    expect(retry.attachments).toMatchObject([{ id: "pending-3" }, { id: "pending-4" }]);
+  });
+});

--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -119,21 +119,94 @@ describe("prepareMobileTurnAttachments", () => {
     expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
   });
 
-  it("keeps inline attachments for environments without HTTP upload support", async () => {
+  it("requires an updated environment instead of sending inline attachments", async () => {
     const dependencies = uploadDependencies();
     const images = [image("legacy.png")];
 
-    const prepared = await prepareMobileTurnAttachments({
-      environmentId,
-      httpBaseUrl: "https://older.example.test/",
-      supportsUploads: false,
-      attachments: images,
-      ...dependencies,
+    await expect(
+      prepareMobileTurnAttachments({
+        environmentId,
+        httpBaseUrl: "https://older.example.test/",
+        supportsUploads: false,
+        attachments: images,
+        ...dependencies,
+      }),
+    ).rejects.toMatchObject({
+      _tag: "ConnectionBlockedError",
+      message: "Image attachments require an updated environment.",
     });
-
-    expect(prepared.attachments).toEqual(images);
     expect(dependencies.createUploadUrl).not.toHaveBeenCalled();
     expect(mocks.upload).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      attachment: { ...image("unsupported.png"), mimeType: "image/tiff" },
+      message: "Could not upload 'unsupported.png': image type is not supported.",
+    },
+    {
+      attachment: { ...image("invalid.png"), dataUrl: "not-a-data-url" },
+      message: "Could not upload 'invalid.png': image data is invalid.",
+    },
+  ])("does not retry invalid image attachments", async ({ attachment, message }) => {
+    const dependencies = uploadDependencies();
+
+    await expect(
+      prepareMobileTurnAttachments({
+        environmentId,
+        httpBaseUrl: "https://remote.example.test/",
+        supportsUploads: true,
+        attachments: [attachment],
+        ...dependencies,
+      }),
+    ).rejects.toMatchObject({ _tag: "ConnectionBlockedError", message });
+    expect(dependencies.createUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it("keeps underlying upload errors out of caller-visible messages", async () => {
+    const dependencies = uploadDependencies();
+    dependencies.createUploadUrl.mockRejectedValueOnce(new Error("private remote error details"));
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      prepareMobileTurnAttachments({
+        environmentId,
+        httpBaseUrl: "https://remote.example.test/",
+        supportsUploads: true,
+        attachments: [image("private.png")],
+        ...dependencies,
+      }),
+    ).rejects.toMatchObject({
+      _tag: "ConnectionTransientError",
+      message: "Could not upload 'private.png'.",
+    });
+    expect(warning).toHaveBeenCalledWith(
+      "Image attachment upload failed.",
+      expect.objectContaining({
+        attachmentName: "private.png",
+        cause: expect.objectContaining({ message: "private remote error details" }),
+      }),
+    );
+    warning.mockRestore();
+  });
+
+  it("does not retry an upload rejected by a permanent HTTP error", async () => {
+    const dependencies = uploadDependencies();
+    mocks.upload.mockResolvedValueOnce({ status: 400 });
+
+    await expect(
+      prepareMobileTurnAttachments({
+        environmentId,
+        httpBaseUrl: "https://remote.example.test/",
+        supportsUploads: true,
+        attachments: [image("rejected.png")],
+        ...dependencies,
+      }),
+    ).rejects.toMatchObject({
+      _tag: "ConnectionBlockedError",
+      message: "Could not upload 'rejected.png': upload rejected (400).",
+    });
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
   });
 
   it("removes pending uploads after a failed request and can retry the original images", async () => {

--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -389,6 +389,38 @@ describe("prepareMobileTurnAttachments", () => {
     expect(mocks.upload).not.toHaveBeenCalled();
   });
 
+  it("rejects an upload that finishes after its queued turn was deleted", async () => {
+    const dependencies = uploadDependencies();
+    let finishUpload!: (result: { status: number }) => void;
+    let signalUploadStarted!: () => void;
+    const uploadStarted = new Promise<void>((resolve) => {
+      signalUploadStarted = resolve;
+    });
+    mocks.upload.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishUpload = resolve;
+          signalUploadStarted();
+        }),
+    );
+    const preparing = prepareMobileTurnAttachments({
+      environmentId,
+      commandId: "deleted-while-finishing",
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [image("deleted.png")],
+      ...dependencies,
+    });
+    await uploadStarted;
+
+    await releaseMobileTurnAttachments({ environmentId, commandId: "deleted-while-finishing" });
+    finishUpload({ status: 204 });
+
+    await expect(preparing).rejects.toMatchObject({ _tag: "ConnectionTransientError" });
+    expect(dependencies.deleteUpload).toHaveBeenCalledTimes(2);
+    expect(dependencies.deleteUpload).toHaveBeenLastCalledWith("pending-1");
+  });
+
   it("releases every cached upload when an environment is removed", async () => {
     const dependencies = uploadDependencies();
     for (const commandId of ["removed-first", "removed-second"]) {

--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -119,6 +119,25 @@ describe("prepareMobileTurnAttachments", () => {
     expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
   });
 
+  it("uses the encoded image size when picker metadata reports a different size", async () => {
+    const dependencies = uploadDependencies();
+
+    const prepared = await prepareMobileTurnAttachments({
+      environmentId,
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [{ ...image("picked.png"), sizeBytes: 12 }],
+      ...dependencies,
+    });
+
+    expect(dependencies.createUploadUrl).toHaveBeenCalledWith({
+      name: "picked.png",
+      mimeType: "image/png",
+      sizeBytes: 3,
+    });
+    expect(prepared.attachments).toMatchObject([{ sizeBytes: 3 }]);
+  });
+
   it("requires an updated environment instead of sending inline attachments", async () => {
     const dependencies = uploadDependencies();
     const images = [image("legacy.png")];
@@ -137,6 +156,24 @@ describe("prepareMobileTurnAttachments", () => {
     });
     expect(dependencies.createUploadUrl).not.toHaveBeenCalled();
     expect(mocks.upload).not.toHaveBeenCalled();
+  });
+
+  it("retries while environment upload capabilities are still loading", async () => {
+    const dependencies = uploadDependencies();
+
+    await expect(
+      prepareMobileTurnAttachments({
+        environmentId,
+        httpBaseUrl: "https://remote.example.test/",
+        supportsUploads: null,
+        attachments: [image("waiting.png")],
+        ...dependencies,
+      }),
+    ).rejects.toMatchObject({
+      _tag: "ConnectionTransientError",
+      message: "Environment upload capabilities are still loading.",
+    });
+    expect(dependencies.createUploadUrl).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -207,6 +244,28 @@ describe("prepareMobileTurnAttachments", () => {
       message: "Could not upload 'rejected.png': upload rejected (400).",
     });
     expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+  });
+
+  it("reuses uploaded attachment IDs when the same turn is retried", async () => {
+    const dependencies = uploadDependencies();
+    const input = {
+      environmentId,
+      commandId: "retryable-turn",
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [image("retry.png")],
+      ...dependencies,
+    };
+
+    const first = await prepareMobileTurnAttachments(input);
+    const retry = await prepareMobileTurnAttachments(input);
+
+    expect(retry.attachments).toEqual(first.attachments);
+    expect(dependencies.createUploadUrl).toHaveBeenCalledTimes(1);
+    expect(mocks.upload).toHaveBeenCalledTimes(1);
+
+    await retry.release();
+    expect(dependencies.deleteUpload).toHaveBeenCalledTimes(1);
   });
 
   it("removes pending uploads after a failed request and can retry the original images", async () => {

--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -100,7 +100,11 @@ describe("prepareMobileTurnAttachments", () => {
     expect(mocks.upload).toHaveBeenNthCalledWith(
       1,
       "https://remote.example.test/api/attachments/upload/pending-1",
-      { httpMethod: "POST", headers: { "Content-Type": "image/png" } },
+      {
+        httpMethod: "POST",
+        headers: { "Content-Type": "image/png" },
+        signal: expect.any(AbortSignal),
+      },
       expect.stringMatching(/^file:\/\/\/cache\/t3-attachment-/),
     );
     expect(prepared.attachments).toEqual([
@@ -292,6 +296,47 @@ describe("prepareMobileTurnAttachments", () => {
     await edited.release();
   });
 
+  it("keeps the previous upload until replacement preparation finishes", async () => {
+    const dependencies = uploadDependencies();
+    const input = {
+      environmentId,
+      commandId: "replaced-turn",
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [image("before.png")],
+      ...dependencies,
+    };
+    const previous = await prepareMobileTurnAttachments(input);
+    let finishReplacement!: (result: { status: number }) => void;
+    let replacementStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      replacementStarted = resolve;
+    });
+    mocks.upload.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishReplacement = resolve;
+          replacementStarted();
+        }),
+    );
+
+    const replacing = prepareMobileTurnAttachments({
+      ...input,
+      attachments: [image("after.png")],
+    });
+    await started;
+    expect(dependencies.deleteUpload).not.toHaveBeenCalledWith("pending-1");
+
+    finishReplacement({ status: 204 });
+    const replacement = await replacing;
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+
+    await previous.release();
+    await releaseMobileTurnAttachments({ environmentId, commandId: "replaced-turn" });
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
+    await replacement.release();
+  });
+
   it("releases cached uploads when a queued turn is deleted", async () => {
     const dependencies = uploadDependencies();
     await prepareMobileTurnAttachments({
@@ -306,6 +351,42 @@ describe("prepareMobileTurnAttachments", () => {
     await releaseMobileTurnAttachments({ environmentId, commandId: "deleted-turn" });
 
     expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+  });
+
+  it("removes an upload URL that resolves after its queued turn was deleted", async () => {
+    const dependencies = uploadDependencies();
+    let resolveUploadUrl!: (result: AttachmentCreateUploadUrlResult) => void;
+    let signalMintStarted!: () => void;
+    const mintStarted = new Promise<void>((resolve) => {
+      signalMintStarted = resolve;
+    });
+    dependencies.createUploadUrl.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUploadUrl = resolve;
+          signalMintStarted();
+        }),
+    );
+    const preparing = prepareMobileTurnAttachments({
+      environmentId,
+      commandId: "deleted-during-upload",
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [image("deleted.png")],
+      ...dependencies,
+    });
+    await mintStarted;
+
+    await releaseMobileTurnAttachments({ environmentId, commandId: "deleted-during-upload" });
+    resolveUploadUrl({
+      attachmentId: "pending-late",
+      relativeUrl: "/api/attachments/upload/pending-late",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await expect(preparing).rejects.toMatchObject({ _tag: "ConnectionTransientError" });
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-late");
+    expect(mocks.upload).not.toHaveBeenCalled();
   });
 
   it("releases every cached upload when an environment is removed", async () => {
@@ -325,6 +406,37 @@ describe("prepareMobileTurnAttachments", () => {
 
     expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
     expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
+  });
+
+  it("keeps environment and command IDs with colons isolated", async () => {
+    const firstEnvironmentId = EnvironmentId.make("a");
+    const secondEnvironmentId = EnvironmentId.make("a:b");
+    const first = uploadDependencies();
+    const second = uploadDependencies();
+
+    await prepareMobileTurnAttachments({
+      environmentId: firstEnvironmentId,
+      commandId: "b:c",
+      httpBaseUrl: "https://first.example.test/",
+      supportsUploads: true,
+      attachments: [image("first.png")],
+      ...first,
+    });
+    await prepareMobileTurnAttachments({
+      environmentId: secondEnvironmentId,
+      commandId: "c",
+      httpBaseUrl: "https://second.example.test/",
+      supportsUploads: true,
+      attachments: [image("second.png")],
+      ...second,
+    });
+
+    await releaseMobileTurnAttachments({ environmentId: firstEnvironmentId });
+    expect(first.deleteUpload).toHaveBeenCalledWith("pending-1");
+    expect(second.deleteUpload).not.toHaveBeenCalled();
+
+    await releaseMobileTurnAttachments({ environmentId: secondEnvironmentId });
+    expect(second.deleteUpload).toHaveBeenCalledWith("pending-1");
   });
 
   it("removes pending uploads after a failed request and can retry the original images", async () => {

--- a/apps/mobile/src/lib/attachmentUpload.test.ts
+++ b/apps/mobile/src/lib/attachmentUpload.test.ts
@@ -42,7 +42,7 @@ vi.mock("expo-file-system", () => ({
   },
 }));
 
-import { prepareMobileTurnAttachments } from "./attachmentUpload";
+import { prepareMobileTurnAttachments, releaseMobileTurnAttachments } from "./attachmentUpload";
 
 const environmentId = EnvironmentId.make("environment-1");
 
@@ -266,6 +266,65 @@ describe("prepareMobileTurnAttachments", () => {
 
     await retry.release();
     expect(dependencies.deleteUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces cached uploads when a queued turn is edited", async () => {
+    const dependencies = uploadDependencies();
+    const input = {
+      environmentId,
+      commandId: "edited-turn",
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [image("before.png")],
+      ...dependencies,
+    };
+
+    await prepareMobileTurnAttachments(input);
+    const edited = await prepareMobileTurnAttachments({
+      ...input,
+      attachments: [{ ...image("after.png"), dataUrl: "data:image/png;base64,ZGVm" }],
+    });
+
+    expect(edited.attachments).toMatchObject([{ id: "pending-2", name: "after.png" }]);
+    expect(dependencies.createUploadUrl).toHaveBeenCalledTimes(2);
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+
+    await edited.release();
+  });
+
+  it("releases cached uploads when a queued turn is deleted", async () => {
+    const dependencies = uploadDependencies();
+    await prepareMobileTurnAttachments({
+      environmentId,
+      commandId: "deleted-turn",
+      httpBaseUrl: "https://remote.example.test/",
+      supportsUploads: true,
+      attachments: [image("deleted.png")],
+      ...dependencies,
+    });
+
+    await releaseMobileTurnAttachments({ environmentId, commandId: "deleted-turn" });
+
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+  });
+
+  it("releases every cached upload when an environment is removed", async () => {
+    const dependencies = uploadDependencies();
+    for (const commandId of ["removed-first", "removed-second"]) {
+      await prepareMobileTurnAttachments({
+        environmentId,
+        commandId,
+        httpBaseUrl: "https://remote.example.test/",
+        supportsUploads: true,
+        attachments: [image(`${commandId}.png`)],
+        ...dependencies,
+      });
+    }
+
+    await releaseMobileTurnAttachments({ environmentId });
+
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-1");
+    expect(dependencies.deleteUpload).toHaveBeenCalledWith("pending-2");
   });
 
   it("removes pending uploads after a failed request and can retry the original images", async () => {

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -1,4 +1,7 @@
-import { ConnectionTransientError } from "@t3tools/client-runtime/connection";
+import {
+  ConnectionBlockedError,
+  ConnectionTransientError,
+} from "@t3tools/client-runtime/connection";
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import {
   PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
@@ -9,6 +12,8 @@ import {
   type UploadChatAttachment,
 } from "@t3tools/contracts";
 import type { File } from "expo-file-system";
+
+import { estimateBase64ByteSize } from "./base64";
 
 type TurnAttachment = ChatAttachment | UploadChatAttachment;
 
@@ -29,19 +34,25 @@ interface PreparedMobileTurnAttachments {
 }
 
 function transientUploadError(name: string, cause: unknown): ConnectionTransientError {
-  const reason = cause instanceof Error ? cause.message : "upload failed";
+  console.warn("Image attachment upload failed.", { attachmentName: name, cause });
   return new ConnectionTransientError({
     reason: "network",
-    detail: `Could not upload '${name}': ${reason.replace(/\.$/, "")}.`,
+    detail: `Could not upload '${name}'.`,
   });
 }
 
-/** Uploads mobile images as native binary requests and keeps old servers on the inline format. */
+/** Uploads mobile images as native binary requests before their turn is sent. */
 export async function prepareMobileTurnAttachments(
   input: MobileAttachmentUploadInput,
 ): Promise<PreparedMobileTurnAttachments> {
-  if (!input.supportsUploads || input.attachments.length === 0) {
+  if (input.attachments.length === 0) {
     return { attachments: input.attachments, release: async () => undefined };
+  }
+  if (!input.supportsUploads) {
+    throw new ConnectionBlockedError({
+      reason: "unsupported",
+      detail: "Image attachments require an updated environment.",
+    });
   }
 
   const { File: ExpoFile, Paths } = await import("expo-file-system");
@@ -62,13 +73,31 @@ export async function prepareMobileTurnAttachments(
     let temporaryFile: File | null = null;
     try {
       if (input.httpBaseUrl === null) {
-        throw new Error("environment is not connected");
+        throw new ConnectionTransientError({
+          reason: "endpoint-unavailable",
+          detail: `Could not upload '${attachment.name}': environment is not connected.`,
+        });
       }
       const mimeType = PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES.find(
         (supportedMimeType) => supportedMimeType === attachment.mimeType.toLowerCase(),
       );
       if (!mimeType) {
-        throw new Error("image type is not supported");
+        throw new ConnectionBlockedError({
+          reason: "unsupported",
+          detail: `Could not upload '${attachment.name}': image type is not supported.`,
+        });
+      }
+      const separatorIndex = attachment.dataUrl.indexOf(",");
+      const base64 = attachment.dataUrl.slice(separatorIndex + 1);
+      if (
+        separatorIndex < 0 ||
+        !attachment.dataUrl.slice(0, separatorIndex).endsWith(";base64") ||
+        estimateBase64ByteSize(base64) !== attachment.sizeBytes
+      ) {
+        throw new ConnectionBlockedError({
+          reason: "configuration",
+          detail: `Could not upload '${attachment.name}': image data is invalid.`,
+        });
       }
 
       const upload = await input.createUploadUrl({
@@ -80,22 +109,27 @@ export async function prepareMobileTurnAttachments(
 
       const url = resolveAssetUrl(input.httpBaseUrl, upload.relativeUrl);
       if (url === null) {
-        throw new Error("upload URL is invalid");
-      }
-
-      const separatorIndex = attachment.dataUrl.indexOf(",");
-      if (separatorIndex < 0) {
-        throw new Error("image data is invalid");
+        throw new ConnectionBlockedError({
+          reason: "configuration",
+          detail: `Could not upload '${attachment.name}': upload URL is invalid.`,
+        });
       }
       temporaryFile = new ExpoFile(Paths.cache, `t3-attachment-${upload.attachmentId}`);
-      temporaryFile.write(attachment.dataUrl.slice(separatorIndex + 1), { encoding: "base64" });
+      temporaryFile.write(base64, { encoding: "base64" });
 
       const result = await temporaryFile.upload(url, {
         httpMethod: "POST",
         headers: { "Content-Type": mimeType },
       });
       if (result.status < 200 || result.status >= 300) {
-        throw new Error(`upload rejected (${result.status})`);
+        const detail = `Could not upload '${attachment.name}': upload rejected (${result.status}).`;
+        if (result.status >= 400 && result.status < 500 && ![408, 429].includes(result.status)) {
+          throw new ConnectionBlockedError({
+            reason: result.status === 401 || result.status === 403 ? "permission" : "configuration",
+            detail,
+          });
+        }
+        throw new ConnectionTransientError({ reason: "network", detail });
       }
 
       uploadedAttachments.push({
@@ -107,7 +141,9 @@ export async function prepareMobileTurnAttachments(
       });
     } catch (cause) {
       await release();
-      throw transientUploadError(attachment.name, cause);
+      throw cause instanceof ConnectionBlockedError || cause instanceof ConnectionTransientError
+        ? cause
+        : transientUploadError(attachment.name, cause);
     } finally {
       if (temporaryFile?.exists) {
         try {

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -35,7 +35,51 @@ interface PreparedMobileTurnAttachments {
   readonly release: () => Promise<void>;
 }
 
-const preparedAttachmentsByCommand = new Map<string, PreparedMobileTurnAttachments>();
+const preparedAttachmentsByCommand = new Map<
+  string,
+  {
+    readonly sourceAttachments: ReadonlyArray<TurnAttachment>;
+    readonly prepared: PreparedMobileTurnAttachments;
+  }
+>();
+
+/** Releases uploads retained for one queued turn or for every turn in an environment. */
+export async function releaseMobileTurnAttachments(input: {
+  readonly environmentId: EnvironmentId;
+  readonly commandId?: string;
+}): Promise<void> {
+  const keyPrefix = `${input.environmentId}:`;
+  const matching =
+    input.commandId === undefined
+      ? [...preparedAttachmentsByCommand.entries()]
+          .filter(([key]) => key.startsWith(keyPrefix))
+          .map(([, entry]) => entry.prepared)
+      : [preparedAttachmentsByCommand.get(`${keyPrefix}${input.commandId}`)?.prepared].filter(
+          (prepared): prepared is PreparedMobileTurnAttachments => prepared !== undefined,
+        );
+  await Promise.allSettled(matching.map((prepared) => prepared.release()));
+}
+
+function sameAttachments(
+  left: ReadonlyArray<TurnAttachment>,
+  right: ReadonlyArray<TurnAttachment>,
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((attachment, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        attachment.name === other.name &&
+        attachment.mimeType === other.mimeType &&
+        attachment.sizeBytes === other.sizeBytes &&
+        ("dataUrl" in attachment
+          ? "dataUrl" in other && attachment.dataUrl === other.dataUrl
+          : "id" in other && attachment.id === other.id)
+      );
+    })
+  );
+}
 
 function transientUploadError(name: string, cause: unknown): ConnectionTransientError {
   console.warn("Image attachment upload failed.", { attachmentName: name, cause });
@@ -69,7 +113,10 @@ export async function prepareMobileTurnAttachments(
     input.commandId === undefined ? null : `${input.environmentId}:${input.commandId}`;
   const existing = commandKey === null ? undefined : preparedAttachmentsByCommand.get(commandKey);
   if (existing) {
-    return existing;
+    if (sameAttachments(existing.sourceAttachments, input.attachments)) {
+      return existing.prepared;
+    }
+    await existing.prepared.release();
   }
 
   const { File: ExpoFile, Paths } = await import("expo-file-system");
@@ -179,7 +226,10 @@ export async function prepareMobileTurnAttachments(
 
   const prepared = { attachments: uploadedAttachments, release };
   if (commandKey !== null) {
-    preparedAttachmentsByCommand.set(commandKey, prepared);
+    preparedAttachmentsByCommand.set(commandKey, {
+      sourceAttachments: input.attachments,
+      prepared,
+    });
   }
   return prepared;
 }

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -4,6 +4,7 @@ import {
 } from "@t3tools/client-runtime/connection";
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import {
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
   type AttachmentCreateUploadUrlInput,
   type AttachmentCreateUploadUrlResult,
@@ -19,8 +20,9 @@ type TurnAttachment = ChatAttachment | UploadChatAttachment;
 
 interface MobileAttachmentUploadInput {
   readonly environmentId: EnvironmentId;
+  readonly commandId?: string;
   readonly httpBaseUrl: string | null;
-  readonly supportsUploads: boolean;
+  readonly supportsUploads: boolean | null;
   readonly attachments: ReadonlyArray<TurnAttachment>;
   readonly createUploadUrl: (
     input: AttachmentCreateUploadUrlInput,
@@ -32,6 +34,8 @@ interface PreparedMobileTurnAttachments {
   readonly attachments: ReadonlyArray<TurnAttachment>;
   readonly release: () => Promise<void>;
 }
+
+const preparedAttachmentsByCommand = new Map<string, PreparedMobileTurnAttachments>();
 
 function transientUploadError(name: string, cause: unknown): ConnectionTransientError {
   console.warn("Image attachment upload failed.", { attachmentName: name, cause });
@@ -48,6 +52,12 @@ export async function prepareMobileTurnAttachments(
   if (input.attachments.length === 0) {
     return { attachments: input.attachments, release: async () => undefined };
   }
+  if (input.supportsUploads === null) {
+    throw new ConnectionTransientError({
+      reason: "endpoint-unavailable",
+      detail: "Environment upload capabilities are still loading.",
+    });
+  }
   if (!input.supportsUploads) {
     throw new ConnectionBlockedError({
       reason: "unsupported",
@@ -55,9 +65,19 @@ export async function prepareMobileTurnAttachments(
     });
   }
 
+  const commandKey =
+    input.commandId === undefined ? null : `${input.environmentId}:${input.commandId}`;
+  const existing = commandKey === null ? undefined : preparedAttachmentsByCommand.get(commandKey);
+  if (existing) {
+    return existing;
+  }
+
   const { File: ExpoFile, Paths } = await import("expo-file-system");
   const pendingAttachmentIds = new Set<string>();
   const release = async (): Promise<void> => {
+    if (commandKey !== null) {
+      preparedAttachmentsByCommand.delete(commandKey);
+    }
     const attachmentIds = [...pendingAttachmentIds];
     pendingAttachmentIds.clear();
     await Promise.allSettled(attachmentIds.map((attachmentId) => input.deleteUpload(attachmentId)));
@@ -89,10 +109,12 @@ export async function prepareMobileTurnAttachments(
       }
       const separatorIndex = attachment.dataUrl.indexOf(",");
       const base64 = attachment.dataUrl.slice(separatorIndex + 1);
+      const sizeBytes = estimateBase64ByteSize(base64);
       if (
         separatorIndex < 0 ||
         !attachment.dataUrl.slice(0, separatorIndex).endsWith(";base64") ||
-        estimateBase64ByteSize(base64) !== attachment.sizeBytes
+        sizeBytes <= 0 ||
+        sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
       ) {
         throw new ConnectionBlockedError({
           reason: "configuration",
@@ -103,7 +125,7 @@ export async function prepareMobileTurnAttachments(
       const upload = await input.createUploadUrl({
         name: attachment.name,
         mimeType,
-        sizeBytes: attachment.sizeBytes,
+        sizeBytes,
       });
       pendingAttachmentIds.add(upload.attachmentId);
 
@@ -137,7 +159,7 @@ export async function prepareMobileTurnAttachments(
         id: upload.attachmentId,
         name: attachment.name,
         mimeType,
-        sizeBytes: attachment.sizeBytes,
+        sizeBytes,
       });
     } catch (cause) {
       await release();
@@ -155,5 +177,9 @@ export async function prepareMobileTurnAttachments(
     }
   }
 
-  return { attachments: uploadedAttachments, release };
+  const prepared = { attachments: uploadedAttachments, release };
+  if (commandKey !== null) {
+    preparedAttachmentsByCommand.set(commandKey, prepared);
+  }
+  return prepared;
 }

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -35,12 +35,17 @@ interface PreparedMobileTurnAttachments {
   readonly release: () => Promise<void>;
 }
 
-const preparedAttachmentsByCommand = new Map<
-  string,
-  {
-    readonly sourceAttachments: ReadonlyArray<TurnAttachment>;
-    readonly prepared: PreparedMobileTurnAttachments;
-  }
+interface CachedMobileTurnAttachments {
+  readonly sourceAttachments: ReadonlyArray<TurnAttachment>;
+  readonly prepared: PreparedMobileTurnAttachments;
+  readonly previous?: CachedMobileTurnAttachments;
+  preparation: Promise<PreparedMobileTurnAttachments> | null;
+  released: boolean;
+}
+
+const preparedAttachmentsByEnvironment = new Map<
+  EnvironmentId,
+  Map<string, CachedMobileTurnAttachments>
 >();
 
 /** Releases uploads retained for one queued turn or for every turn in an environment. */
@@ -48,16 +53,19 @@ export async function releaseMobileTurnAttachments(input: {
   readonly environmentId: EnvironmentId;
   readonly commandId?: string;
 }): Promise<void> {
-  const keyPrefix = `${input.environmentId}:`;
-  const matching =
-    input.commandId === undefined
-      ? [...preparedAttachmentsByCommand.entries()]
-          .filter(([key]) => key.startsWith(keyPrefix))
-          .map(([, entry]) => entry.prepared)
-      : [preparedAttachmentsByCommand.get(`${keyPrefix}${input.commandId}`)?.prepared].filter(
-          (prepared): prepared is PreparedMobileTurnAttachments => prepared !== undefined,
-        );
-  await Promise.allSettled(matching.map((prepared) => prepared.release()));
+  const commands = preparedAttachmentsByEnvironment.get(input.environmentId);
+  if (!commands) {
+    return;
+  }
+  const matching = new Set<CachedMobileTurnAttachments>();
+  const current =
+    input.commandId === undefined ? commands.values() : [commands.get(input.commandId)];
+  for (const entry of current) {
+    for (let candidate = entry; candidate; candidate = candidate.previous) {
+      matching.add(candidate);
+    }
+  }
+  await Promise.allSettled([...matching].map((entry) => entry.prepared.release()));
 }
 
 function sameAttachments(
@@ -109,127 +117,175 @@ export async function prepareMobileTurnAttachments(
     });
   }
 
-  const commandKey =
-    input.commandId === undefined ? null : `${input.environmentId}:${input.commandId}`;
-  const existing = commandKey === null ? undefined : preparedAttachmentsByCommand.get(commandKey);
+  const environmentCommands = preparedAttachmentsByEnvironment.get(input.environmentId);
+  const existing =
+    input.commandId === undefined ? undefined : environmentCommands?.get(input.commandId);
   if (existing) {
     if (sameAttachments(existing.sourceAttachments, input.attachments)) {
-      return existing.prepared;
+      return existing.preparation ?? existing.prepared;
     }
-    await existing.prepared.release();
   }
 
-  const { File: ExpoFile, Paths } = await import("expo-file-system");
   const pendingAttachmentIds = new Set<string>();
+  const controller = new AbortController();
+  let releasePromise: Promise<void> | null = null;
+  let entry: CachedMobileTurnAttachments;
   const release = async (): Promise<void> => {
-    if (commandKey !== null) {
-      preparedAttachmentsByCommand.delete(commandKey);
+    if (releasePromise !== null) {
+      return releasePromise;
+    }
+    entry.released = true;
+    controller.abort();
+    if (input.commandId !== undefined) {
+      const commands = preparedAttachmentsByEnvironment.get(input.environmentId);
+      if (commands?.get(input.commandId) === entry) {
+        if (entry.previous && !entry.previous.released) {
+          commands.set(input.commandId, entry.previous);
+        } else {
+          commands.delete(input.commandId);
+        }
+        if (commands.size === 0) {
+          preparedAttachmentsByEnvironment.delete(input.environmentId);
+        }
+      }
     }
     const attachmentIds = [...pendingAttachmentIds];
     pendingAttachmentIds.clear();
-    await Promise.allSettled(attachmentIds.map((attachmentId) => input.deleteUpload(attachmentId)));
+    releasePromise = Promise.allSettled(
+      attachmentIds.map((attachmentId) => input.deleteUpload(attachmentId)),
+    ).then(() => undefined);
+    return releasePromise;
   };
   const uploadedAttachments: TurnAttachment[] = [];
+  const prepared = { attachments: uploadedAttachments, release };
+  entry = {
+    sourceAttachments: input.attachments,
+    prepared,
+    ...(existing ? { previous: existing } : {}),
+    preparation: null,
+    released: false,
+  };
+  if (input.commandId !== undefined) {
+    const commands = environmentCommands ?? new Map<string, CachedMobileTurnAttachments>();
+    preparedAttachmentsByEnvironment.set(input.environmentId, commands);
+    commands.set(input.commandId, entry);
+  }
 
-  for (const attachment of input.attachments) {
-    if (!("dataUrl" in attachment)) {
-      uploadedAttachments.push(attachment);
-      continue;
-    }
-
-    let temporaryFile: File | null = null;
-    try {
-      if (input.httpBaseUrl === null) {
-        throw new ConnectionTransientError({
-          reason: "endpoint-unavailable",
-          detail: `Could not upload '${attachment.name}': environment is not connected.`,
-        });
-      }
-      const mimeType = PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES.find(
-        (supportedMimeType) => supportedMimeType === attachment.mimeType.toLowerCase(),
-      );
-      if (!mimeType) {
-        throw new ConnectionBlockedError({
-          reason: "unsupported",
-          detail: `Could not upload '${attachment.name}': image type is not supported.`,
-        });
-      }
-      const separatorIndex = attachment.dataUrl.indexOf(",");
-      const base64 = attachment.dataUrl.slice(separatorIndex + 1);
-      const sizeBytes = estimateBase64ByteSize(base64);
-      if (
-        separatorIndex < 0 ||
-        !attachment.dataUrl.slice(0, separatorIndex).endsWith(";base64") ||
-        sizeBytes <= 0 ||
-        sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
-      ) {
-        throw new ConnectionBlockedError({
-          reason: "configuration",
-          detail: `Could not upload '${attachment.name}': image data is invalid.`,
-        });
+  const runPreparation = async (): Promise<PreparedMobileTurnAttachments> => {
+    const { File: ExpoFile, Paths } = await import("expo-file-system");
+    for (const attachment of input.attachments) {
+      if (!("dataUrl" in attachment)) {
+        uploadedAttachments.push(attachment);
+        continue;
       }
 
-      const upload = await input.createUploadUrl({
-        name: attachment.name,
-        mimeType,
-        sizeBytes,
-      });
-      pendingAttachmentIds.add(upload.attachmentId);
-
-      const url = resolveAssetUrl(input.httpBaseUrl, upload.relativeUrl);
-      if (url === null) {
-        throw new ConnectionBlockedError({
-          reason: "configuration",
-          detail: `Could not upload '${attachment.name}': upload URL is invalid.`,
-        });
-      }
-      temporaryFile = new ExpoFile(Paths.cache, `t3-attachment-${upload.attachmentId}`);
-      temporaryFile.write(base64, { encoding: "base64" });
-
-      const result = await temporaryFile.upload(url, {
-        httpMethod: "POST",
-        headers: { "Content-Type": mimeType },
-      });
-      if (result.status < 200 || result.status >= 300) {
-        const detail = `Could not upload '${attachment.name}': upload rejected (${result.status}).`;
-        if (result.status >= 400 && result.status < 500 && ![408, 429].includes(result.status)) {
-          throw new ConnectionBlockedError({
-            reason: result.status === 401 || result.status === 403 ? "permission" : "configuration",
-            detail,
+      let temporaryFile: File | null = null;
+      try {
+        if (input.httpBaseUrl === null) {
+          throw new ConnectionTransientError({
+            reason: "endpoint-unavailable",
+            detail: `Could not upload '${attachment.name}': environment is not connected.`,
           });
         }
-        throw new ConnectionTransientError({ reason: "network", detail });
-      }
+        const mimeType = PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES.find(
+          (supportedMimeType) => supportedMimeType === attachment.mimeType.toLowerCase(),
+        );
+        if (!mimeType) {
+          throw new ConnectionBlockedError({
+            reason: "unsupported",
+            detail: `Could not upload '${attachment.name}': image type is not supported.`,
+          });
+        }
+        const separatorIndex = attachment.dataUrl.indexOf(",");
+        const base64 = attachment.dataUrl.slice(separatorIndex + 1);
+        const sizeBytes = estimateBase64ByteSize(base64);
+        if (
+          separatorIndex < 0 ||
+          !attachment.dataUrl.slice(0, separatorIndex).endsWith(";base64") ||
+          sizeBytes <= 0 ||
+          sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+        ) {
+          throw new ConnectionBlockedError({
+            reason: "configuration",
+            detail: `Could not upload '${attachment.name}': image data is invalid.`,
+          });
+        }
 
-      uploadedAttachments.push({
-        type: "image",
-        id: upload.attachmentId,
-        name: attachment.name,
-        mimeType,
-        sizeBytes,
-      });
-    } catch (cause) {
-      await release();
-      throw cause instanceof ConnectionBlockedError || cause instanceof ConnectionTransientError
-        ? cause
-        : transientUploadError(attachment.name, cause);
-    } finally {
-      if (temporaryFile?.exists) {
-        try {
-          temporaryFile.delete();
-        } catch (cause) {
-          console.warn("Failed to remove temporary attachment upload", cause);
+        const upload = await input.createUploadUrl({
+          name: attachment.name,
+          mimeType,
+          sizeBytes,
+        });
+        if (entry.released) {
+          await Promise.allSettled([input.deleteUpload(upload.attachmentId)]);
+          throw new ConnectionTransientError({
+            reason: "transport",
+            detail: `Image upload for '${attachment.name}' was cancelled.`,
+          });
+        }
+        pendingAttachmentIds.add(upload.attachmentId);
+
+        const url = resolveAssetUrl(input.httpBaseUrl, upload.relativeUrl);
+        if (url === null) {
+          throw new ConnectionBlockedError({
+            reason: "configuration",
+            detail: `Could not upload '${attachment.name}': upload URL is invalid.`,
+          });
+        }
+        temporaryFile = new ExpoFile(Paths.cache, `t3-attachment-${upload.attachmentId}`);
+        temporaryFile.write(base64, { encoding: "base64" });
+
+        const result = await temporaryFile.upload(url, {
+          httpMethod: "POST",
+          headers: { "Content-Type": mimeType },
+          signal: controller.signal,
+        });
+        if (result.status < 200 || result.status >= 300) {
+          const detail = `Could not upload '${attachment.name}': upload rejected (${result.status}).`;
+          if (result.status >= 400 && result.status < 500 && ![408, 429].includes(result.status)) {
+            throw new ConnectionBlockedError({
+              reason:
+                result.status === 401 || result.status === 403 ? "permission" : "configuration",
+              detail,
+            });
+          }
+          throw new ConnectionTransientError({ reason: "network", detail });
+        }
+
+        uploadedAttachments.push({
+          type: "image",
+          id: upload.attachmentId,
+          name: attachment.name,
+          mimeType,
+          sizeBytes,
+        });
+      } catch (cause) {
+        await release();
+        throw cause instanceof ConnectionBlockedError || cause instanceof ConnectionTransientError
+          ? cause
+          : transientUploadError(attachment.name, cause);
+      } finally {
+        if (temporaryFile?.exists) {
+          try {
+            temporaryFile.delete();
+          } catch (cause) {
+            console.warn("Failed to remove temporary attachment upload", cause);
+          }
         }
       }
     }
-  }
 
-  const prepared = { attachments: uploadedAttachments, release };
-  if (commandKey !== null) {
-    preparedAttachmentsByCommand.set(commandKey, {
-      sourceAttachments: input.attachments,
-      prepared,
-    });
-  }
-  return prepared;
+    if (existing) {
+      await existing.prepared.release();
+    }
+    return prepared;
+  };
+  entry.preparation = runPreparation().catch(async (cause: unknown) => {
+    await release();
+    if (cause instanceof ConnectionBlockedError || cause instanceof ConnectionTransientError) {
+      throw cause;
+    }
+    throw transientUploadError(input.attachments[0]?.name ?? "image", cause);
+  });
+  return entry.preparation;
 }

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -240,6 +240,13 @@ export async function prepareMobileTurnAttachments(
           headers: { "Content-Type": mimeType },
           signal: controller.signal,
         });
+        if (entry.released) {
+          await Promise.allSettled([input.deleteUpload(upload.attachmentId)]);
+          throw new ConnectionTransientError({
+            reason: "transport",
+            detail: `Image upload for '${attachment.name}' was cancelled.`,
+          });
+        }
         if (result.status < 200 || result.status >= 300) {
           const detail = `Could not upload '${attachment.name}': upload rejected (${result.status}).`;
           if (result.status >= 400 && result.status < 500 && ![408, 429].includes(result.status)) {

--- a/apps/mobile/src/lib/attachmentUpload.ts
+++ b/apps/mobile/src/lib/attachmentUpload.ts
@@ -1,0 +1,123 @@
+import { ConnectionTransientError } from "@t3tools/client-runtime/connection";
+import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
+import {
+  PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
+  type AttachmentCreateUploadUrlInput,
+  type AttachmentCreateUploadUrlResult,
+  type ChatAttachment,
+  type EnvironmentId,
+  type UploadChatAttachment,
+} from "@t3tools/contracts";
+import type { File } from "expo-file-system";
+
+type TurnAttachment = ChatAttachment | UploadChatAttachment;
+
+interface MobileAttachmentUploadInput {
+  readonly environmentId: EnvironmentId;
+  readonly httpBaseUrl: string | null;
+  readonly supportsUploads: boolean;
+  readonly attachments: ReadonlyArray<TurnAttachment>;
+  readonly createUploadUrl: (
+    input: AttachmentCreateUploadUrlInput,
+  ) => Promise<AttachmentCreateUploadUrlResult>;
+  readonly deleteUpload: (attachmentId: string) => Promise<void>;
+}
+
+interface PreparedMobileTurnAttachments {
+  readonly attachments: ReadonlyArray<TurnAttachment>;
+  readonly release: () => Promise<void>;
+}
+
+function transientUploadError(name: string, cause: unknown): ConnectionTransientError {
+  const reason = cause instanceof Error ? cause.message : "upload failed";
+  return new ConnectionTransientError({
+    reason: "network",
+    detail: `Could not upload '${name}': ${reason.replace(/\.$/, "")}.`,
+  });
+}
+
+/** Uploads mobile images as native binary requests and keeps old servers on the inline format. */
+export async function prepareMobileTurnAttachments(
+  input: MobileAttachmentUploadInput,
+): Promise<PreparedMobileTurnAttachments> {
+  if (!input.supportsUploads || input.attachments.length === 0) {
+    return { attachments: input.attachments, release: async () => undefined };
+  }
+
+  const { File: ExpoFile, Paths } = await import("expo-file-system");
+  const pendingAttachmentIds = new Set<string>();
+  const release = async (): Promise<void> => {
+    const attachmentIds = [...pendingAttachmentIds];
+    pendingAttachmentIds.clear();
+    await Promise.allSettled(attachmentIds.map((attachmentId) => input.deleteUpload(attachmentId)));
+  };
+  const uploadedAttachments: TurnAttachment[] = [];
+
+  for (const attachment of input.attachments) {
+    if (!("dataUrl" in attachment)) {
+      uploadedAttachments.push(attachment);
+      continue;
+    }
+
+    let temporaryFile: File | null = null;
+    try {
+      if (input.httpBaseUrl === null) {
+        throw new Error("environment is not connected");
+      }
+      const mimeType = PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES.find(
+        (supportedMimeType) => supportedMimeType === attachment.mimeType.toLowerCase(),
+      );
+      if (!mimeType) {
+        throw new Error("image type is not supported");
+      }
+
+      const upload = await input.createUploadUrl({
+        name: attachment.name,
+        mimeType,
+        sizeBytes: attachment.sizeBytes,
+      });
+      pendingAttachmentIds.add(upload.attachmentId);
+
+      const url = resolveAssetUrl(input.httpBaseUrl, upload.relativeUrl);
+      if (url === null) {
+        throw new Error("upload URL is invalid");
+      }
+
+      const separatorIndex = attachment.dataUrl.indexOf(",");
+      if (separatorIndex < 0) {
+        throw new Error("image data is invalid");
+      }
+      temporaryFile = new ExpoFile(Paths.cache, `t3-attachment-${upload.attachmentId}`);
+      temporaryFile.write(attachment.dataUrl.slice(separatorIndex + 1), { encoding: "base64" });
+
+      const result = await temporaryFile.upload(url, {
+        httpMethod: "POST",
+        headers: { "Content-Type": mimeType },
+      });
+      if (result.status < 200 || result.status >= 300) {
+        throw new Error(`upload rejected (${result.status})`);
+      }
+
+      uploadedAttachments.push({
+        type: "image",
+        id: upload.attachmentId,
+        name: attachment.name,
+        mimeType,
+        sizeBytes: attachment.sizeBytes,
+      });
+    } catch (cause) {
+      await release();
+      throw transientUploadError(attachment.name, cause);
+    } finally {
+      if (temporaryFile?.exists) {
+        try {
+          temporaryFile.delete();
+        } catch (cause) {
+          console.warn("Failed to remove temporary attachment upload", cause);
+        }
+      }
+    }
+  }
+
+  return { attachments: uploadedAttachments, release };
+}

--- a/apps/mobile/src/state/attachments.ts
+++ b/apps/mobile/src/state/attachments.ts
@@ -1,0 +1,15 @@
+import { createEnvironmentRpcCommand } from "@t3tools/client-runtime/state/runtime";
+import { WS_METHODS } from "@t3tools/contracts";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const attachmentEnvironment = {
+  createUploadUrl: createEnvironmentRpcCommand(connectionAtomRuntime, {
+    label: "environment-command:attachments:create-upload-url",
+    tag: WS_METHODS.attachmentsCreateUploadUrl,
+  }),
+  remove: createEnvironmentRpcCommand(connectionAtomRuntime, {
+    label: "environment-command:attachments:delete",
+    tag: WS_METHODS.attachmentsDelete,
+  }),
+};

--- a/apps/mobile/src/state/thread-outbox.ts
+++ b/apps/mobile/src/state/thread-outbox.ts
@@ -1,5 +1,6 @@
 import type { EnvironmentId } from "@t3tools/contracts";
 
+import { releaseMobileTurnAttachments } from "../lib/attachmentUpload";
 import { appAtomRegistry } from "./atom-registry";
 import { createThreadOutboxManager } from "./thread-outbox-manager";
 import type { QueuedThreadMessage } from "./thread-outbox-model";
@@ -41,10 +42,15 @@ export function updateThreadOutboxMessage(message: QueuedThreadMessage): Promise
   return threadOutboxManager.update(message);
 }
 
-export function removeThreadOutboxMessage(message: QueuedThreadMessage): Promise<void> {
-  return threadOutboxManager.remove(message);
+export async function removeThreadOutboxMessage(message: QueuedThreadMessage): Promise<void> {
+  await threadOutboxManager.remove(message);
+  await releaseMobileTurnAttachments({
+    environmentId: message.environmentId,
+    commandId: message.commandId,
+  });
 }
 
-export function clearThreadOutboxEnvironment(environmentId: EnvironmentId): Promise<void> {
-  return threadOutboxManager.clearEnvironment(environmentId);
+export async function clearThreadOutboxEnvironment(environmentId: EnvironmentId): Promise<void> {
+  await threadOutboxManager.clearEnvironment(environmentId);
+  await releaseMobileTurnAttachments({ environmentId });
 }

--- a/apps/mobile/src/state/thread-outbox.ts
+++ b/apps/mobile/src/state/thread-outbox.ts
@@ -38,8 +38,15 @@ export function confirmThreadOutboxMessageQueued(message: QueuedThreadMessage): 
 }
 
 /** Rewrite a queued message; no-op (false) if it was removed in the meantime. */
-export function updateThreadOutboxMessage(message: QueuedThreadMessage): Promise<boolean> {
-  return threadOutboxManager.update(message);
+export async function updateThreadOutboxMessage(message: QueuedThreadMessage): Promise<boolean> {
+  const updated = await threadOutboxManager.update(message);
+  if (updated && message.attachments.length === 0) {
+    await releaseMobileTurnAttachments({
+      environmentId: message.environmentId,
+      commandId: message.commandId,
+    });
+  }
+  return updated;
 }
 
 export async function removeThreadOutboxMessage(message: QueuedThreadMessage): Promise<void> {

--- a/apps/mobile/src/state/threads.ts
+++ b/apps/mobile/src/state/threads.ts
@@ -7,15 +7,85 @@ import {
   type EnvironmentThreadState,
   createThreadEnvironmentAtoms,
 } from "@t3tools/client-runtime/state/threads";
+import { runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { AsyncResult, Atom, type AtomRegistry } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
+import { prepareMobileTurnAttachments } from "../lib/attachmentUpload";
+import { attachmentEnvironment } from "./attachments";
+import { environmentSession } from "./session";
+import { serverEnvironment } from "./server";
 import { environmentSnapshotAtom } from "./shell";
 
-export const threadEnvironment = createThreadEnvironmentAtoms(connectionAtomRuntime);
+const threadCommands = createThreadEnvironmentAtoms(connectionAtomRuntime);
+
+async function startMobileThreadTurn(
+  registry: AtomRegistry.AtomRegistry,
+  target: Parameters<typeof threadCommands.startTurn.run>[1],
+) {
+  const supportsUploads =
+    registry.get(serverEnvironment.configValueAtom(target.environmentId))?.environment.capabilities
+      .attachmentUploads === true;
+  if (!supportsUploads || target.input.message.attachments.length === 0) {
+    return threadCommands.startTurn.run(registry, target);
+  }
+
+  const connection = Option.getOrNull(
+    registry.get(environmentSession.preparedConnectionValueAtom(target.environmentId)),
+  );
+  let prepared: Awaited<ReturnType<typeof prepareMobileTurnAttachments>>;
+  try {
+    prepared = await prepareMobileTurnAttachments({
+      environmentId: target.environmentId,
+      httpBaseUrl: connection?.httpBaseUrl ?? null,
+      supportsUploads,
+      attachments: target.input.message.attachments,
+      createUploadUrl: async (input) => {
+        const result = await runAtomCommand(
+          registry,
+          attachmentEnvironment.createUploadUrl,
+          { environmentId: target.environmentId, input },
+          { reportFailure: false },
+        );
+        if (result._tag === "Failure") {
+          throw Cause.squash(result.cause);
+        }
+        return result.value;
+      },
+      deleteUpload: async (attachmentId) => {
+        await runAtomCommand(
+          registry,
+          attachmentEnvironment.remove,
+          { environmentId: target.environmentId, input: { attachmentId } },
+          { reportFailure: false, reportDefect: false },
+        );
+      },
+    });
+  } catch (error) {
+    return AsyncResult.failure(Cause.fail(error));
+  }
+
+  try {
+    return await threadCommands.startTurn.run(registry, {
+      ...target,
+      input: {
+        ...target.input,
+        message: { ...target.input.message, attachments: prepared.attachments },
+      },
+    });
+  } finally {
+    void prepared.release();
+  }
+}
+
+export const threadEnvironment = {
+  ...threadCommands,
+  startTurn: { label: threadCommands.startTurn.label, run: startMobileThreadTurn },
+};
 export const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
 export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
   environmentThreads.stateAtom,

--- a/apps/mobile/src/state/threads.ts
+++ b/apps/mobile/src/state/threads.ts
@@ -30,7 +30,7 @@ async function startMobileThreadTurn(
   const supportsUploads =
     registry.get(serverEnvironment.configValueAtom(target.environmentId))?.environment.capabilities
       .attachmentUploads === true;
-  if (!supportsUploads || target.input.message.attachments.length === 0) {
+  if (target.input.message.attachments.length === 0) {
     return threadCommands.startTurn.run(registry, target);
   }
 

--- a/apps/mobile/src/state/threads.ts
+++ b/apps/mobile/src/state/threads.ts
@@ -20,6 +20,7 @@ import { attachmentEnvironment } from "./attachments";
 import { environmentSession } from "./session";
 import { serverEnvironment } from "./server";
 import { environmentSnapshotAtom } from "./shell";
+import { shouldRetryThreadOutboxDelivery } from "./thread-outbox-model";
 
 const threadCommands = createThreadEnvironmentAtoms(connectionAtomRuntime);
 
@@ -27,13 +28,13 @@ async function startMobileThreadTurn(
   registry: AtomRegistry.AtomRegistry,
   target: Parameters<typeof threadCommands.startTurn.run>[1],
 ) {
-  const supportsUploads =
-    registry.get(serverEnvironment.configValueAtom(target.environmentId))?.environment.capabilities
-      .attachmentUploads === true;
   if (target.input.message.attachments.length === 0) {
     return threadCommands.startTurn.run(registry, target);
   }
 
+  const serverConfig = registry.get(serverEnvironment.configValueAtom(target.environmentId));
+  const supportsUploads =
+    serverConfig === null ? null : serverConfig.environment.capabilities.attachmentUploads === true;
   const connection = Option.getOrNull(
     registry.get(environmentSession.preparedConnectionValueAtom(target.environmentId)),
   );
@@ -41,6 +42,7 @@ async function startMobileThreadTurn(
   try {
     prepared = await prepareMobileTurnAttachments({
       environmentId: target.environmentId,
+      ...(target.input.commandId === undefined ? {} : { commandId: target.input.commandId }),
       httpBaseUrl: connection?.httpBaseUrl ?? null,
       supportsUploads,
       attachments: target.input.message.attachments,
@@ -69,17 +71,21 @@ async function startMobileThreadTurn(
     return AsyncResult.failure(Cause.fail(error));
   }
 
-  try {
-    return await threadCommands.startTurn.run(registry, {
-      ...target,
-      input: {
-        ...target.input,
-        message: { ...target.input.message, attachments: prepared.attachments },
-      },
-    });
-  } finally {
+  const result = await threadCommands.startTurn.run(registry, {
+    ...target,
+    input: {
+      ...target.input,
+      message: { ...target.input.message, attachments: prepared.attachments },
+    },
+  });
+  const retryable =
+    result._tag === "Failure" &&
+    (Cause.hasInterruptsOnly(result.cause) ||
+      shouldRetryThreadOutboxDelivery(Cause.squash(result.cause)));
+  if (target.input.commandId === undefined || !retryable) {
     void prepared.release();
   }
+  return result;
 }
 
 export const threadEnvironment = {


### PR DESCRIPTION
Two 10 MiB images make mobile send a 26.67 MiB WebSocket message, above Bun's 16 MiB limit. Eight allowed images reach 106.67 MiB and can add more than 200 MiB of JavaScript heap.

Mobile now uploads every image through the existing signed HTTP endpoint before starting a turn and sends only attachment IDs. Servers without HTTP upload support show a clear upgrade error instead of falling back to inline base64. Paired remote origins, previews, pending upload cleanup, and queued retries remain supported.

Verified with 85 focused mobile and server tests, the signed upload integration test, mobile type checking, and targeted lint and format checks.

Built by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core message-send path and adds concurrent upload/cache cleanup; mistakes could leak pending attachments or break queued retries, but behavior is heavily tested and scoped to mobile attachment handling.
> 
> **Overview**
> **Mobile no longer embeds image `dataUrl` payloads in WebSocket turn messages.** Turns with images are prepared by uploading bytes to the paired environment’s signed HTTP endpoint first, then `startTurn` sends only attachment IDs—avoiding oversized messages that could drop connections.
> 
> New `prepareMobileTurnAttachments` / `releaseMobileTurnAttachments` handle minting upload URLs, writing temp cache files via `expo-file-system`, native POST upload, validation (MIME, size from base64), and user-safe `ConnectionBlockedError` / `ConnectionTransientError` messaging. Upload capability must be known (`supportsUploads`); legacy environments get a clear upgrade error instead of inline base64.
> 
> **Queued-turn lifecycle** is wired through the thread outbox and `startTurn`: per-`commandId` caching reuses uploads on retry, replaces uploads on edit (keeping the prior upload until replacement completes), aborts/cleans up when a turn or environment is removed, and retains uploads for retryable outbox failures until delivery succeeds or the message is cleared. Mobile attachment RPC commands (`createUploadUrl`, `delete`) back the upload flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5528fe8694d05fb8a50c93de3c8a67d9db5db5d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile image attachments by pre-uploading images and sending id-based references
> - Adds `prepareMobileTurnAttachments` in [attachmentUpload.ts](https://github.com/pingdotgg/t3code/pull/8180/files#diff-4d05cc0f79a9e8586bb8d94108fa5f73b9129359631ec36caca45de4ae8db0ee) to upload image `dataUrl` attachments to remote storage before sending a turn, then sends only id-based references instead of inline payloads
> - Introduces a per-environment cache (`preparedAttachmentsByEnvironment`) keyed by `commandId` so uploads are reused across retries and replaced cleanly on edits
> - Adds `releaseMobileTurnAttachments` to abort pending work, remove cache entries, and delete remote uploads; calls it from outbox update, remove, and clear paths in [thread-outbox.ts](https://github.com/pingdotgg/t3code/pull/8180/files#diff-4b3fa0e476a5c9eca2199e06342d4bc348e85d100e3440a215dcea2bbf6d2b9e)
> - Wraps `startTurn` in [threads.ts](https://github.com/pingdotgg/t3code/pull/8180/files#diff-4a8348305da09ead7d94fa6ff43e50e2b74b524c01e3db3b3c4d9af8f4d18801) via `startMobileThreadTurn` to prepare attachments, send references, and retain uploads only for retryable turns with a `commandId`
> - Adds environment RPCs for `attachmentsCreateUploadUrl` and `attachmentsDelete` in [attachments.ts](https://github.com/pingdotgg/t3code/pull/8180/files#diff-e1d6a08fff3611c831eb316bf84f18cabf27b52913508eba6b05d2455bbe04c8)
> - Maps HTTP 4xx (except 408/429) to `ConnectionBlockedError` and other non-2xx to `ConnectionTransientError`; caller-facing error messages omit low-level details
> - Risk: outbox functions `updateThreadOutboxMessage`, `removeThreadOutboxMessage`, and `clearThreadOutboxEnvironment` are now async; any callers that do not await them may see deferred upload cleanup
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5528fe8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->