### PR TITLE
feat(markdown): render frontmatter in file previews

### DIFF
--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import { parseMarkdownFrontmatter } from "@t3tools/client-runtime/markdown-frontmatter";
 import {
   Markdown,
   type CustomRenderers,
@@ -20,6 +21,7 @@ import {
   SelectableMarkdownText,
   type NativeMarkdownTextStyle,
 } from "../../native/SelectableMarkdownText";
+import { MarkdownFrontmatterTable } from "./MarkdownFrontmatterTable";
 
 interface MarkdownPreviewStyles {
   readonly theme: PartialMarkdownTheme;
@@ -187,6 +189,7 @@ export function FileMarkdownPreview(props: {
     }
   }, [props.onRefresh]);
   const styles = useMarkdownPreviewStyles();
+  const frontmatter = useMemo(() => parseMarkdownFrontmatter(props.markdown), [props.markdown]);
   const onLinkPress = useCallback((href: string) => {
     void tryOpenExternalUrl(href, "markdown-link");
   }, []);
@@ -205,9 +208,12 @@ export function FileMarkdownPreview(props: {
       }
     >
       <View className="mx-auto w-full max-w-[760px]">
+        {frontmatter.entries.length > 0 ? (
+          <MarkdownFrontmatterTable entries={frontmatter.entries} />
+        ) : null}
         {hasNativeSelectableMarkdownText() ? (
           <SelectableMarkdownText
-            markdown={props.markdown}
+            markdown={frontmatter.body}
             onLinkPress={onLinkPress}
             textStyle={styles.nativeTextStyle}
           />
@@ -218,7 +224,7 @@ export function FileMarkdownPreview(props: {
             styles={styles.styles}
             theme={styles.theme}
           >
-            {props.markdown}
+            {frontmatter.body}
           </Markdown>
         )}
       </View>

--- a/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
+++ b/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
@@ -1,7 +1,11 @@
 import type { MarkdownFrontmatterEntry } from "@t3tools/client-runtime/markdown-frontmatter";
+import { useState } from "react";
 import { ScrollView, Text as NativeText, View } from "react-native";
 
 import { useThemeColor } from "../../lib/useThemeColor";
+
+const MIN_KEY_COLUMN_WIDTH = 160;
+const MIN_VALUE_COLUMN_WIDTH = 400;
 
 function MarkdownFrontmatterList({
   items,
@@ -41,6 +45,18 @@ export function MarkdownFrontmatterTable({
   const textColor = String(useThemeColor("--color-md-body"));
   const strongColor = String(useThemeColor("--color-md-strong"));
   const codeColor = String(useThemeColor("--color-md-code-text"));
+  const [keyWidths, setKeyWidths] = useState<ReadonlyMap<string, number>>(() => new Map());
+  let measuredKeyColumnWidth = MIN_KEY_COLUMN_WIDTH;
+  let hasEveryKeyWidth = true;
+  for (const entry of entries) {
+    const keyWidth = keyWidths.get(entry.key);
+    if (keyWidth === undefined) {
+      hasEveryKeyWidth = false;
+      break;
+    }
+    measuredKeyColumnWidth = Math.max(measuredKeyColumnWidth, keyWidth);
+  }
+  const keyColumnWidth = hasEveryKeyWidth ? measuredKeyColumnWidth : null;
 
   return (
     <ScrollView
@@ -49,13 +65,34 @@ export function MarkdownFrontmatterTable({
       contentContainerStyle={{ minWidth: "100%" }}
       showsHorizontalScrollIndicator={false}
     >
-      <View className="min-w-[560px] flex-1 overflow-hidden border border-border">
+      <View
+        className="flex-1 overflow-hidden border border-border"
+        style={{ minWidth: (keyColumnWidth ?? MIN_KEY_COLUMN_WIDTH) + MIN_VALUE_COLUMN_WIDTH }}
+      >
         {entries.map((entry, index) => (
           <View
             key={entry.key}
             className={index === 0 ? "flex-row" : "flex-row border-t border-border"}
           >
-            <View className="min-w-40 shrink-0 items-end justify-center border-r border-border bg-card px-3 py-2">
+            <View
+              className="min-w-40 shrink-0 items-end justify-center border-r border-border bg-card px-3 py-2"
+              style={keyColumnWidth === null ? undefined : { width: keyColumnWidth }}
+              onLayout={
+                keyColumnWidth === null
+                  ? (event) => {
+                      const measuredWidth = Math.ceil(event.nativeEvent.layout.width);
+                      setKeyWidths((current) => {
+                        if (current.get(entry.key) === measuredWidth) {
+                          return current;
+                        }
+                        const next = new Map(current);
+                        next.set(entry.key, measuredWidth);
+                        return next;
+                      });
+                    }
+                  : undefined
+              }
+            >
               <NativeText
                 numberOfLines={1}
                 className="font-t3-bold text-sm"

--- a/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
+++ b/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
@@ -6,11 +6,9 @@ import { useThemeColor } from "../../lib/useThemeColor";
 function MarkdownFrontmatterList({
   items,
   textColor,
-  backgroundColor,
 }: {
   readonly items: ReadonlyArray<string>;
   readonly textColor: string;
-  readonly backgroundColor: string;
 }) {
   const occurrences = new Map<string, number>();
 
@@ -23,8 +21,7 @@ function MarkdownFrontmatterList({
         return (
           <View
             key={`${item}:${occurrence}`}
-            className="max-w-full rounded-sm border border-border px-2.5 py-1"
-            style={{ backgroundColor }}
+            className="max-w-full rounded-full border border-secondary-border bg-secondary px-2.5 py-1"
           >
             <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>
               {item}
@@ -43,42 +40,46 @@ export function MarkdownFrontmatterTable({
 }) {
   const textColor = String(useThemeColor("--color-md-body"));
   const strongColor = String(useThemeColor("--color-md-strong"));
-  const mutedBackgroundColor = String(useThemeColor("--color-md-blockquote-bg"));
   const codeColor = String(useThemeColor("--color-md-code-text"));
 
   return (
-    <View className="mb-6 overflow-hidden border border-border">
-      {entries.map((entry, index) => (
-        <View
-          key={entry.key}
-          className={index === 0 ? "flex-row" : "flex-row border-t border-border"}
-        >
-          <View className="w-28 shrink-0 items-end border-r border-border bg-card px-3 py-2">
-            <NativeText className="font-t3-bold text-sm" style={{ color: strongColor }}>
-              {entry.key}
-            </NativeText>
-          </View>
-          <View className="min-w-0 flex-1 px-3 py-2">
-            {entry.value.kind === "text" ? (
-              <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>
-                {entry.value.text}
+    <ScrollView
+      horizontal
+      className="mb-6"
+      contentContainerStyle={{ minWidth: "100%" }}
+      showsHorizontalScrollIndicator={false}
+    >
+      <View className="min-w-[560px] flex-1 overflow-hidden border border-border">
+        {entries.map((entry, index) => (
+          <View
+            key={entry.key}
+            className={index === 0 ? "flex-row" : "flex-row border-t border-border"}
+          >
+            <View className="w-40 shrink-0 items-end justify-center border-r border-border bg-card px-3 py-2">
+              <NativeText
+                numberOfLines={1}
+                className="font-t3-bold text-sm"
+                style={{ color: strongColor }}
+              >
+                {entry.key}
               </NativeText>
-            ) : entry.value.kind === "list" ? (
-              <MarkdownFrontmatterList
-                items={entry.value.items}
-                textColor={textColor}
-                backgroundColor={mutedBackgroundColor}
-              />
-            ) : (
-              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            </View>
+            <View className="min-w-0 flex-1 px-3 py-2">
+              {entry.value.kind === "text" ? (
+                <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>
+                  {entry.value.text}
+                </NativeText>
+              ) : entry.value.kind === "list" ? (
+                <MarkdownFrontmatterList items={entry.value.items} textColor={textColor} />
+              ) : (
                 <NativeText className="font-mono text-xs" style={{ color: codeColor }}>
                   {entry.value.source}
                 </NativeText>
-              </ScrollView>
-            )}
+              )}
+            </View>
           </View>
-        </View>
-      ))}
-    </View>
+        ))}
+      </View>
+    </ScrollView>
   );
 }

--- a/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
+++ b/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
@@ -20,7 +20,7 @@ function MarkdownFrontmatterList({
 
         return (
           <View
-            key={`${item}:${occurrence}`}
+            key={JSON.stringify([item, occurrence])}
             className="max-w-full rounded-full border border-secondary-border bg-secondary px-2.5 py-1"
           >
             <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>
@@ -55,7 +55,7 @@ export function MarkdownFrontmatterTable({
             key={entry.key}
             className={index === 0 ? "flex-row" : "flex-row border-t border-border"}
           >
-            <View className="w-40 shrink-0 items-end justify-center border-r border-border bg-card px-3 py-2">
+            <View className="min-w-40 shrink-0 items-end justify-center border-r border-border bg-card px-3 py-2">
               <NativeText
                 numberOfLines={1}
                 className="font-t3-bold text-sm"

--- a/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
+++ b/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
@@ -23,7 +23,7 @@ function MarkdownFrontmatterList({
         return (
           <View
             key={`${item}:${occurrence}`}
-            className="rounded-sm border border-border px-2.5 py-1"
+            className="max-w-full rounded-sm border border-border px-2.5 py-1"
             style={{ backgroundColor }}
           >
             <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>

--- a/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
+++ b/apps/mobile/src/features/files/MarkdownFrontmatterTable.tsx
@@ -1,0 +1,84 @@
+import type { MarkdownFrontmatterEntry } from "@t3tools/client-runtime/markdown-frontmatter";
+import { ScrollView, Text as NativeText, View } from "react-native";
+
+import { useThemeColor } from "../../lib/useThemeColor";
+
+function MarkdownFrontmatterList({
+  items,
+  textColor,
+  backgroundColor,
+}: {
+  readonly items: ReadonlyArray<string>;
+  readonly textColor: string;
+  readonly backgroundColor: string;
+}) {
+  const occurrences = new Map<string, number>();
+
+  return (
+    <View className="flex-row flex-wrap gap-1">
+      {items.map((item) => {
+        const occurrence = occurrences.get(item) ?? 0;
+        occurrences.set(item, occurrence + 1);
+
+        return (
+          <View
+            key={`${item}:${occurrence}`}
+            className="rounded-sm border border-border px-2.5 py-1"
+            style={{ backgroundColor }}
+          >
+            <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>
+              {item}
+            </NativeText>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export function MarkdownFrontmatterTable({
+  entries,
+}: {
+  readonly entries: ReadonlyArray<MarkdownFrontmatterEntry>;
+}) {
+  const textColor = String(useThemeColor("--color-md-body"));
+  const strongColor = String(useThemeColor("--color-md-strong"));
+  const mutedBackgroundColor = String(useThemeColor("--color-md-blockquote-bg"));
+  const codeColor = String(useThemeColor("--color-md-code-text"));
+
+  return (
+    <View className="mb-6 overflow-hidden border border-border">
+      {entries.map((entry, index) => (
+        <View
+          key={entry.key}
+          className={index === 0 ? "flex-row" : "flex-row border-t border-border"}
+        >
+          <View className="w-28 shrink-0 items-end border-r border-border bg-card px-3 py-2">
+            <NativeText className="font-t3-bold text-sm" style={{ color: strongColor }}>
+              {entry.key}
+            </NativeText>
+          </View>
+          <View className="min-w-0 flex-1 px-3 py-2">
+            {entry.value.kind === "text" ? (
+              <NativeText className="font-t3-regular text-sm" style={{ color: textColor }}>
+                {entry.value.text}
+              </NativeText>
+            ) : entry.value.kind === "list" ? (
+              <MarkdownFrontmatterList
+                items={entry.value.items}
+                textColor={textColor}
+                backgroundColor={mutedBackgroundColor}
+              />
+            ) : (
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <NativeText className="font-mono text-xs" style={{ color: codeColor }}>
+                  {entry.value.source}
+                </NativeText>
+              </ScrollView>
+            )}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -12,6 +12,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { parseMarkdownFrontmatter } from "@t3tools/client-runtime/markdown-frontmatter";
 import { ChevronRight, Code2, Eye, FolderTree, Globe2, LoaderCircle } from "lucide-react";
 import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -58,6 +59,7 @@ import { projectFileCacheKey, projectFileEditorCacheKey } from "./fileContentRev
 import { fileBreadcrumbs } from "./filePath";
 import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
+import { MarkdownFrontmatterTable } from "./MarkdownFrontmatterTable";
 import {
   confirmProjectFileQueryData,
   getOptimisticProjectFileQueryData,
@@ -724,24 +726,34 @@ function RenderedMarkdownSurface({
     relativePath,
     onPendingChange,
   });
+  const frontmatter = useMemo(() => parseMarkdownFrontmatter(contents), [contents]);
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <ChatMarkdown
-        text={contents}
-        cwd={cwd}
-        threadRef={threadRef}
-        className="mx-auto max-w-4xl px-6 py-5"
-        onTaskListChange={({ markerOffset, checked }) => {
-          const currentContents =
-            getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
-            contents;
-          const nextContents = setMarkdownTaskChecked(currentContents, markerOffset, checked);
-          if (nextContents === currentContents) return;
-          setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
-          saveCoordinator.change(nextContents);
-        }}
-      />
+      <div className="mx-auto max-w-4xl px-6 py-5">
+        {frontmatter.entries.length > 0 ? (
+          <MarkdownFrontmatterTable entries={frontmatter.entries} />
+        ) : null}
+        <ChatMarkdown
+          text={frontmatter.body}
+          cwd={cwd}
+          threadRef={threadRef}
+          className={frontmatter.entries.length > 0 ? "mt-8" : ""}
+          onTaskListChange={({ markerOffset, checked }) => {
+            const currentContents =
+              getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??
+              contents;
+            const nextContents = setMarkdownTaskChecked(
+              currentContents,
+              frontmatter.bodyOffset + markerOffset,
+              checked,
+            );
+            if (nextContents === currentContents) return;
+            setProjectFileQueryData(environmentId, cwd, relativePath, nextContents);
+            saveCoordinator.change(nextContents);
+          }}
+        />
+      </div>
     </ScrollArea>
   );
 }

--- a/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
+++ b/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
@@ -32,9 +32,9 @@ export function MarkdownFrontmatterTable({
       chainVerticalScroll
       scrollFade
       hideScrollbars
-      className="chat-markdown w-full max-w-full rounded-none"
+      className="w-full max-w-full rounded-none"
     >
-      <table>
+      <table className="markdown-table">
         <tbody>
           {entries.map((entry) => (
             <tr key={entry.key}>

--- a/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
+++ b/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
@@ -1,0 +1,59 @@
+import type { MarkdownFrontmatterEntry } from "@t3tools/client-runtime/markdown-frontmatter";
+
+function MarkdownFrontmatterList({ items }: { readonly items: ReadonlyArray<string> }) {
+  const occurrences = new Map<string, number>();
+
+  return (
+    <span className="flex flex-wrap gap-1">
+      {items.map((item) => {
+        const occurrence = occurrences.get(item) ?? 0;
+        occurrences.set(item, occurrence + 1);
+
+        return (
+          <span
+            key={`${item}:${occurrence}`}
+            className="rounded-sm border border-border bg-muted/30 px-2.5 py-0.5"
+          >
+            {item}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+export function MarkdownFrontmatterTable({
+  entries,
+}: {
+  readonly entries: ReadonlyArray<MarkdownFrontmatterEntry>;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm text-foreground/80">
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.key}>
+              <th
+                scope="row"
+                className="w-px whitespace-nowrap border border-border bg-muted/30 px-4 py-2 text-right align-top font-semibold text-foreground"
+              >
+                {entry.key}
+              </th>
+              <td className="border border-border px-4 py-2 align-top">
+                {entry.value.kind === "text" ? (
+                  <span className="whitespace-pre-wrap">{entry.value.text}</span>
+                ) : entry.value.kind === "list" ? (
+                  <MarkdownFrontmatterList items={entry.value.items} />
+                ) : (
+                  <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-xs leading-relaxed">
+                    {entry.value.source}
+                  </pre>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
+++ b/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
@@ -40,7 +40,7 @@ export function MarkdownFrontmatterTable({
             <tr key={entry.key}>
               <th
                 scope="row"
-                className="w-px whitespace-nowrap bg-muted/30 !text-right align-middle font-semibold text-foreground"
+                className="w-px whitespace-nowrap bg-muted/30 text-right align-middle font-semibold text-foreground"
               >
                 {entry.key}
               </th>

--- a/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
+++ b/apps/web/src/components/files/MarkdownFrontmatterTable.tsx
@@ -1,5 +1,8 @@
 import type { MarkdownFrontmatterEntry } from "@t3tools/client-runtime/markdown-frontmatter";
 
+import { Badge } from "~/components/ui/badge";
+import { ScrollArea } from "~/components/ui/scroll-area";
+
 function MarkdownFrontmatterList({ items }: { readonly items: ReadonlyArray<string> }) {
   const occurrences = new Map<string, number>();
 
@@ -10,12 +13,9 @@ function MarkdownFrontmatterList({ items }: { readonly items: ReadonlyArray<stri
         occurrences.set(item, occurrence + 1);
 
         return (
-          <span
-            key={`${item}:${occurrence}`}
-            className="rounded-sm border border-border bg-muted/30 px-2.5 py-0.5"
-          >
+          <Badge key={JSON.stringify([item, occurrence])} variant="outline">
             {item}
-          </span>
+          </Badge>
         );
       })}
     </span>
@@ -28,18 +28,23 @@ export function MarkdownFrontmatterTable({
   readonly entries: ReadonlyArray<MarkdownFrontmatterEntry>;
 }) {
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-sm text-foreground/80">
+    <ScrollArea
+      chainVerticalScroll
+      scrollFade
+      hideScrollbars
+      className="chat-markdown w-full max-w-full rounded-none"
+    >
+      <table>
         <tbody>
           {entries.map((entry) => (
             <tr key={entry.key}>
               <th
                 scope="row"
-                className="w-px whitespace-nowrap border border-border bg-muted/30 px-4 py-2 text-right align-top font-semibold text-foreground"
+                className="w-px whitespace-nowrap bg-muted/30 !text-right align-middle font-semibold text-foreground"
               >
                 {entry.key}
               </th>
-              <td className="border border-border px-4 py-2 align-top">
+              <td className="align-top text-foreground/80">
                 {entry.value.kind === "text" ? (
                   <span className="whitespace-pre-wrap">{entry.value.text}</span>
                 ) : entry.value.kind === "list" ? (
@@ -54,6 +59,6 @@ export function MarkdownFrontmatterTable({
           ))}
         </tbody>
       </table>
-    </div>
+    </ScrollArea>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2343,7 +2343,8 @@ code {
    wrapping rules (overflow-wrap: anywhere) would let columns shrink to single
    characters and defeat the overflow — restore word-boundary wrapping so the
    min column width is the longest word. */
-.chat-markdown table {
+.chat-markdown table,
+.markdown-table {
   width: 100%;
   min-width: max-content;
   border-collapse: collapse;
@@ -2353,12 +2354,15 @@ code {
 }
 
 .chat-markdown th,
-.chat-markdown td {
+.chat-markdown td,
+.markdown-table th,
+.markdown-table td {
   padding: 0.45rem 0.75rem;
   text-align: left;
 }
 
-.chat-markdown thead th {
+.chat-markdown thead th,
+.markdown-table thead th {
   border-bottom: 1px solid color-mix(in srgb, var(--contrast-border) 60%, transparent);
   padding-block: 0.55rem;
   font-weight: 600;
@@ -2366,7 +2370,9 @@ code {
 }
 
 .chat-markdown tbody th,
-.chat-markdown tbody td {
+.chat-markdown tbody td,
+.markdown-table tbody th,
+.markdown-table tbody td {
   border-bottom: 1px solid color-mix(in srgb, var(--contrast-border) 60%, transparent);
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2346,11 +2346,14 @@ code {
 .chat-markdown table,
 .markdown-table {
   width: 100%;
-  min-width: max-content;
   border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+.chat-markdown table {
+  min-width: max-content;
   overflow-wrap: normal;
   word-break: normal;
-  font-size: 0.75rem;
 }
 
 .chat-markdown th,
@@ -2358,6 +2361,11 @@ code {
 .markdown-table th,
 .markdown-table td {
   padding: 0.45rem 0.75rem;
+}
+
+.chat-markdown th,
+.chat-markdown td,
+.markdown-table td {
   text-align: left;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2365,6 +2365,7 @@ code {
   white-space: nowrap;
 }
 
+.chat-markdown tbody th,
 .chat-markdown tbody td {
   border-bottom: 1px solid color-mix(in srgb, var(--contrast-border) 60%, transparent);
 }

--- a/docs/user/file-previews.md
+++ b/docs/user/file-previews.md
@@ -1,0 +1,16 @@
+# File previews
+
+Markdown files can switch between source and rendered views on web and desktop. Mobile opens
+Markdown files in the rendered view.
+
+## YAML frontmatter
+
+Rendered Markdown recognizes YAML frontmatter when the file starts with a `---` line, ends the
+frontmatter with another `---` line, and contains a YAML mapping. T3 Code displays the mapping as a
+metadata table above the Markdown body.
+
+Scalar values appear as text. Arrays containing only scalar values appear as pills. Nested objects
+and arrays remain formatted as YAML.
+
+Invalid YAML, an unclosed frontmatter block, or a frontmatter value that is not a mapping remains in
+the Markdown body unchanged.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -19,6 +19,10 @@
       "types": "./src/markdownImages.ts",
       "default": "./src/markdownImages.ts"
     },
+    "./markdown-frontmatter": {
+      "types": "./src/markdownFrontmatter.ts",
+      "default": "./src/markdownFrontmatter.ts"
+    },
     "./errors": {
       "types": "./src/errors/index.ts",
       "default": "./src/errors/index.ts"

--- a/packages/client-runtime/src/markdownFrontmatter.ts
+++ b/packages/client-runtime/src/markdownFrontmatter.ts
@@ -1,0 +1,99 @@
+import { fromYaml } from "@t3tools/shared/schemaYaml";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+const FrontmatterDocument = fromYaml(Schema.Record(Schema.String, Schema.Json));
+const decodeFrontmatterDocument = Schema.decodeUnknownOption(FrontmatterDocument);
+const encodeYamlValue = Schema.encodeSync(fromYaml(Schema.Json));
+
+export type MarkdownFrontmatterValue =
+  | { readonly kind: "text"; readonly text: string }
+  | {
+      readonly kind: "list";
+      readonly items: ReadonlyArray<string>;
+    }
+  | { readonly kind: "yaml"; readonly source: string };
+
+export interface MarkdownFrontmatterEntry {
+  readonly key: string;
+  readonly value: MarkdownFrontmatterValue;
+}
+
+export interface MarkdownFrontmatter {
+  readonly body: string;
+  readonly bodyOffset: number;
+  readonly entries: ReadonlyArray<MarkdownFrontmatterEntry>;
+}
+
+function displayFrontmatterValue(value: Schema.Json): MarkdownFrontmatterValue {
+  if (value === null) {
+    return { kind: "text", text: "null" };
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return { kind: "text", text: String(value) };
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    const items: Array<string> = [];
+    for (const item of value) {
+      if (item === null) {
+        items.push("null");
+      } else if (
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "boolean"
+      ) {
+        items.push(String(item));
+      } else {
+        return { kind: "yaml", source: encodeYamlValue(value).trimEnd() };
+      }
+    }
+    return { kind: "list", items };
+  }
+  return { kind: "yaml", source: encodeYamlValue(value).trimEnd() };
+}
+
+export function parseMarkdownFrontmatter(markdown: string): MarkdownFrontmatter {
+  const unparsed: MarkdownFrontmatter = { body: markdown, bodyOffset: 0, entries: [] };
+  const openingLineEnd = markdown.indexOf("\n");
+  if (openingLineEnd === -1) {
+    return unparsed;
+  }
+
+  const openingLine = markdown.slice(0, openingLineEnd).replace(/\r$/, "");
+  if (openingLine !== "---") {
+    return unparsed;
+  }
+
+  const yamlStart = openingLineEnd + 1;
+  let lineStart = yamlStart;
+  while (lineStart <= markdown.length) {
+    const nextLineEnd = markdown.indexOf("\n", lineStart);
+    const lineEnd = nextLineEnd === -1 ? markdown.length : nextLineEnd;
+    const line = markdown.slice(lineStart, lineEnd).replace(/\r$/, "");
+
+    if (line === "---") {
+      const decoded = decodeFrontmatterDocument(markdown.slice(yamlStart, lineStart));
+      if (Option.isNone(decoded)) {
+        return unparsed;
+      }
+
+      const entries = Object.entries(decoded.value).map(([key, value]) => ({
+        key,
+        value: displayFrontmatterValue(value),
+      }));
+      const bodyOffset = nextLineEnd === -1 ? lineEnd : nextLineEnd + 1;
+      return {
+        body: markdown.slice(bodyOffset),
+        bodyOffset,
+        entries,
+      };
+    }
+
+    if (nextLineEnd === -1) {
+      break;
+    }
+    lineStart = nextLineEnd + 1;
+  }
+
+  return unparsed;
+}


### PR DESCRIPTION
## What Changed

Markdown file previews now render leading YAML frontmatter as a metadata table on web, desktop, and mobile.

Scalar arrays render as pills. Nested values render as YAML. Invalid, unclosed, and non-mapping frontmatter remains unchanged.

## Why

File previews previously displayed frontmatter as raw Markdown delimiters and YAML. This matches GitHub's metadata-table presentation while keeping parsing shared and platform rendering local.

## UI Changes

Before: <img width="1580" height="1059" alt="browser-screenshot-linux-t3-tarik02-me-mt8pqmtj" src="https://github.com/user-attachments/assets/ba9e6610-8afa-4a8b-a83b-6bfce0d7c795" />

After: <img width="1600" height="1000" alt="browser-screenshot-localhost-mt8ppbw6" src="https://github.com/user-attachments/assets/c35e24d3-c425-4cae-b76d-757c41737a65" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] No animation or interaction changes require a video

Implemented with GPT-5.6 Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Strips frontmatter from the rendered stream and shifts task-list save offsets; a parsing or offset bug could mis-edit markdown files that include frontmatter.
> 
> **Overview**
> **Rendered markdown file previews** now peel off leading `---` YAML frontmatter and show it as a **metadata table** above the body on web/desktop and mobile, instead of rendering the raw delimiter block as markdown.
> 
> A shared **`parseMarkdownFrontmatter`** export splits the file into `entries`, `body`, and **`bodyOffset`** (for mapping edits back into the full source). Scalars render as text, homogeneous scalar arrays as pills/badges, and nested structures as monospace YAML. Invalid, unclosed, or non-mapping frontmatter is left in the body unchanged.
> 
> **Web** `RenderedMarkdownSurface` passes only `frontmatter.body` to `ChatMarkdown` and adds **`frontmatter.bodyOffset`** when applying task-list checkbox toggles via `setMarkdownTaskChecked`. **Mobile** `FileMarkdownPreview` does the same split for native/selectable markdown renderers. New platform **`MarkdownFrontmatterTable`** components handle layout; web adds a **`.markdown-table`** CSS hook sharing compact table styling with chat markdown. User docs describe detection and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9eea87011f9d965e892b1f4a819c55a79206df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render YAML frontmatter as a metadata table in file previews
> - Adds shared `parseMarkdownFrontmatter` in [markdownFrontmatter.ts](https://github.com/pingdotgg/t3code/pull/8202/files#diff-7bdeb47272203f99d2d9ad92e8164cf47daa37453dd62b5d6b6d82420e6e4c71) (exported via `./markdown-frontmatter`) that splits a markdown string into frontmatter entries, a body segment, and a `bodyOffset` for source mapping
> - Mobile ([FileMarkdownPreview.tsx](https://github.com/pingdotgg/t3code/pull/8202/files#diff-a649b163d6f705bb43fa65e79710284d49d101eb4a555659a1547585863d61d4)) and web ([FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/8202/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea)) now render a new `MarkdownFrontmatterTable` above the markdown body and pass only `frontmatter.body` to the markdown renderer
> - Frontmatter values render as text, pill/badge lists, or monospace YAML depending on their inferred type
> - Web adjusts `onTaskListChange` marker offsets by `frontmatter.bodyOffset` so checkbox mutations map back to the original file contents
> - Extends [index.css](https://github.com/pingdotgg/t3code/pull/8202/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) with a `.markdown-table` class sharing compact table styles with `.chat-markdown` without the chat-specific overflow rules
> - Behavioral Change: rendered markdown no longer includes the raw frontmatter block; files without valid `---` delimited frontmatter render unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae9eea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown file previews now detect and display YAML frontmatter metadata in formatted tables across web and mobile.
  * Metadata values support text, lists, and structured YAML formatting.
  * Markdown content renders separately from its frontmatter, with task-list editing preserved.
  * Invalid or unsupported frontmatter safely falls back to standard Markdown rendering.

* **Documentation**
  * Added documentation covering frontmatter detection, display, formatting, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->