### PR TITLE
fix(contracts): accept legacy pull request checkout results

### DIFF
--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import {
   VcsCreateWorktreeInput,
   GitPreparePullRequestThreadInput,
+  GitPreparePullRequestThreadResult,
   GitRunStackedActionResult,
   GitRunStackedActionInput,
   GitResolvePullRequestResult,
@@ -12,6 +13,9 @@ import {
 const decodeCreateWorktreeInput = Schema.decodeUnknownSync(VcsCreateWorktreeInput);
 const decodePreparePullRequestThreadInput = Schema.decodeUnknownSync(
   GitPreparePullRequestThreadInput,
+);
+const decodePreparePullRequestThreadResult = Schema.decodeUnknownSync(
+  GitPreparePullRequestThreadResult,
 );
 const decodeRunStackedActionInput = Schema.decodeUnknownSync(GitRunStackedActionInput);
 const decodeRunStackedActionResult = Schema.decodeUnknownSync(GitRunStackedActionResult);
@@ -52,6 +56,43 @@ describe("GitPreparePullRequestThreadInput", () => {
 
     expect(parsed.reference).toBe("#42");
     expect(parsed.mode).toBe("worktree");
+  });
+});
+
+describe("GitPreparePullRequestThreadResult", () => {
+  it("defaults legacy responses to the pull request head", () => {
+    const parsed = decodePreparePullRequestThreadResult({
+      pullRequest: {
+        number: 42,
+        title: "PR threads",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/42",
+        baseBranch: "main",
+        headBranch: "feature/pr-threads",
+        state: "open",
+      },
+      branch: "feature/pr-threads",
+      worktreePath: "/tmp/pr-threads",
+    });
+
+    expect(parsed.isOnPullRequestHead).toBe(true);
+  });
+
+  it("preserves an explicit stale pull request checkout result", () => {
+    const parsed = decodePreparePullRequestThreadResult({
+      pullRequest: {
+        number: 42,
+        title: "PR threads",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/42",
+        baseBranch: "main",
+        headBranch: "feature/pr-threads",
+        state: "open",
+      },
+      branch: "feature/pr-threads",
+      worktreePath: "/tmp/pr-threads",
+      isOnPullRequestHead: false,
+    });
+
+    expect(parsed.isOnPullRequestHead).toBe(false);
   });
 });
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,3 +1,4 @@
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
@@ -289,7 +290,7 @@ export const GitPreparePullRequestThreadResult = Schema.Struct({
    * holding local commits or uncommitted changes keeps its own state, so the code being handed
    * over is older than the pull request.
    */
-  isOnPullRequestHead: Schema.Boolean,
+  isOnPullRequestHead: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true))),
 });
 export type GitPreparePullRequestThreadResult = typeof GitPreparePullRequestThreadResult.Type;
 


### PR DESCRIPTION
A newer client rejects a successful `git.preparePullRequestThread` response from an older remote server when the response predates `isOnPullRequestHead`. By then the remote server has already prepared the pull-request checkout, but the client reports that it failed.

Decode a missing `isOnPullRequestHead` as `true` for backward compatibility while preserving explicit `false` values from current servers. The contracts tests cover both cases.

Validation:
- `vp test run packages/contracts/src/git.test.ts`
- `vp run --filter @t3tools/contracts typecheck`

Built with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible schema decoding in contracts only; no runtime server or client behavior changes beyond accepting older response shapes.
> 
> **Overview**
> Fixes **newer clients** treating successful `git.preparePullRequestThread` responses as failures when the remote never sends **`isOnPullRequestHead`**.
> 
> **`GitPreparePullRequestThreadResult`** now decodes a missing `isOnPullRequestHead` as **`true`** via `Schema.withDecodingDefaultKey`, matching the assumption that legacy servers prepared checkout at the PR head. Explicit **`false`** from current servers (stale/reused worktree) is still preserved.
> 
> Contract tests cover both the legacy payload shape and an explicit `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd87fac14d862f3762daed35bed02b739ab3a588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `isOnPullRequestHead` to `true` in `GitPreparePullRequestThreadResult` decoder
> Updates the `GitPreparePullRequestThreadResult` schema in [git.ts](https://github.com/pingdotgg/t3code/pull/8238/files#diff-2282301d92a7a9ddc7e8d88b986c9628fdf70497dc6a09fe80eb8d46d6a769e7) to use `Schema.withDecodingDefaultKey(Effect.succeed(true))` so legacy inputs without `isOnPullRequestHead` decode as `true` instead of failing. Adds tests in [git.test.ts](https://github.com/pingdotgg/t3code/pull/8238/files#diff-75bc4565cdc40f101d5aefa07d39bcfe12d89c0e5366836213a672096d48dcd1) covering the missing-field default and explicit `false` preservation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd87fac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->