### PR TITLE
feat(ci): download macOS preview DMGs without signing in

### DIFF
--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -144,13 +144,17 @@ jobs:
 
           tag="desktop-preview"
 
+          # True while the PR is open and still carries the preview label.
+          preview_eligible() {
+            [[ "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --json state,labels \
+              --jq '.state + " " + (.labels | map(.name) | contains(["preview:mac"]) | tostring)')" == "OPEN true" ]]
+          }
+
           # The build ran for many minutes. If the PR closed or lost the label
           # meanwhile, cleanup already ran in its own concurrency group, so
           # publishing now would resurrect a deleted download.
-          pr_state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json state,labels \
-            --jq '.state + " " + (.labels | map(.name) | contains(["preview:mac"]) | tostring)')"
-          if [[ "$pr_state" != "OPEN true" ]]; then
+          if ! preview_eligible; then
             echo "PR closed or preview label removed while building. Skipping publish."
             exit 0
           fi
@@ -182,6 +186,17 @@ jobs:
               done
 
           gh release upload "$tag" "$dmg_path" --repo "$GITHUB_REPOSITORY" --clobber
+
+          # Re-check after uploading. A cleanup run that started during the
+          # upload listed assets before ours existed, so it cannot delete it.
+          # Whichever writer acts last sees the final PR state; if the preview
+          # became ineligible, delete what we just uploaded.
+          if ! preview_eligible; then
+            gh release delete-asset "$tag" "$(basename "$dmg_path")" --repo "$GITHUB_REPOSITORY" --yes
+            echo "PR closed or preview label removed during upload. Removed the download."
+            exit 0
+          fi
+
           echo "download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/$(basename "$dmg_path")" >> "$GITHUB_OUTPUT"
 
       - name: Comment download link

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -295,7 +295,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Delete this PR's preview assets
+      - id: delete
+        name: Delete this PR's preview assets
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -312,8 +313,11 @@ jobs:
             --json state,labels \
             --jq '.state + " " + (.labels | map(.name) | contains(["preview:mac"]) | tostring)')" == "OPEN true" ]]; then
             echo "PR is open and labeled again. Skipping cleanup."
+            echo "removed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          echo "removed=true" >> "$GITHUB_OUTPUT"
 
           if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "No preview release exists. Nothing to clean up."
@@ -328,6 +332,7 @@ jobs:
               done
 
       - name: Mark the preview comment as removed
+        if: steps.delete.outputs.removed == 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -7,8 +7,11 @@ on:
 permissions:
   contents: read
 
+# Build events and cleanup events use separate groups: a push must cancel a
+# stale in-flight build, but must never cancel a cleanup run mid-delete. The
+# publish job re-checks PR state before uploading to cover the reverse race.
 concurrency:
-  group: desktop-macos-preview-${{ github.event.pull_request.number }}
+  group: desktop-macos-preview-${{ github.event.pull_request.number }}-${{ contains(fromJSON('["closed", "unlabeled"]'), github.event.action) && 'cleanup' || 'build' }}
   cancel-in-progress: true
 
 jobs:
@@ -141,6 +144,17 @@ jobs:
 
           tag="desktop-preview"
 
+          # The build ran for many minutes. If the PR closed or lost the label
+          # meanwhile, cleanup already ran in its own concurrency group, so
+          # publishing now would resurrect a deleted download.
+          pr_state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json state,labels \
+            --jq '.state + " " + (.labels | map(.name) | contains(["preview:mac"]) | tostring)')"
+          if [[ "$pr_state" != "OPEN true" ]]; then
+            echo "PR closed or preview label removed while building. Skipping publish."
+            exit 0
+          fi
+
           dmg_path="$(find release -type f -name '*.dmg' -print -quit)"
           if [[ -z "$dmg_path" ]]; then
             echo "No DMG found in the downloaded artifact." >&2
@@ -171,6 +185,7 @@ jobs:
           echo "download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/$(basename "$dmg_path")" >> "$GITHUB_OUTPUT"
 
       - name: Comment download link
+        if: steps.upload.outputs.download_url != ''
         uses: actions/github-script@v8
         env:
           DOWNLOAD_URL: ${{ steps.upload.outputs.download_url }}

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -207,7 +207,7 @@ jobs:
               "No GitHub sign-in is needed. The download stays available until this PR closes or the preview label is removed.",
             ].join("\n");
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
@@ -270,7 +270,7 @@ jobs:
         with:
           script: |
             const marker = "<!-- desktop-macos-preview -->";
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -230,7 +230,11 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
             });
