### PR TITLE
fix(server): fall back to local-only base branches

### DIFF
--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -73,6 +73,11 @@ export class GitWorkflowService extends Context.Service<
       readonly cwd: string;
       readonly remoteName: string;
     }) => Effect.Effect<boolean, GitCommandError>;
+    readonly remoteBranchExists: (input: {
+      readonly cwd: string;
+      readonly remoteName: string;
+      readonly refName: string;
+    }) => Effect.Effect<boolean, GitCommandError>;
     readonly resolveRemoteTrackingCommit: (input: {
       readonly cwd: string;
       readonly refName: string;
@@ -313,6 +318,10 @@ export const make = Effect.gen(function* () {
     remoteExists: (input) =>
       ensureGitCommand("GitWorkflowService.remoteExists", input.cwd).pipe(
         Effect.andThen(git.remoteExists(input)),
+      ),
+    remoteBranchExists: (input) =>
+      ensureGitCommand("GitWorkflowService.remoteBranchExists", input.cwd).pipe(
+        Effect.andThen(git.remoteBranchExists(input)),
       ),
     resolveRemoteTrackingCommit: (input) =>
       ensureGitCommand("GitWorkflowService.resolveRemoteTrackingCommit", input.cwd).pipe(

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7606,6 +7606,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             }),
         );
         const fetchedOriginCommit = "0123456789abcdef0123456789abcdef01234567";
+        const remoteBranchExists = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteBranchExists"]>[0]) =>
+            Effect.succeed(true),
+        );
         const resolveRemoteTrackingCommit = vi.fn(
           (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]>[0]) =>
             Effect.sync(() => {
@@ -7648,6 +7652,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             gitVcsDriver: {
               remoteExists,
               fetchRemote,
+              remoteBranchExists,
               resolveRemoteTrackingCommit,
               createWorktree,
             },
@@ -7800,6 +7805,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             gitVcsDriver: {
               remoteExists,
               fetchRemote,
+              remoteBranchExists: () => Effect.succeed(false),
               resolveRemoteTrackingCommit,
               createWorktree,
             },
@@ -7868,6 +7874,116 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           path: null,
         });
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("falls back to the local base branch when its origin tracking ref does not exist", () =>
+    Effect.gen(function* () {
+      const dispatchedCommands: Array<OrchestrationCommand> = [];
+      const remoteExists = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteExists"]>[0]) =>
+          Effect.succeed(true),
+      );
+      const fetchRemote = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"]>[0]) => Effect.void,
+      );
+      const remoteBranchExists = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteBranchExists"]>[0]) =>
+          Effect.succeed(false),
+      );
+      const resolveRemoteTrackingCommit = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]>[0]) =>
+          Effect.fail(
+            new GitCommandError({
+              operation: "GitVcsDriver.resolveRemoteTrackingCommit",
+              command: "git rev-parse --verify refs/remotes/origin/local-only^{commit}",
+              cwd: "/tmp/project",
+              detail: "remote tracking ref does not exist",
+            }),
+          ),
+      );
+      const createWorktree = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+          Effect.succeed({
+            worktree: {
+              refName: "t3code/bootstrap-refName",
+              path: "/tmp/bootstrap-worktree",
+            },
+          }),
+      );
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitVcsDriver: {
+            remoteExists,
+            fetchRemote,
+            remoteBranchExists,
+            resolveRemoteTrackingCommit,
+            createWorktree,
+          },
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                dispatchedCommands.push(command);
+                return { sequence: dispatchedCommands.length };
+              }),
+            readEvents: () => Stream.empty,
+          },
+        },
+      });
+
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-bootstrap-turn-start-local-only-base"),
+            threadId: ThreadId.make("thread-bootstrap-local-only-base"),
+            message: {
+              messageId: MessageId.make("msg-bootstrap-local-only-base"),
+              role: "user",
+              text: "hello",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              createThread: {
+                projectId: defaultProjectId,
+                title: "Bootstrap Thread",
+                modelSelection: defaultModelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                branch: "local-only",
+                worktreePath: null,
+                createdAt,
+              },
+              prepareWorktree: {
+                projectCwd: "/tmp/project",
+                baseBranch: "local-only",
+                branch: "t3code/bootstrap-refName",
+                startFromOrigin: true,
+              },
+            },
+            createdAt,
+          }),
+        ),
+      );
+
+      assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
+        cwd: "/tmp/project",
+        refName: "local-only",
+        newRefName: "t3code/bootstrap-refName",
+        baseRefName: "local-only",
+        path: null,
+      });
+      assert.deepEqual(
+        dispatchedCommands.map((command) => command.type),
+        ["thread.create", "thread.meta.update", "thread.turn.start"],
+      );
+      assert.equal(resolveRemoteTrackingCommit.mock.calls.length, 0);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
   it.effect("records setup-script failures without aborting bootstrap turn start", () =>

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -204,6 +204,10 @@ export interface GitRemoteExistsInput {
   remoteName: string;
 }
 
+export interface GitRemoteBranchExistsInput extends GitRemoteExistsInput {
+  refName: string;
+}
+
 export interface GitResolveRemoteTrackingCommitInput {
   cwd: string;
   refName: string;
@@ -295,6 +299,9 @@ export class GitVcsDriver extends Context.Service<
     ) => Effect.Effect<string | null, GitCommandError>;
     readonly fetchRemote: (input: GitFetchRemoteInput) => Effect.Effect<void, GitCommandError>;
     readonly remoteExists: (input: GitRemoteExistsInput) => Effect.Effect<boolean, GitCommandError>;
+    readonly remoteBranchExists: (
+      input: GitRemoteBranchExistsInput,
+    ) => Effect.Effect<boolean, GitCommandError>;
     readonly resolveRemoteTrackingCommit: (
       input: GitResolveRemoteTrackingCommitInput,
     ) => Effect.Effect<GitResolveRemoteTrackingCommitResult, GitCommandError>;

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -3314,6 +3314,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     resolveDefaultBranchName,
     fetchRemote: (input) => withListRefsInvalidation(input.cwd, fetchRemote(input)),
     remoteExists,
+    remoteBranchExists: (input) => remoteBranchExists(input.cwd, input.remoteName, input.refName),
     resolveRemoteTrackingCommit,
     fetchRemoteBranch: (input) => withListRefsInvalidation(input.cwd, fetchRemoteBranch(input)),
     fetchRemoteTrackingBranch: (input) =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1030,12 +1030,20 @@ const makeWsRpcLayer = (
                   cwd: bootstrap.prepareWorktree.projectCwd,
                   remoteName: "origin",
                 });
