### PR TITLE
fix(web): thread jump hints no longer stick after a dictation paste

### DIFF
--- a/apps/web/src/shortcutModifierState.test.ts
+++ b/apps/web/src/shortcutModifierState.test.ts
@@ -110,4 +110,29 @@ describe("shortcutModifierState", () => {
       shiftKey: false,
     });
   });
+
+  it("ignores poisoned modifier flags on non-modifier keys", () => {
+    // A dictation paste (synthetic ⌘V) can leave the browser reporting
+    // metaKey=true on later real key events. Enter to submit must not
+    // re-mark ⌘ as held.
+    const state = shortcutModifierStateAfterKeyboardEvent(
+      emptyState(),
+      keyboardEventLike("keydown", { key: "Enter", metaKey: true }),
+    );
+    expect(state).toEqual(emptyState());
+  });
+
+  it("clears a held modifier when a non-modifier key reports it released", () => {
+    const heldMeta: ShortcutModifierState = {
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    };
+    const state = shortcutModifierStateAfterKeyboardEvent(
+      heldMeta,
+      keyboardEventLike("keydown", { key: "a", metaKey: false }),
+    );
+    expect(state).toEqual(emptyState());
+  });
 });

--- a/apps/web/src/shortcutModifierState.ts
+++ b/apps/web/src/shortcutModifierState.ts
@@ -91,11 +91,17 @@ export function shortcutModifierStateAfterKeyboardEvent(
       [normalizedModifierKey]: event.type === "keydown",
     };
   } else {
+    // Flags on non-modifier keys may only clear a bit, never set one. After a
+    // dictation tool's synthetic ⌘V (Wispr Flow), the browser can keep
+    // reporting metaKey=true on real key events (Enter to submit) until the
+    // user physically taps ⌘. Trusting that flag would mark ⌘ as held and
+    // stick the thread jump hints. Setting a bit requires a real modifier
+    // keydown, handled above.
     nextState = {
-      metaKey: event.metaKey,
-      ctrlKey: event.ctrlKey,
-      altKey: event.altKey,
-      shiftKey: event.shiftKey,
+      metaKey: currentState.metaKey && event.metaKey,
+      ctrlKey: currentState.ctrlKey && event.ctrlKey,
+      altKey: currentState.altKey && event.altKey,
+      shiftKey: currentState.shiftKey && event.shiftKey,
     };
   }
 

--- a/apps/web/src/shortcutModifierState.ts
+++ b/apps/web/src/shortcutModifierState.ts
@@ -33,7 +33,12 @@ export function useShortcutModifierState(): ShortcutModifierState {
     const onKeyboardEvent = (event: KeyboardEvent) => {
       setState((current) => shortcutModifierStateAfterKeyboardEvent(current, event));
     };
-    const onWindowBlur = () => {
+    // Dictation tools (Wispr Flow) paste with a synthetic ⌘V whose Meta keyup
+    // never reaches the page, so the tracked state stays "⌘ held" forever and
+    // the thread jump hints stick on screen. A paste is never jump intent, so
+    // treat it like a blur and reset. A physically held modifier re-registers
+    // on the next real key event.
+    const onResetEvent = () => {
       setState((current) =>
         areShortcutModifierStatesEqual(current, EMPTY_SHORTCUT_MODIFIER_STATE)
           ? current
@@ -43,11 +48,13 @@ export function useShortcutModifierState(): ShortcutModifierState {
 
     window.addEventListener("keydown", onKeyboardEvent, true);
     window.addEventListener("keyup", onKeyboardEvent, true);
-    window.addEventListener("blur", onWindowBlur);
+    window.addEventListener("paste", onResetEvent, true);
+    window.addEventListener("blur", onResetEvent);
     return () => {
       window.removeEventListener("keydown", onKeyboardEvent, true);
       window.removeEventListener("keyup", onKeyboardEvent, true);
-      window.removeEventListener("blur", onWindowBlur);
+      window.removeEventListener("paste", onResetEvent, true);
+      window.removeEventListener("blur", onResetEvent);
     };
   }, []);
 


### PR DESCRIPTION
Pasting from Wispr Flow made the thread shortcut hints appear and stay on screen until you tapped ⌘ or switched windows. #8172 only delayed the hints by 200 ms, which cannot help here: the dictation paste is a synthetic ⌘V whose Meta keyup never reaches the page, so `useShortcutModifierState` believes ⌘ is held forever.

Two changes to the modifier tracking:

1. A `paste` event resets the tracked state, the same way window blur already does. A paste is never jump intent.
2. Modifier flags on non-modifier keys can only clear a bit, never set one. After the synthetic ⌘V, the browser keeps reporting `metaKey: true` on real key events (Enter to submit a new thread) until you physically tap ⌘, which re-stuck the hints. Marking a modifier as held now requires a real modifier keydown.

If you are physically holding ⌘, ⌘1..9 still works since the jump handler reads the event directly. Both sidebars share the hook, so both are covered.

Made with Claude Fable 5 using the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard/modifier tracking UX in the web app with no security or data-path changes; behavior is intentionally more conservative about trusting browser modifier flags.
> 
> **Overview**
> Fixes **stuck thread jump hints** after dictation tools (e.g. Wispr Flow) paste via synthetic ⌘V when the browser never delivers Meta keyup and tracked state thinks ⌘ stays held.
> 
> **`useShortcutModifierState`** now resets modifier tracking on **`paste`** (capture), same as window blur, since paste is not jump intent; a physically held ⌘ still comes back on the next real modifier keydown.
> 
> **`shortcutModifierStateAfterKeyboardEvent`** no longer copies `metaKey`/`ctrlKey`/etc. from arbitrary key events—those flags may only **clear** an already-held bit, not set one—so poisoned `metaKey: true` on Enter or other keys cannot re-lock ⌘.
> 
> Adds unit tests for ignored poisoned flags and clearing held meta when a normal key reports it released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c25a3e649e29838d84357898aec01531d3003b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset `useShortcutModifierState` on paste and fix stale modifier bits
> - The `useShortcutModifierState` hook now resets modifier state when a capturing `paste` event fires, preventing sticky hints after dictation. It replaces the dedicated `blur` handler with a generalized `onResetEvent` that preserves object identity when empty.
> - The `shortcutModifierStateAfterKeyboardEvent` util now ANDs incoming modifier flags with the current state for non-modifier keys. This stops non-modifier keys from setting bits to true, but lets them clear a held modifier if the event reports it as released.
> - Risk: Non-modifier key events can no longer set modifier bits to true in `shortcutModifierStateAfterKeyboardEvent` in [shortcutModifierState.ts](https://github.com/pingdotgg/t3code/pull/8189/files#diff-a430df27adc48e36c2ffbeaf75855a6c040c12e0389cd0c36b2115710cad35e5); consumers relying on this behavior must update their logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78c25a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->