### PR TITLE
fix(desktop): let Clerk UI receive stable auth fixes

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -30,11 +30,6 @@ if (isElectron) {
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
-// First Clerk UI build containing https://github.com/clerk/javascript/pull/9500.
-const electronClerkUI = {
-  __internal_clerkUIVersion: "1.30.5-canary.v20260819050620",
-};
-
 const app = <AppRoot router={router} />;
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
@@ -42,7 +37,6 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     {clerkPublishableKey && hasCloudPublicConfig() ? (
       isElectron ? (
         <ElectronClerkProvider
-          {...electronClerkUI}
           appearance={clerkAppearance}
           publishableKey={clerkPublishableKey}
           passkeys={passkeys}


### PR DESCRIPTION
Desktop sign-in still loads an August 19 Clerk UI canary, even after #8240 updated the Electron SDK. #7522 added that pin to stop automatic passkey prompts. Clerk released that fix in stable UI 1.30.5, but the old pin blocks the later OAuth transfer fixes in 1.30.7.

Remove the UI version override. Electron now uses the SDK default, which requests the latest stable Clerk UI within major version 1 from the CDN. SDK dependency versions stay unchanged. Web and mobile auth are unchanged.

Checks passed: web typecheck, targeted lint, five existing passkey and redirect tests, and a direct check that the default loader requests `@clerk/ui@1`. Packaged sign-in is not tested yet. Theo will test the macOS preview. No layout changes.

Upstream: https://github.com/clerk/javascript/pull/9530

Made with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Clerk UI build loads for Electron sign-in; regression risk around passkeys and OAuth until desktop sign-in is verified.
> 
> **Overview**
> **Electron desktop auth** no longer forces a fixed Clerk UI canary (`1.30.5-canary.v20260819050620`). The `electronClerkUI` override and its spread on `ElectronClerkProvider` are removed so the Electron SDK picks the default stable `@clerk/ui@1` from the CDN.
> 
> That unblocks newer stable Clerk UI fixes (including OAuth transfer in 1.30.7) while keeping the existing passkey configuration on `ElectronClerkProvider`. Web `ClerkProvider` and SDK dependency versions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8654aeb7d439505620d4394959d0eae237f31574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `__internal_clerkUIVersion` override from `ElectronClerkProvider`
> Drops the `electronClerkUI` constant from [main.tsx](https://github.com/pingdotgg/t3code/pull/8248/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) and stops passing it as a prop to `ElectronClerkProvider`. The provider now uses its default internal UI version. Risk: `ElectronClerkProvider` no longer receives the version pin; any downstream behavior tied to the previous override value should be checked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8654aeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->