### PR TITLE
feat: merge a pull request as a repository administrator

### DIFF
--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -1089,6 +1089,47 @@ layer("GitHubPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("adds the administrator override to the merge, and to nothing else", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValue(Effect.succeed(output("")));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      yield* cli.runPullRequestAction({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+        action: "merge",
+        mergeMethod: "squash",
+        adminMerge: true,
+      });
+
+      expect(callAt(0).args).toEqual([
+        "pr",
+        "merge",
+        "7",
+        "--repo",
+        "github.com/acme/web",
+        "--squash",
+        "--admin",
+      ]);
+
+      // `gh` refuses `--admin` beside `--auto`, and an armed merge that skipped the requirements
+      // it exists to wait for would be a standing instruction to do nothing.
+      yield* cli.runPullRequestAction({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+        action: "enable-auto-merge",
+        mergeMethod: "squash",
+        adminMerge: true,
+      });
+
+      expect(callAt(1).args).not.toContain("--admin");
+    }),
+  );
+
   it.effect("arms auto-merge with the same strategy a merge would have used", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValue(Effect.succeed(output("")));
@@ -2300,7 +2341,12 @@ layer("GitHubPullRequestCli.layer", (it) => {
         // One request, because both answers hang off the same repository object.
         assert.strictEqual(mockedExecute.mock.calls.length, 1);
         expect(callAt(0).args).toContain("number=7");
-        expect(access).toEqual({ canWrite: false, canUpdate: true, didAuthor: true });
+        expect(access).toEqual({
+          canWrite: false,
+          canUpdate: true,
+          didAuthor: true,
+          canAdminister: false,
+        });
       }),
   );
 
@@ -2463,7 +2509,12 @@ layer("GitHubPullRequestCli.layer", (it) => {
       });
 
       assert.strictEqual(mockedExecute.mock.calls.length, 2);
-      expect(access).toEqual({ canWrite: false, canUpdate: true, didAuthor: true });
+      expect(access).toEqual({
+        canWrite: false,
+        canUpdate: true,
+        didAuthor: true,
+        canAdminister: false,
+      });
       yield* TestClock.setTime(Date.parse("2100-01-01T00:00:00Z"));
     }),
   );

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -485,6 +485,8 @@ export class GitHubPullRequestCli extends Context.Service<
       readonly action: PullRequestAction;
       readonly mergeMethod?: PullRequestMergeMethod;
       readonly updateMethod?: PullRequestUpdateMethod;
