### PR TITLE
fix(client-runtime): stop resubscribing threads the server reports missing

### DIFF
--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1527,6 +1527,7 @@ const makeWsRpcLayer = (
                 return yield* new OrchestrationGetSnapshotError({
                   message: `Thread ${input.threadId} was not found`,
                   cause: input.threadId,
+                  threadDisposition: "not-found",
                 });
               }
 

--- a/packages/client-runtime/src/errors/orchestration.test.ts
+++ b/packages/client-runtime/src/errors/orchestration.test.ts
@@ -1,7 +1,54 @@
-import { OrchestrationDispatchCommandError } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import {
+  OrchestrationDispatchCommandError,
+  OrchestrationGetSnapshotError,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
 
-import { wasBootstrapThreadDeleted } from "./orchestration.ts";
+import { wasBootstrapThreadDeleted, wasSubscribeThreadNotFound } from "./orchestration.ts";
+
+describe("wasSubscribeThreadNotFound", () => {
+  it("matches the typed not-found error", () => {
+    expect(
+      wasSubscribeThreadNotFound(
+        new OrchestrationGetSnapshotError({
+          message: "Thread thread-1 was not found",
+          cause: "thread-1",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects messages with trailing content", () => {
+    expect(
+      wasSubscribeThreadNotFound(
+        new OrchestrationGetSnapshotError({
+          message: "Thread thread-1 was not found (will retry)",
+          cause: "thread-1",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects plain errors with a matching message", () => {
+    expect(wasSubscribeThreadNotFound(new Error("Thread thread-1 was not found"))).toBe(false);
+  });
+
+  it("rejects other snapshot errors", () => {
+    expect(
+      wasSubscribeThreadNotFound(
+        new OrchestrationGetSnapshotError({
+          message: "Failed to load thread thread-1",
+          cause: "thread-1",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects unrelated errors", () => {
+    expect(wasSubscribeThreadNotFound(new Error("boom"))).toBe(false);
+    expect(wasSubscribeThreadNotFound(null)).toBe(false);
+  });
+});
 
 describe("wasBootstrapThreadDeleted", () => {
   it("accepts only a confirmed deleted bootstrap thread", () => {
@@ -13,11 +60,17 @@ describe("wasBootstrapThreadDeleted", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it("rejects a missing disposition", () => {
     expect(
       wasBootstrapThreadDeleted(
         new OrchestrationDispatchCommandError({ message: "Failed to create worktree." }),
       ),
     ).toBe(false);
+  });
+
+  it("rejects unrelated errors", () => {
     expect(wasBootstrapThreadDeleted(new Error("connection lost"))).toBe(false);
   });
 });

--- a/packages/client-runtime/src/errors/orchestration.test.ts
+++ b/packages/client-runtime/src/errors/orchestration.test.ts
@@ -13,16 +13,17 @@ describe("wasSubscribeThreadNotFound", () => {
         new OrchestrationGetSnapshotError({
           message: "Thread thread-1 was not found",
           cause: "thread-1",
+          threadDisposition: "not-found",
         }),
       ),
     ).toBe(true);
   });
 
-  it("rejects messages with trailing content", () => {
+  it("rejects a missing disposition", () => {
     expect(
       wasSubscribeThreadNotFound(
         new OrchestrationGetSnapshotError({
-          message: "Thread thread-1 was not found (will retry)",
+          message: "Thread thread-1 was not found",
           cause: "thread-1",
         }),
       ),

--- a/packages/client-runtime/src/errors/orchestration.ts
+++ b/packages/client-runtime/src/errors/orchestration.ts
@@ -1,4 +1,7 @@
-import { OrchestrationDispatchCommandError } from "@t3tools/contracts";
+import {
+  OrchestrationDispatchCommandError,
+  OrchestrationGetSnapshotError,
+} from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
@@ -7,4 +10,13 @@ export function wasBootstrapThreadDeleted(error: unknown): boolean {
   return (
     isOrchestrationDispatchCommandError(error) && error.bootstrapThreadDisposition === "deleted"
   );
+}
+
+const isOrchestrationGetSnapshotError = Schema.is(OrchestrationGetSnapshotError);
+
+/** Server wording for a subscribeThread miss (`apps/server/src/ws.ts`: `Thread ${threadId} was not found`). */
+const THREAD_NOT_FOUND_MESSAGE = /^Thread .+ was not found$/;
+
+export function wasSubscribeThreadNotFound(error: unknown): boolean {
+  return isOrchestrationGetSnapshotError(error) && THREAD_NOT_FOUND_MESSAGE.test(error.message);
 }

--- a/packages/client-runtime/src/errors/orchestration.ts
+++ b/packages/client-runtime/src/errors/orchestration.ts
@@ -14,9 +14,7 @@ export function wasBootstrapThreadDeleted(error: unknown): boolean {
 
 const isOrchestrationGetSnapshotError = Schema.is(OrchestrationGetSnapshotError);
 
-/** Server wording for a subscribeThread miss (`apps/server/src/ws.ts`: `Thread ${threadId} was not found`). */
-const THREAD_NOT_FOUND_MESSAGE = /^Thread .+ was not found$/;
-
+/** Set by the server when a subscribeThread miss has no snapshot (`apps/server/src/ws.ts`). */
 export function wasSubscribeThreadNotFound(error: unknown): boolean {
-  return isOrchestrationGetSnapshotError(error) && THREAD_NOT_FOUND_MESSAGE.test(error.message);
+  return isOrchestrationGetSnapshotError(error) && error.threadDisposition === "not-found";
 }

--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -355,6 +355,104 @@ describe("environment RPC", () => {
     }),
   );
 
+  it.effect("ends the subscription permanently when the failure is terminal", () =>
+    Effect.gen(function* () {
+      const notFound = new Error("thread was not found");
+      const subscriptionCount = yield* Ref.make(0);
+      const handled = yield* Ref.make<Cause.Cause<unknown> | null>(null);
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.unwrap(
+            Ref.updateAndGet(subscriptionCount, (count) => count + 1).pipe(
+              Effect.map(() => Stream.fail(notFound)),
+            ),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, supervisor } = yield* makeHarness();
+
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      const subscriptionFiber = yield* subscribe(
+        WS_METHODS.subscribeTerminalEvents,
+        {},
+        {
+          terminalFailure: {
+            matches: (error) => error === notFound,
+            handle: (cause) => Ref.set(handled, cause),
+          },
+        },
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      for (let attempt = 0; attempt < 100 && (yield* Ref.get(handled)) === null; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+
+      expect(yield* Ref.get(subscriptionCount)).toBe(1);
+      expect(yield* Ref.get(handled)).not.toBeNull();
+
+      // Far past any retry delay: a terminal failure must not re-attempt.
+      yield* TestClock.adjust("30 seconds");
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(subscriptionCount)).toBe(1);
+    }),
+  );
+
+  it.effect("does not treat failures rejected by the terminal classifier as terminal", () =>
+    Effect.gen(function* () {
+      const transient = new Error("transient snapshot failure");
+      const subscriptionCount = yield* Ref.make(0);
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.unwrap(
+            Ref.getAndUpdate(subscriptionCount, (count) => count + 1).pipe(
+              Effect.map((count) => (count === 0 ? Stream.fail(transient) : Stream.never)),
+            ),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, supervisor } = yield* makeHarness();
+
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      const subscriptionFiber = yield* subscribe(
+        WS_METHODS.subscribeTerminalEvents,
+        {},
+        {
+          onExpectedFailure: () => Effect.void,
+          retryExpectedFailureAfter: "100 millis",
+          terminalFailure: {
+            matches: () => false,
+            handle: () => Effect.void,
+          },
+        },
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+
+      // The retry sleep must be scheduled before virtual time advances.
+      for (
+        let attempt = 0;
+        attempt < 100 && (yield* Ref.get(subscriptionCount)) < 1;
+        attempt += 1
+      ) {
+        yield* Effect.yieldNow;
+      }
+      yield* TestClock.adjust("100 millis");
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* Ref.get(subscriptionCount)) >= 2) break;
+        yield* Effect.yieldNow;
+      }
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      // Classified as a regular expected failure: retried once, handler untouched.
+      expect(yield* Ref.get(subscriptionCount)).toBe(2);
+    }),
+  );
+
   it.effect("does not classify subscription defects as expected failures", () =>
     Effect.gen(function* () {
       const defect = new Error("subscription invariant failed");

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -173,6 +173,15 @@ interface SubscriptionOptions<TTag extends EnvironmentSubscriptionRpcTag> {
   ) => Effect.Effect<void, never, never>;
   readonly retryExpectedFailureAfter?: Duration.Input;
   readonly resubscribe?: Stream.Stream<unknown, never, never>;
+  /**
+   * Classifies an all-Fail cause as terminal: the attempt ends for this
+   * session with no retry, after `handle` runs. Checked after transport
+   * failures and before expected-failure retry.
+   */
+  readonly terminalFailure?: {
+    readonly matches: (error: EnvironmentRpcStreamFailure<TTag>) => boolean;
+    readonly handle: (cause: Cause.Cause<EnvironmentRpcStreamFailure<TTag>>) => Effect.Effect<void>;
+  };
 }
 
 export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
@@ -225,14 +234,18 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                       return method(input).pipe(
                         Stream.ensuring(completeObservation),
                         Stream.catchCause((cause) => {
+                          const failErrors = cause.reasons.flatMap((reason) =>
+                            reason._tag === "Fail" ? [reason.error] : [],
+                          );
                           const hasOnlyExpectedFailures =
-                            cause.reasons.length > 0 &&
-                            cause.reasons.every((reason) => reason._tag === "Fail");
+                            cause.reasons.length > 0 && failErrors.length === cause.reasons.length;
                           const isTransportFailure =
                             hasOnlyExpectedFailures &&
-                            cause.reasons.every(
-                              (reason) => reason._tag === "Fail" && isRpcClientError(reason.error),
-                            );
+                            failErrors.every((error) => isRpcClientError(error));
+                          const isTerminal =
+                            hasOnlyExpectedFailures &&
+                            options?.terminalFailure !== undefined &&
+                            failErrors.every((error) => options.terminalFailure!.matches(error));
                           if (isTransportFailure) {
                             return Stream.fromEffect(
                               Effect.logWarning(
@@ -244,6 +257,11 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                                 },
                               ),
                             ).pipe(Stream.drain);
+                          }
+                          if (isTerminal && options.terminalFailure !== undefined) {
+                            return Stream.fromEffect(options.terminalFailure.handle(cause)).pipe(
+                              Stream.drain,
+                            );
                           }
                           if (hasOnlyExpectedFailures && options?.onExpectedFailure !== undefined) {
                             const handled = Stream.fromEffect(

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -1,6 +1,7 @@
 import {
   EnvironmentId,
   EventId,
+  OrchestrationGetSnapshotError,
   ORCHESTRATION_WS_METHODS,
   ProjectId,
   ProviderInstanceId,
@@ -709,6 +710,34 @@ describe("EnvironmentThreads", () => {
         yield* Effect.yieldNow;
       }
       expect(yield* Ref.get(harness.subscriptionCount)).toBe(3);
+    }),
+  );
+
+  it.effect("marks the thread deleted and stops subscribing when the thread is missing", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* Queue.offer(
+        harness.inputs,
+        new OrchestrationGetSnapshotError({
+          message: `Thread ${THREAD_ID} was not found`,
+          cause: THREAD_ID,
+        }),
+      );
+
+      const state = yield* awaitThreadState(
+        harness.observed,
+        (value) => value.status === "deleted",
+      );
+      expect(Option.isNone(state.data)).toBe(true);
+      expect(Option.isNone(state.error)).toBe(true);
+      // Deletion parity with the normal thread.deleted event path.
+      expect(yield* Ref.get(harness.removedThreads)).toEqual([THREAD_ID]);
+
+      // No retry storm: far past any retry delay there is exactly one
+      // subscribe attempt for a deleted thread.
+      yield* TestClock.adjust("30 seconds");
+      yield* Effect.yieldNow;
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(1);
     }),
   );
 });

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -721,6 +721,7 @@ describe("EnvironmentThreads", () => {
         new OrchestrationGetSnapshotError({
           message: `Thread ${THREAD_ID} was not found`,
           cause: THREAD_ID,
+          threadDisposition: "not-found",
         }),
       );
 

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -22,6 +22,7 @@ import { EnvironmentRegistry } from "../connection/registry.ts";
 import { connectionProjectionPhase } from "../connection/model.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
 import * as ConnectionWakeups from "../connection/wakeups.ts";
+import { wasSubscribeThreadNotFound } from "../errors/orchestration.ts";
 import { EnvironmentCacheStore } from "../platform/persistence.ts";
 import { subscribeDynamic } from "../rpc/client.ts";
 import { ThreadSnapshotLoader, type ThreadSnapshotWindow } from "./threadSnapshotHttp.ts";
@@ -640,6 +641,14 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
         onExpectedFailure: setStreamError,
         retryExpectedFailureAfter: "250 millis",
         resubscribe: foregroundResubscriptions,
+        terminalFailure: {
+          matches: wasSubscribeThreadNotFound,
+          handle: (cause) =>
+            Effect.logWarning("Subscribed thread is gone; stopping.", {
+              threadId,
+              cause: Cause.pretty(cause),
+            }).pipe(Effect.andThen(setDeleted())),
+        },
       },
     ).pipe(Stream.runForEach(applyItem)),
   );

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1740,6 +1740,7 @@ export class OrchestrationGetSnapshotError extends Schema.TaggedErrorClass<Orche
   {
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),
+    threadDisposition: Schema.optional(Schema.Literal("not-found")),
   },
 ) {}
 


### PR DESCRIPTION
# PR-A — fix(client-runtime): stop resubscribing threads the server reports missing

## Body

Following up on #4589 (dead subscriptions on healthy connections) with the first of three small fixes from a production incident on a long-lived deployment.

**Problem:** `subscribeDynamic` retries every all-Fail cause forever. When a thread is deleted while its subscription is mid-flight, `orchestration.subscribeThread` keeps failing with `OrchestrationGetSnapshotError: Thread … was not found` — classified as an expected failure and retried at the fixed delay for the rest of the session. We counted **12,000+ consecutive misses (~4/s), still firing when we gave up and restarted the client after 80+ minutes** — against a healthy connection throughout.

**Fix:** adds a `terminalFailure` classification to `SubscriptionOptions`: an all-Fail cause whose errors all match a terminal predicate ends the attempt for the session, with no retry, after running its handler. The thread subscription call site classifies the server's `Thread … was not found` wording as terminal and applies the existing `setDeleted()` path — full deletion parity including cache clearing, so the UI drops the row instead of silently hammering a dead RPC.

Transport dormancy and defect propagation are unchanged. This intentionally does not touch reconnection/backoff design (#4602, #4405) — it only stops retrying when the server has said the thing is permanently gone.

**Validation** (cleanly applicable to upstream main `c6b8bb825` — zero file intersection with the last four upstream commits):
- `vp test run packages/client-runtime/src/rpc/client.test.ts packages/client-runtime/src/errors/orchestration.test.ts packages/client-runtime/src/state/threads-sync.test.ts` → 33 passed
- Full `@t3tools/client-runtime` suite → 676 passed (51 files)
- `tsgo --noEmit -p packages/client-runtime/tsconfig.json` → exit 0
- New tests cover: terminal classification edges, deleted-thread session replacement, and that non-terminal failures still retry.

Effect idioms match the repo's current v4-beta usage (no new deps; the only API surface added is the `terminalFailure` option on `SubscriptionOptions` plus the new exported `wasSubscribeThreadNotFound` predicate in `errors/orchestration.ts`).

**Merge-order note (for #4589's three-PR set):** the input-envelope PR relocates the `catchCause` this PR classifies inside. Whichever lands second conflicts by design; the combined result is the relocated envelope with this PR's classifier interior (transport → terminal → expected-failure retry → failCause). Do not resolve toward the old attachment point — it compiles but silently reintroduces the input-stage fiber death.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable subscription retry semantics and thread lifecycle on missing-server threads; requires server and client to agree on the new error field for correct classification.
> 
> **Overview**
> Stops **infinite `subscribeThread` retries** when the server says a thread no longer exists. Previously those failures were treated as expected errors and retried on a fixed delay for the whole session.
> 
> **Contract & server:** `OrchestrationGetSnapshotError` gains optional `threadDisposition: "not-found"`. `subscribeThread` sets it when the thread detail snapshot is missing (`apps/server/src/ws.ts`).
> 
> **Client-runtime:** `subscribeDynamic` adds a **`terminalFailure`** option—if every `Fail` in the cause matches `matches`, the handler runs and **that subscription attempt ends with no retry** (after transport handling, before expected-failure retry). Thread sync wires this to **`wasSubscribeThreadNotFound`** (typed disposition, not error message text) and **`setDeleted()`** so behavior matches a normal `thread.deleted` path (cache cleared, UI drops the row).
> 
> Tests cover the predicate, terminal vs retried failures in the RPC layer, and a single subscribe attempt after a not-found snapshot error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89a86e6338e1515ef5c4e72e546cbd731caab6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop resubscribing to threads the server reports as missing
> - Server WS layer now tags missing-thread snapshot errors with `threadDisposition: "not-found"` on `OrchestrationGetSnapshotError` in [ws.ts](https://github.com/pingdotgg/t3code/pull/8192/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125)
> - Client runtime adds a `terminalFailure` option to `subscribeDynamic` in [client.ts](https://github.com/pingdotgg/t3code/pull/8192/files#diff-f60493a8e60511194714ca2543e1d58cfb8198eb71d2bf0c9655acdc93220c38); when all `Fail` errors match the classifier, the subscription stops retrying and invokes the handler
> - Thread state factory in [threads.ts](https://github.com/pingdotgg/t3code/pull/8192/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815) wires `wasSubscribeThreadNotFound` as the classifier and calls `setDeleted()` on match, so missing threads transition to `deleted` instead of looping retries
> - Risk: subscriptions that previously retried indefinitely on missing threads now terminate; any code expecting the subscription to stay alive after a server-side thread deletion needs to handle the `deleted` state transition
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d89a86e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->