### PR TITLE
fix(client-runtime): retry subscription input failures instead of dying

### DIFF
--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -1,5 +1,7 @@
 import {
+  EnvironmentAuthorizationError,
   EnvironmentId,
+  AuthTerminalOperateScope,
   type RelayClientInstallProgressEvent,
   WS_METHODS,
 } from "@t3tools/contracts";
@@ -25,7 +27,13 @@ import {
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import * as RpcSession from "../rpc/session.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
-import { EnvironmentRpcRequestObserver, request, runStream, subscribe } from "./client.ts";
+import {
+  EnvironmentRpcRequestObserver,
+  request,
+  runStream,
+  subscribe,
+  subscribeDynamic,
+} from "./client.ts";
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -352,6 +360,66 @@ describe("environment RPC", () => {
 
       expect(yield* Ref.get(subscriptionCount)).toBe(2);
       expect(yield* Ref.get(expectedFailureCount)).toBe(1);
+    }),
+  );
+
+  it.effect("keeps retrying and recovers when input construction fails", () =>
+    Effect.gen(function* () {
+      const inputFailure = new EnvironmentAuthorizationError({
+        message: "http snapshot load failed",
+        requiredScope: AuthTerminalOperateScope,
+      });
+      let failInput = true;
+      const observedFailures: unknown[] = [];
+      const subscriptionCount = yield* Ref.make(0);
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.unwrap(
+            Ref.updateAndGet(subscriptionCount, (count) => count + 1).pipe(
+              Effect.map(() => Stream.never),
+            ),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, supervisor } = yield* makeHarness();
+
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      const subscriptionFiber = yield* subscribeDynamic(
+        WS_METHODS.subscribeTerminalEvents,
+        () => Effect.suspend(() => (failInput ? Effect.fail(inputFailure) : Effect.succeed({}))),
+        {
+          onExpectedFailure: (cause) =>
+            Effect.sync(() => {
+              observedFailures.push(Cause.squash(cause));
+            }),
+          retryExpectedFailureAfter: "100 millis",
+        },
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      for (let attempt = 0; attempt < 100 && observedFailures.length < 1; attempt += 1) {
+        yield* Effect.yieldNow;
+      }
+
+      // The failure surfaced and the RPC was never issued.
+      expect(observedFailures).toEqual([inputFailure]);
+      expect(yield* Ref.get(subscriptionCount)).toBe(0);
+
+      // The next attempt constructs input successfully and subscribes: the
+      // fiber survived the input failure.
+      failInput = false;
+      yield* TestClock.adjust("100 millis");
+      for (
+        let attempt = 0;
+        attempt < 100 && (yield* Ref.get(subscriptionCount)) < 1;
+        attempt += 1
+      ) {
+        yield* Effect.yieldNow;
+      }
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(subscriptionCount)).toBe(1);
     }),
   );
 

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -177,7 +177,12 @@ interface SubscriptionOptions<TTag extends EnvironmentSubscriptionRpcTag> {
 
 export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
   tag: TTag,
-  makeInput: (session: RpcSession) => Effect.Effect<EnvironmentRpcInput<TTag>>,
+  // Input construction may fail with the method's own error domain: those
+  // Fail reasons join the stream's resilience envelope instead of killing
+  // the subscription fiber.
+  makeInput: (
+    session: RpcSession,
+  ) => Effect.Effect<EnvironmentRpcInput<TTag>, EnvironmentRpcStreamFailure<TTag>>,
   options?: SubscriptionOptions<TTag>,
 ): Stream.Stream<
   EnvironmentRpcStreamValue<TTag>,
@@ -222,50 +227,49 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                         method: tag,
                         input,
                       });
-                      return method(input).pipe(
-                        Stream.ensuring(completeObservation),
-                        Stream.catchCause((cause) => {
-                          const hasOnlyExpectedFailures =
-                            cause.reasons.length > 0 &&
-                            cause.reasons.every((reason) => reason._tag === "Fail");
-                          const isTransportFailure =
-                            hasOnlyExpectedFailures &&
-                            cause.reasons.every(
-                              (reason) => reason._tag === "Fail" && isRpcClientError(reason.error),
-                            );
-                          if (isTransportFailure) {
-                            return Stream.fromEffect(
-                              Effect.logWarning(
-                                "Durable RPC subscription lost its transport; waiting for the next session.",
-                                {
-                                  cause: Cause.pretty(cause),
-                                  method: tag,
-                                  environmentId: supervisor.target.environmentId,
-                                },
-                              ),
-                            ).pipe(Stream.drain);
-                          }
-                          if (hasOnlyExpectedFailures && options?.onExpectedFailure !== undefined) {
-                            const handled = Stream.fromEffect(
-                              options.onExpectedFailure(cause),
-                            ).pipe(Stream.drain);
-                            if (options.retryExpectedFailureAfter === undefined) {
-                              return handled;
-                            }
-                            return handled.pipe(
-                              Stream.concat(
-                                Stream.fromEffect(
-                                  Effect.sleep(options.retryExpectedFailureAfter),
-                                ).pipe(Stream.drain),
-                              ),
-                              Stream.concat(subscribeToSession()),
-                            );
-                          }
-                          return Stream.failCause(cause);
-                        }),
-                      );
+                      return method(input).pipe(Stream.ensuring(completeObservation));
                     }),
                   ),