+      /** Only read for `merge`, where it merges without waiting for the branch's requirements. */
+      readonly adminMerge?: boolean;
     }) => Effect.Effect<void, GitHubPullRequestCliError>;
 
     readonly commentOnPullRequest: (input: {
@@ -805,10 +807,14 @@ function actionArgs(
   action: PullRequestAction,
   mergeMethod: PullRequestMergeMethod | undefined,
   updateMethod: PullRequestUpdateMethod | undefined,
+  adminMerge: boolean | undefined,
 ): ReadonlyArray<string> {
   switch (action) {
+    // `--admin` merges without waiting for what the branch's protection asks for. Only here:
+    // `gh` refuses it alongside `--auto`, and an auto-merge that skipped the requirements it
+    // exists to wait for would be a standing instruction to do nothing.
     case "merge":
-      return ["merge", `--${mergeMethod ?? "merge"}`];
+      return ["merge", `--${mergeMethod ?? "merge"}`, ...(adminMerge === true ? ["--admin"] : [])];
     // `--auto` arms the same command instead of running it, and still needs the strategy: GitHub
     // stores the strategy with the standing instruction rather than choosing one at merge time.
     case "enable-auto-merge":
@@ -1701,6 +1707,7 @@ export const make = Effect.gen(function* () {
         input.action,
         input.mergeMethod,
         input.updateMethod,
+        input.adminMerge,
       );
       return github
         .execute({

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -9,7 +9,14 @@ import type { GitHubReviewThreadComments } from "./gitHubPullRequestJson.ts";
 
 describe("gitHubViewerPermissions", () => {
   it("offers everything to a viewer who can write to the repository", () => {
-    expect(gitHubViewerPermissions({ canWrite: true, canUpdate: true, didAuthor: false })).toEqual({
+    expect(
+      gitHubViewerPermissions({
+        canWrite: true,
+        canUpdate: true,
+        didAuthor: false,
+        canAdminister: false,
+      }),
+    ).toEqual({
       // Arming a merge for later is the merge, so it travels with it.
       actions: [
         "merge",
@@ -31,7 +38,12 @@ describe("gitHubViewerPermissions", () => {
     // Every open-source pull request somebody else opened: GitHub says no to all five actions
     // and to resolving, and yes to commenting and to every verdict.
     expect(
-      gitHubViewerPermissions({ canWrite: false, canUpdate: false, didAuthor: false }),
+      gitHubViewerPermissions({
+        canWrite: false,
+        canUpdate: false,
+        didAuthor: false,
+        canAdminister: false,
+      }),
     ).toEqual({
       actions: [],
       comment: true,
@@ -43,7 +55,14 @@ describe("gitHubViewerPermissions", () => {
   });
 
   it("keeps an author's own pull request theirs to close, with read access and no more", () => {
-    expect(gitHubViewerPermissions({ canWrite: false, canUpdate: true, didAuthor: true })).toEqual({
+    expect(
+      gitHubViewerPermissions({
+        canWrite: false,
+        canUpdate: true,
+        didAuthor: true,
+        canAdminister: false,
+      }),
+    ).toEqual({
       // Merging is the one thing writing is needed for, now or later; the rest an author may do.
       actions: ["ready", "draft", "close", "reopen"],
       comment: true,
@@ -52,6 +71,27 @@ describe("gitHubViewerPermissions", () => {
       verdicts: ["comment"],
       requestReviewers: false,
     });
+  });
+
+  it("offers the override merge to an administrator, and to nobody else", () => {
+    expect(
+      gitHubViewerPermissions({
+        canWrite: true,
+        canUpdate: true,
+        didAuthor: false,
+        canAdminister: true,
+      }).adminMerge,
+    ).toBe(true);
+    // A writer who is not an administrator gets the merge and not the override: GitHub refuses
+    // them the bypass, so the control would only ever hand back the refusal they already had.
+    expect(
+      gitHubViewerPermissions({
+        canWrite: true,
+        canUpdate: true,
+        didAuthor: false,
+        canAdminister: false,
+      }).adminMerge,
+    ).toBeUndefined();
   });
 
   it.effect("uses the small viewer-access read for core permissions", () =>
@@ -107,10 +147,16 @@ describe("gitHubViewerPermissions", () => {
           getRepositoryAccess: () =>
             Effect.succeed({
               canWrite: false,
+              canAdminister: false,
               mergeCapabilities: { merge: true, squash: true, rebase: true },
             }),
           getViewerAccess: () =>
-            Effect.succeed({ canWrite: false, canUpdate: true, didAuthor: false }),
+            Effect.succeed({
+              canWrite: false,
+              canUpdate: true,
+              didAuthor: false,
+              canAdminister: false,
+            }),
         }),
       ),
     ),
@@ -157,7 +203,8 @@ describe("getViewerPermissions", () => {
     Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
       getPullRequestDetail: () => Effect.succeed(openDetail),
       getPullRequestBaseComparison: () => comparison,
-      getViewerAccess: () => Effect.succeed({ canWrite: true, canUpdate: true, didAuthor: false }),
+      getViewerAccess: () =>
+        Effect.succeed({ canWrite: true, canUpdate: true, didAuthor: false, canAdminister: false }),
     });
 
   it.effect("offers update-branch when the comparison grants it", () =>
@@ -203,7 +250,7 @@ describe("getViewerPermissions", () => {
           getViewerAccess: (input) =>
             Effect.sync(() => {
               viewerAllowReserve = input.allowReserve;
-              return { canWrite: true, canUpdate: true, didAuthor: false };
+              return { canWrite: true, canUpdate: true, didAuthor: false, canAdminister: false };
             }),
         }),
       ),
@@ -238,7 +285,12 @@ describe("getViewerPermissions", () => {
               }),
             ),
           getViewerAccess: () =>
-            Effect.succeed({ canWrite: true, canUpdate: true, didAuthor: false }),
+            Effect.succeed({
+              canWrite: true,
+              canUpdate: true,
+              didAuthor: false,
+              canAdminister: false,
+            }),
         }),
       ),
     ),

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -30,6 +30,8 @@ const CAPABILITIES: PullRequestCapabilities = {
     "disable-auto-merge",
   ],
   mergeMethods: ["merge", "squash", "rebase"],
+  // `gh pr merge --admin` merges without waiting for what the branch's protection asks for.
+  adminMerge: true,
   updateMethods: ["merge", "rebase"],
   search: true,
   reactions: true,
@@ -59,6 +61,9 @@ const CAPABILITIES: PullRequestCapabilities = {
  * Asking somebody else for a review needs write access, which is the one thing here an author
  * cannot do on their own pull request: GitHub shows an outside contributor the reviewer control
  * and refuses the request behind it.
+ *
+ * Merging past what the branch's protection asks for is narrower than merging: administrators
+ * only, which is why it is a permission of its own rather than another entry in `actions`.
  */
 export function gitHubViewerPermissions(access: GitHubViewerAccess): PullRequestViewerPermissions {
   return {
@@ -79,6 +84,9 @@ export function gitHubViewerPermissions(access: GitHubViewerAccess): PullRequest
     verdicts: access.didAuthor ? (["comment"] as const) : CAPABILITIES.review.verdicts,
     requestReviewers: access.canWrite,
     ...(access.canUpdateBranch === true ? { updateMethods: CAPABILITIES.updateMethods } : {}),
+    // Said only when it is true. The field is withheld by default, so an administrator who is
+    // also somehow without write access is offered neither merge — which is the honest answer.
+    ...(access.canAdminister && access.canWrite ? { adminMerge: true } : {}),
   };
 }
 
@@ -424,6 +432,7 @@ export const make = Effect.gen(function* () {
           action: input.action,
           ...(input.mergeMethod === undefined ? {} : { mergeMethod: input.mergeMethod }),
           ...(input.updateMethod === undefined ? {} : { updateMethod: input.updateMethod }),
+          ...(input.adminMerge === undefined ? {} : { adminMerge: input.adminMerge }),
         })
         .pipe(Effect.mapError(fail("runAction"))),
 

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -363,6 +363,11 @@ export interface PullRequestProviderApi {
       readonly mergeMethod?: PullRequestMergeMethod;
       /** Only meaningful for `update-branch`; absent takes the host's own default. */
       readonly updateMethod?: PullRequestUpdateMethod;
+      /**
+       * Only meaningful for `merge`, and only reaches a provider whose `capabilities.adminMerge`
+       * says it can: merge without waiting for the requirements the host would otherwise enforce.
+       */
+      readonly adminMerge?: boolean;
     },
   ) => Effect.Effect<void, PullRequestProviderError>;
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1072,6 +1072,132 @@ it.effect("gates arming a merge for later exactly as it gates merging now", () =
   }),
 );
 
+it.effect("refuses an override merge to a host that has no override to ask for", () =>
+  Effect.gen(function* () {
+    let ran = false;
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          capabilities: {
+            diff: true,
+            comment: true,
+            actions: ["merge"],
+            mergeMethods: ["merge", "squash"],
+            search: true,
+            reactions: true,
+            review: FULL_REVIEW,
+            reviewers: FULL_REVIEWERS,
+          },
+          getViewerPermissions: () =>
+            Effect.succeed({
+              actions: ["merge"],
+              comment: true,
+              resolve: true,
+              verdicts: ["comment"],
+              requestReviewers: true,
+              adminMerge: true,
+            }),
+          runAction: () => {
+            ran = true;
+            return Effect.void;
+          },
+        }),
+      ],
+    });
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+
+    // Standing on the repository is not the question here. A host with no override would have
+    // merged the ordinary way and reported a bypass that never happened — and on a branch whose
+    // protection is what stopped the merge, it would not have merged at all.
+    const refused = yield* Effect.flip(
+      service.runAction({
+        ...reference,
+        action: "merge",
+        mergeMethod: "squash",
+        adminMerge: true,
+      }),
+    );
+    assert.strictEqual(refused._tag, "PullRequestOperationError");
+    assert.include(refused.message, "cannot merge past the requirements it enforces");
+    assert.isFalse(ran);
+
+    // The merge this host does have is still the reader's to make.
+    yield* service.runAction({ ...reference, action: "merge", mergeMethod: "squash" });
+    assert.isTrue(ran);
+  }),
+);
+
+it.effect("hands on an override merge only where the viewer administers the repository", () =>
+  Effect.gen(function* () {
+    let ranWith: { readonly action: string; readonly adminMerge?: boolean } | null = null;
+    let administers = false;
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          capabilities: {
+            diff: true,
+            comment: true,
+            actions: ["merge"],
+            mergeMethods: ["merge", "squash"],
+            adminMerge: true,
+            search: true,
+            reactions: true,
+            review: FULL_REVIEW,
+            reviewers: FULL_REVIEWERS,
+          },
+          getViewerPermissions: () =>
+            Effect.succeed({
+              actions: ["merge"],
+              comment: true,
+              resolve: true,
+              verdicts: ["comment"],
+              requestReviewers: true,
+              ...(administers ? { adminMerge: true } : {}),
+            }),
+          runAction: (input) => {
+            ranWith = {
+              action: input.action,
+              ...(input.adminMerge === undefined ? {} : { adminMerge: input.adminMerge }),
+            };
+            return Effect.void;
+          },
+        }),
+      ],
+    });
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+
+    // A writer asking for the bypass is told what it would take, rather than being handed the
+    // host's own refusal a moment later with nothing said about why.
+    const refused = yield* Effect.flip(
+      service.runAction({
+        ...reference,
+        action: "merge",
+        mergeMethod: "squash",
+        adminMerge: true,
+      }),
+    );
+    assert.strictEqual(refused._tag, "PullRequestOperationError");
+    assert.include(refused.message, "administrator access");
+    assert.strictEqual(ranWith, null);
+
+    // The permissions are read at the moment of the write, so the answer follows the role.
+    administers = true;
+    yield* service.runAction({
+      ...reference,
+      action: "merge",
+      mergeMethod: "squash",
+      adminMerge: true,
+    });
+    assert.deepStrictEqual(ranWith, { action: "merge", adminMerge: true });
+
+    // And an ordinary merge from the same administrator carries no override with it.
+    yield* service.runAction({ ...reference, action: "merge", mergeMethod: "squash" });
+    assert.deepStrictEqual(ranWith, { action: "merge" });
+  }),
+);
+
 it.effect("hands the host the strategy an armed merge was asked for", () =>
   Effect.gen(function* () {
     let ranWith: { readonly action: string; readonly mergeMethod?: string } | null = null;

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1072,6 +1072,72 @@ it.effect("gates arming a merge for later exactly as it gates merging now", () =
   }),
 );
 
+it.effect("refuses an override on any action but the merge itself", () =>
+  Effect.gen(function* () {
+    let ranWith: { readonly action: string; readonly adminMerge?: boolean } | null = null;
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          capabilities: {
+            diff: true,
+            comment: true,
+            actions: ["merge", "enable-auto-merge", "close"],
+            mergeMethods: ["merge", "squash"],
+            adminMerge: true,
+            search: true,
+            reactions: true,
+            review: FULL_REVIEW,
+            reviewers: FULL_REVIEWERS,
+          },
+          getViewerPermissions: () =>
+            Effect.succeed({
+              actions: ["merge", "enable-auto-merge", "close"],
+              comment: true,
+              resolve: true,
+              verdicts: ["comment"],
+              requestReviewers: true,
+              adminMerge: true,
+            }),
+          runAction: (input) => {
+            ranWith = {
+              action: input.action,
+              ...(input.adminMerge === undefined ? {} : { adminMerge: input.adminMerge }),
+            };
+            return Effect.void;
+          },
+        }),
+      ],
+    });
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+
+    // Arming an auto-merge that skips what it exists to wait for is a contradiction, and running
+    // it as the ordinary action would report a bypass that never happened.
+    const refused = yield* Effect.flip(
+      service.runAction({
+        ...reference,
+        action: "enable-auto-merge",
+        mergeMethod: "squash",
+        adminMerge: true,
+      }),
+    );
+    assert.strictEqual(refused._tag, "PullRequestOperationError");
+    assert.include(refused.message, "Only a merge can be made past the requirements");
+    assert.strictEqual(ranWith, null);
+
+    // Nothing else takes one either, whatever the viewer's standing.
+    const closeRefused = yield* Effect.flip(
+      service.runAction({ ...reference, action: "close", adminMerge: true }),
+    );
+    assert.strictEqual(closeRefused._tag, "PullRequestOperationError");
+    assert.strictEqual(ranWith, null);
+
+    // The same actions without one are untouched.
+    yield* service.runAction({ ...reference, action: "enable-auto-merge", mergeMethod: "squash" });
+    assert.deepStrictEqual(ranWith, { action: "enable-auto-merge" });
+  }),
+);
+
 it.effect("refuses an override merge to a host that has no override to ask for", () =>
   Effect.gen(function* () {
     let ran = false;

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1324,6 +1324,18 @@ export const make = Effect.gen(function* () {
             }),
           );
         }
+        // The merge is the only action an override belongs to. `gh` refuses `--admin` beside
+        // `--auto`, and an armed auto-merge that skipped the requirements it exists to wait for
+        // would be a standing instruction to do nothing — so a request pairing the two is turned
+        // away rather than carried out as the ordinary action and reported as a bypass.
+        if (input.adminMerge === true && input.action !== "merge") {
+          return Effect.fail(
+            new PullRequestOperationError({
+              operation: "runAction",
+              detail: "Only a merge can be made past the requirements this host enforces.",
+            }),
+          );
+        }
         // An override a host has no notion of is refused rather than dropped: quietly merging
         // the ordinary way would report success for a merge that asked to step over the branch's
         // requirements and did not, and the pull request would still be sitting there.

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -194,6 +194,15 @@ const ACTION_ACCESS_REFUSALS: Record<PullRequestAction, string> = {
 };
 
 /**
+ * Why an override merge is refused, said as the standing it takes rather than as the merge that
+ * did not happen. Separate from the merge refusal above because it is said to a reader who may
+ * merge perfectly well: they asked for more than that, and being told to get write access they
+ * already have would read as the app not knowing who they are.
+ */
+const ADMIN_MERGE_ACCESS_REFUSAL =
+  "You need administrator access on this repository to merge past the requirements it enforces.";
+
+/**
  * Why asking for a review is refused, and why the menu behind it is too. Write access is what the
  * hosts that state anything about this want; the ones that state nothing grant it, so this
  * sentence is only ever the answer where a host said no.
@@ -1315,6 +1324,17 @@ export const make = Effect.gen(function* () {
             }),
           );
         }
+        // An override a host has no notion of is refused rather than dropped: quietly merging
+        // the ordinary way would report success for a merge that asked to step over the branch's
+        // requirements and did not, and the pull request would still be sitting there.
+        if (input.adminMerge === true && project.api.capabilities.adminMerge !== true) {
+          return Effect.fail(
+            new PullRequestOperationError({
+              operation: "runAction",
+              detail: "This host cannot merge past the requirements it enforces.",
+            }),
+          );
+        }
         // The same for the way a stale branch is brought up to date: a host that only merges
         // must not be asked to rebase and left to pick something else.
         if (
@@ -1352,6 +1372,17 @@ export const make = Effect.gen(function* () {
                 }),
               );
             }
+            // Asked of the permissions read a moment ago rather than of what the page was told
+            // when it loaded, which is the whole reason this read happens on the write path: an
+            // administrator who has since been demoted must not still be handed `--admin`.
+            if (input.adminMerge === true && viewer.adminMerge !== true) {
+              return Effect.fail(
+                new PullRequestOperationError({
+                  operation: "runAction",
+                  detail: ADMIN_MERGE_ACCESS_REFUSAL,
+                }),
+              );
+            }
             return project.api
               .runAction({
                 cwd: project.project.workspaceRoot,
@@ -1361,6 +1392,7 @@ export const make = Effect.gen(function* () {
                 action: input.action,
                 ...(input.mergeMethod === undefined ? {} : { mergeMethod: input.mergeMethod }),
                 ...(input.updateMethod === undefined ? {} : { updateMethod: input.updateMethod }),
+                ...(input.adminMerge === undefined ? {} : { adminMerge: input.adminMerge }),
               })
               .pipe(Effect.mapError(toPullRequestError("runAction")));
           }),

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -763,7 +763,7 @@ describe("viewer permission decoding", () => {
           }),
         ),
       ),
-    ).toEqual({ canWrite: false, canUpdate: true, didAuthor: true });
+    ).toEqual({ canWrite: false, canUpdate: true, didAuthor: true, canAdminister: false });
   });
 
   it("says no to a passer-by on a repository they can only read", () => {
@@ -776,7 +776,26 @@ describe("viewer permission decoding", () => {
           }),
         ),
       ),
-    ).toEqual({ canWrite: false, canUpdate: false, didAuthor: false });
+    ).toEqual({ canWrite: false, canUpdate: false, didAuthor: false, canAdminister: false });
+  });
+
+  it("calls an administrator one, and stops there", () => {
+    const administers = (permission: string) =>
+      expectSuccess(
+        decodeViewerPermissionsJson(
+          viewerJson({
+            viewerPermission: permission,
+            pullRequest: { viewerCanUpdate: true, viewerDidAuthor: false },
+          }),
+        ),
+      ).canAdminister;
+
+    expect(administers("ADMIN")).toBe(true);
+    // A maintainer pushes and merges like any other writer, and branch protection refuses them
+    // exactly as it refuses a writer. Reading MAINTAIN as an override would offer a bypass the
+    // host never grants.
+    expect(administers("MAINTAIN")).toBe(false);
+    expect(administers("WRITE")).toBe(false);
   });
 
   it("reads silence as permission, but not as authorship", () => {
@@ -787,6 +806,7 @@ describe("viewer permission decoding", () => {
       canWrite: false,
       canUpdate: true,
       didAuthor: false,
+      canAdminister: false,
     });
   });
 });

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -1890,6 +1890,20 @@ function toCanWrite(viewerPermission: string | null | undefined): boolean {
   }
 }
 
+/**
+ * Whether the viewer's role is the one GitHub lets step over a protected branch. ADMIN alone:
+ * MAINTAIN can push and merge like any other writer and is refused by branch protection exactly
+ * as a writer is, so treating it as an override would offer a button the host always refuses.
+ *
+ * Nothing softer than an outright ADMIN counts, and an install that reports no permission counts
+ * as no. A repository whose administrators are themselves held to the rules — GitHub's "do not
+ * allow bypassing" setting — still answers ADMIN here, and refuses the merge; that refusal is the
+ * host's to give, and is carried back with its own words rather than guessed at from here.
+ */
+function toCanAdminister(viewerPermission: string | null | undefined): boolean {
+  return viewerPermission?.trim().toUpperCase() === "ADMIN";
+}
+
 export function decodeRepositoryAccessJson(
   raw: string,
 ): Result.Result<GitHubRepositoryAccess, DecodeFailure> {
@@ -2125,6 +2139,8 @@ export function buildReviewerRequestJson(
  */
 export interface GitHubViewerAccess {
   readonly canWrite: boolean;
+  /** The viewer is an administrator of the repository, which is what an override merge takes. */
+  readonly canAdminister: boolean;
   /** GitHub's own `viewerCanUpdate`, true for the author as well as for anyone with write. */
   readonly canUpdate: boolean;
   readonly didAuthor: boolean;
@@ -2171,6 +2187,7 @@ export function decodeViewerPermissionsJson(
   const repository = decoded.success.data.repository;
   return Result.succeed({
     canWrite: toCanWrite(repository.viewerPermission),
+    canAdminister: toCanAdminister(repository.viewerPermission),
     ...toPullRequestViewerFields(repository.pullRequest),
   });
 }

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -34,6 +34,7 @@ import {
   PencilIcon,
   RefreshCwIcon,
   ServerIcon,
+  ShieldIcon,
   TriangleAlertIcon,
 } from "lucide-react";
 import {
@@ -105,6 +106,7 @@ import {
   buildFixFindingHandoff,
   buildFixFindingsHandoff,
   buildResolveConflictsPrompt,
+  canAdminMergePullRequest,
   handoffPrompt,
   handoffReviewComments,
   latestPullRequestReviewOutcomes,
@@ -199,6 +201,15 @@ const ACTION_FAILURE_HINTS: Record<PullRequestAction, string> = {
  */
 const UPDATE_BRANCH_REBASE_FAILURE_HINT =
   "The host refused it. A rebase stops at the first commit that does not apply cleanly; updating with a merge commit may still work.";
+
+/**
+ * Said instead of the merge hint when the override was the thing that was refused. Everything the
+ * ordinary hint offers to check has already been stepped over, so repeating it would send the
+ * reader after the checks they just chose to skip. What is left is the one rule an administrator
+ * does not outrank: a repository can be set to hold its administrators to its own protections.
+ */
+const ADMIN_MERGE_FAILURE_HINT =
+  "The host refused it even with administrator privileges. Check that this repository allows its rules to be bypassed, and that the branch is not conflicting.";
 
 const TABS: ReadonlyArray<{ value: DetailTab; label: string }> = [
   { value: "summary", label: "Summary" },
@@ -456,7 +467,7 @@ export function PullRequestDetailPanel({
   const [mergeMethod, setMergeMethod] = useState<PullRequestMergeMethod>("merge");
   const [confirmation, setConfirmation] = useState<{
     readonly open: boolean;
-    readonly action: "merge" | "close" | "enable-auto-merge";
+    readonly action: "merge" | "admin-merge" | "close" | "enable-auto-merge";
   }>({ open: false, action: "merge" });
   const confirmAction = confirmation.action;
   // Which handoff is preparing, keyed so a per-finding button can say "Preparing..." on itself
@@ -625,6 +636,8 @@ export function PullRequestDetailPanel({
     action: PullRequestAction,
     method?: PullRequestMergeMethod,
     updateMethod?: PullRequestUpdateMethod,
+    /** Only sent when it is true: an explicit false would claim an override was considered. */
+    adminMerge?: boolean,
   ) => {
     if (pendingAction !== null) return;
     setPendingAction(action);
@@ -635,6 +648,7 @@ export function PullRequestDetailPanel({
         action,
         ...(method ? { mergeMethod: method } : {}),
         ...(updateMethod ? { updateMethod } : {}),
+        ...(adminMerge === true ? { adminMerge: true } : {}),
       },
     });
     setPendingAction(null);
@@ -649,7 +663,9 @@ export function PullRequestDetailPanel({
       const hint =
         updateMethod === "rebase"
           ? UPDATE_BRANCH_REBASE_FAILURE_HINT
-          : ACTION_FAILURE_HINTS[action];
+          : adminMerge === true
+            ? ADMIN_MERGE_FAILURE_HINT
+            : ACTION_FAILURE_HINTS[action];
       toastManager.add({
         type: "error",
         title: ACTION_FAILURE_LABELS[action],
@@ -1084,6 +1100,12 @@ export function PullRequestDetailPanel({
     !detail.isDraft &&
     !conflicting &&
     allowedMergeMethods.length > 1;
+  // The same merge, with the host told not to wait for what the branch requires. Offered beside
+  // the ordinary one rather than instead of it: the reader who wants the rules and the reader who
+  // has decided to step over them are the same person, and which one they are is today's answer.
+  const showsAdminMerge =
+    detail !== null &&
+    canAdminMergePullRequest(detail, can("merge") && allowedMergeMethods.length > 0);
   // The pull request number carries this state in the overview and the right-panel tab mirrors
   // it. The conflict action is separate from this state: an open pull request remains green.
   const statePresentation = detail
@@ -1405,6 +1427,25 @@ export function PullRequestDetailPanel({
                           Enable auto-merge
                         </MenuItem>
                       ) : null}
+                      {/* The same merge again, with the host told not to wait for what the
+                          branch requires. Its own item rather than a modifier welded to the
+                          Merge button: pressing the control you always press and getting a
+                          different promise is how a protected branch gets stepped over by
+                          somebody who did not mean to. */}
+                      {showsAdminMerge ? (
+                        <MenuItem
+                          disabled={actionPending}
+                          onClick={() => setConfirmation({ open: true, action: "admin-merge" })}
+                        >
+                          <ShieldIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                          <span className="flex min-w-0 flex-col">
+                            <span>Merge as administrator</span>
+                            <span className="text-xs text-muted-foreground">
+                              Merges past the checks and approvals this branch requires.
+                            </span>
+                          </span>
+                        </MenuItem>
+                      ) : null}
                       {/* A preference for the merge action rather than a second action, so it
                           is a radio group here instead of a chevron welded to the Merge pill.
                           Hidden while conflicting: every method would fail. */}
@@ -1438,6 +1479,7 @@ export function PullRequestDetailPanel({
                       {pullRequestActionMenuHasGroup(
                         showsDraftToggle,
                         showsAutoMerge,
+                        showsAdminMerge,
                         showsMergeMethods,
                       ) ? (
                         <MenuSeparator />
@@ -1981,19 +2023,26 @@ export function PullRequestDetailPanel({
             <AlertDialogTitle>
               {confirmAction === "merge"
                 ? "Merge pull request?"
-                : confirmAction === "enable-auto-merge"
-                  ? "Enable auto-merge?"
-                  : "Close pull request?"}
+                : confirmAction === "admin-merge"
+                  ? "Merge past this branch's requirements?"
+                  : confirmAction === "enable-auto-merge"
+                    ? "Enable auto-merge?"
+                    : "Close pull request?"}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {confirmAction === "merge"
                 ? `This merges #${reference.number} using ${selectedMergeMethod}.`
-                : confirmAction === "enable-auto-merge"
-                  ? // The host merges this as soon as it considers the pull request ready, which
-                    // may be immediately — there is no telling from here whether anything is
-                    // still outstanding.
-                    `This merges #${reference.number} using ${selectedMergeMethod} as soon as the host considers it ready, which may be immediately.`
-                  : `This closes #${reference.number} without merging it.`}
+                : confirmAction === "admin-merge"
+                  ? // Said as what is being skipped rather than as the privilege being used: the
+                    // reader knows they are an administrator, and what they are deciding is
+                    // whether this change goes in without what the branch asks of everyone else.
+                    `This merges #${reference.number} using ${selectedMergeMethod} without waiting for the checks, approvals and protections this branch requires.`
+                  : confirmAction === "enable-auto-merge"
+                    ? // The host merges this as soon as it considers the pull request ready, which
+                      // may be immediately — there is no telling from here whether anything is
+                      // still outstanding.
+                      `This merges #${reference.number} using ${selectedMergeMethod} as soon as the host considers it ready, which may be immediately.`
+                    : `This closes #${reference.number} without merging it.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -2002,12 +2051,20 @@ export function PullRequestDetailPanel({
             </AlertDialogClose>
             <Button
               size="sm"
-              variant={confirmAction === "close" ? "destructive" : "default"}
+              // The override wears the same red as the close: both are the button on this page
+              // whose result nobody else asked for.
+              variant={
+                confirmAction === "close" || confirmAction === "admin-merge"
+                  ? "destructive"
+                  : "default"
+              }
               disabled={actionPending}
               onClick={() => {
                 const action = confirmAction;
                 setConfirmation((current) => ({ ...current, open: false }));
                 if (action === "merge") void perform("merge", selectedMergeMethod);
+                if (action === "admin-merge")
+                  void perform("merge", selectedMergeMethod, undefined, true);
                 if (action === "enable-auto-merge")
                   void perform("enable-auto-merge", selectedMergeMethod);
                 if (action === "close") void perform("close");
@@ -2015,9 +2072,11 @@ export function PullRequestDetailPanel({
             >
               {confirmAction === "merge"
                 ? selectedMergeMethodLabel
-                : confirmAction === "enable-auto-merge"
-                  ? "Enable auto-merge"
-                  : "Close"}
+                : confirmAction === "admin-merge"
+                  ? `${selectedMergeMethodLabel} as administrator`
+                  : confirmAction === "enable-auto-merge"
+                    ? "Enable auto-merge"
+                    : "Close"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogPopup>

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -23,6 +23,7 @@ import {
   newestPullRequestCommitAt,
   mergePullRequestThreadComments,
   orderPullRequestComments,
+  canAdminMergePullRequest,
   pullRequestActionMenuHasGroup,
   pullRequestActionNeedsHostRefresh,
   pullRequestComposerTarget,
@@ -125,6 +126,41 @@ describe("review thread comment pages", () => {
 describe("pull request action menu", () => {
   it("keeps the group divider when auto-merge is the only action", () => {
     expect(pullRequestActionMenuHasGroup(false, true, false)).toBe(true);
+  });
+});
+
+describe("administrator merge", () => {
+  const detail = {
+    state: "open" as const,
+    isDraft: false,
+    mergeability: "mergeable" as const,
+    capabilities: { adminMerge: true },
+    viewerPermissions: { adminMerge: true },
+  };
+
+  it("offers the override where the host and the viewer both allow it", () => {
+    expect(canAdminMergePullRequest(detail, true)).toBe(true);
+  });
+
+  it("withholds it from a viewer the host does not call an administrator", () => {
+    expect(canAdminMergePullRequest({ ...detail, viewerPermissions: {} }, true)).toBe(false);
+  });
+
+  it("withholds it on a host that cannot merge past its own requirements", () => {
+    expect(canAdminMergePullRequest({ ...detail, capabilities: {} }, true)).toBe(false);
+  });
+
+  it("withholds it where there is no ordinary merge for it to be an override of", () => {
+    // A repository that allows no strategy this viewer may use: an override of nothing.
+    expect(canAdminMergePullRequest(detail, false)).toBe(false);
+  });
+
+  it("withholds it from a draft and from a conflicting branch", () => {
+    // No standing resolves a collision, and a draft is not asking to be merged at all. Failing
+    // checks are the one thing it does not look at, which is the whole point of the control.
+    expect(canAdminMergePullRequest({ ...detail, isDraft: true }, true)).toBe(false);
+    expect(canAdminMergePullRequest({ ...detail, mergeability: "conflicting" }, true)).toBe(false);
+    expect(canAdminMergePullRequest({ ...detail, state: "merged" }, true)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -92,12 +92,8 @@ export function pullRequestComposerTarget<T>(
 }
 
 /** Whether the open pull-request action group contains at least one action. */
-export function pullRequestActionMenuHasGroup(
-  showsDraftToggle: boolean,
-  showsAutoMerge: boolean,
-  showsMergeMethods: boolean,
-): boolean {
-  return showsDraftToggle || showsAutoMerge || showsMergeMethods;
+export function pullRequestActionMenuHasGroup(...shown: ReadonlyArray<boolean>): boolean {
+  return shown.some((entry) => entry);
 }
 
 export function isStackedPullRequestBase(
@@ -914,6 +910,33 @@ export function resolveBaseFreshness(detail: {
     behindBy: detail.behindBy ?? null,
     methods: offered.filter((method) => allowed.includes(method)),
   };
+}
+
+/**
+ * Whether the override merge is on offer: the host can step over what a branch requires, this
+ * viewer is one of the few it will do that for, and there is an ordinary merge for it to be an
+ * override of — a strategy nobody may use makes an override of nothing.
+ *
+ * Withheld on a draft and on a conflicting branch for the reasons the Merge button itself is:
+ * no standing resolves a collision, and a draft is not asking to be merged at all. What it does
+ * not look at is the checks, which is the whole point — this is the control for the moment the
+ * host says no.
+ */
+export function canAdminMergePullRequest(
+  detail: {
+    readonly state: PullRequestState;
+    readonly isDraft: boolean;
+    readonly mergeability: PullRequestMergeability;
+    readonly capabilities: { readonly adminMerge?: boolean | undefined };
+    readonly viewerPermissions: { readonly adminMerge?: boolean | undefined };
+  },
+  /** Whether an ordinary merge is offered here at all, which the panel has already worked out. */
+  mergeOnOffer: boolean,
+): boolean {
+  if (!mergeOnOffer) return false;
+  if (detail.state !== "open" || detail.isDraft) return false;
+  if (detail.mergeability === "conflicting") return false;
+  return detail.capabilities.adminMerge === true && detail.viewerPermissions.adminMerge === true;
 }
 
 /**

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -45,6 +45,17 @@ T3 Code works with the platforms your team already uses:
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
 
+**Merge when it's ready**
+
+- Merge, squash, or rebase from the review's own actions, with the strategies your repository
+  allows and no others
+- Turn on auto-merge and let the host land the change once its requirements are met
+- If you administer the repository on GitHub, **Merge as administrator** merges past the checks
+  and approvals the branch requires — the same override GitHub offers its administrators, without
+  leaving T3 Code. It asks you to confirm, and it never appears for anyone the host would refuse
+  it to. A repository set to hold its administrators to its own rules still says no, and passes
+  that answer back in its own words.
+
 **Fix what you wrote, in place**
 
 - Rewrite a pull request's title and description from the review itself, in Markdown, with a

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -832,8 +832,12 @@ export const PullRequestActionInput = Schema.Struct({
   updateMethod: Schema.optional(PullRequestUpdateMethod),
   /**
    * Merge past the requirements the host would otherwise enforce, which only a viewer the host
-   * calls an administrator may ask for. Only read for `merge`: an auto-merge exists to wait for
-   * exactly the requirements this steps over, so arming one that skipped them is a contradiction.
+   * calls an administrator may ask for.
+   *
+   * `merge` is the only action that takes it, and any other action carrying it is refused rather
+   * than run without it: an auto-merge exists to wait for exactly the requirements this steps
+   * over, so arming one that skipped them is a contradiction, and quietly arming an ordinary one
+   * instead would report a bypass that never happened.
    *
    * Absent is the ordinary merge, which is what every request before this field asked for.
    */

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -366,6 +366,13 @@ export const PullRequestCapabilities = Schema.Struct({
   /** Merge strategies the provider itself offers, before repository settings narrow them. */
   mergeMethods: Schema.Array(PullRequestMergeMethod),
   /**
+   * The host can merge past the requirements it would otherwise enforce — a protected branch, an
+   * approval nobody has given, a check still running — for a viewer whose standing allows it.
+   * Optional for the same reason as `updateMethods`: a server that says nothing about it cannot
+   * do it, which is what every server before this field was.
+   */
+  adminMerge: Schema.optional(Schema.Boolean),
+  /**
    * How this host can bring a stale branch up to date. Absent where it cannot at all, which is
    * every host that has not said otherwise — so a provider that says nothing offers nothing.
    */
@@ -421,6 +428,18 @@ export const PullRequestViewerPermissions = Schema.Struct({
    * Absent or empty means they may not, which is also what a host with no such action says.
    */
   updateMethods: Schema.optional(Schema.Array(PullRequestUpdateMethod)),
+  /**
+   * This viewer may merge past the requirements the host enforces, which is a stronger thing than
+   * being allowed to merge at all: on GitHub it is the repository's administrators and nobody
+   * else.
+   *
+   * The one permission here withheld rather than granted when the host says nothing. The granting
+   * default exists so a control is never hidden from somebody who could have used it, and it is
+   * the wrong default for this one: an override offered to a viewer who does not have it promises
+   * that branch protection will be stepped over, and the host answers that promise with the same
+   * refusal the ordinary merge already gave them.
+   */
+  adminMerge: Schema.optional(Schema.Boolean),
 });
 export type PullRequestViewerPermissions = typeof PullRequestViewerPermissions.Type;
 
@@ -811,6 +830,14 @@ export const PullRequestActionInput = Schema.Struct({
   mergeMethod: Schema.optional(PullRequestMergeMethod),
   /** Only read for `update-branch`, where absent means the host's own default. */
   updateMethod: Schema.optional(PullRequestUpdateMethod),
+  /**
+   * Merge past the requirements the host would otherwise enforce, which only a viewer the host
+   * calls an administrator may ask for. Only read for `merge`: an auto-merge exists to wait for
+   * exactly the requirements this steps over, so arming one that skipped them is a contradiction.
+   *
+   * Absent is the ordinary merge, which is what every request before this field asked for.
+   */
+  adminMerge: Schema.optional(Schema.Boolean),
 });
 export type PullRequestActionInput = typeof PullRequestActionInput.Type;
 


### PR DESCRIPTION
## The problem

The PR viewer offers whichever merge strategies a repository allows, but on a branch behind protection every one of them is refused: you press Squash, GitHub says no, and if you are an administrator of that repository — someone who *can* land it — your only way through is to leave for the browser. The panel has no way to ask for the override the host would grant you.

## The change

`gh pr merge --admin`, surfaced properly rather than bolted onto the existing button.

- **`capabilities.adminMerge`** — whether a host has an override at all. GitHub only; GitLab, Bitbucket and Azure DevOps say nothing and so offer nothing.
- **`viewerPermissions.adminMerge`** — whether this account is one. `ADMIN` and nothing softer: `MAINTAIN` pushes and merges like any other writer and is refused by branch protection exactly as a writer is, so reading it as an override would offer a button the host always refuses. This is the one permission in that struct withheld rather than granted when the host says nothing.
- **`adminMerge` on the action input** — asks for it. The server checks the host capability and then the viewer's standing, read at the moment of the write rather than taken from what the page was told when it loaded, before the flag ever reaches `gh`. An override a host cannot make is refused rather than quietly merged the ordinary way.

Only `merge` carries it. `gh` refuses `--admin` alongside `--auto` outright, and an auto-merge that skipped the requirements it exists to wait for would be a standing instruction to do nothing.

In the panel it is its own item in the actions menu — **Merge as administrator**, with "Merges past the checks and approvals this branch requires." under it — rather than a modifier welded to the Merge button, because pressing the control you always press and getting a different promise is how a protected branch gets stepped over by somebody who did not mean to. It is behind a confirmation that says what is being skipped, with a destructive confirm button. Hidden on a draft and on a conflicting branch for the same reasons the Merge button is; deliberately *not* hidden by failing checks, which is the whole point of the control.

A repository set to hold its administrators to its own protections still refuses, and that refusal comes back in the host's own words with a hint that points at the setting rather than at the checks the reader just chose to skip.

## Surfaces

- **Contracts / server / web** — touched. Behaviour is unchanged for every other host and every non-administrator.
- **Mobile** — no pull request merge controls exist there today, so nothing to decide.
- **Desktop** — wraps web, comes along for free.
- **Docs** — `docs/user/source-control.md` gains a short "Merge when it's ready" entry.

## Tests

- `GitHubPullRequestCli` — `--admin` is appended to the merge and never to an armed auto-merge.
- `gitHubPullRequestJson` — `ADMIN` administers; `MAINTAIN` and `WRITE` do not.
- `GitHubPullRequestProvider` — the override is offered to an administrator and withheld from a plain writer.
- `PullRequestService` — refused on a host without the capability, refused for a viewer without the standing, handed on when both agree, and absent from an ordinary merge by the same administrator.
- `pullRequestDetail.logic` — the panel's gate, including draft, conflicting, and "no strategy to override".

`vp fmt --check`, targeted `typecheck` for contracts/server/web, targeted lint, and the touched test files all pass locally.

## Before / after images

The same pull request, the same actions menu, on a repository the signed-in account administers. The only difference is the new item.

**Before** — `main`. Merging is offered; there is no way to ask for the override, so a protected branch simply refuses and the reader has to leave for the browser.

![Actions menu before the change](https://raw.githubusercontent.com/khalil-omer/t3code/pr-assets-8225/before-menu.png)

**After** — this branch. **Merge as administrator** sits between "Enable auto-merge" and the merge-strategy group, with the consequence written under it.

![Actions menu after the change, showing Merge as administrator](https://raw.githubusercontent.com/khalil-omer/t3code/pr-assets-8225/after-menu.png)

**The confirmation.** Destructive styling, and the wording says what is being skipped rather than which privilege is being spent.

![Confirmation dialog: Merge past this branch's requirements?](https://raw.githubusercontent.com/khalil-omer/t3code/pr-assets-8225/after-dialog.png)

Both shots come from a real host read, not a fixture: `viewerPermission: ADMIN` on that repository. Pointed at a repository where the account only has write access, the item does not appear at all.

<sup>Images live on an orphan branch of my fork so nothing here lands in this repo's tree.</sup>

## On this being feature work

I read CONTRIBUTING before opening this, and I know it is a feature on a repo that is not asking for features. If you would rather it started life as an Ideas discussion, say the word and I will move it and close this.

---

Model: Claude Opus 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Merge behavior changes for GitHub administrators (bypassing protections is high-impact), though gated by capability checks, confirmation UI, and fresh permission validation on each action.
> 
> **Overview**
> Adds **Merge as administrator** for GitHub pull requests — the in-app equivalent of `gh pr merge --admin`, so repo admins can merge past branch protection without leaving T3 Code.
> 
> **Contracts and server:** Optional `adminMerge` on capabilities, viewer permissions, and `runAction` input. GitHub maps `viewerPermission === ADMIN` to `canAdminister` (not `MAINTAIN`). `PullRequestService` rejects override merges on non-merge actions, hosts without the capability, or viewers without `adminMerge`, with dedicated error copy; permissions are re-checked on the write path.
> 
> **GitHub integration:** `GitHubPullRequestCli` appends `--admin` only for `merge`, never for `enable-auto-merge`.
> 
> **Web:** Separate actions-menu item with confirmation and a failure hint tuned for admin bypass refusals. `canAdminMergePullRequest` gates on host + viewer capability, ordinary merge availability, and excludes drafts/conflicts. `pullRequestActionMenuHasGroup` is now variadic (`...shown: boolean[]`).
> 
> **Docs:** Short “Merge when it's ready” note in `docs/user/source-control.md`. Other hosts and non-admins are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7232736b85f0067424f4a46e30456a7c79c66f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub "Merge as administrator" action with `adminMerge` flag
> - Introduces an optional `adminMerge` boolean across `PullRequestActionInput`, `PullRequestCapabilities`, and `PullRequestViewerPermissions` in [pullRequest.ts](https://github.com/pingdotgg/t3code/pull/8225/files#diff-3698440642964c6a34f717f82a7bcd5991bfa0d1a341e2a84baf11b1acdf0dfe) so providers can advertise and viewers can request administrative merges that bypass branch requirements.
> - The GitHub provider ([GitHubPullRequestProvider.ts](https://github.com/pingdotgg/t3code/pull/8225/files#diff-387272edccb4588cc73a89c98619738ef3bb2de960377976b2b9b430eb3fe0dd)) advertises `adminMerge: true` and derives viewer permission from `viewerPermission == 'ADMIN'`; the CLI layer ([GitHubPullRequestCli.ts](https://github.com/pingdotgg/t3code/pull/8225/files#diff-5f996ba58ab5dee2c62090f97591f9434b30c9db0025bf3f8212b5732391e966)) appends `--admin` to `gh pr merge` only for the `merge` action.
> - `PullRequestService.make.runAction` ([PullRequestService.ts](https://github.com/pingdotgg/t3code/pull/8225/files#diff-6dc74968ebcf535ce84fea9f44369080aa5246f4a8c9d10824bf988651c4f0bf)) rejects `adminMerge` for non-merge actions, unsupported hosts, or non-admin viewers before forwarding to the provider.
> - The web UI ([PullRequestDetailPanel.tsx](https://github.com/pingdotgg/t3code/pull/8225/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a)) adds a "Merge as administrator" menu item with a destructive confirmation, gated by `canAdminMergePullRequest` logic.
> - Behavioral Change: `decodeViewerPermissionsJson` now includes a `canAdminister` field in decoded viewer access objects; existing consumers that pattern-match on this shape may need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b723273.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
