### PR TITLE
feat(source-control): allow custom branch prefixes

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -145,6 +145,7 @@ describe("ProviderCommandReactor", () => {
 
   async function createHarness(input?: {
     readonly baseDir?: string;
+    readonly branchPrefix?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
@@ -426,7 +427,9 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest({ branchPrefix: input?.branchPrefix ?? "" }),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -1473,7 +1476,7 @@ describe("ProviderCommandReactor", () => {
   });
 
   it("generates a worktree branch name for the first turn", async () => {
-    const harness = await createHarness();
+    const harness = await createHarness({ branchPrefix: "jesse/" });
     const now = "2026-01-01T00:00:00.000Z";
 
     await Effect.runPromise(
@@ -1522,6 +1525,11 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
     expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
       message: "Add a safer reconnect backoff.",
+    });
+    expect(harness.renameBranch).toHaveBeenCalledWith({
+      cwd: "/tmp/provider-project-worktree",
+      oldBranch: "t3code/1234abcd",
+      newBranch: "jesse/feature/gpt-5-6-luna",
     });
     expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,7 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { buildGeneratedWorktreeBranchName, isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -274,29 +274,6 @@ function stalePendingRequestDetail(
   requestId: string,
 ): string {
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
-}
-
-function buildGeneratedWorktreeBranchName(raw: string): string {
-  const normalized = raw
-    .trim()
-    .toLowerCase()
-    .replace(/^refs\/heads\//, "")
-    .replace(/['"`]/g, "");
-
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
-
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
 }
 
 const make = Effect.gen(function* () {
@@ -866,7 +843,10 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        generated.branch,
+        settings.branchPrefix,
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -2,20 +2,22 @@ import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useState, type ReactNode } from "react";
-import type {
-  BackgroundActivitySettings,
-  SourceControlProviderKind,
-  SourceControlDiscoveryResult,
-  SourceControlProviderAuth,
-  SourceControlProviderDiscoveryItem,
-  VcsDriverKind,
-  VcsDiscoveryItem,
+import {
+  MAX_BRANCH_PREFIX_LENGTH,
+  type BackgroundActivitySettings,
+  type SourceControlProviderKind,
+  type SourceControlDiscoveryResult,
+  type SourceControlProviderAuth,
+  type SourceControlProviderDiscoveryItem,
+  type VcsDriverKind,
+  type VcsDiscoveryItem,
 } from "@t3tools/contracts";
 import {
   getBackgroundActivityBaseProfile,
   getBackgroundActivityPresetSettings,
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
+import { WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
 
 import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
@@ -34,6 +36,7 @@ import {
   EmptyTitle,
 } from "../ui/empty";
 import { Skeleton } from "../ui/skeleton";
+import { DraftInput } from "../ui/draft-input";
 import {
   NumberField,
   NumberFieldDecrement,
@@ -331,7 +334,7 @@ function DiscoveryItemRow({
   );
 }
 
-function GitFetchIntervalSettings() {
+function GitSettings() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
@@ -348,6 +351,42 @@ function GitFetchIntervalSettings() {
 
   return (
     <div className="grid gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="flex min-w-0 items-center gap-1">
+            <span className="text-xs font-medium text-foreground">
+              {searchableSetting("branch-prefix").title}
+            </span>
+            <span
+              className={cn(
+                "inline-flex size-5 shrink-0 items-center justify-center transition-opacity",
+                settings.branchPrefix ? "opacity-100" : "pointer-events-none opacity-0",
+              )}
+              aria-hidden={!settings.branchPrefix}
+            >
+              {settings.branchPrefix ? (
+                <SettingResetButton
+                  label="branch prefix"
+                  onClick={() => updateSettings({ branchPrefix: "" })}
+                />
+              ) : null}
+            </span>
+          </div>
+          <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">
+            Prefix used when T3 Code creates new branches.
+          </p>
+        </div>
+        <DraftInput
+          className="w-full shrink-0 sm:w-64"
+          size="sm"
+          value={settings.branchPrefix}
+          onCommit={(branchPrefix) => updateSettings({ branchPrefix })}
+          placeholder={`${WORKTREE_BRANCH_PREFIX}/`}
+          maxLength={MAX_BRANCH_PREFIX_LENGTH}
+          spellCheck={false}
+          aria-label="Branch prefix"
+        />
+      </div>
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
           <div className="flex min-w-0 items-center gap-1">
@@ -553,9 +592,7 @@ export function SourceControlSettingsPanel() {
             >
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
-                  {item.kind === "git" && isPrimaryEnvironment ? (
-                    <GitFetchIntervalSettings />
-                  ) : undefined}
+                  {item.kind === "git" && isPrimaryEnvironment ? <GitSettings /> : undefined}
                 </DiscoveryItemRow>
               ))}
             </SettingsSection>

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -90,4 +90,12 @@ describe("searchSettings", () => {
       targetId: "appearance",
     });
   });
+
+  it("routes branch prefix to source control", () => {
+    expect(searchSettings("branch prefix")[0]).toMatchObject({
+      id: "branch-prefix",
+      to: "/settings/source-control",
+      targetId: "source-control",
+    });
+  });
 });

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -244,6 +244,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/source-control",
   },
   {
+    id: "branch-prefix",
+    title: "Branch prefix",
+    to: "/settings/source-control",
+    targetId: "source-control",
+  },
+  {
     id: "remote-environments",
     title: "Remote environments",
     to: "/settings/connections",

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -63,6 +63,12 @@ The **Source Control settings** page shows you exactly what's connected:
 
 Run a quick **Rescan** after setting up a new machine or changing credentials.
 
+### Choose the Branch Prefix
+
+T3 Code gives new worktree branches a short, agent-generated name. To customize the prefix placed
+before that name, open **Settings → Source Control**, expand **Git**, and set **Branch prefix**.
+Clearing the field restores the default `t3code/` prefix.
+
 ## Getting Started
 
 ### For GitHub (Recommended for most users)

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -226,6 +226,20 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   });
 });
 
+describe("ServerSettings branch prefix", () => {
+  it("uses an empty configured value so the client can present the default as a placeholder", () => {
+    expect(decodeServerSettings({}).branchPrefix).toBe("");
+  });
+
+  it("trims custom prefixes at the settings boundary", () => {
+    expect(decodeServerSettingsPatch({ branchPrefix: "  jesse/  " }).branchPrefix).toBe("jesse/");
+  });
+
+  it("rejects prefixes longer than the supported input", () => {
+    expect(() => decodeServerSettingsPatch({ branchPrefix: "a".repeat(65) })).toThrow();
+  });
+});
+
 describe("provider enabled defaults", () => {
   it("enables only the stable bindings by default", () => {
     const decoded = decodeServerSettings({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -576,6 +576,9 @@ export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyle
 
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
+export const MAX_BRANCH_PREFIX_LENGTH = 64;
+export const BranchPrefix = TrimmedString.check(Schema.isMaxLength(MAX_BRANCH_PREFIX_LENGTH));
+export type BranchPrefix = typeof BranchPrefix.Type;
 
 export const BackgroundActivityProfile = Schema.Literals([
   "balanced",
@@ -658,6 +661,7 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  branchPrefix: BranchPrefix.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -863,6 +867,7 @@ export const ServerSettingsPatch = Schema.Struct({
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  branchPrefix: Schema.optionalKey(BranchPrefix),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -3,12 +3,42 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   applyGitStatusStreamEvent,
+  buildGeneratedWorktreeBranchName,
   buildTemporaryWorktreeBranchName,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
   WORKTREE_BRANCH_PREFIX,
 } from "./git.ts";
+
+describe("buildGeneratedWorktreeBranchName", () => {
+  it("uses the T3 Code prefix when the configured field is empty", () => {
+    expect(buildGeneratedWorktreeBranchName("Fix reconnect state", "")).toBe(
+      "t3code/fix-reconnect-state",
+    );
+  });
+
+  it("uses and sanitizes a custom prefix", () => {
+    expect(buildGeneratedWorktreeBranchName("Fix reconnect state", " Jesse Team/ ")).toBe(
+      "jesse-team/fix-reconnect-state",
+    );
+  });
+
+  it("does not duplicate a prefix echoed by the generator", () => {
+    expect(buildGeneratedWorktreeBranchName("jesse/fix-reconnect-state", "jesse/")).toBe(
+      "jesse/fix-reconnect-state",
+    );
+    expect(buildGeneratedWorktreeBranchName("t3code/fix-reconnect-state", "jesse/")).toBe(
+      "jesse/fix-reconnect-state",
+    );
+  });
+
+  it("strips a fully qualified local branch ref", () => {
+    expect(buildGeneratedWorktreeBranchName("refs/heads/fix-reconnect-state", "jesse/")).toBe(
+      "jesse/fix-reconnect-state",
+    );
+  });
+});
 
 describe("normalizeGitRemoteUrl", () => {
   it("canonicalizes equivalent GitHub remotes across protocol variants", () => {

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -104,6 +104,26 @@ export function buildTemporaryWorktreeBranchName(
   return `${WORKTREE_BRANCH_PREFIX}/${token}`;
 }
 
+/**
+ * Build the semantic branch name used after a new worktree's first prompt.
+ * An empty configured prefix restores the product default, matching Codex's
+ * empty-field behavior for its branch prefix setting.
+ */
+export function buildGeneratedWorktreeBranchName(raw: string, configuredPrefix: string): string {
+  const trimmedPrefix = configuredPrefix.trim().replace(/\/+$/g, "");
+  const prefix =
+    trimmedPrefix.length > 0 ? sanitizeBranchFragment(trimmedPrefix) : WORKTREE_BRANCH_PREFIX;
+  const normalizedBranch = sanitizeBranchFragment(raw.trim().replace(/^refs\/heads\//i, ""));
+  const matchingPrefix = [prefix, WORKTREE_BRANCH_PREFIX].find((candidate) =>
+    normalizedBranch.startsWith(`${candidate}/`),
+  );
+  const withoutPrefix = matchingPrefix
+    ? normalizedBranch.slice(`${matchingPrefix}/`.length)
+    : normalizedBranch;
+
+  return `${prefix}/${sanitizeBranchFragment(withoutPrefix)}`;
+}
+
 export function isTemporaryWorktreeBranch(refName: string): boolean {
   return TEMP_WORKTREE_BRANCH_PATTERN.test(refName.trim().toLowerCase());
 }


### PR DESCRIPTION
## What Changed

T3 Code always renamed generated worktree branches under `t3code/`.
Users who organize branches by author or team could not change it.
This adds a persisted Branch prefix setting under Settings > Source Control > Git and applies it to first-turn branch renames.
A custom value such as `jesse/` now produces `jesse/<generated-name>`; clearing the field restores `t3code/`.

## Why

The branch prefix is a user preference, not a project invariant. Keeping an empty stored value as the default also matches Codex's behavior while preserving T3 Code's existing `t3code/` result.

## UI Changes

**Before: direct base.** Git settings only exposed the fetch interval.

![Before: expanded Git settings show Fetch interval with no branch prefix control](https://github.com/user-attachments/assets/40c7a5d3-c5d0-4f87-a314-6df389313ab2)

**After: PR.** Git settings expose the saved `jesse/` branch prefix above the fetch interval.

![After: expanded Git settings show Branch prefix saved as jesse above Fetch interval](https://github.com/user-attachments/assets/1a052c54-5333-453c-999f-83aa1ace569b)

## Branch behavior proof

```text
Before: direct base
setting: unavailable
created branch: t3code/generated-name

After: PR
empty setting: t3code/generated-name
setting `jesse/`: jesse/generated-name
cleared setting: t3code/generated-name
```

The local web app was exercised end to end: `jesse/` saved, survived reload, and clearing the field restored the `t3code/` empty state.

## Checks

- 131 focused tests passed across contracts, shared Git helpers, the provider command reactor, and settings search.
- Targeted typecheck, lint, formatting, and `git diff --check` passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or interaction timing changed; a video is not needed

Model: GPT-5.6 Sol via the Codex harness in T3 Code.
