### PR TITLE
feat(desktop): build macOS previews from a PR label

### DIFF
--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -1,0 +1,178 @@
+name: Desktop macOS Preview
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: desktop-macos-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build macOS Apple Silicon preview
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'preview:mac') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview:mac')
+    runs-on: blacksmith-12vcpu-macos-26
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: false
+
+      - name: Install desktop dependencies
+        run: vp install --filter=@t3tools/desktop... --filter=t3... --filter=@t3tools/scripts...
+
+      - name: Cache resource monitor
+        id: resource_monitor_cache
+        uses: actions/cache@v6
+        with:
+          path: native/resource-monitor/target/aarch64-apple-darwin/release/t3-resource-monitor
+          key: resource-monitor-aarch64-apple-darwin-${{ hashFiles('native/resource-monitor/Cargo.lock', 'native/resource-monitor/Cargo.toml', 'native/resource-monitor/src/**') }}
+
+      - name: Setup Rust
+        if: steps.resource_monitor_cache.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - id: version
+        name: Set preview version and public configuration
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          base_version="$(node -p "require('./apps/desktop/package.json').version")"
+          preview_version="${base_version}-pr.${PR_NUMBER}.${GITHUB_RUN_NUMBER}"
+          node scripts/update-release-package-versions.ts "$preview_version"
+          cp .env.example .env
+
+          echo "version=$preview_version" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed macOS DMG
+        shell: bash
+        env:
+          T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR: ${{ steps.resource_monitor_cache.outputs.cache-hit == 'true' }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          MACOS_PROVISIONING_PROFILE: ${{ secrets.MACOS_PROVISIONING_PROFILE }}
+          PREVIEW_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          required=(
+            CSC_LINK
+            CSC_KEY_PASSWORD
+            APPLE_API_KEY
+            APPLE_API_KEY_ID
+            APPLE_API_ISSUER
+            APPLE_TEAM_ID
+            MACOS_PROVISIONING_PROFILE
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required macOS signing configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY" > "$key_path"
+          export APPLE_API_KEY="$key_path"
+
+          profile_path="$RUNNER_TEMP/t3code.provisionprofile"
+          printf '%s' "$MACOS_PROVISIONING_PROFILE" | base64 -D > "$profile_path"
+          security cms -D -i "$profile_path" >/dev/null
+          export T3CODE_APPLE_TEAM_ID="$APPLE_TEAM_ID"
+          export T3CODE_MACOS_PROVISIONING_PROFILE="$profile_path"
+
+          vp run dist:desktop:artifact \
+            --platform mac \
+            --target dmg \
+            --arch arm64 \
+            --build-version "$PREVIEW_VERSION" \
+            --signed \
+            --verbose
+
+      - id: upload
+        name: Upload macOS DMG
+        uses: actions/upload-artifact@v7
+        with:
+          path: release/*.dmg
+          if-no-files-found: error
+          archive: false
+          overwrite: true
+          retention-days: 7
+
+      - name: Comment download link
+        uses: actions/github-script@v8
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PREVIEW_VERSION: ${{ steps.version.outputs.version }}
+        with:
+          script: |
+            const marker = "<!-- desktop-macos-preview -->";
+            const body = [
+              marker,
+              "### macOS preview",
+              "",
+              `[Download Apple Silicon DMG](${process.env.ARTIFACT_URL})`,
+              "",
+              `Version: ${process.env.PREVIEW_VERSION}`,
+              `Commit: ${process.env.HEAD_SHA.slice(0, 7)}`,
+              "",
+              "The download requires GitHub access and expires after 7 days.",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -13,53 +13,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  authorize:
-    name: Authorize macOS signing
+  build:
+    name: Build macOS Apple Silicon preview
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.labels.*.name, 'preview:mac') &&
       (github.event.action != 'labeled' || github.event.label.name == 'preview:mac')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    outputs:
-      trusted: ${{ steps.authorize.outputs.trusted }}
-    steps:
-      - id: authorize
-        name: Check repository access
-        uses: actions/github-script@v8
-        env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-        with:
-          script: |
-            const trustedRoles = new Set(["admin", "maintain"]);
-            const accounts = new Set([
-              process.env.PR_AUTHOR,
-              context.actor,
-              process.env.TRIGGERING_ACTOR,
-            ]);
-
-            for (const username of accounts) {
-              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                username,
-              });
-              const role = data.role_name ?? data.permission;
-              if (!trustedRoles.has(role)) {
-                core.warning(`${username} has ${role} access and cannot run signed previews.`);
-                core.setOutput("trusted", "false");
-                return;
-              }
-            }
-
-            core.setOutput("trusted", "true");
-
-  build:
-    name: Build macOS Apple Silicon preview
-    needs: authorize
-    if: needs.authorize.outputs.trusted == 'true'
     runs-on: blacksmith-12vcpu-macos-26
     timeout-minutes: 30
     steps:
@@ -110,59 +69,29 @@ jobs:
 
           echo "version=$preview_version" >> "$GITHUB_OUTPUT"
 
-      - name: Build signed macOS DMG
+      - id: build
+        name: Build unsigned macOS DMG
         shell: bash
         env:
           T3CODE_DESKTOP_REUSE_RESOURCE_MONITOR: ${{ steps.resource_monitor_cache.outputs.cache-hit == 'true' }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-          MACOS_PROVISIONING_PROFILE: ${{ secrets.MACOS_PROVISIONING_PROFILE }}
           PREVIEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
 
-          required=(
-            CSC_LINK
-            CSC_KEY_PASSWORD
-            APPLE_API_KEY
-            APPLE_API_KEY_ID
-            APPLE_API_ISSUER
-            APPLE_TEAM_ID
-            MACOS_PROVISIONING_PROFILE
-          )
-          missing=()
-          for name in "${required[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              missing+=("$name")
-            fi
-          done
-          if (( ${#missing[@]} > 0 )); then
-            printf 'Missing required macOS signing configuration: %s\n' "${missing[*]}" >&2
-            exit 1
-          fi
-
-          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          printf '%s' "$APPLE_API_KEY" > "$key_path"
-          export APPLE_API_KEY="$key_path"
-
-          profile_path="$RUNNER_TEMP/t3code.provisionprofile"
-          printf '%s' "$MACOS_PROVISIONING_PROFILE" | base64 -D > "$profile_path"
-          security cms -D -i "$profile_path" >/dev/null
-          export T3CODE_APPLE_TEAM_ID="$APPLE_TEAM_ID"
-          export T3CODE_MACOS_PROVISIONING_PROFILE="$profile_path"
-
-          env -u GITHUB_REPOSITORY -u T3CODE_DESKTOP_UPDATE_REPOSITORY \
-            vp run dist:desktop:artifact \
+          vp run dist:desktop:artifact \
             --platform mac \
             --target dmg \
             --arch arm64 \
             --build-version "$PREVIEW_VERSION" \
-            --signed \
             --verbose
+
+          shopt -s nullglob
+          dmg_files=(release/*.dmg)
+          if (( ${#dmg_files[@]} != 1 )); then
+            printf 'Expected one DMG, found %s.\n' "${#dmg_files[@]}" >&2
+            exit 1
+          fi
+          printf 'dmg_name=%s\n' "$(basename "${dmg_files[0]}")" >> "$GITHUB_OUTPUT"
 
       - id: upload
         name: Upload macOS DMG
@@ -178,6 +107,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          DMG_NAME: ${{ steps.build.outputs.dmg_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PREVIEW_VERSION: ${{ steps.version.outputs.version }}
         with:
@@ -201,6 +131,11 @@ jobs:
               "",
               `Version: ${process.env.PREVIEW_VERSION}`,
               `Commit: ${process.env.HEAD_SHA.slice(0, 7)}`,
+              "",
+              "Unsigned build. Clear quarantine before opening:",
+              "```sh",
+              `xattr -d com.apple.quarantine ~/Downloads/${process.env.DMG_NAME}`,
+              "```",
               "",
               "The download requires GitHub access and expires after 7 days.",
             ].join("\n");

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -182,6 +182,16 @@ jobs:
           PREVIEW_VERSION: ${{ steps.version.outputs.version }}
         with:
           script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            if (pullRequest.head.sha !== process.env.HEAD_SHA) {
+              core.info("Skipping the outdated macOS preview comment.");
+              return;
+            }
+
             const marker = "<!-- desktop-macos-preview -->";
             const body = [
               marker,

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -13,12 +13,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build macOS Apple Silicon preview
+  authorize:
+    name: Authorize macOS signing
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.labels.*.name, 'preview:mac') &&
       (github.event.action != 'labeled' || github.event.label.name == 'preview:mac')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      trusted: ${{ steps.authorize.outputs.trusted }}
+    steps:
+      - id: authorize
+        name: Check repository access
+        uses: actions/github-script@v8
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        with:
+          script: |
+            const trustedRoles = new Set(["admin", "maintain"]);
+            const accounts = new Set([
+              process.env.PR_AUTHOR,
+              context.actor,
+              process.env.TRIGGERING_ACTOR,
+            ]);
+
+            for (const username of accounts) {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              const role = data.role_name ?? data.permission;
+              if (!trustedRoles.has(role)) {
+                core.warning(`${username} has ${role} access and cannot run signed previews.`);
+                core.setOutput("trusted", "false");
+                return;
+              }
+            }
+
+            core.setOutput("trusted", "true");
+
+  build:
+    name: Build macOS Apple Silicon preview
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
     runs-on: blacksmith-12vcpu-macos-26
     timeout-minutes: 30
     steps:
@@ -114,7 +155,8 @@ jobs:
           export T3CODE_APPLE_TEAM_ID="$APPLE_TEAM_ID"
           export T3CODE_MACOS_PROVISIONING_PROFILE="$profile_path"
 
-          vp run dist:desktop:artifact \
+          env -u GITHUB_REPOSITORY -u T3CODE_DESKTOP_UPDATE_REPOSITORY \
+            vp run dist:desktop:artifact \
             --platform mac \
             --target dmg \
             --arch arm64 \

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -223,6 +223,45 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     }),
   );
 
+  it.effect("omits update feeds for pull request preview builds", () =>
+    Effect.gen(function* () {
+      const preview = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "0.0.33-pr.8182.1",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+      const release = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "0.0.33",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+
+      assert.notProperty(preview, "publish");
+      assert.deepStrictEqual(release.publish, [
+        {
+          provider: "github",
+          owner: "pingdotgg",
+          repo: "t3code",
+          releaseType: "release",
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromEnv({ env: { GITHUB_REPOSITORY: "pingdotgg/t3code" } }),
+        ),
+      ),
+    ),
+  );
+
   it("omits bundled workspace packages from staged desktop dependencies", () => {
     assert.deepStrictEqual(
       resolveDesktopRuntimeDependencies(

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2017,6 +2017,10 @@ export function resolveDesktopUpdateChannel(version: string): "latest" | "nightl
   return /-nightly\.\d{8}\.\d+$/.test(version) ? "nightly" : "latest";
 }
 
+function isDesktopPreviewVersion(version: string): boolean {
+  return /-pr\./.test(version);
+}
+
 export function resolveDesktopWebAssetBrand(version: string): WebAssetBrand {
   return resolveWebAssetBrandForChannel(resolveDesktopUpdateChannel(version));
 }
@@ -2093,16 +2097,18 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     ],
   };
   const updateChannel = resolveDesktopUpdateChannel(version);
-  const publishConfig = yield* resolveGitHubPublishConfig(updateChannel);
-  if (publishConfig) {
-    buildConfig.publish = [publishConfig];
-  } else if (mockUpdates) {
-    buildConfig.publish = [
-      {
-        provider: "generic",
-        url: resolveMockUpdateServerUrl(mockUpdateServerPort),
-      },
-    ];
+  if (!isDesktopPreviewVersion(version)) {
+    const publishConfig = yield* resolveGitHubPublishConfig(updateChannel);
+    if (publishConfig) {
+      buildConfig.publish = [publishConfig];
+    } else if (mockUpdates) {
+      buildConfig.publish = [
+        {
+          provider: "generic",
+          url: resolveMockUpdateServerUrl(mockUpdateServerPort),
+        },
+      ];
+    }
   }
 
   if (platform === "mac") {


### PR DESCRIPTION
Testing a desktop pull request on a real Mac currently requires building the app by hand.

Add the `preview:mac` label to a same-repository pull request to build an unsigned Apple Silicon DMG and post its download link with quarantine instructions. Preview builds do not receive production signing credentials or production update feeds.

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and desktop build metadata (no publish feeds for preview versions). Unsigned DMGs are only produced for labeled same-repo PRs; reviewers should treat them as untrusted binaries like any CI artifact.
> 
> **Overview**
> Adds a **GitHub Actions workflow** that builds an **unsigned Apple Silicon macOS DMG** when a same-repo pull request has the **`preview:mac`** label (also on sync/reopen). It stamps a preview version (`<app version>-pr.<PR>.<run>`), runs `dist:desktop:artifact`, uploads the DMG for **7 days**, and **creates or updates** a PR comment with the artifact link and quarantine instructions.
> 
> Desktop packaging now treats versions containing **`pr.`** as **PR previews** and **skips electron-builder `publish` / GitHub update feeds** so preview builds cannot point auto-updaters at release channels. A test locks in that behavior versus normal release builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdabac597faa95aec9b088dfc6210646926b7a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `preview:mac` PR label workflow to build unsigned Apple Silicon macOS DMG previews
> - Adds a new GitHub Actions workflow that triggers on PRs labeled `preview:mac`, building an unsigned `arm64` macOS DMG with a `-pr.<PR_NUMBER>.<GITHUB_RUN_NUMBER>` version suffix and posting a time-limited download link as a PR comment
> - Introduces `isDesktopPreviewVersion` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/8182/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), which detects versions matching `/-pr\./` and omits the `publish` config for those builds so preview builds do not configure update feeds
> - Adds a test in [build-desktop-artifact.test.ts](https://github.com/pingdotgg/t3code/pull/8182/files#diff-a199d37af35c35dd3b48cf71436cb06b23acccd6857a9fe74db6d48cb73c7663) verifying preview configs omit `publish` while release configs include GitHub publish settings
> - Risk: `createBuildConfig` now returns no `publish` field for any version containing `-pr.`; callers relying on publish config for such versions will need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdabac5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
