### PR TITLE
fix(mobile): open the existing project when adding a duplicate path

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -33,7 +33,7 @@ import { CommandId, type EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { CommonActions, StackActions, useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { ActivityIndicator, Alert, Pressable, ScrollView, View } from "react-native";
+import { ActivityIndicator, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Arr from "effect/Array";
 import * as Cause from "effect/Cause";
@@ -565,39 +565,52 @@ export function AddProjectSourceScreen() {
   );
 }
 
-function useCreateProject(environment: EnvironmentOption | null) {
+// Adding a path the environment already tracks should feel like picking that
+// project from the list, so callers hand off to its draft instead of failing.
+// Returns whether the path matched an existing project.
+function useOpenExistingProject(environment: EnvironmentOption | null) {
   const navigation = useNavigation();
-  const createProject = useAtomCommand(projectEnvironment.create, { reportFailure: false });
   const projects = useProjects();
 
   return useCallback(
-    async (workspaceRoot: string) => {
-      if (!environment || !canCreateProjectInEnvironment(environment.connectionState)) return;
-
+    (workspaceRoot: string) => {
+      if (!environment) return false;
       const existing = findExistingAddProject({
         projects,
         environmentId: environment.environmentId,
         path: workspaceRoot,
       });
-      if (existing) {
-        Alert.alert("Project already exists", existing.title);
-        navigation.dispatch(
-          CommonActions.reset({
-            index: 0,
-            routes: [
-              {
-                name: "NewTaskDraft",
-                params: {
-                  environmentId: existing.environmentId,
-                  projectId: existing.id,
-                  title: existing.title,
-                },
+      if (!existing) return false;
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [
+            {
+              name: "NewTaskDraft",
+              params: {
+                environmentId: existing.environmentId,
+                projectId: existing.id,
+                title: existing.title,
               },
-            ],
-          }),
-        );
-        return;
-      }
+            },
+          ],
+        }),
+      );
+      return true;
+    },
+    [environment, navigation, projects],
+  );
+}
+
+function useCreateProject(environment: EnvironmentOption | null) {
+  const navigation = useNavigation();
+  const createProject = useAtomCommand(projectEnvironment.create, { reportFailure: false });
+  const openExistingProject = useOpenExistingProject(environment);
+
+  return useCallback(
+    async (workspaceRoot: string) => {
+      if (!environment || !canCreateProjectInEnvironment(environment.connectionState)) return;
+      if (openExistingProject(workspaceRoot)) return;
 
       const projectId = ProjectId.make(uuidv4());
       const command = buildProjectCreateCommand({
@@ -630,7 +643,7 @@ function useCreateProject(environment: EnvironmentOption | null) {
       );
       return result;
     },
-    [createProject, environment, projects, navigation],
+    [createProject, environment, navigation, openExistingProject],
   );
 }
 
@@ -894,6 +907,7 @@ export function AddProjectDestinationScreen(props: {
   });
   const environment = useEnvironmentFromParam(props.environmentId);
   const createProject = useCreateProject(environment);
+  const openExistingProject = useOpenExistingProject(environment);
   const remoteUrl = stringParam(props.remoteUrl);
   const repositoryTitle = stringParam(props.repositoryTitle);
   // A lookup derives this from "owner/repo", a pasted clone URL from its own
@@ -920,6 +934,9 @@ export function AddProjectDestinationScreen(props: {
       setError(resolved.error);
       return;
     }
+    // Cloning into a directory that is already a project would fail on a
+    // non-empty destination, so open that project instead of reporting it.
+    if (openExistingProject(resolved.path)) return;
 
     setIsSubmitting(true);
     const cloneResult = await cloneRepository({
@@ -944,6 +961,7 @@ export function AddProjectDestinationScreen(props: {
     environment,
     isBrowseNavigating,
     isSubmitting,
+    openExistingProject,
     pathInput,
     remoteUrl,
   ]);


### PR DESCRIPTION
On mobile, starting a new chat and adding a project by URL instead of picking one from the list failed when the chosen destination directory was already a T3 Code project: the clone was rejected with "Destination path already exists and is not empty" and the screen showed an error banner. The local folder flow had a milder version of the same problem — it popped a "Project already exists" alert before navigating.

Both flows now look the path up first (`findExistingAddProject`, normalized comparison scoped to the environment) and hand off to that project's new-task draft, so the user just starts prompting as if they had selected it from the list. In the clone flow the check runs before `cloneRepository`, so no doomed clone is attempted. This matches how the web command palette already treats a duplicate path.

The shared lookup and navigation live in a new `useOpenExistingProject` hook that both `useCreateProject` and `AddProjectDestinationScreen` call.

## The flow

New task → **Choose project** → **+** → **Git URL** → paste the clone URL → the destination path is prefilled as `<add-project base directory>/<repo name>`, which here is a directory that is already a project.

<table>
<tr>
<td width="25%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/step-choose-project.jpg" width="100%"></td>
<td width="25%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/step-add-project.jpg" width="100%"></td>
<td width="25%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/step-git-url.jpg" width="100%"></td>
<td width="25%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/step-destination.jpg" width="100%"></td>
</tr>
<tr>
<td align="center"><sub>1. Choose project</sub></td>
<td align="center"><sub>2. Add Project</sub></td>
<td align="center"><sub>3. Git URL</sub></td>
<td align="center"><sub>4. Destination — already a project</sub></td>
</tr>
</table>

## Before / after

Tapping **Clone project** on that destination:

<table>
<tr>
<td width="50%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/before-clone-error.jpg" width="100%"></td>
<td width="50%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/after-existing-project-draft.jpg" width="100%"></td>
</tr>
<tr>
<td align="center"><sub><b>Before</b> — the clone fails and the banner blames the destination</sub></td>
<td align="center"><sub><b>After</b> — the existing project's draft, ready to prompt</sub></td>
</tr>
</table>

The local folder flow, browsing to a directory that is already a project and tapping **Add project**:

<table>
<tr>
<td width="50%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/before-local-folder-alert.jpg" width="100%"></td>
<td width="50%"><img src="https://raw.githubusercontent.com/Zandor300/t3code/pr-assets-8229/screenshots/after-prompting.jpg" width="100%"></td>
</tr>
<tr>
<td align="center"><sub><b>Before</b> — an alert to dismiss on the way to the same draft</sub></td>
<td align="center"><sub><b>After</b> — straight to the draft, typing works immediately</sub></td>
</tr>
</table>

## Verification

iPhone 17 Pro Max simulator against a disposable local environment seeded with two projects. The "before" captures are the parent commit's version of the file loaded through Metro, then the fix restored and the identical steps repeated. After both runs the environment still held exactly two projects — no duplicate project and no stray clone.

Model: Claude Opus 5 (1M context). Harness: Claude Code, driven from T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
