### PR TITLE
fix(web): linked pull requests stay in the thread panel

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -1,6 +1,10 @@
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  useOpenChangeRequestLink: vi.fn(() => vi.fn()),
+}));
 
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
 vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -25,7 +29,7 @@ vi.mock("~/lib/openPullRequestLink", () => ({
   findProjectForChangeRequest: () => undefined,
   matchesLinkedPullRequestUrl: () => false,
   parseChangeRequestUrl: () => null,
-  useOpenChangeRequestLink: () => vi.fn(),
+  useOpenChangeRequestLink: mocks.useOpenChangeRequestLink,
 }));
 
 import ChatMarkdown, {
@@ -101,6 +105,29 @@ describe("ChatMarkdown file option chips", () => {
     expect(html).toContain("<button");
     expect(html).toContain('aria-haspopup="menu"');
     expect(html).toContain("select-text");
+  });
+});
+
+describe("ChatMarkdown pull request links", () => {
+  it("uses a navigation-only thread without enabling thread file actions", () => {
+    const pullRequestLinkThreadRef = {
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    mocks.useOpenChangeRequestLink.mockClear();
+
+    renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/foreign-workspace"
+        environmentId={pullRequestLinkThreadRef.environmentId}
+        pullRequestLinkThreadRef={pullRequestLinkThreadRef}
+        text="[Related pull request](https://github.com/pingdotgg/t3code/pull/6446)"
+      />,
+    );
+
+    expect(mocks.useOpenChangeRequestLink).toHaveBeenCalledExactlyOnceWith(
+      pullRequestLinkThreadRef,
+    );
   });
 });
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -139,6 +139,8 @@ interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
   threadRef?: ScopedThreadRef | undefined;
+  /** Thread that owns pull request link navigation when the markdown itself is not thread-scoped. */
+  pullRequestLinkThreadRef?: ScopedThreadRef | undefined;
   /** Environment that owns non-thread markdown, such as a pull request panel. */
   environmentId?: EnvironmentId | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