-                const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
+                const baseBranch = bootstrap.prepareWorktree.baseBranch;
+                const hasRemoteBase = yield* gitWorkflow.remoteBranchExists({
                   cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  fallbackRemoteName: "origin",
+                  remoteName: "origin",
+                  refName: baseBranch,
                 });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
+                if (hasRemoteBase) {
+                  const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
+                    cwd: bootstrap.prepareWorktree.projectCwd,
+                    refName: baseBranch,
+                    fallbackRemoteName: "origin",
+                  });
+                  worktreeBaseRef = resolvedRemoteBase.commitSha;
+                }
               }
               const worktree = yield* gitWorkflow.createWorktree({
                 cwd: bootstrap.prepareWorktree.projectCwd,


### PR DESCRIPTION
## What Changed

When **Start from origin** is enabled, check whether the selected base branch has an `origin` tracking ref after fetching. If it does, create the worktree from the fetched remote commit. If it only exists locally, create the worktree from the local branch instead.

This keeps unrelated Git resolution failures visible instead of treating every failure as a missing branch.

## Why

T3 previously checked only whether the repository had an `origin` remote. Selecting a valid local-only base branch then caused `resolveRemoteTrackingCommit` to fail, aborting bootstrap and deleting the provisional thread.

Closes #8191

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Added focused regression coverage for remote-backed, no-origin, and local-only base branches
- [x] Ran the complete server test file (132 tests)
- [x] Ran the server typecheck

Created with GPT-5.6 Sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread bootstrap and worktree creation when “Start from origin” is on; mistakes could pick the wrong base commit, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> **Bootstrap worktrees with “Start from origin”** no longer always resolve the base branch through `origin`. After fetching `origin`, the server checks whether `origin/<baseBranch>` exists via a new **`remoteBranchExists`** API on the Git workflow/VCS driver stack. Only when that ref exists does it call `resolveRemoteTrackingCommit` and base the worktree on the remote commit; otherwise it keeps the local base branch name, so local-only branches bootstrap successfully instead of failing and tearing down the thread.
> 
> **`remoteBranchExists`** is wired from `GitVcsDriverCore` (git `show-ref` on `refs/remotes/<remote>/<ref>`) through `GitVcsDriver`, `GitWorkflowService`, and the WS bootstrap path. Server tests mock the new hook and add a regression case asserting `createWorktree` uses the local branch and skips remote commit resolution when the origin tracking ref is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5762a2bada26176b430f0ae5042d4f62b374bb73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to local base branch when remote tracking ref is missing
> Adds a `remoteBranchExists` method to `GitVcsDriver` and `GitWorkflowService` so the server can check whether a remote branch exists before resolving it. In the `prepareWorktree` bootstrap flow in [ws.ts](https://github.com/pingdotgg/t3code/pull/8241/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125), when `startFromOrigin` is true the server now calls `gitWorkflow.remoteBranchExists`; if the remote base branch does not exist, it skips `resolveRemoteTrackingCommit` and creates the worktree from the local base branch instead.
> - Risk: if `remoteBranchExists` throws (e.g. network failure to remote), the `ensureGitCommand` guard in `GitWorkflowService.make` surfaces a `GitCommandError` rather than silently falling back to local; callers in `ws.ts` rely on this error propagating correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5762a2b. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->