### PR TITLE
fix(mobile): recover keyboard composers after Android resume

### DIFF
--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
@@ -54,7 +54,7 @@ class T3TerminalModule : Module() {
         view.mutedForegroundColorHex = mutedForegroundColor
       }
 
-      Events("onInput", "onResize")
+      Events("onInput", "onResize", "onTerminalFocus")
 
       OnViewDestroys { view: T3TerminalView ->
         view.cleanup()

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -23,6 +23,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   private val inputView = EditText(context)
   private val onInput by EventDispatcher()
   private val onResize by EventDispatcher()
+  private val onTerminalFocus by EventDispatcher()
   private var terminalHandle = 0L
   private var fedBuffer = ""
   private var cols = 0
@@ -189,6 +190,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     if (isCleanedUp) return
     isCleanedUp = true
     inputView.setOnEditorActionListener(null)
+    inputView.setOnFocusChangeListener(null)
     terminalCanvas.onScrollRows = null
     terminalCanvas.onRequestKeyboard = null
     terminalCanvas.onCellMetricsChanged = null
@@ -213,6 +215,11 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD or
       InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
     inputView.setPadding(0, 0, 0, 0)
+    inputView.setOnFocusChangeListener { _, hasFocus ->
+      if (hasFocus) {
+        onTerminalFocus(emptyMap<String, Any>())
+      }
+    }
     inputView.setOnEditorActionListener { _, actionId, event ->
       val isKeyUp = event?.action == KeyEvent.ACTION_UP
       val isImeSend = actionId == EditorInfo.IME_ACTION_SEND && !isKeyUp

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -12,6 +12,8 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
@@ -380,12 +382,16 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
 
   private fun requestKeyboardFocus() {
     // requestFocus on an already-focused EditText fires no focus callback, so
-    // emit it here: an explicit show request means the keyboard stream is live
-    // again, and the JS recovery quarantine must lift even when the IME was
-    // retained across an Android resume.
+    // emit it here when the window insets prove the IME is genuinely visible:
+    // the keyboard stream is live, and the JS recovery quarantine must lift
+    // even without a keyboardWillShow. Gating on the insets (not the touch
+    // that reached this call) keeps a post-resume scroll with a stale
+    // snapshot from clearing the quarantine.
     val retainedFocus = inputView.hasFocus()
     inputView.requestFocus()
-    if (retainedFocus) {
+    val imeVisible =
+      ViewCompat.getRootWindowInsets(this)?.isVisible(WindowInsetsCompat.Type.ime()) == true
+    if (retainedFocus && imeVisible) {
       onTerminalFocus(emptyMap<String, Any>())
     }
     val inputMethodManager = context.getSystemService(

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -379,7 +379,15 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   }
 
   private fun requestKeyboardFocus() {
+    // requestFocus on an already-focused EditText fires no focus callback, so
+    // emit it here: an explicit show request means the keyboard stream is live
+    // again, and the JS recovery quarantine must lift even when the IME was
+    // retained across an Android resume.
+    val retainedFocus = inputView.hasFocus()
     inputView.requestFocus()
+    if (retainedFocus) {
+      onTerminalFocus(emptyMap<String, Any>())
+    }
     val inputMethodManager = context.getSystemService(
       Context.INPUT_METHOD_SERVICE
     ) as? InputMethodManager

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
@@ -51,7 +51,7 @@ public class T3TerminalModule: Module {
         view.mutedForegroundColorHex = mutedForegroundColor
       }
 
-      Events("onInput", "onResize")
+      Events("onInput", "onResize", "onTerminalFocus")
     }
   }
 }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -215,6 +215,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
 
   let onInput = EventDispatcher()
   let onResize = EventDispatcher()
+  let onTerminalFocus = EventDispatcher()
 
   var terminalKey: String = "" {
     didSet {
@@ -440,6 +441,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
 
   @objc
   private func handleInputEditingDidBegin() {
+    onTerminalFocus()
     textInputModeDidChange()
   }
 

--- a/apps/mobile/src/features/keyboard/androidKeyboardRecovery.test.ts
+++ b/apps/mobile/src/features/keyboard/androidKeyboardRecovery.test.ts
@@ -1,10 +1,25 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  getInitialAndroidKeyboardRecoveryState,
   isAndroidKeyboardAnimationUsable,
   reduceAndroidKeyboardRecovery,
   type AndroidKeyboardRecoveryState,
 } from "./androidKeyboardRecovery";
+
+describe("getInitialAndroidKeyboardRecoveryState", () => {
+  it("quarantines Android surfaces mounted while the app is active", () => {
+    expect(getInitialAndroidKeyboardRecoveryState({ isAndroid: true, isAppActive: true })).toBe(
+      "quarantined",
+    );
+    expect(getInitialAndroidKeyboardRecoveryState({ isAndroid: true, isAppActive: false })).toBe(
+      "ready",
+    );
+    expect(getInitialAndroidKeyboardRecoveryState({ isAndroid: false, isAppActive: true })).toBe(
+      "ready",
+    );
+  });
+});
 
 describe("reduceAndroidKeyboardRecovery", () => {
   it("quarantines keyboard translation after the app resumes", () => {

--- a/apps/mobile/src/features/keyboard/androidKeyboardRecovery.test.ts
+++ b/apps/mobile/src/features/keyboard/androidKeyboardRecovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isAndroidKeyboardAnimationUsable,
+  reduceAndroidKeyboardRecovery,
+  type AndroidKeyboardRecoveryState,
+} from "./androidKeyboardRecovery";
+
+describe("reduceAndroidKeyboardRecovery", () => {
+  it("quarantines keyboard translation after the app resumes", () => {
+    expect(reduceAndroidKeyboardRecovery("ready", "resume")).toBe("quarantined");
+  });
+
+  it("keeps the quarantine while the keyboard snapshot is unchanged", () => {
+    let state: AndroidKeyboardRecoveryState = "ready";
+    state = reduceAndroidKeyboardRecovery(state, "resume");
+    state = reduceAndroidKeyboardRecovery(state, "resume");
+
+    expect(state).toBe("quarantined");
+    expect(
+      isAndroidKeyboardAnimationUsable({
+        isKeyboardVisible: true,
+        isQuarantined: state === "quarantined",
+      }),
+    ).toBe(false);
+  });
+
+  it("releases the quarantine when a live keyboard or input event arrives", () => {
+    expect(reduceAndroidKeyboardRecovery("quarantined", "keyboard-show")).toBe("ready");
+    expect(reduceAndroidKeyboardRecovery("quarantined", "input-focus")).toBe("ready");
+  });
+});

--- a/apps/mobile/src/features/keyboard/androidKeyboardRecovery.ts
+++ b/apps/mobile/src/features/keyboard/androidKeyboardRecovery.ts
@@ -1,0 +1,21 @@
+export type AndroidKeyboardRecoveryState = "ready" | "quarantined";
+
+export type AndroidKeyboardRecoveryEvent = "resume" | "keyboard-show" | "input-focus";
+
+export function reduceAndroidKeyboardRecovery(
+  state: AndroidKeyboardRecoveryState,
+  event: AndroidKeyboardRecoveryEvent,
+): AndroidKeyboardRecoveryState {
+  if (event === "resume") {
+    return "quarantined";
+  }
+
+  return "ready";
+}
+
+export function isAndroidKeyboardAnimationUsable(input: {
+  readonly isKeyboardVisible: boolean;
+  readonly isQuarantined: boolean;
+}): boolean {
+  return input.isKeyboardVisible && !input.isQuarantined;
+}

--- a/apps/mobile/src/features/keyboard/androidKeyboardRecovery.ts
+++ b/apps/mobile/src/features/keyboard/androidKeyboardRecovery.ts
@@ -2,6 +2,13 @@ export type AndroidKeyboardRecoveryState = "ready" | "quarantined";
 
 export type AndroidKeyboardRecoveryEvent = "resume" | "keyboard-show" | "input-focus";
 
+export function getInitialAndroidKeyboardRecoveryState(input: {
+  readonly isAndroid: boolean;
+  readonly isAppActive: boolean;
+}): AndroidKeyboardRecoveryState {
+  return input.isAndroid && input.isAppActive ? "quarantined" : "ready";
+}
+
 export function reduceAndroidKeyboardRecovery(
   state: AndroidKeyboardRecoveryState,
   event: AndroidKeyboardRecoveryEvent,

--- a/apps/mobile/src/features/keyboard/useAndroidKeyboardRecovery.ts
+++ b/apps/mobile/src/features/keyboard/useAndroidKeyboardRecovery.ts
@@ -3,6 +3,7 @@ import { AppState, Platform } from "react-native";
 import { KeyboardEvents } from "react-native-keyboard-controller";
 
 import {
+  getInitialAndroidKeyboardRecoveryState,
   reduceAndroidKeyboardRecovery,
   type AndroidKeyboardRecoveryState,
 } from "./androidKeyboardRecovery";
@@ -11,7 +12,12 @@ export function useAndroidKeyboardRecovery(): {
   readonly isQuarantined: boolean;
   readonly markInputFocused: () => void;
 } {
-  const [recoveryState, setRecoveryState] = useState<AndroidKeyboardRecoveryState>("ready");
+  const [recoveryState, setRecoveryState] = useState<AndroidKeyboardRecoveryState>(() =>
+    getInitialAndroidKeyboardRecoveryState({
+      isAndroid: Platform.OS === "android",
+      isAppActive: AppState.currentState === "active",
+    }),
+  );
 
   useEffect(() => {
     if (Platform.OS !== "android") {
@@ -26,6 +32,12 @@ export function useAndroidKeyboardRecovery(): {
     const keyboardShowSubscription = KeyboardEvents.addListener("keyboardWillShow", () => {
       setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "keyboard-show"));
     });
+
+    // The screen may mount after the app has already resumed. In that case
+    // there is no future active transition for this instance to observe.
+    if (AppState.currentState === "active") {
+      setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "resume"));
+    }
 
     return () => {
       appStateSubscription.remove();

--- a/apps/mobile/src/features/keyboard/useAndroidKeyboardRecovery.ts
+++ b/apps/mobile/src/features/keyboard/useAndroidKeyboardRecovery.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { AppState, Platform } from "react-native";
+import { KeyboardEvents } from "react-native-keyboard-controller";
+
+import {
+  reduceAndroidKeyboardRecovery,
+  type AndroidKeyboardRecoveryState,
+} from "./androidKeyboardRecovery";
+
+export function useAndroidKeyboardRecovery(): {
+  readonly isQuarantined: boolean;
+  readonly markInputFocused: () => void;
+} {
+  const [recoveryState, setRecoveryState] = useState<AndroidKeyboardRecoveryState>("ready");
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+
+    const appStateSubscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "resume"));
+      }
+    });
+    const keyboardShowSubscription = KeyboardEvents.addListener("keyboardWillShow", () => {
+      setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "keyboard-show"));
+    });
+
+    return () => {
+      appStateSubscription.remove();
+      keyboardShowSubscription.remove();
+    };
+  }, []);
+
+  const markInputFocused = useCallback(() => {
+    setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "input-focus"));
+  }, []);
+
+  return {
+    isQuarantined: recoveryState === "quarantined",
+    markInputFocused,
+  };
+}

