### PR TITLE
feat(server): fetch legacy model classification from a hosted manifest

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -128,7 +128,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
-      const instanceScope = yield* Effect.scope;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
@@ -170,7 +169,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       // Kick the TTL-gated manifest refresh in the background and classify
       // with the in-memory manifest, so a slow or hung fetch never delays the
       // provider check. A refresh that lands mid-probe applies on the next one.
-      const checkProvider = Effect.forkIn(modelManifest.refreshed, instanceScope).pipe(
+      const checkProvider = modelManifest.refreshInBackground.pipe(
         Effect.andThen(
           Effect.zipWith(
             checkClaudeProviderStatus(

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -36,6 +36,7 @@ import {
 } from "../Layers/ClaudeProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import { applyModelManifest, ModelManifest } from "../ModelManifest.ts";
 import {
   defaultProviderContinuationIdentity,
   type ProviderDriver,
@@ -87,6 +88,7 @@ export type ClaudeDriverEnv =
   | Crypto.Crypto
   | FileSystem.FileSystem
   | HttpClient.HttpClient
+  | ModelManifest
   | Path.Path
   | ProviderEventLoggers
   | ServerConfig
@@ -125,6 +127,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
+      const modelManifest = yield* ModelManifest;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
@@ -163,13 +166,19 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
-      const checkProvider = checkClaudeProviderStatus(
-        effectiveConfig,
-        () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
-        processEnv,
-        cwd,
+      // The manifest refresh runs concurrently with the CLI probe, so a
+      // TTL-expired fetch adds no wall-clock to the provider check.
+      const checkProvider = Effect.zipWith(
+        checkClaudeProviderStatus(
+          effectiveConfig,
+          () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
+          processEnv,
+          cwd,
+        ),
+        modelManifest.refreshed,
+        (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+        { concurrent: true },
       ).pipe(
-        Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, path),
@@ -182,7 +191,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
         initialSnapshot: (settings) =>
-          makePendingClaudeProvider(settings.provider).pipe(Effect.map(stampIdentity)),
+          Effect.zipWith(
+            makePendingClaudeProvider(settings.provider),
+            modelManifest.current,
+            (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+          ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
           enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -36,7 +36,7 @@ import {
 } from "../Layers/ClaudeProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
-import { applyModelManifest, ModelManifest } from "../ModelManifest.ts";
+import * as ModelManifest from "../ModelManifest.ts";
 import {
   defaultProviderContinuationIdentity,
   type ProviderDriver,
@@ -88,7 +88,7 @@ export type ClaudeDriverEnv =
   | Crypto.Crypto
   | FileSystem.FileSystem
   | HttpClient.HttpClient
-  | ModelManifest
+  | ModelManifest.ModelManifest
   | Path.Path
   | ProviderEventLoggers
   | ServerConfig
@@ -127,7 +127,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const modelManifest = yield* ModelManifest;
+      const modelManifest = yield* ModelManifest.ModelManifest;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
@@ -176,7 +176,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           cwd,
         ),
         modelManifest.refreshed,
-        (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+        (draft, manifest) =>
+          stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
         { concurrent: true },
       ).pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
@@ -194,7 +195,8 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           Effect.zipWith(
             makePendingClaudeProvider(settings.provider),
             modelManifest.current,
-            (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+            (draft, manifest) =>
+              stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
           ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -128,6 +128,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
+      const instanceScope = yield* Effect.scope;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
@@ -166,20 +167,24 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
-      // The manifest refresh runs concurrently with the CLI probe, so a
-      // TTL-expired fetch adds no wall-clock to the provider check.
-      const checkProvider = Effect.zipWith(
-        checkClaudeProviderStatus(
-          effectiveConfig,
-          () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
-          processEnv,
-          cwd,
+      // Kick the TTL-gated manifest refresh in the background and classify
+      // with the in-memory manifest, so a slow or hung fetch never delays the
+      // provider check. A refresh that lands mid-probe applies on the next one.
+      const checkProvider = Effect.forkIn(modelManifest.refreshed, instanceScope).pipe(
+        Effect.andThen(
+          Effect.zipWith(
+            checkClaudeProviderStatus(
+              effectiveConfig,
+              () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
+              processEnv,
+              cwd,
+            ),
+            modelManifest.current,
+            (draft, manifest) =>
+              stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
+            { concurrent: true },
+          ),
         ),
-        modelManifest.refreshed,
-        (draft, manifest) =>
-          stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
-        { concurrent: true },
-      ).pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, path),

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -39,7 +39,7 @@ import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
 import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
-import { applyModelManifest, ModelManifest } from "../ModelManifest.ts";
+import * as ModelManifest from "../ModelManifest.ts";
 import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
@@ -79,7 +79,7 @@ export type CodexDriverEnv =
   | Crypto.Crypto
   | FileSystem.FileSystem
   | HttpClient.HttpClient
-  | ModelManifest
+  | ModelManifest.ModelManifest
   | Path.Path
   | ProviderEventLoggers
   | ServerConfig
@@ -121,7 +121,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
-      const modelManifest = yield* ModelManifest;
+      const modelManifest = yield* ModelManifest.ModelManifest;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
@@ -174,7 +174,8 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const checkProvider = Effect.zipWith(
         checkCodexProviderStatus(effectiveConfig, undefined, processEnv),
         modelManifest.refreshed,
-        (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+        (draft, manifest) =>
+          stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
         { concurrent: true },
       ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
@@ -187,7 +188,8 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
           Effect.zipWith(
             makePendingCodexProvider(settings.provider),
             modelManifest.current,
-            (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+            (draft, manifest) =>
+              stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
           ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -122,6 +122,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
+      const instanceScope = yield* Effect.scope;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
@@ -169,15 +170,21 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // in as instance rebuilds from the registry rather than in-place
       // updates. Pre-provide `ChildProcessSpawner` so the check fits
       // `makeManagedServerProvider.checkProvider`'s `R = never`.
-      // The manifest refresh runs concurrently with the CLI probe, so a
-      // TTL-expired fetch adds no wall-clock to the provider check.
-      const checkProvider = Effect.zipWith(
-        checkCodexProviderStatus(effectiveConfig, undefined, processEnv),
-        modelManifest.refreshed,
-        (draft, manifest) =>
-          stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
-        { concurrent: true },
-      ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+      // Kick the TTL-gated manifest refresh in the background and classify
+      // with the in-memory manifest, so a slow or hung fetch never delays the
+      // provider check. A refresh that lands mid-probe applies on the next one.
+      const checkProvider = Effect.forkIn(modelManifest.refreshed, instanceScope).pipe(
+        Effect.andThen(
+          Effect.zipWith(
+            checkCodexProviderStatus(effectiveConfig, undefined, processEnv),
+            modelManifest.current,
+            (draft, manifest) =>
+              stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
+            { concurrent: true },
+          ),
+        ),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
         maintenanceCapabilities,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -39,6 +39,7 @@ import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
 import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import { applyModelManifest, ModelManifest } from "../ModelManifest.ts";
 import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
@@ -78,6 +79,7 @@ export type CodexDriverEnv =
   | Crypto.Crypto
   | FileSystem.FileSystem
   | HttpClient.HttpClient
+  | ModelManifest
   | Path.Path
   | ProviderEventLoggers
   | ServerConfig
@@ -119,6 +121,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
+      const modelManifest = yield* ModelManifest;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
@@ -166,10 +169,14 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // in as instance rebuilds from the registry rather than in-place
       // updates. Pre-provide `ChildProcessSpawner` so the check fits
       // `makeManagedServerProvider.checkProvider`'s `R = never`.
-      const checkProvider = checkCodexProviderStatus(effectiveConfig, undefined, processEnv).pipe(
-        Effect.map(stampIdentity),
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-      );
+      // The manifest refresh runs concurrently with the CLI probe, so a
+      // TTL-expired fetch adds no wall-clock to the provider check.
+      const checkProvider = Effect.zipWith(
+        checkCodexProviderStatus(effectiveConfig, undefined, processEnv),
+        modelManifest.refreshed,
+        (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+        { concurrent: true },
+      ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CodexSettings>>({
         maintenanceCapabilities,
@@ -177,7 +184,11 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
         initialSnapshot: (settings) =>
-          makePendingCodexProvider(settings.provider).pipe(Effect.map(stampIdentity)),
+          Effect.zipWith(
+            makePendingCodexProvider(settings.provider),
+            modelManifest.current,
+            (draft, manifest) => stampIdentity(applyModelManifest(draft, manifest, DRIVER_KIND)),
+          ),
         checkProvider,
         enrichSnapshot: ({ settings, snapshot, publishSnapshot }) =>
           enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities, {

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -122,7 +122,6 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const modelManifest = yield* ModelManifest.ModelManifest;
-      const instanceScope = yield* Effect.scope;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
@@ -173,7 +172,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // Kick the TTL-gated manifest refresh in the background and classify
       // with the in-memory manifest, so a slow or hung fetch never delays the
       // provider check. A refresh that lands mid-probe applies on the next one.
-      const checkProvider = Effect.forkIn(modelManifest.refreshed, instanceScope).pipe(
+      const checkProvider = modelManifest.refreshInBackground.pipe(
         Effect.andThen(
           Effect.zipWith(
             checkCodexProviderStatus(effectiveConfig, undefined, processEnv),

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -9,26 +9,10 @@ import * as Schema from "effect/Schema";
 import {
   buildClaudeCapabilitiesProbeQueryOptions,
   CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES,
-  isLegacyClaudeModel,
   probeClaudeCapabilities,
 } from "./ClaudeProvider.ts";
 
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
-
-it("keeps only the Claude 5 family out of legacy models", () => {
-  assert.deepStrictEqual(
-    ["claude-fable-5", "claude-opus-5", "claude-sonnet-5", "claude-opus-4-8"].map((model) => [
-      model,
-      isLegacyClaudeModel(model),
-    ]),
-    [
-      ["claude-fable-5", false],
-      ["claude-opus-5", false],
-      ["claude-sonnet-5", false],
-      ["claude-opus-4-8", true],
-    ],
-  );
-});
 
 it("isolates Claude capability probes without dropping workspace setting sources", () => {
   const abortController = new AbortController();

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -56,12 +56,6 @@ const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
 
-const CURRENT_CLAUDE_MODELS = new Set(["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]);
-
-export function isLegacyClaudeModel(model: string): boolean {
-  return !CURRENT_CLAUDE_MODELS.has(model);
-}
-
 const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
   {
     slug: "claude-fable-5",
@@ -327,9 +321,9 @@ const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
   },
 ];
 
-const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG.map((model) =>
-  isLegacyClaudeModel(model.slug) ? { ...model, isLegacy: true } : model,
-);
+// Legacy classification happens at the driver boundary via `applyModelManifest`,
+// so the catalog itself carries no `isLegacy` flags.
+const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG;
 
 function supportsClaudeOpus5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,31 +1,6 @@
 import { assert, it } from "@effect/vitest";
 
-import {
-  applyPreferredCodexDefaultModel,
-  isLegacyCodexModel,
-  mapCodexModelCapabilities,
-} from "./CodexProvider.ts";
-
-it("keeps current Codex models out of legacy models", () => {
-  assert.deepStrictEqual(
-    [
-      "gpt-5.6-luna",
-      "gpt-5.6-terra",
-      "gpt-5.6-sol",
-      "gpt-daybreak-blue-latest",
-      "gpt-daybreak-red-latest",
-      "gpt-5.4",
-    ].map((model) => [model, isLegacyCodexModel(model)]),
-    [
-      ["gpt-5.6-luna", false],
-      ["gpt-5.6-terra", false],
-      ["gpt-5.6-sol", false],
-      ["gpt-daybreak-blue-latest", false],
-      ["gpt-daybreak-red-latest", false],
-      ["gpt-5.4", true],
-    ],
-  );
-});
+import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -62,17 +62,6 @@ const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
 };
 
 const DEFAULT_SERVICE_TIER_ID = "default";
-const CURRENT_CODEX_MODELS = new Set([
-  "gpt-5.6-luna",
-  "gpt-5.6-terra",
-  "gpt-5.6-sol",
-  "gpt-daybreak-blue-latest",
-  "gpt-daybreak-red-latest",
-]);
-
-export function isLegacyCodexModel(model: string): boolean {
-  return !CURRENT_CODEX_MODELS.has(model);
-}
 
 function reasoningEffortLabel(reasoningEffort: string): string {
   return REASONING_EFFORT_LABELS[reasoningEffort] ?? reasoningEffort;
@@ -201,7 +190,6 @@ function parseCodexModelListResponse(
     name: toDisplayName(model),
     isCustom: false,
     ...(model.isDefault ? { isDefault: true } : {}),
-    ...(isLegacyCodexModel(model.model) ? { isLegacy: true } : {}),
     capabilities: mapCodexModelCapabilities(model),
   }));
 }

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -41,6 +41,7 @@ import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import type { BuiltInDriversEnv } from "../builtInDrivers.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ClaudeDriver } from "../Drivers/ClaudeDriver.ts";
@@ -48,6 +49,7 @@ import { CodexDriver } from "../Drivers/CodexDriver.ts";
 import { CursorDriver } from "../Drivers/CursorDriver.ts";
 import { GrokDriver } from "../Drivers/GrokDriver.ts";
 import { OpenCodeDriver } from "../Drivers/OpenCodeDriver.ts";
+import * as ModelManifest from "../ModelManifest.ts";
 import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
 import { NoOpProviderEventLoggers, ProviderEventLoggers } from "./ProviderEventLoggers.ts";
 import { makeProviderInstanceRegistry } from "./ProviderInstanceRegistryLive.ts";
@@ -148,6 +150,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
     Layer.provideMerge(ServerSettingsService.layerTest()),
     Layer.provideMerge(TestHttpClientLive),
     Layer.provideMerge(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
+    Layer.provideMerge(ModelManifest.layerTest),
   );
 
   it.live("boots two independent codex instances from a ProviderInstanceConfigMap", () =>
@@ -313,6 +316,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
     Layer.provideMerge(ServerSettingsService.layerTest()),
     Layer.provideMerge(TestHttpClientLive),
     Layer.provideMerge(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
+    Layer.provideMerge(ModelManifest.layerTest),
   );
 
   it.live("boots one instance of every shipped driver from a single config map", () =>
@@ -365,7 +369,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         },
       };
 
-      const { registry } = yield* makeProviderInstanceRegistry({
+      const { registry } = yield* makeProviderInstanceRegistry<BuiltInDriversEnv>({
         drivers: [CodexDriver, ClaudeDriver, CursorDriver, GrokDriver, OpenCodeDriver],
         configMap,
       });

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -34,6 +34,7 @@ import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 import { checkCodexProviderStatus, type CodexAppServerProviderSnapshot } from "./CodexProvider.ts";
 import { checkClaudeProviderStatus } from "./ClaudeProvider.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import * as ModelManifest from "../ModelManifest.ts";
 import * as OpenCodeRuntime from "../opencodeRuntime.ts";
 import * as ProviderEventLoggers from "./ProviderEventLoggers.ts";
 import { ProviderInstanceRegistryHydrationLive } from "./ProviderInstanceRegistryHydration.ts";
@@ -1423,6 +1424,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 ProviderEventLoggers.NoOpProviderEventLoggers,
               ),
             ),
+            Layer.provideMerge(ModelManifest.layerTest),
             Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
             Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
             // NO spawner mock — `ChildProcessSpawner` is supplied by the
@@ -1516,6 +1518,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 ProviderEventLoggers.NoOpProviderEventLoggers,
               ),
             ),
+            Layer.provideMerge(ModelManifest.layerTest),
             Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
             Layer.updateService(ChildProcessSpawner.ChildProcessSpawner, (spawner) =>
               ChildProcessSpawner.make((command) => {
@@ -1638,6 +1641,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 ProviderEventLoggers.NoOpProviderEventLoggers,
               ),
             ),
+            Layer.provideMerge(ModelManifest.layerTest),
             Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
             Layer.provideMerge(NodeServices.layer),
             Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
@@ -1697,6 +1701,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                   ProviderEventLoggers.NoOpProviderEventLoggers,
                 ),
               ),
+              Layer.provideMerge(ModelManifest.layerTest),
               Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
               Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
               Layer.provideMerge(

--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -5,8 +5,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
-import { ServerConfig } from "../config.ts";
-import { ServerSettingsService } from "../serverSettings.ts";
+import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   BUNDLED_MODEL_MANIFEST,
   classifyModels,
@@ -111,11 +111,11 @@ const httpClientLayer = (handler: () => Response) =>
 const serviceLayers = (input: {
   readonly prefix: string;
   readonly response: () => Response;
-  readonly settings?: Parameters<typeof ServerSettingsService.layerTest>[0];
+  readonly settings?: Parameters<typeof ServerSettings.layerTest>[0];
 }) =>
   ServerConfig.layerTest(process.cwd(), { prefix: input.prefix }).pipe(
     Layer.provideMerge(NodeServices.layer),
-    Layer.provideMerge(ServerSettingsService.layerTest(input.settings ?? {})),
+    Layer.provideMerge(ServerSettings.layerTest(input.settings ?? {})),
     Layer.provideMerge(httpClientLayer(input.response)),
   );
 

--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -1,0 +1,185 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ProviderDriverKind, type ServerProviderModel } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import { ServerConfig } from "../config.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+import {
+  BUNDLED_MODEL_MANIFEST,
+  classifyModels,
+  isLegacyModel,
+  make,
+  type ModelManifestData,
+} from "./ModelManifest.ts";
+
+const CODEX = ProviderDriverKind.make("codex");
+const CLAUDE = ProviderDriverKind.make("claudeAgent");
+const CURSOR = ProviderDriverKind.make("cursor");
+
+describe("isLegacyModel (bundled manifest)", () => {
+  it("keeps current Codex models out of legacy models", () => {
+    assert.deepStrictEqual(
+      [
+        "gpt-5.6-luna",
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
+        "gpt-daybreak-blue-latest",
+        "gpt-daybreak-red-latest",
+        "gpt-5.4",
+      ].map((model) => [model, isLegacyModel(BUNDLED_MODEL_MANIFEST, CODEX, model)]),
+      [
+        ["gpt-5.6-luna", false],
+        ["gpt-5.6-terra", false],
+        ["gpt-5.6-sol", false],
+        ["gpt-daybreak-blue-latest", false],
+        ["gpt-daybreak-red-latest", false],
+        ["gpt-5.4", true],
+      ],
+    );
+  });
+
+  it("keeps only the Claude 5 family out of legacy models", () => {
+    assert.deepStrictEqual(
+      ["claude-fable-5", "claude-opus-5", "claude-sonnet-5", "claude-opus-4-8"].map((model) => [
+        model,
+        isLegacyModel(BUNDLED_MODEL_MANIFEST, CLAUDE, model),
+      ]),
+      [
+        ["claude-fable-5", false],
+        ["claude-opus-5", false],
+        ["claude-sonnet-5", false],
+        ["claude-opus-4-8", true],
+      ],
+    );
+  });
+
+  it("leaves driver kinds without a manifest entry unflagged", () => {
+    assert.isFalse(isLegacyModel(BUNDLED_MODEL_MANIFEST, CURSOR, "composer-1.5"));
+  });
+});
+
+const model = (overrides: Partial<ServerProviderModel>): ServerProviderModel => ({
+  slug: "gpt-test",
+  name: "GPT Test",
+  isCustom: false,
+  capabilities: null,
+  ...overrides,
+});
+
+describe("classifyModels", () => {
+  it("flags non-current models, clears stale flags, and skips custom models", () => {
+    const models = [
+      model({ slug: "gpt-5.6-sol" }),
+      // Stale flag from a previous classification pass must be cleared.
+      model({ slug: "gpt-5.6-luna", isLegacy: true }),
+      model({ slug: "gpt-5.4" }),
+      // Custom models are user-defined and never reclassified.
+      model({ slug: "my-own-model", isCustom: true }),
+    ];
+    assert.deepStrictEqual(
+      classifyModels(models, BUNDLED_MODEL_MANIFEST, CODEX).map((entry) => [
+        entry.slug,
+        entry.isLegacy ?? false,
+      ]),
+      [
+        ["gpt-5.6-sol", false],
+        ["gpt-5.6-luna", false],
+        ["gpt-5.4", true],
+        ["my-own-model", false],
+      ],
+    );
+  });
+});
+
+const REMOTE_MANIFEST: ModelManifestData = {
+  version: 1,
+  currentModels: {
+    codex: ["gpt-5.4"],
+    claudeAgent: ["claude-fable-5"],
+  },
+};
+
+const httpClientLayer = (handler: () => Response) =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, handler()))),
+  );
+
+const serviceLayers = (input: {
+  readonly prefix: string;
+  readonly response: () => Response;
+  readonly settings?: Parameters<typeof ServerSettingsService.layerTest>[0];
+}) =>
+  ServerConfig.layerTest(process.cwd(), { prefix: input.prefix }).pipe(
+    Layer.provideMerge(NodeServices.layer),
+    Layer.provideMerge(ServerSettingsService.layerTest(input.settings ?? {})),
+    Layer.provideMerge(httpClientLayer(input.response)),
+  );
+
+describe("ModelManifest service", () => {
+  it.live("prefers a fetched manifest over the bundle and caches it to disk", () =>
+    Effect.gen(function* () {
+      const service = yield* make;
+      const refreshed = yield* service.refreshed;
+      assert.deepStrictEqual(refreshed, REMOTE_MANIFEST);
+      assert.isTrue(isLegacyModel(refreshed, CODEX, "gpt-5.6-sol"));
+      assert.isFalse(isLegacyModel(refreshed, CODEX, "gpt-5.4"));
+
+      // A fresh service instance sees the disk cache without another fetch:
+      // its HTTP layer is still stubbed, but `current` never fetches at all.
+      const rebooted = yield* make;
+      assert.deepStrictEqual(yield* rebooted.current, REMOTE_MANIFEST);
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        serviceLayers({
+          prefix: "model-manifest-fetch-test",
+          response: () => Response.json(REMOTE_MANIFEST),
+        }),
+      ),
+    ),
+  );
+
+  it.live("keeps the bundled manifest when the remote payload is malformed", () =>
+    Effect.gen(function* () {
+      const service = yield* make;
+      assert.deepStrictEqual(yield* service.refreshed, BUNDLED_MODEL_MANIFEST);
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        serviceLayers({
+          prefix: "model-manifest-malformed-test",
+          response: () => Response.json({ version: 999, nonsense: true }),
+        }),
+      ),
+    ),
+  );
+
+  it.live("does not fetch when provider update checks are disabled", () =>
+    Effect.gen(function* () {
+      let fetchCount = 0;
+      const service = yield* make.pipe(
+        Effect.provide(
+          httpClientLayer(() => {
+            fetchCount += 1;
+            return Response.json(REMOTE_MANIFEST);
+          }),
+        ),
+      );
+      assert.deepStrictEqual(yield* service.refreshed, BUNDLED_MODEL_MANIFEST);
+      assert.strictEqual(fetchCount, 0);
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        serviceLayers({
+          prefix: "model-manifest-optout-test",
+          response: () => Response.json(REMOTE_MANIFEST),
+          settings: { enableProviderUpdateChecks: false },
+        }),
+      ),
+    ),
+  );
+});

--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -123,7 +123,7 @@ describe("ModelManifest service", () => {
   it.live("prefers a fetched manifest over the bundle and caches it to disk", () =>
     Effect.gen(function* () {
       const service = yield* make;
-      const refreshed = yield* service.refreshed;
+      const refreshed = yield* service.refresh;
       assert.deepStrictEqual(refreshed, REMOTE_MANIFEST);
       assert.isTrue(isLegacyModel(refreshed, CODEX, "gpt-5.6-sol"));
       assert.isFalse(isLegacyModel(refreshed, CODEX, "gpt-5.4"));
@@ -146,7 +146,7 @@ describe("ModelManifest service", () => {
   it.live("keeps the bundled manifest when the remote payload is malformed", () =>
     Effect.gen(function* () {
       const service = yield* make;
-      assert.deepStrictEqual(yield* service.refreshed, BUNDLED_MODEL_MANIFEST);
+      assert.deepStrictEqual(yield* service.refresh, BUNDLED_MODEL_MANIFEST);
     }).pipe(
       Effect.scoped,
       Effect.provide(
@@ -169,7 +169,7 @@ describe("ModelManifest service", () => {
           }),
         ),
       );
-      assert.deepStrictEqual(yield* service.refreshed, BUNDLED_MODEL_MANIFEST);
+      assert.deepStrictEqual(yield* service.refresh, BUNDLED_MODEL_MANIFEST);
       assert.strictEqual(fetchCount, 0);
     }).pipe(
       Effect.scoped,

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -146,22 +146,24 @@ export const make = Effect.gen(function* () {
   let manifest = BUNDLED_MODEL_MANIFEST;
   let fetchedAtMs: number | null = null;
   let lastAttemptMs: number | null = null;
-  let diskCacheLoaded = false;
   const refreshSemaphore = yield* Semaphore.make(1);
 
-  const ensureDiskCacheLoaded = Effect.gen(function* () {
-    if (diskCacheLoaded) return;
-    diskCacheLoaded = true;
-    const fromDisk = yield* fileSystem.readFileString(cachePath).pipe(
-      Effect.flatMap((raw) => decodeManifestCache(raw)),
-      Effect.catchCause(() => Effect.succeed(null)),
-    );
-    if (fromDisk === null) return;
-    // The disk copy is the last-seen remote manifest, so it outranks the
-    // bundle even when stale: it is refreshed on the next successful fetch.
-    manifest = fromDisk.manifest;
-    fetchedAtMs = fromDisk.fetchedAtMs;
-  });
+  // `Effect.cached` makes concurrent first readers await the same disk load
+  // rather than racing a "loaded" flag. Only `refreshed` takes the fetch
+  // semaphore; `current` must never wait behind an in-flight network refresh.
+  const ensureDiskCacheLoaded = yield* Effect.cached(
+    Effect.gen(function* () {
+      const fromDisk = yield* fileSystem.readFileString(cachePath).pipe(
+        Effect.flatMap((raw) => decodeManifestCache(raw)),
+        Effect.catchCause(() => Effect.succeed(null)),
+      );
+      if (fromDisk === null) return;
+      // The disk copy is the last-seen remote manifest, so it outranks the
+      // bundle even when stale: it is refreshed on the next successful fetch.
+      manifest = fromDisk.manifest;
+      fetchedAtMs = fromDisk.fetchedAtMs;
+    }),
+  );
 
   const refresh = Effect.fn("ModelManifest.refresh")(function* () {
     yield* ensureDiskCacheLoaded;
@@ -203,9 +205,7 @@ export const make = Effect.gen(function* () {
   });
 
   return ModelManifest.of({
-    current: refreshSemaphore.withPermits(1)(
-      ensureDiskCacheLoaded.pipe(Effect.map(() => manifest)),
-    ),
+    current: ensureDiskCacheLoaded.pipe(Effect.map(() => manifest)),
     refreshed: refreshSemaphore.withPermits(1)(refresh()),
   });
 });

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -1,0 +1,206 @@
+/**
+ * ModelManifest — decides which provider models are current and which belong
+ * in the model picker's legacy section.
+ *
+ * The classification data (current slugs per driver kind) lives in
+ * `model-manifest.json` next to this file. The bundled copy ships with every
+ * release. At runtime the service refreshes it from the same file on `main`
+ * via raw.githubusercontent.com, so a new model can leave the legacy section
+ * with a commit to `main` instead of a release. Preference order is remote,
+ * then the on-disk copy of the last successful fetch, then the bundle. A
+ * failed fetch never fails a provider check.
+ *
+ * Drivers apply the manifest to snapshot drafts with `applyModelManifest`
+ * before publishing, so every path that produces models (pending, probe,
+ * error fallbacks) is classified the same way.
+ */
+import type { ProviderDriverKind, ServerProviderModel } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import { ServerConfig } from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import bundledManifestJson from "./model-manifest.json" with { type: "json" };
+import type { ServerProviderDraft } from "./providerSnapshot.ts";
+
+const MODEL_MANIFEST_URL =
+  "https://raw.githubusercontent.com/pingdotgg/t3code/main/apps/server/src/provider/model-manifest.json";
+
+/** How long a fetched manifest stays fresh before the next probe re-fetches. */
+const MANIFEST_TTL_MS = 60 * 60 * 1000;
+
+/** Minimum gap between fetch attempts after a failure, so an offline server
+ * does not pay a network timeout on every provider check. */
+const MANIFEST_RETRY_MS = 5 * 60 * 1000;
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * `version` gates breaking schema changes: a build only accepts remote
+ * manifests whose version it understands, and keeps its bundled copy
+ * otherwise. `currentModels` is keyed by driver kind; kinds absent from the
+ * map have no legacy concept and their models are left unflagged.
+ */
+const ModelManifestSchema = Schema.Struct({
+  version: Schema.Literal(1),
+  currentModels: Schema.Record(Schema.String, Schema.Array(Schema.String)),
+});
+export type ModelManifestData = typeof ModelManifestSchema.Type;
+
+const decodeManifest = Schema.decodeUnknownEffect(ModelManifestSchema);
+
+export const BUNDLED_MODEL_MANIFEST: ModelManifestData =
+  Schema.decodeUnknownSync(ModelManifestSchema)(bundledManifestJson);
+
+/** On-disk shape of the last successfully fetched manifest. */
+const ManifestCacheFile = Schema.Struct({
+  fetchedAtMs: Schema.Number,
+  manifest: ModelManifestSchema,
+});
+const decodeManifestCache = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    ManifestCacheFile as unknown as Schema.Codec<typeof ManifestCacheFile.Type>,
+  ),
+);
+const encodeManifestCache = Schema.encodeEffect(
+  Schema.fromJsonString(
+    ManifestCacheFile as unknown as Schema.Codec<typeof ManifestCacheFile.Type>,
+  ),
+);
+
+/** True when the manifest classifies `slug` as legacy for `driverKind`. */
+export function isLegacyModel(
+  manifest: ModelManifestData,
+  driverKind: ProviderDriverKind,
+  slug: string,
+): boolean {
+  const currentModels = manifest.currentModels[driverKind];
+  if (!currentModels) return false;
+  return !currentModels.includes(slug);
+}
+
+/**
+ * Reclassifies every built-in model on a snapshot draft against the manifest.
+ * Custom models are user-defined and never reclassified.
+ */
+export function applyModelManifest(
+  draft: ServerProviderDraft,
+  manifest: ModelManifestData,
+  driverKind: ProviderDriverKind,
+): ServerProviderDraft {
+  return { ...draft, models: classifyModels(draft.models, manifest, driverKind) };
+}
+
+/** Model-level half of `applyModelManifest`, exported for focused tests. */
+export function classifyModels(
+  models: ReadonlyArray<ServerProviderModel>,
+  manifest: ModelManifestData,
+  driverKind: ProviderDriverKind,
+): ReadonlyArray<ServerProviderModel> {
+  return models.map((model) => {
+    if (model.isCustom) return model;
+    if (isLegacyModel(manifest, driverKind, model.slug)) {
+      return model.isLegacy ? model : { ...model, isLegacy: true };
+    }
+    if (!model.isLegacy) return model;
+    const { isLegacy: _isLegacy, ...rest } = model;
+    return rest;
+  });
+}
+
+export class ModelManifest extends Context.Service<
+  ModelManifest,
+  {
+    /** Manifest already in memory (disk cache or bundle); never fetches.
+     * For pending snapshots, which must publish instantly. */
+    readonly current: Effect.Effect<ModelManifestData>;
+    /** Manifest after a TTL-gated remote refresh; never fails.
+     * For provider checks, which already tolerate multi-second probes. */
+    readonly refreshed: Effect.Effect<ModelManifestData>;
+  }
+>()("t3/provider/ModelManifest") {}
+
+/** Constant service for tests and callers that only need the bundled data. */
+export const BundledOnlyModelManifest: ModelManifest["Service"] = {
+  current: Effect.succeed(BUNDLED_MODEL_MANIFEST),
+  refreshed: Effect.succeed(BUNDLED_MODEL_MANIFEST),
+};
+
+export const layerTest = Layer.succeed(ModelManifest, BundledOnlyModelManifest);
+
+export const make = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const config = yield* ServerConfig;
+  const settingsService = yield* ServerSettings.ServerSettingsService;
+  const httpClient = yield* HttpClient.HttpClient;
+
+  const cachePath = path.join(config.stateDir, "model-manifest.json");
+  let manifest = BUNDLED_MODEL_MANIFEST;
+  let fetchedAtMs: number | null = null;
+  let lastAttemptMs: number | null = null;
+  let diskCacheLoaded = false;
+  const refreshSemaphore = yield* Semaphore.make(1);
+
+  const ensureDiskCacheLoaded = Effect.gen(function* () {
+    if (diskCacheLoaded) return;
+    diskCacheLoaded = true;
+    const fromDisk = yield* fileSystem.readFileString(cachePath).pipe(
+      Effect.flatMap((raw) => decodeManifestCache(raw)),
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (fromDisk === null) return;
+    // The disk copy is the last-seen remote manifest, so it outranks the
+    // bundle even when stale: it is refreshed on the next successful fetch.
+    manifest = fromDisk.manifest;
+    fetchedAtMs = fromDisk.fetchedAtMs;
+  });
+
+  const refresh = Effect.fn("ModelManifest.refresh")(function* () {
+    yield* ensureDiskCacheLoaded;
+    const now = yield* Clock.currentTimeMillis;
+    if (fetchedAtMs !== null && now - fetchedAtMs < MANIFEST_TTL_MS) return manifest;
+    if (lastAttemptMs !== null && now - lastAttemptMs < MANIFEST_RETRY_MS) return manifest;
+
+    // The same switch that gates provider CLI update checks: users who turned
+    // off phoning home for version metadata keep the bundled classification.
+    const settings = yield* settingsService.getSettings.pipe(
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (settings !== null && !settings.enableProviderUpdateChecks) return manifest;
+
+    lastAttemptMs = now;
+    const fetched = yield* httpClient.get(MODEL_MANIFEST_URL).pipe(
+      Effect.flatMap(HttpClientResponse.filterStatusOk),
+      Effect.flatMap((response) => response.json),
+      Effect.flatMap((json) => decodeManifest(json)),
+      Effect.timeout(FETCH_TIMEOUT_MS),
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (fetched === null) return manifest;
+
+    manifest = fetched;
+    fetchedAtMs = now;
+    yield* encodeManifestCache({ fetchedAtMs: now, manifest: fetched }).pipe(
+      Effect.flatMap((serialized) => fileSystem.writeFileString(cachePath, serialized)),
+      Effect.catchCause(() => Effect.void),
+    );
+    return manifest;
+  });
+
+  return ModelManifest.of({
+    current: refreshSemaphore.withPermits(1)(
+      ensureDiskCacheLoaded.pipe(Effect.map(() => manifest)),
+    ),
+    refreshed: refreshSemaphore.withPermits(1)(refresh()),
+  });
+});
+
+export const layer = Layer.effect(ModelManifest, make);

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -166,8 +166,13 @@ export const make = Effect.gen(function* () {
   const refresh = Effect.fn("ModelManifest.refresh")(function* () {
     yield* ensureDiskCacheLoaded;
     const now = yield* Clock.currentTimeMillis;
-    if (fetchedAtMs !== null && now - fetchedAtMs < MANIFEST_TTL_MS) return manifest;
-    if (lastAttemptMs !== null && now - lastAttemptMs < MANIFEST_RETRY_MS) return manifest;
+    // A timestamp in the future means the wall clock moved backwards (the
+    // disk cache crosses restarts, so monotonic time cannot cover it). Treat
+    // it as expired: the refetch rewrites both timestamps and self-heals.
+    const isWithin = (sinceMs: number | null, windowMs: number) =>
+      sinceMs !== null && now >= sinceMs && now - sinceMs < windowMs;
+    if (isWithin(fetchedAtMs, MANIFEST_TTL_MS)) return manifest;
+    if (isWithin(lastAttemptMs, MANIFEST_RETRY_MS)) return manifest;
 
     // The same switch that gates provider CLI update checks. It stops network
     // fetches only: a manifest already cached on disk from an earlier fetch

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -119,19 +119,22 @@ export class ModelManifest extends Context.Service<
   ModelManifest,
   {
     /** Manifest already in memory (disk cache or bundle); never fetches.
-     * For pending snapshots, which must publish instantly. */
+     * Snapshot classification reads this, so it never waits on the network. */
     readonly current: Effect.Effect<ModelManifestData>;
-    /** Manifest after a TTL-gated remote refresh; never fails. Drivers fork
-     * this into their instance scope and classify with `current`, so a slow
-     * fetch delays nothing and the next check applies the update. */
-    readonly refreshed: Effect.Effect<ModelManifestData>;
+    /** Manifest after a TTL-gated remote refresh; never fails. */
+    readonly refresh: Effect.Effect<ModelManifestData>;
+    /** Forks `refresh` into the service's own scope. Drivers call this from
+     * provider checks: the fetch is process-shared state, so it must survive
+     * the teardown of whichever instance happened to trigger it. */
+    readonly refreshInBackground: Effect.Effect<void>;
   }
 >()("t3/provider/ModelManifest") {}
 
 /** Constant service for tests and callers that only need the bundled data. */
 export const BundledOnlyModelManifest: ModelManifest["Service"] = {
   current: Effect.succeed(BUNDLED_MODEL_MANIFEST),
-  refreshed: Effect.succeed(BUNDLED_MODEL_MANIFEST),
+  refresh: Effect.succeed(BUNDLED_MODEL_MANIFEST),
+  refreshInBackground: Effect.void,
 };
 
 export const layerTest = Layer.succeed(ModelManifest, BundledOnlyModelManifest);
@@ -142,6 +145,7 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const settingsService = yield* ServerSettings.ServerSettingsService;
   const httpClient = yield* HttpClient.HttpClient;
+  const serviceScope = yield* Effect.scope;
 
   const cachePath = path.join(config.stateDir, "model-manifest.json");
   let manifest = BUNDLED_MODEL_MANIFEST;
@@ -205,9 +209,12 @@ export const make = Effect.gen(function* () {
     return manifest;
   });
 
+  const guardedRefresh = refreshSemaphore.withPermits(1)(refresh());
+
   return ModelManifest.of({
     current: ensureDiskCacheLoaded.pipe(Effect.map(() => manifest)),
-    refreshed: refreshSemaphore.withPermits(1)(refresh()),
+    refresh: guardedRefresh,
+    refreshInBackground: Effect.forkIn(guardedRefresh, serviceScope).pipe(Effect.asVoid),
   });
 });
 

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -169,8 +169,10 @@ export const make = Effect.gen(function* () {
     if (fetchedAtMs !== null && now - fetchedAtMs < MANIFEST_TTL_MS) return manifest;
     if (lastAttemptMs !== null && now - lastAttemptMs < MANIFEST_RETRY_MS) return manifest;
 
-    // The same switch that gates provider CLI update checks: users who turned
-    // off phoning home for version metadata keep the bundled classification.
+    // The same switch that gates provider CLI update checks. It stops network
+    // fetches only: a manifest already cached on disk from an earlier fetch
+    // stays in effect, since the setting is about phoning home, not about
+    // discarding data the server already holds.
     const settings = yield* settingsService.getSettings.pipe(
       Effect.catchCause(() => Effect.succeed(null)),
     );

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -121,8 +121,9 @@ export class ModelManifest extends Context.Service<
     /** Manifest already in memory (disk cache or bundle); never fetches.
      * For pending snapshots, which must publish instantly. */
     readonly current: Effect.Effect<ModelManifestData>;
-    /** Manifest after a TTL-gated remote refresh; never fails.
-     * For provider checks, which already tolerate multi-second probes. */
+    /** Manifest after a TTL-gated remote refresh; never fails. Drivers fork
+     * this into their instance scope and classify with `current`, so a slow
+     * fetch delays nothing and the next check applies the update. */
     readonly refreshed: Effect.Effect<ModelManifestData>;
   }
 >()("t3/provider/ModelManifest") {}

--- a/apps/server/src/provider/model-manifest.json
+++ b/apps/server/src/provider/model-manifest.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "currentModels": {
+    "codex": [
+      "gpt-5.6-luna",
+      "gpt-5.6-terra",
+      "gpt-5.6-sol",
+      "gpt-daybreak-blue-latest",
+      "gpt-daybreak-red-latest"
+    ],
+    "claudeAgent": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -32,6 +32,7 @@ import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory.ts";
 import * as ProviderSessionRuntime from "./persistence/ProviderSessionRuntime.ts";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry.ts";
+import * as ModelManifest from "./provider/ModelManifest.ts";
 import * as ProviderEventLoggers from "./provider/Layers/ProviderEventLoggers.ts";
 import { ProviderServiceLive } from "./provider/Layers/ProviderService.ts";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper.ts";
@@ -395,7 +396,10 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // `ProviderService` (canonical stream, written after event normalization).
   // Provided once at the runtime level so every consumer sees the same
   // logger instances.
-  Layer.provideMerge(ProviderEventLoggers.layer),
+  // `ModelManifest.layer` is the legacy-model classification data, refreshed
+  // from the repo's `model-manifest.json` on `main` and applied by the
+  // Codex/Claude drivers.
+  Layer.provideMerge(Layer.mergeAll(ProviderEventLoggers.layer, ModelManifest.layer)),
   // `OpenCodeDriver.create()` yields `OpenCodeRuntime`; previously the old
   // `ProviderRegistryLive` pulled `OpenCodeRuntimeLive` in for itself, but
   // the rewritten registry reads snapshots off the instance registry and

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -116,6 +116,10 @@ Controls how assistant text reaches the thread timeline. In [the contracts][1], 
 
 A point-in-time view of state. The word is used in multiple layers, including orchestration, provider, and checkpointing. See [ProjectionSnapshotQuery.ts][10], [ProviderAdapter.ts][15], and [CheckpointStore.ts][19].
 
+#### Model manifest
+
+The per-driver list of current model slugs that decides which models land in the model picker's legacy section. Bundled at `apps/server/src/provider/model-manifest.json` and refreshed at runtime from the same file on `main`, so classification updates ship as commits instead of releases. See the [provider architecture][16] model manifest section.
+
 ### Checkpointing
 
 Checkpointing captures workspace state over time so the app can diff turns and restore earlier points. The main pieces are [CheckpointStore.ts][19], [CheckpointDiffQuery.ts][20], and [CheckpointReactor.ts][6].

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -39,6 +39,18 @@ directory to route session and turn operations for a thread, so callers name a t
 Adding a driver means writing the driver plus adapter and adding it to `BUILT_IN_DRIVERS`. No
 orchestration, contract, or client change is required for the common case.
 
+## Model manifest
+
+The model picker's legacy section is driven by `apps/server/src/provider/model-manifest.json`, which
+lists the current (non-legacy) model slugs per driver kind. The `ModelManifest` service
+(`apps/server/src/provider/ModelManifest.ts`) refreshes that data from the same file on `main` via
+raw.githubusercontent.com, so moving a model in or out of the legacy section is a commit, not a
+release. Preference order is remote fetch, then the on-disk copy of the last successful fetch (in
+the state directory), then the bundled copy. Fetches are TTL-gated, run concurrently with provider
+probes, respect the `enableProviderUpdateChecks` setting, and never fail a provider check. The
+Codex and Claude drivers apply the classification to every snapshot with `applyModelManifest`;
+driver kinds absent from the manifest have no legacy concept.
+
 ## How provider work is requested
 
 Clients never call a provider directly. They dispatch orchestration commands over the RPC method


### PR DESCRIPTION
## Problem

The model picker's legacy section was driven by hardcoded allowlists in bundled server code (`CURRENT_CODEX_MODELS`, `CURRENT_CLAUDE_MODELS`). When a provider ships a new model, it lands in the legacy section until we cut a release.

## Solution

The lists now live in `apps/server/src/provider/model-manifest.json`, keyed by driver kind. A new `ModelManifest` service refreshes that data at runtime from the same file on `main` via raw.githubusercontent.com, so reclassifying a model is a one-line commit instead of a release. This mirrors the existing LiteLLM rate-table fetch in `UsageService`.

- Preference order: remote fetch, then the on-disk copy of the last successful fetch, then the bundled copy. A failed fetch never fails a provider check.
- Fetches are TTL-gated (1 hour, 5 minute retry backoff after failures, 10 second timeout) and run concurrently with the CLI probe, so they add no wall-clock to provider checks.
- The fetch respects the existing `enableProviderUpdateChecks` setting: disabling it stops the network fetch. A manifest already cached on disk from an earlier fetch stays in effect.
- The Codex and Claude drivers apply the manifest to every published snapshot (pending, probe, and error paths) via `applyModelManifest`. Custom models are never reclassified. Driver kinds absent from the manifest have no legacy concept, which keeps Cursor, Grok, and OpenCode unchanged.
- The remote manifest is schema-validated and version-gated. A malformed or incompatible payload is ignored.

Verified locally: booted a worktree dev server and confirmed the published Codex snapshot flags the three live gpt-5.6 models as current and all 40 other slugs as legacy, the Claude snapshot keeps the Claude 5 family current, and the pre-merge 404 from the raw URL falls back to the bundle silently.

Written by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes model-picker labeling only, with non-blocking fetches and bundled fallbacks; no auth or session behavior changes.
> 
> **Overview**
> Moves **which models appear in the legacy picker section** out of hardcoded Codex/Claude allowlists into a bundled `model-manifest.json`, with a new **`ModelManifest` service** that can refresh the same file from GitHub at runtime.
> 
> **Codex and Claude drivers** now classify every published snapshot (pending, probe, and check paths) via `applyModelManifest`, using in-memory manifest data while a **TTL-gated background refresh** runs alongside provider checks so network slowness does not block probes. **`enableProviderUpdateChecks`** still gates remote fetches; disk cache and the bundle remain as fallbacks, and fetch failures never fail a provider check.
> 
> **ClaudeProvider** and **CodexProvider** no longer set `isLegacy` when building model catalogs; that logic is centralized at the driver boundary. **Server runtime** wires `ModelManifest.layer`; tests and internal docs describe the manifest behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862c049bb2ee3b6d3455f07f1762c4a28cce91dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hosted `ModelManifest` service for legacy model classification in Claude and Codex drivers
> - Introduces [ModelManifest.ts](https://github.com/pingdotgg/t3code/pull/8227/files#diff-90c8a7d2335de8efb8f559e4e63dfa1d33e525f9906c327988726c51bbaf750a): a runtime service that classifies built-in models as legacy/current from a bundled [model-manifest.json](https://github.com/pingdotgg/t3code/pull/8227/files#diff-fdf6ac0d1183f70794b15b8034d7d7405e3a3d35139c12a62e154b44322ea175), with TTL-gated background refresh and disk caching so provider checks are not delayed by network waits.
> - `ClaudeDriver` and `CodexDriver` now require `ModelManifest` in their environment and apply manifest classification to both initial and probed snapshots before stamping identity.
> - Removes `isLegacyClaudeModel` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/8227/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) and `isLegacyCodexModel` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/8227/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53); built-in models no longer carry `isLegacy` flags at the provider layer — classification is deferred to the driver boundary via `applyModelManifest`.
> - The `ModelManifest.layer` is wired into the runtime in [server.ts](https://github.com/pingdotgg/t3code/pull/8227/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd), and test layers are updated to provide `ModelManifest.layerTest`.
> - Behavioral Change: `BUILT_IN_MODELS` in `ClaudeProvider` and parsed models from `CodexProvider.parseCodexModelListResponse` no longer set `isLegacy` at their layer; any downstream code reading `isLegacy` before the driver applies the manifest will see `undefined`. Custom (non-built-in) models are never reclassified by the manifest.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 862c049.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
