### PR TITLE
feat(codex): show context compaction while it runs

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -998,7 +998,12 @@ function renderFeedEntry(
   const { markdownStyles, iconSubtleColor, userBubbleColor } = props;
 
   if (entry.type === "working") {
-    return <WorkingTimelineRow startedAt={entry.createdAt} />;
+    return (
+      <WorkingTimelineRow
+        startedAt={entry.createdAt}
+        compactionStartedAt={entry.compactionStartedAt}
+      />
+    );
   }
 
   if (entry.type === "turn-fold") {
@@ -1190,7 +1195,10 @@ function renderFeedEntry(
   );
 }
 
-const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly startedAt: string }) {
+const WorkingTimelineRow = memo(function WorkingTimelineRow(props: {
+  readonly startedAt: string;
+  readonly compactionStartedAt?: string;
+}) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
@@ -1198,9 +1206,11 @@ const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly st
       setNowMs(Date.now());
     }, 1_000);
     return () => clearInterval(intervalId);
-  }, [props.startedAt]);
+  }, [props.startedAt, props.compactionStartedAt]);
 
-  const durationLabel = formatElapsed(props.startedAt, new Date(nowMs).toISOString()) ?? "0s";
+  const durationLabel =
+    formatElapsed(props.compactionStartedAt ?? props.startedAt, new Date(nowMs).toISOString()) ??
+    "0s";
 
   return (
     <View className="mb-4 flex-row items-center gap-2 px-1.5 py-1">
@@ -1210,7 +1220,7 @@ const WorkingTimelineRow = memo(function WorkingTimelineRow(props: { readonly st
         <View className="h-1 w-1 rounded-full bg-neutral-400/60 dark:bg-neutral-500/60" />
       </View>
       <Text className="font-t3-medium text-xs tabular-nums text-neutral-600 dark:text-neutral-400">
-        Working for {durationLabel}
+        {props.compactionStartedAt ? "Compacting context for" : "Working for"} {durationLabel}
       </Text>
     </View>
   );

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -752,6 +752,76 @@ describe("buildThreadFeed", () => {
     expect(deriveThreadFeedPresentation(presented, null, new Set())).toEqual([]);
   });
 
+  it("moves active context compaction into the working row", () => {
+    const turnId = TurnId.make("turn-compaction");
+    const startedAt = "2026-04-01T00:00:01.000Z";
+    const compactionStartedAt = "2026-04-01T00:00:12.000Z";
+    const thread = makeThread({
+      id: ThreadId.make("thread-compaction"),
+      projectId: ProjectId.make("project-1"),
+      title: "Context compaction",
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: startedAt,
+        startedAt,
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("context-compaction:thread-compaction:item-1"),
+          kind: "context-compaction",
+          summary: "Compacting context",
+          createdAt: compactionStartedAt,
+          turnId,
+          payload: { status: "inProgress", itemId: "item-1" },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+
+    expect(feed[0]).toMatchObject({
+      type: "activity-group",
+      activities: [{ summary: "Compacting context", icon: "agent", compacting: true }],
+    });
+    expect(
+      deriveThreadFeedPresentation(feed, thread.latestTurn, new Set(), new Set(), startedAt),
+    ).toEqual([
+      {
+        type: "working",
+        id: "working-indicator-row",
+        createdAt: startedAt,
+        compactionStartedAt,
+      },
+    ]);
+  });
+
+  it("keeps completed context compaction in the work log", () => {
+    const turnId = TurnId.make("turn-compaction-completed");
+    const thread = makeThread({
+      id: ThreadId.make("thread-compaction-completed"),
+      projectId: ProjectId.make("project-1"),
+      title: "Completed context compaction",
+      activities: [
+        makeActivity({
+          id: EventId.make("context-compaction:thread-compaction:item-1"),
+          kind: "context-compaction",
+          summary: "Context compacted",
+          createdAt: "2026-04-01T00:01:12.000Z",
+          turnId,
+          payload: { status: "completed", itemId: "item-1" },
+        }),
+      ],
+    });
+
+    expect(buildThreadFeed(thread)[0]).toMatchObject({
+      type: "activity-group",
+      activities: [{ summary: "Context compacted", icon: "agent" }],
+    });
+  });
+
   it("models work-log overflow as list rows", () => {
     const activity = (
       id: string,

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -65,6 +65,7 @@ export interface ThreadFeedActivity {
     | "zap";
   readonly toolLike: boolean;
   readonly status: "success" | "failure" | "neutral" | null;
+  readonly compacting?: boolean;
 }
 
 const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
@@ -116,6 +117,7 @@ export type ThreadFeedEntry =
       readonly type: "working";
       readonly id: string;
       readonly createdAt: string;
+      readonly compactionStartedAt?: string;
     }
   | {
       readonly type: "activity-group";
@@ -635,6 +637,7 @@ function workEntryStatus(entry: WorkLogEntry): ThreadFeedActivity["status"] {
 }
 
 function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
+  if (entry.activityKind === "context-compaction") return "agent";
   if (
     entry.activityKind === "user-input.requested" ||
     entry.activityKind === "user-input.resolved"
@@ -1278,6 +1281,16 @@ export function deriveThreadFeedPresentation(
     (entry) =>
       entry.type !== "turn-fold" && entry.type !== "work-toggle" && entry.type !== "working",
   );
+  const activeCompaction =
+    activeWorkStartedAt === null
+      ? undefined
+      : sourceFeed
+          .flatMap((entry) => (entry.type === "activity-group" ? entry.activities : []))
+          .findLast(
+            (activity) =>
+              activity.compacting === true &&
+              (latestTurn === null || activity.turnId === latestTurn.turnId),
+          );
   const foldsByAnchorId = deriveThreadFeedTurnFolds(sourceFeed, latestTurn);
   const collapsedEntryIds = new Set<string>();
   for (const fold of foldsByAnchorId.values()) {
@@ -1302,7 +1315,16 @@ export function deriveThreadFeedPresentation(
       });
     }
     if (!collapsedEntryIds.has(entry.id)) {
-      appendPresentedFeedEntry(result, entry, expandedWorkGroupIds);
+      if (entry.type === "activity-group" && activeCompaction !== undefined) {
+        const activities = entry.activities.filter(
+          (activity) => activity.id !== activeCompaction.id,
+        );
+        if (activities.length > 0) {
+          appendPresentedFeedEntry(result, { ...entry, activities }, expandedWorkGroupIds);
+        }
+      } else {
+        appendPresentedFeedEntry(result, entry, expandedWorkGroupIds);
+      }
     }
   }
   if (activeWorkStartedAt !== null) {
@@ -1310,6 +1332,7 @@ export function deriveThreadFeedPresentation(
       type: "working",
       id: "working-indicator-row",
       createdAt: activeWorkStartedAt,
+      ...(activeCompaction ? { compactionStartedAt: activeCompaction.createdAt } : {}),
     });
   }
   return result;
@@ -1597,6 +1620,10 @@ export function buildThreadFeed(
               icon: workEntryIcon(entry),
               toolLike: workLogEntryIsToolLike(entry),
               status: workEntryStatus(entry),
+              ...(entry.activityKind === "context-compaction" &&
+              entry.toolLifecycleStatus === "inProgress"
+                ? { compacting: true }
+                : {}),
             },
           };
         }),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -1,8 +1,10 @@
 import {
   EventId,
   ProviderDriverKind,
+  RuntimeItemId,
   RuntimeTaskId,
   ThreadId,
+  TurnId,
   type ProviderRuntimeEvent,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
@@ -82,6 +84,57 @@ describe("runtimeEventToActivities task progress", () => {
     expect(usagePayload).not.toHaveProperty("status");
   });
 });
+
+describe("runtimeEventToActivities context compaction", () => {
+  it("updates one activity as Codex compaction starts and finishes", () => {
+    const started = {
+      ...base,
+      type: "item.started",
+      eventId: EventId.make("evt-compaction-started"),
+      itemId: RuntimeItemId.make("compaction-1"),
+      turnId: TurnId.make("turn-1"),
+      payload: {
+        itemType: "context_compaction",
+        status: "inProgress",
+      },
+    } satisfies ProviderRuntimeEvent;
+    const completed = {
+      ...base,
+      type: "item.completed",
+      eventId: EventId.make("evt-compaction-completed"),
+      itemId: RuntimeItemId.make("compaction-1"),
+      turnId: TurnId.make("turn-1"),
+      payload: {
+        itemType: "context_compaction",
+        status: "completed",
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    expect(runtimeEventToActivities(started)).toEqual([
+      {
+        id: "context-compaction:thread-1:compaction-1",
+        createdAt: base.createdAt,
+        tone: "info",
+        kind: "context-compaction",
+        summary: "Compacting context",
+        payload: { status: "inProgress", itemId: "compaction-1" },
+        turnId: "turn-1",
+      },
+    ]);
+    expect(runtimeEventToActivities(completed)).toEqual([
+      {
+        id: "context-compaction:thread-1:compaction-1",
+        createdAt: base.createdAt,
+        tone: "info",
+        kind: "context-compaction",
+        summary: "Context compacted",
+        payload: { status: "completed", itemId: "compaction-1" },
+        turnId: "turn-1",
+      },
+    ]);
+  });
+});
+
 describe("runtimeEventToActivities tool streaming persistence", () => {
   const accumulatedStdout = [
     "first line of output",

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3215,6 +3215,60 @@ describe("ProviderRuntimeIngestion", () => {
     expect(activity?.tone).toBe("info");
   });
 
+  it("replaces an active Codex compaction activity when compaction finishes", async () => {
+    const harness = await createHarness();
+    const itemId = asItemId("compaction-1");
+    const turnId = asTurnId("turn-1");
+
+    harness.emit({
+      type: "item.started",
+      eventId: asEventId("evt-compaction-started"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "context_compaction", status: "inProgress" },
+    });
+    await harness.drain();
+
+    const startedThread = (await harness.readModel()).threads.find(
+      (thread) => thread.id === "thread-1",
+    );
+    expect(startedThread?.activities).toEqual([
+      expect.objectContaining({
+        id: "context-compaction:thread-1:compaction-1",
+        kind: "context-compaction",
+        summary: "Compacting context",
+        payload: { status: "inProgress", itemId: "compaction-1" },
+      }),
+    ]);
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-compaction-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:01:35.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "context_compaction", status: "completed" },
+    });
+    await harness.drain();
+
+    const completedThread = (await harness.readModel()).threads.find(
+      (thread) => thread.id === "thread-1",
+    );
+    expect(completedThread?.activities).toEqual([
+      expect.objectContaining({
+        id: "context-compaction:thread-1:compaction-1",
+        kind: "context-compaction",
+        summary: "Context compacted",
+        payload: { status: "completed", itemId: "compaction-1" },
+      }),
+    ]);
+  });
+
   it("projects Codex task lifecycle chunks into thread activities", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -371,6 +371,32 @@ export function runtimeEventToActivities(
       ? { sequence: eventWithSequence.sessionSequence }
       : {};
   })();
+
+  if (
+    (event.type === "item.started" || event.type === "item.completed") &&
+    event.payload.itemType === "context_compaction"
+  ) {
+    const completed = event.type === "item.completed";
+
+    return [
+      {
+        id: event.itemId
+          ? EventId.make(`context-compaction:${event.threadId}:${event.itemId}`)
+          : event.eventId,
+        createdAt: event.createdAt,
+        tone: "info",
+        kind: "context-compaction",
+        summary: completed ? "Context compacted" : "Compacting context",
+        payload: {
+          status: event.payload.status ?? (completed ? "completed" : "inProgress"),
+          ...(event.itemId ? { itemId: event.itemId } : {}),
+        },
+        turnId: toTurnId(event.turnId) ?? null,
+        ...maybeSequence,
+      },
+    ];
+  }
+
   switch (event.type) {
     case "request.opened": {
       if (event.payload.requestType === "tool_user_input") {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1218,6 +1218,83 @@ describe("deriveMessagesTimelineRows", () => {
     });
   });
 
+  it("shows active context compaction in the working row without a duplicate work entry", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "compaction-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:12Z",
+          entry: {
+            id: "compaction-1",
+            createdAt: "2026-01-01T00:00:12Z",
+            turnId: "turn-1" as never,
+            label: "Compacting context",
+            tone: "info",
+            sourceActivityKind: "context-compaction",
+            toolLifecycleStatus: "inProgress",
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows).toEqual([
+      {
+        kind: "working",
+        id: "working-indicator-row",
+        createdAt: "2026-01-01T00:00:00Z",
+        showThinking: false,
+        compactionStartedAt: "2026-01-01T00:00:12Z",
+      },
+    ]);
+  });
+
+  it("keeps completed context compaction in the work log", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "compaction-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:01:12Z",
+          entry: {
+            id: "compaction-1",
+            createdAt: "2026-01-01T00:01:12Z",
+            turnId: "turn-1" as never,
+            label: "Context compacted",
+            tone: "info",
+            sourceActivityKind: "context-compaction",
+            toolLifecycleStatus: "completed",
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.find((row) => row.kind === "working")).not.toHaveProperty("compactionStartedAt");
+    expect(rows.find((row) => row.kind === "work")).toMatchObject({
+      groupedEntries: [{ label: "Context compacted" }],
+    });
+  });
+
   it("does not fold the session's running turn when latestTurn regresses", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -244,6 +244,7 @@ export type MessagesTimelineRow =
       id: string;
       createdAt: string | null;
       showThinking: boolean;
+      compactionStartedAt?: string;
     };
 
 export interface StableMessagesTimelineRowsState {
@@ -719,6 +720,12 @@ export function deriveMessagesTimelineRows(input: {
   const activeEntries = input.isWorking
     ? input.timelineEntries.filter((entry, index) => entryBelongsToActiveTurn(entry, index))
     : [];
+  const activeCompactionEntry = activeEntries.findLast(
+    (entry) =>
+      entry.kind === "work" &&
+      entry.entry.sourceActivityKind === "context-compaction" &&
+      entry.entry.toolLifecycleStatus === "inProgress",
+  );
   const activeTurnHasVisibleContent = activeEntries.some((entry) => {
     if (entry.kind === "message") {
       return entry.message.role === "assistant" && (entry.message.text?.trim().length ?? 0) > 0;
@@ -776,7 +783,11 @@ export function deriveMessagesTimelineRows(input: {
       kind: "working",
       id: "working-indicator-row",
       createdAt: input.activeTurnStartedAt,
-      showThinking: activeWorkRow === null && !activeTurnHasVisibleContent,
+      showThinking:
+        activeCompactionEntry === undefined &&
+        activeWorkRow === null &&
+        !activeTurnHasVisibleContent,
+      ...(activeCompactionEntry ? { compactionStartedAt: activeCompactionEntry.createdAt } : {}),
     });
   };
   const appendActiveWorkRows = () => {
@@ -825,6 +836,10 @@ export function deriveMessagesTimelineRows(input: {
       continue;
     }
 
+    if (timelineEntry.id === activeCompactionEntry?.id) {
+      continue;
+    }
+
     if (activeWorkEntryIds.has(timelineEntry.id)) {
       continue;
     }
@@ -837,6 +852,7 @@ export function deriveMessagesTimelineRows(input: {
         if (
           !nextEntry ||
           nextEntry.kind !== "work" ||
+          nextEntry.id === activeCompactionEntry?.id ||
           activeWorkEntryIds.has(nextEntry.id) ||
           collapsedEntryIds.has(nextEntry.id) ||
           foldsByAnchorEntryId.has(nextEntry.id)
@@ -1067,7 +1083,9 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
   switch (a.kind) {
     case "working":
       return (
-        a.createdAt === (b as typeof a).createdAt && a.showThinking === (b as typeof a).showThinking
+        a.createdAt === (b as typeof a).createdAt &&
+        a.showThinking === (b as typeof a).showThinking &&
+        a.compactionStartedAt === (b as typeof a).compactionStartedAt
       );
 
     case "turn-fold": {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -908,6 +908,46 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Work Log");
   });
 
+  it("shows an active context compaction with its own timer and icon", () => {
+    const turnId = TurnId.make("turn-compaction");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        isWorking
+        activeTurnStartedAt="2026-03-17T19:12:00.000Z"
+        latestTurn={{
+          turnId,
+          state: "running",
+          startedAt: "2026-03-17T19:12:00.000Z",
+          completedAt: null,
+        }}
+        runningTurnId={turnId}
+        timelineEntries={[
+          {
+            id: "entry-compaction",
+            kind: "work",
+            createdAt: MESSAGE_CREATED_AT,
+            entry: {
+              id: "work-compaction",
+              createdAt: MESSAGE_CREATED_AT,
+              turnId,
+              label: "Compacting context",
+              tone: "info",
+              sourceActivityKind: "context-compaction",
+              toolLifecycleStatus: "inProgress",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Compacting context for");
+    expect(markup).toContain("lucide-shrink");
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).not.toContain("Working for");
+    expect(markup).not.toContain("Thinking");
+  });
+
   it("summarizes changed files in one line", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -57,6 +57,7 @@ import {
   MousePointerClickIcon,
   PaintbrushIcon,
   SearchIcon,
+  ShrinkIcon,
   SquarePenIcon,
   TerminalIcon,
   Undo2Icon,
@@ -1313,11 +1314,25 @@ const TurnPlanTimelineRow = memo(function TurnPlanTimelineRow({
 
 function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "working" }> }) {
   const { workingStepLabel } = use(TimelineRowActivityCtx);
+  const compactionStartedAt = row.compactionStartedAt;
+  const compacting = compactionStartedAt !== undefined;
+
   return (
     <div>
       <div className="border-b border-border/60 pb-2 pt-1">
-        <div className="px-1 text-sm leading-relaxed text-muted-foreground tabular-nums">
-          {row.createdAt ? (
+        <div
+          className={cn(
+            "flex items-center gap-1.5 px-1 text-sm leading-relaxed tabular-nums",
+            compacting ? "text-foreground" : "text-muted-foreground",
+          )}
+          aria-live={compacting ? "polite" : undefined}
+        >
+          {compacting ? <ShrinkIcon className="size-4 shrink-0 text-sky-400" aria-hidden /> : null}
+          {compacting ? (
+            <>
+              Compacting context for <WorkingTimer createdAt={compactionStartedAt} />
+            </>
+          ) : row.createdAt ? (
             <>
               Working for <WorkingTimer createdAt={row.createdAt} />
             </>
@@ -2150,6 +2165,7 @@ type WorkEntryIconName =
   | "hammer"
   | "message-circle"
   | "search"
+  | "shrink"
   | "square-pen"
   | "terminal"
   | "wrench"
@@ -2174,6 +2190,8 @@ function WorkEntryIconSvg({ name, className }: { name: WorkEntryIconName; classN
       return <MessageCircleIcon className={className} aria-hidden />;
     case "search":
       return <SearchIcon className={className} aria-hidden />;
+    case "shrink":
+      return <ShrinkIcon className={className} aria-hidden />;
     case "square-pen":
       return <SquarePenIcon className={className} aria-hidden />;
     case "terminal":
@@ -2458,6 +2476,10 @@ const toolCallExpandedBodyClassName =
   "max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-secondary-label text-[length:var(--font-size-code,0.6875rem)] leading-relaxed select-text";
 
 function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
+  if (workEntry.sourceActivityKind === "context-compaction") {
+    return "shrink";
+  }
+
   if (
     workEntry.sourceActivityKind === "user-input.requested" ||
     workEntry.sourceActivityKind === "user-input.resolved"

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -34,6 +34,12 @@ In an existing Codex thread, send `/feedback` or `/feedback` followed by a descr
 issue. T3 Code uploads the thread and Codex logs to OpenAI and shows a thread ID that you can copy
 and share with OpenAI employees.
 
+## Automatic context compaction
+
+Codex compacts long conversations automatically when it needs more context space. While this runs,
+the thread shows "Compacting context" and the elapsed time. When it finishes, the work log shows
+"Context compacted" and the agent continues the same turn.
+
 ## Approve access to other apps
 
 When a Codex tool needs access to an app such as Safari, T3 Code shows the app name and asks for


### PR DESCRIPTION
Codex compaction can leave a thread looking stuck for more than a minute. Codex already sends start and finish events, but T3 discarded both.

Show "Compacting context" with its elapsed time on web, desktop, and mobile. Keep one work-log entry and update it to "Context compacted" when Codex finishes.

## Before

![A running Codex turn only shows Working and Thinking](https://files.tslop.org/2026/08/codex-compaction-before-4ae99f62.png)

## After

![A running Codex turn shows Compacting context with a compression icon and elapsed time](https://files.tslop.org/2026/08/codex-compaction-after-7dd2122a.png)

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and activity-mapping changes for a new Codex event type; no auth, payments, or data migration.
> 
> **Overview**
> Codex **context compaction** is no longer dropped: `item.started` / `item.completed` events with `context_compaction` become thread activities with a stable id, **"Compacting context"** while in progress and **"Context compacted"** when done.
> 
> While compaction runs on an active turn, clients **hoist it into the working indicator** instead of duplicating it in the work log—the timer counts from compaction start, copy switches from "Working for" to **"Compacting context for"** (web adds a shrink icon and `aria-live`), and completed compaction stays in the work log. Mobile and web timeline logic both filter the in-progress compaction row from grouped activities when appending the working row.
> 
> Tests cover ingestion, presentation, and UI; Codex user docs describe automatic compaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9375733e46892898f89a392852c2857ba7b10f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show active context compaction status in web and mobile working rows
> - Server `runtimeEventToActivities` now maps `context_compaction` started/completed events to a single normalized `context-compaction` activity with a stable ID so projections can replace the in-progress entry on completion.
> - Web `MessagesTimeline` and mobile `ThreadFeed` detect the latest in-progress compaction in the active turn, remove it from work entry lists, and render a dedicated working row with label `Compacting context for`, a shrink icon, and a timer starting at `compactionStartedAt`.
> - Web hides the `Thinking` indicator while compaction is active and sets `aria-live="polite"` on the compaction row.
> - Added user docs for automatic context compaction in [providers-codex.md](https://github.com/pingdotgg/t3code/pull/8197/files#diff-6dfeeb32c01b3cdb47a08ab85207fa688100295d19274792e75b67465ee06a70).
> - Behavioral Change: `deriveMessagesTimelineRows` and `deriveThreadFeedPresentation` suppress active compaction from work rows and set `showThinking` to false during compaction; completed compaction entries still appear in work logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9375733.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->