### PR TITLE
fix(server): Grok and Cursor now prefer the in-app browser

### DIFF
--- a/apps/server/src/mcp/toolkits/preview/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.test.ts
@@ -56,6 +56,11 @@ it("exports provider-compatible object schemas with described parameters", () =>
   }
 });
 
+it("names the in-app browser on status and open", () => {
+  expect(PreviewToolkit.tools.preview_status.description).toContain("in-app browser");
+  expect(PreviewToolkit.tools.preview_open.description).toContain("in-app browser");
+});
+
 it("exports exact object result schemas for preview actions", () => {
   const actionNames = [
     "preview_click",

--- a/apps/server/src/mcp/toolkits/preview/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.test.ts
@@ -59,6 +59,8 @@ it("exports provider-compatible object schemas with described parameters", () =>
 it("names the in-app browser on status and open", () => {
   expect(PreviewToolkit.tools.preview_status.description).toContain("in-app browser");
   expect(PreviewToolkit.tools.preview_open.description).toContain("in-app browser");
+  expect(PreviewToolkit.tools.preview_open.description).toContain("auto-show preference");
+  expect(PreviewToolkit.tools.preview_open.description).not.toContain("by default");
 });
 
 it("exports exact object result schemas for preview actions", () => {

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -61,7 +61,7 @@ export const PreviewStatusTool = Tool.make("preview_status", {
 export const PreviewOpenTool = browserTool(
   Tool.make("preview_open", {
     description:
-      "Initialize an in-app browser tab and open the collaborative browser in the thread's right-panel surface by default. Set open=false for background-only automation. Pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
+      "Initialize an in-app browser tab. Visibility follows the user's auto-show preference unless you set open=true (right panel) or open=false (background-only). Pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
     parameters: PreviewAutomationOpenInput,
     success: PreviewAutomationStatus,
     failure: PreviewAutomationError,

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -47,7 +47,7 @@ const readonlyBrowserTool = <T extends Tool.Any>(tool: T): T =>
 
 export const PreviewStatusTool = Tool.make("preview_status", {
   description:
-    "Report whether a collaborative browser tab is automation-capable, including its URL, title, visibility, loading state, viewport mode, and measured CSS-pixel size. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab.",
+    "Report whether an in-app browser tab is automation-capable, including its URL, title, visibility, loading state, viewport mode, and measured CSS-pixel size. The tab is a collaborative browser surface: visible=false means it is offscreen or in the background, but it is still automatable. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab.",
   parameters: PreviewAutomationTabTargetInput,
   success: PreviewAutomationStatus,
   failure: PreviewAutomationError,
@@ -61,7 +61,7 @@ export const PreviewStatusTool = Tool.make("preview_status", {
 export const PreviewOpenTool = browserTool(
   Tool.make("preview_open", {
     description:
-      "Initialize a collaborative browser tab and open its thread-bound inline preview by default. Set open=false for background-only automation. Pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
+      "Initialize an in-app browser tab and open the collaborative browser in the thread's right-panel surface by default. Set open=false for background-only automation. Pass tabId to reuse a specific existing tab, set reuseExistingTab=false to create another tab, or omit both to use this agent session's current tab.",
     parameters: PreviewAutomationOpenInput,
     success: PreviewAutomationStatus,
     failure: PreviewAutomationError,

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -1,16 +1,7 @@
 import type { ProviderInteractionMode } from "@t3tools/contracts";
 import { buildRuntimeInstructions } from "./RuntimeInstructions.ts";
 
-const T3_CODE_BROWSER_TOOL_INSTRUCTIONS = `
-
-## T3 Code collaborative browser
-
-You are running inside T3 Code. The \`t3-code\` MCP server is the product-native collaborative browser shared with the user. When it exposes \`preview_*\` tools, prefer those tools for browser navigation, inspection, interaction, screenshots, and recordings.
-
-For browser work, first call \`preview_status\`. If no automation-capable preview is attached, call \`preview_open\` before concluding that the browser is unavailable. Then use \`preview_navigate\`, \`preview_snapshot\`, and the focused interaction tools. Prefer snapshot-provided locators over coordinates.
-
-Do not switch to global browser skills, Chrome, Node REPL browser automation, standalone Playwright, or agent-browser merely because the preview is initially closed or a first call fails. Use an alternative browser system only when the T3 preview tools are absent, the user explicitly requests another browser, or \`preview_open\` returns an explicit unsupported/unavailable error. A failed T3 preview tool call should be inspected and retried with corrected arguments when the error is actionable.
-`;
+import { HOST_BROWSER_TOOL_INSTRUCTIONS } from "./HostBrowserToolInstructions.ts";
 
 /**
  * The browser block is omitted entirely when the preview tools aren't attached.
@@ -20,7 +11,7 @@ Do not switch to global browser skills, Chrome, Node REPL browser automation, st
  * the only browser automation it still has.
  */
 const browserToolInstructions = (browserToolsAvailable: boolean): string =>
-  browserToolsAvailable ? T3_CODE_BROWSER_TOOL_INSTRUCTIONS : "";
+  browserToolsAvailable ? HOST_BROWSER_TOOL_INSTRUCTIONS : "";
 
 export const codexPlanModeDeveloperInstructions = (
   browserToolsAvailable: boolean,

--- a/apps/server/src/provider/HostBrowserToolInstructions.test.ts
+++ b/apps/server/src/provider/HostBrowserToolInstructions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  HOST_BROWSER_TOOL_INSTRUCTIONS,
+  prefixHostBrowserToolInstructions,
+} from "./HostBrowserToolInstructions.ts";
+
+describe("HOST_BROWSER_TOOL_INSTRUCTIONS", () => {
+  it("steers browser work to the in-app preview and names Aside as an alternative", () => {
+    expect(HOST_BROWSER_TOOL_INSTRUCTIONS).toContain("in-app browser");
+    expect(HOST_BROWSER_TOOL_INSTRUCTIONS).toContain("collaborative browser");
+    expect(HOST_BROWSER_TOOL_INSTRUCTIONS).toContain("preview_status");
+    expect(HOST_BROWSER_TOOL_INSTRUCTIONS).toContain("Aside");
+    expect(HOST_BROWSER_TOOL_INSTRUCTIONS).toContain("aside exec");
+  });
+
+  it("prefixes only when the preview tools are attached", () => {
+    expect(prefixHostBrowserToolInstructions("open the app", { includeBrowserTools: false })).toBe(
+      "open the app",
+    );
+    expect(
+      prefixHostBrowserToolInstructions("open the app", { includeBrowserTools: true }),
+    ).toContain("open the app");
+    expect(
+      prefixHostBrowserToolInstructions("open the app", { includeBrowserTools: true }),
+    ).toContain(HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+  });
+});

--- a/apps/server/src/provider/HostBrowserToolInstructions.test.ts
+++ b/apps/server/src/provider/HostBrowserToolInstructions.test.ts
@@ -24,5 +24,8 @@ describe("HOST_BROWSER_TOOL_INSTRUCTIONS", () => {
     expect(
       prefixHostBrowserToolInstructions("open the app", { includeBrowserTools: true }),
     ).toContain(HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+    expect(prefixHostBrowserToolInstructions("", { includeBrowserTools: true })).toBe(
+      HOST_BROWSER_TOOL_INSTRUCTIONS.trim(),
+    );
   });
 });

--- a/apps/server/src/provider/HostBrowserToolInstructions.ts
+++ b/apps/server/src/provider/HostBrowserToolInstructions.ts
@@ -1,0 +1,27 @@
+/**
+ * Host-side steering for the product-native in-app browser when its MCP tools
+ * exist. Codex already had this block. Grok and Cursor get it on the first
+ * new-session prompt. Claude and OpenCode are not wired here: Claude uses a
+ * preset system prompt, and OpenCode sessions on an external server skip mcp.add.
+ */
+
+export const HOST_BROWSER_TOOL_INSTRUCTIONS = `
+
+## T3 Code in-app browser
+
+You are running inside T3 Code. The \`t3-code\` MCP server is the product-native collaborative browser shared with the user. When it exposes \`preview_*\` tools, prefer those tools for browser navigation, inspection, interaction, screenshots, and recordings.
+
+For browser work, first call \`preview_status\`. If no automation-capable preview is attached, call \`preview_open\` before concluding that the browser is unavailable. Then use \`preview_navigate\`, \`preview_snapshot\`, and the focused interaction tools. Prefer snapshot-provided locators over coordinates.
+
+Do not switch to global browser skills, Aside (\`aside exec\`, \`aside repl\`, or the Aside MCP \`repl\` tool), Chrome, Node REPL browser automation, standalone Playwright, or agent-browser merely because the preview is initially closed or a first call fails. Use an alternative browser system only when the T3 preview tools are absent, the user explicitly requests another browser, or \`preview_open\` returns an explicit unsupported/unavailable error. A failed T3 preview tool call should be inspected and retried with corrected arguments when the error is actionable.
+`;
+
+export function prefixHostBrowserToolInstructions(
+  userText: string,
+  options: { readonly includeBrowserTools: boolean },
+): string {
+  if (!options.includeBrowserTools) return userText;
+  const trimmed = userText.trim();
+  const block = HOST_BROWSER_TOOL_INSTRUCTIONS.trim();
+  return trimmed.length > 0 ? `${block}\n\n${trimmed}` : block;
+}

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -522,6 +522,7 @@ describe("T3 browser developer instructions", () => {
       NodeAssert.match(instructions, /preview_status/);
       NodeAssert.match(instructions, /preview_open/);
       NodeAssert.match(instructions, /Do not switch to global browser skills/);
+      NodeAssert.match(instructions, /Aside/);
     }
   });
 
@@ -532,7 +533,7 @@ describe("T3 browser developer instructions", () => {
     ]) {
       NodeAssert.doesNotMatch(instructions, /preview_status/);
       NodeAssert.doesNotMatch(instructions, /preview_open/);
-      NodeAssert.doesNotMatch(instructions, /T3 Code collaborative browser/);
+      NodeAssert.doesNotMatch(instructions, /T3 Code in-app browser/);
       // Steering away from other browser automation must go with the tools;
       // keeping it would leave the model talked out of its only option.
       NodeAssert.doesNotMatch(instructions, /Do not switch to global browser skills/);

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -1625,4 +1625,68 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
       McpProviderSession.clearMcpProviderSession(threadId);
     }),
   );
+
+  it.effect("prefixes browser instructions after an attachments-only first turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const serverSettings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-browser-image-first");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-acp-browser-image-first-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const argvLogPath = NodePath.join(tempDir, "argv.txt");
+      yield* Effect.promise(() => NodeFSP.writeFile(requestLogPath, "", "utf8"));
+      const wrapperPath = yield* Effect.promise(() =>
+        makeProbeWrapper(requestLogPath, argvLogPath),
+      );
+      yield* serverSettings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const { attachmentsDir } = yield* Effect.service(ServerConfig);
+      const attachmentId = "browser-prefix-shot";
+      yield* Effect.promise(async () => {
+        await NodeFSP.mkdir(attachmentsDir, { recursive: true });
+        await NodeFSP.writeFile(NodePath.join(attachmentsDir, `${attachmentId}.png`), "pixels");
+      });
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("cursor-browser-image-first-environment"),
+        threadId,
+        providerSessionId: "cursor-browser-image-first-provider-session",
+        providerInstanceId: ProviderInstanceId.make("cursor-browser-image-first-instance"),
+        endpoint: "http://127.0.0.1:43123/mcp",
+        authorizationHeader: "Bearer test-token",
+      });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "",
+        attachments: [
+          {
+            type: "image",
+            id: attachmentId,
+            name: "shot.png",
+            mimeType: "image/png",
+            sizeBytes: 6,
+          },
+        ],
+      });
+      yield* adapter.sendTurn({ threadId, input: "what is this", attachments: [] });
+
+      const prompts = promptTextsFromLog(
+        yield* Effect.promise(() => readJsonLines(requestLogPath)),
+      );
+      assert.equal(prompts.length, 2);
+      assert.equal(prompts[0], HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+      assert.equal(prompts[1], "what is this");
+
+      yield* adapter.stopSession(threadId);
+      McpProviderSession.clearMcpProviderSession(threadId);
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -110,7 +110,12 @@ function promptTextsFromLog(requests: ReadonlyArray<Record<string, unknown>>): s
     const prompt = (entry.params as { prompt?: ReadonlyArray<{ type?: string; text?: string }> })
       ?.prompt;
     return (prompt ?? [])
-      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .filter(
+        (part) =>
+          part.type === "text" &&
+          typeof part.text === "string" &&
+          !part.text.startsWith("<runtime_info>"),
+      )
       .map((part) => part.text ?? "");
   });
 }

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -19,6 +19,7 @@ import { createModelSelection } from "@t3tools/shared/model";
 import {
   ApprovalRequestId,
   CursorSettings,
+  EnvironmentId,
   ProviderDriverKind,
   type ProviderRuntimeEvent,
   ThreadId,
@@ -26,8 +27,10 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../../config.ts";
-import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { HOST_BROWSER_TOOL_INSTRUCTIONS } from "../HostBrowserToolInstructions.ts";
+import { buildRuntimeInstructions } from "../RuntimeInstructions.ts";
 import type { CursorAdapterShape } from "../Services/CursorAdapter.ts";
 import { makeCursorAdapter } from "./CursorAdapter.ts";
 const decodeCursorSettings = Schema.decodeSync(CursorSettings);
@@ -99,6 +102,17 @@ async function readJsonLines(filePath: string) {
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function promptTextsFromLog(requests: ReadonlyArray<Record<string, unknown>>): string[] {
+  return requests.flatMap((entry) => {
+    if (entry.method !== "session/prompt") return [];
+    const prompt = (entry.params as { prompt?: ReadonlyArray<{ type?: string; text?: string }> })
+      ?.prompt;
+    return (prompt ?? [])
+      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .map((part) => part.text ?? "");
+  });
 }
 
 async function waitForFileContent(filePath: string, attempts = 40) {
@@ -1563,5 +1577,52 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
       // they wait on virtual time that never advances, and a regression would
       // hang until the suite timeout instead of failing here.
     }).pipe(TestClock.withLive),
+  );
+
+  it.effect("prefixes in-app browser instructions only when preview MCP is attached", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const serverSettings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-browser-prefix");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-acp-browser-prefix-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const argvLogPath = NodePath.join(tempDir, "argv.txt");
+      yield* Effect.promise(() => NodeFSP.writeFile(requestLogPath, "", "utf8"));
+      const wrapperPath = yield* Effect.promise(() =>
+        makeProbeWrapper(requestLogPath, argvLogPath),
+      );
+      yield* serverSettings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("cursor-browser-prefix-environment"),
+        threadId,
+        providerSessionId: "cursor-browser-prefix-provider-session",
+        providerInstanceId: ProviderInstanceId.make("cursor-browser-prefix-instance"),
+        endpoint: "http://127.0.0.1:43123/mcp",
+        authorizationHeader: "Bearer test-token",
+      });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+      yield* adapter.sendTurn({ threadId, input: "open the app", attachments: [] });
+      yield* adapter.sendTurn({ threadId, input: "continue", attachments: [] });
+
+      const prompts = promptTextsFromLog(
+        yield* Effect.promise(() => readJsonLines(requestLogPath)),
+      );
+      assert.equal(prompts.length, 2);
+      assert.include(prompts[0], HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+      assert.match(prompts[0] ?? "", /open the app$/);
+      assert.equal(prompts[1], "continue");
+
+      yield* adapter.stopSession(threadId);
+      McpProviderSession.clearMcpProviderSession(threadId);
+    }),
   );
 });

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -995,16 +995,20 @@ export function makeCursorAdapter(
           }
 
           const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          const rawPrompt = input.input?.trim() ?? "";
+          const userText = input.input?.trim() ?? "";
           const includeBrowserTools =
             ctx.browserToolsAttached &&
             ctx.createdViaNewSession &&
             !ctx.browserInstructionsPrefixed &&
             steeringTurnId === undefined &&
-            (rawPrompt.length > 0 || (input.attachments?.length ?? 0) > 0);
-          if (rawPrompt.length > 0 || includeBrowserTools) {
+            (userText.length > 0 || (input.attachments?.length ?? 0) > 0);
+          if (userText.length > 0 || includeBrowserTools) {
             let cursorSkillNames = ctx.cursorSkillNames;
-            if (rawPrompt.length > 0 && hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
+            if (
+              userText.length > 0 &&
+              hasCursorSkillMention(userText) &&
+              cursorSkillNames === undefined
+            ) {
               const skills = yield* discoverCursorSkills(
                 ctx.session.cwd,
                 options?.environment,
@@ -1020,8 +1024,8 @@ export function makeCursorAdapter(
               ctx.cursorSkillNames = cursorSkillNames;
             }
             const prompt = cursorSkillNames
-              ? rewriteCursorSkillMentions(rawPrompt, cursorSkillNames)
-              : rawPrompt;
+              ? rewriteCursorSkillMentions(userText, cursorSkillNames)
+              : userText;
             promptParts.push({
               type: "text",
               text: prefixHostBrowserToolInstructions(prompt, { includeBrowserTools }),

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1000,7 +1000,6 @@ export function makeCursorAdapter(
             ctx.browserToolsAttached &&
             ctx.createdViaNewSession &&
             !ctx.browserInstructionsPrefixed &&
-            steeringTurnId === undefined &&
             (userText.length > 0 || (input.attachments?.length ?? 0) > 0);
           if (userText.length > 0 || includeBrowserTools) {
             let cursorSkillNames = ctx.cursorSkillNames;
@@ -1092,7 +1091,7 @@ export function makeCursorAdapter(
                 mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
               ),
             );
-          if (includeBrowserTools) {
+          if (includeBrowserTools && result.stopReason !== "cancelled") {
             ctx.browserInstructionsPrefixed = true;
           }
 

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -67,6 +67,7 @@ import {
 } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import { applyCursorAcpModelSelection, makeCursorAcpRuntime } from "../acp/CursorAcpSupport.ts";
+import { prefixHostBrowserToolInstructions } from "../HostBrowserToolInstructions.ts";
 import {
   CursorAskQuestionRequest,
   CursorCreatePlanRequest,
@@ -144,6 +145,12 @@ interface CursorSessionContext {
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
+  /** False when this process loaded an existing ACP session. */
+  readonly createdViaNewSession: boolean;
+  /** True when the product-native preview MCP server was attached at session start. */
+  readonly browserToolsAttached: boolean;
+  /** True after the first successful prompt that carried in-app browser steering. */
+  browserInstructionsPrefixed: boolean;
   stopped: boolean;
 }
 
@@ -788,6 +795,9 @@ export function makeCursorAdapter(
             activeTurnId: undefined,
             cursorSkillNames: undefined,
             promptsInFlight: 0,
+            createdViaNewSession: resumeSessionId === undefined,
+            browserToolsAttached: mcpSession !== undefined,
+            browserInstructionsPrefixed: false,
             stopped: false,
           };
 
@@ -924,16 +934,25 @@ export function makeCursorAdapter(
 
     const sendTurn: CursorAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
-        const ctx = yield* requireSession(input.threadId);
-        // A sendTurn while a prompt is in flight is a steer: the agent folds
-        // the new prompt into the ongoing work, so the active turn id is
-        // reused instead of opening a new turn.
-        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
-        const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
-        // Count this prompt immediately so a superseded in-flight prompt
-        // resolving from here on does not settle the turn; the matching
-        // decrement is the `ensuring` below.
-        ctx.promptsInFlight += 1;
+        const { ctx, steeringTurnId, turnId } = yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(input.threadId);
+            // Reserve the turn while holding the thread lock. Without this,
+            // two initial sends can both observe an idle session before the
+            // first one yields for its turn id and both start new turns.
+            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+            // Count this prompt immediately so a superseded in-flight prompt
+            // resolving from here on does not settle the turn; the matching
+            // decrement is the `ensuring` below.
+            ctx.promptsInFlight += 1;
+            if (steeringTurnId === undefined) {
+              ctx.activeTurnId = turnId;
+            }
+            return { ctx, steeringTurnId, turnId };
+          }),
+        );
 
         return yield* Effect.gen(function* () {
           const turnModelSelection =
@@ -977,9 +996,15 @@ export function makeCursorAdapter(
 
           const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
           const rawPrompt = input.input?.trim() ?? "";
-          if (rawPrompt) {
+          const includeBrowserTools =
+            ctx.browserToolsAttached &&
+            ctx.createdViaNewSession &&
+            !ctx.browserInstructionsPrefixed &&
+            steeringTurnId === undefined &&
+            (rawPrompt.length > 0 || (input.attachments?.length ?? 0) > 0);
+          if (rawPrompt.length > 0 || includeBrowserTools) {
             let cursorSkillNames = ctx.cursorSkillNames;
-            if (hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
+            if (rawPrompt.length > 0 && hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
               const skills = yield* discoverCursorSkills(
                 ctx.session.cwd,
                 options?.environment,
@@ -997,7 +1022,10 @@ export function makeCursorAdapter(
             const prompt = cursorSkillNames
               ? rewriteCursorSkillMentions(rawPrompt, cursorSkillNames)
               : rawPrompt;
-            promptParts.push({ type: "text", text: prompt });
+            promptParts.push({
+              type: "text",
+              text: prefixHostBrowserToolInstructions(prompt, { includeBrowserTools }),
+            });
           }
           if (input.attachments && input.attachments.length > 0) {
             for (const attachment of input.attachments) {
@@ -1060,6 +1088,9 @@ export function makeCursorAdapter(
                 mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
               ),
             );
+          if (includeBrowserTools) {
+            ctx.browserInstructionsPrefixed = true;
+          }
 
           const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
           if (turnRecord) {

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -934,25 +934,16 @@ export function makeCursorAdapter(
 
     const sendTurn: CursorAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
-        const { ctx, steeringTurnId, turnId } = yield* withThreadLock(
-          input.threadId,
-          Effect.gen(function* () {
-            const ctx = yield* requireSession(input.threadId);
-            // Reserve the turn while holding the thread lock. Without this,
-            // two initial sends can both observe an idle session before the
-            // first one yields for its turn id and both start new turns.
-            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
-            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
-            // Count this prompt immediately so a superseded in-flight prompt
-            // resolving from here on does not settle the turn; the matching
-            // decrement is the `ensuring` below.
-            ctx.promptsInFlight += 1;
-            if (steeringTurnId === undefined) {
-              ctx.activeTurnId = turnId;
-            }
-            return { ctx, steeringTurnId, turnId };
-          }),
-        );
+        const ctx = yield* requireSession(input.threadId);
+        // A sendTurn while a prompt is in flight is a steer: the agent folds
+        // the new prompt into the ongoing work, so the active turn id is
+        // reused instead of opening a new turn.
+        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+        const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+        // Count this prompt immediately so a superseded in-flight prompt
+        // resolving from here on does not settle the turn; the matching
+        // decrement is the `ensuring` below.
+        ctx.promptsInFlight += 1;
 
         return yield* Effect.gen(function* () {
           const turnModelSelection =

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -2515,4 +2515,64 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       McpProviderSession.clearMcpProviderSession(threadId);
     }),
   );
+
+  it.effect("prefixes browser instructions after an attachments-only first turn", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-browser-image-first");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-browser-image-first-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const { attachmentsDir } = yield* Effect.service(ServerConfig);
+      const attachmentId = "browser-prefix-shot";
+      yield* Effect.promise(async () => {
+        await NodeFSP.mkdir(attachmentsDir, { recursive: true });
+        await NodeFSP.writeFile(NodePath.join(attachmentsDir, `${attachmentId}.png`), "pixels");
+      });
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("grok-browser-image-first-environment"),
+        threadId,
+        providerSessionId: "grok-browser-image-first-provider-session",
+        providerInstanceId: ProviderInstanceId.make("grok-browser-image-first-instance"),
+        endpoint: "http://127.0.0.1:43123/mcp",
+        authorizationHeader: "Bearer test-token",
+      });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "",
+        attachments: [
+          {
+            type: "image",
+            id: attachmentId,
+            name: "shot.png",
+            mimeType: "image/png",
+            sizeBytes: 6,
+          },
+        ],
+      });
+      yield* adapter.sendTurn({ threadId, input: "what is this", attachments: [] });
+      yield* waitForFileContent(requestLogPath, 80, '"method":"session/prompt"');
+
+      const prompts = promptTextsFromLog(
+        yield* Effect.promise(() => readJsonLines(requestLogPath)),
+      );
+      assert.equal(prompts.length, 2);
+      assert.equal(prompts[0], HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+      assert.equal(prompts[1], "what is this");
+
+      yield* adapter.stopSession(threadId);
+      McpProviderSession.clearMcpProviderSession(threadId);
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -17,6 +17,7 @@ import * as TestClock from "effect/testing/TestClock";
 
 import {
   ApprovalRequestId,
+  EnvironmentId,
   GrokSettings,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -26,6 +27,8 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import { HOST_BROWSER_TOOL_INSTRUCTIONS } from "../HostBrowserToolInstructions.ts";
 import {
   grokPromptSettlementBelongsToContext,
   isGrokEnterPlanModeToolCall,
@@ -86,6 +89,17 @@ async function readJsonLines(filePath: string) {
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function promptTextsFromLog(requests: ReadonlyArray<Record<string, unknown>>): string[] {
+  return requests.flatMap((entry) => {
+    if (entry.method !== "session/prompt") return [];
+    const prompt = (entry.params as { prompt?: ReadonlyArray<{ type?: string; text?: string }> })
+      ?.prompt;
+    return (prompt ?? [])
+      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .map((part) => part.text ?? "");
+  });
 }
 
 const grokAdapterTestLayer = ServerConfig.layerTest(process.cwd(), {
@@ -2457,5 +2471,48 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       // they wait on virtual time that never advances, and a regression would
       // hang until the suite timeout instead of failing here.
     }).pipe(TestClock.withLive),
+  );
+
+  it.effect("prefixes in-app browser instructions on the first prompt when MCP is attached", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-browser-prefix");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-browser-prefix-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("grok-browser-prefix-environment"),
+        threadId,
+        providerSessionId: "grok-browser-prefix-provider-session",
+        providerInstanceId: ProviderInstanceId.make("grok-browser-prefix-instance"),
+        endpoint: "http://127.0.0.1:43123/mcp",
+        authorizationHeader: "Bearer test-token",
+      });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "open the app", attachments: [] });
+      yield* adapter.sendTurn({ threadId, input: "continue", attachments: [] });
+      yield* waitForFileContent(requestLogPath, 80, '"method":"session/prompt"');
+
+      const prompts = promptTextsFromLog(
+        yield* Effect.promise(() => readJsonLines(requestLogPath)),
+      );
+      assert.equal(prompts.length, 2);
+      assert.include(prompts[0], HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+      assert.match(prompts[0] ?? "", /open the app$/);
+      assert.equal(prompts[1], "continue");
+
+      yield* adapter.stopSession(threadId);
+      McpProviderSession.clearMcpProviderSession(threadId);
+    }),
   );
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -97,7 +97,12 @@ function promptTextsFromLog(requests: ReadonlyArray<Record<string, unknown>>): s
     const prompt = (entry.params as { prompt?: ReadonlyArray<{ type?: string; text?: string }> })
       ?.prompt;
     return (prompt ?? [])
-      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .filter(
+        (part) =>
+          part.type === "text" &&
+          typeof part.text === "string" &&
+          !part.text.startsWith("<runtime_info>"),
+      )
       .map((part) => part.text ?? "");
   });
 }

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -1130,6 +1130,14 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         }),
       );
       const adapter = yield* makeTestAdapter(wrapperPath);
+      McpProviderSession.setMcpProviderSession({
+        environmentId: EnvironmentId.make("grok-cancelled-browser-prefix-environment"),
+        threadId,
+        providerSessionId: "grok-cancelled-browser-prefix-provider-session",
+        providerInstanceId: ProviderInstanceId.make("grok-cancelled-browser-prefix-instance"),
+        endpoint: "http://127.0.0.1:43123/mcp",
+        authorizationHeader: "Bearer test-token",
+      });
 
       const runtimeEvents: ProviderRuntimeEvent[] = [];
       const firstTurnStarted = yield* Deferred.make<TurnId>();
@@ -1193,8 +1201,16 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       assert.equal(readySession?.status, "ready");
       assert.isUndefined(readySession?.activeTurnId);
 
+      const prompts = promptTextsFromLog(
+        yield* Effect.promise(() => readJsonLines(requestLogPath)),
+      );
+      assert.equal(prompts.length, 2);
+      assert.include(prompts[0], HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+      assert.include(prompts[1], HOST_BROWSER_TOOL_INSTRUCTIONS.trim());
+
       yield* Fiber.interrupt(runtimeEventsFiber);
       yield* adapter.stopSession(threadId);
+      McpProviderSession.clearMcpProviderSession(threadId);
     }).pipe(TestClock.withLive),
   );
 

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1810,9 +1810,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   detail: "Grok session changed before the turn completed.",
                 });
               }
-              if (prepared.prefixBrowserTools) {
-                ctx.browserInstructionsPrefixed = true;
-              }
               // Keep prompt settlement atomic with respect to Stop and steering.
               // interruptTurn marks its target before waiting for this lock, so
               // cancellation can still win while queued ACP events are drained.
@@ -1844,6 +1841,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               }
 
               appendPromptResultToTurn(ctx, prepared.turnId, prepared.promptParts, result);
+              if (prepared.prefixBrowserTools) {
+                ctx.browserInstructionsPrefixed = true;
+              }
               ctx.session = {
                 ...ctx.session,
                 status: "running",

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1532,7 +1532,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 ctx.browserToolsAttached &&
                 ctx.createdViaNewSession &&
                 !ctx.browserInstructionsPrefixed &&
-                steeringTurnId === undefined &&
                 (userText.length > 0 || (input.attachments?.length ?? 0) > 0);
               const text = includeBrowserTools
                 ? prefixHostBrowserToolInstructions(userText, { includeBrowserTools: true })
@@ -1841,7 +1840,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               }
 
               appendPromptResultToTurn(ctx, prepared.turnId, prepared.promptParts, result);
-              if (prepared.prefixBrowserTools) {
+              if (prepared.prefixBrowserTools && result.stopReason !== "cancelled") {
                 ctx.browserInstructionsPrefixed = true;
               }
               ctx.session = {
@@ -1950,6 +1949,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       prepared.promptParts,
                       promptResult,
                     );
+                    if (prepared.prefixBrowserTools && promptResult.stopReason !== "cancelled") {
+                      ctx.browserInstructionsPrefixed = true;
+                    }
                     yield* settlePromptInFlight(
                       input.threadId,
                       prepared.turnId,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -80,6 +80,7 @@ import {
   XAiExitPlanModeRequest,
 } from "../acp/XAiAcpExtension.ts";
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
+import { prefixHostBrowserToolInstructions } from "../HostBrowserToolInstructions.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
@@ -170,6 +171,12 @@ interface GrokSessionContext {
   promptResponsesReady: number;
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
+  /** False when this process loaded an existing ACP session. */
+  readonly createdViaNewSession: boolean;
+  /** True when the product-native preview MCP server was attached at session start. */
+  readonly browserToolsAttached: boolean;
+  /** True after the first successful prompt that carried in-app browser steering. */
+  browserInstructionsPrefixed: boolean;
   stopped: boolean;
 }
 
@@ -1301,6 +1308,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               requestedStartReasoningEffort !== undefined
                 ? normalizeGrokReasoningEffort(requestedStartReasoningEffort)
                 : currentStartReasoningEffort,
+            createdViaNewSession: resumeSessionId === undefined,
+            browserToolsAttached: mcpSession !== undefined,
+            browserInstructionsPrefixed: false,
             stopped: false,
           };
 
@@ -1517,7 +1527,16 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 "reasoningEffort",
               );
 
-              const text = input.input?.trim();
+              const userText = input.input?.trim() ?? "";
+              const includeBrowserTools =
+                ctx.browserToolsAttached &&
+                ctx.createdViaNewSession &&
+                !ctx.browserInstructionsPrefixed &&
+                steeringTurnId === undefined &&
+                (userText.length > 0 || (input.attachments?.length ?? 0) > 0);
+              const text = includeBrowserTools
+                ? prefixHostBrowserToolInstructions(userText, { includeBrowserTools: true })
+                : userText;
               // Grok ingests images only. Generic files reach the agent
               // through the path line ProviderService puts in the prompt.
               const imagePromptParts = yield* Effect.forEach(
@@ -1649,6 +1668,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 promptEpoch,
                 promptLifecycle: ctx.promptLifecycle,
                 steeringTurnId,
+                prefixBrowserTools: includeBrowserTools,
               };
             }).pipe(
               Effect.tapCause(() =>
@@ -1789,6 +1809,9 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   method: "session/prompt",
                   detail: "Grok session changed before the turn completed.",
                 });
+              }
+              if (prepared.prefixBrowserTools) {
+                ctx.browserInstructionsPrefixed = true;
               }
               // Keep prompt settlement atomic with respect to Stop and steering.
               // interruptTurn marks its target before waiting for this lock, so


### PR DESCRIPTION
Asking Grok or Cursor to use the in-app browser did not bind them to `preview_*`. Codex already received that preference, but these providers could open Aside or another browser while the right-panel tab stayed empty.

The browser instruction block is now shared. Codex still receives it in developer instructions. Grok and Cursor receive it on the first new-session prompt when preview MCP is attached, including attachment-only turns. Cancelled or superseded prompts keep the instruction eligible until a non-cancelled prompt completes. Existing Cursor turn reservation and concurrency behavior is unchanged.

The `preview_status` and `preview_open` descriptions now identify the in-app browser and accurately describe preference-controlled visibility. Claude and OpenCode are unchanged because their provider integration paths differ.

Verification:

- 109 focused provider and preview-tool tests
- server typecheck
- targeted lint, formatting, and `git diff --check`

Originally implemented with Grok 4.6 through Grok CLI. Rebased and updated with GPT-5.6 Sol through Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer in-app browser in `GrokAdapter` and `CursorAdapter` first turns
> - Adds `HOST_BROWSER_TOOL_INSTRUCTIONS` in [HostBrowserToolInstructions.ts](https://github.com/pingdotgg/t3code/pull/8255/files#diff-87e088f1dc73ab0babf79037e096e35f451daf073bca25ef56e407df4beb2277) to direct browser work to the in-app browser via preview tools
> - `GrokAdapter` and `CursorAdapter` prepend this block to the first eligible turn (nonempty text or attachments) of a newly created session with attached preview MCP tools. Later turns and resumed sessions are not prefixed
> - Updates `preview_status` and `preview_open` tool definitions in [tools.ts](https://github.com/pingdotgg/t3code/pull/8255/files#diff-d7c6963f373bb55873fb4513dbf26923eb77ba575bc372d61d84743b26bd9676) to use "in-app browser" terminology and document the auto-show preference
> - Risk: If an eligible first turn is cancelled, `GrokAdapter.sendTurn` and `CursorAdapter.sendTurn` leave the prefix-unused flag false, so the block is prepended to a later turn
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a0ea4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->