--- a/apps/mobile/src/features/keyboard/useAndroidKeyboardRecovery.ts
+++ b/apps/mobile/src/features/keyboard/useAndroidKeyboardRecovery.ts
@@ -12,6 +12,9 @@ export function useAndroidKeyboardRecovery(): {
   readonly isQuarantined: boolean;
   readonly markInputFocused: () => void;
 } {
+  // A surface mounted while the app is already active has no future resume
+  // transition to observe, so it starts quarantined. Re-applying "resume" in
+  // the mount effect would clobber an autoFocus release that landed first.
   const [recoveryState, setRecoveryState] = useState<AndroidKeyboardRecoveryState>(() =>
     getInitialAndroidKeyboardRecoveryState({
       isAndroid: Platform.OS === "android",
@@ -32,12 +35,6 @@ export function useAndroidKeyboardRecovery(): {
     const keyboardShowSubscription = KeyboardEvents.addListener("keyboardWillShow", () => {
       setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "keyboard-show"));
     });
-
-    // The screen may mount after the app has already resumed. In that case
-    // there is no future active transition for this instance to observe.
-    if (AppState.currentState === "active") {
-      setRecoveryState((current) => reduceAndroidKeyboardRecovery(current, "resume"));
-    }
 
     return () => {
       appStateSubscription.remove();

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -3,7 +3,11 @@ import { TextInputWrapper } from "expo-paste-input";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Platform, Pressable, ScrollView, View, useWindowDimensions } from "react-native";
-import { KeyboardAvoidingView, KeyboardStickyView } from "react-native-keyboard-controller";
+import {
+  KeyboardAvoidingView,
+  KeyboardStickyView,
+  useKeyboardState,
+} from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FilePreviewModal, type FilePreviewSource } from "../../components/FilePreviewModal";
 
@@ -17,6 +21,8 @@ import { convertPastedImagesToAttachments, pickComposerImages } from "../../lib/
 import { useNativePaste } from "../../lib/useNativePaste";
 import { setPendingConnectionError } from "../../state/use-remote-environment-registry";
 import { appendReviewCommentToDraft } from "../../state/use-thread-composer-state";
+import { isAndroidKeyboardAnimationUsable } from "../keyboard/androidKeyboardRecovery";
+import { useAndroidKeyboardRecovery } from "../keyboard/useAndroidKeyboardRecovery";
 import {
   clearReviewCommentTarget,
   formatReviewCommentContext,
@@ -43,6 +49,13 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
   const isAndroid = Platform.OS === "android";
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
+  const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
+  const { isQuarantined: isKeyboardStateQuarantined, markInputFocused } =
+    useAndroidKeyboardRecovery();
+  const isKeyboardAnimationUsable = isAndroidKeyboardAnimationUsable({
+    isKeyboardVisible,
+    isQuarantined: isKeyboardStateQuarantined,
+  });
   const { width } = useWindowDimensions();
   const { themeAppearance: selectedTheme } = useAppearancePreferences();
   const target = useReviewCommentTarget();
@@ -262,6 +275,7 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         textAlignVertical="top"
                         value={commentText}
                         onChangeText={setCommentText}
+                        onFocus={markInputFocused}
                         className="h-full min-h-0 flex-1 border-0 bg-transparent px-0 py-0 font-sans text-base"
                       />
                     </TextInputWrapper>
@@ -308,6 +322,7 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
       </KeyboardAvoidingView>
       {isAndroid && target ? (
         <KeyboardStickyView
+          enabled={isKeyboardAnimationUsable}
           className="absolute inset-x-0 bottom-0"
           offset={{ closed: 0, opened: 0 }}
         >

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -42,6 +42,7 @@ interface TerminalSurfaceProps extends ViewProps {
   readonly theme?: TerminalTheme;
   readonly onInput: (data: string) => void;
   readonly onResize: (size: { readonly cols: number; readonly rows: number }) => void;
+  readonly onTerminalFocus?: () => void;
 }
 
 function estimateGridSize(input: {
@@ -150,6 +151,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
               props.onInput(`${text}\r`);
             }
           }}
+          onFocus={props.onTerminalFocus}
         />
         <Pressable
           disabled={!props.isRunning}
@@ -228,6 +230,7 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
           themeConfig={buildGhosttyThemeConfig(theme)}
           onInput={handleNativeInput}
           onResize={handleNativeResize}
+          onTerminalFocus={props.onTerminalFocus}
         />
       </View>
     );

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -1091,9 +1091,8 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   }, []);
 
   const handleShowKeyboard = useCallback(() => {
-    markInputFocused();
     setKeyboardFocusRequest((current) => current + 1);
-  }, [markInputFocused]);
+  }, []);
   const handleRetryEnvironment = useCallback(() => {
     if (routeEnvironmentId !== null) {
       void retryEnvironment(routeEnvironmentId);
@@ -1278,6 +1277,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 keyboardFocusRequest={keyboardFocusRequest}
                 onInput={handleInput}
                 onResize={handleResize}
+                onTerminalFocus={markInputFocused}
                 style={{ flex: 1 }}
                 terminalKey={terminalKey}
                 theme={terminalTheme}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -45,6 +45,8 @@ import {
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadDetail } from "../../state/use-thread-detail";
 import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
+import { isAndroidKeyboardAnimationUsable } from "../keyboard/androidKeyboardRecovery";
+import { useAndroidKeyboardRecovery } from "../keyboard/useAndroidKeyboardRecovery";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { TerminalSurface } from "./NativeTerminalSurface";
 import { getMobileTerminalTheme } from "./terminalTheme";
@@ -507,9 +509,14 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     height: state.height,
     isVisible: state.isVisible,
   }));
