### PR TITLE
fix(mobile): stop Android desktop windows from clipping text

### DIFF
--- a/apps/mobile/plugins/withAndroidTabletOrientation.cjs
+++ b/apps/mobile/plugins/withAndroidTabletOrientation.cjs
@@ -5,16 +5,61 @@ const { withMainActivity } = require("expo/config-plugins");
 // portrait. iOS doesn't have this problem: iPads must support all orientations
 // because the app is multitasking-capable, so only iPhones end up portrait-only.
 // Mirror that split on Android: keep the manifest lock for phones and lift it at
-// runtime on tablets (smallest width >= 600dp, the standard tablet breakpoint),
-// since requestedOrientation set at runtime overrides the manifest value.
-// FULL_USER allows all four orientations while still respecting the user's
-// auto-rotate lock, matching iPad behavior. Foldables change
-// smallestScreenWidthDp on fold/unfold without recreating the activity
-// (smallestScreenSize is in the manifest's configChanges), so the policy is
-// re-evaluated in onConfigurationChanged: unfolding past the tablet breakpoint
-// unlocks rotation, and folding back restores the portrait lock.
+// runtime when the window is a tablet/fold (smallest width >= 600dp) OR a desktop
+// shell (UI_MODE_TYPE_DESK: Samsung DeX, Pixel Desktop, ChromeOS).
+// requestedOrientation set at runtime overrides the manifest value. FULL_USER
+// allows all four orientations while still respecting the user's auto-rotate
+// lock, matching iPad behavior.
+//
+// Foldables change smallestScreenWidthDp on fold/unfold without recreating the
+// activity (smallestScreenSize is in the manifest's configChanges), and desktop
+// windowing changes density the same way. Re-evaluate in onConfigurationChanged.
+//
+// Keep the unlock predicate in lockstep with
+// apps/mobile/src/lib/androidWindowing.ts.
 
