### PR TITLE
fix(server): skip change requests for unsupported remotes

### DIFF
--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -31,6 +31,8 @@ export function GitActionProgressOverlay(props: {
 
     if (prev === "running" && progress.phase === "success") {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    } else if (prev === "running" && progress.phase === "warning") {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     } else if (prev === "running" && progress.phase === "error") {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     }
@@ -41,7 +43,11 @@ export function GitActionProgressOverlay(props: {
       void tryOpenExternalUrl(progress.prUrl, "pull-request");
       return;
     }
-    if (progress.phase === "success" || progress.phase === "error") {
+    if (
+      progress.phase === "success" ||
+      progress.phase === "warning" ||
+      progress.phase === "error"
+    ) {
       onDismiss();
     }
   }, [onDismiss, progress.phase, progress.prUrl]);
@@ -133,7 +139,9 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
   const bgClass =
     progress.phase === "error"
       ? "bg-red-50 dark:bg-red-950/80 border-red-200 dark:border-red-800"
-      : "bg-card border-border";
+      : progress.phase === "warning"
+        ? "bg-amber-50 dark:bg-amber-950/80 border-amber-200 dark:border-amber-800"
+        : "bg-card border-border";
 
   return (
     <Animated.View
@@ -161,6 +169,17 @@ function OverlayIcon(props: {
     case "error":
       return (
         <View className="h-6 w-6 items-center justify-center rounded-full bg-red-500">
+          <SymbolView
+            name="exclamationmark.triangle"
+            size={12}
+            tintColor="white"
+            type="monochrome"
+          />
+        </View>
+      );
+    case "warning":
+      return (
+        <View className="h-6 w-6 items-center justify-center rounded-full bg-amber-500">
           <SymbolView
             name="exclamationmark.triangle"
             size={12}

--- a/apps/mobile/src/state/use-selected-thread-git-actions.ts
+++ b/apps/mobile/src/state/use-selected-thread-git-actions.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { EnvironmentProject, EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
 import {
+  resolveGitActionResultToastType,
   type GitActionRequestInput,
   type VcsActionOperation,
   type VcsRef,
@@ -336,7 +337,7 @@ export function useSelectedThreadGitActions() {
           }
 
           showGitActionResult({
-            type: "success",
+            type: resolveGitActionResultToastType(result.value),
             title: result.value.toast.title,
             description: result.value.toast.description,
             prUrl:

--- a/apps/mobile/src/state/use-vcs-action-state.ts
+++ b/apps/mobile/src/state/use-vcs-action-state.ts
@@ -11,7 +11,7 @@ export function useVcsActionState(target: VcsActionTarget): VcsActionState {
 }
 
 export interface GitActionResultNotification {
-  readonly type: "success" | "error";
+  readonly type: "success" | "warning" | "error";
   readonly title: string;
   readonly description?: string;
   readonly prUrl?: string;
@@ -52,7 +52,7 @@ export function useGitActionResultNotification(): {
   return { result, dismiss: dismissGitActionResult };
 }
 
-export type GitActionProgressPhase = "idle" | "running" | "success" | "error";
+export type GitActionProgressPhase = "idle" | "running" | "success" | "warning" | "error";
 
 export interface GitActionProgress {
   readonly phase: GitActionProgressPhase;

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -27,9 +27,11 @@ import {
   GitCommandError,
   ProviderDriverKind,
   ProviderInstanceId,
+  SourceControlProviderError,
   TextGenerationError,
 } from "@t3tools/contracts";
 import * as GitHubCli from "../sourceControl/GitHubCli.ts";
+import * as SourceControlProvider from "../sourceControl/SourceControlProvider.ts";
 import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
@@ -615,11 +617,40 @@ function preparePullRequestThread(
   return manager.preparePullRequestThread(input);
 }
 
+/**
+ * Stands in for what the registry hands back when a repository's remote is hosted somewhere no
+ * provider is registered for: an "unknown" provider whose every call fails. Records the calls it
+ * receives so a test can assert the change-request steps never reach it.
+ */
+function unsupportedSourceControlProvider(calls: string[]) {
+  const fail = (operation: string, cwd: string) => {
+    calls.push(operation);
+    return new SourceControlProviderError({
+      provider: "unknown",
+      operation,
+      cwd,
+      detail: "No unknown source control provider is registered.",
+    });
+  };
+
+  return SourceControlProvider.SourceControlProvider.of({
+    kind: "unknown",
+    listChangeRequests: (input) => fail("listChangeRequests", input.cwd),
+    getChangeRequest: (input) => fail("getChangeRequest", input.cwd),
+    createChangeRequest: (input) => fail("createChangeRequest", input.cwd),
+    getRepositoryCloneUrls: (input) => fail("getRepositoryCloneUrls", input.cwd),
+    createRepository: (input) => fail("createRepository", input.cwd),
+    getDefaultBranch: (input) => fail("getDefaultBranch", input.cwd),
+    checkoutChangeRequest: (input) => fail("checkoutChangeRequest", input.cwd),
+  });
+}
+
 function makeManager(input?: {
   ghScenario?: FakeGhScenario;
   textGeneration?: Partial<FakeGitTextGeneration>;
   serverSettings?: Parameters<typeof ServerSettings.layerTest>[0];
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
+  sourceControlProvider?: SourceControlProvider.SourceControlProvider["Service"];
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
   const textGeneration = createTextGeneration(input?.textGeneration);
@@ -637,14 +668,15 @@ function makeManager(input?: {
   const sourceControlRegistryLayer = Layer.effect(
     SourceControlProviderRegistry.SourceControlProviderRegistry,
     GitHubSourceControlProvider.make.pipe(
-      Effect.map((provider) =>
-        SourceControlProviderRegistry.SourceControlProviderRegistry.of({
+      Effect.map((gitHubProvider) => {
+        const provider = input?.sourceControlProvider ?? gitHubProvider;
+        return SourceControlProviderRegistry.SourceControlProviderRegistry.of({
           get: () => Effect.succeed(provider),
           resolveHandle: () => Effect.succeed({ provider, context: null }),
           resolve: () => Effect.succeed(provider),
           discover: Effect.succeed([]),
-        }),
-      ),
+        });
+      }),
       Effect.provide(Layer.succeed(GitHubCli.GitHubCli, gitHubCli)),
     ),
   );
@@ -2452,6 +2484,37 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           call.includes("pr create --base master --head feature/master-default"),
         ),
       ).toBe(true);
+    }),
+  );
+
+  it.effect("commits and pushes but skips the PR step on an unsupported provider", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/unsupported-provider"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/unsupported-provider"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "feature.txt"), "feature\n");
+
+      const providerCalls: string[] = [];
+      const { manager } = yield* makeManager({
+        sourceControlProvider: unsupportedSourceControlProvider(providerCalls),
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit_push_pr",
+      });
+
+      expect(result.commit.status).toBe("created");
+      expect(result.push.status).toBe("pushed");
+      expect(result.pr.status).toBe("skipped_unsupported_provider");
+      expect(result.toast.description).toBe(
+        "Creating a change request is not supported for this remote.",
+      );
+      expect(result.toast.cta).toEqual({ kind: "none" });
+      expect(providerCalls).toEqual([]);
     }),
   );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -434,6 +434,13 @@ function summarizeGitActionResult(
     return withDescription(title, truncateText(result.pr.title));
   }
 
+  // The commit and push still happened, so they stay the headline; the note explains why no
+  // change request followed them.
+  const unsupportedProviderNote =
+    result.pr.status === "skipped_unsupported_provider"
+      ? `Creating a ${terms.singular} is not supported for this remote.`
+      : undefined;
+
   if (result.push.status === "pushed") {
     const shortSha = shortenSha(result.commit.commitSha);
     const branch = result.push.upstreamBranch ?? result.push.branch;
@@ -441,14 +448,18 @@ function summarizeGitActionResult(
     const branchPart = branch ? ` to ${branch}` : "";
     return withDescription(
       `Pushed${pushedCommitPart}${branchPart}`,
-      truncateText(result.commit.subject),
+      unsupportedProviderNote ?? truncateText(result.commit.subject),
     );
   }
 
   if (result.commit.status === "created") {
     const shortSha = shortenSha(result.commit.commitSha);
     const title = shortSha ? `Committed ${shortSha}` : "Committed changes";
-    return withDescription(title, truncateText(result.commit.subject));
+    return withDescription(title, unsupportedProviderNote ?? truncateText(result.commit.subject));
+  }
+
+  if (unsupportedProviderNote) {
+    return withDescription("Unsupported source control provider", unsupportedProviderNote);
   }
 
   return { title: "Done" };
@@ -1695,6 +1706,12 @@ export const make = Effect.gen(function* () {
     emit: GitActionProgressEmitter,
   ) {
     const provider = yield* sourceControlProvider(cwd);
+    // Remotes hosted somewhere we have no provider for resolve to the "unknown" kind, whose
+    // change-request calls only ever fail. Stop before touching them so the action reports an
+    // expected limitation instead of an internal provider error.
+    if (provider.kind === "unknown") {
+      return { status: "skipped_unsupported_provider" as const };
+    }
     const terms = getChangeRequestTerminologyForKind(provider.kind);
     const details = yield* gitCore.statusDetails(cwd);
     const branch = details.branch ?? fallbackBranch;

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1,4 +1,4 @@
-import type { VcsStatusResult } from "@t3tools/contracts";
+import type { GitRunStackedActionResult, VcsStatusResult } from "@t3tools/contracts";
 import { assert, describe, it } from "vite-plus/test";
 import {
   buildGitActionProgressStages,
@@ -6,11 +6,43 @@ import {
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
+  resolveGitActionToastType,
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
   resolveThreadBranchUpdate,
   resolveThreadBranchMetadataPatch,
 } from "./GitActionsControl.logic";
+
+function stackedActionResult(
+  prStatus: GitRunStackedActionResult["pr"]["status"],
+): GitRunStackedActionResult {
+  return {
+    action: "commit_push_pr",
+    branch: { status: "skipped_not_requested" },
+    commit: { status: "skipped_not_requested" },
+    push: { status: "pushed", branch: "feature/test" },
+    pr: { status: prStatus },
+    toast: { title: "Changes pushed", cta: { kind: "none" } },
+  };
+}
+
+describe("Git stacked action result toast type", () => {
+  it("uses a warning for an unsupported change-request provider", () => {
+    assert.equal(
+      resolveGitActionToastType(stackedActionResult("skipped_unsupported_provider")),
+      "warning",
+    );
+  });
+
+  it("keeps success for other completed change-request states", () => {
+    assert.equal(resolveGitActionToastType(stackedActionResult("created")), "success");
+    assert.equal(resolveGitActionToastType(stackedActionResult("opened_existing")), "success");
+    assert.equal(
+      resolveGitActionToastType(stackedActionResult("skipped_not_requested")),
+      "success",
+    );
+  });
+});
 
 function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
   return {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -12,6 +12,8 @@ import {
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
+export { resolveGitActionResultToastType as resolveGitActionToastType } from "@t3tools/client-runtime/state/vcs";
+
 export type GitDialogAction = "commit" | "push" | "create_pr";
 
 export interface GitActionMenuItem {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -4,6 +4,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { resolveGitActionResultToastType } from "@t3tools/client-runtime/state/vcs";
 import type {
   GitActionProgressEvent,
   GitRunStackedActionResult,
@@ -1466,7 +1467,8 @@ export default function GitActionsControl({
         };
       }
 
-      const successToastData = {
+      const resultToastType = resolveGitActionResultToastType(actionResult);
+      const resultToastData = {
         ...scopedToastData,
         dismissAfterVisibleMs: 10_000,
       };
@@ -1475,21 +1477,21 @@ export default function GitActionsControl({
         toastManager.update(
           resolvedProgressToastId,
           stackedThreadToast({
-            type: "success",
+            type: resultToastType,
             title: actionResult.toast.title,
             description: actionResult.toast.description,
             timeout: 0,
             actionProps: toastActionProps,
-            data: successToastData,
+            data: resultToastData,
           }),
         );
       } else {
         toastManager.update(resolvedProgressToastId, {
-          type: "success",
+          type: resultToastType,
           title: actionResult.toast.title,
           description: actionResult.toast.description,
           timeout: 0,
-          data: successToastData,
+          data: resultToastData,
         });
       }
     },

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -143,6 +143,7 @@ Control settings**.
 - **GitHub says it could not verify sign-in status** – T3 Code needs GitHub CLI 2.81.0 or newer to check sign-in status. Update `gh` (e.g., `brew upgrade gh`), then rescan
 - **Bitbucket not connecting** – Double-check your environment variables are set in the correct shell profile and the server was restarted
 - **Can't push to a remote** – Verify your Git remote URL matches the provider you've authenticated with (SSH vs HTTPS remotes may need different credentials)
+- **Pull request step is skipped** – The repository's remote is hosted somewhere T3 Code does not support yet. Commits and pushes still run normally; create the pull request on your host's own site
 
 **Need more help?** Check your provider's CLI documentation:
 

--- a/packages/client-runtime/src/state/gitActions.ts
+++ b/packages/client-runtime/src/state/gitActions.ts
@@ -8,6 +8,14 @@ import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
+export type GitActionResultToastType = "success" | "warning";
+
+export function resolveGitActionResultToastType(
+  result: Pick<GitRunStackedActionResult, "pr">,
+): GitActionResultToastType {
+  return result.pr.status === "skipped_unsupported_provider" ? "warning" : "success";
+}
+
 export type GitDialogAction = "commit" | "push" | "create_pr";
 
 export interface GitActionMenuItem {

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -41,7 +41,14 @@ const GitPushStepStatus = Schema.Literals([
   "skipped_up_to_date",
 ]);
 const GitBranchStepStatus = Schema.Literals(["created", "skipped_not_requested"]);
-const GitPrStepStatus = Schema.Literals(["created", "opened_existing", "skipped_not_requested"]);
+const GitPrStepStatus = Schema.Literals([
+  "created",
+  "opened_existing",
+  "skipped_not_requested",
+  // The repository's remote is hosted somewhere T3 Code has no source control provider for, so
+  // the change-request step is an expected no-op rather than a failure.
+  "skipped_unsupported_provider",
+]);
 const VcsStatusChangeRequestState = Schema.Literals(["open", "closed", "merged"]);
 const GitPullRequestReference = TrimmedNonEmptyStringSchema;
 const GitPullRequestState = Schema.Literals(["open", "closed", "merged"]);


### PR DESCRIPTION
Unsupported remotes currently reach source-control provider lookup after a successful commit and push, turning an unsupported change-request step into a misleading failure.

This change models that step as skipped for unsupported providers, preserves the successful commit and push result, and presents the limitation as a warning across web and mobile.

## Verification

- 171 focused tests passed across server, contracts, client runtime, and web presentation.
- Integrated Docker comparison confirmed the pre-fix provider-registration failure and the fixed warning state.
- The test container had no host mounts and did not use the live T3 home or credentials.

## UI evidence

Before and after screenshots will be attached to the PR without adding them to the repository.

Generated with GPT-5.6 Codex in the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stacked git/PR workflow and result semantics on the server and across clients; behavior is scoped to unknown providers with new tests, but users may interpret warnings differently than prior failures.
> 
> **Overview**
> Stacked git actions on remotes with no registered source-control provider no longer fail at the PR step after a successful commit and push. The server short-circuits when the resolved provider is **`unknown`**, records **`skipped_unsupported_provider`**, and keeps toast copy focused on what succeeded while noting that change requests are not supported for that host.
> 
> **Web and mobile** map that outcome to a **warning** (not success or error) via shared **`resolveGitActionResultToastType`**. Mobile adds a warning progress phase (amber styling, warning haptics, dismiss). Contracts and docs document the new PR status and the “PR step skipped” troubleshooting case. Server tests cover commit/push completing without calling the unsupported provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3956faf117aa0229aa70a9c024d20355b4dcea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip PR step for unsupported source control providers and surface warning toasts
> - `GitManager.runPrStep` early-returns `skipped_unsupported_provider` when the resolved provider has kind `unknown`, so commit and push still run but PR creation is skipped
> - Adds `skipped_unsupported_provider` to `GitPrStepStatus` in [git.ts](https://github.com/pingdotgg/t3code/pull/8223/files#diff-2282301d92a7a9ddc7e8d88b986c9628fdf70497dc6a09fe80eb8d46d6a769e7) so the new status validates against the contract
> - Introduces `resolveGitActionResultToastType` in [gitActions.ts](https://github.com/pingdotgg/t3code/pull/8223/files#diff-056843e714dffa8cdcebb4fdb83cbed68894e82a446be8f7fb85a220a841b4d0) which maps skipped-provider outcomes to `warning` instead of `success`; web and mobile clients use it for result toasts
> - Mobile progress overlay gains a `warning` phase with amber styling and warning haptics; summaries from `summarizeGitActionResult` explain the skipped PR
> - Behavioral Change: `GitActionResultNotification.type` and `GitActionProgressPhase` now include `warning`; clients that exhaustively match these unions must handle the new variant
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3956fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->