### PR TITLE
feat(desktop): allow Command-Escape keybindings

### DIFF
--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -7,6 +7,7 @@ export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const PROBE_REMOTE_EDITORS_CHANNEL = "desktop:probe-remote-editors";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const QUIT_SHORTCUT_CHANNEL = "desktop:quit-shortcut";
+export const COMMAND_ESCAPE_CHANNEL = "desktop:command-escape";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -11,6 +11,20 @@ import * as IpcChannels from "./ipc/channels.ts";
 
 exposeClerkBridge({ passkeys: true });
 
+ipcRenderer.on(IpcChannels.COMMAND_ESCAPE_CHANNEL, () => {
+  const activeElement = document.activeElement;
+  const target = activeElement?.hasAttribute("data-keybinding-capture") ? activeElement : window;
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Escape",
+      code: "Escape",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+});
+
 function unwrapEnsureSshEnvironmentResult(result: unknown) {
   if (
     typeof result === "object" &&

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -14,8 +14,23 @@ import * as TestClock from "effect/testing/TestClock";
 import * as Electron from "electron";
 import { vi } from "vite-plus/test";
 
+const { globalShortcutIsRegistered, globalShortcutRegister, globalShortcutUnregister } = vi.hoisted(
+  () => ({
+    globalShortcutIsRegistered: vi.fn(() => false),
+    globalShortcutRegister: vi.fn<(accelerator: string, callback: () => void) => boolean>(
+      () => true,
+    ),
+    globalShortcutUnregister: vi.fn<(accelerator: string) => void>(),
+  }),
+);
+
 vi.mock("electron", async (importOriginal) => ({
   ...(await importOriginal<typeof import("electron")>()),
+  globalShortcut: {
+    isRegistered: globalShortcutIsRegistered,
+    register: globalShortcutRegister,
+    unregister: globalShortcutUnregister,
+  },
   session: {
     fromPartition: vi.fn(() => ({
       getUserAgent: vi.fn(() => "Mozilla/5.0 Electron/41.5.0 t3code/1.2.3"),
@@ -43,7 +58,11 @@ import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
-import { MENU_ACTION_CHANNEL, WINDOW_FULLSCREEN_STATE_CHANNEL } from "../ipc/channels.ts";
+import {
+  COMMAND_ESCAPE_CHANNEL,
+  MENU_ACTION_CHANNEL,
+  WINDOW_FULLSCREEN_STATE_CHANNEL,
+} from "../ipc/channels.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 import * as PreviewManager from "../preview/Manager.ts";
@@ -461,6 +480,15 @@ describe("DesktopWindow", () => {
         assert.deepEqual(fakeWindow.setAutoHideCursor.mock.calls, [[false]]);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+
+        fakeWindow.windowListeners.get("focus")?.();
+        const registration = globalShortcutRegister.mock.calls.at(-1);
+        assert.equal(registration?.[0], "Command+Escape");
+        registration?.[1]();
+        assert.deepEqual(fakeWindow.send.mock.calls, [[COMMAND_ESCAPE_CHANNEL]]);
+
+        fakeWindow.windowListeners.get("blur")?.();
+        assert.deepEqual(globalShortcutUnregister.mock.calls.at(-1), ["Command+Escape"]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -19,6 +19,7 @@ import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import {
+  COMMAND_ESCAPE_CHANNEL,
   MENU_ACTION_CHANNEL,
   QUIT_SHORTCUT_CHANNEL,
   WINDOW_FULLSCREEN_STATE_CHANNEL,
@@ -374,6 +375,26 @@ export const make = Effect.gen(function* () {
 
     if (environment.platform === "darwin") {
       window.setAutoHideCursor(false);
+    }
+    let unregisterCommandEscape = () => {};
+    if (environment.platform === "darwin") {
+      const accelerator = "Command+Escape";
+      let registered = false;
+      const registerCommandEscape = () => {
+        if (registered || Electron.globalShortcut.isRegistered(accelerator)) return;
+        registered = Electron.globalShortcut.register(accelerator, () => {
+          if (!window.isDestroyed()) {
+            window.webContents.send(COMMAND_ESCAPE_CHANNEL);
+          }
+        });
+      };
+      unregisterCommandEscape = () => {
+        if (!registered) return;
+        Electron.globalShortcut.unregister(accelerator);
+        registered = false;
+      };
+      window.on("focus", registerCommandEscape);
+      window.on("blur", unregisterCommandEscape);
     }
     let boundsPersistFiber: Fiber.Fiber<void, never> | undefined;
     let pendingBoundsPersistFiber: Fiber.Fiber<void, never> | undefined;
@@ -750,6 +771,7 @@ export const make = Effect.gen(function* () {
     }
 
     window.on("closed", () => {
+      unregisterCommandEscape();
       clearDevelopmentLoadRetry();
       clearBoundsPersist();
       void runPromise(electronWindow.clearMain(Option.some(window)));

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -62,6 +62,12 @@ describe("KeybindingsSettings.logic", () => {
         "Win32",
       ),
     ).toBe("mod+shift+k");
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "Escape", metaKey: true, ctrlKey: false, altKey: false, shiftKey: false },
+        "MacIntel",
+      ),
+    ).toBe("mod+esc");
   });
 
   it("serializes shortcuts and when expressions for upserts", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -777,11 +777,11 @@ function KeybindingTableRow({
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Tab") return;
     event.preventDefault();
-    if (event.key === "Escape") {
+    const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
+    if (!next && event.key === "Escape") {
       setDraft({ keyDraft: row.key, isRecording: false });
       return;
     }
-    const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
     if (!next) return;
     setDraft({ keyDraft: next, isRecording: false });
   };
@@ -948,11 +948,11 @@ function NewKeybindingTableRow({
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Tab") return;
     event.preventDefault();
-    if (event.key === "Escape") {
+    const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
+    if (!next && event.key === "Escape") {
       setDraft({ keyDraft: "", isRecording: false });
       return;
     }
-    const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
     if (!next) return;
     setDraft({ keyDraft: next, isRecording: false });
   };


### PR DESCRIPTION
macOS consumes Command-Escape before Chromium emits a renderer keyboard event, so the Settings keybinding recorder cannot capture `mod+esc`.

Register only the exact `Command+Escape` accelerator while the main desktop window is focused, forward it to the renderer as a normal keydown, and let the existing Settings recorders distinguish modified Escape from their bare-Escape cancel action. This intentionally avoids preview plumbing, additional modifier permutations, and broad overlay dismissal changes.

Validation:
- `vp test run apps/desktop/src/window/DesktopWindow.test.ts apps/web/src/components/settings/KeybindingsSettings.logic.test.ts` (34 tests)
- targeted lint and formatting for all six changed files
- desktop typecheck
- web typecheck

Built with GPT-5.6 Codex via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS main-window focus, a single accelerator, and keybinding UI capture; no auth or data-path changes.
> 
> **Overview**
> macOS swallows **Command+Escape** before the renderer sees it, so Settings could not record **`mod+esc`**. This PR adds a narrow desktop bridge for that shortcut only.
> 
> On **darwin**, the main window registers **`Command+Escape`** via `globalShortcut` while focused and unregisters on blur and close. The handler sends **`desktop:command-escape`** to the renderer; preload turns that into a bubbling **`keydown`** with **metaKey** (targeting `data-keybinding-capture` when focused). **KeybindingsSettings** now serializes the shortcut first and only treats **unmodified Escape** as cancel during recording. Tests cover shortcut registration/IPC and **`mod+esc`** serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50477c67695d41127eb54152fea35c0587ad0bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Command+Escape` global shortcut support to desktop app on macOS
> - Registers an Electron `globalShortcut` for `Command+Escape` when the `BrowserWindow` gains focus on macOS, and unregisters it on blur and close; the handler posts `COMMAND_ESCAPE_CHANNEL` to the renderer.
> - The preload listener synthesizes a bubbling `KeyboardEvent` with `key: "Escape"` and `metaKey: true`, targeted at the active element with `data-keybinding-capture` or the window.
> - Fixes keybinding capture in `KeybindingSettings` so `Escape` combos like `Meta+Escape` are recorded instead of cancelling; bare `Escape` still cancels recording.
> - Risk: `globalShortcut.register("Command+Escape")` in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/8249/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) may fail silently if another app already holds the shortcut; the registration return value is not checked.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 50477c6. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->