### PR TITLE
feat(web): accept PDF and text files in composer drag and drop

### DIFF
--- a/apps/server/src/assets/AttachmentUpload.ts
+++ b/apps/server/src/assets/AttachmentUpload.ts
@@ -29,7 +29,7 @@ import {
 } from "../auth/utils.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfig from "../config.ts";
-import { inferImageExtension } from "../imageMime.ts";
+import { inferAttachmentExtension } from "../attachmentMime.ts";
 
 export const ATTACHMENT_UPLOAD_ROUTE_PREFIX = "/api/attachments/upload";
 
@@ -152,7 +152,7 @@ export const storeAttachmentUpload = Effect.fn("AttachmentUpload.store")(functio
   }
 
   const config = yield* ServerConfig.ServerConfig;
-  const extension = inferImageExtension({ mimeType: claims.mimeType, fileName: claims.name });
+  const extension = inferAttachmentExtension({ mimeType: claims.mimeType, fileName: claims.name });
   const relativePath = `${claims.attachmentId}${extension}`;
   const finalPath = resolveAttachmentRelativePath({
     attachmentsDir: config.attachmentsDir,

--- a/apps/server/src/attachmentMime.ts
+++ b/apps/server/src/attachmentMime.ts
@@ -1,0 +1,48 @@
+import { inferImageExtension, SAFE_IMAGE_FILE_EXTENSIONS } from "./imageMime.ts";
+
+export const DOCUMENT_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  "application/pdf": ".pdf",
+};
+
+export const SAFE_DOCUMENT_FILE_EXTENSIONS = new Set([".pdf"]);
+
+export const SAFE_ATTACHMENT_FILE_EXTENSIONS = new Set([
+  ...SAFE_IMAGE_FILE_EXTENSIONS,
+  ...SAFE_DOCUMENT_FILE_EXTENSIONS,
+]);
+
+export function isDocumentMimeType(mimeType: string): boolean {
+  return Object.hasOwn(DOCUMENT_EXTENSION_BY_MIME_TYPE, mimeType.trim().toLowerCase());
+}
+
+export function inferDocumentExtension(input: { mimeType: string; fileName?: string }): string {
+  const fromMime = DOCUMENT_EXTENSION_BY_MIME_TYPE[input.mimeType.trim().toLowerCase()];
+  if (fromMime) {
+    return fromMime;
+  }
+  const extensionMatch = /\.([a-z0-9]{1,8})$/i.exec(input.fileName?.trim() ?? "");
+  const fileNameExtension = extensionMatch ? `.${extensionMatch[1]!.toLowerCase()}` : "";
+  return SAFE_DOCUMENT_FILE_EXTENSIONS.has(fileNameExtension) ? fileNameExtension : ".bin";
+}
+
+/**
+ * Stored-file extension for an upload that only carries a mime type and a
+ * filename. The upload token predates the attachment record, so the kind has
+ * to be recovered from the mime type rather than a discriminant.
+ */
+export function inferAttachmentExtension(input: { mimeType: string; fileName?: string }): string {
+  return isDocumentMimeType(input.mimeType)
+    ? inferDocumentExtension(input)
+    : inferImageExtension(input);
+}
+
+/**
+ * Rejection text for providers whose turn payload only models images. Kept
+ * here so every adapter tells the user the same thing and names a way out.
+ */
+export function documentAttachmentUnsupportedDetail(input: {
+  readonly providerLabel: string;
+  readonly fileName: string;
+}): string {
+  return `${input.providerLabel} does not accept document attachments. Remove '${input.fileName}' and try again, or send it to a provider that supports PDFs, such as Claude or OpenCode.`;
+}

--- a/apps/server/src/attachmentStore.test.ts
+++ b/apps/server/src/attachmentStore.test.ts
@@ -5,7 +5,9 @@ import * as NodePath from "node:path";
 
 import { describe, expect, it } from "vite-plus/test";
 
+import { inferAttachmentExtension } from "./attachmentMime.ts";
 import {
+  attachmentRelativePath,
   createAttachmentId,
   createPendingAttachmentId,
   parseAttachmentUuid,
@@ -16,6 +18,48 @@ import {
 } from "./attachmentStore.ts";
 
 describe("attachmentStore", () => {
+  it("stores document attachments under a .pdf filename", () => {
+    const relativePath = attachmentRelativePath({
+      type: "document",
+      id: "thread-12345678-1234-1234-1234-123456789abc",
+      name: "spec.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 4,
+    });
+    expect(relativePath).toBe("thread-12345678-1234-1234-1234-123456789abc.pdf");
+  });
+
+  it("still stores image attachments under their image extension", () => {
+    const relativePath = attachmentRelativePath({
+      type: "image",
+      id: "thread-12345678-1234-1234-1234-123456789abc",
+      name: "diagram.png",
+      mimeType: "image/png",
+      sizeBytes: 4,
+    });
+    expect(relativePath).toBe("thread-12345678-1234-1234-1234-123456789abc.png");
+  });
+
+  it("routes upload extensions by mime type, since the token has no kind", () => {
+    expect(inferAttachmentExtension({ mimeType: "application/pdf", fileName: "a.pdf" })).toBe(
+      ".pdf",
+    );
+    expect(inferAttachmentExtension({ mimeType: "image/png", fileName: "a.png" })).toBe(".png");
+  });
+
+  it("finds a stored pdf by attachment id", () => {
+    const attachmentsDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "attachment-pdf-"));
+    try {
+      const attachmentId = "thread-12345678-1234-1234-1234-123456789abc";
+      NodeFS.writeFileSync(NodePath.join(attachmentsDir, `${attachmentId}.pdf`), "pdf");
+      expect(resolveAttachmentPathById({ attachmentsDir, attachmentId })).toBe(
+        NodePath.join(attachmentsDir, `${attachmentId}.pdf`),
+      );
+    } finally {
+      NodeFS.rmSync(attachmentsDir, { recursive: true, force: true });
+    }
+  });
+
   it("sanitizes thread ids when creating attachment ids", () => {
     const attachmentId = createAttachmentId("thread.folder/unsafe space");
     expect(attachmentId).toBeTruthy();

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -9,9 +9,10 @@ import {
   normalizeAttachmentRelativePath,
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
-import { inferImageExtension, SAFE_IMAGE_FILE_EXTENSIONS } from "./imageMime.ts";
+import { inferDocumentExtension, SAFE_ATTACHMENT_FILE_EXTENSIONS } from "./attachmentMime.ts";
+import { inferImageExtension } from "./imageMime.ts";
 
-const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".bin"];
+const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_ATTACHMENT_FILE_EXTENSIONS, ".bin"];
 const ATTACHMENT_ID_THREAD_SEGMENT_MAX_CHARS = 80;
 const ATTACHMENT_ID_THREAD_SEGMENT_PATTERN = "[a-z0-9_]+(?:-[a-z0-9_]+)*";
 const ATTACHMENT_ID_UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
@@ -75,6 +76,13 @@ export function attachmentRelativePath(attachment: ChatAttachment): string {
   switch (attachment.type) {
     case "image": {
       const extension = inferImageExtension({
+        mimeType: attachment.mimeType,
+        fileName: attachment.name,
+      });
+      return `${attachment.id}${extension}`;
+    }
+    case "document": {
+      const extension = inferDocumentExtension({
         mimeType: attachment.mimeType,
         fileName: attachment.name,
       });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -361,9 +361,6 @@ function collectThreadAttachmentRelativePaths(
   const relativePaths = new Set<string>();
   for (const message of messages) {
     for (const attachment of message.attachments ?? []) {
-      if (attachment.type !== "image") {
-        continue;
-      }
       const attachmentThreadSegment = parseThreadSegmentFromAttachmentId(attachment.id);
       if (!attachmentThreadSegment || attachmentThreadSegment !== threadSegment) {
         continue;

--- a/apps/server/src/orchestration/Normalizer.attachments.test.ts
+++ b/apps/server/src/orchestration/Normalizer.attachments.test.ts
@@ -312,7 +312,7 @@ describe("normalizeDispatchCommand attachments", () => {
           })),
         },
       }).pipe(Effect.flip);
-      expect(mismatchedType.message).toContain("image type");
+      expect(mismatchedType.message).toContain("file type");
     }).pipe(Effect.provide(testLayer)),
   );
 });

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -7,6 +7,8 @@ import {
   type IsoDateTime,
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
+  isProviderSendTurnSupportedDocumentMimeType,
+  PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 
@@ -176,7 +178,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
             });
             if (expectedPath !== claim.finalPath) {
               return yield* new OrchestrationDispatchCommandError({
-                message: `Attachment '${attachment.name}' cannot be sent: image type does not match the upload.`,
+                message: `Attachment '${attachment.name}' cannot be sent: file type does not match the upload.`,
               });
             }
 
@@ -197,16 +199,25 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
           }
 
           const parsed = parseBase64DataUrl(attachment.dataUrl);
-          if (!parsed || !parsed.mimeType.startsWith("image/")) {
+          const parsedMimeType = parsed?.mimeType ?? "";
+          const mimeTypeMatchesKind =
+            attachment.type === "document"
+              ? isProviderSendTurnSupportedDocumentMimeType(parsedMimeType)
+              : parsedMimeType.startsWith("image/");
+          if (!parsed || !mimeTypeMatchesKind) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Invalid image attachment payload for '${attachment.name}'.`,
+              message: `Invalid ${attachment.type} attachment payload for '${attachment.name}'.`,
             });
           }
 
+          const maxBytes =
+            attachment.type === "document"
+              ? PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES
+              : PROVIDER_SEND_TURN_MAX_IMAGE_BYTES;
           const bytes = Buffer.from(parsed.base64, "base64");
-          if (bytes.byteLength === 0 || bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+          if (bytes.byteLength === 0 || bytes.byteLength > maxBytes) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Image attachment '${attachment.name}' is empty or too large.`,
+              message: `Attachment '${attachment.name}' is empty or too large.`,
             });
           }
 