-  const isAccessoryVisible = keyboardState.isVisible && !isAccessoryDismissed;
+  const { isQuarantined: isKeyboardStateQuarantined } = useAndroidKeyboardRecovery();
+  const isKeyboardAnimationUsable = isAndroidKeyboardAnimationUsable({
+    isKeyboardVisible: keyboardState.isVisible,
+    isQuarantined: isKeyboardStateQuarantined,
+  });
+  const isAccessoryVisible = isKeyboardAnimationUsable && !isAccessoryDismissed;
   const terminalBottomInset =
-    (keyboardState.isVisible ? keyboardState.height : 0) +
+    (isKeyboardAnimationUsable ? keyboardState.height : 0) +
     (isAccessoryVisible ? TERMINAL_ACCESSORY_HEIGHT : 0);
 
   useEffect(() => {
@@ -1277,6 +1284,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
 
             {isAccessoryVisible ? (
               <KeyboardStickyView
+                enabled={Platform.OS !== "android" || isKeyboardAnimationUsable}
                 style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
                 offset={{ closed: 0, opened: 0 }}
               >
@@ -1325,7 +1333,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                   </ComposerToolbarRow>
                 </View>
               </KeyboardStickyView>
-            ) : !keyboardState.isVisible ? (
+            ) : !isKeyboardAnimationUsable ? (
               <Pressable
                 accessibilityLabel="Show keyboard"
                 accessibilityRole="button"

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -509,7 +509,8 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     height: state.height,
     isVisible: state.isVisible,
   }));
-  const { isQuarantined: isKeyboardStateQuarantined } = useAndroidKeyboardRecovery();
+  const { isQuarantined: isKeyboardStateQuarantined, markInputFocused } =
+    useAndroidKeyboardRecovery();
   const isKeyboardAnimationUsable = isAndroidKeyboardAnimationUsable({
     isKeyboardVisible: keyboardState.isVisible,
     isQuarantined: isKeyboardStateQuarantined,
@@ -1090,8 +1091,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   }, []);
 
   const handleShowKeyboard = useCallback(() => {
+    markInputFocused();
     setKeyboardFocusRequest((current) => current + 1);
-  }, []);
+  }, [markInputFocused]);
   const handleRetryEnvironment = useCallback(() => {
     if (routeEnvironmentId !== null) {
       void retryEnvironment(routeEnvironmentId);

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -34,6 +34,7 @@ export interface NativeTerminalSurfaceProps extends ViewProps {
   readonly fontSize: number;
   readonly onInput?: (event: NativeSyntheticEvent<TerminalInputEvent>) => void;
   readonly onResize?: (event: NativeSyntheticEvent<TerminalResizeEvent>) => void;
+  readonly onTerminalFocus?: () => void;
 }
 
 let cachedNativeTerminalSurfaceView: ComponentType<NativeTerminalSurfaceProps> | undefined;

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -106,6 +106,8 @@ import { useIncomingShare } from "../sharing/IncomingShareProvider";
 import { selectIncomingShareAttachmentsForServer } from "../sharing/incoming-share-model";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { serverEnvironment } from "../../state/server";
+import { isAndroidKeyboardAnimationUsable } from "../keyboard/androidKeyboardRecovery";
+import { useAndroidKeyboardRecovery } from "../keyboard/useAndroidKeyboardRecovery";
 
 function NewTaskWorkspaceIcon(props: {
   readonly workspaceMode: "local" | "worktree";
@@ -165,6 +167,12 @@ export function NewTaskDraftScreen(props: {
   } = useIncomingShare();
   const insets = useSafeAreaInsets();
   const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
+  const { isQuarantined: isKeyboardStateQuarantined, markInputFocused } =
+    useAndroidKeyboardRecovery();
+  const isKeyboardAnimationUsable = isAndroidKeyboardAnimationUsable({
+    isKeyboardVisible,
+    isQuarantined: isKeyboardStateQuarantined,
+  });
   const controlsBottomPadding = Math.max(insets.bottom, 10);
   const keyboardOpenedOffset = Math.max(0, controlsBottomPadding - 8);
   const { projectScopes, selectedProject, selectedProjectKey, setProject } = flow;
@@ -1080,7 +1088,10 @@ export function NewTaskDraftScreen(props: {
       selection={composerMenu.selection}
       onChangeText={flow.setPrompt}
       onSelectionChange={composerMenu.onSelectionChange}
-      onFocus={() => setIsComposerFocused(true)}
+      onFocus={() => {
+        markInputFocused();
+        setIsComposerFocused(true);
+      }}
       onBlur={() => setIsComposerFocused(false)}
       onPasteImages={(uris) => void handleNativePasteImages(uris)}
       placeholder="Ask anything…"
@@ -1405,6 +1416,7 @@ export function NewTaskDraftScreen(props: {
         {heroViewport}
 
         <KeyboardStickyView
+          enabled={Platform.OS !== "android" || isKeyboardAnimationUsable}
           style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
           offset={{ closed: 0, opened: keyboardOpenedOffset }}
         >
@@ -1433,6 +1445,7 @@ export function NewTaskDraftScreen(props: {
 
       {heroViewport}
       <KeyboardStickyView
+        enabled={Platform.OS !== "android" || isKeyboardAnimationUsable}
         pointerEvents="box-none"
         style={{ position: "absolute", top: 0, bottom: 0, left: 0, right: 0 }}
         offset={{ closed: 0, opened: keyboardOpenedOffset }}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -33,7 +33,6 @@ import {
   useState,
 } from "react";
 import {
-  AppState,
   Keyboard,
   Platform,
   useWindowDimensions,
@@ -69,6 +68,8 @@ import type {
   PendingUserInputDraftAnswer,
   ThreadFeedEntry,
 } from "../../lib/threadActivity";
+import { isAndroidKeyboardAnimationUsable } from "../keyboard/androidKeyboardRecovery";
+import { useAndroidKeyboardRecovery } from "../keyboard/useAndroidKeyboardRecovery";
 import { PendingApprovalCard } from "./PendingApprovalCard";
 import { PendingUserInputCard } from "./PendingUserInputCard";
 import {
@@ -236,32 +237,23 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   // hide — then Home within a second). The keyboard library's height AND
   // visibility then stay frozen open, so gating the sticky translation on
   // visibility alone still strands the composer after resume. Quarantine the
-  // translation on every Android resume instead; any sign of a live keyboard
-  // stream — an owned input gaining focus, or any visibility/height movement —
-  // lifts it. A healthy resume sees no visual difference (the translation is
-  // already zero while the keyboard is closed).
-  const [keyboardStateSuspect, setKeyboardStateSuspect] = useState(false);
-  useEffect(() => {
-    if (Platform.OS !== "android") {
-      return;
-    }
-    const subscription = AppState.addEventListener("change", (state) => {
-      if (state === "active") {
-        setKeyboardStateSuspect(true);
+  // translation on every Android resume instead; only a fresh keyboard show or
+  // an owned input gaining focus lifts it. A healthy resume sees no visual
+  // difference (the translation is already zero while the keyboard is closed).
+  const { isQuarantined: isKeyboardStateQuarantined, markInputFocused } =
+    useAndroidKeyboardRecovery();
+  const isKeyboardAnimationUsable = isAndroidKeyboardAnimationUsable({
+    isKeyboardVisible,
+    isQuarantined: isKeyboardStateQuarantined,
+  });
+  const handleOwnedInputFocusChange = useCallback(
+    (focused: boolean) => {
+      if (focused) {
+        markInputFocused();
       }
-    });
-    return () => {
-      subscription.remove();
-    };
-  }, []);
-  useEffect(() => {
-    setKeyboardStateSuspect(false);
-  }, [isKeyboardVisible, liveKeyboardHeight]);
-  const handleOwnedInputFocusChange = useCallback((focused: boolean) => {
-    if (focused) {
-      setKeyboardStateSuspect(false);
-    }
-  }, []);
+    },
+    [markInputFocused],
+  );
   const windowHeight = useWindowDimensions().height;
   const navigationHeaderHeight = useContext(HeaderHeightContext) || insets.top + IOS_NAV_BAR_HEIGHT;
   const agentLabel = `${props.selectedThread.modelSelection.instanceId} agent`;
@@ -295,7 +287,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   // focus-keyed inset is already in place while the composer rides down.
   // Dictation keeps that focus while the composer switches to its compact pill.
   const composerBottomInset = (
-    Platform.OS === "android" ? isKeyboardVisible : composerExpanded || composerFocused
+    Platform.OS === "android" ? isKeyboardAnimationUsable : composerExpanded || composerFocused
   )
     ? 0
     : Math.max(insets.bottom, 12);
@@ -754,7 +746,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
           // iOS emits a native animated height target on both will-show and
           // will-hide, so stay subscribed for the full transition. Android
           // retains its background/resume stale-state quarantine.
-          enabled={Platform.OS === "ios" || (isKeyboardVisible && !keyboardStateSuspect)}
+          enabled={Platform.OS === "ios" || isKeyboardAnimationUsable}
           pointerEvents="box-none"
           style={{ position: "absolute", bottom: 0, left: 0, right: 0, top: 0 }}
           offset={{ closed: 0, opened: 0 }}


### PR DESCRIPTION
## Problem

On Android, task switching while the IME is dismissing can leave `KeyboardStickyView` with a stale animated height after resume, so the composer remains high on the screen after the keyboard closes.

## Reproduction

![Android keyboard composer remains elevated after task switching](https://gist.githubusercontent.com/mrmg/533a153d9e72104d8f2c174df7acf593/raw/acc30995b9e9368549ef7eb7606f2af21992809a/android-keyboard-composer-stale-after-resume.svg)

## Fix

Quarantine keyboard translation on Android resume and release it only after a fresh keyboard-show event or owned input focus. Apply the guard to the thread, new-task, terminal, and review sticky surfaces, with a pure lifecycle regression test.

## Verification

- `vp test run apps/mobile/src/features/keyboard/androidKeyboardRecovery.test.ts apps/mobile/src/features/threads/pendingUserInputLayout.test.ts`
- `vp run --filter @t3tools/mobile typecheck`
- Scoped `vp fmt --check`
- Scoped `vp lint --report-unused-disable-directives`

Android emulator/device verification was not available in this environment.

Built with GPT-5.6-Luna in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native terminal events and keyboard layout across several high-traffic Android screens; incorrect quarantine timing could briefly mis-position composers or sticky toolbars, but changes are scoped to Android keyboard recovery with iOS paths largely unchanged.
> 
> **Overview**
> Fixes Android composers and terminal chrome staying elevated after task-switching during IME dismiss by **quarantining** reliance on `react-native-keyboard-controller` visibility/height until the keyboard stream is known-good again.
> 
> Introduces a small recovery state machine (`useAndroidKeyboardRecovery` + helpers) that enters **quarantined** on app resume (and for Android surfaces mounted while already active) and returns to **ready** on `keyboardWillShow` or when an owned text field gains focus. Thread detail, new task, review comment composer, and the terminal route now gate `KeyboardStickyView`, bottom insets, and accessory visibility on `isAndroidKeyboardAnimationUsable` instead of raw keyboard visibility; thread detail drops its ad-hoc `keyboardStateSuspect` logic in favor of the shared hook.
> 
> Adds native **`onTerminalFocus`** on the T3 terminal view (iOS + Android) so focusing the hidden terminal `EditText` can release the quarantine; Android also emits focus when `requestKeyboardFocus` runs with retained focus and IME window insets show the keyboard is actually visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370d8293fabbcab04e039103532bdaf0c72a295c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale keyboard composers after Android resume with recovery quarantine
> - Adds a shared Android keyboard-recovery state machine in [androidKeyboardRecovery.ts](https://github.com/pingdotgg/t3code/pull/8212/files#diff-a81df590d822f0b13252491ab847f27a51dbb1f3d7183af7df891bd62106f96d) and a `useAndroidKeyboardRecovery` hook that quarantines keyboard animation after app resume or active-state mounting, releasing on a fresh keyboard-show or owned-input-focus event
> - Adds a `terminal-focus` native event on both Android ([T3TerminalView.kt](https://github.com/pingdotgg/t3code/pull/8212/files#diff-969fd9c949fd2b5dc8b72a8347c9e8ec59a5a06320a21e79548f7476265a0fc3)) and iOS ([T3TerminalView.swift](https://github.com/pingdotgg/t3code/pull/8212/files#diff-f62e0027105bee3eafacb6199a2218932ecbbd4b8bba7193a3a0da4f065a62ca)), forwarded through [NativeTerminalSurface.tsx](https://github.com/pingdotgg/t3code/pull/8212/files#diff-37b3b866e5be2bb0fd0a111d99f9a997565617068bfac584a343199a67fb4722), so terminal input focus can release the quarantine
> - Updates [ThreadDetailScreen.tsx](https://github.com/pingdotgg/t3code/pull/8212/files#diff-4a36307d6c720c14cd36832a71a74b980215a01d29282c4f03d82889219d2fae), [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/8212/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2), [ReviewCommentComposerSheet.tsx](https://github.com/pingdotgg/t3code/pull/8212/files#diff-b423e58ff0e014c7a707b658117b1b001dbc2c9f29dd413d20418f932484eb74), and [ThreadTerminalRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/8212/files#diff-0815b7fd5b544c4241d321358e819d5904da641dfefcb502e256ad3173f71df2) to gate sticky keyboard layouts and bottom insets on the shared usability predicate instead of raw keyboard visibility
> - Risk: the `requestKeyboardFocus` handler in `T3TerminalView` now checks window insets for IME visibility before dispatching focus; if insets are unavailable on a device, the focus event may not fire and the quarantine could persist until the next keyboard-show event
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 370d829.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
