### PR TITLE
perf(ci): cut about a minute from every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
       - "v*.*.*"
       - "!v*-nightly.*"
   schedule:
-    - cron: "0 */3 * * *"
+    # Off minute zero: GitHub delays scheduled runs most at the top of the hour.
+    - cron: "7 */3 * * *"
   workflow_dispatch:
     inputs:
       channel:
@@ -21,6 +22,14 @@ on:
         description: "Release version (for example 1.2.3 or v1.2.3)"
         required: false
         type: string
+
+# Serialize nightlies (scheduled and manual) so overlapping runs cannot build
+# the same commit twice or publish out of order. Stable tag releases get their
+# own group so a nightly never blocks them. Running publishers are never
+# canceled; only a not-yet-started run waiting in the same group is replaced.
+concurrency:
+  group: release-${{ (github.event_name == 'schedule' || inputs.channel == 'nightly') && 'nightly' || 'stable' }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -199,8 +208,14 @@ jobs:
 
   relay_public_config:
     name: Resolve T3 Connect public config
-    needs: preflight
-    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' }}
+    # Consumes only the commit SHA, not preflight's resolved version, so it runs
+    # alongside preflight instead of after it. The condition mirrors preflight's:
+    # check_changes is skipped on non-schedule events (skipped is neither failure
+    # nor success, so success() would be wrong here).
+    needs: [check_changes]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 5
     environment:
@@ -222,7 +237,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.preflight.outputs.ref }}
+          ref: ${{ github.sha }}
           sparse-checkout: |
             /*
             !/.repos/
@@ -295,15 +310,19 @@ jobs:
   # machine. node-pty is N-API, so one binary works across all WSL Node versions.
   build_wsl_node_pty:
     name: Build WSL node-pty (linux-x64)
-    needs: [preflight]
-    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' }}
+    # Same gating as relay_public_config: only the commit SHA is needed, so this
+    # runs alongside preflight. See the condition comment there.
+    needs: [check_changes]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.preflight.outputs.ref }}
+          ref: ${{ github.sha }}
           sparse-checkout: |
             /*
             !/.repos/
@@ -758,9 +777,8 @@ jobs:
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
 
-      - name: Build web package
-        run: vp run --filter @t3tools/web build
-
+      # The t3 build task depends on @t3tools/web#build, so the web client is
+      # built (once) as part of this step.
       - name: Build CLI package
         run: vp run --filter t3 build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,13 @@ on:
 # Serialize nightlies (scheduled and manual) so overlapping runs cannot build
 # the same commit twice or publish out of order. Stable tag releases get their
 # own group so a nightly never blocks them. Running publishers are never
-# canceled; only a not-yet-started run waiting in the same group is replaced.
+# canceled, and queue: max keeps every pending run instead of the default
+# newest-wins single slot, so a queued stable tag can never be silently
+# dropped. Queued nightlies with no new commits skip via check_changes.
 concurrency:
   group: release-${{ (github.event_name == 'schedule' || inputs.channel == 'nightly') && 'nightly' || 'stable' }}
   cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: read


### PR DESCRIPTION
Releases take a median 13m37s. Two pieces of that are pure waste: the CLI publish job builds the web client twice, and two startup jobs wait for version resolution they never use. This PR removes both, worth about a minute per release. It also fixes two scheduling problems found in the same audit.

- **publish_cli built the web client twice.** The `t3` build task already depends on `@t3tools/web#build`, so the explicit web build step repeated ~35s of work on the serial publish path. Verified locally: `vp run --filter t3 build` emits exactly one web build and still produces `dist/bin.mjs`, `dist/service-launcher.mjs`, and `dist/client/index.html`.
- **relay_public_config and build_wsl_node_pty now run alongside preflight.** Both consume only the commit SHA. They previously waited ~30s for preflight to resolve the version, which they never read. Desktop builds still hard-gate on preflight and relay config succeeding.
- **Nightly cron moves to minute 7.** Scheduled runs started a median 13m late across 56 sampled runs. GitHub documents the worst scheduling delays at the top of the hour.
- **Concurrency groups per channel.** Overlapping nightlies double-built the same commit on August 23. Nightlies now queue behind each other with `cancel-in-progress: false`, so no running publisher is ever canceled. Stable tag releases get their own group and are never blocked by a nightly.

Timing data comes from an audit of 60 release runs. The larger follow-ups from that audit (prebuilt hosted-web deploy, early CLI build, Windows cache benchmark) are separate work.

Changes by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions release orchestration; artifact contents should be unchanged aside from avoiding a redundant web build.
> 
> **Overview**
> This PR trims **release workflow** wall time (~1 minute per run) and hardens **nightly scheduling**.
> 
> **Parallelism:** `relay_public_config` and `build_wsl_node_pty` no longer wait on **preflight**—they only need the commit SHA, so they start in parallel with version resolution (same gating as preflight on scheduled runs when `check_changes` finds new commits). Both jobs check out **`github.sha`** instead of a preflight ref.
> 
> **Duplicate work:** **`publish_cli`** drops the explicit `@t3tools/web` build step; **`vp run --filter t3 build`** already pulls in the web client via the existing task dependency.
> 
> **Scheduling / safety:** The nightly cron moves from **minute 0** to **minute 7** every 3 hours to reduce GitHub’s top-of-hour delay. A **concurrency** block serializes **nightly** runs (`cancel-in-progress: false`, `queue: max`) while **stable** tag releases use a separate group so they are not blocked or dropped when nightlies queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe3ebf5c3ac8f69c0f9ed4d508500293a3d5441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `relay_public_config` and `build_wsl_node_pty` in parallel with `preflight` in release workflow
> - Changes `relay_public_config` and `build_wsl_node_pty` to depend on `check_changes` instead of `preflight`, so they run in parallel with preflight rather than waiting for it
> - Both jobs are skipped on scheduled runs when `has_changes` is not `true`, avoiding redundant builds
> - Checkout now uses `github.sha` directly instead of `needs.preflight.outputs.ref`
> - Removes the explicit "Build web package" step since the CLI build already produces it
> - Adds concurrency grouping by channel (`nightly` vs `stable`) with `cancel-in-progress: false`, and shifts the cron schedule from minute 0 to minute 7 to avoid GitHub peak load
> - Risk: jobs no longer wait for `preflight` to complete, so a `preflight` failure will not prevent these jobs from starting; verify that `relay_public_config` and `build_wsl_node_pty` do not rely on any output from `preflight` beyond `ref`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebe3ebf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->