### PR TITLE
fix(web): stop worktree drafts inheriting checkout branch

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -27,6 +27,7 @@ import {
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
   resolveBackgroundDraftWorkspaceOptions,
+  resolveBranchAfterEnvModeChange,
   resolveDraftPromotionNavigationTarget,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
@@ -75,6 +76,38 @@ describe("draft hero submission transition", () => {
         backgroundSubmissionPending: true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("environment mode branch selection", () => {
+  it("drops the checkout branch when entering new-worktree mode", () => {
+    expect(
+      resolveBranchAfterEnvModeChange({
+        currentMode: "local",
+        nextMode: "worktree",
+        currentBranch: "feature/current-checkout",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps an explicit base while already in new-worktree mode", () => {
+    expect(
+      resolveBranchAfterEnvModeChange({
+        currentMode: "worktree",
+        nextMode: "worktree",
+        currentBranch: "origin/main",
+      }),
+    ).toBe("origin/main");
+  });
+
+  it("keeps the selected branch when returning to the current checkout", () => {
+    expect(
+      resolveBranchAfterEnvModeChange({
+        currentMode: "worktree",
+        nextMode: "local",
+        currentBranch: "origin/main",
+      }),
+    ).toBe("origin/main");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -98,6 +98,16 @@ export function resolveDraftPromotionNavigationTarget(input: {
   return input.serverThreadStarted ? input.serverThreadRef : null;
 }
 
+export function resolveBranchAfterEnvModeChange(input: {
+  currentMode: DraftThreadEnvMode;
+  nextMode: DraftThreadEnvMode;
+  currentBranch: string | null;
+}): string | null {
+  return input.currentMode !== "worktree" && input.nextMode === "worktree"
+    ? null
+    : input.currentBranch;
+}
+
 export function scheduleEnvironmentReconnectWarning(showWarning: () => void): () => void {
   const timeoutId = globalThis.setTimeout(showWarning, ENVIRONMENT_RECONNECT_WARNING_GRACE_MS);
   return () => globalThis.clearTimeout(timeoutId);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -355,6 +355,7 @@ import {
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
   resolveBackgroundDraftWorkspaceOptions,
+  resolveBranchAfterEnvModeChange,
   resolveDraftHeroState,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
@@ -6588,14 +6589,23 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const onEnvModeChange = useCallback(
     (mode: DraftThreadEnvMode) => {
+      const nextBranch = resolveBranchAfterEnvModeChange({
+        currentMode: envMode,
+        nextMode: mode,
+        currentBranch: activeThreadBranch,
+      });
       if (canOverrideServerThreadEnvMode) {
         setPendingServerThreadEnvMode(mode);
+        if (nextBranch !== activeThreadBranch) {
+          setPendingServerThreadBranch(nextBranch);
+        }
         scheduleComposerFocus();
         return;
       }
       if (isLocalDraftThread) {
         setDraftThreadContext(composerDraftTarget, {
           envMode: mode,
+          ...(nextBranch !== activeThreadBranch ? { branch: nextBranch } : {}),
           startFromOrigin: resolveNewDraftStartFromOrigin({
             envMode: mode,
             newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
@@ -6606,9 +6616,11 @@ function ChatViewContent(props: ChatViewProps) {
       scheduleComposerFocus();
     },
     [
+      activeThreadBranch,
       canOverrideServerThreadEnvMode,
       composerDraftTarget,
       draftThread?.worktreePath,
+      envMode,
       isLocalDraftThread,
       primaryServerSettings.newWorktreesStartFromOrigin,
       setPendingServerThreadEnvMode,


### PR DESCRIPTION
Switching an empty composer from Current checkout to New worktree retained the checkout branch. With start-from-origin enabled, a feature checkout was presented and submitted as a nonexistent origin feature ref, causing bootstrap cleanup and exposing a duplicate-thread error on retry in older clients.

Clear the inherited branch only when entering New worktree mode. The existing branch selector then resolves the repository default ref, while explicit worktree base selections remain intact.

Verification:
- `vp test run apps/web/src/components/ChatView.logic.test.ts`
- `vp test run apps/web/src/composerDraftStore.test.ts -t "rotates a failed bootstrap thread id without losing its draft"`
- `vp test run packages/client-runtime/src/errors/orchestration.test.ts`
- `vp test run apps/server/src/server.test.ts -t "cleans up created bootstrap threads when worktree creation defects"`
- `vp lint apps/web/src/components/ChatView.tsx apps/web/src/components/ChatView.logic.ts apps/web/src/components/ChatView.logic.test.ts`
- `vp run --filter @t3tools/web typecheck`

Implemented with GPT-5.6 SOL via the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix worktree drafts inheriting checkout branch in `ChatViewContent`
> - Adds `resolveBranchAfterEnvModeChange` utility that returns `null` when switching into `'worktree'` mode from a non-worktree mode, preserving the current branch otherwise.
> - Updates `onEnvModeChange` in `ChatViewContent` to use the utility for both pending server threads and local draft threads, conditionally setting the branch only when it differs from the active thread branch.
> - Extends the `useCallback` dependency list to include `activeThreadBranch` and `envMode`.
> - Risk: changing env mode to `'worktree'` now clears the selected branch (`setPendingServerThreadBranch` / draft context `branch`); reviewers should check `onEnvModeChange` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8184/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and tests in [ChatView.logic.test.ts](https://github.com/pingdotgg/t3code/pull/8184/files#diff-3a44a5ed18de7fbfcac8db792c8d6a88d889b6c29bc2fe3bb44d4e6041c7ef91).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eceec70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->