### PR TITLE
fix(usage): identify client version mismatches

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -13,6 +13,7 @@ import {
   formatHourShort,
   formatPercent,
   formatTokens,
+  formatUsageContractMismatch,
   formatUsd,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
@@ -631,7 +632,12 @@ function usageEnvironmentStatus(environment: EnvironmentUsageStatus): string {
     environment.summary &&
     !isCompatibleUsageContractVersion(environment.summary.contractVersion, USAGE_CONTRACT_VERSION)
   ) {
-    return "Older server · excluded from usage totals";
+    return formatUsageContractMismatch(environment.label, {
+      direction:
+        environment.summary.contractVersion < USAGE_CONTRACT_VERSION
+          ? "serverBehind"
+          : "clientBehind",
+    });
   }
   if (!environment.isConnected)
     return environment.summary ? "Disconnected · showing saved usage" : "Waiting for connection…";

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -17,6 +17,7 @@ import {
   isCompatibleUsageContractVersion,
   type DailyTotals,
   type HourlyTotals,
+  type MergedUsage,
 } from "@t3tools/shared/usageMerge";
 
 import { isElectron } from "../../env";
@@ -34,6 +35,7 @@ import {
   formatHourShort,
   formatPercent,
   formatTokens,
+  formatUsageContractMismatch,
   formatUsd,
   makeWindow,
 } from "@t3tools/shared/usageFormat";
@@ -217,7 +219,7 @@ export function UsagePage() {
             showUsageStatus={!showingLimits}
             isPartial={isPartial}
             duplicateSources={merged.duplicateSources}
-            staleEnvironments={merged.staleEnvironments}
+            contractMismatches={merged.contractMismatches}
           />
         </WorkspaceBreadcrumbItem>
       </WorkspaceBreadcrumb>
@@ -625,17 +627,21 @@ function Metric({ label, value }: { readonly label: string; readonly value: stri
 function UsageCoverageNotice({
   environments,
   duplicateSources,
-  staleEnvironments,
+  contractMismatches,
 }: {
   readonly environments: readonly EnvironmentUsageStatus[];
   readonly duplicateSources: readonly string[];
-  readonly staleEnvironments: readonly string[];
+  readonly contractMismatches: MergedUsage["contractMismatches"];
 }) {
   const failed = environments.filter((environment) => environment.error !== null);
-  const stale = environments.filter((environment) =>
-    staleEnvironments.includes(environment.environmentId),
+  const mismatchByEnvironment = new Map(
+    contractMismatches.map((mismatch) => [mismatch.environmentId, mismatch]),
   );
-  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0) {
+  const incompatible = environments.flatMap((environment) => {
+    const mismatch = mismatchByEnvironment.get(environment.environmentId);
+    return mismatch === undefined ? [] : [{ environment, mismatch }];
+  });
+  if (failed.length === 0 && incompatible.length === 0 && duplicateSources.length === 0) {
     return null;
   }
 
@@ -644,9 +650,9 @@ function UsageCoverageNotice({
       {failed.map((environment) => (
         <span key={environment.label}>{environment.label} could not report usage.</span>
       ))}
-      {stale.map((environment) => (
-        <span key={environment.label}>
-          {environment.label} runs an older server version and is excluded from totals.
+      {incompatible.map(({ environment, mismatch }) => (
+        <span key={environment.environmentId}>
+          {formatUsageContractMismatch(environment.label, mismatch)}
         </span>
       ))}
       {duplicateSources.length > 0 ? (
@@ -668,7 +674,7 @@ function UsageEnvironmentFilter({
   showUsageStatus,
   isPartial,
   duplicateSources,
-  staleEnvironments,
+  contractMismatches,
 }: {
   readonly environments: readonly EnvironmentUsageStatus[];
   readonly selectedEnvironments: readonly EnvironmentUsageStatus[];
@@ -677,7 +683,7 @@ function UsageEnvironmentFilter({
   readonly showUsageStatus: boolean;
   readonly isPartial: boolean;
   readonly duplicateSources: readonly string[];
-  readonly staleEnvironments: readonly string[];
+  readonly contractMismatches: MergedUsage["contractMismatches"];
 }) {
   const [modelPricesOpen, setModelPricesOpen] = useState(false);
   const allSelected = selectedEnvironmentIds === null;
@@ -692,7 +698,7 @@ function UsageEnvironmentFilter({
   ).length;
   const hasIssue =
     selectedEnvironments.some((environment) => environment.error !== null) ||
-    staleEnvironments.length > 0;
+    contractMismatches.length > 0;
 
   return (
     <>
@@ -790,7 +796,7 @@ function UsageEnvironmentFilter({
             <UsageCoverageNotice
               environments={selectedEnvironments}
               duplicateSources={duplicateSources}
-              staleEnvironments={staleEnvironments}
+              contractMismatches={contractMismatches}
             />
           ) : null}
           <MenuSeparator />

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -6,6 +6,8 @@
  */
 import { UsageDay, type UsageResolution, type UsageSummaryInput } from "@t3tools/contracts";
 
+import type { UsageContractMismatch } from "./usageMerge.ts";
+
 const CURRENCY = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
@@ -44,6 +46,15 @@ function trim(value: number): string {
 
 export function formatPercent(share: number, digits = 1): string {
   return `${(share * 100).toFixed(digits)}%`;
+}
+
+export function formatUsageContractMismatch(
+  environmentLabel: string,
+  mismatch: Pick<UsageContractMismatch, "direction">,
+): string {
+  return mismatch.direction === "serverBehind"
+    ? `${environmentLabel} runs an older server version and is excluded from totals.`
+    : `This client is older than the server on ${environmentLabel}; its usage is excluded from totals.`;
 }
 
 /** `2026-08-07` to `Aug 7`. */

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -146,7 +146,7 @@ describe("mergeUsage", () => {
     ).toEqual({ claude: 1, codex: 1 });
   });
 
-  it("excludes an environment reporting an older contract version", () => {
+  it("identifies an environment reporting an older contract version", () => {
     const merged = mergeUsage(
       [
         environment(
@@ -166,7 +166,38 @@ describe("mergeUsage", () => {
     );
 
     expect(merged.costUsd).toBe(10);
-    expect(merged.staleEnvironments).toEqual(["env-b"]);
+    expect(merged.contractMismatches).toEqual([
+      {
+        environmentId: "env-b",
+        direction: "serverBehind",
+        contractVersion: USAGE_CONTRACT_VERSION - 2,
+      },
+    ]);
+  });
+
+  it("identifies an environment reporting a newer contract version", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [bucket()],
+            [{ provider: "claude", hostId: "mac", homePath: "/a" }],
+            USAGE_CONTRACT_VERSION + 1,
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(0);
+    expect(merged.contractMismatches).toEqual([
+      {
+        environmentId: "env-a",
+        direction: "clientBehind",
+        contractVersion: USAGE_CONTRACT_VERSION + 1,
+      },
+    ]);
   });
 
   it("keeps the previous compatible contract version so additive provider expansions still merge", () => {
@@ -192,7 +223,7 @@ describe("mergeUsage", () => {
     );
 
     expect(merged.costUsd).toBe(14);
-    expect(merged.staleEnvironments).toEqual([]);
+    expect(merged.contractMismatches).toEqual([]);
   });
 
   it("derives provider shares and cost quality", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -62,6 +62,12 @@ export interface CostQuality {
   readonly cacheSavingsUsd: number;
 }
 
+export interface UsageContractMismatch {
+  readonly environmentId: EnvironmentId;
+  readonly direction: "serverBehind" | "clientBehind";
+  readonly contractVersion: number;
+}
+
 export interface MergedUsage {
   readonly costUsd: number;
   readonly uncachedInputTokens: number;
@@ -80,7 +86,7 @@ export interface MergedUsage {
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
   readonly contributingEnvironments: readonly EnvironmentId[];
-  readonly staleEnvironments: readonly EnvironmentId[];
+  readonly contractMismatches: readonly UsageContractMismatch[];
 }
 
 /**
@@ -199,15 +205,15 @@ const EMPTY_MERGED: MergedUsage = {
   },
   duplicateSources: [],
   contributingEnvironments: [],
-  staleEnvironments: [],
+  contractMismatches: [],
 };
 
 /**
  * Merges every connected environment's summary.
  *
- * `expectedContractVersion` guards against an environment running older server
- * code: rather than blocking the page, incompatible data is excluded and its
- * id is reported so the UI can say coverage is partial. Versions in
+ * `expectedContractVersion` guards against incompatible server code: rather
+ * than blocking the page, its data is excluded and the mismatch direction is
+ * reported so the UI can identify which side needs updating. Versions in
  * [{@link USAGE_MERGE_COMPATIBLE_SINCE}, expected] still merge, so an additive
  * provider expansion does not drop Claude/Codex totals from older servers.
  */
@@ -218,14 +224,21 @@ export function mergeUsage(
   if (environments.length === 0) return EMPTY_MERGED;
 
   const current: EnvironmentUsage[] = [];
-  const staleEnvironments: EnvironmentId[] = [];
+  const contractMismatches: UsageContractMismatch[] = [];
   for (const environment of environments) {
     if (
       isCompatibleUsageContractVersion(environment.summary.contractVersion, expectedContractVersion)
     ) {
       current.push(environment);
     } else {
-      staleEnvironments.push(environment.environmentId);
+      contractMismatches.push({
+        environmentId: environment.environmentId,
+        direction:
+          environment.summary.contractVersion < expectedContractVersion
+            ? "serverBehind"
+            : "clientBehind",
+        contractVersion: environment.summary.contractVersion,
+      });
     }
   }
 
@@ -421,6 +434,6 @@ export function mergeUsage(
     },
     duplicateSources: duplicates,
     contributingEnvironments,
-    staleEnvironments,
+    contractMismatches,
   };
 }


### PR DESCRIPTION
Fixes #8145

## Problem

When a connected environment reports a newer usage contract than the client expects, the usage page excludes its data but incorrectly says that the environment runs an older server version.

## Changes

- Record whether each usage contract mismatch means the server or client is behind.
- Format the version-specific notice in shared usage formatting code.
- Use the same notice on web and mobile.

## Screenshots

Before:
<img width="2234" height="207" alt="Screenshot_2026-08-25_16-47-04" src="https://github.com/user-attachments/assets/451b4b88-5200-4973-a1e0-8eb1e397c242" />

After:
<img width="2234" height="207" alt="Screenshot_2026-08-25_16-47-38" src="https://github.com/user-attachments/assets/bc0a424e-732c-44c3-9bb1-637349a0ec79" />


## Verification

- `pnpm exec vp test run packages/shared/src/usageMerge.test.ts`
- `pnpm exec vp lint apps/mobile/src/features/usage/UsageRouteScreen.tsx apps/web/src/components/usage/UsagePage.tsx packages/shared/src/usageFormat.ts packages/shared/src/usageMerge.test.ts packages/shared/src/usageMerge.ts`
- `pnpm --filter @t3tools/shared typecheck`
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/mobile typecheck`

Built with GPT-5.6 using the Codex harness in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized usage merge/UI messaging change with tests; breaking rename of `staleEnvironments` is fully updated in-repo.
> 
> **Overview**
> Fixes incorrect usage coverage copy when a server reports a **newer** usage contract than the client expects: those environments were still excluded from totals, but the UI always blamed an older server.
> 
> **`mergeUsage`** now emits **`contractMismatches`** (replacing **`staleEnvironments`**) with **`serverBehind`** vs **`clientBehind`** and the reported contract version. Incompatible environments are still dropped from aggregation.
> 
> Shared **`formatUsageContractMismatch`** centralizes the two user-facing messages. **Web** and **mobile** coverage notices and the web environment filter consume **`contractMismatches`** and show the direction-specific text. Tests cover both mismatch directions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec785bdbb6acb7fd7b0a5f26cc2116eae1cd136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace stale environment IDs with `UsageContractMismatch` records in `mergeUsage`
> - The `mergeUsage` function now records `server-behind` or `client-behind` direction and the reported version for incompatible environments instead of just listing stale environment IDs.
> - Web and mobile usage components consume these structured mismatch records to display accurate exclusion messages via the new `formatUsageContractMismatch` formatter.
> - Behavioral Change: `MergedUsage` replaces the stale environment ID collection with `contractMismatches`; consumers must handle the new `UsageContractMismatch` type instead of string IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ec785b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->