### PR TITLE
fix(server): one-click provider updates no longer wedge brew-installed Codex on macOS

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -321,11 +321,11 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       provider: driver("packageTool"),
       packageName: "@example/package-tool",
       update: {
-        command: "brew upgrade package-tool",
+        command: "brew upgrade --no-quarantine package-tool",
 
         executable: "brew",
 
-        args: ["upgrade", "package-tool"],
+        args: ["upgrade", "--no-quarantine", "package-tool"],
 
         lockKey: "homebrew",
       },
@@ -418,11 +418,11 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       provider: driver("nativePackageTool"),
       packageName: "@example/native-package-tool",
       update: {
-        command: "brew upgrade native-package-tool",
+        command: "brew upgrade --no-quarantine native-package-tool",
 
         executable: "brew",
 
-        args: ["upgrade", "native-package-tool"],
+        args: ["upgrade", "--no-quarantine", "native-package-tool"],
 
         lockKey: "homebrew",
       },
@@ -441,11 +441,11 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       provider: driver("scopedPackageTool"),
       packageName: "@example/scoped-package-tool",
       update: {
-        command: "brew upgrade example/tap/scoped-package-tool",
+        command: "brew upgrade --no-quarantine example/tap/scoped-package-tool",
 
         executable: "brew",
 
-        args: ["upgrade", "example/tap/scoped-package-tool"],
+        args: ["upgrade", "--no-quarantine", "example/tap/scoped-package-tool"],
 
         lockKey: "homebrew",
       },

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -202,7 +202,11 @@ function makeHomebrewProviderMaintenanceCapabilities(
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "brew",
-    updateArgs: ["upgrade", definition.homebrewFormula],
+    // Cask upgrades quarantine the new binary by default. macOS then blocks
+    // the next exec behind a Gatekeeper approval prompt, which the T3 server
+    // cannot answer, so the provider probe hangs until a human approves the
+    // binary. --no-quarantine skips that and is a no-op for formulae.
+    updateArgs: ["upgrade", "--no-quarantine", definition.homebrewFormula],
     updateLockKey: "homebrew",
   });
 }


### PR DESCRIPTION
Codex broke on a machine right before the stable cut: the provider status check timed out and the model picker showed no models. The cause was not a recent merge. A fresh \`brew\` cask install of codex left the binary quarantined, and macOS blocked every exec behind a Gatekeeper approval prompt that a background server can never answer. The T3 probe then timed out forever.

Our one-click provider update runs the same command (\`brew upgrade codex\`), so any stable user with a brew-installed Codex who clicks Update reproduces this exact wedge. This PR passes \`--no-quarantine\` to \`brew upgrade\` for Homebrew-managed providers, so the updated binary is never quarantined. The flag is a no-op for formulae and only changes cask behavior. Verified the flag parses with \`brew upgrade --dry-run --no-quarantine codex\` (exit 0).

Changes by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Homebrew upgrade flags for provider maintenance; slightly relaxes quarantine on cask upgrades but targets a known headless-server failure mode.
> 
> **Overview**
> **Fixes one-click Homebrew provider updates wedging provider health checks on macOS** when the installed tool is a cask whose binary gets quarantined after `brew upgrade`.
> 
> Homebrew-managed provider maintenance now runs `brew upgrade --no-quarantine <formula>` instead of plain `brew upgrade`. The flag avoids Gatekeeper quarantine on cask binaries so the T3 server can execute the provider probe without a manual approval dialog; it is documented as a no-op for formulae. Expectations in `providerMaintenance.test.ts` for Homebrew-resolved binaries are updated to match the new command and args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c736e4be91eaa5f23e6fe85968a3f703572a1fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--no-quarantine` flag to Homebrew update args in `makeHomebrewProviderMaintenanceCapabilities`
> One-click provider updates invoke `brew upgrade` with a new `--no-quarantine` argument inserted before the formula identifier. This prevents macOS Gatekeeper quarantine from wedging brew-installed Codex after an update. Tests in [providerMaintenance.test.ts](https://github.com/pingdotgg/t3code/pull/8247/files#diff-40e44f8465f8c4e465f1d73d81229b1ff72980f8fa6e6711363d9ef9c1fb54ad) are updated to expect the new argument shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c736e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->