### PR TITLE
fix(web): theme circle click now switches appearance mode

### DIFF
--- a/apps/web/src/components/settings/ThemeSettings.test.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.test.tsx
@@ -1,0 +1,249 @@
+import type { ReactElement } from "react";
+import type { ThemeAppearance, ThemeDefinition, ThemeHalves, ThemeMode } from "../../themePalette";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { visitElements } from "../../test/reactElementTree";
+import { reactHookHarness as hooks } from "../../test/reactHookHarness";
+
+const themeEditorStore = vi.hoisted(() => ({
+  openThemeEditor: vi.fn(),
+}));
+
+const toast = vi.hoisted(() => ({
+  add: vi.fn(),
+  stackedThreadToast: vi.fn(() => ({})),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return {
+    ...actual,
+    useCallback: reactHookHarness.useCallback,
+    useMemo: reactHookHarness.useMemo,
+    useRef: reactHookHarness.useRef,
+    useState: reactHookHarness.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", async () => {
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return { c: reactHookHarness.useMemoCache };
+});
+
+vi.mock("./themeEditorStore", () => ({
+  useThemeEditorStore: (selector: (store: { openThemeEditor: unknown }) => unknown) =>
+    selector(themeEditorStore),
+}));
+
+vi.mock("../ui/toast", () => ({
+  toastManager: { add: toast.add },
+  stackedThreadToast: toast.stackedThreadToast,
+}));
+
+// The Tooltip components use @base-ui/react Portal, which needs a real DOM.
+// Replace them with pass-through stubs so the element tree stays inspectable.
+vi.mock("../ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: unknown }) => children,
+  Tooltip: ({ children }: { children: unknown }) => children,
+  TooltipTrigger: ({ render }: { render: unknown }) => render,
+  TooltipPopup: ({ children }: { children: unknown }) => children,
+}));
+
+import { ThemeLibrary } from "./ThemeSettings";
+
+// Grove is the first maintainer theme with both light and dark modes.
+const GROVE_THEME_ID = "grove";
+const OCEAN_THEME_ID = "ocean";
+
+function renderLibrary(overrides?: {
+  readonly appearanceMode?: ThemeMode;
+  readonly themeHalves?: ThemeHalves | null;
+}): {
+  element: ReactElement<Record<string, unknown>>;
+  setAppearanceMode: ReturnType<typeof vi.fn>;
+  setThemeHalf: ReturnType<typeof vi.fn>;
+  setTheme: ReturnType<typeof vi.fn>;
+} {
+  const setAppearanceMode = vi.fn(() => true);
+  const setThemeHalf = vi.fn(() => true);
+  const setTheme = vi.fn(() => true);
+
+  hooks.beginRender();
+  const element = ThemeLibrary({
+    theme: "system",
+    setTheme,
+    appearanceMode: overrides?.appearanceMode ?? "dark",
+    setAppearanceMode,
+    customThemes: [] as ReadonlyArray<ThemeDefinition>,
+    initialAppearance: "dark" as ThemeAppearance,
+    refreshTheme: vi.fn(),
+    isImportOpen: false,
+    onImportOpenChange: vi.fn(),
+    themeHalves: overrides?.themeHalves ?? null,
+    setThemeHalf,
+  }) as ReactElement<Record<string, unknown>>;
+
+  return { element, setAppearanceMode, setThemeHalf, setTheme };
+}
+
+function findCard(
+  tree: ReactElement<Record<string, unknown>>,
+  themeId: string,
+): ReactElement<Record<string, unknown>> | null {
+  return visitElements(tree, (el) => el.props.theme?.id === themeId);
+}
+
+describe("ThemeLibrary — assignHalf switches appearance mode", () => {
+  beforeEach(() => {
+    hooks.reset();
+    themeEditorStore.openThemeEditor.mockReset();
+    toast.add.mockReset();
+  });
+
+  it("switches to light mode when clicking light circle on a maintainer theme while in dark mode", () => {
+    const { element, setAppearanceMode, setThemeHalf } = renderLibrary({
+      appearanceMode: "dark",
+    });
+    const card = findCard(element, GROVE_THEME_ID);
+    expect(card).not.toBeNull();
+
+    (card!.props.onUseMode as (mode: ThemeMode) => void)("light");
+
+    expect(setThemeHalf).toHaveBeenCalledWith("light", GROVE_THEME_ID);
+    expect(setAppearanceMode).toHaveBeenCalledWith("light");
+  });
+
+  it("does not call setAppearanceMode when clicking dark circle while already in dark mode", () => {
+    const { element, setAppearanceMode, setThemeHalf } = renderLibrary({
+      appearanceMode: "dark",
+    });
+    const card = findCard(element, GROVE_THEME_ID);
+    expect(card).not.toBeNull();
+
+    (card!.props.onUseMode as (mode: ThemeMode) => void)("dark");
+
+    expect(setThemeHalf).toHaveBeenCalledWith("dark", GROVE_THEME_ID);
+    expect(setAppearanceMode).not.toHaveBeenCalled();
+  });
+
+  it("does not call setAppearanceMode when clicking light circle while already in light mode", () => {
+    const { element, setAppearanceMode, setThemeHalf } = renderLibrary({
+      appearanceMode: "light",
+    });
+    const card = findCard(element, GROVE_THEME_ID);
+    expect(card).not.toBeNull();
+
+    (card!.props.onUseMode as (mode: ThemeMode) => void)("light");
+
+    expect(setThemeHalf).toHaveBeenCalledWith("light", GROVE_THEME_ID);
+    expect(setAppearanceMode).not.toHaveBeenCalled();
+  });
+
+  it("switches to dark mode when clicking dark circle on a maintainer theme while in light mode", () => {
+    const { element, setAppearanceMode, setThemeHalf } = renderLibrary({
+      appearanceMode: "light",
+    });
+    const card = findCard(element, GROVE_THEME_ID);
+    expect(card).not.toBeNull();
+
+    (card!.props.onUseMode as (mode: ThemeMode) => void)("dark");
+
+    expect(setThemeHalf).toHaveBeenCalledWith("dark", GROVE_THEME_ID);
+    expect(setAppearanceMode).toHaveBeenCalledWith("dark");
+  });
+
+  it("does not call setAppearanceMode or setThemeHalf for system mode", () => {
+    const { element, setAppearanceMode, setThemeHalf } = renderLibrary();
+    const card = findCard(element, GROVE_THEME_ID);
+    expect(card).not.toBeNull();
+
+    (card!.props.onUseMode as (mode: ThemeMode) => void)("system");
+
+    expect(setThemeHalf).not.toHaveBeenCalled();
+    expect(setAppearanceMode).not.toHaveBeenCalled();
+  });
+
+  it("switches to light mode when clicking light circle on the default card while in dark mode", () => {
+    const { element, setAppearanceMode, setThemeHalf } = renderLibrary({
+      appearanceMode: "dark",
+    });
+    const defaultCard = findCard(element, "default");
+    expect(defaultCard).not.toBeNull();
+
+    (defaultCard!.props.onUseMode as (mode: ThemeMode) => void)("light");
+
+    expect(setThemeHalf).toHaveBeenCalledWith("light", null);
+    expect(setAppearanceMode).toHaveBeenCalledWith("light");
+  });
+});
+
+describe("ThemeLibrary — pickedModesFor highlights only the current appearance mode", () => {
+  beforeEach(() => {
+    hooks.reset();
+    themeEditorStore.openThemeEditor.mockReset();
+    toast.add.mockReset();
+  });
+
+  it("highlights only the dark circle on the default card in dark mode with no halves", () => {
+    const { element } = renderLibrary({ appearanceMode: "dark", themeHalves: null });
+    const defaultCard = findCard(element, "default");
+    expect(defaultCard).not.toBeNull();
+    expect(defaultCard!.props.activeModes).toEqual(["dark"]);
+  });
+
+  it("highlights only the light circle on the default card in light mode with no halves", () => {
+    const { element } = renderLibrary({ appearanceMode: "light", themeHalves: null });
+    const defaultCard = findCard(element, "default");
+    expect(defaultCard).not.toBeNull();
+    expect(defaultCard!.props.activeModes).toEqual(["light"]);
+  });
+
+  it("highlights only the owning card's circle when a non-default theme owns the current mode", () => {
+    const { element } = renderLibrary({
+      appearanceMode: "light",
+      themeHalves: { light: GROVE_THEME_ID },
+    });
+    const groveCard = findCard(element, GROVE_THEME_ID);
+    expect(groveCard).not.toBeNull();
+    expect(groveCard!.props.activeModes).toEqual(["light"]);
+
+    const defaultCard = findCard(element, "default");
+    expect(defaultCard).not.toBeNull();
+    expect(defaultCard!.props.activeModes).toEqual([]);
+  });
+
+  it("does not highlight any card for the non-active mode", () => {
+    const { element } = renderLibrary({
+      appearanceMode: "dark",
+      themeHalves: { light: GROVE_THEME_ID },
+    });
+    // Light mode is owned by Grove but we're in dark mode, so no card
+    // should highlight light. Default owns dark.
+    const groveCard = findCard(element, GROVE_THEME_ID);
+    expect(groveCard).not.toBeNull();
+    expect(groveCard!.props.activeModes).toEqual([]);
+
+    const defaultCard = findCard(element, "default");
+    expect(defaultCard).not.toBeNull();
+    expect(defaultCard!.props.activeModes).toEqual(["dark"]);
+  });
+
+  it("highlights only one card when different themes own each mode", () => {
+    const { element } = renderLibrary({
+      appearanceMode: "light",
+      themeHalves: { light: GROVE_THEME_ID, dark: OCEAN_THEME_ID },
+    });
+    const groveCard = findCard(element, GROVE_THEME_ID);
+    expect(groveCard).not.toBeNull();
+    expect(groveCard!.props.activeModes).toEqual(["light"]);
+
+    const oceanCard = findCard(element, OCEAN_THEME_ID);
+    expect(oceanCard).not.toBeNull();
+    expect(oceanCard!.props.activeModes).toEqual([]);
+
+    const defaultCard = findCard(element, "default");
+    expect(defaultCard).not.toBeNull();
+    expect(defaultCard!.props.activeModes).toEqual([]);
+  });
+});