@@ -218,7 +229,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
           }
 
           const persistedAttachment = {
-            type: "image" as const,
+            type: attachment.type,
             id: attachmentId,
             name: attachment.name,
             mimeType: parsed.mimeType.toLowerCase(),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -847,6 +847,71 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("embeds document attachments as Claude document blocks", () => {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-documents-"));
+    const harness = makeHarness({
+      cwd: "/tmp/project-claude-documents",
+      baseDir,
+    });
+    return Effect.gen(function* () {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() =>
+          NodeFS.rmSync(baseDir, {
+            recursive: true,
+            force: true,
+          }),
+        ),
+      );
+
+      const adapter = yield* ClaudeAdapter;
+      const { attachmentsDir } = yield* ServerConfig;
+
+      const attachment = {
+        type: "document" as const,
+        id: "thread-claude-attachment-12345678-1234-1234-1234-123456789abc",
+        name: "spec.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 4,
+      };
+      const attachmentPath = NodePath.join(attachmentsDir, attachmentRelativePath(attachment));
+      assert.isTrue(attachmentPath.endsWith(".pdf"));
+      NodeFS.mkdirSync(NodePath.dirname(attachmentPath), { recursive: true });
+      NodeFS.writeFileSync(attachmentPath, Uint8Array.from([1, 2, 3, 4]));
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "Summarize this.",
+        attachments: [attachment],
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      const promptMessage = yield* Effect.promise(() => readFirstPromptMessage(createInput));
+      assert.deepEqual(promptMessage?.message.content, [
+        {
+          type: "text",
+          text: "Summarize this.",
+        },
+        {
+          type: "document",
+          source: {
+            type: "base64",
+            media_type: "application/pdf",
+            data: "AQIDBA==",
+          },
+        },
+      ]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("maps Claude stream/runtime messages to canonical provider runtime events", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1240,6 +1240,7 @@ const SUPPORTED_CLAUDE_IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/webp",
 ]);
+const SUPPORTED_CLAUDE_DOCUMENT_MIME_TYPES = new Set(["application/pdf"]);
 const CLAUDE_SETTING_SOURCES = [
   "user",
   "project",
@@ -1290,6 +1291,22 @@ function buildClaudeImageContentBlock(input: {
   };
 }
 
+// Claude accepts PDFs as first-class document blocks, so the file is handed
+// over intact rather than described to the model in text.
+function buildClaudeDocumentContentBlock(input: {
+  readonly mimeType: string;
+  readonly bytes: Uint8Array;
+}): Record<string, unknown> {
+  return {
+    type: "document",
+    source: {
+      type: "base64",
+      media_type: input.mimeType,
+      data: Buffer.from(input.bytes).toString("base64"),
+    },
+  };
+}
+
 const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
   input: ProviderSendTurnInput,
   dependencies: {
@@ -1306,15 +1323,15 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
   }
 
   for (const attachment of input.attachments ?? []) {
-    if (attachment.type !== "image") {
-      continue;
-    }
-
-    if (!SUPPORTED_CLAUDE_IMAGE_MIME_TYPES.has(attachment.mimeType)) {
+    const supportedMimeTypes =
+      attachment.type === "image"
+        ? SUPPORTED_CLAUDE_IMAGE_MIME_TYPES
+        : SUPPORTED_CLAUDE_DOCUMENT_MIME_TYPES;
+    if (!supportedMimeTypes.has(attachment.mimeType.toLowerCase())) {
       return yield* new ProviderAdapterRequestError({
         provider: PROVIDER,
         method: "turn/start",
-        detail: `Unsupported Claude image attachment type '${attachment.mimeType}'.`,
+        detail: `Unsupported Claude ${attachment.type} attachment type '${attachment.mimeType}'.`,
       });
     }
 
@@ -1343,10 +1360,9 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
     );
 
     sdkContent.push(
-      buildClaudeImageContentBlock({
-        mimeType: attachment.mimeType,
-        bytes,
-      }),
+      attachment.type === "image"
+        ? buildClaudeImageContentBlock({ mimeType: attachment.mimeType, bytes })
+        : buildClaudeDocumentContentBlock({ mimeType: attachment.mimeType, bytes }),
     );
   }
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -336,6 +336,39 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
     }),
   );
 
+  it.effect("rejects document attachments with a reason naming the file", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("sess-document");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const result = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "summarize",
+          attachments: [
+            {
+              type: "document",
+              id: "sess-document-12345678-1234-1234-1234-123456789abc",
+              name: "spec.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 4,
+            },
+          ],
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterRequestError");
+      NodeAssert.ok(result.failure.detail.includes("spec.pdf"));
+      NodeAssert.ok(result.failure.detail.includes("Codex"));
+    }),
+  );
+
   it.effect("uploads feedback for the active Codex thread", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -52,6 +52,7 @@ import {
   type ProviderAdapterError,
 } from "../Errors.ts";
 import { type CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import { documentAttachmentUnsupportedDetail } from "../../attachmentMime.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import {
@@ -1787,6 +1788,16 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     input: ProviderSendTurnInput,
     attachment: NonNullable<ProviderSendTurnInput["attachments"]>[number],
   ) {
+    if (attachment.type === "document") {
+      return yield* new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "turn/start",
+        detail: documentAttachmentUnsupportedDetail({
+          providerLabel: "Codex",
+          fileName: attachment.name,
+        }),
+      });
+    }
     const attachmentPath = resolveAttachmentPath({
       attachmentsDir: serverConfig.attachmentsDir,
       attachment,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -40,6 +40,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
+import { documentAttachmentUnsupportedDetail } from "../../attachmentMime.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
@@ -972,6 +973,16 @@ export function makeCursorAdapter(
           }
           if (input.attachments && input.attachments.length > 0) {
             for (const attachment of input.attachments) {
+              if (attachment.type === "document") {
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/prompt",
+                  detail: documentAttachmentUnsupportedDetail({
+                    providerLabel: "Cursor",
+                    fileName: attachment.name,
+                  }),
+                });
+              }
               const attachmentPath = resolveAttachmentPath({
                 attachmentsDir: serverConfig.attachmentsDir,
                 attachment,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -32,6 +32,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
+import { documentAttachmentUnsupportedDetail } from "../../attachmentMime.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
@@ -961,6 +962,16 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 input.attachments ?? [],
                 (attachment) =>
                   Effect.gen(function* () {
+                    if (attachment.type === "document") {
+                      return yield* new ProviderAdapterRequestError({
+                        provider: PROVIDER,
+                        method: "session/prompt",
+                        detail: documentAttachmentUnsupportedDetail({
+                          providerLabel: "Grok",
+                          fileName: attachment.name,
+                        }),
+                      });
+                    }
                     const attachmentPath = resolveAttachmentPath({
                       attachmentsDir: serverConfig.attachmentsDir,
                       attachment,

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -12,7 +12,7 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { type ChatMessage, type SessionPhase, type Thread, type ThreadShell } from "../types";
-import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
+import { type ComposerAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentThreadDetails } from "../state/threads";
@@ -344,9 +344,7 @@ export function resolveBackgroundDraftWorkspaceOptions(input: {
   };
 }
 
-export function cloneComposerImageForRetry(
-  image: ComposerImageAttachment,
-): ComposerImageAttachment {
+export function cloneComposerImageForRetry(image: ComposerAttachment): ComposerAttachment {
   if (typeof URL === "undefined" || !image.previewUrl.startsWith("blob:")) {
     return image;
   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -230,7 +230,7 @@ import {
   beginBackgroundDraftSubmissionByRef,
   clearBackgroundDraftSubmissionByRef,
   composerDraftHasUserContent,
-  type ComposerImageAttachment,
+  type ComposerAttachment,
   type DraftThreadEnvMode,
   finalizePromotedDraftThreadByRef,
   markPromotedDraftThreadByRef,
@@ -1384,7 +1384,7 @@ function ChatViewContent(props: ChatViewProps) {
     composerDraftHasUserContent(store.getComposerDraft(composerDraftTarget)),
   );
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
-  const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
+  const addComposerDraftAttachments = useComposerDraftStore((store) => store.addAttachments);
   const setComposerDraftTerminalContexts = useComposerDraftStore(
     (store) => store.setTerminalContexts,
   );
@@ -1410,7 +1410,7 @@ function ChatViewContent(props: ChatViewProps) {
     (store) => store.setLogicalProjectDraftThreadId,
   );
   const promptRef = useRef("");
-  const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
+  const composerAttachmentsRef = useRef<ComposerAttachment[]>([]);
   const composerTerminalContextsRef = useRef<TerminalContextDraft[]>([]);
   const composerElementContextsRef = useRef<ElementContextDraft[]>([]);
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
@@ -5332,7 +5332,7 @@ function ChatViewContent(props: ChatViewProps) {
     submissionIntent: ComposerSubmissionIntent = "foreground",
     directAnnotation?: {
       annotation: PreviewAnnotationPayload;
-      image: ComposerImageAttachment | null;
+      image: ComposerAttachment | null;
     },
   ) => {
     e?.preventDefault();
@@ -5392,7 +5392,7 @@ function ChatViewContent(props: ChatViewProps) {
       selectedPromptEffort: ctxSelectedPromptEffort,
       selectedModelSelection: ctxSelectedModelSelection,
     } = sendCtx;
-    const composerImages =
+    const composerAttachments =
       directAnnotation?.image &&
       !sendContextImages.some((image) => image.id === directAnnotation.image?.id)
         ? [...sendContextImages, directAnnotation.image]
@@ -5420,7 +5420,7 @@ function ChatViewContent(props: ChatViewProps) {
       hasSendableContent,
     } = deriveComposerSendState({
       prompt: promptForSend,
-      imageCount: composerImages.length,
+      imageCount: composerAttachments.length,
       terminalContexts: composerTerminalContexts,
       elementContextCount:
         composerElementContexts.length +
@@ -5429,7 +5429,7 @@ function ChatViewContent(props: ChatViewProps) {
     });
     const feedbackCommand =
       ctxSelectedProvider === "codex" &&
-      composerImages.length === 0 &&
+      composerAttachments.length === 0 &&
       sendableComposerTerminalContexts.length === 0 &&
       composerElementContexts.length === 0 &&
       composerPreviewAnnotations.length === 0 &&
@@ -5550,7 +5550,7 @@ function ChatViewContent(props: ChatViewProps) {
     // otherwise they send as plain text like any other message.
     const standaloneSlashCommand =
       settings.planModeEnabled &&
-      composerImages.length === 0 &&
+      composerAttachments.length === 0 &&
       sendableComposerTerminalContexts.length === 0 &&
       composerElementContexts.length === 0 &&
       composerPreviewAnnotations.length === 0 &&
@@ -5606,7 +5606,7 @@ function ChatViewContent(props: ChatViewProps) {
       return;
     }
 
-    const composerImagesSnapshot = [...composerImages];
+    const composerImagesSnapshot = [...composerAttachments];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
@@ -5938,7 +5938,7 @@ function ChatViewContent(props: ChatViewProps) {
     if (failure !== null) {
       if (
         promptRef.current.length === 0 &&
-        composerImagesRef.current.length === 0 &&
+        composerAttachmentsRef.current.length === 0 &&
         composerTerminalContextsRef.current.length === 0 &&
         composerElementContextsRef.current.length === 0 &&
         (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)?.previewAnnotations
@@ -5956,11 +5956,11 @@ function ChatViewContent(props: ChatViewProps) {
         });
         promptRef.current = promptForSend;
         const retryComposerImages = composerImagesSnapshot.map(cloneComposerImageForRetry);
-        composerImagesRef.current = retryComposerImages;
+        composerAttachmentsRef.current = retryComposerImages;
         composerTerminalContextsRef.current = composerTerminalContextsSnapshot;
         composerElementContextsRef.current = composerElementContextsSnapshot;
         setComposerDraftPrompt(composerDraftTarget, promptForSend);
-        addComposerDraftImages(composerDraftTarget, retryComposerImages);
+        addComposerDraftAttachments(composerDraftTarget, retryComposerImages);
         setComposerDraftTerminalContexts(composerDraftTarget, composerTerminalContextsSnapshot);
         setComposerDraftElementContexts(composerDraftTarget, composerElementContextsSnapshot);
         setComposerDraftPreviewAnnotations(composerDraftTarget, composerPreviewAnnotationsSnapshot);
@@ -7081,7 +7081,7 @@ function ChatViewContent(props: ChatViewProps) {
                             terminalOpen={Boolean(terminalUiState.terminalOpen)}
                             gitCwd={gitCwd}
                             promptRef={promptRef}
-                            composerImagesRef={composerImagesRef}
+                            composerAttachmentsRef={composerAttachmentsRef}
                             composerTerminalContextsRef={composerTerminalContextsRef}
                             composerElementContextsRef={composerElementContextsRef}
                             onSend={onSend}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -482,7 +482,7 @@ const SidebarDraftRow = memo(function SidebarDraftRow(props: {
   // images mirrors persistedAttachments once rehydration finishes; before
   // that only the persisted list is populated, hence max not sum.
   const attachmentCount =
-    Math.max(composer.images.length, composer.persistedAttachments.length) +
+    Math.max(composer.attachments.length, composer.persistedAttachments.length) +
     composer.terminalContexts.length +
     composer.elementContexts.length +
     composer.previewAnnotations.length +

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -13,10 +13,12 @@ import type {
   TurnId,
 } from "@t3tools/contracts";
 import {
+  isProviderSendTurnSupportedDocumentMimeType,
   isProviderSendTurnSupportedImageMimeType,
   ProviderDriverKind,
   ProviderInstanceId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
@@ -51,10 +53,10 @@ import {
   makeComposerMentionDragHandlers,
 } from "./composerMentionDrag";
 import {
-  type ComposerImageAttachment,
+  type ComposerAttachment,
   type DraftId,
-  type PersistedComposerImageAttachment,
-  hydrateImagesFromPersisted,
+  type PersistedComposerAttachment,
+  hydrateAttachmentsFromPersisted,
   useComposerDraftStore,
   useComposerThreadDraft,
   useEffectiveComposerModelState,
@@ -127,6 +129,11 @@ import {
 } from "./composerProviderState";
 import { ContextWindowMeter } from "./ContextWindowMeter";
 import { resolveContextWindowModelDisplayName } from "./ContextWindowMeter.logic";
+import {
+  classifyDroppedFile,
+  formatInlinedTextFile,
+  MAX_INLINE_TEXT_FILE_BYTES,
+} from "./composerDroppedFiles";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
@@ -241,6 +248,7 @@ import { toastManager } from "../ui/toast";
 import {
   BotIcon,
   CircleAlertIcon,
+  FileTextIcon,
   PencilRulerIcon,
   type LucideIcon,
   LockIcon,
@@ -531,7 +539,7 @@ export interface ChatComposerHandle {
   /** Get the current prompt/effort/model state for use in send. */
   getSendContext: () => {
     prompt: string;
-    images: ComposerImageAttachment[];
+    images: ComposerAttachment[];
     terminalContexts: TerminalContextDraft[];
     elementContexts: ElementContextDraft[];
     previewAnnotations: PreviewAnnotationPayload[];
@@ -629,7 +637,7 @@ export interface ChatComposerProps {
 
   // Refs the parent needs kept in sync
   promptRef: React.RefObject<string>;
-  composerImagesRef: React.RefObject<ComposerImageAttachment[]>;
+  composerAttachmentsRef: React.RefObject<ComposerAttachment[]>;
   composerTerminalContextsRef: React.RefObject<TerminalContextDraft[]>;
   composerElementContextsRef: React.RefObject<ElementContextDraft[]>;
   composerRef: React.RefObject<ChatComposerHandle | null>;
@@ -720,7 +728,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     gitCwd,
     promptRef,
     composerRef,
-    composerImagesRef,
+    composerAttachmentsRef,
     composerTerminalContextsRef,
     composerElementContextsRef,
     onSend,
@@ -746,16 +754,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const composerDraft = useComposerThreadDraft(composerDraftTarget);
   const prompt = composerDraft.prompt;
-  const composerImages = composerDraft.images;
+  const composerAttachments = composerDraft.attachments;
   const composerTerminalContexts = composerDraft.terminalContexts;
   const composerElementContexts = composerDraft.elementContexts;
   const composerPreviewAnnotations = composerDraft.previewAnnotations;
   const composerReviewComments = composerDraft.reviewComments;
-  const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
+  const nonPersistedComposerAttachmentIds = composerDraft.nonPersistedAttachmentIds;
   const uploadsByImageId = useAttachmentUploadStore((state) => state.uploadsByImageId);
   const attachmentBlockReason = supportsAttachmentUploads
     ? attachmentUploadBlockReason({
-        imageIds: composerImages.map((image) => image.id),
+        imageIds: composerAttachments.map((image) => image.id),
         uploadsByImageId,
         environmentId,
       })
@@ -765,9 +773,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const isSendDisabled = sendDisabledReason !== null;
 
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
-  const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
-  const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
-  const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
+  const addComposerDraftAttachment = useComposerDraftStore((store) => store.addAttachment);
+  const addComposerDraftAttachments = useComposerDraftStore((store) => store.addAttachments);
+  const removeComposerDraftAttachment = useComposerDraftStore((store) => store.removeAttachment);
   const insertComposerDraftTerminalContext = useComposerDraftStore(
     (store) => store.insertTerminalContext,
   );
@@ -790,7 +798,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     (store) => store.clearPersistedAttachments,
   );
   const clearComposerDraftPromptAndImages = useComposerDraftStore(
-    (store) => store.clearComposerPromptAndImages,
+    (store) => store.clearComposerPromptAndAttachments,
   );
   const syncComposerDraftPersistedAttachments = useComposerDraftStore(
     (store) => store.syncPersistedAttachments,
@@ -802,15 +810,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return;
     }
     if (!supportsAttachmentUploads) {
-      for (const image of composerImages) {
+      for (const image of composerAttachments) {
         releaseAttachmentUpload(image.id);
       }
       return;
     }
-    for (const image of composerImages) {
+    for (const image of composerAttachments) {
       startAttachmentUpload({ environmentId, image });
     }
-  }, [attachmentUploadsCapabilityKnown, composerImages, environmentId, supportsAttachmentUploads]);
+  }, [
+    attachmentUploadsCapabilityKnown,
+    composerAttachments,
+    environmentId,
+    supportsAttachmentUploads,
+  ]);
 
   // ------------------------------------------------------------------
   // Model state
@@ -1094,7 +1107,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () =>
       deriveComposerSendState({
         prompt,
-        imageCount: composerImages.length,
+        imageCount: composerAttachments.length,
         terminalContexts: composerTerminalContexts,
         elementContextCount:
           composerElementContexts.length +
@@ -1103,7 +1116,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }),
     [
       composerElementContexts.length,
-      composerImages.length,
+      composerAttachments.length,
       composerPreviewAnnotations.length,
       composerReviewComments.length,
       composerTerminalContexts,
@@ -1246,8 +1259,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   activeComposerMenuItemRef.current = activeComposerMenuItem;
 
   const nonPersistedComposerImageIdSet = useMemo(
-    () => new Set(nonPersistedComposerImageIds),
-    [nonPersistedComposerImageIds],
+    () => new Set(nonPersistedComposerAttachmentIds),
+    [nonPersistedComposerAttachmentIds],
   );
 
   const isComposerApprovalState = activePendingApproval !== null;
@@ -1373,26 +1386,26 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [composerDraftTarget, setComposerDraftPrompt],
   );
 
-  const addComposerImage = useCallback(
-    (image: ComposerImageAttachment) => {
-      addComposerDraftImage(composerDraftTarget, image);
+  const addComposerAttachment = useCallback(
+    (image: ComposerAttachment) => {
+      addComposerDraftAttachment(composerDraftTarget, image);
     },
-    [composerDraftTarget, addComposerDraftImage],
+    [composerDraftTarget, addComposerDraftAttachment],
   );
 
-  const addComposerImagesToDraft = useCallback(
-    (images: ComposerImageAttachment[]) => {
-      addComposerDraftImages(composerDraftTarget, images);
+  const addComposerAttachmentsToDraft = useCallback(
+    (images: ComposerAttachment[]) => {
+      addComposerDraftAttachments(composerDraftTarget, images);
     },
-    [composerDraftTarget, addComposerDraftImages],
+    [composerDraftTarget, addComposerDraftAttachments],
   );
 
-  const removeComposerImageFromDraft = useCallback(
+  const removeComposerAttachmentFromDraft = useCallback(
     (imageId: string) => {
       releaseAttachmentUpload(imageId);
-      removeComposerDraftImage(composerDraftTarget, imageId);
+      removeComposerDraftAttachment(composerDraftTarget, imageId);
     },
-    [composerDraftTarget, removeComposerDraftImage],
+    [composerDraftTarget, removeComposerDraftAttachment],
   );
 
   const removeComposerTerminalContextFromDraft = useCallback(
@@ -1448,8 +1461,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   ]);
 
   useEffect(() => {
-    composerImagesRef.current = composerImages;
-  }, [composerImages, composerImagesRef]);
+    composerAttachmentsRef.current = composerAttachments;
+  }, [composerAttachments, composerAttachmentsRef]);
 
   useEffect(() => {
     composerTerminalContextsRef.current = composerTerminalContexts;
@@ -1597,7 +1610,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      if (composerImages.length === 0) {
+      if (composerAttachments.length === 0) {
         clearComposerDraftPersistedAttachments(composerDraftTarget);
         return;
       }
@@ -1608,9 +1621,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         const existingPersistedById = new Map(
           currentPersistedAttachments.map((attachment) => [attachment.id, attachment]),
         );
-        const stagedAttachmentById = new Map<string, PersistedComposerImageAttachment>();
+        const stagedAttachmentById = new Map<string, PersistedComposerAttachment>();
         await Promise.all(
-          composerImages.map(async (image) => {
+          composerAttachments.map(async (image) => {
             try {
               const dataUrl = await readFileAsDataUrl(image.file);
               stagedAttachmentById.set(image.id, {
@@ -1632,7 +1645,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (cancelled) return;
         syncComposerDraftPersistedAttachments(composerDraftTarget, serialized);
       } catch {
-        const currentImageIds = new Set(composerImages.map((image) => image.id));
+        const currentImageIds = new Set(composerAttachments.map((image) => image.id));
         const fallbackPersistedAttachments = getPersistedAttachmentsForThread();
         const fallbackPersistedIds: Array<string> = [];
         for (const attachment of fallbackPersistedAttachments) {
@@ -1654,7 +1667,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [
     composerDraftTarget,
     clearComposerDraftPersistedAttachments,
-    composerImages,
+    composerAttachments,
     getComposerDraft,
     syncComposerDraftPersistedAttachments,
   ]);
@@ -2183,19 +2196,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
       let unrestoredImageNames: string[] = [];
       if (entry.attachments.length > 0) {
-        const existingIds = new Set(composerImagesRef.current.map((image) => image.id));
+        const existingIds = new Set(composerAttachmentsRef.current.map((image) => image.id));
         // The draft store also dedupes by mimeType+sizeBytes+name, so filter
         // on the same key here. Counting a duplicate against capacity would
         // burn a slot the store then refuses to fill, pushing a genuinely
         // unique image into the overflow list for nothing.
         const existingDedupKeys = new Set(
-          composerImagesRef.current.map(
+          composerAttachmentsRef.current.map(
             (image) => `${image.mimeType} ${image.sizeBytes} ${image.name}`,
           ),
         );
         const capacity = Math.max(
           0,
-          PROVIDER_SEND_TURN_MAX_ATTACHMENTS - composerImagesRef.current.length,
+          PROVIDER_SEND_TURN_MAX_ATTACHMENTS - composerAttachmentsRef.current.length,
         );
         const pending = entry.attachments.filter(
           (attachment) =>
@@ -2208,9 +2221,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         // already out of the queue, so report the overflow by name instead of
         // discarding it silently.
         unrestoredImageNames = pending.slice(capacity).map((attachment) => attachment.name);
-        const restoredImages = hydrateImagesFromPersisted(pending.slice(0, capacity));
+        const restoredImages = hydrateAttachmentsFromPersisted(pending.slice(0, capacity));
         if (restoredImages.length > 0) {
-          addComposerDraftImages(composerDraftTarget, restoredImages);
+          addComposerDraftAttachments(composerDraftTarget, restoredImages);
         }
       }
 
@@ -2254,9 +2267,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
     },
     [
-      addComposerDraftImages,
+      addComposerDraftAttachments,
       composerDraftTarget,
-      composerImagesRef,
+      composerAttachmentsRef,
       promptRef,
       setComposerDraftPrompt,
       takeStashEntry,
@@ -2283,7 +2296,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     // Terminal-context placeholders reference live sessions the stash can't
     // round-trip, so they are stripped from the stashed prompt.
     const prompt = promptRef.current.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER).join("").trim();
-    const images = [...composerImagesRef.current];
+    const images = [...composerAttachmentsRef.current];
     if (prompt.length === 0 && images.length === 0) {
       setIsStashMenuOpen((open) => !open);
       return;
@@ -2369,10 +2382,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       // composer allows up to 10MB per image, but localStorage gives the whole
       // origin ~5MB. Only the stashed copy shrinks; the live attachment (and
       // anything sent without stashing) keeps the original file.
-      const candidateAttachments: PersistedComposerImageAttachment[] = [];
+      const candidateAttachments: PersistedComposerAttachment[] = [];
       const oversizedImageNames: string[] = [];
       const unreadableImageNames: string[] = [];
       for (const image of images) {
+        // Documents are never stashed: a PDF cannot be downscaled the way an
+        // image can, and one would exhaust the origin's localStorage budget.
+        if (image.type === "document") {
+          oversizedImageNames.push(image.name);
+          continue;
+        }
         const result = await compressImageForStash(image.file);
         if (!result.ok) {
           // "too large" and "could not be read" are distinct outcomes; the
@@ -2383,6 +2402,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           continue;
         }
         candidateAttachments.push({
+          type: "image",
           id: image.id,
           name: image.name,
           mimeType: result.image.mimeType,
@@ -2432,7 +2452,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [
     clearComposerDraftPromptAndImages,
     composerDraftTarget,
-    composerImagesRef,
+    composerAttachmentsRef,
     finalizeStashEntryImages,
     promptRef,
     pulseStashBadge,
@@ -2580,12 +2600,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Callbacks: images
   // ------------------------------------------------------------------
-  const addComposerImages = async (files: File[]) => {
+  const addComposerAttachments = async (files: File[]) => {
     if (!activeThreadId || files.length === 0) return;
     if (pendingUserInputs.length > 0) {
       toastManager.add({
         type: "error",
-        title: "Attach images after answering plan questions.",
+        title: "Attach files after answering plan questions.",
       });
       return;
     }
@@ -2598,21 +2618,33 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     // accepted files reserve their attachment slots (via the pending counter)
     // before the first await, keeping the total under the limit.
     const pendingCount = pendingImageCompressionsRef.current.get(threadId) ?? 0;
-    let reservedCount = composerImagesRef.current.length + pendingCount;
+    let reservedCount = composerAttachmentsRef.current.length + pendingCount;
     const acceptedFiles: File[] = [];
     let error: string | null = null;
     for (const file of files) {
       const isHeicImage = isHeicImageFile(file);
-      if (!file.type.startsWith("image/") && !isHeicImage) {
-        error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
+      const kind = classifyDroppedFile(file, { isHeicImage });
+      if (kind === "unsupported" || kind === "text") {
+        error = `Unsupported file type for '${file.name}'. Attach images, PDFs, or text files.`;
         continue;
       }
-      if (!isHeicImage && !isProviderSendTurnSupportedImageMimeType(file.type)) {
+      if (
+        kind === "image" &&
+        !isHeicImage &&
+        !isProviderSendTurnSupportedImageMimeType(file.type)
+      ) {
         error = `'${file.name}' is not a supported image type. Attach GIF, HEIC, HEIF, JPEG, PNG, or WebP images.`;
         continue;
       }
+      if (kind === "document" && file.size > PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES) {
+        // Unlike an image, a PDF cannot be downscaled to fit the wire cap.
+        error = `'${file.name}' is too large to attach. PDFs must be under ${Math.floor(
+          PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES / (1024 * 1024),
+        )}MB.`;
+        continue;
+      }
       if (reservedCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
+        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} files per message.`;
         break;
       }
       acceptedFiles.push(file);
@@ -2623,9 +2655,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
     pendingImageCompressionsRef.current.set(threadId, pendingCount + acceptedFiles.length);
     try {
-      const nextImages: ComposerImageAttachment[] = [];
+      const nextImages: ComposerAttachment[] = [];
       let compressionError: string | null = null;
       for (const file of acceptedFiles) {
+        if (classifyDroppedFile(file, { isHeicImage: isHeicImageFile(file) }) === "document") {
+          nextImages.push({
+            type: "document",
+            id: randomUUID(),
+            name: file.name || "document.pdf",
+            mimeType: isProviderSendTurnSupportedDocumentMimeType(file.type)
+              ? file.type.toLowerCase()
+              : "application/pdf",
+            sizeBytes: file.size,
+            previewUrl: URL.createObjectURL(file),
+            file,
+          });
+          continue;
+        }
         // Images over the wire cap are downscaled to fit rather than
         // refused; files already within it pass through byte-for-byte.
         const compressed = await prepareImageForAttachment(
@@ -2652,9 +2698,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         });
       }
       if (nextImages.length === 1 && nextImages[0]) {
-        addComposerImage(nextImages[0]);
+        addComposerAttachment(nextImages[0]);
       } else if (nextImages.length > 1) {
-        addComposerImagesToDraft(nextImages);
+        addComposerAttachmentsToDraft(nextImages);
       }
       // Only failures are reported here. Success must not pass `null`: by
       // now other work (a failed send, an overlapping paste) may have set a
@@ -2674,13 +2720,70 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
   };
 
-  const removeComposerImage = (imageId: string) => {
-    removeComposerImageFromDraft(imageId);
+  const removeComposerAttachment = (imageId: string) => {
+    removeComposerAttachmentFromDraft(imageId);
   };
 
   // ------------------------------------------------------------------
   // Callbacks: paste / drag
   // ------------------------------------------------------------------
+  /**
+   * Text files are inlined into the prompt and everything else is staged as an
+   * attachment. A dropped file carries no path the environment could open, so
+   * inlining is the only way its contents reach the agent.
+   */
+  const addDroppedComposerFiles = async (files: File[]) => {
+    if (files.length === 0) return;
+    const attachmentFiles: File[] = [];
+    const textFiles: File[] = [];
+    for (const file of files) {
+      const kind = classifyDroppedFile(file, { isHeicImage: isHeicImageFile(file) });
+      (kind === "text" ? textFiles : attachmentFiles).push(file);
+    }
+
+    if (attachmentFiles.length > 0) {
+      void addComposerAttachments(attachmentFiles);
+    }
+    if (textFiles.length === 0) return;
+
+    const threadId = activeThreadId;
+    const oversizedNames: string[] = [];
+    const unreadableNames: string[] = [];
+    const blocks: string[] = [];
+    for (const file of textFiles) {
+      if (file.size > MAX_INLINE_TEXT_FILE_BYTES) {
+        oversizedNames.push(file.name);
+        continue;
+      }
+      try {
+        const contents = await file.text();
+        if (contents.trim().length === 0) continue;
+        blocks.push(formatInlinedTextFile({ name: file.name, contents }));
+      } catch {
+        unreadableNames.push(file.name);
+      }
+    }
+
+    if (
+      blocks.length > 0 &&
+      !insertComposerTextAtEnd(blocks.join("\n\n"), {
+        ensureLeadingBoundary: true,
+      })
+    ) {
+      unreadableNames.push(...textFiles.map((file) => file.name));
+    }
+
+    const failure =
+      oversizedNames.length > 0
+        ? `${oversizedNames.join(", ")} ${oversizedNames.length === 1 ? "is" : "are"} too large to inline. Files must be under ${Math.floor(MAX_INLINE_TEXT_FILE_BYTES / 1024)}KB.`
+        : unreadableNames.length > 0
+          ? `Could not read ${unreadableNames.join(", ")}.`
+          : null;
+    if (failure !== null && threadId) {
+      setThreadError(threadId, failure);
+    }
+  };
+
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) return;
@@ -2689,7 +2792,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     );
     if (imageFiles.length === 0) return;
     event.preventDefault();
-    void addComposerImages(imageFiles);
+    void addComposerAttachments(imageFiles);
   };
 
   const insertComposerTextAtEnd = (
@@ -2815,7 +2918,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         composerEditorRef.current?.focusAt(cursor);
       },
       addDroppedFiles: (files: File[]) => {
-        void addComposerImages(files);
+        void addDroppedComposerFiles(files);
         focusComposer();
       },
       insertTextAtEnd: insertComposerTextAtEnd,
@@ -2885,7 +2988,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       },
       getSendContext: () => ({
         prompt: promptRef.current,
-        images: composerImagesRef.current,
+        images: composerAttachmentsRef.current,
         terminalContexts: composerTerminalContextsRef.current,
         elementContexts: composerElementContextsRef.current,
         previewAnnotations: composerPreviewAnnotations,
@@ -2911,13 +3014,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }),
     [
       activeThread,
-      addComposerImages,
+      addComposerAttachments,
       composerDraftTarget,
       composerCursor,
       composerTerminalContexts,
       insertComposerDraftTerminalContext,
       promptRef,
-      composerImagesRef,
+      composerAttachmentsRef,
       composerTerminalContextsRef,
       composerElementContextsRef,
       composerPreviewAnnotations,
@@ -3221,11 +3324,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 composerPreviewAnnotations.length > 0 && (
                   <ComposerPreviewAnnotationCards
                     annotations={composerPreviewAnnotations}
-                    images={composerImages}
+                    images={composerAttachments}
                     {...(supportsAttachmentUploads
                       ? {
                           uploadsByImageId,
-                          onRetryUpload: (image: ComposerImageAttachment) =>
+                          onRetryUpload: (image: ComposerAttachment) =>
                             retryAttachmentUpload({ environmentId, image }),
                         }
                       : {})}
@@ -3234,7 +3337,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       removeComposerDraftPreviewAnnotation(composerDraftTarget, annotationId);
                     }}
                     onExpandImage={(imageId) => {
-                      const preview = buildExpandedImagePreview(composerImages, imageId);
+                      const preview = buildExpandedImagePreview(composerAttachments, imageId);
                       if (preview) onExpandImage(preview);
                     }}
                     className="mb-3"
@@ -3270,12 +3373,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               {!isComposerCollapsedMobile &&
                 !isComposerApprovalState &&
                 pendingUserInputs.length === 0 &&
-                composerImages.some(
+                composerAttachments.some(
                   (image) =>
                     !composerPreviewAnnotations.some((annotation) => annotation.id === image.id),
                 ) && (
                   <div className="mb-3 flex flex-wrap gap-2">
-                    {composerImages
+                    {composerAttachments
                       .filter(
                         (image) =>
                           !composerPreviewAnnotations.some(
@@ -3291,14 +3394,30 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                             key={image.id}
                             className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
                           >
-                            {image.previewUrl ? (
+                            {image.type === "document" ? (
+                              <Tooltip>
+                                <TooltipTrigger
+                                  render={
+                                    <span className="flex h-full w-full flex-col items-center justify-center gap-1 px-1 text-center">
+                                      <FileTextIcon className="size-5 text-secondary-label" />
+                                      <span className="line-clamp-2 break-all text-[10px] leading-tight text-secondary-label">
+                                        {image.name}
+                                      </span>
+                                    </span>
+                                  }
+                                />
+                                <TooltipPopup side="top" className="max-w-64 whitespace-normal">
+                                  {image.name}
+                                </TooltipPopup>
+                              </Tooltip>
+                            ) : image.previewUrl ? (
                               <button
                                 type="button"
                                 className="h-full w-full cursor-zoom-in"
                                 aria-label={`Preview ${image.name}`}
                                 onClick={() => {
                                   const preview = buildExpandedImagePreview(
-                                    composerImages,
+                                    composerAttachments,
                                     image.id,
                                   );
                                   if (!preview) return;
@@ -3372,7 +3491,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                               variant="ghost"
                               size="icon-xs"
                               className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
-                              onClick={() => removeComposerImage(image.id)}
+                              onClick={() => removeComposerAttachment(image.id)}
                               aria-label={`Remove ${image.name}`}
                             >
                               <XIcon />

--- a/apps/web/src/components/chat/ComposerPreviewAnnotationCards.tsx
+++ b/apps/web/src/components/chat/ComposerPreviewAnnotationCards.tsx
@@ -2,7 +2,7 @@ import type { PreviewAnnotationPayload } from "@t3tools/contracts";
 import { Frame, MousePointerClick, Paintbrush, PenLine, RotateCcw, X } from "lucide-react";
 import type { ReactNode } from "react";
 
-import type { ComposerImageAttachment } from "~/composerDraftStore";
+import type { ComposerAttachment } from "~/composerDraftStore";
 import { formatElementContextLabel, normalizeElementContextSelection } from "~/lib/elementContext";
 import {
   formatAttachmentUploadProgress,
@@ -14,11 +14,11 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 interface ComposerPreviewAnnotationCardsProps {
   annotations: ReadonlyArray<PreviewAnnotationPayload>;
-  images: ReadonlyArray<ComposerImageAttachment>;
+  images: ReadonlyArray<ComposerAttachment>;
   onRemove: (annotationId: string) => void;
   onExpandImage: (imageId: string) => void;
   uploadsByImageId?: Readonly<Record<string, AttachmentUploadState>>;
-  onRetryUpload?: (image: ComposerImageAttachment) => void;
+  onRetryUpload?: (image: ComposerAttachment) => void;
   className?: string;
 }
 

--- a/apps/web/src/components/chat/ExpandedImagePreview.tsx
+++ b/apps/web/src/components/chat/ExpandedImagePreview.tsx
@@ -9,11 +9,14 @@ export interface ExpandedImagePreview {
 }
 
 export function buildExpandedImagePreview(
-  images: ReadonlyArray<{ id: string; name: string; previewUrl?: string }>,
+  images: ReadonlyArray<{ id: string; name: string; previewUrl?: string; type?: string }>,
   selectedImageId: string,
 ): ExpandedImagePreview | null {
+  // Documents share the attachment list but have nothing to show in a lightbox.
   const previewableImages = images.flatMap((image) =>
-    image.previewUrl ? [{ id: image.id, src: image.previewUrl, name: image.name }] : [],
+    image.previewUrl && image.type !== "document"
+      ? [{ id: image.id, src: image.previewUrl, name: image.name }]
+      : [],
   );
   if (previewableImages.length === 0) {
     return null;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -51,6 +51,7 @@ import {
   ChevronRightIcon,
   CircleAlertIcon,
   EyeIcon,
+  FileTextIcon,
   GlobeIcon,
   HammerIcon,
   MessageCircleIcon,
@@ -1017,7 +1018,12 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
                 key={image.id}
                 className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
               >
-                {image.previewUrl ? (
+                {image.type === "document" ? (
+                  <div className="flex min-h-[72px] items-center gap-2 px-3 py-3 text-left text-[11px] text-secondary-label">
+                    <FileTextIcon className="size-4 shrink-0" />
+                    <span className="break-all">{image.name}</span>
+                  </div>
+                ) : image.previewUrl ? (
                   <button
                     type="button"
                     className="h-full w-full cursor-zoom-in"

--- a/apps/web/src/components/chat/composerDroppedFiles.test.ts
+++ b/apps/web/src/components/chat/composerDroppedFiles.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { classifyDroppedFile, formatInlinedTextFile, fileExtension } from "./composerDroppedFiles";
+
+const classify = (name: string, type: string, isHeicImage = false) =>
+  classifyDroppedFile({ name, type }, { isHeicImage });
+
+describe("classifyDroppedFile", () => {
+  it("keeps image drops on the image path", () => {
+    expect(classify("shot.png", "image/png")).toBe("image");
+    expect(classify("photo.heic", "", true)).toBe("image");
+  });
+
+  it("treats PDFs as documents", () => {
+    expect(classify("spec.pdf", "application/pdf")).toBe("document");
+  });
+
+  it("treats a PDF with no mime type as a document", () => {
+    // Some apps hand over a dragged PDF without a mime type.
+    expect(classify("spec.pdf", "")).toBe("document");
+  });
+
+  it("treats text and markdown as inlineable text", () => {
+    expect(classify("notes.txt", "text/plain")).toBe("text");
+    expect(classify("README.md", "")).toBe("text");
+    expect(classify("post.mdx", "")).toBe("text");
+  });
+
+  it("rejects everything else", () => {
+    expect(classify("archive.zip", "application/zip")).toBe("unsupported");
+    expect(classify("bin", "")).toBe("unsupported");
+  });
+
+  it("is case insensitive on extension and mime type", () => {
+    expect(classify("SPEC.PDF", "APPLICATION/PDF")).toBe("document");
+    expect(classify("NOTES.MD", "")).toBe("text");
+  });
+});
+
+describe("fileExtension", () => {
+  it("returns a lowercased extension or an empty string", () => {
+    expect(fileExtension("a/b/File.MD")).toBe(".md");
+    expect(fileExtension("noextension")).toBe("");
+  });
+});
+
+describe("formatInlinedTextFile", () => {
+  it("fences the contents under the file name", () => {
+    expect(formatInlinedTextFile({ name: "notes.txt", contents: "hello" })).toBe(
+      "notes.txt:\n```\nhello\n```",
+    );
+  });
+
+  it("grows the fence past any backtick run in the file", () => {
+    // A markdown file containing a fenced block must not close its own fence.
+    const contents = "before\n```js\ncode\n```\nafter";
+    const formatted = formatInlinedTextFile({ name: "post.md", contents });
+    expect(formatted.startsWith("post.md:\n````\n")).toBe(true);
+    expect(formatted.endsWith("\n````")).toBe(true);
+    expect(formatted).toContain("```js");
+  });
+
+  it("trims trailing whitespace so the closing fence stays on its own line", () => {
+    expect(formatInlinedTextFile({ name: "a.txt", contents: "body\n\n" })).toBe(
+      "a.txt:\n```\nbody\n```",
+    );
+  });
+});

--- a/apps/web/src/components/chat/composerDroppedFiles.ts
+++ b/apps/web/src/components/chat/composerDroppedFiles.ts
@@ -1,0 +1,65 @@
+import { isProviderSendTurnSupportedDocumentMimeType } from "@t3tools/contracts";
+
+/**
+ * Plain-text drops are inlined into the prompt rather than uploaded. A dropped
+ * file has no filesystem path the environment could open — browsers never
+ * expose one, and a remote environment could not read a local path anyway — so
+ * the contents are the only thing that can actually cross the wire.
+ */
+export const MAX_INLINE_TEXT_FILE_BYTES = 256 * 1024;
+
+const TEXT_FILE_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".mdx"]);
+const TEXT_FILE_MIME_TYPES = new Set(["text/plain", "text/markdown", "text/x-markdown"]);
+
+export type DroppedFileKind = "image" | "document" | "text" | "unsupported";
+
+export interface DroppedFileLike {
+  readonly name: string;
+  readonly type: string;
+}
+
+export function fileExtension(fileName: string): string {
+  const match = /\.[a-z0-9]+$/i.exec(fileName.trim());
+  return match ? match[0].toLowerCase() : "";
+}
+
+/**
+ * Kind of composer handling a dropped file gets. Extension wins over mime type
+ * for text because browsers report an empty type for many `.md` files.
+ */
+export function classifyDroppedFile(
+  file: DroppedFileLike,
+  options: { readonly isHeicImage: boolean },
+): DroppedFileKind {
+  const mimeType = file.type.trim().toLowerCase();
+  if (options.isHeicImage || mimeType.startsWith("image/")) {
+    return "image";
+  }
+  if (isProviderSendTurnSupportedDocumentMimeType(mimeType)) {
+    return "document";
+  }
+  const extension = fileExtension(file.name);
+  if (TEXT_FILE_EXTENSIONS.has(extension) || TEXT_FILE_MIME_TYPES.has(mimeType)) {
+    return "text";
+  }
+  // A PDF dragged from some apps arrives with an empty mime type.
+  return extension === ".pdf" ? "document" : "unsupported";
+}
+
+/**
+ * Wraps inlined file contents in a fence long enough to survive whatever
+ * backticks the file itself contains, so a dropped markdown file cannot
+ * terminate its own block.
+ */
+export function formatInlinedTextFile(input: {
+  readonly name: string;
+  readonly contents: string;
+}): string {
+  const longestBacktickRun = [...input.contents.matchAll(/`+/g)].reduce(
+    (longest, match) => Math.max(longest, match[0].length),
+    0,
+  );
+  const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+  const body = input.contents.replace(/\s+$/, "");
+  return `${input.name}:\n${fence}\n${body}\n${fence}`;
+}

--- a/apps/web/src/components/preview/PreviewPanel.tsx
+++ b/apps/web/src/components/preview/PreviewPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { PreviewAnnotationPayload, ScopedThreadRef } from "@t3tools/contracts";
 
-import type { ComposerImageAttachment } from "~/composerDraftStore";
+import type { ComposerAttachment } from "~/composerDraftStore";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 
 import { PreviewPanelShell, type PreviewPanelMode } from "./PreviewPanelShell";
@@ -16,7 +16,7 @@ interface Props {
   visible: boolean;
   onSendAnnotation?: (
     annotation: PreviewAnnotationPayload,
-    image: ComposerImageAttachment | null,
+    image: ComposerAttachment | null,
   ) => void;
 }
 

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   pickElement: vi.fn(),
   previewAnnotationScreenshotFile: vi.fn(),
   addPreviewAnnotation: vi.fn(),
-  addImage: vi.fn(),
+  addAttachment: vi.fn(),
   toggleAnnotation: null as (() => void) | null,
   pictureInPicture: false,
   showEmptyState: false,
@@ -79,11 +79,11 @@ vi.mock("~/browser/browserDefaults", () => ({
 
 vi.mock("~/composerDraftStore", () => ({
   useComposerDraftStore: (
-    select: (store: { addPreviewAnnotation: () => void; addImage: () => void }) => unknown,
+    select: (store: { addPreviewAnnotation: () => void; addAttachment: () => void }) => unknown,
   ) =>
     select({
       addPreviewAnnotation: mocks.addPreviewAnnotation,
-      addImage: mocks.addImage,
+      addAttachment: mocks.addAttachment,
     }),
 }));
 
@@ -338,7 +338,7 @@ describe("PreviewView navigation", () => {
     mocks.pickElement.mockReset();
     mocks.previewAnnotationScreenshotFile.mockReset();
     mocks.addPreviewAnnotation.mockClear();
-    mocks.addImage.mockClear();
+    mocks.addAttachment.mockClear();
     mocks.toggleAnnotation = null;
     mocks.pictureInPicture = false;
     mocks.showEmptyState = false;
@@ -575,6 +575,6 @@ describe("PreviewView navigation", () => {
     mocks.toggleAnnotation?.();
 
     await vi.waitFor(() => expect(onSendAnnotation).toHaveBeenCalledWith(annotation, null));
-    expect(mocks.addImage).not.toHaveBeenCalled();
+    expect(mocks.addAttachment).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -18,7 +18,7 @@ import {
   setTitleForThreadUrl,
   useThreadRecentHistory,
 } from "~/browserHistoryStore";
-import { type ComposerImageAttachment, useComposerDraftStore } from "~/composerDraftStore";
+import { type ComposerAttachment, useComposerDraftStore } from "~/composerDraftStore";
 import { previewAnnotationScreenshotFile } from "~/lib/previewAnnotation";
 import { ensureLocalApi } from "~/localApi";
 import {
@@ -68,7 +68,7 @@ interface Props {
   visible: boolean;
   onSendAnnotation?: (
     annotation: PreviewAnnotationPayload,
-    image: ComposerImageAttachment | null,
+    image: ComposerAttachment | null,
   ) => void;
 }
 
@@ -103,7 +103,7 @@ export function PreviewView({
     selectThreadPreviewMiniPlayer(state.byThreadKey, threadRef),
   );
   const addPreviewAnnotation = useComposerDraftStore((store) => store.addPreviewAnnotation);
-  const addImage = useComposerDraftStore((store) => store.addImage);
+  const addAttachment = useComposerDraftStore((store) => store.addAttachment);
   const environmentHttpBaseUrl = useEnvironmentHttpBaseUrl(threadRef.environmentId);
   const environmentHostname = environmentHttpBaseUrl
     ? new URL(environmentHttpBaseUrl).hostname
@@ -577,10 +577,10 @@ export function PreviewView({
                 sizeBytes: screenshotFile.size,
                 previewUrl: annotation.screenshot.dataUrl,
                 file: screenshotFile,
-              } satisfies ComposerImageAttachment)
+              } satisfies ComposerAttachment)
             : null;
         if (image) {
-          addImage(threadRef, image);
+          addAttachment(threadRef, image);
         }
         if (submission === "send") {
           onSendAnnotation?.(annotation, image);
@@ -608,7 +608,7 @@ export function PreviewView({
         }
       }
     })();
-  }, [addImage, addPreviewAnnotation, onSendAnnotation, runtimeTabId, threadRef]);
+  }, [addAttachment, addPreviewAnnotation, onSendAnnotation, runtimeTabId, threadRef]);
 
   // If the active tab changes mid-pick (close, thread switch, hot restart),
   // tell main to tear down the in-flight session AND reset our local toggle

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -65,7 +65,7 @@ import {
   markPromotedDraftThreadByRef,
   markPromotedDraftThreads,
   markPromotedDraftThreadsByRef,
-  type ComposerImageAttachment,
+  type ComposerAttachment,
   useComposerDraftStore,
   DraftId,
 } from "./composerDraftStore";
@@ -84,7 +84,7 @@ function makeImage(input: {
   mimeType?: string;
   sizeBytes?: number;
   lastModified?: number;
-}): ComposerImageAttachment {
+}): ComposerAttachment {
   const name = input.name ?? "image.png";
   const mimeType = input.mimeType ?? "image/png";
   const sizeBytes = input.sizeBytes ?? 4;
@@ -171,7 +171,7 @@ function draftByKey(key: string) {
   return useComposerDraftStore.getState().draftsByThreadKey[key] ?? undefined;
 }
 
-describe("composerDraftStore addImages", () => {
+describe("composerDraftStore addAttachments", () => {
   const threadId = ThreadId.make("thread-dedupe");
   const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
   let originalRevokeObjectUrl: typeof URL.revokeObjectURL;
@@ -206,10 +206,10 @@ describe("composerDraftStore addImages", () => {
       lastModified: 12345,
     });
 
-    useComposerDraftStore.getState().addImages(threadRef, [first, duplicate]);
+    useComposerDraftStore.getState().addAttachments(threadRef, [first, duplicate]);
 
     const draft = draftFor(threadId, TEST_ENVIRONMENT_ID);
-    expect(draft?.images.map((image) => image.id)).toEqual(["img-1"]);
+    expect(draft?.attachments.map((image) => image.id)).toEqual(["img-1"]);
     expect(revokeSpy).toHaveBeenCalledWith("blob:duplicate");
   });
 
@@ -231,11 +231,11 @@ describe("composerDraftStore addImages", () => {
       lastModified: 999,
     });
 
-    useComposerDraftStore.getState().addImage(threadRef, first);
-    useComposerDraftStore.getState().addImage(threadRef, duplicateLater);
+    useComposerDraftStore.getState().addAttachment(threadRef, first);
+    useComposerDraftStore.getState().addAttachment(threadRef, duplicateLater);
 
     const draft = draftFor(threadId, TEST_ENVIRONMENT_ID);
-    expect(draft?.images.map((image) => image.id)).toEqual(["img-a"]);
+    expect(draft?.attachments.map((image) => image.id)).toEqual(["img-a"]);
     expect(revokeSpy).toHaveBeenCalledWith("blob:b");
   });
 
@@ -249,10 +249,10 @@ describe("composerDraftStore addImages", () => {
       previewUrl: "blob:shared",
     });
 
-    useComposerDraftStore.getState().addImages(threadRef, [first, duplicateSameUrl]);
+    useComposerDraftStore.getState().addAttachments(threadRef, [first, duplicateSameUrl]);
 
     const draft = draftFor(threadId, TEST_ENVIRONMENT_ID);
-    expect(draft?.images.map((image) => image.id)).toEqual(["img-shared"]);
+    expect(draft?.attachments.map((image) => image.id)).toEqual(["img-shared"]);
     expect(revokeSpy).not.toHaveBeenCalledWith("blob:shared");
   });
 });
@@ -279,7 +279,7 @@ describe("composerDraftStore clearComposerContent", () => {
       id: "img-optimistic",
       previewUrl: "blob:optimistic",
     });
-    useComposerDraftStore.getState().addImage(threadRef, first);
+    useComposerDraftStore.getState().addAttachment(threadRef, first);
 
     useComposerDraftStore.getState().clearComposerContent(threadRef);
 
@@ -289,7 +289,7 @@ describe("composerDraftStore clearComposerContent", () => {
   });
 });
 
-describe("composerDraftStore moveComposerPromptAndImages", () => {
+describe("composerDraftStore moveComposerPromptAndAttachments", () => {
   const sourceDraftId = DraftId.make("draft-move-source");
   const destinationDraftId = DraftId.make("draft-move-destination");
   let originalRevokeObjectUrl: typeof URL.revokeObjectURL;
@@ -309,14 +309,14 @@ describe("composerDraftStore moveComposerPromptAndImages", () => {
   it("moves prompt and images to the destination without revoking preview URLs", () => {
     const store = useComposerDraftStore.getState();
     store.setPrompt(sourceDraftId, "fix the login redirect");
-    store.addImages(sourceDraftId, [makeImage({ id: "img-move", previewUrl: "blob:move" })]);
+    store.addAttachments(sourceDraftId, [makeImage({ id: "img-move", previewUrl: "blob:move" })]);
 
-    store.moveComposerPromptAndImages(sourceDraftId, destinationDraftId);
+    store.moveComposerPromptAndAttachments(sourceDraftId, destinationDraftId);
 
     expect(draftByKey(sourceDraftId)).toBeUndefined();
     const destination = draftByKey(destinationDraftId);
     expect(destination?.prompt).toBe("fix the login redirect");
-    expect(destination?.images.map((image) => image.id)).toEqual(["img-move"]);
+    expect(destination?.attachments.map((image) => image.id)).toEqual(["img-move"]);
     expect(revokeSpy).not.toHaveBeenCalled();
   });
 
@@ -327,7 +327,7 @@ describe("composerDraftStore moveComposerPromptAndImages", () => {
     store.addTerminalContext(sourceThreadRef, makeTerminalContext({ id: "ctx-stay" }));
     store.setPrompt(sourceThreadRef, `${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} explain this error`);
 
-    store.moveComposerPromptAndImages(sourceThreadRef, destinationDraftId);
+    store.moveComposerPromptAndAttachments(sourceThreadRef, destinationDraftId);
 
     const source = draftFor(sourceThreadId, TEST_ENVIRONMENT_ID);
     expect(source?.terminalContexts.map((context) => context.id)).toEqual(["ctx-stay"]);
@@ -339,7 +339,7 @@ describe("composerDraftStore moveComposerPromptAndImages", () => {
     const store = useComposerDraftStore.getState();
     store.setPrompt(sourceDraftId, "keep me");
 
-    store.moveComposerPromptAndImages(sourceDraftId, sourceDraftId);
+    store.moveComposerPromptAndAttachments(sourceDraftId, sourceDraftId);
 
     expect(draftByKey(sourceDraftId)?.prompt).toBe("keep me");
   });
@@ -369,7 +369,7 @@ describe("composerDraftStore syncPersistedAttachments", () => {
       id: "img-persisted",
       previewUrl: "blob:persisted",
     });
-    useComposerDraftStore.getState().addImage(threadRef, image);
+    useComposerDraftStore.getState().addAttachment(threadRef, image);
     setLocalStorageItem(
       COMPOSER_DRAFT_STORAGE_KEY,
       {
@@ -397,7 +397,7 @@ describe("composerDraftStore syncPersistedAttachments", () => {
     await Promise.resolve();
 
     expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.persistedAttachments).toEqual([]);
-    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.nonPersistedImageIds).toEqual([image.id]);
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.nonPersistedAttachmentIds).toEqual([image.id]);
   });
 });
 
@@ -768,7 +768,10 @@ describe("composerDraftStore project draft thread mapping", () => {
       });
       store.setPrompt(localDraftId, "local draft");
       store.setPrompt(remoteDraftId, "remote draft");
-      store.addImage(localDraftId, makeImage({ id: "img-local", previewUrl: "blob:local-draft" }));
+      store.addAttachment(
+        localDraftId,
+        makeImage({ id: "img-local", previewUrl: "blob:local-draft" }),
+      );
       store.setPrompt(localThreadRef, "local thread draft");
       store.setPrompt(remoteThreadRef, "remote thread draft");
 
@@ -894,7 +897,10 @@ describe("composerDraftStore project draft thread mapping", () => {
 
     try {
       store.setProjectDraftThreadId(projectRef, draftId, { threadId });
-      store.addImage(draftId, makeImage({ id: "img-project-clear", previewUrl: "blob:clear" }));
+      store.addAttachment(
+        draftId,
+        makeImage({ id: "img-project-clear", previewUrl: "blob:clear" }),
+      );
 
       store.clearProjectDraftThreadId(projectRef);
 
@@ -914,7 +920,7 @@ describe("composerDraftStore project draft thread mapping", () => {
 
     try {
       store.setProjectDraftThreadId(projectRef, draftId, { threadId });
-      store.addImage(
+      store.addAttachment(
         draftId,
         makeImage({ id: "img-project-clear-by-id", previewUrl: "blob:clear-by-id" }),
       );

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -33,7 +33,12 @@ import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model"
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatDocumentAttachment,
+  type ChatImageAttachment,
+} from "./types";
 import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
@@ -79,19 +84,30 @@ if (typeof window !== "undefined" && typeof window.addEventListener === "functio
   });
 }
 
-export const PersistedComposerImageAttachment = Schema.Struct({
+export const PersistedComposerAttachment = Schema.Struct({
+  // Optional so drafts persisted before documents existed still decode.
+  type: Schema.optional(Schema.Literals(["image", "document"])),
   id: Schema.String,
   name: Schema.String,
   mimeType: Schema.String,
   sizeBytes: Schema.Number,
   dataUrl: Schema.String,
 });
-export type PersistedComposerImageAttachment = typeof PersistedComposerImageAttachment.Type;
+export type PersistedComposerAttachment = typeof PersistedComposerAttachment.Type;
 
-export interface ComposerImageAttachment extends Omit<ChatImageAttachment, "previewUrl"> {
+interface ComposerAttachmentFile {
+  /** Object URL for the staged file; images render it, documents open it. */
   previewUrl: string;
   file: File;
 }
+
+export interface ComposerImageAttachment
+  extends Omit<ChatImageAttachment, "previewUrl">, ComposerAttachmentFile {}
+
+export interface ComposerDocumentAttachment
+  extends Omit<ChatDocumentAttachment, "previewUrl">, ComposerAttachmentFile {}
+
+export type ComposerAttachment = ComposerImageAttachment | ComposerDocumentAttachment;
 
 const PersistedTerminalContextDraft = Schema.Struct({
   id: Schema.String,
@@ -128,7 +144,7 @@ type PersistedElementContextDraft = typeof PersistedElementContextDraft.Type;
 
 const PersistedComposerThreadDraftState = Schema.Struct({
   prompt: Schema.String,
-  attachments: Schema.Array(PersistedComposerImageAttachment),
+  attachments: Schema.Array(PersistedComposerAttachment),
   terminalContexts: Schema.optionalKey(Schema.Array(PersistedTerminalContextDraft)),
   elementContexts: Schema.optionalKey(Schema.Array(PersistedElementContextDraft)),
   previewAnnotations: Schema.optionalKey(Schema.Array(PreviewAnnotationPayloadSchema)),
@@ -250,9 +266,9 @@ const PersistedComposerDraftStoreStorage = Schema.Struct({
  */
 export interface ComposerThreadDraftState {
   prompt: string;
-  images: ComposerImageAttachment[];
-  nonPersistedImageIds: string[];
-  persistedAttachments: PersistedComposerImageAttachment[];
+  attachments: ComposerAttachment[];
+  nonPersistedAttachmentIds: string[];
+  persistedAttachments: PersistedComposerAttachment[];
   terminalContexts: TerminalContextDraft[];
   /**
    * Element-pick attachments captured from the in-app preview browser. The
@@ -294,7 +310,7 @@ export function composerDraftHasUserContent(
   }
   return (
     draft.prompt.trim().length > 0 ||
-    draft.images.length > 0 ||
+    draft.attachments.length > 0 ||
     draft.persistedAttachments.length > 0 ||
     draft.terminalContexts.length > 0 ||
     draft.elementContexts.length > 0 ||
@@ -470,9 +486,9 @@ interface ComposerDraftStoreState {
     threadRef: ComposerThreadTarget,
     interactionMode: ProviderInteractionMode | null | undefined,
   ) => void;
-  addImage: (threadRef: ComposerThreadTarget, image: ComposerImageAttachment) => void;
-  addImages: (threadRef: ComposerThreadTarget, images: ComposerImageAttachment[]) => void;
-  removeImage: (threadRef: ComposerThreadTarget, imageId: string) => void;
+  addAttachment: (threadRef: ComposerThreadTarget, image: ComposerAttachment) => void;
+  addAttachments: (threadRef: ComposerThreadTarget, attachments: ComposerAttachment[]) => void;
+  removeAttachment: (threadRef: ComposerThreadTarget, imageId: string) => void;
   insertTerminalContext: (
     threadRef: ComposerThreadTarget,
     prompt: string,
@@ -519,7 +535,7 @@ interface ComposerDraftStoreState {
   clearPersistedAttachments: (threadRef: ComposerThreadTarget) => void;
   syncPersistedAttachments: (
     threadRef: ComposerThreadTarget,
-    attachments: PersistedComposerImageAttachment[],
+    attachments: PersistedComposerAttachment[],
   ) => void;
   clearComposerContent: (threadRef: ComposerThreadTarget) => void;
   /**
@@ -528,7 +544,7 @@ interface ComposerDraftStoreState {
    * prompt stash, which can only round-trip text + images: clearing the
    * session-bound contexts would destroy state nothing can restore.
    */
-  clearComposerPromptAndImages: (threadRef: ComposerThreadTarget) => void;
+  clearComposerPromptAndAttachments: (threadRef: ComposerThreadTarget) => void;
   /**
    * Moves the prompt text and image attachments from one composer target to
    * another. Used when a draft changes project: the new project gets its own
@@ -537,7 +553,7 @@ interface ComposerDraftStoreState {
    * on the source — they reference sessions of the source thread that the
    * destination cannot use.
    */
-  moveComposerPromptAndImages: (from: ComposerThreadTarget, to: ComposerThreadTarget) => void;
+  moveComposerPromptAndAttachments: (from: ComposerThreadTarget, to: ComposerThreadTarget) => void;
 }
 
 export interface EffectiveComposerModelState {
@@ -603,14 +619,14 @@ const EMPTY_PERSISTED_DRAFT_STORE_STATE = Object.freeze<PersistedComposerDraftSt
   stickyActiveProvider: null,
 });
 
-const EMPTY_IMAGES: ComposerImageAttachment[] = [];
+const EMPTY_ATTACHMENTS: ComposerAttachment[] = [];
 const EMPTY_IDS: string[] = [];
-const EMPTY_PERSISTED_ATTACHMENTS: PersistedComposerImageAttachment[] = [];
+const EMPTY_PERSISTED_ATTACHMENTS: PersistedComposerAttachment[] = [];
 const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
 const EMPTY_ELEMENT_CONTEXTS: ElementContextDraft[] = [];
 const EMPTY_PREVIEW_ANNOTATIONS: PreviewAnnotationPayload[] = [];
 const EMPTY_REVIEW_COMMENTS: ReviewCommentContext[] = [];
-Object.freeze(EMPTY_IMAGES);
+Object.freeze(EMPTY_ATTACHMENTS);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
 Object.freeze(EMPTY_ELEMENT_CONTEXTS);
@@ -625,8 +641,8 @@ const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>(
 
 const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   prompt: "",
-  images: EMPTY_IMAGES,
-  nonPersistedImageIds: EMPTY_IDS,
+  attachments: EMPTY_ATTACHMENTS,
+  nonPersistedAttachmentIds: EMPTY_IDS,
   persistedAttachments: EMPTY_PERSISTED_ATTACHMENTS,
   terminalContexts: EMPTY_TERMINAL_CONTEXTS,
   elementContexts: EMPTY_ELEMENT_CONTEXTS,
@@ -647,8 +663,8 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
 export function createEmptyThreadDraft(): ComposerThreadDraftState {
   return {
     prompt: "",
-    images: [],
-    nonPersistedImageIds: [],
+    attachments: [],
+    nonPersistedAttachmentIds: [],
     persistedAttachments: [],
     terminalContexts: [],
     elementContexts: [],
@@ -661,7 +677,7 @@ export function createEmptyThreadDraft(): ComposerThreadDraftState {
   };
 }
 
-function composerImageDedupKey(image: ComposerImageAttachment): string {
+function composerAttachmentDedupKey(image: ComposerAttachment): string {
   // Keep this independent from File.lastModified so dedupe is stable for hydrated
   // images reconstructed from localStorage (which get a fresh lastModified value).
   return `${image.mimeType}\u0000${image.sizeBytes}\u0000${image.name}`;
@@ -721,7 +737,7 @@ function normalizeTerminalContextsForThread(
 function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
   return (
     draft.prompt.length === 0 &&
-    draft.images.length === 0 &&
+    draft.attachments.length === 0 &&
     draft.persistedAttachments.length === 0 &&
     draft.terminalContexts.length === 0 &&
     draft.elementContexts.length === 0 &&
@@ -1084,12 +1100,12 @@ function revokeDraftThreadPreviewUrls(draft: ComposerThreadDraftState | undefine
   if (!draft) {
     return;
   }
-  for (const image of draft.images) {
+  for (const image of draft.attachments) {
     revokeObjectPreviewUrl(image.previewUrl);
   }
 }
 
-function normalizePersistedAttachment(value: unknown): PersistedComposerImageAttachment | null {
+function normalizePersistedAttachment(value: unknown): PersistedComposerAttachment | null {
   if (!value || typeof value !== "object") {
     return null;
   }
@@ -1111,7 +1127,9 @@ function normalizePersistedAttachment(value: unknown): PersistedComposerImageAtt
   ) {
     return null;
   }
+  const type = candidate.type === "document" ? "document" : "image";
   return {
+    type,
     id,
     name,
     mimeType,
@@ -2083,7 +2101,7 @@ function readPersistedAttachmentIdsFromStorage(threadKey: string): string[] {
 
 function verifyPersistedAttachments(
   threadKey: string,
-  attachments: PersistedComposerImageAttachment[],
+  attachments: PersistedComposerAttachment[],
   set: (
     partial:
       | ComposerDraftStoreState
@@ -2106,20 +2124,20 @@ function verifyPersistedAttachments(
     if (!current) {
       return state;
     }
-    const imageIdSet = new Set(current.images.map((image) => image.id));
+    const imageIdSet = new Set(current.attachments.map((image) => image.id));
     const persistedAttachments = attachments.filter(
       (attachment) => imageIdSet.has(attachment.id) && persistedIdSet.has(attachment.id),
     );
-    const nonPersistedImageIds: string[] = [];
-    for (const image of current.images) {
+    const nonPersistedAttachmentIds: string[] = [];
+    for (const image of current.attachments) {
       if (!persistedIdSet.has(image.id)) {
-        nonPersistedImageIds.push(image.id);
+        nonPersistedAttachmentIds.push(image.id);
       }
     }
     const nextDraft: ComposerThreadDraftState = {
       ...current,
       persistedAttachments,
-      nonPersistedImageIds,
+      nonPersistedAttachmentIds,
     };
     const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
     if (shouldRemoveDraft(nextDraft)) {
@@ -2132,7 +2150,7 @@ function verifyPersistedAttachments(
 }
 
 function hydratePersistedComposerImageAttachment(
-  attachment: PersistedComposerImageAttachment,
+  attachment: PersistedComposerAttachment,
 ): File | null {
   const commaIndex = attachment.dataUrl.indexOf(",");
   const header = commaIndex === -1 ? attachment.dataUrl : attachment.dataUrl.slice(0, commaIndex);
@@ -2163,23 +2181,23 @@ function hydratePersistedComposerImageAttachment(
   }
 }
 
-export function hydrateImagesFromPersisted(
-  attachments: ReadonlyArray<PersistedComposerImageAttachment>,
-): ComposerImageAttachment[] {
+export function hydrateAttachmentsFromPersisted(
+  attachments: ReadonlyArray<PersistedComposerAttachment>,
+): ComposerAttachment[] {
   return attachments.flatMap((attachment) => {
     const file = hydratePersistedComposerImageAttachment(attachment);
     if (!file) return [];
 
     return [
       {
-        type: "image" as const,
+        type: attachment.type ?? "image",
         id: attachment.id,
         name: attachment.name,
         mimeType: attachment.mimeType,
         sizeBytes: attachment.sizeBytes,
         previewUrl: attachment.dataUrl,
         file,
-      } satisfies ComposerImageAttachment,
+      } satisfies ComposerAttachment,
     ];
   });
 }
@@ -2194,8 +2212,8 @@ function toHydratedThreadDraft(
 
   return {
     prompt: persistedDraft.prompt,
-    images: hydrateImagesFromPersisted(persistedDraft.attachments),
-    nonPersistedImageIds: [],
+    attachments: hydrateAttachmentsFromPersisted(persistedDraft.attachments),
+    nonPersistedAttachmentIds: [],
     persistedAttachments: [...persistedDraft.attachments],
     terminalContexts:
       persistedDraft.terminalContexts?.map((context) => ({
@@ -2955,31 +2973,34 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
-        addImage: (threadRef, image) => {
+        addAttachment: (threadRef, image) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef);
           const threadId = resolveComposerThreadId(get(), threadRef);
           if (!threadKey || !threadId) {
             return;
           }
-          get().addImages(typeof threadRef === "string" ? DraftId.make(threadKey) : threadRef, [
-            image,
-          ]);
+          get().addAttachments(
+            typeof threadRef === "string" ? DraftId.make(threadKey) : threadRef,
+            [image],
+          );
         },
-        addImages: (threadRef, images) => {
+        addAttachments: (threadRef, attachments) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
-          if (threadKey.length === 0 || images.length === 0) {
+          if (threadKey.length === 0 || attachments.length === 0) {
             return;
           }
           set((state) => {
             const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
-            const existingIds = new Set(existing.images.map((image) => image.id));
+            const existingIds = new Set(existing.attachments.map((image) => image.id));
             const existingDedupKeys = new Set(
-              existing.images.map((image) => composerImageDedupKey(image)),
+              existing.attachments.map((image) => composerAttachmentDedupKey(image)),
             );
-            const acceptedPreviewUrls = new Set(existing.images.map((image) => image.previewUrl));
-            const dedupedIncoming: ComposerImageAttachment[] = [];
-            for (const image of images) {
-              const dedupKey = composerImageDedupKey(image);
+            const acceptedPreviewUrls = new Set(
+              existing.attachments.map((image) => image.previewUrl),
+            );
+            const dedupedIncoming: ComposerAttachment[] = [];
+            for (const image of attachments) {
+              const dedupKey = composerAttachmentDedupKey(image);
               if (existingIds.has(image.id) || existingDedupKeys.has(dedupKey)) {
                 // Avoid revoking a blob URL that's still referenced by an accepted image.
                 if (!acceptedPreviewUrls.has(image.previewUrl)) {
@@ -3000,13 +3021,13 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 ...state.draftsByThreadKey,
                 [threadKey]: {
                   ...existing,
-                  images: [...existing.images, ...dedupedIncoming],
+                  attachments: [...existing.attachments, ...dedupedIncoming],
                 },
               },
             };
           });
         },
-        removeImage: (threadRef, imageId) => {
+        removeAttachment: (threadRef, imageId) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
             return;
@@ -3015,7 +3036,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
           if (!existing) {
             return;
           }
-          const removedImage = existing.images.find((image) => image.id === imageId);
+          const removedImage = existing.attachments.find((image) => image.id === imageId);
           if (removedImage) {
             revokeObjectPreviewUrl(removedImage.previewUrl);
           }
@@ -3026,8 +3047,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             }
             const nextDraft: ComposerThreadDraftState = {
               ...current,
-              images: current.images.filter((image) => image.id !== imageId),
-              nonPersistedImageIds: current.nonPersistedImageIds.filter((id) => id !== imageId),
+              attachments: current.attachments.filter((image) => image.id !== imageId),
+              nonPersistedAttachmentIds: current.nonPersistedAttachmentIds.filter(
+                (id) => id !== imageId,
+              ),
               persistedAttachments: current.persistedAttachments.filter(
                 (attachment) => attachment.id !== imageId,
               ),
@@ -3309,11 +3332,11 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft = {
               ...current,
               previewAnnotations,
-              images: current.images.filter((image) => image.id !== annotationId),
+              attachments: current.attachments.filter((image) => image.id !== annotationId),
               persistedAttachments: current.persistedAttachments.filter(
                 (image) => image.id !== annotationId,
               ),
-              nonPersistedImageIds: current.nonPersistedImageIds.filter(
+              nonPersistedAttachmentIds: current.nonPersistedAttachmentIds.filter(
                 (imageId) => imageId !== annotationId,
               ),
             };
@@ -3385,7 +3408,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...current,
               persistedAttachments: [],
-              nonPersistedImageIds: [],
+              nonPersistedAttachmentIds: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {
@@ -3411,7 +3434,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               ...current,
               // Stage attempted attachments so persist middleware can try writing them.
               persistedAttachments: attachments,
-              nonPersistedImageIds: current.nonPersistedImageIds.filter(
+              nonPersistedAttachmentIds: current.nonPersistedAttachmentIds.filter(
                 (id) => !attachmentIdSet.has(id),
               ),
             };
@@ -3440,8 +3463,8 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...current,
               prompt: "",
-              images: [],
-              nonPersistedImageIds: [],
+              attachments: [],
+              nonPersistedAttachmentIds: [],
               persistedAttachments: [],
               terminalContexts: [],
               elementContexts: [],
@@ -3457,7 +3480,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
-        clearComposerPromptAndImages: (threadRef) => {
+        clearComposerPromptAndAttachments: (threadRef) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
             return;
@@ -3467,14 +3490,14 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             if (!current) {
               return state;
             }
-            for (const image of current.images) {
+            for (const image of current.attachments) {
               revokeObjectPreviewUrl(image.previewUrl);
             }
             const nextDraft: ComposerThreadDraftState = {
               ...current,
               prompt: ensureInlineTerminalContextPlaceholders("", current.terminalContexts.length),
-              images: [],
-              nonPersistedImageIds: [],
+              attachments: [],
+              nonPersistedAttachmentIds: [],
               persistedAttachments: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
@@ -3486,7 +3509,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
-        moveComposerPromptAndImages: (from, to) => {
+        moveComposerPromptAndAttachments: (from, to) => {
           const fromKey = resolveComposerDraftKey(get(), from) ?? "";
           const toKey = resolveComposerDraftKey(get(), to) ?? "";
           if (fromKey.length === 0 || toKey.length === 0 || fromKey === toKey) {
@@ -3508,24 +3531,24 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDestination: ComposerThreadDraftState = {
               ...destination,
               prompt: movedPrompt,
-              images: [...destination.images, ...source.images],
-              nonPersistedImageIds: [
-                ...destination.nonPersistedImageIds,
-                ...source.nonPersistedImageIds,
+              attachments: [...destination.attachments, ...source.attachments],
+              nonPersistedAttachmentIds: [
+                ...destination.nonPersistedAttachmentIds,
+                ...source.nonPersistedAttachmentIds,
               ],
               persistedAttachments: [
                 ...destination.persistedAttachments,
                 ...source.persistedAttachments,
               ],
             };
-            // Same clearing shape as clearComposerPromptAndImages, but the
+            // Same clearing shape as clearComposerPromptAndAttachments, but the
             // preview URLs are NOT revoked: the images moved and their blobs
             // are still referenced from the destination.
             const nextSource: ComposerThreadDraftState = {
               ...source,
               prompt: ensureInlineTerminalContextPlaceholders("", source.terminalContexts.length),
-              images: [],
-              nonPersistedImageIds: [],
+              attachments: [],
+              nonPersistedAttachmentIds: [],
               persistedAttachments: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };

--- a/apps/web/src/composerPlaceholder.ts
+++ b/apps/web/src/composerPlaceholder.ts
@@ -1,2 +1,2 @@
 export const DISCONNECTED_COMPOSER_PLACEHOLDER =
-  "Ask for changes, send follow-ups, or attach images";
+  "Ask for changes, send follow-ups, or attach files";

--- a/apps/web/src/historyBootstrap.ts
+++ b/apps/web/src/historyBootstrap.ts
@@ -19,17 +19,18 @@ function messageRoleLabel(message: ChatMessage): "USER" | "ASSISTANT" {
 }
 
 function attachmentSummary(message: ChatMessage): string | null {
-  const imageAttachments = message.attachments?.filter((attachment) => attachment.type === "image");
-  const count = imageAttachments?.length ?? 0;
+  const attachments = message.attachments ?? [];
+  const count = attachments.length;
   if (count === 0) {
     return null;
   }
 
-  const names = imageAttachments?.slice(0, 3).map((image) => image.name) ?? [];
+  const names = attachments.slice(0, 3).map((attachment) => attachment.name);
   const namesSummary = names.join(", ");
   const extraCount = count - names.length;
   const extraSummary = extraCount > 0 ? ` (+${extraCount} more)` : "";
-  return `[Attached image${count === 1 ? "" : "s"}: ${namesSummary}${extraSummary}]`;
+  const noun = attachments.every((attachment) => attachment.type === "image") ? "image" : "file";
+  return `[Attached ${noun}${count === 1 ? "" : "s"}: ${namesSummary}${extraSummary}]`;
 }
 
 function buildMessageBlock(message: ChatMessage): string {

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -93,7 +93,7 @@ export function useNewThreadHandler() {
         getDraftSession,
         getDraftThread,
         applyStickyState,
-        moveComposerPromptAndImages,
+        moveComposerPromptAndAttachments,
         setDraftThreadContext,
         setLogicalProjectDraftThreadId,
         setModelSelection,
@@ -153,7 +153,7 @@ export function useNewThreadHandler() {
           !composerDraftHasUserContent(getComposerDraft(destinationDraftId)) &&
           composerDraftHasUserContent(getComposerDraft(carryContentSourceDraftId))
         ) {
-          moveComposerPromptAndImages(carryContentSourceDraftId, destinationDraftId);
+          moveComposerPromptAndAttachments(carryContentSourceDraftId, destinationDraftId);
         }
       };
       const project = projects.find(

--- a/apps/web/src/lib/attachmentUploadQueue.test.ts
+++ b/apps/web/src/lib/attachmentUploadQueue.test.ts
@@ -1,7 +1,7 @@
 import { EnvironmentId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import type { ComposerImageAttachment } from "../composerDraftStore";
+import type { ComposerAttachment } from "../composerDraftStore";
 
 const mocks = vi.hoisted(() => ({
   createUploadUrl: Symbol("create-upload-url"),
@@ -97,7 +97,7 @@ class TestXmlHttpRequest {
 const firstEnvironment = EnvironmentId.make("environment-1");
 const secondEnvironment = EnvironmentId.make("environment-2");
 
-function makeImage(id: string): ComposerImageAttachment {
+function makeImage(id: string): ComposerAttachment {
   const file = new File([new Uint8Array([1, 2, 3])], `${id}.png`, { type: "image/png" });
   return {
     type: "image",

--- a/apps/web/src/lib/attachmentUploadQueue.ts
+++ b/apps/web/src/lib/attachmentUploadQueue.ts
@@ -1,4 +1,5 @@
 import {
+  PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPES,
   PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
   type ChatAttachment,
   type EnvironmentId,
@@ -7,7 +8,7 @@ import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import { runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import { create } from "zustand";
 
-import type { ComposerImageAttachment } from "../composerDraftStore";
+import type { ComposerAttachment } from "../composerDraftStore";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { attachmentEnvironment } from "../state/attachments";
 import { readPreparedConnection } from "../state/session";
@@ -25,7 +26,7 @@ export const useAttachmentUploadStore = create<AttachmentUploadStore>(() => ({
 }));
 
 interface UploadJob {
-  readonly image: ComposerImageAttachment;
+  readonly image: ComposerAttachment;
   readonly environmentId: EnvironmentId;
   readonly previous?: ReadyAttachmentUpload;
   readonly settled: Promise<void>;
@@ -101,14 +102,19 @@ function uploadBytes(input: {
 }
 
 async function runUpload(job: UploadJob): Promise<void> {
-  const mimeType = PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES.find(
-    (supportedMimeType) => supportedMimeType === job.image.mimeType.toLowerCase(),
+  const supportedMimeTypes =
+    job.image.type === "document"
+      ? PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPES
+      : PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES;
+  const requestedMimeType = job.image.mimeType.toLowerCase();
+  const mimeType = supportedMimeTypes.find(
+    (supportedMimeType: string) => supportedMimeType === requestedMimeType,
   );
   if (!mimeType) {
     setUploadState(job.image.id, {
       status: "failed",
       environmentId: job.environmentId,
-      reason: "Unsupported image type",
+      reason: `Unsupported ${job.image.type} type`,
       ...(job.previous ? { previous: job.previous } : {}),
     });
     return;
@@ -249,7 +255,7 @@ function pumpUploads(): void {
 
 export function startAttachmentUpload(input: {
   readonly environmentId: EnvironmentId;
-  readonly image: ComposerImageAttachment;
+  readonly image: ComposerAttachment;
 }): void {
   const existingJob = jobsByImageId.get(input.image.id);
   if (existingJob?.environmentId === input.environmentId) {
@@ -342,7 +348,7 @@ export function releaseAttachmentUpload(imageId: string): void {
 
 export function retryAttachmentUpload(input: {
   readonly environmentId: EnvironmentId;
-  readonly image: ComposerImageAttachment;
+  readonly image: ComposerAttachment;
 }): void {
   const previous = readAttachmentUpload(input.image.id);
   cancelAttachmentUpload(input.image.id);
@@ -363,7 +369,7 @@ export async function awaitAttachmentUploads(imageIds: ReadonlyArray<string>): P
 
 export function getUploadedAttachments(input: {
   readonly environmentId: EnvironmentId;
-  readonly images: ReadonlyArray<ComposerImageAttachment>;
+  readonly images: ReadonlyArray<ComposerAttachment>;
 }): ChatAttachment[] | null {
   const attachments: ChatAttachment[] = [];
   for (const image of input.images) {
@@ -371,18 +377,22 @@ export function getUploadedAttachments(input: {
     if (upload?.status !== "ready" || upload.environmentId !== input.environmentId) {
       return null;
     }
-    attachments.push({
-      type: "image",
+    const uploaded = {
       id: upload.attachmentId,
       name: image.name,
       mimeType: image.mimeType,
       sizeBytes: image.sizeBytes,
-    });
+    };
+    attachments.push(
+      image.type === "document"
+        ? { type: "document", ...uploaded }
+        : { type: "image", ...uploaded },
+    );
   }
   return attachments;
 }
 
-export function releaseAttachmentUploads(images: ReadonlyArray<ComposerImageAttachment>): void {
+export function releaseAttachmentUploads(images: ReadonlyArray<ComposerAttachment>): void {
   for (const image of images) {
     releaseAttachmentUpload(image.id);
   }

--- a/apps/web/src/lib/composerDraftUploads.ts
+++ b/apps/web/src/lib/composerDraftUploads.ts
@@ -6,7 +6,7 @@ import { releaseAttachmentUploads } from "./attachmentUploadQueue";
 export function releaseComposerDraftUploads(target: ScopedThreadRef | DraftId): void {
   const draft = useComposerDraftStore.getState().getComposerDraft(target);
   if (draft) {
-    releaseAttachmentUploads(draft.images);
+    releaseAttachmentUploads(draft.attachments);
   }
 }
 
@@ -17,7 +17,7 @@ export function releaseProjectDraftUploads(projectRef: ScopedProjectRef): void {
       session.environmentId === projectRef.environmentId &&
       session.projectId === projectRef.projectId
     ) {
-      releaseAttachmentUploads(store.draftsByThreadKey[draftKey]?.images ?? []);
+      releaseAttachmentUploads(store.draftsByThreadKey[draftKey]?.attachments ?? []);
     }
   }
 }

--- a/apps/web/src/promptStashStore.ts
+++ b/apps/web/src/promptStashStore.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { create } from "zustand";
 
-import { PersistedComposerImageAttachment } from "./composerDraftStore";
+import { PersistedComposerAttachment } from "./composerDraftStore";
 import { createMemoryStorage, type StateStorage } from "./lib/storage";
 
 export const PROMPT_STASH_STORAGE_KEY = "t3code:prompt-stash:v2";
@@ -36,7 +36,7 @@ const StashEntrySchema = Schema.Struct({
   id: Schema.String,
   createdAt: Schema.String,
   prompt: Schema.String,
-  attachments: Schema.Array(PersistedComposerImageAttachment),
+  attachments: Schema.Array(PersistedComposerAttachment),
   /** Names of images that exceeded the attachment budget and were not saved. */
   droppedImageNames: Schema.Array(Schema.String),
   /**
@@ -99,12 +99,12 @@ function clearOrphanedPendingImages(
  * admitted in order so the earliest-added images win.
  */
 export function partitionStashAttachments(
-  attachments: ReadonlyArray<PersistedComposerImageAttachment>,
+  attachments: ReadonlyArray<PersistedComposerAttachment>,
 ): {
-  kept: PersistedComposerImageAttachment[];
+  kept: PersistedComposerAttachment[];
   droppedNames: string[];
 } {
-  const kept: PersistedComposerImageAttachment[] = [];
+  const kept: PersistedComposerAttachment[] = [];
   const droppedNames: string[] = [];
   let usedChars = 0;
   for (const attachment of attachments) {
@@ -216,7 +216,7 @@ interface PromptStashStoreState {
   finalizeEntryImages: (
     entryId: string,
     images: {
-      attachments: ReadonlyArray<PersistedComposerImageAttachment>;
+      attachments: ReadonlyArray<PersistedComposerAttachment>;
       droppedImageNames: ReadonlyArray<string>;
       unreadableImageNames: ReadonlyArray<string>;
     },

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatDocumentAttachment as ContractChatDocumentAttachment,
   ChatImageAttachment as ContractChatImageAttachment,
   OrchestrationCheckpointFile,
   OrchestrationCheckpointSummary,
@@ -35,7 +36,11 @@ export interface ChatImageAttachment extends ContractChatImageAttachment {
   readonly previewUrl?: string;
 }
 
-export type ChatAttachment = ChatImageAttachment;
+export interface ChatDocumentAttachment extends ContractChatDocumentAttachment {
+  readonly previewUrl?: string;
+}
+
+export type ChatAttachment = ChatImageAttachment | ChatDocumentAttachment;
 
 export interface ChatMessage extends Omit<OrchestrationMessage, "attachments"> {
   readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -2,7 +2,9 @@ import * as Schema from "effect/Schema";
 
 import { NonNegativeInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import {
+  PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPES,
   PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
   ProjectFaviconPath,
 } from "./orchestration.ts";
@@ -44,10 +46,15 @@ export const ATTACHMENT_UPLOAD_URL_TTL_MS = 10 * 60_000;
 
 export const AttachmentCreateUploadUrlInput = Schema.Struct({
   name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
-  mimeType: Schema.Literals(PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES),
+  mimeType: Schema.Literals([
+    ...PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
+    ...PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPES,
+  ]),
   sizeBytes: NonNegativeInt.check(
     Schema.isGreaterThanOrEqualTo(1),
-    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES),
+    Schema.isLessThanOrEqualTo(
+      Math.max(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES, PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES),
+    ),
   ),
 });
 export type AttachmentCreateUploadUrlInput = typeof AttachmentCreateUploadUrlInput.Type;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -170,6 +170,21 @@ const PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPE_SET = new Set<string>(
 export function isProviderSendTurnSupportedImageMimeType(mimeType: string): boolean {
   return PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPE_SET.has(mimeType.toLowerCase());
 }
+
+export const PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES = 10 * 1024 * 1024;
+export const PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPES = ["application/pdf"] as const;
+const PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPE_SET = new Set<string>(
+  PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPES,
+);
+
+/**
+ * Whether a dropped or picked document mime type can be sent on a provider
+ * turn. Unlike images, documents are not universally supported: adapters that
+ * cannot forward them reject the turn with an explicit reason.
+ */
+export function isProviderSendTurnSupportedDocumentMimeType(mimeType: string): boolean {
+  return PROVIDER_SEND_TURN_SUPPORTED_DOCUMENT_MIME_TYPE_SET.has(mimeType.toLowerCase());
+}
 const PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS = 14_000_000;
 const CHAT_ATTACHMENT_ID_MAX_CHARS = 128;
 // Correlation id is command id by design in this model.
@@ -202,9 +217,42 @@ const UploadChatImageAttachment = Schema.Struct({
 });
 export type UploadChatImageAttachment = typeof UploadChatImageAttachment.Type;
 
-export const ChatAttachment = Schema.Union([ChatImageAttachment]);
+export const ChatDocumentAttachment = Schema.Struct({
+  type: Schema.Literal("document"),
+  id: ChatAttachmentId,
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(100),
+    Schema.isPattern(/^application\/pdf$/i),
+  ),
+  sizeBytes: NonNegativeInt.check(
+    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES),
+  ),
+});
+export type ChatDocumentAttachment = typeof ChatDocumentAttachment.Type;
+
+const UploadChatDocumentAttachment = Schema.Struct({
+  type: Schema.Literal("document"),
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(100),
+    Schema.isPattern(/^application\/pdf$/i),
+  ),
+  sizeBytes: NonNegativeInt.check(
+    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES),
+  ),
+  dataUrl: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS),
+  ),
+});
+export type UploadChatDocumentAttachment = typeof UploadChatDocumentAttachment.Type;
+
+export const ChatAttachment = Schema.Union([ChatImageAttachment, ChatDocumentAttachment]);
 export type ChatAttachment = typeof ChatAttachment.Type;
-const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
+const UploadChatAttachment = Schema.Union([
+  UploadChatImageAttachment,
+  UploadChatDocumentAttachment,
+]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
 export const ProjectScriptIcon = Schema.Literals([


### PR DESCRIPTION
## Problem

Dropping a file on the composer only worked for images. PDFs, `.txt`, and `.md` were rejected with *"Unsupported file type for 'x'. Please attach image files only."*

## What changed

**PDFs** are now a first-class document attachment. `ChatAttachment` was an image-only union with a `/^image\//` mimeType check, so this widens the contract, the attachment store's stored-file extension, the upload token, and the normalizer.

Per adapter, since PDF support is not uniform:

| Provider | Behavior |
| --- | --- |
| Claude | Native `document` content block |
| OpenCode | Already forwards arbitrary mime types as file parts; works unchanged |
| Codex / Cursor / Grok | Only model image blocks, so they reject the turn with a reason naming the file and pointing at a provider that works |

**Text files** (`.txt`, `.md`, `.mdx`) are inlined into the prompt instead of uploaded. A dropped file carries no filesystem path — browsers never expose one, `File.path` was removed in Electron 32 (this repo is on 41.5.0), and a local path is meaningless to a remote environment — so the contents are the only thing that can cross the wire. They are fenced under the file name, with a fence long enough to survive whatever backticks the file already contains.

The composer's staged-attachment list is widened rather than duplicated: persistence, hydration, clearing, moving, upload, and send already operate on that one list. It is renamed `images` → `attachments` to match what it now holds, which is most of the line count here. Documents are excluded from the lightbox and from the prompt stash, which re-encodes images to fit localStorage and cannot do the same for a PDF.

## Verification

Before (`main`) and after, captured by swapping branches under one running dev server and dropping the same two files:

- **Before:** `Unsupported file type for 'notes.md'. Please attach image files only.` — nothing attached, prompt empty
- **After:** `quarterly-spec.pdf` staged as a document chip; `notes.md` inlined fenced under its filename; no error

Tests: 2830 web tests plus the server and contracts suites pass. New focused tests cover drop classification, fence sizing, the `.pdf` stored path, Claude document blocks, and Codex rejection. Typecheck and targeted lint are clean on contracts, server, and web.

`apps/web/src/terminal/ghostty/runtimeAbi.test.ts` fails on this branch, but it fails identically on a clean `main` checkout — pre-existing vendored-wasm issue, unrelated.

## Not included

Mobile. React Native has no drag-and-drop target, and its share intake gates on a native `shareType`, so parity would mean adding `expo-document-picker` and editing the iOS/Android share extensions — native work worth its own PR. `apps/mobile` is untouched.

---

Model: Claude Opus 5 (1M context). Harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attachment contracts, upload persistence, and orchestration normalization across server and web; provider adapters diverge on PDF support, so misconfiguration could surface as turn failures rather than silent drops.
> 
> **Overview**
> **PDFs** are now a real attachment kind end-to-end: contracts add `document` on `ChatAttachment`, uploads and on-disk paths use `.pdf` via `inferAttachmentExtension`, and the normalizer validates size and mime per kind. **Claude** forwards PDFs as native `document` blocks; **Codex, Cursor, and Grok** fail the turn with a shared message naming the file and suggesting Claude/OpenCode.
> 
> The web composer treats staged files as **attachments** (renamed from `images`) with document chips in the timeline and composer, upload queue support for PDF mime types, and PDFs excluded from the image lightbox and prompt stash.
> 
> **Dropped text** (`.txt`, `.md`, `.mdx`) is inlined into the prompt with adaptive fencing instead of uploading, since dropped files have no path the agent can open. Drag/drop routing uses `classifyDroppedFile`; paste still targets images only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90f78b60508830f24f455802ff9e53cfd2ff12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PDF and text file support to composer drag and drop
> - Generalizes the composer attachment system from image-only to a union of images and documents (PDFs), renaming store APIs, schemas, and refs from image-specific to attachment-generic across web and server (e.g. `addImage` → `addAttachment`, `draft.images` → `draft.attachments`).
> - Dropped text/markdown files are inlined into the prompt as fenced code blocks (capped at `MAX_INLINE_TEXT_FILE_BYTES` = 256KB) rather than attached; unsupported files are rejected.
> - The Claude adapter forwards PDF attachments as native `document` content blocks with base64 encoding; Codex, Cursor, and Grok adapters reject document attachments with a `ProviderAdapterRequestError` naming the file and provider.
> - Contracts schemas (`AttachmentCreateUploadUrlInput`, `ChatAttachment`, `UploadChatAttachment`) now accept document MIME types and size limits up to `PROVIDER_SEND_TURN_MAX_DOCUMENT_BYTES`.
> - Risk: persisted draft state shape changes (`ComposerThreadDraftState.images` → `.attachments`, `nonPersistedImageIds` → `nonPersistedAttachmentIds`); missing `type` on persisted attachments decodes as `'image'` for backwards compatibility but any out-of-tree readers of the old fields will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d90f78b. 29 files reviewed, 41 issues evaluated, 24 issues filtered, 14 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 2 comments posted, 10 evaluated, 8 filtered</summary>
>
> - [line 1629](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L1629): The composer persistence effect serializes each `ComposerAttachment` without its discriminant: the object written to `stagedAttachmentById` includes `id`, `name`, `mimeType`, `sizeBytes`, and `dataUrl`, but omits `type`. Since `normalizePersistedAttachment` defaults missing types to `"image"` for backward compatibility, a persisted PDF is rehydrated as an image after reload and is then sent/rendered with the wrong kind. Persist `type: image.type` for new attachments. <b>[ Cross-file consolidated ]</b>
> - [line 2759](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L2759): Dropped text is read asynchronously, but after `await file.text()` the code inserts via the live composer helpers without checking that the composer/thread is still the one that received the drop. If the user navigates to another thread while a text file is being read, the completed contents can be inserted into the new prompt (or the old draft can be updated using the new prompt snapshot), mixing content between drafts. Capture and validate the drop target before insertion, or write directly to the original draft target. <b>[ Skipped comment generation ]</b>
> - [line 2769](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L2769): After successfully reading text blocks, any insertion refusal is reported as a read failure: `insertComposerTextAtEnd` returns false while connecting, during approval/pending input, or when project selection is required, but the code appends all text filenames to `unreadableNames` and reports `Could not read ...`. The file was readable; the user gets misleading recovery guidance and the content is discarded. Handle a busy/blocked composer separately from `file.text()` failures. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 5631](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L5631): A document-only send uses `IMAGE_ONLY_BOOTSTRAP_PROMPT`, whose text explicitly says the user attached images and asks the provider to use image(s). With a PDF-only drop and no prompt, Claude receives a contradictory bootstrap message even though the attachment is a document, which can cause it to misinterpret or ignore the PDF. Choose the bootstrap text based on whether the attachments are images or documents. <b>[ Cross-file consolidated ]</b>
> - [line 5645](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L5645): The upload preflight error remains image-specific: when a PDF upload fails, `onSend` reports `Retry or remove failed image uploads before sending.` even though the failed item is a document. This gives the user incorrect recovery guidance for the newly supported file type; use attachment/file wording. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 5692](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L5692): When attachment uploads are unavailable, the `turnAttachmentsPromise` fallback serializes every staged attachment as `{ type: "image" }`. A newly supported PDF therefore reaches the turn as an image attachment instead of a `document`, so the no-upload path cannot send PDFs correctly and may trigger the wrong provider validation/adapter behavior. Preserve the attachment's type when constructing this fallback payload. <b>[ Cross-file consolidated ]</b>
> - [line 5700](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L5700): The optimistic user message created for a send labels every attachment as `type: "image"`, including newly supported documents. Until the server message replaces it, a PDF is rendered through the image preview/lightbox path (and its blob URL is treated as an image), producing a broken preview and incorrect attachment semantics. Derive the optimistic attachment type from `image.type`. <b>[ Cross-file consolidated ]</b>
> - [line 5767](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/ChatView.tsx#L5767): For an attachment-only first message, the thread title fallback is hard-coded to `Image: ...`. A PDF-only drop therefore creates a misleading thread title such as `Image: spec.pdf`, even though the attachment is a document. Use a generic file/attachment label or branch on `firstComposerImage.type`. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/chat/ChatComposer.tsx — 2 comments posted, 11 evaluated, 9 filtered</summary>
>
> - [line 765](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L765): Once PDFs are included in `composerAttachments`, this call feeds them into `attachmentUploadBlockReason`, whose user-facing messages still say `Image still uploading` / `failed image`. A PDF upload failure or pending upload therefore gives the user the wrong object and makes the new file attachment UI misleading. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 1629](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L1629): The persistence effect serializes every staged attachment without copying its `type` field. A dropped PDF is therefore saved as an attachment with no type, and `hydrateAttachmentsFromPersisted` defaults missing types to `"image"`; after a reload the PDF is rendered and dispatched as an image instead of a document, breaking the new PDF flow and potentially causing provider rejection or corrupted attachment handling. <b>[ Cross-file consolidated ]</b>
> - [line 2392](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2392): The intentional document exclusion from the stash records the PDF name in `oversizedImageNames`. Restoring that stash consequently tells the user the PDF “exceeded the stash size limit,” even when it is tiny; the actual reason is that documents are unsupported by the image re-encoding stash. This gives a false explanation for a dropped attachment. <b>[ Already posted ]</b>
> - [line 2663](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2663): The new document attachment is added to the same list that `ChatView` uses for its image-only title fallback. Sending a PDF without text therefore auto-titles the thread `Image: <file>.pdf`, which is incorrect for a document attachment and makes the new document support misleading in thread history. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 2663](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2663): The new document branch creates a `ComposerAttachment` with `type: "document"`, but the existing send path in `ChatView` converts every attachment in the no-upload-capability fallback to `type: "image"` before calling `startThreadTurn`. Thus PDFs dropped in an environment where `supportsAttachmentUploads` is false are sent as image blocks (and the Codex/Cursor/etc. image path), so Claude/OpenCode document support cannot work for that common fallback. <b>[ Cross-file consolidated ]</b>
> - [line 2769](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2769): The async text-drop handler captures `activeThreadId` only for error reporting, then resumes by calling the render's `insertComposerTextAtEnd` after each `file.text()` await. If the user switches threads while the file is being read, that stale callback reads the shared `promptRef` for the new thread but writes through the old `composerDraftTarget`, mixing the new thread's prompt and the dropped file into the wrong draft (and leaving the visible thread without the file). <b>[ Cross-file consolidated ]</b>
> - [line 2773](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2773): When `insertComposerTextAtEnd` rejects insertion, the handler appends every `textFiles` name to `unreadableNames`, including files that were successfully read and already produced blocks (and even oversized files). The resulting `Could not read ...` error is false and hides the actual reason insertion was rejected, while the successfully read contents are discarded. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 2776](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2776): The text-drop failure expression reports `oversizedNames` instead of `unreadableNames` whenever both lists are non-empty. Dropping one oversized file and one unreadable file therefore hides the read failure entirely, so the user is not told that the second file was also not inserted. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 2992](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/ChatComposer.tsx#L2992): `getSendContext` now returns document attachments through the renamed attachments ref, but the existing optimistic-message construction in `ChatView` hardcodes every returned attachment to `type: "image"`. After sending a PDF on a server that uploads it correctly, the immediate timeline renders the PDF blob as an image (a broken preview) until the server message replaces it, so document attachments are not displayed correctly during the send handoff. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/chat/MessagesTimeline.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1021](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/components/chat/MessagesTimeline.tsx#L1021): The new document branch only runs for `regularImages`, but `UserTimelineRow` partitions attachments into `previewImages` by the reserved `preview-annotation-` filename prefix before reaching this branch. A normal PDF can legally have that name prefix; if its message has no parsed preview annotation, it is removed from `regularImages` and never rendered at all (and with an annotation it is forced through the image-only annotation card). This makes such document attachments disappear from the timeline. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/composerDraftStore.ts — 0 comments posted, 4 evaluated, 1 filtered</summary>
>
> - [line 147](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/composerDraftStore.ts#L147): `PersistedComposerThreadDraftState.attachments` is widened to persist documents, but the normal composer serialization path writes staged attachments without a `type` field. On reload, `normalizePersistedAttachment`/`hydrateAttachmentsFromPersisted` treats an absent type as `"image"`, so a staged PDF is restored as an image; its upload path then rejects `application/pdf` as an unsupported image and the PDF cannot be sent after a refresh/restart. <b>[ Already posted ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/lib/attachmentUploadQueue.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 106](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/lib/attachmentUploadQueue.ts#L106): The new document branch routes PDFs through the existing upload-status path, but `attachmentUploadBlockReason` still reports `"Image still uploading"` and `"Retry or remove the failed image"` for every attachment. While a PDF is uploading or fails, the composer therefore shows misleading image-only guidance instead of describing the document, which is especially confusing for the newly supported document flow. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 258](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/lib/attachmentUploadQueue.ts#L258): By widening `startAttachmentUpload` to accept `ComposerAttachment`, PDF drops can reach the no-upload fallback used by `ChatView`. That fallback serializes every local attachment as `{ type: "image", ... }` before reading its data URL, so when `supportsAttachmentUploads` is false a PDF is sent as an image and the server rejects it as an invalid image payload. The UI must either preserve `image.type` in that fallback or reject document drops when the capability is unavailable. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/types.ts — 5 comments posted, 8 evaluated, 3 filtered</summary>
>
> - [line 39](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/types.ts#L39): PDF uploads are now included in the shared attachment upload wait, but the failure path still reports `Retry or remove failed image uploads before sending.` for any failed attachment. A failed PDF consequently gets an inaccurate error message and users are not told that the document upload is the problem. The message should refer to failed attachment/file uploads. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 39](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/types.ts#L39): Because documents are now valid `ChatAttachment` values but are deliberately routed into `droppedImageNames` when stashing, the stash UI counts an omitted PDF as an image and displays messages such as `Some images were not restored` / `1 image dropped`. This misleads users about what happened to their PDF; the stash metadata and copy should use generic file/attachment wording for document omissions. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 39](https://github.com/pingdotgg/t3code/blob/d90f78b60508830f24f455802ff9e53cfd2ff12a/apps/web/src/types.ts#L39): The new document member also flows through PDF-only thread creation, but `ChatView` still uses the attachment-independent fallback `titleSeed = \`Image: ${firstComposerImageName}\`` whenever there is no text. As a result, dropping and sending only `spec.pdf` creates a thread titled `Image: spec.pdf`, which is incorrect for the newly supported document kind; the fallback must distinguish documents from images. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->