+                ).pipe(
+                  Stream.catchCause((cause) => {
+                    const hasOnlyExpectedFailures =
+                      cause.reasons.length > 0 &&
+                      cause.reasons.every((reason) => reason._tag === "Fail");
+                    const isTransportFailure =
+                      hasOnlyExpectedFailures &&
+                      cause.reasons.every(
+                        (reason) => reason._tag === "Fail" && isRpcClientError(reason.error),
+                      );
+                    if (isTransportFailure) {
+                      return Stream.fromEffect(
+                        Effect.logWarning(
+                          "Durable RPC subscription lost its transport; waiting for the next session.",
+                          {
+                            cause: Cause.pretty(cause),
+                            method: tag,
+                            environmentId: supervisor.target.environmentId,
+                          },
+                        ),
+                      ).pipe(Stream.drain);
+                    }
+                    if (hasOnlyExpectedFailures && options?.onExpectedFailure !== undefined) {
+                      const handled = Stream.fromEffect(options.onExpectedFailure(cause)).pipe(
+                        Stream.drain,
+                      );
+                      if (options.retryExpectedFailureAfter === undefined) {
+                        return handled;
+                      }
+                      return handled.pipe(
+                        Stream.concat(
+                          Stream.fromEffect(Effect.sleep(options.retryExpectedFailureAfter)).pipe(
+                            Stream.drain,
+                          ),
+                        ),
+                        Stream.concat(subscribeToSession()),
+                      );
+                    }
+                    return Stream.failCause(cause);
+                  }),
                 );
               return subscribeToSession();
             },


### PR DESCRIPTION
# PR-B — fix(client-runtime): retry subscription input failures instead of dying

## Body

Second fix from the #4589 production incident (dead subscriptions on healthy connections). This one is deliberately minimal: it changes **where** input construction runs, nothing else.

**Problem:** in `subscribeDynamic`, `makeInput` runs inside `unwrap` **before** the `catchCause` pipe. Its real work includes the HTTP snapshot load plus reducer application, so a transient failure there kills the subscription fiber out of `Stream.runForEach` — no log, no retry, no error state. Signature from the incident: RPC works, streams never come back until the client restarts.

**Fix:** move the `makeInput` invocation inside the effect wrapped by `catchCause`, so input-construction failures flow through the same expected-failure classification as stream failures and are retried at the existing `retryExpectedFailureAfter` fixed delay. `makeInput` may now fail with the method's own error domain (`EnvironmentRpcStreamFailure`).

**Scope guards:**
- `retryExpectedFailureAfter` and its fixed-delay semantics are untouched.
- Transport dormancy ("waiting for the next session.") is byte-identical to main.
- Defects still die loudly (the existing "does not classify subscription defects as expected failures" test is untouched and passing).
- No backoff redesign here — that's #4405's active ground; this PR is orthogonal to scheduling and composes with whichever design lands.

**Validation** (upstream main `1baf99195` + this commit; full `@t3tools/client-runtime` suite 667/667 across 51 files):
- `vp test run packages/client-runtime/src/rpc/client.test.ts` → 9 passed (incl. new: failing input construction retries and converges once construction succeeds; defects still fatal)
- `tsgo --noEmit -p packages/client-runtime/tsconfig.json` → exit 0
- Both existing `subscribeDynamic` call sites (`state/threads.ts`, `state/shell.ts`) compile unchanged — their `makeInput` generators are total today; the widened type is forward-compatible with fallible inputs.

**Merge-order note (for #4589's three-PR set):** this PR and the terminal-classification PR rewrite the same `catchCause` region in opposite shapes — whichever lands second will conflict by design. The correct combined result is this PR's **outer envelope** (catchCause wrapping the `suspend`/`unwrap` containing `makeInput`) with the terminal PR's **classifier interior** inside it, precedence transport → terminal → expected-failure retry → failCause. Do not resolve toward the old attachment point: it compiles but silently reintroduces the input-stage fiber death.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable subscription retry semantics for input-prep failures in client-runtime; misclassification could cause extra retries, but defects and transport handling stay the same.
> 
> **Overview**
> Fixes durable RPC subscriptions that could **permanently die** when `subscribeDynamic`'s `makeInput` failed (e.g. transient HTTP snapshot / auth errors) even though the WebSocket session was healthy.
> 
> **`subscribeDynamic`** now runs `makeInput` inside the same `catchCause` envelope as stream failures, so those errors can use `onExpectedFailure` and `retryExpectedFailureAfter` instead of killing the subscription fiber before any RPC runs. The `makeInput` callback is typed to allow `EnvironmentRpcStreamFailure` errors; transport dormancy and defect handling are unchanged.
> 
> Adds a test that an `EnvironmentAuthorizationError` during input construction is observed once, does not subscribe until input succeeds, then recovers after the configured retry delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c670d0bca2920fea124bb71f7c1bf53bacc26080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry `makeInput` failures in `subscribeDynamic` instead of letting the fiber die
> - `subscribeDynamic` now treats failures from `makeInput` as expected stream failures instead of fatal errors. The RPC method is not called until input construction succeeds.
> - Moves `Stream.catchCause` out one level to wrap both `makeInput` and the RPC method stream, so both share the same resilience logic: transport failures are logged and drained, expected failures invoke `options.onExpectedFailure` and optionally sleep for `options.retryExpectedFailureAfter` before resubscribing.
> - Changes the `makeInput` parameter type from `Effect<EnvironmentRpcInput<TTag>>` to `Effect<EnvironmentRpcInput<TTag>, EnvironmentRpcStreamFailure<TTag>>`.
> - Adds a test verifying the subscription fiber stays alive across an `EnvironmentAuthorizationError` during input construction and recovers once input construction succeeds.
> - Risk: callers passing a `makeInput` that fails with a non-`EnvironmentRpcStreamFailure` error may see different propagation behavior since the error channel type changed in [client.ts](https://github.com/pingdotgg/t3code/pull/8193/files#diff-f60493a8e60511194714ca2543e1d58cfb8198eb71d2bf0c9655acdc93220c38).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c670d0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->