### PR TITLE
fix(pull-requests): open Azure PRs with pullRequestRepositoryOf

### DIFF
--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -10,6 +10,7 @@ import {
   PullRequestUnavailableError,
   pullRequestHostOf,
   pullRequestProviderRequirement,
+  pullRequestRepositoryOf,
   resolvePullRequestAuthorFilter,
   type OrchestrationProjectShell,
   type PullRequestAction,
@@ -461,27 +462,13 @@ function withRateLimitBackoff(
 }
 
 /**
- * The provider-native repository selector. `displayName` is the full path below the host, which
- * is what nested GitLab groups need; owner/name is the two-segment fallback for identities
- * recorded before that field existed.
- *
- * Azure DevOps is the exception: `az repos pr list --repository` takes a repository name, and
- * takes the organisation and project from the checkout it detects — so the recorded
- * `org/project/_git/repo` path is refused outright and the whole repository reads as
- * unavailable. Its name is the last segment, which is what this hands over.
- *
- * One function because everything downstream is keyed by what it answers: the rows' own
- * `repository`, the per-repository cursors, and the detail and diff reads a row leads to.
+ * The provider-native repository selector. Shared as `pullRequestRepositoryOf` so the page and
+ * this service name a repository the same way. Everything downstream is keyed by what it
+ * answers: the rows' own `repository`, the per-repository cursors, and the detail and diff
+ * reads a row leads to.
  */
 export function repositoryIdentityOf(project: OrchestrationProjectShell): string | null {
-  const identity = project.repositoryIdentity;
-  if (!identity) return null;
-  if (identity.provider === "azure-devops") {
-    const segments = (identity.displayName ?? "").split("/").filter((part) => part !== "_git");
-    return identity.name || segments.at(-1) || null;
-  }
-  if (identity.displayName) return identity.displayName;
-  return identity.owner && identity.name ? `${identity.owner}/${identity.name}` : null;
+  return pullRequestRepositoryOf(project.repositoryIdentity);
 }
 
 export const make = Effect.gen(function* () {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -111,6 +111,7 @@ import {
   findProjectForChangeRequest,
   matchesLinkedPullRequestUrl,
   parseChangeRequestUrl,
+  pullRequestTargetOf,
   useOpenChangeRequestLink,
 } from "~/lib/openPullRequestLink";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
@@ -1561,10 +1562,12 @@ function ChatMarkdown({
         parsed,
       );
       if (project === undefined) return null;
+      const target = pullRequestTargetOf(project, parsed.number);
+      if (target === null) return null;
       return {
-        projectId: project.id,
-        repository: project.repositoryIdentity?.displayName ?? parsed.repository,
-        number: parsed.number,
+        projectId: target.projectId as ThreadLinkedPullRequest["projectId"],
+        repository: target.repository,
+        number: target.number,
         url: href,
       };
     },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3476,16 +3476,26 @@ function ChatViewContent(props: ChatViewProps) {
   );
   // The thread's own change request, placed against the project it belongs to. Without a
   // project there is nothing to resolve it against, so the caller falls back to the browser.
+  // Repository comes from pullRequestRepositoryOf on that project, not from a stored link path:
+  // Azure used to persist displayName, which requireProject refuses.
   const linkedThreadPullRequest = activeThread?.linkedPullRequest ?? null;
+  const linkedProject =
+    linkedThreadPullRequest === null
+      ? undefined
+      : allProjects.find((project) => project.id === linkedThreadPullRequest.projectId);
   const activeProjectRepository = pullRequestRepositoryOf(activeProject?.repositoryIdentity);
-  const threadRepository = linkedThreadPullRequest?.repository ?? activeProjectRepository;
+  const linkedRepository =
+    pullRequestRepositoryOf(linkedProject?.repositoryIdentity) ??
+    linkedThreadPullRequest?.repository ??
+    null;
+  const threadRepository = linkedRepository ?? activeProjectRepository;
   const openThreadPullRequest = useCallback(
     (number: number) => {
       if (!supportsPullRequests || !activeThreadRef) {
         return;
       }
       const projectId = linkedThreadPullRequest?.projectId ?? activeProject?.id;
-      const repository = linkedThreadPullRequest?.repository ?? activeProjectRepository;
+      const repository = linkedRepository ?? activeProjectRepository;
       if (projectId === undefined || repository === null) return;
       useRightPanelStore.getState().openPullRequest(activeThreadRef, {
         projectId,
@@ -3497,6 +3507,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeProject,
       activeProjectRepository,
       activeThreadRef,
+      linkedRepository,
       linkedThreadPullRequest,
       supportsPullRequests,
     ],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -10,6 +10,7 @@ import {
   type ProviderApprovalDecision,
   type PreviewAnnotationPayload,
   ProviderInstanceId,
+  pullRequestRepositoryOf,
   type ServerProvider,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
@@ -3476,7 +3477,7 @@ function ChatViewContent(props: ChatViewProps) {
   // The thread's own change request, placed against the project it belongs to. Without a
   // project there is nothing to resolve it against, so the caller falls back to the browser.
   const linkedThreadPullRequest = activeThread?.linkedPullRequest ?? null;
-  const activeProjectRepository = activeProject?.repositoryIdentity?.displayName ?? null;
+  const activeProjectRepository = pullRequestRepositoryOf(activeProject?.repositoryIdentity);
   const threadRepository = linkedThreadPullRequest?.repository ?? activeProjectRepository;
   const openThreadPullRequest = useCallback(
     (number: number) => {

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -7,6 +7,7 @@ import {
   openPullRequestLink,
   parseChangeRequestUrl,
   PullRequestLinkOpenError,
+  pullRequestTargetOf,
   shouldOpenPullRequestExternally,
 } from "./openPullRequestLink";
 import { ProjectId } from "@t3tools/contracts";
@@ -258,5 +259,24 @@ describe("findProjectForChangeRequest", () => {
         number: 1,
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("pullRequestTargetOf", () => {
+  it("opens and navigates to an Azure DevOps pull request by its short repository name", () => {
+    const project = {
+      id: "p1",
+      repositoryIdentity: {
+        provider: "azure-devops",
+        displayName: "bcagroup/bristol%20thin%20slice/_git/genus-yard-mobile",
+        name: "genus-yard-mobile",
+      },
+    } as never;
+
+    expect(pullRequestTargetOf(project, 17)).toEqual({
+      projectId: "p1",
+      repository: "genus-yard-mobile",
+      number: 17,
+    });
   });
 });

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -279,4 +279,18 @@ describe("pullRequestTargetOf", () => {
       number: 17,
     });
   });
+
+  it("keeps a GitLab nested path when linking a thread pull request", () => {
+    const project = {
+      id: "p2",
+      repositoryIdentity: {
+        provider: "gitlab",
+        displayName: "group/subgroup/service",
+        owner: "group",
+        name: "service",
+      },
+    } as never;
+
+    expect(pullRequestTargetOf(project, 9)?.repository).toBe("group/subgroup/service");
+  });
 });

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -8,7 +8,11 @@ import { useNavigate } from "@tanstack/react-router";
 import * as Schema from "effect/Schema";
 import { type MouseEvent, useCallback } from "react";
 
-import { pullRequestHostOf, type SourceControlProviderKind } from "@t3tools/contracts";
+import {
+  pullRequestHostOf,
+  pullRequestRepositoryOf,
+  type SourceControlProviderKind,
+} from "@t3tools/contracts";
 
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { readLocalApi } from "../localApi";
@@ -197,6 +201,15 @@ export function findProjectForChangeRequest(
   });
 }
 
+/** The project-bound reference both the panel and the pull requests page open. */
+export function pullRequestTargetOf(
+  project: Pick<EnvironmentProject, "id" | "repositoryIdentity">,
+  number: number,
+) {
+  const repository = pullRequestRepositoryOf(project.repositoryIdentity);
+  return repository === null ? null : { projectId: project.id, repository, number };
+}
+
 /**
  * Opens a change request link on the page, and says whether it did. Anything else — another
  * organisation's repository, a host nothing here is checked out from, a link that merely looks
@@ -257,16 +270,12 @@ export function useOpenChangeRequestLink(
             );
       const project = findProjectForChangeRequest(projects, parsed);
       if (project === undefined || !reads(project.environmentId)) return false;
+      const target = pullRequestTargetOf(project, parsed.number);
+      if (target === null) return false;
       event.preventDefault();
       event.stopPropagation();
       if (resolvedThreadRef) {
-        useRightPanelStore.getState().openPullRequest(resolvedThreadRef, {
-          projectId: project.id,
-          // The identity's own spelling, not the one read out of the URL: the panel asks the
-          // provider for this repository, while matching a link only ever compares lower case.
-          repository: project.repositoryIdentity?.displayName ?? parsed.repository,
-          number: parsed.number,
-        });
+        useRightPanelStore.getState().openPullRequest(resolvedThreadRef, target);
         return true;
       }
       void navigate({
@@ -276,8 +285,8 @@ export function useOpenChangeRequestLink(
           // Every state, so the pull request being opened is also in the list behind it whether
           // it is open, merged or closed.
           state: "all",
-          repository: parsed.repository,
-          number: parsed.number,
+          repository: target.repository,
+          number: target.number,
           selectedProjectId: project.id,
           // Named so the page opens the right one of two servers holding this project.
           selectedEnvironmentId: project.environmentId,

--- a/packages/contracts/src/pullRequest.test.ts
+++ b/packages/contracts/src/pullRequest.test.ts
@@ -7,6 +7,7 @@ import {
   PullRequestListInput,
   PullRequestListResult,
   PullRequestReviewerRequestInput,
+  pullRequestRepositoryOf,
   resolvePullRequestAuthorFilter,
 } from "./pullRequest.ts";
 
@@ -228,5 +229,43 @@ describe("naming the reader as the author to narrow by", () => {
   it("stands as typed where the host has not said who the reader is", () => {
     expect(resolvePullRequestAuthorFilter("me", null)).toBe("me");
     expect(resolvePullRequestAuthorFilter("me", "  ")).toBe("me");
+  });
+});
+
+describe("naming a repository for pull request operations", () => {
+  it("uses an Azure DevOps repository's short name", () => {
+    expect(
+      pullRequestRepositoryOf({
+        provider: "azure-devops",
+        displayName: "contoso/payments/_git/checkout",
+        name: "checkout",
+      }),
+    ).toBe("checkout");
+  });
+
+  it("falls back to the final Azure DevOps path segment", () => {
+    expect(
+      pullRequestRepositoryOf({
+        provider: "azure-devops",
+        displayName: "contoso/payments/_git/checkout",
+      }),
+    ).toBe("checkout");
+  });
+
+  it("keeps a GitLab repository's full path", () => {
+    expect(
+      pullRequestRepositoryOf({
+        provider: "gitlab",
+        displayName: "group/subgroup/service",
+        owner: "group",
+        name: "service",
+      }),
+    ).toBe("group/subgroup/service");
+  });
+
+  it("falls back to a GitHub owner and name", () => {
+    expect(pullRequestRepositoryOf({ provider: "github", owner: "t3tools", name: "t3code" })).toBe(
+      "t3tools/t3code",
+    );
   });
 });

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -1025,6 +1025,39 @@ export function pullRequestHostOf(
 }
 
 /**
+ * The provider-native repository selector the page and the server both use for pull request
+ * refs. `displayName` is the full path below the host, which nested GitLab groups need;
+ * owner/name is the two-segment fallback for identities recorded before that field existed.
+ *
+ * Azure DevOps is the exception: `az repos pr list --repository` takes a repository name and
+ * takes the organisation and project from the checkout it detects — so the recorded
+ * `org/project/_git/repo` path is refused. Its name is the last segment, which is what this
+ * hands over.
+ *
+ * Shared so a link or thread that opens a change request names the repository the same way
+ * `requireProject` will check it, rather than sending a path the host cannot be asked with.
+ */
+export function pullRequestRepositoryOf(
+  identity:
+    | {
+        readonly provider?: string | undefined;
+        readonly displayName?: string | undefined;
+        readonly owner?: string | undefined;
+        readonly name?: string | undefined;
+      }
+    | null
+    | undefined,
+): string | null {
+  if (!identity) return null;
+  if (identity.provider === "azure-devops") {
+    const segments = (identity.displayName ?? "").split("/").filter((part) => part !== "_git");
+    return identity.name || segments.at(-1) || null;
+  }
+  if (identity.displayName) return identity.displayName;
+  return identity.owner && identity.name ? `${identity.owner}/${identity.name}` : null;
+}
+
+/**
  * `author:me` names whoever is signed in to the host being read, GitHub's `@me` spelled either
  * way. A host's own search would answer it, but the page and the server both re-check an author
  * against the row's login, so the name is resolved before either comparison rather than being


### PR DESCRIPTION
## Why

Opening an Azure DevOps pull request from a thread or an in-app link failed with `The change request does not belong to the selected project.` The server selects Azure repositories by short name (`az repos pr list --repository`), while the web client sent `repositoryIdentity.displayName` (the full `org/project/_git/repo` path).

## Scope

- Adds shared `pullRequestRepositoryOf` in `packages/contracts/src/pullRequest.ts` next to `pullRequestHostOf`.
- `PullRequestService.repositoryIdentityOf` delegates to that helper.
- `ChatView` and `openPullRequestLink` (`pullRequestTargetOf`) open change requests with the shared selector.
- Tests cover Azure short names, GitLab full paths, and the Azure open target.

## Blast Radius

Azure DevOps pull request detail, activity, and thread/link open paths. GitHub, GitLab, and Bitbucket keep their existing selectors. List rows already used the short name, so list behavior is unchanged.

## Verification

- Red harness: client `displayName` vs server short name → `belongs=false`.
- Green harness after fix: both sides `genus-yard-mobile` → `belongs=true`.
- `vp test run packages/contracts/src/pullRequest.test.ts apps/web/src/lib/openPullRequestLink.test.ts apps/server/src/pullRequest/PullRequestService.test.ts` → 129 passed.
- Nightly traces showed the same `resolveRepository` failure on `pullRequests.detail` / `activity` before the fix. Desktop UI repro was blocked (agent-device held by another Xcode session).


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Azure PR links to use `pullRequestRepositoryOf` for provider-native repo names
> - Adds `pullRequestRepositoryOf` in [pullRequest.ts](https://github.com/pingdotgg/t3code/pull/8203/files#diff-3698440642964c6a34f717f82a7bcd5991bfa0d1a341e2a84baf11b1acdf0dfe): returns the Azure DevOps short repo name, preserves GitLab nested paths, and falls back to GitHub owner/name
> - Adds `pullRequestTargetOf` in [openPullRequestLink.ts](https://github.com/pingdotgg/t3code/pull/8203/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) and rewrites `useOpenChangeRequestLink` to open PRs using the project-derived repository instead of the URL-parsed string
> - Updates [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8203/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) and [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8203/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to resolve thread-linked PR repositories via the same helper; server-side [PullRequestService.ts](https://github.com/pingdotgg/t3code/pull/8203/files#diff-6dc74968ebcf535ce84fea9f44369080aa5246f4a8c9d10824bf988651c4f0bf) delegates to it too
> - Behavioral Change: PR links and thread-PR resolution now prefer the provider-native repository name from the project identity over any stored or URL-derived path; `pullRequestTargetOf` returns null (link not handled) when the repository cannot be derived
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 588d1ce. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->