-const ORIENTATION_METHODS = `
+const WINDOWING_IMPORTS = `
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
+import com.facebook.react.uimanager.DisplayMetricsHolder`;
+
+const WINDOWING_METHODS = `
+  // Applied in onCreate and re-applied on fold/unfold and desktop-window
+  // attach; added by withAndroidTabletOrientation.
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    applyWindowedOrientation()
+    rebindWindowDisplayMetrics()
+  }
+
+  private fun applyWindowedOrientation() {
+    val config = resources.configuration
+    val uiModeType = config.uiMode and Configuration.UI_MODE_TYPE_MASK
+    val unlockOrientation =
+      config.smallestScreenWidthDp >= 600 || uiModeType == Configuration.UI_MODE_TYPE_DESK
+    requestedOrientation =
+      if (unlockOrientation) {
+        ActivityInfo.SCREEN_ORIENTATION_FULL_USER
+      } else {
+        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+      }
+  }
+
+  // RN's host re-inits DisplayMetricsHolder from the React/application
+  // context, which keeps the phone's density inside a desktop window. Super
+  // already ran that path; re-bind from this activity so Yoga and text paint
+  // use the window metrics, then relayout.
+  private fun rebindWindowDisplayMetrics() {
+    DisplayMetricsHolder.initDisplayMetrics(this)
+    window.decorView.post { window.decorView.requestLayout() }
+  }
+`;
+
+const WINDOWING_ON_CREATE_CALL = `
+    applyWindowedOrientation()
+    rebindWindowDisplayMetrics()`;
+
+const LEGACY_ORIENTATION_METHODS = `
   // Applied in onCreate and re-applied on fold/unfold; added by
   // withAndroidTabletOrientation.
   override fun onConfigurationChanged(newConfig: Configuration) {
@@ -31,9 +76,6 @@ const ORIENTATION_METHODS = `
   }
 `;
 
-const ORIENTATION_ON_CREATE_CALL = `
-    applyTabletOrientation()`;
-
 function insertAfter(contents, anchor, insertion, description) {
   const index = contents.indexOf(anchor);
   if (index === -1) {
@@ -45,36 +87,61 @@ function insertAfter(contents, anchor, insertion, description) {
   return contents.slice(0, end) + insertion + contents.slice(end);
 }
 
-module.exports = function withAndroidTabletOrientation(config) {
+function patchMainActivity(contents) {
+  if (contents.includes("rebindWindowDisplayMetrics")) {
+    return contents;
+  }
+
+  if (contents.includes("applyTabletOrientation")) {
+    if (!contents.includes(LEGACY_ORIENTATION_METHODS.trim())) {
+      throw new Error(
+        "withAndroidTabletOrientation: found applyTabletOrientation but could not replace the legacy injection; update the plugin anchors.",
+      );
+    }
+    contents = contents.replace(LEGACY_ORIENTATION_METHODS, WINDOWING_METHODS);
+    contents = contents.replace("\n    applyTabletOrientation()", WINDOWING_ON_CREATE_CALL);
+    if (!contents.includes("import com.facebook.react.uimanager.DisplayMetricsHolder")) {
+      contents = insertAfter(
+        contents,
+        "import android.content.res.Configuration",
+        "\nimport com.facebook.react.uimanager.DisplayMetricsHolder",
+        "the Configuration import from the legacy injection",
+      );
+    }
+    return contents;
+  }
+
+  contents = insertAfter(
+    contents,
+    "import android.os.Bundle",
+    WINDOWING_IMPORTS,
+    "the android.os.Bundle import",
+  );
+  contents = insertAfter(
+    contents,
+    "class MainActivity : ReactActivity() {",
+    WINDOWING_METHODS,
+    "the MainActivity class declaration",
+  );
+  contents = insertAfter(
+    contents,
+    "super.onCreate(null)",
+    WINDOWING_ON_CREATE_CALL,
+    "the super.onCreate call",
+  );
+  return contents;
+}
+
+function withAndroidTabletOrientation(config) {
   return withMainActivity(config, (nextConfig) => {
-    let contents = nextConfig.modResults.contents;
     if (nextConfig.modResults.language !== "kt") {
       throw new Error("withAndroidTabletOrientation: MainActivity must be Kotlin.");
     }
-    if (contents.includes("SCREEN_ORIENTATION_FULL_USER")) {
-      return nextConfig;
-    }
-
-    contents = insertAfter(
-      contents,
-      "import android.os.Bundle",
-      "\nimport android.content.pm.ActivityInfo\nimport android.content.res.Configuration",
-      "the android.os.Bundle import",
-    );
-    contents = insertAfter(
-      contents,
-      "class MainActivity : ReactActivity() {",
-      ORIENTATION_METHODS,
-      "the MainActivity class declaration",
-    );
-    contents = insertAfter(
-      contents,
-      "super.onCreate(null)",
-      ORIENTATION_ON_CREATE_CALL,
-      "the super.onCreate call",
-    );
-
-    nextConfig.modResults.contents = contents;
+    nextConfig.modResults.contents = patchMainActivity(nextConfig.modResults.contents);
     return nextConfig;
   });
-};
+}
+
+withAndroidTabletOrientation.patchMainActivity = patchMainActivity;
+
+module.exports = withAndroidTabletOrientation;

--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -64,6 +64,7 @@ export function CompactBrandTitle(
           fontFamily: "DMSans-Medium",
           fontSize: 21,
           letterSpacing: -0.5,
+          ...(Platform.OS === "android" ? { includeFontPadding: false } : null),
         }}
       >
         Code
@@ -84,6 +85,7 @@ export function CompactBrandTitle(
             fontSize: 9,
             letterSpacing: 0.9,
             textTransform: "uppercase",
+            ...(Platform.OS === "android" ? { includeFontPadding: false } : null),
           }}
         >
           {stageLabel}

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -21,15 +21,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { SearchBarCommands } from "react-native-screens";
 
 import { AppText as Text } from "../../components/AppText";
-import { CompactBrandTitle } from "../../components/CompactBrandTitle";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { SymbolView } from "../../components/AppSymbol";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import {
-  ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
-  ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
   ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT,
+  androidSidebarPageTitleTextStyle,
 } from "../../lib/layoutMetrics";
 import { scopedProjectKey, scopedThreadKey } from "../../lib/scopedEntities";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -1305,24 +1303,20 @@ function ThreadNavigationSidebarPane(
           style={{ minHeight: ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT }}
         >
           {/* Title slot doubles as the connection status surface: while an
-              environment reconnects, the brand fades to a status label in
+              environment reconnects, "Threads" fades to a status label in
               place (no layout shift in the list below). */}
           <WorkspaceConnectionTitle
             grow
             onPress={props.onOpenEnvironmentSettings}
             size="pageTitle"
             brand={
-              <View
-                className="flex-1 justify-center"
-                style={{
-                  minHeight: Math.max(
-                    ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
-                    ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
-                  ),
-                }}
+              <Text
+                className="flex-1 font-t3-bold text-foreground"
+                numberOfLines={1}
+                style={androidSidebarPageTitleTextStyle()}
               >
-                <CompactBrandTitle allowFontScaling={false} />
-              </View>
+                Threads
+              </Text>
             }
           />
           <View className="flex-row items-center gap-2.5">

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -27,7 +27,7 @@ import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
 import {
   ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT,
-  androidSidebarPageTitleTextStyle,
+  androidSidebarPageTitleProps,
 } from "../../lib/layoutMetrics";
 import { scopedProjectKey, scopedThreadKey } from "../../lib/scopedEntities";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -1311,13 +1311,9 @@ function ThreadNavigationSidebarPane(
             size="pageTitle"
             brand={
               <Text
-                accessible
-                accessibilityLabel="T3 Code, Threads"
-                aria-level={1}
+                {...androidSidebarPageTitleProps()}
                 className="flex-1 font-t3-bold text-foreground"
                 numberOfLines={1}
-                role="heading"
-                style={androidSidebarPageTitleTextStyle()}
               >
                 Threads
               </Text>

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -26,6 +26,11 @@ import { ControlPillMenu } from "../../components/ControlPill";
 import { SymbolView } from "../../components/AppSymbol";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
+import {
+  ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
+  ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
+  ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT,
+} from "../../lib/layoutMetrics";
 import { scopedProjectKey, scopedThreadKey } from "../../lib/scopedEntities";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
@@ -1295,7 +1300,10 @@ function ThreadNavigationSidebarPane(
           backgroundColor,
         }}
       >
-        <View className="h-[50px] flex-row items-end gap-0.5 pr-2 pl-5">
+        <View
+          className="flex-row items-end gap-0.5 pr-2 pl-5"
+          style={{ minHeight: ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT }}
+        >
           {/* Title slot doubles as the connection status surface: while an
               environment reconnects, the brand fades to a status label in
               place (no layout shift in the list below). */}
@@ -1304,7 +1312,15 @@ function ThreadNavigationSidebarPane(
             onPress={props.onOpenEnvironmentSettings}
             size="pageTitle"
             brand={
-              <View className="h-11 flex-1 justify-center">
+              <View
+                className="flex-1 justify-center"
+                style={{
+                  minHeight: Math.max(
+                    ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
+                    ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
+                  ),
+                }}
+              >
                 <CompactBrandTitle allowFontScaling={false} />
               </View>
             }

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1311,8 +1311,12 @@ function ThreadNavigationSidebarPane(
             size="pageTitle"
             brand={
               <Text
+                accessible
+                accessibilityLabel="T3 Code, Threads"
+                aria-level={1}
                 className="flex-1 font-t3-bold text-foreground"
                 numberOfLines={1}
+                role="heading"
                 style={androidSidebarPageTitleTextStyle()}
               >
                 Threads

--- a/apps/mobile/src/lib/androidWindowing.test.ts
+++ b/apps/mobile/src/lib/androidWindowing.test.ts
@@ -1,0 +1,121 @@
+import * as NodeModule from "node:module";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ANDROID_TABLET_SMALLEST_WIDTH_DP,
+  ANDROID_UI_MODE_TYPE_CAR,
+  ANDROID_UI_MODE_TYPE_DESK,
+  ANDROID_UI_MODE_TYPE_NORMAL,
+  shouldUnlockAndroidScreenOrientation,
+} from "./androidWindowing";
+
+const require = NodeModule.createRequire(import.meta.url);
+const { patchMainActivity } = require("../../plugins/withAndroidTabletOrientation.cjs") as {
+  patchMainActivity: (contents: string) => string;
+};
+
+const EXPO_MAIN_ACTIVITY = `package com.t3tools.t3code
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+
+class MainActivity : ReactActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
+}
+`;
+
+const LEGACY_MAIN_ACTIVITY = `package com.t3tools.t3code
+import android.os.Bundle
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
+import com.facebook.react.ReactActivity
+
+class MainActivity : ReactActivity() {
+  // Applied in onCreate and re-applied on fold/unfold; added by
+  // withAndroidTabletOrientation.
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    applyTabletOrientation()
+  }
+
+  private fun applyTabletOrientation() {
+    requestedOrientation = if (resources.configuration.smallestScreenWidthDp >= 600) {
+      ActivityInfo.SCREEN_ORIENTATION_FULL_USER
+    } else {
+      ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+  }
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+    applyTabletOrientation()
+  }
+}
+`;
+
+describe("shouldUnlockAndroidScreenOrientation", () => {
+  it("keeps phones in the portrait manifest lock", () => {
+    expect(
+      shouldUnlockAndroidScreenOrientation({
+        smallestScreenWidthDp: 411,
+        uiModeType: ANDROID_UI_MODE_TYPE_NORMAL,
+      }),
+    ).toBe(false);
+  });
+
+  it("unlocks foldables and tablets at the 600dp smallest-width breakpoint", () => {
+    expect(
+      shouldUnlockAndroidScreenOrientation({
+        smallestScreenWidthDp: ANDROID_TABLET_SMALLEST_WIDTH_DP,
+        uiModeType: ANDROID_UI_MODE_TYPE_NORMAL,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUnlockAndroidScreenOrientation({
+        smallestScreenWidthDp: ANDROID_TABLET_SMALLEST_WIDTH_DP - 1,
+        uiModeType: ANDROID_UI_MODE_TYPE_NORMAL,
+      }),
+    ).toBe(false);
+  });
+
+  it("unlocks desktop windows (DeX, Pixel Desktop, ChromeOS) even when smallest width is phone-sized", () => {
+    expect(
+      shouldUnlockAndroidScreenOrientation({
+        smallestScreenWidthDp: 411,
+        uiModeType: ANDROID_UI_MODE_TYPE_DESK,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat other UI modes as desktop", () => {
+    expect(
+      shouldUnlockAndroidScreenOrientation({
+        smallestScreenWidthDp: 411,
+        uiModeType: ANDROID_UI_MODE_TYPE_CAR,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("withAndroidTabletOrientation MainActivity patch", () => {
+  it("unlocks desk-mode windows and rebinds display metrics from the activity", () => {
+    const patched = patchMainActivity(EXPO_MAIN_ACTIVITY);
+    expect(patched).toContain("UI_MODE_TYPE_DESK");
+    expect(patched).toContain(`smallestScreenWidthDp >= ${ANDROID_TABLET_SMALLEST_WIDTH_DP}`);
+    expect(patched).toContain("DisplayMetricsHolder.initDisplayMetrics(this)");
+    expect(patched).toContain("applyWindowedOrientation()");
+    expect(patched).toContain("rebindWindowDisplayMetrics()");
+  });
+
+  it("replaces the tablet-only injection on existing MainActivity files", () => {
+    const patched = patchMainActivity(LEGACY_MAIN_ACTIVITY);
+    expect(patched).not.toContain("applyTabletOrientation");
+    expect(patched).toContain("UI_MODE_TYPE_DESK");
+    expect(patched).toContain("DisplayMetricsHolder.initDisplayMetrics(this)");
+  });
+
+  it("is idempotent", () => {
+    const once = patchMainActivity(EXPO_MAIN_ACTIVITY);
+    expect(patchMainActivity(once)).toBe(once);
+  });
+});

--- a/apps/mobile/src/lib/androidWindowing.test.ts
+++ b/apps/mobile/src/lib/androidWindowing.test.ts
@@ -107,11 +107,29 @@ describe("withAndroidTabletOrientation MainActivity patch", () => {
     expect(patched).toContain("rebindWindowDisplayMetrics()");
   });
 
+  it("emits the complete phone/tablet/desk policy and configuration rebind path", () => {
+    const patched = patchMainActivity(EXPO_MAIN_ACTIVITY);
+    expect(patched).toContain(`val uiModeType = config.uiMode and Configuration.UI_MODE_TYPE_MASK`);
+    expect(patched).toContain(
+      `val unlockOrientation =\n      config.smallestScreenWidthDp >= ${ANDROID_TABLET_SMALLEST_WIDTH_DP} || uiModeType == Configuration.UI_MODE_TYPE_DESK`,
+    );
+    expect(patched).toContain(
+      `if (unlockOrientation) {\n        ActivityInfo.SCREEN_ORIENTATION_FULL_USER\n      } else {\n        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT`,
+    );
+    expect(patched).toContain(
+      "DisplayMetricsHolder.initDisplayMetrics(this)\n    window.decorView.post { window.decorView.requestLayout() }",
+    );
+    expect(patched).toContain(
+      "super.onConfigurationChanged(newConfig)\n    applyWindowedOrientation()\n    rebindWindowDisplayMetrics()",
+    );
+  });
+
   it("replaces the tablet-only injection on existing MainActivity files", () => {
     const patched = patchMainActivity(LEGACY_MAIN_ACTIVITY);
     expect(patched).not.toContain("applyTabletOrientation");
     expect(patched).toContain("UI_MODE_TYPE_DESK");
     expect(patched).toContain("DisplayMetricsHolder.initDisplayMetrics(this)");
+    expect(patched).toContain("applyWindowedOrientation()\n    rebindWindowDisplayMetrics()");
   });
 
   it("is idempotent", () => {

--- a/apps/mobile/src/lib/androidWindowing.ts
+++ b/apps/mobile/src/lib/androidWindowing.ts
@@ -1,0 +1,26 @@
+/**
+ * Android windowing policy for orientation. The Kotlin in
+ * `plugins/withAndroidTabletOrientation.cjs` must stay in lockstep with this
+ * function: phones stay portrait-locked, everything else that is a real
+ * window (tablet/fold inner screen, DeX, Pixel Desktop, ChromeOS) unlocks.
+ *
+ * `uiModeType` is `Configuration.uiMode & UI_MODE_TYPE_MASK`.
+ */
+export const ANDROID_TABLET_SMALLEST_WIDTH_DP = 600;
+
+/** `android.content.res.Configuration.UI_MODE_TYPE_NORMAL` */
+export const ANDROID_UI_MODE_TYPE_NORMAL = 1;
+/** `android.content.res.Configuration.UI_MODE_TYPE_DESK` — DeX, Pixel Desktop, ChromeOS. */
+export const ANDROID_UI_MODE_TYPE_DESK = 2;
+/** `android.content.res.Configuration.UI_MODE_TYPE_CAR` */
+export const ANDROID_UI_MODE_TYPE_CAR = 3;
+
+export function shouldUnlockAndroidScreenOrientation(input: {
+  readonly smallestScreenWidthDp: number;
+  readonly uiModeType: number;
+}): boolean {
+  if (input.smallestScreenWidthDp >= ANDROID_TABLET_SMALLEST_WIDTH_DP) {
+    return true;
+  }
+  return input.uiModeType === ANDROID_UI_MODE_TYPE_DESK;
+}

--- a/apps/mobile/src/lib/layoutMetrics.test.ts
+++ b/apps/mobile/src/lib/layoutMetrics.test.ts
@@ -4,6 +4,7 @@ import {
   ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
   ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
   ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT,
+  androidSidebarPageTitleProps,
   androidSidebarPageTitleTextStyle,
 } from "./layoutMetrics";
 
@@ -22,6 +23,16 @@ describe("Android sidebar page title geometry", () => {
       fontSize: ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
       lineHeight: ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
       includeFontPadding: false,
+    });
+  });
+
+  it("keeps the painted title's accessibility contract with its layout style", () => {
+    expect(androidSidebarPageTitleProps()).toEqual({
+      accessible: true,
+      accessibilityLabel: "T3 Code, Threads",
+      "aria-level": 1,
+      role: "heading",
+      style: androidSidebarPageTitleTextStyle(),
     });
   });
 });

--- a/apps/mobile/src/lib/layoutMetrics.test.ts
+++ b/apps/mobile/src/lib/layoutMetrics.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
+  ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
+  ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT,
+} from "./layoutMetrics";
+
+describe("Android sidebar page title geometry", () => {
+  it("gives the large Threads title a line box that fits inside its row", () => {
+    expect(ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT).toBeGreaterThan(
+      ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
+    );
+    expect(ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT).toBeGreaterThanOrEqual(
+      ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
+    );
+  });
+});

--- a/apps/mobile/src/lib/layoutMetrics.test.ts
+++ b/apps/mobile/src/lib/layoutMetrics.test.ts
@@ -4,6 +4,7 @@ import {
   ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
   ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
   ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT,
+  androidSidebarPageTitleTextStyle,
 } from "./layoutMetrics";
 
 describe("Android sidebar page title geometry", () => {
@@ -14,5 +15,13 @@ describe("Android sidebar page title geometry", () => {
     expect(ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT).toBeGreaterThanOrEqual(
       ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
     );
+  });
+
+  it("paints the title at that line box with Android font padding off", () => {
+    expect(androidSidebarPageTitleTextStyle()).toEqual({
+      fontSize: ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
+      lineHeight: ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
+      includeFontPadding: false,
+    });
   });
 });

--- a/apps/mobile/src/lib/layoutMetrics.ts
+++ b/apps/mobile/src/lib/layoutMetrics.ts
@@ -29,6 +29,21 @@ export function androidSidebarPageTitleTextStyle(): {
 }
 
 /**
+ * Accessibility and layout contract for the painted Android Threads title.
+ * Keep these props together so replacing the title cannot drop its TalkBack
+ * heading semantics while preserving the window-density line box.
+ */
+export function androidSidebarPageTitleProps() {
+  return {
+    accessible: true as const,
+    accessibilityLabel: "T3 Code, Threads" as const,
+    "aria-level": 1 as const,
+    role: "heading" as const,
+    style: androidSidebarPageTitleTextStyle(),
+  };
+}
+
+/**
  * Height of the native iOS navigation bar below the safe-area inset, used as
  * a fallback when the measured HeaderHeightContext is unavailable.
  */

--- a/apps/mobile/src/lib/layoutMetrics.ts
+++ b/apps/mobile/src/lib/layoutMetrics.ts
@@ -14,6 +14,20 @@ export const ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE = 34;
 export const ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT = 41;
 export const ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT = 50;
 
+/** Paint style for the Android split-view Threads heading. `includeFontPadding`
+ * must be off: the default extra ascent clips a 34px glyph inside the 50px row. */
+export function androidSidebarPageTitleTextStyle(): {
+  readonly fontSize: number;
+  readonly lineHeight: number;
+  readonly includeFontPadding: false;
+} {
+  return {
+    fontSize: ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE,
+    lineHeight: ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT,
+    includeFontPadding: false,
+  };
+}
+
 /**
  * Height of the native iOS navigation bar below the safe-area inset, used as
  * a fallback when the measured HeaderHeightContext is unavailable.

--- a/apps/mobile/src/lib/layoutMetrics.ts
+++ b/apps/mobile/src/lib/layoutMetrics.ts
@@ -5,6 +5,16 @@ export const HOME_HORIZONTAL_INSET = 20;
 export const IPAD_HOME_TITLE_OFFSET = 10;
 
 /**
+ * Android split-view "Threads" heading. Sized like an iOS large title, but the
+ * row must clear the line box: a 34px font in a 50px row with default Android
+ * `includeFontPadding` clips and smears, which desktop-window density misses
+ * make unreadable.
+ */
+export const ANDROID_SIDEBAR_PAGE_TITLE_FONT_SIZE = 34;
+export const ANDROID_SIDEBAR_PAGE_TITLE_LINE_HEIGHT = 41;
+export const ANDROID_SIDEBAR_PAGE_TITLE_ROW_MIN_HEIGHT = 50;
+
+/**
  * Height of the native iOS navigation bar below the safe-area inset, used as
  * a fallback when the measured HeaderHeightContext is unavailable.
  */


### PR DESCRIPTION
## Problem

This is a **bug fix** for already-broken Android desktop windows, not a new desktop-window feature.

On Samsung DeX and Pixel Desktop, T3 Code Android renders with clipped, overlapping type. Split layout turns on (so the window size is seen), but glyphs paint at the phone's density inside the desktop window. The same build is fine on a Fold inner screen.

Both reports are the same failure:

- #8195 — Galaxy Z Fold 4 in a 1920×1080 Samsung DeX window. Inner screen OK; DeX window unreadable.
- #8135 — Pixel 10a on Pixel Desktop / an external monitor (closed as a duplicate of #8195). Extra evidence: the **entire** UI is vertically clipped, the chat pane and settings do not fill the window, user and agent messages cut off, and resizing makes it worse.

## Fix

React Native's `DisplayMetricsHolder` re-inits from the application context, so `PixelUtil` (text, layout, `react-native-screens` frames) keeps the **phone** density inside a desktop window. That is why JS `useWindowDimensions()` can turn on split layout while painted glyphs and screen frames are still wrong.

- Unlock orientation for `UI_MODE_TYPE_DESK` as well as the 600dp tablet breakpoint (DeX / Pixel Desktop / ChromeOS, not just foldables).
- After RN's config-change path, rebind `DisplayMetricsHolder` from the **Activity** and request a relayout so Yoga, type, and screen frames use window metrics. This is the #8135 "content does not fill the window / settings is a tiny island" path, not only the sidebar title.
- Size the Android "Threads" title so a 34px font has a line box that fits its row (`includeFontPadding: false`).

Native fingerprint change (MainActivity). Needs a store/preview binary, not an OTA.

## Test plan

- [x] Unit tests for desk-mode orientation policy and MainActivity patch
- [ ] Install the EAS preview APK on a Galaxy Z Fold (DeX) or Pixel Desktop and open T3 Code in a freeform window
- [ ] Confirm sidebar/header type is legible, the chat pane fills the window, settings is not a tiny island, and resize keeps glyphs in their boxes
- [ ] Confirm the window still pairs over Tailscale

Fixes #8195
Fixes #8135

Made with Grok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android tablets, foldables, and desktop-mode windows can rotate when appropriate, while phones and car-mode windows remain portrait-locked.
  * Improved Android window metrics and relayout behavior for more accurate sizing and text rendering.
  * Updated the Threads sidebar title with improved sizing, spacing, and accessibility semantics.
* **Bug Fixes**
  * Removed excess Android font padding from branding and sidebar title text for more consistent alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->