### PR TITLE
feat(desktop): forward SSH agents to remote environments

### DIFF
--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -147,6 +147,7 @@ describe("DesktopConnectionCatalogStore", () => {
               hostname: "devbox.example.com",
               username: "julius",
               port: 22,
+              forwardAgent: true,
             },
           },
           {
@@ -200,6 +201,7 @@ describe("DesktopConnectionCatalogStore", () => {
             hostname: "devbox.example.com",
             username: "julius",
             port: 22,
+            forwardAgent: true,
           },
         });
         assert.deepInclude(catalog.profiles[1], {

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
@@ -28,6 +28,7 @@ const savedRegistryRecord: PersistedSavedEnvironmentRecord = {
     hostname: "devbox.example.com",
     username: "julius",
     port: 22,
+    forwardAgent: true,
   },
 };
 
@@ -193,6 +194,7 @@ describe("DesktopSavedEnvironments", () => {
                   "hostname": "devbox.example.com",
                   "username": "julius",
                   "port": 22,
+                  "forwardAgent": true,
                 },
               },
             ],

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.ts
@@ -41,6 +41,7 @@ const DesktopSshTargetSchema = Schema.Struct({
   hostname: Schema.String,
   username: Schema.NullOr(Schema.String),
   port: Schema.NullOr(Schema.Number),
+  forwardAgent: Schema.optionalKey(Schema.Boolean),
 });
 
 const PersistedSavedEnvironmentStorageRecordSchema = Schema.Struct({

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -254,6 +254,7 @@ function parseManualDesktopSshTarget(input: {
   readonly host: string;
   readonly username: string;
   readonly port: string;
+  readonly forwardAgent: boolean;
 }): DesktopSshEnvironmentTarget {
   const rawHost = input.host.trim();
   if (rawHost.length === 0) {
@@ -305,6 +306,7 @@ function parseManualDesktopSshTarget(input: {
     hostname,
     username,
     port,
+    ...(input.forwardAgent ? { forwardAgent: true } : {}),
   };
 }
 
@@ -1826,6 +1828,7 @@ export function ConnectionsSettings() {
   const [savedBackendSshHost, setSavedBackendSshHost] = useState("");
   const [savedBackendSshUsername, setSavedBackendSshUsername] = useState("");
   const [savedBackendSshPort, setSavedBackendSshPort] = useState("");
+  const [savedBackendSshForwardAgent, setSavedBackendSshForwardAgent] = useState(false);
   const [savedBackendError, setSavedBackendError] = useState<string | null>(null);
   const [isAddingSavedBackend, setIsAddingSavedBackend] = useState(false);
   const [removingSavedEnvironmentId, setRemovingSavedEnvironmentId] =
@@ -2151,6 +2154,7 @@ export function ConnectionsSettings() {
           host: savedBackendSshHost,
           username: savedBackendSshUsername,
           port: savedBackendSshPort,
+          forwardAgent: savedBackendSshForwardAgent,
         });
       } catch (error) {
         setSavedBackendError(formatDesktopSshConnectionError(error));
@@ -2172,6 +2176,7 @@ export function ConnectionsSettings() {
       setSavedBackendSshHost("");
       setSavedBackendSshUsername("");
       setSavedBackendSshPort("");
+      setSavedBackendSshForwardAgent(false);
       setAddBackendDialogOpen(false);
       toastManager.add({
         type: "success",
@@ -2242,6 +2247,7 @@ export function ConnectionsSettings() {
     savedBackendPairingCode,
     savedBackendSshHost,
     savedBackendSshPort,
+    savedBackendSshForwardAgent,
     savedBackendSshUsername,
   ]);
 
@@ -2304,6 +2310,7 @@ export function ConnectionsSettings() {
         setSavedBackendSshHost("");
         setSavedBackendSshUsername("");
         setSavedBackendSshPort("");
+        setSavedBackendSshForwardAgent(false);
         setAddBackendDialogOpen(false);
         toastManager.add({
           type: "success",
@@ -2507,6 +2514,21 @@ export function ConnectionsSettings() {
             />
           </label>
         </div>
+        <label className="flex items-start justify-between gap-4 rounded-md border border-border/60 px-3 py-2.5">
+          <span className="min-w-0">
+            <span className="block text-xs font-medium text-foreground">Forward SSH agent</span>
+            <span className="mt-0.5 block text-[11px] leading-4 text-muted-foreground">
+              Let Git and signing commands on this trusted host use your local SSH agent, including
+              1Password.
+            </span>
+          </span>
+          <Switch
+            checked={savedBackendSshForwardAgent}
+            onCheckedChange={setSavedBackendSshForwardAgent}
+            disabled={isAddingSavedBackend}
+            aria-label="Forward SSH agent"
+          />
+        </label>
         {savedBackendError || discoveredSshHostsError ? (
           <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
             {savedBackendError ?? discoveredSshHostsError}
@@ -2549,7 +2571,12 @@ export function ConnectionsSettings() {
                 key={`${target.alias}:${target.hostname}:${target.port ?? ""}`}
                 target={target}
                 connectingHostAlias={connectingSshHostAlias}
-                onConnect={(nextTarget) => void handleConnectSshHost(nextTarget)}
+                onConnect={(nextTarget) =>
+                  void handleConnectSshHost({
+                    ...nextTarget,
+                    ...(savedBackendSshForwardAgent ? { forwardAgent: true } : {}),
+                  })
+                }
               />
             ))}
             {hasLoadedDiscoveredSshHosts &&

--- a/docs/internals/remote.md
+++ b/docs/internals/remote.md
@@ -170,6 +170,13 @@ The desktop main process owns this because it can spawn SSH, manage prompts, wri
 and clean up forwards. The renderer connects through the forwarded URL like any other environment and
 needs no SSH-specific RPC path.
 
+SSH agent forwarding is an explicit per-target opt-in. The manager disables forwarding on ordinary
+SSH commands, opens one retained `ssh -A` channel when requested, publishes that channel's remote
+socket under the launch state directory, and starts the launcher-managed server with the socket in
+`SSH_AUTH_SOCK`. The agent channel and port tunnel share the environment connection scope, so
+disconnect and reconnect replace both. Pre-existing external servers are rejected for this mode
+because their process environment cannot be updated safely.
+
 Failure handling is explicit: SSH auth failure surfaces before an environment is saved, remote launch
 failure includes launcher output where available, forwarded-port failure leaves the environment
 disconnected rather than falling back to an unrelated endpoint, and reconnect restores the SSH bridge

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -130,7 +130,8 @@ Use this when you want the desktop app to start or reuse T3 Code on another mach
 2. Under **Remote Environments**, choose **Add environment**.
 3. Select the SSH launch flow.
 4. Enter the SSH target, such as `user@example.com`.
-5. Confirm the launch. The desktop app probes the host, starts or reuses a remote T3 server, opens a local port forward, and saves the environment.
+5. If Git or commit signing on that host should use your local SSH agent, enable **Forward SSH agent**. Only enable it for hosts you trust.
+6. Confirm the launch. The desktop app probes the host, starts or reuses a remote T3 server, opens a local port forward, and saves the environment.
 
 After setup, the renderer connects to a local forwarded HTTP/WebSocket endpoint. The remote host still owns the actual T3 server, projects, files, git state, terminals, and provider sessions.
 
@@ -139,6 +140,10 @@ SSH launch is a desktop feature because it needs local process and SSH access. O
 #### SSH Launch Troubleshooting
 
 The desktop SSH launcher connects with a non-interactive `sh` session, writes a small launcher script under `~/.t3/ssh-launch/<host-key>/`, starts or reuses a remote T3 server, and forwards the remote loopback port back to your desktop.
+
+When **Forward SSH agent** is enabled, T3 Code keeps a separate SSH agent channel open and starts its managed remote server with that channel's `SSH_AUTH_SOCK`. This works with standard agents and the 1Password SSH agent without copying private keys to the remote host. The local agent must be running, and the remote SSH server must allow agent forwarding. Forwarding is unavailable for an independently started T3 server because its environment is outside the desktop launcher's control; stop that server and reconnect so the desktop app can start it.
+
+If the remote machine also runs 1Password, make sure its SSH configuration does not force a remote `IdentityAgent` over the forwarded `SSH_AUTH_SOCK`. You can confirm forwarding in a T3 terminal with `ssh-add -l`.
 
 The remote host must have a compatible Node.js runtime. T3 Code uses the server package's `engines.node` requirement:
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -295,6 +295,7 @@ export const DesktopSshEnvironmentTargetSchema = Schema.Struct({
   hostname: Schema.String,
   username: Schema.NullOr(Schema.String),
   port: Schema.NullOr(Schema.Number),
+  forwardAgent: Schema.optionalKey(Schema.Boolean),
 });
 export type DesktopSshEnvironmentTarget = typeof DesktopSshEnvironmentTargetSchema.Type;
 

--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -14,8 +14,10 @@ import {
   baseSshArgs,
   getLastNonEmptyOutputLine,
   parseSshResolveOutput,
+  remoteStateKey,
   resolveRemoteT3CliPackageSpec,
   runSshCommand,
+  targetConnectionKey,
 } from "./command.ts";
 import { SshCommandError } from "./errors.ts";
 
@@ -94,8 +96,37 @@ describe("ssh command", () => {
           },
           { batchMode: "no" },
         ),
-        ["-o", "BatchMode=no", "-o", "ConnectTimeout=10", "-p", "2222"],
+        ["-a", "-o", "BatchMode=no", "-o", "ConnectTimeout=10", "-p", "2222"],
       );
+    }),
+  );
+
+  it.effect("only forwards the SSH agent when explicitly requested", () =>
+    Effect.sync(() => {
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+
+      assert.equal(baseSshArgs(target)[0], "-a");
+      assert.equal(baseSshArgs(target, { forwardAgent: true })[0], "-A");
+    }),
+  );
+
+  it.effect("reconnects when forwarding changes without orphaning remote launch state", () =>
+    Effect.sync(() => {
+      const target = {
+        alias: "devbox",
+        hostname: "devbox.example.com",
+        username: "julius",
+        port: 2222,
+      } as const;
+      const forwardingTarget = { ...target, forwardAgent: true } as const;
+
+      assert.notEqual(targetConnectionKey(target), targetConnectionKey(forwardingTarget));
+      assert.equal(remoteStateKey(target), remoteStateKey(forwardingTarget));
     }),
   );
 

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -70,12 +70,14 @@ export function parseSshResolveOutput(alias: string, stdout: string): DesktopSsh
 }
 
 export function targetConnectionKey(target: DesktopSshEnvironmentTarget): string {
-  return `${target.alias}\u0000${target.hostname}\u0000${target.username ?? ""}\u0000${target.port ?? ""}`;
+  return `${target.alias}\u0000${target.hostname}\u0000${target.username ?? ""}\u0000${target.port ?? ""}\u0000${target.forwardAgent === true ? "forward-agent" : "no-agent"}`;
 }
 
 export function remoteStateKey(target: DesktopSshEnvironmentTarget): string {
   return NodeCrypto.createHash("sha256")
-    .update(targetConnectionKey(target))
+    .update(
+      `${target.alias}\u0000${target.hostname}\u0000${target.username ?? ""}\u0000${target.port ?? ""}`,
+    )
     .digest("hex")
     .slice(0, 16);
 }
@@ -101,9 +103,10 @@ export const buildSshHostSpecEffect = (
 
 export function baseSshArgs(
   target: DesktopSshEnvironmentTarget,
-  input?: { readonly batchMode?: "yes" | "no" },
+  input?: { readonly batchMode?: "yes" | "no"; readonly forwardAgent?: boolean },
 ): string[] {
   return [
+    input?.forwardAgent === true ? "-A" : "-a",
     "-o",
     `BatchMode=${input?.batchMode ?? "no"}`,
     "-o",

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -14,6 +14,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { SshPasswordPrompt } from "./auth.ts";
 import {
+  buildRemoteAgentForwardScript,
   buildRemoteLaunchScript,
   buildRemotePairingScript,
   buildRemoteStopScript,
@@ -79,6 +80,16 @@ const makeRunningProcess = (onKill: () => void) => {
     getOutputFd: () => Stream.empty,
     unref: Effect.succeed(Effect.void),
   });
+};
+
+const makeRunningProcessWithStdout = (stdout: string, onKill: () => void) => {
+  const process = makeRunningProcess(onKill);
+  const stdoutStream = Stream.make(new TextEncoder().encode(stdout));
+  return {
+    ...process,
+    stdout: stdoutStream,
+    all: stdoutStream,
+  };
 };
 
 const testHttpClient = HttpClient.make((request) =>
@@ -234,6 +245,19 @@ describe("ssh tunnel scripts", () => {
       buildRemoteLaunchScript().indexOf('DEFAULT_RUNTIME_INFO="$(resolve_default_runtime_port'),
       buildRemoteLaunchScript().indexOf('elif [ -n "$REMOTE_PID" ]'),
     );
+  });
+
+  it("configures the managed server to use the retained forwarded agent socket", () => {
+    const forwardScript = buildRemoteAgentForwardScript();
+    const launchScript = buildRemoteLaunchScript({ forwardAgent: true });
+    const ordinaryLaunchScript = buildRemoteLaunchScript();
+
+    assert.include(forwardScript, 'FORWARDED_SOCKET="${SSH_AUTH_SOCK:-}"');
+    assert.include(forwardScript, "t3-agent-forward-ready");
+    assert.include(forwardScript, 'rm -f "$SOCKET_FILE"');
+    assert.include(launchScript, "FORWARD_AGENT=1");
+    assert.include(launchScript, 'SSH_AUTH_SOCK="$FORWARDED_SSH_AUTH_SOCK" nohup');
+    assert.include(ordinaryLaunchScript, "FORWARD_AGENT=0");
   });
 
   it.effect("accepts launch JSON after remote shell startup noise", () => {
@@ -438,6 +462,61 @@ describe("ssh tunnel scripts", () => {
       yield* manager.ensureEnvironment(target);
 
       assert.equal(spawnedCommands.filter((args) => args.includes("-N")).length, 2);
+      assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("retains an explicitly requested agent forwarding channel", () => {
+    const spawnedCommands: Array<ReadonlyArray<string>> = [];
+    let agentForwarderKillCount = 0;
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        spawnedCommands.push(args);
+        if (args.includes("-A")) {
+          return makeRunningProcessWithStdout("t3-agent-forward-ready\n", () => {
+            agentForwarderKillCount += 1;
+          });
+        }
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          });
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773,"serverKind":"managed"}\n');
+        }
+        return makeSuccessfulProcess('{"stopped":true}\n');
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+      forwardAgent: true,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment(target);
+
+      const agentArgs = spawnedCommands.find((args) => args.includes("-A"));
+      assert.isDefined(agentArgs);
+      assert.include(agentArgs, "sh");
+      assert.isTrue(spawnedCommands.filter((args) => args.includes("-a")).length >= 2);
+
+      yield* manager.disconnectEnvironment(target);
+      assert.equal(agentForwarderKillCount, 1);
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -11,10 +11,12 @@ import { extractJsonObject, fromLenientJson } from "@t3tools/shared/schemaJson";
 import { satisfiesSemverRange } from "@t3tools/shared/semver";
 import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
@@ -57,11 +59,14 @@ const TUNNEL_SHUTDOWN_TIMEOUT_MS = 2_000;
 const REMOTE_READY_TIMEOUT_MS = 60_000;
 const REMOTE_LAUNCH_TIMEOUT_MS = 90_000;
 const REMOTE_REUSE_READY_TIMEOUT_MS = 2_000;
+const AGENT_FORWARD_READY_TIMEOUT = Duration.seconds(10);
+const AGENT_FORWARD_READY_MARKER = "t3-agent-forward-ready";
 
 export interface RemoteT3RunnerOptions {
   readonly packageSpec?: string;
   readonly nodeScriptPath?: string | null;
   readonly nodeEngineRange?: string | null;
+  readonly forwardAgent?: boolean;
 }
 
 export interface SshEnvironmentManagerOptions {
@@ -113,6 +118,7 @@ function sshTargetLogFields(target: DesktopSshEnvironmentTarget) {
     hostname: target.hostname,
     username: target.username,
     port: target.port,
+    forwardAgent: target.forwardAgent === true,
   };
 }
 
@@ -452,6 +458,33 @@ printf 'Remote host is missing the t3 CLI and could not install @@T3_PACKAGE_SPE
 exit 1
 `;
 
+export const REMOTE_AGENT_FORWARD_SCRIPT = `set -eu
+STATE_KEY="$1"
+STATE_DIR="$HOME/.t3/ssh-launch/$STATE_KEY"
+SOCKET_FILE="$STATE_DIR/agent-sock"
+SOCKET_NEXT="$STATE_DIR/agent-sock.next.$$"
+FORWARDED_SOCKET="\${SSH_AUTH_SOCK:-}"
+if [ -z "$FORWARDED_SOCKET" ] || [ ! -S "$FORWARDED_SOCKET" ]; then
+  printf 'SSH agent forwarding was requested, but the remote SSH session did not receive an agent socket. Check AllowAgentForwarding on the remote host.\n' >&2
+  exit 1
+fi
+mkdir -p "$STATE_DIR"
+printf '%s\n' "$FORWARDED_SOCKET" >"$SOCKET_NEXT"
+mv "$SOCKET_NEXT" "$SOCKET_FILE"
+cleanup_forwarded_socket() {
+  CURRENT_SOCKET="$(cat "$SOCKET_FILE" 2>/dev/null || true)"
+  if [ "$CURRENT_SOCKET" = "$FORWARDED_SOCKET" ]; then
+    rm -f "$SOCKET_FILE"
+  fi
+  rm -f "$SOCKET_NEXT"
+}
+trap cleanup_forwarded_socket EXIT HUP INT TERM
+printf '@@T3_AGENT_FORWARD_READY_MARKER@@\n'
+while :; do
+  sleep 60
+done
+`;
+
 export const REMOTE_LAUNCH_SCRIPT = `set -eu
 @@T3_NODE_ENV_SCRIPT@@
 STATE_KEY="$1"
@@ -464,6 +497,8 @@ MANAGED_FILE="$STATE_DIR/managed"
 LOG_FILE="$STATE_DIR/server.log"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
 RUNNER_NEXT="$STATE_DIR/run-t3.next.$$"
+FORWARD_AGENT=@@T3_FORWARD_AGENT@@
+AGENT_SOCKET_FILE="$STATE_DIR/agent-sock"
 mkdir -p "$STATE_DIR"
 cleanup_runner_next() {
   rm -f "$RUNNER_NEXT"
@@ -584,13 +619,29 @@ else
   REMOTE_PORT=""
   REMOTE_MANAGED=""
 fi
+if [ "$FORWARD_AGENT" = "1" ] && [ "$REMOTE_MANAGED" = "managed" ] && [ -n "$REMOTE_PID" ]; then
+  kill "$REMOTE_PID" 2>/dev/null || true
+  wait_for_pid_exit "$REMOTE_PID"
+  REMOTE_PID=""
+  REMOTE_PORT=""
+  REMOTE_MANAGED=""
+fi
 if [ -z "$REMOTE_PORT" ]; then
   REMOTE_PORT="$(pick_port)" || true
   if [ -z "$REMOTE_PORT" ]; then
     printf 'Failed to find an available port on the remote host. Ensure node is available on PATH.\\n' >&2
     exit 1
   fi
-  nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
+  if [ "$FORWARD_AGENT" = "1" ]; then
+    FORWARDED_SSH_AUTH_SOCK="$(cat "$AGENT_SOCKET_FILE" 2>/dev/null || true)"
+    if [ -z "$FORWARDED_SSH_AUTH_SOCK" ] || [ ! -S "$FORWARDED_SSH_AUTH_SOCK" ]; then
+      printf 'SSH agent forwarding was requested, but its remote socket is unavailable.\n' >&2
+      exit 1
+    fi
+    SSH_AUTH_SOCK="$FORWARDED_SSH_AUTH_SOCK" nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
+  else
+    nohup env T3CODE_NO_BROWSER=1 "$RUNNER_FILE" serve --host 127.0.0.1 --port "$REMOTE_PORT" --base-dir "$DEFAULT_SERVER_HOME" >>"$LOG_FILE" 2>&1 < /dev/null &
+  fi
   REMOTE_PID="$!"
   printf '%s\\n' "$REMOTE_PID" >"$PID_FILE"
   printf '%s\\n' "$REMOTE_PORT" >"$PORT_FILE"
@@ -683,6 +734,13 @@ export function buildRemoteLaunchScript(input?: RemoteT3RunnerOptions): string {
     T3_READY_TIMEOUT_MS: String(REMOTE_READY_TIMEOUT_MS),
     T3_REUSE_READY_TIMEOUT_MS: String(REMOTE_REUSE_READY_TIMEOUT_MS),
     T3_READY_PROBE_TIMEOUT_MS: String(SSH_READY_PROBE_TIMEOUT_MS),
+    T3_FORWARD_AGENT: input?.forwardAgent === true ? "1" : "0",
+  });
+}
+
+export function buildRemoteAgentForwardScript(): string {
+  return applyScriptPlaceholders(REMOTE_AGENT_FORWARD_SCRIPT, {
+    T3_AGENT_FORWARD_READY_MARKER: AGENT_FORWARD_READY_MARKER,
   });
 }
 
@@ -937,6 +995,109 @@ export const resolveLoopbackSshHttpBaseUrl = Effect.fn("ssh/tunnel.resolveLoopba
 const reserveLocalTunnelPort = Effect.fn("ssh/tunnel.reserveLocalTunnelPort")(function* () {
   const net = yield* NetService.NetService;
   return yield* net.reserveLoopbackPort();
+});
+
+const startSshAgentForwarder = Effect.fn("ssh/tunnel.startSshAgentForwarder")(function* (input: {
+  readonly target: DesktopSshEnvironmentTarget;
+  readonly authOptions: SshAuthOptions;
+  readonly scope: Scope.Scope;
+}): Effect.fn.Return<
+  ChildProcessSpawner.ChildProcessHandle,
+  SshCommandError | SshInvalidTargetError,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> {
+  const hostSpec = yield* buildSshHostSpecEffect(input.target);
+  const childEnvironment = yield* buildSshChildEnvironment({
+    ...(input.authOptions.authSecret === undefined
+      ? {}
+      : { authSecret: input.authOptions.authSecret }),
+    ...(input.authOptions.interactiveAuth === undefined
+      ? {}
+      : { interactiveAuth: input.authOptions.interactiveAuth }),
+  }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new SshCommandError({
+          command: ["ssh"],
+          exitCode: null,
+          stderr: "",
+          message: "Failed to prepare SSH agent forwarding helpers.",
+          cause,
+        }),
+    ),
+  );
+  const args = [
+    ...baseSshArgs(input.target, {
+      batchMode: input.authOptions.batchMode ?? "no",
+      forwardAgent: true,
+    }),
+    hostSpec,
+    "sh",
+    "-s",
+    "--",
+    remoteStateKey(input.target),
+  ];
+  const sshCommand = yield* resolveSshCommand;
+  const command = [sshCommand, ...args];
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const child = yield* spawner
+    .spawn(
+      ChildProcess.make(sshCommand, args, {
+        env: childEnvironment,
+        extendEnv: true,
+        stdin: {
+          stream: Stream.encodeText(Stream.make(buildRemoteAgentForwardScript())),
+          endOnDone: true,
+        },
+      }),
+    )
+    .pipe(
+      Effect.provideService(Scope.Scope, input.scope),
+      Effect.mapError(
+        (cause) =>
+          new SshCommandError({
+            command,
+            exitCode: null,
+            stderr: "",
+            message: `Failed to start SSH agent forwarding for ${hostSpec}.`,
+            cause,
+          }),
+      ),
+    );
+
+  const readyLine = yield* child.stdout.pipe(
+    Stream.decodeText(),
+    Stream.splitLines,
+    Stream.filter((line) => line.trim() === AGENT_FORWARD_READY_MARKER),
+    Stream.runHead,
+    Effect.mapError(
+      (cause) =>
+        new SshCommandError({
+          command,
+          exitCode: null,
+          stderr: "",
+          message: `Failed while waiting for SSH agent forwarding on ${hostSpec}.`,
+          cause,
+        }),
+    ),
+    Effect.timeoutOption(AGENT_FORWARD_READY_TIMEOUT),
+  );
+  if (Option.isNone(readyLine) || Option.isNone(readyLine.value)) {
+    yield* child
+      .kill({ killSignal: "SIGTERM", forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS })
+      .pipe(Effect.ignore);
+    return yield* new SshCommandError({
+      command,
+      exitCode: null,
+      stderr: "",
+      message: `SSH agent forwarding did not become ready for ${hostSpec}. Check that the local agent is running and AllowAgentForwarding is enabled on the remote host.`,
+    });
+  }
+  yield* Effect.logInfo("ssh.agentForward.ready", {
+    ...sshTargetLogFields(input.target),
+    pid: child.pid,
+  });
+  return child;
 });
 
 const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: {
@@ -1339,12 +1500,58 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...sshRunnerLogFields(input.runner),
       key: input.key,
     });
+    const entryScope = yield* Scope.make("sequential");
+    const agentForwarderProcess =
+      input.resolvedTarget.forwardAgent === true
+        ? yield* runWithSshAuth({
+            key: input.key,
+            target: input.resolvedTarget,
+            operation: (authOptions) =>
+              startSshAgentForwarder({
+                target: input.resolvedTarget,
+                authOptions,
+                scope: entryScope,
+              }),
+          }).pipe(
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit)
+                ? Effect.void
+                : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
+            ),
+          )
+        : undefined;
+    const stopAgentForwarder = agentForwarderProcess
+      ? agentForwarderProcess
+          .kill({
+            killSignal: "SIGTERM",
+            forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+          })
+          .pipe(Effect.ignore)
+      : Effect.void;
+    if (agentForwarderProcess) {
+      yield* Scope.addFinalizer(entryScope, stopAgentForwarder);
+    }
+    const closeEntryScope = Scope.close(entryScope, Exit.void).pipe(Effect.ignore);
     const remoteLaunch = yield* runWithSshAuth({
       key: input.key,
       target: input.resolvedTarget,
       operation: (authOptions) =>
-        launchOrReuseRemoteServer(input.resolvedTarget, authOptions, input.runner),
-    });
+        launchOrReuseRemoteServer(input.resolvedTarget, authOptions, {
+          ...input.runner,
+          forwardAgent: input.resolvedTarget.forwardAgent === true,
+        }),
+    }).pipe(Effect.onExit((exit) => (Exit.isSuccess(exit) ? Effect.void : closeEntryScope)));
+    if (
+      input.resolvedTarget.forwardAgent === true &&
+      remoteLaunch.remoteServerKind === "external"
+    ) {
+      yield* closeEntryScope;
+      return yield* new SshLaunchError({
+        message:
+          "SSH agent forwarding requires a T3 server managed by this desktop connection. Stop the pre-existing remote T3 server and reconnect.",
+        stdout: "",
+      });
+    }
     const remotePort = remoteLaunch.remotePort;
     yield* Effect.logDebug("ssh.environment.remotePort.ready", {
       ...sshTargetLogFields(input.resolvedTarget),
@@ -1352,7 +1559,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       remotePort,
       remoteServerKind: remoteLaunch.remoteServerKind,
     });
-    const localPort = yield* reserveLocalTunnelPort();
+    const localPort = yield* reserveLocalTunnelPort().pipe(
+      Effect.onExit((exit) => (Exit.isSuccess(exit) ? Effect.void : closeEntryScope)),
+    );
     const httpBaseUrl = `http://127.0.0.1:${localPort}/`;
     const wsBaseUrl = `ws://127.0.0.1:${localPort}/`;
     yield* Effect.logDebug("ssh.environment.localPort.reserved", {
@@ -1361,7 +1570,6 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       localPort,
       remotePort,
     });
-    const entryScope = yield* Scope.make("sequential");
     const tunnelEntry = yield* runWithSshAuth({
       key: input.key,
       target: input.resolvedTarget,
@@ -1381,6 +1589,26 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
         Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
       ),
     );
+    if (agentForwarderProcess) {
+      yield* agentForwarderProcess.exitCode.pipe(
+        Effect.flatMap((exitCode) =>
+          Effect.logWarning("ssh.agentForward.process.exited", {
+            ...sshTargetLogFields(input.resolvedTarget),
+            pid: agentForwarderProcess.pid,
+            exitCode: Number(exitCode),
+          }).pipe(
+            Effect.andThen(
+              tunnelEntry.process.kill({
+                killSignal: "SIGTERM",
+                forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+              }),
+            ),
+          ),
+        ),
+        Effect.ignore,
+        Effect.forkIn(entryScope),
+      );
+    }
     tunnels.set(input.key, tunnelEntry);
     const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
     const fileSystemService = yield* FileSystem.FileSystem;
@@ -1531,6 +1759,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...baseResolved,
       ...(target.username !== null ? { username: target.username } : {}),
       ...(target.port !== null ? { port: target.port } : {}),
+      ...(target.forwardAgent === true ? { forwardAgent: true } : {}),
     };
     const key = targetConnectionKey(resolvedTarget);
     yield* Effect.logDebug("ssh.environment.target.resolved", {
@@ -1587,6 +1816,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...baseResolved,
       ...(target.username !== null ? { username: target.username } : {}),
       ...(target.port !== null ? { port: target.port } : {}),
+      ...(target.forwardAgent === true ? { forwardAgent: true } : {}),
     };
     const key = targetConnectionKey(resolvedTarget);
     const entry = tunnels.get(key) ?? null;


### PR DESCRIPTION
Desktop-managed SSH launch sessions are short-lived, so an agent socket enabled only through `ForwardAgent yes` disappears before provider commands can use it. This is especially visible with the 1Password SSH agent: Git authentication and SSH commit signing fail in the managed remote environment even though ordinary SSH works.

Add an explicit **Forward SSH agent** option for desktop-managed SSH environments. When enabled, the desktop keeps a dedicated `ssh -A` channel alive, validates the remote agent socket, and starts its managed T3 server with that `SSH_AUTH_SOCK`. Connections without the option explicitly use `ssh -a`, keeping forwarding opt-in even when the host's SSH config enables it.

## Testing

- Focused SSH command, tunnel, persistence, and connection-catalog tests (77 passing)
- Scoped typechecks for `@t3tools/ssh`, `@t3tools/contracts`, `@t3tools/web`, and `@t3tools/desktop`
- Targeted lint
- Generated remote shell scripts validated with `sh -n`

## UI

Before: the SSH environment form had no agent-forwarding control.

After: the form exposes an opt-in **Forward SSH agent** toggle, including guidance for 1Password users.

![SSH environment form with Forward SSH agent toggle](https://raw.githubusercontent.com/fsargent/t3code/1e28231c01497043deb27446867912e870096ed8/.github/pr-assets/8190-after.png)

Built with GPT-5.6 Sol through the Codex harness.