-            if (pullRequest.head.sha !== process.env.HEAD_SHA) {
+            if (
+              pullRequest.head.sha !== process.env.HEAD_SHA ||
+              pullRequest.state !== "open" ||
+              !pullRequest.labels.some((label) => label.name === "preview:mac")
+            ) {
               core.info("Skipping the outdated macOS preview comment.");
               return;
             }

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -12,9 +12,11 @@ permissions:
 # publish job re-checks PR state before uploading to cover the reverse race.
 concurrency:
   group: desktop-macos-preview-${{ github.event.pull_request.number }}-${{ contains(fromJSON('["closed", "unlabeled"]'), github.event.action) && 'cleanup' || 'build' }}
-  # Cleanup runs must complete. A close event right after an unlabel queues
-  # behind the running cleanup instead of canceling it mid-delete.
-  cancel-in-progress: ${{ !contains(fromJSON('["closed", "unlabeled"]'), github.event.action) }}
+  # Cleanup runs must complete (a close event right after an unlabel queues
+  # behind the running cleanup instead of canceling it mid-delete), and events
+  # that skip the build job, such as adding an unrelated label, must not
+  # cancel an in-flight build either.
+  cancel-in-progress: ${{ !contains(fromJSON('["closed", "unlabeled"]'), github.event.action) && (github.event.action != 'labeled' || github.event.label.name == 'preview:mac') }}
 
 jobs:
   # Builds run PR code, so this job keeps a read-only token. Publishing to the
@@ -169,6 +171,14 @@ jobs:
             exit 1
           fi
 
+          # The filename comes out of the build, which runs PR code. Requiring
+          # this PR's marker keeps a build from clobbering or deleting another
+          # PR's asset, since those names carry a different -pr.N. marker.
+          if [[ "$(basename "$dmg_path")" != *"-pr.${PR_NUMBER}."* ]]; then
+            echo "DMG name '$(basename "$dmg_path")' does not carry this PR's -pr.${PR_NUMBER}. marker. Refusing to publish." >&2
+            exit 1
+          fi
+
           if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             # "|| true" tolerates a concurrent publish job creating the
             # release between the check and the create.
@@ -288,6 +298,17 @@ jobs:
           set -euo pipefail
 
           tag="desktop-preview"
+
+          # A stale cleanup must not delete a download that became valid
+          # again. If the PR is open and labeled once more, the next publish
+          # owns this PR's assets and replaces them itself.
+          if [[ "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json state,labels \
+            --jq '.state + " " + (.labels | map(.name) | contains(["preview:mac"]) | tostring)')" == "OPEN true" ]]; then
+            echo "PR is open and labeled again. Skipping cleanup."
+            exit 0
+          fi
+
           if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "No preview release exists. Nothing to clean up."
             exit 0

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -196,7 +196,8 @@ jobs:
           gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' \
             | { grep -F -- "-pr.${PR_NUMBER}." || true; } \
             | while read -r asset; do
-                gh release delete-asset "$tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+                gh release delete-asset "$tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes \
+                  || echo "Asset $asset was already removed by a concurrent run."
               done
 
           gh release upload "$tag" "$dmg_path" --repo "$GITHUB_REPOSITORY" --clobber
@@ -206,7 +207,8 @@ jobs:
           # Whichever writer acts last sees the final PR state; if the preview
           # became ineligible, delete what we just uploaded.
           if ! preview_eligible; then
-            gh release delete-asset "$tag" "$(basename "$dmg_path")" --repo "$GITHUB_REPOSITORY" --yes
+            gh release delete-asset "$tag" "$(basename "$dmg_path")" --repo "$GITHUB_REPOSITORY" --yes \
+              || echo "Asset was already removed by a concurrent run."
             echo "PR closed or preview label removed during upload. Removed the download."
             exit 0
           fi
@@ -317,7 +319,8 @@ jobs:
           gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' \
             | { grep -F -- "-pr.${PR_NUMBER}." || true; } \
             | while read -r asset; do
-                gh release delete-asset "$tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+                gh release delete-asset "$tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes \
+                  || echo "Asset $asset was already removed by a concurrent run."
               done
 
       - name: Mark the preview comment as removed

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -12,7 +12,9 @@ permissions:
 # publish job re-checks PR state before uploading to cover the reverse race.
 concurrency:
   group: desktop-macos-preview-${{ github.event.pull_request.number }}-${{ contains(fromJSON('["closed", "unlabeled"]'), github.event.action) && 'cleanup' || 'build' }}
-  cancel-in-progress: true
+  # Cleanup runs must complete. A close event right after an unlabel queues
+  # behind the running cleanup instead of canceling it mid-delete.
+  cancel-in-progress: ${{ !contains(fromJSON('["closed", "unlabeled"]'), github.event.action) }}
 
 jobs:
   # Builds run PR code, so this job keeps a read-only token. Publishing to the
@@ -102,10 +104,11 @@ jobs:
           fi
           printf 'dmg_name=%s\n' "$(basename "${dmg_files[0]}")" >> "$GITHUB_OUTPUT"
 
+      # archive: false uploads the file as its own artifact named after the
+      # file, so the publish job downloads by *.dmg pattern, not by name.
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v7
         with:
-          name: macos-preview-dmg
           path: release/*.dmg
           if-no-files-found: error
           archive: false
@@ -129,7 +132,8 @@ jobs:
       - name: Download macOS DMG
         uses: actions/download-artifact@v8
         with:
-          name: macos-preview-dmg
+          pattern: "*.dmg"
+          merge-multiple: true
           path: release
 
       - id: upload

--- a/.github/workflows/desktop-macos-preview.yml
+++ b/.github/workflows/desktop-macos-preview.yml
@@ -2,25 +2,31 @@ name: Desktop macOS Preview
 
 on:
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [labeled, unlabeled, synchronize, reopened, closed]
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: desktop-macos-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  # Builds run PR code, so this job keeps a read-only token. Publishing to the
+  # release happens in the publish job below, which never checks out PR code.
   build:
     name: Build macOS Apple Silicon preview
     if: >-
+      github.event.action != 'closed' &&
+      github.event.action != 'unlabeled' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.labels.*.name, 'preview:mac') &&
       (github.event.action != 'labeled' || github.event.label.name == 'preview:mac')
     runs-on: blacksmith-12vcpu-macos-26
     timeout-minutes: 30
+    outputs:
+      dmg_name: ${{ steps.build.outputs.dmg_name }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -93,23 +99,84 @@ jobs:
           fi
           printf 'dmg_name=%s\n' "$(basename "${dmg_files[0]}")" >> "$GITHUB_OUTPUT"
 
-      - id: upload
-        name: Upload macOS DMG
+      - name: Upload macOS DMG
         uses: actions/upload-artifact@v7
         with:
+          name: macos-preview-dmg
           path: release/*.dmg
           if-no-files-found: error
           archive: false
           overwrite: true
           retention-days: 7
 
+  # Release assets download without a GitHub account, unlike workflow
+  # artifacts. All preview DMGs live on one rolling prerelease tagged
+  # "desktop-preview" (release.yml only matches v*.*.* tags), so publishing a
+  # build never notifies release watchers. This job holds the write token and
+  # only handles the artifact the build job produced; it never runs PR code.
+  publish:
+    name: Publish anonymous download
+    needs: build
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Download macOS DMG
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-preview-dmg
+          path: release
+
+      - id: upload
+        name: Upload DMG to the rolling preview release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          tag="desktop-preview"
+
+          dmg_path="$(find release -type f -name '*.dmg' -print -quit)"
+          if [[ -z "$dmg_path" ]]; then
+            echo "No DMG found in the downloaded artifact." >&2
+            exit 1
+          fi
+
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            # "|| true" tolerates a concurrent publish job creating the
+            # release between the check and the create.
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$DEFAULT_BRANCH" \
+              --prerelease \
+              --title "Desktop preview builds" \
+              --notes "Rolling unsigned desktop builds from pull requests with a preview label. Each download is removed when its pull request closes or loses the label. Install stable builds from the latest release instead." \
+              || true
+          fi
+
+          # Keep one DMG per PR: drop this PR's older builds first. The
+          # trailing dot keeps -pr.12. from matching -pr.123. builds.
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' \
+            | { grep -F -- "-pr.${PR_NUMBER}." || true; } \
+            | while read -r asset; do
+                gh release delete-asset "$tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+              done
+
+          gh release upload "$tag" "$dmg_path" --repo "$GITHUB_REPOSITORY" --clobber
+          echo "download_url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/$(basename "$dmg_path")" >> "$GITHUB_OUTPUT"
+
       - name: Comment download link
         uses: actions/github-script@v8
         env:
-          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
-          DMG_NAME: ${{ steps.build.outputs.dmg_name }}
+          DOWNLOAD_URL: ${{ steps.upload.outputs.download_url }}
+          DMG_NAME: ${{ needs.build.outputs.dmg_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PREVIEW_VERSION: ${{ steps.version.outputs.version }}
+          PREVIEW_VERSION: ${{ needs.build.outputs.version }}
         with:
           script: |
             const { data: pullRequest } = await github.rest.pulls.get({
@@ -127,7 +194,7 @@ jobs:
               marker,
               "### macOS preview",
               "",
-              `[Download Apple Silicon DMG](${process.env.ARTIFACT_URL})`,
+              `[Download Apple Silicon DMG](${process.env.DOWNLOAD_URL})`,
               "",
               `Version: ${process.env.PREVIEW_VERSION}`,
               `Commit: ${process.env.HEAD_SHA.slice(0, 7)}`,
@@ -137,7 +204,7 @@ jobs:
               `xattr -d com.apple.quarantine ~/Downloads/${process.env.DMG_NAME}`,
               "```",
               "",
-              "The download requires GitHub access and expires after 7 days.",
+              "No GitHub sign-in is needed. The download stays available until this PR closes or the preview label is removed.",
             ].join("\n");
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -163,3 +230,65 @@ jobs:
                 body,
               });
             }
+
+  # The way out: closing the PR or removing the label deletes its DMG from the
+  # rolling release and updates the PR comment to say so.
+  cleanup:
+    name: Remove preview download
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ((github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview:mac')) ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview:mac'))
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Delete this PR's preview assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          tag="desktop-preview"
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "No preview release exists. Nothing to clean up."
+            exit 0
+          fi
+
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' \
+            | { grep -F -- "-pr.${PR_NUMBER}." || true; } \
+            | while read -r asset; do
+                gh release delete-asset "$tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+              done
+
+      - name: Mark the preview comment as removed
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = "<!-- desktop-macos-preview -->";
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (!existing) {
+              return;
+            }
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body: [
+                marker,
+                "### macOS preview",
+                "",
+                "The preview download was removed because this PR closed or the preview label was removed.",
+              ].join("\n"),
+            });


### PR DESCRIPTION
Preview DMGs from `preview:mac` PRs upload as Actions artifacts, and GitHub requires a signed-in account to download those. That breaks testing on headless devices. For a public repo the login gate adds no real protection, since any GitHub account can already download them.

Now the workflow publishes each DMG as an asset on a rolling `desktop-preview` prerelease. Release assets download anonymously with a stable URL, so `curl` from a headless box works. The PR comment links to that URL.

How it stays safe and tidy:

- The build job keeps a read-only token and still runs PR code. A new publish job holds the write token, and it only downloads the built artifact and talks to the GitHub API. It never checks out PR code.
- One rolling prerelease holds all preview DMGs. Publishing a new build uploads an asset instead of creating a release, so release watchers get no notification and the releases page gets no clutter. The `desktop-preview` tag does not match the `v*.*.*` pattern in `release.yml`.
- Each PR keeps one DMG on the release. A new build replaces the old one.
- A cleanup job deletes the PR's DMG and updates the comment when the PR closes or the label comes off. This replaces the old 7-day artifact expiry.

Build restrictions are unchanged: same-repo PRs with the `preview:mac` label only, unsigned build, no Apple secrets.

Change made by Claude Fable 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces release publishing and asset deletion driven by PR events, but mitigated by isolating write permissions to jobs that do not run PR code and by filename and PR-state guards against cross-PR clobbering.
> 
> **Overview**
> macOS preview builds no longer rely on **Actions artifacts** (which require a GitHub login). A new **`publish`** job uploads each DMG to a rolling **`desktop-preview`** prerelease and the PR comment links to the public release asset URL so headless testers can **`curl`** without signing in.
> 
> The **`build`** job still runs PR code with **read-only** `contents`; **`publish`** and **`cleanup`** hold **`contents: write`** and never check out PR code. **`publish`** re-checks that the PR is still open and labeled before and after upload, and refuses filenames that lack this PR’s **`‑pr.N.`** marker so one build cannot touch another PR’s assets. **`cleanup`** runs on PR close or **`preview:mac`** removal, deletes matching release assets, and updates the comment; it skips if the label was re-applied.
> 
> Workflow triggers now include **`unlabeled`** and **`closed`**. **Concurrency** is split into separate **build** vs **cleanup** groups so in-flight cleanups are not canceled mid-delete and unrelated label events do not cancel builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c4c7e488a454f56a5a74da731cde08a1699bd24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish macOS preview DMGs as public release assets
> - Adds a `publish` job that uploads the built DMG to a rolling prerelease tagged `desktop-preview`, so download links are public and require no GitHub sign-in. Prior assets for the same PR are deleted before upload, and the upload is reverted if the PR is closed or loses the `preview:mac` label mid-publish.
> - Adds a `cleanup` job that deletes a PR's DMG from the release when the PR is closed or the `preview:mac` label is removed, then updates the PR comment to note removal.
> - Reworks workflow concurrency to distinguish build runs from cleanup runs so cleanup is never canceled mid-delete; build runs are still canceled on superseding pushes.
> - The `build` job now exposes `dmg_name` and `version` as job outputs for `publish` to consume, and skips on closed or unlabeled events.
> - Risk: `publish` uses a rolling tag `desktop-preview` with multiple PR assets coexisting; the deletion logic in `publish` and `cleanup` matches assets by the `-pr.<PR_NUMBER>.` filename marker, so any asset not matching that pattern will not be managed or removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c4c7e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->