@@ -1629,6 +1631,7 @@ function ChatMarkdown({
   text,
   cwd,
   threadRef,
+  pullRequestLinkThreadRef,
   environmentId: explicitEnvironmentId,
   onTaskListChange,
   isStreaming = false,
@@ -1742,7 +1745,7 @@ function ChatMarkdown({
     event.clipboardData.setData("text/plain", payload.text);
     event.clipboardData.setData("text/html", payload.html);
   }, []);
-  const openChangeRequestLink = useOpenChangeRequestLink(threadRef);
+  const openChangeRequestLink = useOpenChangeRequestLink(pullRequestLinkThreadRef ?? threadRef);
   const resolveThreadPullRequest = useCallback(
     (href: string): ThreadLinkedPullRequest | null => {
       if (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6770,7 +6770,8 @@ function ChatViewContent(props: ChatViewProps) {
       // reader's feet. A link the agent wrote can open any other one here, and that one has to be
       // checkable out like it is anywhere else.
       <PullRequestThreadRefProvider
-        threadRef={activePullRequestBelongsToThread ? activeThreadRef : undefined}
+        threadRef={activeThreadRef}
+        scopeWorkspaceToThread={activePullRequestBelongsToThread}
       >
         <PullRequestDetailPanel
           key={`${activeRightPanelSurface.repository}#${activeRightPanelSurface.number}`}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -163,6 +163,7 @@ import {
 } from "../previewMiniPlayerStore";
 import { isThreadOwnPullRequest } from "./pullRequest/pullRequestDetail.logic";
 import { PullRequestDetailPanel } from "./pullRequest/PullRequestDetailPanel";
+import { PullRequestThreadRefProvider } from "./pullRequest/PullRequestMarkdown";
 import { PullRequestDetailGhost } from "./pullRequest/PullRequestGhosts";
 import { PullRequestsUnavailableState } from "./pullRequest/PullRequestsUnavailableState";
 import { RightPanelTabs, type PullRequestTabStatus } from "./RightPanelTabs";
@@ -6754,33 +6755,35 @@ function ChatViewContent(props: ChatViewProps) {
       // is only right for the thread's own pull request, whose branch is already under the
       // reader's feet. A link the agent wrote can open any other one here, and that one has to be
       // checkable out like it is anywhere else.
-      <PullRequestDetailPanel
-        key={`${activeRightPanelSurface.repository}#${activeRightPanelSurface.number}`}
-        environmentId={activeThread.environmentId}
-        reference={{
-          projectId: activeRightPanelSurface.projectId as ProjectId,
-          repository: activeRightPanelSurface.repository,
-          number: activeRightPanelSurface.number,
-        }}
-        context={
-          isThreadOwnPullRequest(
-            {
-              projectId: linkedThreadPullRequest?.projectId ?? activeProject?.id ?? null,
-              repository: threadRepository,
-              number: activeThreadPr?.number ?? null,
-            },
-            {
-              projectId: activeRightPanelSurface.projectId,
-              repository: activeRightPanelSurface.repository,
-              number: activeRightPanelSurface.number,
-            },
-          )
-            ? "thread"
-            : "page"
-        }
-        composerDraftTarget={composerDraftTarget}
-        onStateChange={handlePullRequestTabStatusChange}
-      />
+      <PullRequestThreadRefProvider threadRef={activeThreadRef}>
+        <PullRequestDetailPanel
+          key={`${activeRightPanelSurface.repository}#${activeRightPanelSurface.number}`}
+          environmentId={activeThread.environmentId}
+          reference={{
+            projectId: activeRightPanelSurface.projectId as ProjectId,
+            repository: activeRightPanelSurface.repository,
+            number: activeRightPanelSurface.number,
+          }}
+          context={
+            isThreadOwnPullRequest(
+              {
+                projectId: linkedThreadPullRequest?.projectId ?? activeProject?.id ?? null,
+                repository: threadRepository,
+                number: activeThreadPr?.number ?? null,
+              },
+              {
+                projectId: activeRightPanelSurface.projectId,
+                repository: activeRightPanelSurface.repository,
+                number: activeRightPanelSurface.number,
+              },
+            )
+              ? "thread"
+              : "page"
+          }
+          composerDraftTarget={composerDraftTarget}
+          onStateChange={handlePullRequestTabStatusChange}
+        />
+      </PullRequestThreadRefProvider>
     ) : activeRightPanelSurface?.kind === "agents" ? (
       <AgentsPanel
         model={agentPanelModel}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6701,6 +6701,20 @@ function ChatViewContent(props: ChatViewProps) {
       {panelToggleControls}
     </div>
   );
+  const activePullRequestBelongsToThread =
+    activeRightPanelSurface?.kind === "pull-request" &&
+    isThreadOwnPullRequest(
+      {
+        projectId: linkedThreadPullRequest?.projectId ?? activeProject?.id ?? null,
+        repository: threadRepository,
+        number: activeThreadPr?.number ?? null,
+      },
+      {
+        projectId: activeRightPanelSurface.projectId,
+        repository: activeRightPanelSurface.repository,
+        number: activeRightPanelSurface.number,
+      },
+    );
   const rightPanelContent = activeThreadRef ? (
     activeRightPanelSurface?.kind === "preview" ? (
       <Suspense fallback={null}>
@@ -6755,7 +6769,9 @@ function ChatViewContent(props: ChatViewProps) {
       // is only right for the thread's own pull request, whose branch is already under the
       // reader's feet. A link the agent wrote can open any other one here, and that one has to be
       // checkable out like it is anywhere else.
-      <PullRequestThreadRefProvider threadRef={activeThreadRef}>
+      <PullRequestThreadRefProvider
+        threadRef={activePullRequestBelongsToThread ? activeThreadRef : undefined}
+      >
         <PullRequestDetailPanel
           key={`${activeRightPanelSurface.repository}#${activeRightPanelSurface.number}`}
           environmentId={activeThread.environmentId}
@@ -6764,22 +6780,7 @@ function ChatViewContent(props: ChatViewProps) {
             repository: activeRightPanelSurface.repository,
             number: activeRightPanelSurface.number,
           }}
-          context={
-            isThreadOwnPullRequest(
-              {
-                projectId: linkedThreadPullRequest?.projectId ?? activeProject?.id ?? null,
-                repository: threadRepository,
-                number: activeThreadPr?.number ?? null,
-              },
-              {
-                projectId: activeRightPanelSurface.projectId,
-                repository: activeRightPanelSurface.repository,
-                number: activeRightPanelSurface.number,
-              },
-            )
-              ? "thread"
-              : "page"
-          }
+          context={activePullRequestBelongsToThread ? "thread" : "page"}
           composerDraftTarget={composerDraftTarget}
           onStateChange={handlePullRequestTabStatusChange}
         />

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.test.tsx
@@ -1,0 +1,58 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  chatMarkdown: vi.fn(),
+}));
+
+vi.mock("../ChatMarkdown", () => ({
+  default: (props: unknown) => {
+    mocks.chatMarkdown(props);
+    return <div />;
+  },
+}));
+
+import { PullRequestMarkdown, PullRequestThreadRefProvider } from "./PullRequestMarkdown";
+
+const ENVIRONMENT_ID = EnvironmentId.make("environment-1");
+const THREAD_REF = {
+  environmentId: ENVIRONMENT_ID,
+  threadId: ThreadId.make("thread-1"),
+};
+
+describe("pull request markdown", () => {
+  beforeEach(() => {
+    mocks.chatMarkdown.mockClear();
+  });
+
+  it("passes the owning thread to links rendered inside a thread panel", () => {
+    renderToStaticMarkup(
+      <PullRequestThreadRefProvider threadRef={THREAD_REF}>
+        <PullRequestMarkdown
+          text="[Related pull request](https://github.com/pingdotgg/t3code/pull/6446)"
+          cwd="/workspace"
+          environmentId={ENVIRONMENT_ID}
+        />
+      </PullRequestThreadRefProvider>,
+    );
+
+    expect(mocks.chatMarkdown).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ environmentId: ENVIRONMENT_ID, threadRef: THREAD_REF }),
+    );
+  });
+
+  it("leaves links unscoped on the pull requests page", () => {
+    renderToStaticMarkup(
+      <PullRequestMarkdown
+        text="[Related pull request](https://github.com/pingdotgg/t3code/pull/6446)"
+        cwd="/workspace"
+        environmentId={ENVIRONMENT_ID}
+      />,
+    );
+
+    expect(mocks.chatMarkdown).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ environmentId: ENVIRONMENT_ID, threadRef: undefined }),
+    );
+  });
+});

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.test.tsx
@@ -28,7 +28,7 @@ describe("pull request markdown", () => {
 
   it("passes the owning thread to links rendered inside a thread panel", () => {
     renderToStaticMarkup(
-      <PullRequestThreadRefProvider threadRef={THREAD_REF}>
+      <PullRequestThreadRefProvider threadRef={THREAD_REF} scopeWorkspaceToThread>
         <PullRequestMarkdown
           text="[Related pull request](https://github.com/pingdotgg/t3code/pull/6446)"
           cwd="/workspace"
@@ -38,7 +38,31 @@ describe("pull request markdown", () => {
     );
 
     expect(mocks.chatMarkdown).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({ environmentId: ENVIRONMENT_ID, threadRef: THREAD_REF }),
+      expect.objectContaining({
+        environmentId: ENVIRONMENT_ID,
+        pullRequestLinkThreadRef: THREAD_REF,
+        threadRef: THREAD_REF,
+      }),
+    );
+  });
+
+  it("keeps pull request navigation scoped without assigning foreign files to the thread", () => {
+    renderToStaticMarkup(
+      <PullRequestThreadRefProvider threadRef={THREAD_REF} scopeWorkspaceToThread={false}>
+        <PullRequestMarkdown
+          text="[Related pull request](https://github.com/pingdotgg/t3code/pull/6446)"
+          cwd="/foreign-workspace"
+          environmentId={ENVIRONMENT_ID}
+        />
+      </PullRequestThreadRefProvider>,
+    );
+
+    expect(mocks.chatMarkdown).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        environmentId: ENVIRONMENT_ID,
+        pullRequestLinkThreadRef: THREAD_REF,
+        threadRef: undefined,
+      }),
     );
   });
 