--- a/apps/web/src/components/settings/ThemeSettings.tsx
+++ b/apps/web/src/components/settings/ThemeSettings.tsx
@@ -639,6 +639,12 @@ export function ThemeLibrary({
         }
         return;
       }
+      // Switch appearance mode before storing the half so `applyTheme` inside
+      // `setThemeHalf` resolves against the new mode, avoiding a two-frame
+      // flash where both the old and new appearance show as selected.
+      if (appearanceMode !== appearance) {
+        setAppearanceMode(appearance);
+      }
       if (!setThemeHalf(appearance, cardId)) {
         notifyThemeSaveFailure();
       }
@@ -648,6 +654,7 @@ export function ThemeLibrary({
       baseCardId,
       notifyThemeSaveFailure,
       persistTheme,
+      setAppearanceMode,
       setTheme,
       setThemeHalf,
       theme,
@@ -681,15 +688,11 @@ export function ThemeLibrary({
     assignHalf(mode, cardId);
   };
 
-  // Rings always show the effective owner of each appearance: an unpicked
-  // half belongs to the default card (a null owner), so a fresh install
-  // shows T3 Code selected instead of nothing.
-  const pickedModesFor = (cardId: string | null): ThemeMode[] => {
-    const rings: ThemeMode[] = [];
-    if (lightOwner === cardId) rings.push("light");
-    if (darkOwner === cardId) rings.push("dark");
-    return rings;
-  };
+  // Only highlight the circle matching the current appearance mode on the
+  // card that owns it. This keeps exactly one circle selected at a time.
+  const activeOwner = appearanceMode === "light" ? lightOwner : darkOwner;
+  const pickedModesFor = (cardId: string | null): ThemeMode[] =>
+    activeOwner === cardId ? [appearanceMode] : [];
 
   const wireframeColors = (appearance: ThemeAppearance) =>
     pickColors(appearance === "light" ? lightOwner : darkOwner, appearance);


### PR DESCRIPTION
## Problem
When clicking a light/dark theme circle in the theme selector, the appearance mode didn't switch. Users had to manually change the color theme dropdown after clicking a circle.

## Fix
- `assignHalf`: Automatically calls `setAppearanceMode` when clicking a circle for a different mode
- `pickedModesFor`: Changed from pair-model (showing both light/dark highlights) to single-circle model (only highlighting the current appearanceMode's circle)

## Testing
- 11 new unit tests covering both behaviors
- Visual verification confirmed fix works

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI and theme selection ordering only; no auth, data, or API changes.
> 
> **Overview**
> Fixes theme library light/dark circle clicks so they change the active appearance, not only which theme owns that half.
> 
> In **`assignHalf`**, when the picked circle’s mode differs from the current `appearanceMode`, **`setAppearanceMode` runs before `setThemeHalf`** so theme application matches the new mode and avoids a brief UI state where two circles look selected.
> 
> **`pickedModesFor`** no longer rings both light and dark owners on each card; it highlights **only the circle for the current `appearanceMode`** on the card that owns that mode, so one selection indicator is visible at a time.
> 
> Adds **`ThemeSettings.test.tsx`** with unit tests for mode switching (including default card and skipping redundant/`system` calls) and for the new single-circle highlighting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68ab12a12ca78394881eb14166d48aa284449c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ThemeLibrary` circle click to switch appearance mode before persisting half
> - `assignHalf` in [ThemeSettings.tsx](https://github.com/pingdotgg/t3code/pull/8199/files#diff-4cc84a2ea71f7b5fef270e04a72f0110c8530ee83377e432642907950560b408) now calls `setAppearanceMode` before `setThemeHalf` when the selected appearance differs from the current one, so `applyTheme` resolves against the new mode and avoids a transient mismatch where both old and new appearances appear selected.
> - Reworks `pickedModesFor` to highlight only the current `appearanceMode` on its owning card, ensuring exactly one highlighted circle at a time instead of marking both light and dark owners.
> - Adds a test suite in [ThemeSettings.test.tsx](https://github.com/pingdotgg/t3code/pull/8199/files#diff-da2b916987d0418e72d3faac4926315ffddd6602b75202b9394f148500c948a2) covering mode switching, redundant-call suppression, system mode, default card behavior, and single-circle highlighting.
> - Behavioral Change: Card highlighting now shows an active state only for the current appearance mode's card; the non-active mode is no longer highlighted anywhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 68ab12a. 1 file reviewed, 6 issues evaluated, 3 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/settings/ThemeSettings.tsx — 2 comments posted, 6 evaluated, 3 filtered</summary>
>
> - [line 646](https://github.com/pingdotgg/t3code/blob/e037bbc7b47d0bb89248948b9392147b9bf300ea/apps/web/src/components/settings/ThemeSettings.tsx#L646): `setAppearanceMode(appearance)` can return `false` when the appearance preference cannot be persisted, but this result is ignored and `setThemeHalf` still runs. A click from dark to a light circle can therefore save the light half while the app remains in dark mode, with no failure notification; the requested selection is silently only half-applied. Return on a failed mode switch (or roll back the half). <b>[ Already posted ]</b>
> - [line 695](https://github.com/pingdotgg/t3code/blob/e037bbc7b47d0bb89248948b9392147b9bf300ea/apps/web/src/components/settings/ThemeSettings.tsx#L695): With `appearanceMode === "system"`, the new `pickedModesFor` returns `["system"]` for the dark owner. Theme preview components only compare `activeModes` against `"light"` and `"dark"`, so no circle receives `aria-pressed`, the selection ring, or the sun/moon badge while System mode is selected. <b>[ Already posted ]</b>
> - [line 695](https://github.com/pingdotgg/t3code/blob/e037bbc7b47d0bb89248948b9392147b9bf300ea/apps/web/src/components/settings/ThemeSettings.tsx#L695): When `appearanceMode` is ` <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->