@@ -52,7 +76,11 @@ describe("pull request markdown", () => {
     );
 
     expect(mocks.chatMarkdown).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({ environmentId: ENVIRONMENT_ID, threadRef: undefined }),
+      expect.objectContaining({
+        environmentId: ENVIRONMENT_ID,
+        pullRequestLinkThreadRef: undefined,
+        threadRef: undefined,
+      }),
     );
   });
 });

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,24 +1,38 @@
 import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
 import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 
 import { cn } from "~/lib/utils";
 
 import ChatMarkdown from "../ChatMarkdown";
 import { splitPullRequestBody } from "./pullRequestMarkdown.logic";
 
-const PullRequestThreadRefContext = createContext<ScopedThreadRef | undefined>(undefined);
+interface PullRequestThreadScope {
+  readonly threadRef: ScopedThreadRef | undefined;
+  readonly scopeWorkspaceToThread: boolean;
+}
 
-/** Keeps links inside a thread-owned pull request panel beside that thread. */
+const PullRequestThreadRefContext = createContext<PullRequestThreadScope>({
+  threadRef: undefined,
+  scopeWorkspaceToThread: false,
+});
+
+/** Keeps pull request links beside a thread without assigning foreign files to its workspace. */
 export function PullRequestThreadRefProvider({
   threadRef,
+  scopeWorkspaceToThread,
   children,
 }: {
   threadRef: ScopedThreadRef | undefined;
+  scopeWorkspaceToThread: boolean;
   children: ReactNode;
 }) {
+  const value = useMemo(
+    () => ({ threadRef, scopeWorkspaceToThread }),
+    [scopeWorkspaceToThread, threadRef],
+  );
   return (
-    <PullRequestThreadRefContext.Provider value={threadRef}>
+    <PullRequestThreadRefContext.Provider value={value}>
       {children}
     </PullRequestThreadRefContext.Provider>
   );
@@ -46,7 +60,7 @@ export function PullRequestMarkdown({
   environmentId: EnvironmentId;
   className?: string;
 }) {
-  const threadRef = useContext(PullRequestThreadRefContext);
+  const threadScope = useContext(PullRequestThreadRefContext);
   const segments = splitPullRequestBody(text);
   return (
     <div className={cn("space-y-3", className)}>
@@ -58,7 +72,8 @@ export function PullRequestMarkdown({
               text={segment.text}
               cwd={cwd}
               environmentId={environmentId}
-              threadRef={threadRef}
+              threadRef={threadScope.scopeWorkspaceToThread ? threadScope.threadRef : undefined}
+              pullRequestLinkThreadRef={threadScope.threadRef}
             />
           );
         }

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,10 +1,28 @@
 import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
+import { createContext, type ReactNode, useContext } from "react";
 
 import { cn } from "~/lib/utils";
 
 import ChatMarkdown from "../ChatMarkdown";
 import { splitPullRequestBody } from "./pullRequestMarkdown.logic";
+
+const PullRequestThreadRefContext = createContext<ScopedThreadRef | undefined>(undefined);
+
+/** Keeps links inside a thread-owned pull request panel beside that thread. */
+export function PullRequestThreadRefProvider({
+  threadRef,
+  children,
+}: {
+  threadRef: ScopedThreadRef | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <PullRequestThreadRefContext.Provider value={threadRef}>
+      {children}
+    </PullRequestThreadRefContext.Provider>
+  );
+}
 
 /**
  * A pull request body, rendered with the app's markdown renderer plus a card for each upload
@@ -28,6 +46,7 @@ export function PullRequestMarkdown({
   environmentId: EnvironmentId;
   className?: string;
 }) {
+  const threadRef = useContext(PullRequestThreadRefContext);
   const segments = splitPullRequestBody(text);
   return (
     <div className={cn("space-y-3", className)}>
@@ -39,6 +58,7 @@ export function PullRequestMarkdown({
               text={segment.text}
               cwd={cwd}
               environmentId={environmentId}
+              threadRef={threadRef}
             />
           );
         }


### PR DESCRIPTION
Opening a pull request from a chat thread keeps it in the thread's right panel. Clicking another GitHub pull request link inside that pull request instead left the thread route, opened the Pull Requests page, and lost the previous panel context.

### How to reproduce

1. Open a chat thread that contains a GitHub pull request link, such as `https://github.com/pingdotgg/t3code/pull/8089`.
2. Open that pull request in the thread's right panel.
3. In its description, click a link to another pull request, such as `#6446`.
4. The app navigates to the Pull Requests page and opens the linked pull request there instead of keeping the chat thread open.

Pull request markdown rendered in a thread panel now receives the owning thread reference. The existing link handler can then open the linked pull request as another right-panel tab without changing the thread route. Pull request links opened from the standalone Pull Requests page keep their existing page-level behavior.

Tests: 37 focused tests, web typecheck, targeted lint.

### Before

https://github.com/user-attachments/assets/0a6c3762-5f19-49d4-9bf6-857996413b29

### After

https://github.com/user-attachments/assets/d9115b7e-47ac-44f5-94ac-f929165dfea5

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix linked pull request links to stay scoped to the thread panel
> - Adds a `pullRequestLinkThreadRef` prop to `ChatMarkdown` so pull request link navigation can bind to a specific thread even when the markdown itself isn't thread-scoped.
> - Introduces `PullRequestThreadRefProvider` in [PullRequestMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8188/files#diff-e0ad675262612542e104a5b367f3f70bda7a32ec76b460e7e54367f33bdc434e), a context that supplies a `threadRef` and a `scopeWorkspaceToThread` flag to descendants.
> - `PullRequestMarkdown` now passes `pullRequestLinkThreadRef` unconditionally and `threadRef` only when `scopeWorkspaceToThread` is true, so links stay in-thread while file/workspace actions are conditionally scoped.
> - `ChatView` wraps `PullRequestDetailPanel` in the new provider, computing `activePullRequestBelongsToThread` via `isThreadOwnPullRequest`.
> - Risk: `useOpenChangeRequestLink` in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8188/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) now prefers `pullRequestLinkThreadRef ?? threadRef`; callers not passing the new prop fall back to existing `threadRef` behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 996032d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI routing for markdown PR links and context wiring in the thread right panel; no auth or data-layer changes.
> 
> **Overview**
> Fixes PR-to-PR navigation from a pull request body while a chat thread is open: those links no longer jump to the standalone Pull Requests route.
> 
> **`ChatMarkdown`** gains optional `pullRequestLinkThreadRef` so `useOpenChangeRequestLink` can open another PR as a right-panel tab even when `threadRef` is omitted (avoiding thread-scoped file/workspace actions on foreign workspaces).
> 
> **`PullRequestThreadRefProvider`** supplies that scope from **`PullRequestMarkdown`**: it always forwards the active thread for PR link navigation, but only passes `threadRef` into markdown when `scopeWorkspaceToThread` is true. **`ChatView`** wraps the thread-panel **`PullRequestDetailPanel`** with the provider, using `activePullRequestBelongsToThread` to decide whether file paths should stay tied to the thread workspace versus navigation-only threading.
> 
> Tests cover the split between navigation-only and full thread scoping, plus standalone PR page behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996032da07dbaa9da224ca1a932f5b11780f4a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->