### PR TITLE
fix(desktop): preview cookies no longer leak across projects

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -43,41 +43,75 @@ describe("preview IPC methods", () => {
   });
 
   it("derives distinct partition scopes when identifiers contain the delimiter", () => {
-    const first = PreviewIpc.resolvePartitionScope("a", "b::c");
-    const second = PreviewIpc.resolvePartitionScope("a::b", "c");
+    const first = PreviewIpc.resolvePartitionScope("a", "project", "b::c");
+    const second = PreviewIpc.resolvePartitionScope("a::b", "project", "c");
 
-    expect(first).toEqual({ scope: '["a","b::c"]', persistent: true, namespace: "profile" });
-    expect(second).toEqual({ scope: '["a::b","c"]', persistent: true, namespace: "profile" });
+    expect(first).toEqual({
+      scope: JSON.stringify([JSON.stringify(["a", "project"]), "b::c"]),
+      persistent: true,
+      namespace: "profile",
+    });
+    expect(second).toEqual({
+      scope: JSON.stringify([JSON.stringify(["a::b", "project"]), "c"]),
+      persistent: true,
+      namespace: "profile",
+    });
     expect(first.scope).not.toBe(second.scope);
   });
 
   it("preserves lone surrogates without collapsing them to replacement characters", () => {
-    const highSurrogate = PreviewIpc.resolvePartitionScope("environment", "profile-\ud800");
-    const lowSurrogate = PreviewIpc.resolvePartitionScope("environment", "profile-\udc00");
-    const replacement = PreviewIpc.resolvePartitionScope("environment", "profile-�");
+    const highSurrogate = PreviewIpc.resolvePartitionScope(
+      "environment",
+      "project",
+      "profile-\ud800",
+    );
+    const lowSurrogate = PreviewIpc.resolvePartitionScope(
+      "environment",
+      "project",
+      "profile-\udc00",
+    );
+    const replacement = PreviewIpc.resolvePartitionScope("environment", "project", "profile-�");
 
-    expect(highSurrogate.scope).toBe('["environment","profile-\\ud800"]');
-    expect(lowSurrogate.scope).toBe('["environment","profile-\\udc00"]');
+    expect(highSurrogate.scope).toBe(
+      JSON.stringify([JSON.stringify(["environment", "project"]), "profile-\ud800"]),
+    );
+    expect(lowSurrogate.scope).toBe(
+      JSON.stringify([JSON.stringify(["environment", "project"]), "profile-\udc00"]),
+    );
     expect(highSurrogate.scope).not.toBe(lowSurrogate.scope);
     expect(highSurrogate.scope).not.toBe(replacement.scope);
     expect(lowSurrogate.scope).not.toBe(replacement.scope);
   });
 
-  it("keeps the legacy default partition scope and incognito persistence", () => {
-    expect(PreviewIpc.resolvePartitionScope("environment::legacy", undefined)).toEqual({
-      scope: "environment::legacy",
+  it("keeps the default partition persistent and separates incognito", () => {
+    expect(PreviewIpc.resolvePartitionScope("environment::legacy", "project", undefined)).toEqual({
+      scope: '["environment::legacy","project"]',
       persistent: true,
     });
     expect(
-      PreviewIpc.resolvePartitionScope("environment::legacy", DEFAULT_BROWSER_PROFILE_ID),
-    ).toEqual({ scope: "environment::legacy", persistent: true });
-    expect(
-      PreviewIpc.resolvePartitionScope("environment::legacy", INCOGNITO_BROWSER_PROFILE_ID),
+      PreviewIpc.resolvePartitionScope("environment::legacy", "project", DEFAULT_BROWSER_PROFILE_ID),
     ).toEqual({
-      scope: '["environment::legacy","incognito"]',
+      scope: '["environment::legacy","project"]',
+      persistent: true,
+    });
+    expect(
+      PreviewIpc.resolvePartitionScope("environment::legacy", "project", INCOGNITO_BROWSER_PROFILE_ID),
+    ).toEqual({
+      scope: JSON.stringify([
+        '["environment::legacy","project"]',
+        "incognito",
+      ]),
       persistent: false,
       namespace: "profile",
     });
+  });
+
+  it("keeps projects in one environment on separate default partitions", () => {
+    expect(
+      PreviewIpc.resolvePartitionScope("environment", "project-a", DEFAULT_BROWSER_PROFILE_ID),
+    ).not.toEqual(
+      PreviewIpc.resolvePartitionScope("environment", "project-b", DEFAULT_BROWSER_PROFILE_ID),
+    );
   });
 
   effectIt.effect("rejects invalid webContents ids before resolving the preview service", () =>

--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -89,18 +89,23 @@ describe("preview IPC methods", () => {
       persistent: true,
     });
     expect(
-      PreviewIpc.resolvePartitionScope("environment::legacy", "project", DEFAULT_BROWSER_PROFILE_ID),
+      PreviewIpc.resolvePartitionScope(
+        "environment::legacy",
+        "project",
+        DEFAULT_BROWSER_PROFILE_ID,
+      ),
     ).toEqual({
       scope: '["environment::legacy","project"]',
       persistent: true,
     });
     expect(
-      PreviewIpc.resolvePartitionScope("environment::legacy", "project", INCOGNITO_BROWSER_PROFILE_ID),
+      PreviewIpc.resolvePartitionScope(
+        "environment::legacy",
+        "project",
+        INCOGNITO_BROWSER_PROFILE_ID,
+      ),
     ).toEqual({
-      scope: JSON.stringify([
-        '["environment::legacy","project"]',
-        "incognito",
-      ]),
+      scope: JSON.stringify(['["environment::legacy","project"]', "incognito"]),
       persistent: false,
       namespace: "profile",
     });

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -22,6 +22,8 @@ import {
   DesktopPreviewWebviewConfigSchema,
   PreviewAnnotationSubmissionResultSchema,
   PreviewAutomationSnapshot,
+  EnvironmentId,
+  ProjectId,
   DEFAULT_BROWSER_PROFILE_ID,
   INCOGNITO_BROWSER_PROFILE_ID,
 } from "@t3tools/contracts";
@@ -246,7 +248,10 @@ export function resolvePartitionScope(
   readonly persistent: boolean;
   readonly namespace?: "profile";
 } {
-  const projectScope = previewBrowserScope(environmentId, projectId);
+  const projectScope = previewBrowserScope(
+    EnvironmentId.make(environmentId),
+    ProjectId.make(projectId),
+  );
   if (profileId === undefined || profileId === DEFAULT_BROWSER_PROFILE_ID) {
     return { scope: projectScope, persistent: true };
   }
@@ -260,17 +265,42 @@ export function resolvePartitionScope(
   };
 }
 
+const resolveLegacyPartitionScope = (
+  environmentId: string,
+  profileId: string | undefined,
+): {
+  readonly scope: string;
+  readonly persistent: boolean;
+  readonly namespace?: "profile";
+} => {
+  if (profileId === undefined || profileId === DEFAULT_BROWSER_PROFILE_ID) {
+    return { scope: environmentId, persistent: true };
+  }
+  return {
+    scope: JSON.stringify([environmentId, profileId]),
+    persistent: profileId !== INCOGNITO_BROWSER_PROFILE_ID,
+    namespace: "profile",
+  };
+};
+
 /**
  * Resolve the one partition addressed by a clear action. The default profile
- * is explicit when the profile field is omitted, so a clear from one project
- * cannot reach another project's or another profile's storage.
+ * is explicit when the profile field is omitted, so a project-aware clear
+ * cannot reach another project's or another profile's storage. Calls without
+ * a project retain the profile settings' pre-project compatibility path.
  */
 const resolveClearPartitions = Effect.fn("desktop.ipc.preview.resolveClearPartitions")(function* (
   manager: PreviewManager.PreviewManager["Service"],
   environmentId: string,
-  projectId: string,
+  projectId: string | undefined,
   profileId: string | undefined,
 ) {
+  if (projectId === undefined) {
+    if (profileId === undefined) return undefined;
+    const { scope, persistent, namespace } = resolveLegacyPartitionScope(environmentId, profileId);
+    yield* manager.getBrowserSession(scope, persistent, namespace);
+    return [yield* manager.getBrowserPartition(scope, persistent, namespace)];
+  }
   const { scope, persistent, namespace } = resolvePartitionScope(
     environmentId,
     projectId,

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -31,6 +31,7 @@ import * as NodeURL from "node:url";
 
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import * as PreviewManager from "../../preview/Manager.ts";
+import { previewBrowserScope } from "@t3tools/shared/preview";
 import { PREVIEW_WEBVIEW_PREFERENCES } from "../../preview/WebviewPreferences.ts";
 import * as IpcChannels from "../channels.ts";
 import * as DesktopIpc from "../DesktopIpc.ts";
@@ -201,9 +202,15 @@ export const clearCookies = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL,
   payload: DesktopPreviewClearDataInputSchema,
   result: Schema.Void,
-  handler: Effect.fn("desktop.ipc.preview.clearCookies")(function* ({ environmentId, profileId }) {
+  handler: Effect.fn("desktop.ipc.preview.clearCookies")(function* ({
+    environmentId,
+    projectId,
+    profileId,
+  }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.clearCookies(yield* resolveClearPartitions(manager, environmentId, profileId));
+    yield* manager.clearCookies(
+      yield* resolveClearPartitions(manager, environmentId, projectId, profileId),
+    );
   }),
 });
 
@@ -211,52 +218,64 @@ export const clearCache = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL,
   payload: DesktopPreviewClearDataInputSchema,
   result: Schema.Void,
-  handler: Effect.fn("desktop.ipc.preview.clearCache")(function* ({ environmentId, profileId }) {
+  handler: Effect.fn("desktop.ipc.preview.clearCache")(function* ({
+    environmentId,
+    projectId,
+    profileId,
+  }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.clearCache(yield* resolveClearPartitions(manager, environmentId, profileId));
+    yield* manager.clearCache(
+      yield* resolveClearPartitions(manager, environmentId, projectId, profileId),
+    );
   }),
 });
 
 /**
- * Partition scope for an (environment, profile) pair.
+ * Partition scope for an (environment, project, profile) tuple.
  *
- * The default profile keeps the bare environment id it used before profiles
- * existed, so upgrading does not strand anyone's existing logins in an
- * orphaned partition. Incognito derives a non-persistent partition.
+ * The default profile keeps the project-scoped partition. Incognito derives a
+ * non-persistent partition, and named profiles get a separate namespace so
+ * their storage cannot overlap with either the default or another profile.
  */
 export function resolvePartitionScope(
   environmentId: string,
+  projectId: string,
   profileId: string | undefined,
 ): {
   readonly scope: string;
   readonly persistent: boolean;
   readonly namespace?: "profile";
 } {
+  const projectScope = previewBrowserScope(environmentId, projectId);
   if (profileId === undefined || profileId === DEFAULT_BROWSER_PROFILE_ID) {
-    return { scope: environmentId, persistent: true };
+    return { scope: projectScope, persistent: true };
   }
   // JSON's tuple framing is injective for strings, including lone UTF-16
   // surrogates (which it escapes). URI encoding throws on those supported ids,
   // while replacing them with U+FFFD would collapse distinct identities.
   return {
-    scope: JSON.stringify([environmentId, profileId]),
+    scope: JSON.stringify([projectScope, profileId]),
     persistent: profileId !== INCOGNITO_BROWSER_PROFILE_ID,
     namespace: "profile" as const,
   };
 }
 
 /**
- * Clearing without a profile keeps the historical "everything" behaviour for
- * an explicit all-profiles action; naming a profile confines it to that
- * profile's partition so one profile's sign-out cannot reach the others.
+ * Resolve the one partition addressed by a clear action. The default profile
+ * is explicit when the profile field is omitted, so a clear from one project
+ * cannot reach another project's or another profile's storage.
  */
 const resolveClearPartitions = Effect.fn("desktop.ipc.preview.resolveClearPartitions")(function* (
   manager: PreviewManager.PreviewManager["Service"],
   environmentId: string,
+  projectId: string,
   profileId: string | undefined,
 ) {
-  if (profileId === undefined) return undefined;
-  const { scope, persistent, namespace } = resolvePartitionScope(environmentId, profileId);
+  const { scope, persistent, namespace } = resolvePartitionScope(
+    environmentId,
+    projectId,
+    profileId,
+  );
   // Loading the session is what puts the partition in the map the clear walks.
   // Deriving the partition string alone leaves nothing to match, so clearing a
   // profile with no tab open this run — after a restart, or when deleting a
@@ -269,9 +288,17 @@ export const getPreviewConfig = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_GET_CONFIG_CHANNEL,
   payload: DesktopPreviewConfigInputSchema,
   result: DesktopPreviewWebviewConfigSchema,
-  handler: Effect.fn("desktop.ipc.preview.getConfig")(function* ({ environmentId, profileId }) {
+  handler: Effect.fn("desktop.ipc.preview.getConfig")(function* ({
+    environmentId,
+    projectId,
+    profileId,
+  }) {
     const manager = yield* PreviewManager.PreviewManager;
-    const { scope, persistent, namespace } = resolvePartitionScope(environmentId, profileId);
+    const { scope, persistent, namespace } = resolvePartitionScope(
+      environmentId,
+      projectId,
+      profileId,
+    );
     // Creating the session first is what installs the UA rewrite and permission
     // handlers; a guest that attached to an untouched partition would run with
     // Electron's default UA and Chromium's default permission behaviour.

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -223,12 +223,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.invoke(IpcChannels.PREVIEW_SET_AUDIO_MUTED_CHANNEL, { tabId, audioMuted }),
     openDevTools: (tabId) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_OPEN_DEVTOOLS_CHANNEL, { tabId }),
-    clearCookies: (environmentId, profileId) =>
-      ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL, { environmentId, profileId }),
-    clearCache: (environmentId, profileId) =>
-      ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL, { environmentId, profileId }),
-    getPreviewConfig: (environmentId, profileId) =>
-      ipcRenderer.invoke(IpcChannels.PREVIEW_GET_CONFIG_CHANNEL, { environmentId, profileId }),
+    clearCookies: (input) => ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL, input),
+    clearCache: (input) => ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL, input),
+    getPreviewConfig: (input) => ipcRenderer.invoke(IpcChannels.PREVIEW_GET_CONFIG_CHANNEL, input),
     setAnnotationTheme: (theme) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_SET_ANNOTATION_THEME_CHANNEL, { theme }),
     pickElement: (tabId) => ipcRenderer.invoke(IpcChannels.PREVIEW_PICK_ELEMENT_CHANNEL, { tabId }),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -223,8 +223,18 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.invoke(IpcChannels.PREVIEW_SET_AUDIO_MUTED_CHANNEL, { tabId, audioMuted }),
     openDevTools: (tabId) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_OPEN_DEVTOOLS_CHANNEL, { tabId }),
-    clearCookies: (input) => ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL, input),
-    clearCache: (input) => ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL, input),
+    clearCookies: (environmentId, profileId, projectId) =>
+      ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL, {
+        environmentId,
+        profileId,
+        projectId,
+      }),
+    clearCache: (environmentId, profileId, projectId) =>
+      ipcRenderer.invoke(IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL, {
+        environmentId,
+        profileId,
+        projectId,
+      }),
     getPreviewConfig: (input) => ipcRenderer.invoke(IpcChannels.PREVIEW_GET_CONFIG_CHANNEL, input),
     setAnnotationTheme: (theme) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_SET_ANNOTATION_THEME_CHANNEL, { theme }),

--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -1,5 +1,7 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { previewBrowserScope } from "@t3tools/shared/preview";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -219,6 +221,33 @@ describe("BrowserSession", () => {
         `Failed to create a desktop preview browser session for scope environment-b (partition ${partition}).`,
       );
       assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("isolates partitions by environment and project", () =>
+    Effect.gen(function* () {
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const projectA = previewBrowserScope(
+        EnvironmentId.make("environment-a"),
+        ProjectId.make("project-1"),
+      );
+      const projectB = previewBrowserScope(
+        EnvironmentId.make("environment-a"),
+        ProjectId.make("project-2"),
+      );
+      const first = yield* browserSessions.getPartition(projectA);
+      const second = yield* browserSessions.getPartition(projectB);
+      const third = yield* browserSessions.getPartition("environment-a");
+      const colonLeft = yield* browserSessions.getPartition(
+        previewBrowserScope(EnvironmentId.make("a:b"), ProjectId.make("c")),
+      );
+      const colonRight = yield* browserSessions.getPartition(
+        previewBrowserScope(EnvironmentId.make("a"), ProjectId.make("b:c")),
+      );
+      assert.notEqual(first, second);
+      assert.notEqual(first, third);
+      assert.notEqual(second, third);
+      assert.notEqual(colonLeft, colonRight);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -63,6 +63,19 @@ describe("BrowserSession", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("keeps project-scoped preview partitions isolated", () =>
+    Effect.gen(function* () {
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const projectA = JSON.stringify(["environment-a", "project-a"]);
+      const projectB = JSON.stringify(["environment-a", "project-b"]);
+
+      assert.notStrictEqual(
+        yield* browserSessions.getPartition(projectA),
+        yield* browserSessions.getPartition(projectB),
+      );
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("keeps scopes that differ only by a lone surrogate in separate partitions", () =>
     Effect.gen(function* () {
       const browserSessions = yield* BrowserSession.BrowserSession;

--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -65,19 +65,6 @@ describe("BrowserSession", () => {
     }).pipe(Effect.provide(layer)),
   );
 
-  it.effect("keeps project-scoped preview partitions isolated", () =>
-    Effect.gen(function* () {
-      const browserSessions = yield* BrowserSession.BrowserSession;
-      const projectA = JSON.stringify(["environment-a", "project-a"]);
-      const projectB = JSON.stringify(["environment-a", "project-b"]);
-
-      assert.notStrictEqual(
-        yield* browserSessions.getPartition(projectA),
-        yield* browserSessions.getPartition(projectB),
-      );
-    }).pipe(Effect.provide(layer)),
-  );
-
   it.effect("keeps scopes that differ only by a lone surrogate in separate partitions", () =>
     Effect.gen(function* () {
       const browserSessions = yield* BrowserSession.BrowserSession;

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -333,7 +333,6 @@ export const make = Effect.gen(function* () {
     Electron.BrowserWindow,
     DesktopWindowError
   > {
-    yield* previewManager.getBrowserSession();
     const applicationUrl = getDesktopUrl(environment.isDevelopment);
     const iconPaths = yield* assets.iconPaths;
     const iconOption = getIconOption(iconPaths, environment.platform);

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -70,7 +70,6 @@ export function HostedBrowserWebview(props: {
   } = props;
   const projectId = usePreviewProjectId(threadRef);
   const config = usePreviewWebviewConfig(threadRef.environmentId, projectId, profileId);
-  const [initialSrc] = useState(() => initialUrl ?? "about:blank");
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const webviewRef = useRef<ElectronWebview | null>(null);
@@ -106,12 +105,7 @@ export function HostedBrowserWebview(props: {
   }, [runtimeTabId]);
 
   const [webviewGeneration, setWebviewGeneration] = useState(0);
-  const latestUrlRef = useRef(initialUrl);
   const guestSrcRef = useRef<{ readonly key: string; readonly src: string } | null>(null);
-
-  useEffect(() => {
-    latestUrlRef.current = initialUrl;
-  }, [initialUrl]);
 
   const setWebviewRef = useCallback((node: HTMLElement | null) => {
     webviewRef.current = node as ElectronWebview | null;
@@ -165,7 +159,7 @@ export function HostedBrowserWebview(props: {
       webview.removeEventListener("dom-ready", register);
       webview.removeEventListener("render-process-gone", recoverGuest);
     };
-  }, [config, initialSrc, runtimeTabId, webviewGeneration]);
+  }, [config, runtimeTabId, webviewGeneration]);
 
   const active = presentation.visible && presentation.rect !== null;
   const lastRect = presentation.rect;
@@ -268,7 +262,7 @@ export function HostedBrowserWebview(props: {
   guestSrcRef.current = latchHostedBrowserWebviewSrc(
     guestSrcRef.current,
     webviewKey,
-    latestUrlRef.current ?? initialSrc,
+    initialUrl ?? "about:blank",
   );
   const webviewSrc = guestSrcRef.current.src;
 

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -7,7 +7,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { previewBridge } from "~/components/preview/previewBridge";
 import { usePreviewBridge } from "~/components/preview/usePreviewBridge";
 import { cn, isMacPlatform } from "~/lib/utils";
-import { useThreadShell } from "~/state/entities";
 
 import { resolveBrowserSurfacePanelRect, useBrowserSurfaceStore } from "./browserSurfaceStore";
 import { useActiveBrowserRecordingTabIds } from "./browserRecording";
@@ -20,6 +19,7 @@ import { BrowserDeviceToolbar } from "./BrowserDeviceToolbar";
 import { BrowserViewportResizeHandles } from "./BrowserViewportResizeHandles";
 import { acquireDesktopTab, type AcquiredDesktopTab } from "./desktopTabLifetime";
 import { resolveHostedBrowserWebviewWrapperStyle } from "./hostedBrowserWebviewStyle";
+import { usePreviewProjectId } from "./previewProjectId";
 import { usePreviewWebviewConfig } from "./previewWebviewConfigState";
 import { useBrowserViewportResize } from "./useBrowserViewportResize";
 import {
@@ -67,12 +67,8 @@ export function HostedBrowserWebview(props: {
     zoomFactor,
     profileId,
   } = props;
-  const threadShell = useThreadShell(threadRef);
-  const config = usePreviewWebviewConfig(
-    threadRef.environmentId,
-    threadShell?.projectId ?? null,
-    profileId,
-  );
+  const projectId = usePreviewProjectId(threadRef);
+  const config = usePreviewWebviewConfig(threadRef.environmentId, projectId, profileId);
   const [initialSrc] = useState(() => initialUrl ?? "about:blank");
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { previewBridge } from "~/components/preview/previewBridge";
 import { usePreviewBridge } from "~/components/preview/usePreviewBridge";
 import { cn, isMacPlatform } from "~/lib/utils";
+import { useThreadShell } from "~/state/entities";
 
 import { resolveBrowserSurfacePanelRect, useBrowserSurfaceStore } from "./browserSurfaceStore";
 import { useActiveBrowserRecordingTabIds } from "./browserRecording";
@@ -66,7 +67,12 @@ export function HostedBrowserWebview(props: {
     zoomFactor,
     profileId,
   } = props;
-  const config = usePreviewWebviewConfig(threadRef.environmentId, profileId);
+  const threadShell = useThreadShell(threadRef);
+  const config = usePreviewWebviewConfig(
+    threadRef.environmentId,
+    threadShell?.projectId ?? null,
+    profileId,
+  );
   const [initialSrc] = useState(() => initialUrl ?? "about:blank");
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -18,6 +18,7 @@ import {
 import { BrowserDeviceToolbar } from "./BrowserDeviceToolbar";
 import { BrowserViewportResizeHandles } from "./BrowserViewportResizeHandles";
 import { acquireDesktopTab, type AcquiredDesktopTab } from "./desktopTabLifetime";
+import { hostedBrowserWebviewKey, latchHostedBrowserWebviewSrc } from "./hostedBrowserWebviewGuest";
 import { resolveHostedBrowserWebviewWrapperStyle } from "./hostedBrowserWebviewStyle";
 import { usePreviewProjectId } from "./previewProjectId";
 import { usePreviewWebviewConfig } from "./previewWebviewConfigState";
@@ -105,8 +106,8 @@ export function HostedBrowserWebview(props: {
   }, [runtimeTabId]);
 
   const [webviewGeneration, setWebviewGeneration] = useState(0);
-  const [recoverySrc, setRecoverySrc] = useState(initialSrc);
   const latestUrlRef = useRef(initialUrl);
+  const guestSrcRef = useRef<{ readonly key: string; readonly src: string } | null>(null);
 
   useEffect(() => {
     latestUrlRef.current = initialUrl;
@@ -149,7 +150,6 @@ export function HostedBrowserWebview(props: {
       recoveryTimeout = setTimeout(() => {
         recoveryTimeout = null;
         if (!disposed) {
-          setRecoverySrc(latestUrlRef.current ?? initialSrc);
           setWebviewGeneration((generation) => generation + 1);
         }
       }, recovery.delayMs);
@@ -264,10 +264,13 @@ export function HostedBrowserWebview(props: {
     rect: lastRect,
     hiddenSize,
   });
-  // Electron applies `partition` only at guest creation. Key it so a project
-  // change remounts instead of keeping the old cookie jar.
-  const webviewKey = `${config.partition}:${webviewGeneration}`;
-  const webviewSrc = webviewGeneration === 0 ? (latestUrlRef.current ?? initialSrc) : recoverySrc;
+  const webviewKey = hostedBrowserWebviewKey(config.partition, webviewGeneration);
+  guestSrcRef.current = latchHostedBrowserWebviewSrc(
+    guestSrcRef.current,
+    webviewKey,
+    latestUrlRef.current ?? initialSrc,
+  );
+  const webviewSrc = guestSrcRef.current.src;
 
   return (
     <div

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -264,6 +264,10 @@ export function HostedBrowserWebview(props: {
     rect: lastRect,
     hiddenSize,
   });
+  // Electron applies `partition` only at guest creation. Key it so a project
+  // change remounts instead of keeping the old cookie jar.
+  const webviewKey = `${config.partition}:${webviewGeneration}`;
+  const webviewSrc = webviewGeneration === 0 ? (latestUrlRef.current ?? initialSrc) : recoverySrc;
 
   return (
     <div
@@ -285,7 +289,7 @@ export function HostedBrowserWebview(props: {
           />
         ) : null}
         <webview
-          key={webviewGeneration}
+          key={webviewKey}
           ref={setWebviewRef}
           // Must be an attribute on the element itself: Electron reads it when the
           // guest attaches, so setting it from the ref callback lands too late and
@@ -293,7 +297,7 @@ export function HostedBrowserWebview(props: {
           // boolean, but react-dom drops boolean values for unrecognized attributes,
           // so the literal string has to be spread past the type.
           {...({ allowpopups: "true" } as unknown as { readonly allowpopups?: boolean })}
-          src={webviewGeneration === 0 ? initialSrc : recoverySrc}
+          src={webviewSrc}
           partition={config.partition}
           webpreferences={config.webPreferences}
           {...(config.preloadUrl ? { preload: config.preloadUrl } : {})}

--- a/apps/web/src/browser/hostedBrowserWebviewGuest.test.ts
+++ b/apps/web/src/browser/hostedBrowserWebviewGuest.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { hostedBrowserWebviewKey, latchHostedBrowserWebviewSrc } from "./hostedBrowserWebviewGuest";
+
+describe("hostedBrowserWebviewKey", () => {
+  it("changes when the partition or generation changes", () => {
+    expect(hostedBrowserWebviewKey("persist:a", 0)).not.toBe(
+      hostedBrowserWebviewKey("persist:b", 0),
+    );
+    expect(hostedBrowserWebviewKey("persist:a", 0)).not.toBe(
+      hostedBrowserWebviewKey("persist:a", 1),
+    );
+  });
+});
+
+describe("latchHostedBrowserWebviewSrc", () => {
+  it("captures src when the guest key changes", () => {
+    expect(latchHostedBrowserWebviewSrc(null, "persist:a:0", "https://a.example/")).toEqual({
+      key: "persist:a:0",
+      src: "https://a.example/",
+    });
+  });
+
+  it("keeps the latched src for the same guest", () => {
+    const latched = { key: "persist:a:0", src: "https://a.example/" };
+    expect(latchHostedBrowserWebviewSrc(latched, "persist:a:0", "https://b.example/")).toBe(
+      latched,
+    );
+  });
+
+  it("takes the current url when the guest remounts", () => {
+    const latched = { key: "persist:a:0", src: "https://a.example/" };
+    expect(latchHostedBrowserWebviewSrc(latched, "persist:b:0", "https://b.example/")).toEqual({
+      key: "persist:b:0",
+      src: "https://b.example/",
+    });
+  });
+});

--- a/apps/web/src/browser/hostedBrowserWebviewGuest.ts
+++ b/apps/web/src/browser/hostedBrowserWebviewGuest.ts
@@ -1,0 +1,16 @@
+/**
+ * Electron applies `partition` and `src` only when the guest is created.
+ * Key the element by partition so a project change remounts. Latch `src` to
+ * that key so later React renders cannot rewrite it and trigger loadURL.
+ */
+export function hostedBrowserWebviewKey(partition: string, generation: number): string {
+  return `${partition}:${generation}`;
+}
+
+export function latchHostedBrowserWebviewSrc(
+  latched: { readonly key: string; readonly src: string } | null,
+  key: string,
+  src: string,
+): { readonly key: string; readonly src: string } {
+  return latched?.key === key ? latched : { key, src };
+}

--- a/apps/web/src/browser/hostedBrowserWebviewGuest.ts
+++ b/apps/web/src/browser/hostedBrowserWebviewGuest.ts
@@ -1,7 +1,8 @@
 /**
- * Electron applies `partition` and `src` only when the guest is created.
- * Key the element by partition so a project change remounts. Latch `src` to
- * that key so later React renders cannot rewrite it and trigger loadURL.
+ * Electron treats `partition` and `src` as constructor inputs. Changing `src`
+ * after attach triggers navigation. Key the element by partition so a project
+ * change remounts. Latch `src` to that key so later React renders cannot
+ * rewrite it.
  */
 export function hostedBrowserWebviewKey(partition: string, generation: number): string {
   return `${partition}:${generation}`;

--- a/apps/web/src/browser/previewProjectId.test.ts
+++ b/apps/web/src/browser/previewProjectId.test.ts
@@ -1,0 +1,24 @@
+import { ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolvePreviewProjectId } from "./previewProjectId";
+
+describe("resolvePreviewProjectId", () => {
+  it("prefers the server shell over a draft", () => {
+    expect(
+      resolvePreviewProjectId(ProjectId.make("shell-project"), ProjectId.make("draft-project")),
+    ).toBe("shell-project");
+  });
+
+  it("uses the draft when no shell has loaded", () => {
+    expect(resolvePreviewProjectId(null, ProjectId.make("draft-project"))).toBe("draft-project");
+    expect(resolvePreviewProjectId(undefined, ProjectId.make("draft-project"))).toBe(
+      "draft-project",
+    );
+  });
+
+  it("stays null when neither source has a project", () => {
+    expect(resolvePreviewProjectId(null, null)).toBeNull();
+    expect(resolvePreviewProjectId(undefined, undefined)).toBeNull();
+  });
+});

--- a/apps/web/src/browser/previewProjectId.ts
+++ b/apps/web/src/browser/previewProjectId.ts
@@ -1,0 +1,23 @@
+import type { ProjectId, ScopedThreadRef } from "@t3tools/contracts";
+
+import { useComposerDraftStore } from "~/composerDraftStore";
+import { useThreadShell } from "~/state/entities";
+
+/**
+ * Server shells win. Drafts keep a projectId before the orchestration shell
+ * exists, so preview partitions can still mount on a local draft thread.
+ */
+export function resolvePreviewProjectId(
+  shellProjectId: ProjectId | null | undefined,
+  draftProjectId: ProjectId | null | undefined,
+): ProjectId | null {
+  return shellProjectId ?? draftProjectId ?? null;
+}
+
+export function usePreviewProjectId(threadRef: ScopedThreadRef): ProjectId | null {
+  const threadShell = useThreadShell(threadRef);
+  const draftProjectId = useComposerDraftStore(
+    (store) => store.getDraftThreadByRef(threadRef)?.projectId ?? null,
+  );
+  return resolvePreviewProjectId(threadShell?.projectId, draftProjectId);
+}

--- a/apps/web/src/browser/previewProjectRefs.ts
+++ b/apps/web/src/browser/previewProjectRefs.ts
@@ -1,0 +1,14 @@
+import { scopedProjectKey } from "@t3tools/client-runtime/environment";
+import type { ScopedProjectRef } from "@t3tools/contracts";
+
+// Project atoms forget a project after deletion, but its preview partition can
+// still need to be cleared when a browser profile is removed later in this run.
+const rememberedPreviewProjectRefs = new Map<string, ScopedProjectRef>();
+
+export function rememberPreviewProjectRef(ref: ScopedProjectRef): void {
+  rememberedPreviewProjectRefs.set(scopedProjectKey(ref), ref);
+}
+
+export function readRememberedPreviewProjectRefs(): ReadonlyArray<ScopedProjectRef> {
+  return [...rememberedPreviewProjectRefs.values()];
+}

--- a/apps/web/src/browser/previewWebviewConfigState.test.ts
+++ b/apps/web/src/browser/previewWebviewConfigState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 
 import {
@@ -9,17 +9,20 @@ import {
 } from "./previewWebviewConfigState";
 
 const environmentId = EnvironmentId.make("environment-1");
+const projectId = ProjectId.make("project-1");
 
 describe("loadPreviewWebviewConfig", () => {
   it.effect("reports a structurally distinct missing-bridge failure", () =>
     Effect.gen(function* () {
-      const error = yield* loadPreviewWebviewConfig(environmentId, undefined, null).pipe(
+      const error = yield* loadPreviewWebviewConfig(environmentId, projectId, undefined, null).pipe(
         Effect.flip,
       );
 
       expect(error).toBeInstanceOf(PreviewWebviewBridgeUnavailableError);
       expect(error.environmentId).toBe(environmentId);
+      expect(error.projectId).toBe(projectId);
       expect(error.message).toContain(environmentId);
+      expect(error.message).toContain(projectId);
       expect("cause" in error).toBe(false);
     }),
   );
@@ -27,34 +30,38 @@ describe("loadPreviewWebviewConfig", () => {
   it.effect("preserves the bridge rejection as the load failure cause", () =>
     Effect.gen(function* () {
       const cause = new Error("ipc unavailable");
-      const error = yield* loadPreviewWebviewConfig(environmentId, undefined, {
+      const error = yield* loadPreviewWebviewConfig(environmentId, projectId, "work", {
         getPreviewConfig: () => Promise.reject(cause),
       }).pipe(Effect.flip);
 
       expect(error).toBeInstanceOf(PreviewWebviewConfigLoadError);
       expect(error.environmentId).toBe(environmentId);
+      expect(error.projectId).toBe(projectId);
       expect(error.cause).toBe(cause);
       expect(error.message).not.toContain(cause.message);
     }),
   );
 
-  it.effect("forwards the environment id and profile to the bridge", () =>
+  it.effect("forwards the environment, project, and profile ids to the bridge", () =>
     Effect.gen(function* () {
-      let requested: { environmentId: EnvironmentId; profileId: string | undefined } | null = null;
+      let requested: {
+        readonly environmentId: EnvironmentId;
+        readonly projectId: ProjectId;
+        readonly profileId?: string;
+      } | null = null;
       const config = {
         partition: "persist:test-preview",
         webPreferences: "sandbox=yes",
         preloadUrl: null,
       };
-      const result = yield* loadPreviewWebviewConfig(environmentId, "work", {
-        getPreviewConfig: (requestedEnvironmentId, profileId) => {
-          requested = { environmentId: requestedEnvironmentId, profileId };
+      const result = yield* loadPreviewWebviewConfig(environmentId, projectId, "work", {
+        getPreviewConfig: (input) => {
+          requested = input;
           return Promise.resolve(config);
         },
       });
 
-      // The partition is derived in main from both, so both have to arrive.
-      expect(requested).toEqual({ environmentId, profileId: "work" });
+      expect(requested).toEqual({ environmentId, projectId, profileId: "work" });
       expect(result).toEqual(config);
     }),
   );

--- a/apps/web/src/browser/previewWebviewConfigState.ts
+++ b/apps/web/src/browser/previewWebviewConfigState.ts
@@ -1,8 +1,9 @@
 import { useAtomValue } from "@effect/atom-react";
-import type {
-  DesktopPreviewBridge,
-  DesktopPreviewWebviewConfig,
+import {
   EnvironmentId,
+  ProjectId,
+  type DesktopPreviewBridge,
+  type DesktopPreviewWebviewConfig,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
@@ -16,10 +17,10 @@ const PREVIEW_CONFIG_IDLE_TTL_MS = 10 * 60_000;
 
 export class PreviewWebviewBridgeUnavailableError extends Schema.TaggedErrorClass<PreviewWebviewBridgeUnavailableError>()(
   "PreviewWebviewBridgeUnavailableError",
-  { environmentId: Schema.String },
+  { environmentId: Schema.String, projectId: Schema.String },
 ) {
   override get message(): string {
-    return `Desktop preview configuration is unavailable for environment "${this.environmentId}".`;
+    return `Desktop preview configuration is unavailable for environment "${this.environmentId}" project "${this.projectId}".`;
   }
 }
 
@@ -27,11 +28,12 @@ export class PreviewWebviewConfigLoadError extends Schema.TaggedErrorClass<Previ
   "PreviewWebviewConfigLoadError",
   {
     environmentId: Schema.String,
+    projectId: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to load desktop preview configuration for environment "${this.environmentId}".`;
+    return `Failed to load desktop preview configuration for environment "${this.environmentId}" project "${this.projectId}".`;
   }
 }
 
@@ -41,51 +43,79 @@ export const PreviewWebviewConfigError = Schema.Union([
 ]);
 export type PreviewWebviewConfigError = typeof PreviewWebviewConfigError.Type;
 
+class PreviewWebviewConfigKeyParseError extends Schema.TaggedErrorClass<PreviewWebviewConfigKeyParseError>()(
+  "PreviewWebviewConfigKeyParseError",
+  { key: Schema.String },
+) {
+  override get message(): string {
+    return `Invalid preview webview config key: ${this.key}`;
+  }
+}
+
 type PreviewConfigBridge = Pick<DesktopPreviewBridge, "getPreviewConfig">;
 
 export const loadPreviewWebviewConfig = (
   environmentId: EnvironmentId,
-  profileId?: string,
+  projectId: ProjectId,
+  profileId: string | undefined,
   bridge: PreviewConfigBridge | null = previewBridge,
 ): Effect.Effect<DesktopPreviewWebviewConfig, PreviewWebviewConfigError> => {
   if (bridge === null) {
-    return Effect.fail(new PreviewWebviewBridgeUnavailableError({ environmentId }));
+    return Effect.fail(new PreviewWebviewBridgeUnavailableError({ environmentId, projectId }));
   }
 
   return Effect.tryPromise({
-    try: () => bridge.getPreviewConfig(environmentId, profileId),
-    catch: (cause) => new PreviewWebviewConfigLoadError({ environmentId, cause }),
+    try: () => bridge.getPreviewConfig({ environmentId, projectId, profileId }),
+    catch: (cause) => new PreviewWebviewConfigLoadError({ environmentId, projectId, cause }),
   });
 };
 
 /**
- * `Atom.family` keys on its argument, so the environment and profile are
- * folded into one string: passing an object would allocate a fresh entry on
- * every render.
- *
- * The profile is the tail rather than a second field, so an id containing the
- * delimiter round-trips whole instead of being truncated into a different
- * profile's key. `BrowserProfileId` rejects control characters, which is what
- * makes the environment side of the split unambiguous.
+ * Atom.family keys on one string, so encode the full identity in a stable
+ * tuple. JSON framing keeps ids containing the delimiter or a colon distinct.
  */
-const CONFIG_KEY_DELIMITER = "\u0000";
+const configKey = (
+  environmentId: EnvironmentId,
+  projectId: ProjectId,
+  profileId: string | undefined,
+): string => JSON.stringify([environmentId, projectId, profileId ?? null]);
 
-const configKey = (environmentId: EnvironmentId, profileId: string | undefined): string =>
-  `${environmentId}${CONFIG_KEY_DELIMITER}${profileId ?? ""}`;
+interface PreviewWebviewConfigKey {
+  readonly environmentId: EnvironmentId;
+  readonly projectId: ProjectId;
+  readonly profileId: string | undefined;
+}
 
-const parseConfigKey = (key: string): { environmentId: EnvironmentId; profileId?: string } => {
-  const delimiter = key.indexOf(CONFIG_KEY_DELIMITER);
-  const environmentId = (delimiter === -1 ? key : key.slice(0, delimiter)) as EnvironmentId;
-  const profileId = delimiter === -1 ? "" : key.slice(delimiter + CONFIG_KEY_DELIMITER.length);
+const parseConfigKey = (key: string): PreviewWebviewConfigKey => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(key);
+  } catch {
+    throw new PreviewWebviewConfigKeyParseError({ key });
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length !== 3 ||
+    typeof parsed[0] !== "string" ||
+    typeof parsed[1] !== "string" ||
+    (parsed[2] !== null && typeof parsed[2] !== "string")
+  ) {
+    throw new PreviewWebviewConfigKeyParseError({ key });
+  }
   return {
-    environmentId,
-    ...(profileId === "" ? {} : { profileId }),
+    environmentId: EnvironmentId.make(parsed[0]),
+    projectId: ProjectId.make(parsed[1]),
+    profileId: parsed[2] === null ? undefined : parsed[2],
   };
 };
 
+const idlePreviewWebviewConfigAtom = Atom.make(
+  AsyncResult.initial<DesktopPreviewWebviewConfig, PreviewWebviewConfigError>(false),
+).pipe(Atom.withLabel("preview:webview-config:idle"));
+
 const previewWebviewConfigAtom = Atom.family((key: string) => {
-  const { environmentId, profileId } = parseConfigKey(key);
-  return Atom.make(loadPreviewWebviewConfig(environmentId, profileId)).pipe(
+  const { environmentId, projectId, profileId } = parseConfigKey(key);
+  return Atom.make(loadPreviewWebviewConfig(environmentId, projectId, profileId)).pipe(
     Atom.swr({
       staleTime: PREVIEW_CONFIG_STALE_TIME_MS,
       revalidateOnMount: true,
@@ -97,8 +127,13 @@ const previewWebviewConfigAtom = Atom.family((key: string) => {
 
 export function usePreviewWebviewConfig(
   environmentId: EnvironmentId,
-  profileId?: string,
+  projectId: ProjectId | null,
+  profileId: string | undefined,
 ): DesktopPreviewWebviewConfig | null {
-  const result = useAtomValue(previewWebviewConfigAtom(configKey(environmentId, profileId)));
+  const result = useAtomValue(
+    projectId === null
+      ? idlePreviewWebviewConfigAtom
+      : previewWebviewConfigAtom(configKey(environmentId, projectId, profileId)),
+  );
   return Option.getOrNull(AsyncResult.value(result));
 }

--- a/apps/web/src/browser/previewWebviewConfigState.ts
+++ b/apps/web/src/browser/previewWebviewConfigState.ts
@@ -65,7 +65,12 @@ export const loadPreviewWebviewConfig = (
   }
 
   return Effect.tryPromise({
-    try: () => bridge.getPreviewConfig({ environmentId, projectId, profileId }),
+    try: () =>
+      bridge.getPreviewConfig({
+        environmentId,
+        projectId,
+        ...(profileId === undefined ? {} : { profileId }),
+      }),
     catch: (cause) => new PreviewWebviewConfigLoadError({ environmentId, projectId, cause }),
   });
 };

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -92,6 +92,7 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { useThreadDiscoveredPorts } from "../portDiscoveryState";
 import { openDiscoveredPort } from "./preview/openDiscoveredPort";
+import { rememberPreviewProjectRef } from "../browser/previewProjectRefs";
 import { useAtomCommand } from "../state/use-atom-command";
 import { previewEnvironment } from "../state/preview";
 import {
@@ -1482,6 +1483,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const removeProject = useCallback(
     async (member: SidebarProjectGroupMember) => {
       const memberProjectRef = scopeProjectRef(member.environmentId, member.id);
+      rememberPreviewProjectRef(memberProjectRef);
       const result = await deleteProject({
         environmentId: member.environmentId,
         input: {

--- a/apps/web/src/components/preview/PreviewMoreMenu.tsx
+++ b/apps/web/src/components/preview/PreviewMoreMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DesktopPreviewColorScheme, EnvironmentId } from "@t3tools/contracts";
+import type { DesktopPreviewColorScheme, EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { Minus, MoreVertical, Plus as PlusIcon, RotateCcw } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
@@ -32,6 +32,8 @@ const COLOR_SCHEME_OPTIONS: ReadonlyArray<{
 ];
 
 interface Props {
+  environmentId: EnvironmentId;
+  projectId: ProjectId | null;
   /** Active preview tab id. Tab-targeting actions are disabled without it. */
   tabId: string | null;
   /**
@@ -52,8 +54,6 @@ interface Props {
   nativePictureInPicture: boolean;
   /** Toggles the optional native always-on-top preview window. */
   onNativePictureInPicture: () => void;
-  /** Environment the tab belongs to; scopes storage clearing to its partitions. */
-  environmentId: EnvironmentId;
   /** Profile the tab was opened under, if the server recorded one. */
   /**
    * Required: the IPC layer reads an absent profile as "every profile", so a
@@ -71,6 +71,8 @@ interface Props {
  * when the desktop bridge is present, so we can call it unconditionally.
  */
 export function PreviewMoreMenu({
+  environmentId,
+  projectId,
   tabId,
   hasWebContents,
   zoomFactor,
@@ -79,7 +81,6 @@ export function PreviewMoreMenu({
   onToggleDeviceToolbar,
   nativePictureInPicture,
   onNativePictureInPicture,
-  environmentId,
   profileId,
   profileName,
 }: Props) {
@@ -192,38 +193,51 @@ export function PreviewMoreMenu({
             </Button>
           </span>
         </MenuItem>
-        <MenuSeparator />
-        {/*
-          Grouped so the heading has a `MenuGroup` ancestor — `MenuGroupLabel`
-          reads its context and throws without one. The heading also answers
-          which profile the tab is in, which is otherwise invisible: it is fixed
-          at open and nothing else in the chrome shows it.
-        */}
-        <MenuGroup>
-          {/*
-            The heading carries the profile so the actions below can keep
-            fixed-length labels: repeating a name of up to 48 characters in
-            each one drove the popup far past its width.
-          */}
-          {profileName ? (
-            // Truncation sits on the label itself: it renders a block box, so
-            // `text-overflow` on an inline child inside it never applies and a
-            // long name would push the popup past its width instead.
-            <MenuGroupLabel className="max-w-64 truncate">Profile: {profileName}</MenuGroupLabel>
-          ) : null}
-          <MenuItem
-            onClick={() =>
-              void bridge.clearCookies(environmentId, profileId).catch(() => undefined)
-            }
-          >
-            Clear cookies
-          </MenuItem>
-          <MenuItem
-            onClick={() => void bridge.clearCache(environmentId, profileId).catch(() => undefined)}
-          >
-            Clear cache
-          </MenuItem>
-        </MenuGroup>
+        {projectId !== null ? (
+          <>
+            <MenuSeparator />
+            {/*
+              Grouped so the heading has a `MenuGroup` ancestor —
+              `MenuGroupLabel` reads its context and throws without one. The
+              heading also answers which profile the tab is in, which is
+              otherwise invisible: it is fixed at open and nothing else in the
+              chrome shows it.
+            */}
+            <MenuGroup>
+              {/*
+                The heading carries the profile so the actions below can keep
+                fixed-length labels: repeating a name of up to 48 characters in
+                each one drove the popup far past its width.
+              */}
+              {profileName ? (
+                // Truncation sits on the label itself: it renders a block box, so
+                // `text-overflow` on an inline child inside it never applies and a
+                // long name would push the popup past its width instead.
+                <MenuGroupLabel className="max-w-64 truncate">
+                  Profile: {profileName}
+                </MenuGroupLabel>
+              ) : null}
+              <MenuItem
+                onClick={() =>
+                  void bridge
+                    .clearCookies({ environmentId, projectId, profileId })
+                    .catch(() => undefined)
+                }
+              >
+                Clear cookies
+              </MenuItem>
+              <MenuItem
+                onClick={() =>
+                  void bridge
+                    .clearCache({ environmentId, projectId, profileId })
+                    .catch(() => undefined)
+                }
+              >
+                Clear cache
+              </MenuItem>
+            </MenuGroup>
+          </>
+        ) : null}
       </MenuPopup>
     </Menu>
   );

--- a/apps/web/src/components/preview/PreviewMoreMenu.tsx
+++ b/apps/web/src/components/preview/PreviewMoreMenu.tsx
@@ -220,7 +220,7 @@ export function PreviewMoreMenu({
               <MenuItem
                 onClick={() =>
                   void bridge
-                    .clearCookies({ environmentId, projectId, profileId })
+                    .clearCookies(environmentId, profileId, projectId)
                     .catch(() => undefined)
                 }
               >
@@ -228,9 +228,7 @@ export function PreviewMoreMenu({
               </MenuItem>
               <MenuItem
                 onClick={() =>
-                  void bridge
-                    .clearCache({ environmentId, projectId, profileId })
-                    .catch(() => undefined)
+                  void bridge.clearCache(environmentId, profileId, projectId).catch(() => undefined)
                 }
               >
                 Clear cache

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -59,6 +59,9 @@ vi.mock("~/browserHistoryStore", () => ({
 vi.mock("~/state/session", () => ({
   readPreparedConnection: mocks.readPreparedConnection,
 }));
+vi.mock("~/state/entities", () => ({
+  useThreadShell: () => ({ projectId: "project-1" }),
+}));
 
 // Stubbed at the direct dependency rather than letting the real module pull in
 // `useSettings` -> `state/server`, which would drag the whole settings and

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -59,8 +59,8 @@ vi.mock("~/browserHistoryStore", () => ({
 vi.mock("~/state/session", () => ({
   readPreparedConnection: mocks.readPreparedConnection,
 }));
-vi.mock("~/state/entities", () => ({
-  useThreadShell: () => ({ projectId: "project-1" }),
+vi.mock("~/browser/previewProjectId", () => ({
+  usePreviewProjectId: () => "project-1",
 }));
 
 // Stubbed at the direct dependency rather than letting the real module pull in

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -29,7 +29,6 @@ import {
 } from "~/previewStateStore";
 import { resolveDiscoveredServerUrl } from "~/browser/browserTargetResolver";
 import { useEnvironmentHttpBaseUrl } from "~/state/environments";
-import { useThreadShell } from "~/state/entities";
 import { previewEnvironment } from "~/state/preview";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
@@ -46,6 +45,7 @@ import {
   subscribeBrowserViewportChange,
 } from "~/browser/browserViewportActions";
 import { browserResponsiveViewportForToggle, useBrowserDefaults } from "~/browser/browserDefaults";
+import { usePreviewProjectId } from "~/browser/previewProjectId";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 import { PreviewUnreachable } from "./PreviewUnreachable";
 import { revealInFileExplorerLabel } from "./fileExplorerLabel";
@@ -106,7 +106,7 @@ export function PreviewView({
   // instead of the thread object, which is recreated on every update.
   const threadRefRef = useRef(threadRef);
   threadRefRef.current = threadRef;
-  const threadShell = useThreadShell(threadRef);
+  const projectId = usePreviewProjectId(threadRef);
   const previewState = useThreadPreviewState(threadRef);
   const recentHistoryEntries = useThreadRecentHistory(
     threadRef,
@@ -745,7 +745,7 @@ export function PreviewView({
           previewBridge ? (
             <PreviewMoreMenu
               environmentId={threadRef.environmentId}
-              projectId={threadShell?.projectId ?? null}
+              projectId={projectId}
               profileId={activeProfileId}
               profileName={activeProfileName}
               tabId={runtimeTabId}

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -29,6 +29,7 @@ import {
 } from "~/previewStateStore";
 import { resolveDiscoveredServerUrl } from "~/browser/browserTargetResolver";
 import { useEnvironmentHttpBaseUrl } from "~/state/environments";
+import { useThreadShell } from "~/state/entities";
 import { previewEnvironment } from "~/state/preview";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
@@ -105,6 +106,7 @@ export function PreviewView({
   // instead of the thread object, which is recreated on every update.
   const threadRefRef = useRef(threadRef);
   threadRefRef.current = threadRef;
+  const threadShell = useThreadShell(threadRef);
   const previewState = useThreadPreviewState(threadRef);
   const recentHistoryEntries = useThreadRecentHistory(
     threadRef,
@@ -743,6 +745,7 @@ export function PreviewView({
           previewBridge ? (
             <PreviewMoreMenu
               environmentId={threadRef.environmentId}
+              projectId={threadShell?.projectId ?? null}
               profileId={activeProfileId}
               profileName={activeProfileName}
               tabId={runtimeTabId}

--- a/apps/web/src/components/settings/IntegrationsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/IntegrationsSettings.logic.test.ts
@@ -1,39 +1,63 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ProjectId, ScopedProjectRef } from "@t3tools/contracts";
 
 import { browserProfileRemovalAvailable, clearBrowserProfileData } from "./IntegrationsSettings";
 
 const environmentId = "environment-a" as EnvironmentId;
 const secondEnvironmentId = "environment-b" as EnvironmentId;
+const projectRef = {
+  environmentId,
+  projectId: "project-a" as ProjectId,
+} satisfies ScopedProjectRef;
+const secondProjectRef = {
+  environmentId: secondEnvironmentId,
+  projectId: "project-b" as ProjectId,
+} satisfies ScopedProjectRef;
 
 describe("clearBrowserProfileData", () => {
-  it("waits for cookie and cache cleanup", async () => {
+  it("waits for legacy and project-scoped cookie and cache cleanup", async () => {
     const clearCookies = vi.fn().mockResolvedValue(undefined);
     const clearCache = vi.fn().mockResolvedValue(undefined);
 
-    await clearBrowserProfileData({ clearCookies, clearCache }, [environmentId], "profile-a");
+    await clearBrowserProfileData(
+      { clearCookies, clearCache },
+      [environmentId],
+      [projectRef],
+      "profile-a",
+    );
 
-    expect(clearCookies).toHaveBeenCalledWith(environmentId, "profile-a");
-    expect(clearCache).toHaveBeenCalledWith(environmentId, "profile-a");
+    expect(clearCookies.mock.calls).toEqual([
+      [environmentId, "profile-a"],
+      [environmentId, "profile-a", "project-a"],
+    ]);
+    expect(clearCache.mock.calls).toEqual([
+      [environmentId, "profile-a"],
+      [environmentId, "profile-a", "project-a"],
+    ]);
   });
 
-  it("clears every known environment before succeeding", async () => {
+  it("clears every known environment and project before succeeding", async () => {
     const clearCookies = vi.fn().mockResolvedValue(undefined);
     const clearCache = vi.fn().mockResolvedValue(undefined);
 
     await clearBrowserProfileData(
       { clearCookies, clearCache },
       [environmentId, secondEnvironmentId],
+      [projectRef, secondProjectRef],
       "profile-a",
     );
 
     expect(clearCookies.mock.calls).toEqual([
       [environmentId, "profile-a"],
       [secondEnvironmentId, "profile-a"],
+      [environmentId, "profile-a", "project-a"],
+      [secondEnvironmentId, "profile-a", "project-b"],
     ]);
     expect(clearCache.mock.calls).toEqual([
       [environmentId, "profile-a"],
       [secondEnvironmentId, "profile-a"],
+      [environmentId, "profile-a", "project-a"],
+      [secondEnvironmentId, "profile-a", "project-b"],
     ]);
   });
 
@@ -46,6 +70,7 @@ describe("clearBrowserProfileData", () => {
           clearCache: vi.fn().mockResolvedValue(undefined),
         },
         [environmentId],
+        [],
         "profile-a",
       ),
     ).rejects.toBe(failure);
@@ -57,8 +82,8 @@ describe("clearBrowserProfileData", () => {
       clearCache: vi.fn().mockResolvedValue(undefined),
     };
 
-    await expect(clearBrowserProfileData(bridge, [], "profile-a")).rejects.toThrow();
-    await expect(clearBrowserProfileData(null, [environmentId], "profile-a")).rejects.toThrow();
+    await expect(clearBrowserProfileData(bridge, [], [], "profile-a")).rejects.toThrow();
+    await expect(clearBrowserProfileData(null, [environmentId], [], "profile-a")).rejects.toThrow();
     expect(bridge.clearCookies).not.toHaveBeenCalled();
     expect(bridge.clearCache).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -11,6 +11,7 @@ import {
   type BrowserLinkTarget,
   type BrowserProfile,
   type EnvironmentId,
+  type ScopedProjectRef,
   BROWSER_PROFILE_NAME_MAX_LENGTH,
   BROWSER_RECORDING_FRAME_RATES,
   DEFAULT_BROWSER_AUTO_SHOW_FLOATING_PREVIEW,
@@ -41,6 +42,7 @@ import { ScreenRotationIcon } from "~/browser/ScreenRotationIcon";
 import { previewBridge } from "~/components/preview/previewBridge";
 import { cn, randomUUID } from "~/lib/utils";
 import { useEnvironments } from "~/state/environments";
+import { useProjects } from "~/state/entities";
 import { isElectron } from "../../env";
 
 import { Badge } from "../ui/badge";
@@ -95,17 +97,23 @@ type BrowserProfileDataBridge = Pick<
 export async function clearBrowserProfileData(
   bridge: BrowserProfileDataBridge | null,
   environmentIds: ReadonlyArray<EnvironmentId>,
+  projectRefs: ReadonlyArray<ScopedProjectRef>,
   profileId: string,
 ): Promise<void> {
-  if (bridge === null || environmentIds.length === 0) {
+  if (bridge === null || (environmentIds.length === 0 && projectRefs.length === 0)) {
     throw new Error("Browser profile data is not available to clear.");
   }
-  await Promise.all(
-    environmentIds.flatMap((environmentId) => [
+  await Promise.all([
+    // Keep clearing the pre-project partitions left by older desktop builds.
+    ...environmentIds.flatMap((environmentId) => [
       bridge.clearCookies(environmentId, profileId),
       bridge.clearCache(environmentId, profileId),
     ]),
-  );
+    ...projectRefs.flatMap(({ environmentId, projectId }) => [
+      bridge.clearCookies(environmentId, profileId, projectId),
+      bridge.clearCache(environmentId, profileId, projectId),
+    ]),
+  ]);
 }
 
 export function browserProfileRemovalAvailable(
@@ -625,6 +633,7 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
   const settingsHydrated = useClientSettingsHydrated();
   const updateSettings = useUpdatePrimarySettings();
   const { environments, isReady: environmentsReady } = useEnvironments();
+  const projects = useProjects();
   const [profilePendingRemoval, setProfilePendingRemoval] = useState<BrowserProfile | null>(null);
   const [profileRemovalError, setProfileRemovalError] = useState<string | null>(null);
   const [profileRemovalInFlight, setProfileRemovalInFlight] = useState(false);
@@ -676,6 +685,7 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
       await clearBrowserProfileData(
         previewBridge,
         environmentsReady ? environments.map((environment) => environment.environmentId) : [],
+        projects.map(({ environmentId, id: projectId }) => ({ environmentId, projectId })),
         id,
       );
     } catch {

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -33,12 +33,14 @@ import {
   type PreviewAppearancePreference,
   type PreviewViewportSetting,
 } from "@t3tools/contracts";
+import { scopedProjectKey } from "@t3tools/client-runtime/environment";
 import { PREVIEW_VIEWPORT_PRESETS } from "@t3tools/shared/previewViewport";
 import { InfoIcon, Plus as PlusIcon, Trash2 as Trash2Icon } from "lucide-react";
 import { useState } from "react";
 import type { ReactNode } from "react";
 
 import { ScreenRotationIcon } from "~/browser/ScreenRotationIcon";
+import { readRememberedPreviewProjectRefs } from "~/browser/previewProjectRefs";
 import { previewBridge } from "~/components/preview/previewBridge";
 import { cn, randomUUID } from "~/lib/utils";
 import { useEnvironments } from "~/state/environments";
@@ -634,6 +636,12 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
   const updateSettings = useUpdatePrimarySettings();
   const { environments, isReady: environmentsReady } = useEnvironments();
   const projects = useProjects();
+  const projectRefs = new Map(
+    [
+      ...readRememberedPreviewProjectRefs(),
+      ...projects.map(({ environmentId, id: projectId }) => ({ environmentId, projectId })),
+    ].map((ref) => [scopedProjectKey(ref), ref] as const),
+  );
   const [profilePendingRemoval, setProfilePendingRemoval] = useState<BrowserProfile | null>(null);
   const [profileRemovalError, setProfileRemovalError] = useState<string | null>(null);
   const [profileRemovalInFlight, setProfileRemovalInFlight] = useState(false);
@@ -685,7 +693,7 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
       await clearBrowserProfileData(
         previewBridge,
         environmentsReady ? environments.map((environment) => environment.environmentId) : [],
-        projects.map(({ environmentId, id: projectId }) => ({ environmentId, projectId })),
+        [...projectRefs.values()],
         id,
       );
     } catch {

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -39,6 +39,7 @@ import {
 } from "react";
 
 import { useComposerDraftStore } from "../../composerDraftStore";
+import { rememberPreviewProjectRef } from "../../browser/previewProjectRefs";
 import { isElectron } from "../../env";
 import {
   useClientSettings,
@@ -753,6 +754,8 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
 
       const draftStore = useComposerDraftStore.getState();
       for (const member of members) {
+        const projectRef = scopeProjectRef(member.environmentId, member.id);
+        rememberPreviewProjectRef(projectRef);
         const memberThreads = projectThreads.filter(
           (thread) =>
             thread.environmentId === member.environmentId && thread.projectId === member.id,
@@ -771,7 +774,6 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
           reportFailure(`Failed to remove "${member.title}"`, result);
           return;
         }
-        const projectRef = scopeProjectRef(member.environmentId, member.id);
         releaseProjectDraftUploads(
           projectRef,
           memberThreads.map((thread) => scopeThreadRef(thread.environmentId, thread.id)),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -990,9 +990,10 @@ export const DesktopPreviewConfigInputSchema = Schema.Struct({
 
 export const DesktopPreviewClearDataInputSchema = Schema.Struct({
   environmentId: EnvironmentId,
-  projectId: ProjectId,
-  /** Omit to clear the default profile; otherwise only this profile's partition. */
+  /** Profile whose preview storage should be cleared. */
   profileId: Schema.optional(BrowserProfileId),
+  /** Project that owns the partition; omitted by legacy profile maintenance. */
+  projectId: Schema.optional(ProjectId),
 });
 
 export const DesktopPreviewSetColorSchemeInputSchema = Schema.Struct({
@@ -1178,18 +1179,18 @@ export interface DesktopPreviewBridge {
   setAudioMuted: (tabId: string, audioMuted: boolean) => Promise<void>;
   /** Open the guest webview's DevTools (detached). */
   openDevTools: (tabId: string) => Promise<void>;
-  /** Drop cookies + storage data for this environment+project preview partition. */
-  clearCookies: (input: {
-    environmentId: EnvironmentId;
-    projectId: ProjectId;
-    profileId?: string;
-  }) => Promise<void>;
-  /** Drop the HTTP cache for this environment+project preview partition. */
-  clearCache: (input: {
-    environmentId: EnvironmentId;
-    projectId: ProjectId;
-    profileId?: string;
-  }) => Promise<void>;
+  /** Drop cookies + storage data for a preview partition. */
+  clearCookies: (
+    environmentId: EnvironmentId,
+    profileId?: string,
+    projectId?: ProjectId,
+  ) => Promise<void>;
+  /** Drop the HTTP cache for a preview partition. */
+  clearCache: (
+    environmentId: EnvironmentId,
+    profileId?: string,
+    projectId?: ProjectId,
+  ) => Promise<void>;
   /**
    * One-shot config for mounting a preview `<webview>`. Replaces three
    * earlier round-trip calls (`getBrowserPartition`, `getWebviewPreferences`,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -87,7 +87,7 @@ import type {
   OrchestrationSubscribeThreadInput,
   OrchestrationThreadStreamItem,
 } from "./orchestration.ts";
-import { EnvironmentId } from "./baseSchemas.ts";
+import { EnvironmentId, ProjectId } from "./baseSchemas.ts";
 import { BrowserProfileId } from "./browserProfile.ts";
 import { AuthAccessTokenResult, AuthSessionState, AuthWebSocketTicketResult } from "./auth.ts";
 import { AdvertisedEndpoint } from "./remoteAccess.ts";
@@ -626,7 +626,7 @@ export interface DesktopPreviewPointerEvent {
  * can attach.
  */
 export interface DesktopPreviewWebviewConfig {
-  /** `persist:t3code-preview` (or whatever the desktop chose). */
+  /** `persist:t3code-preview-<hash>` for this environment+project. */
   partition: string;
   /**
    * Canonical `<webview webpreferences="...">` string. Encodes the security
@@ -978,6 +978,7 @@ export const DesktopPreviewNavigateInputSchema = Schema.Struct({
 
 export const DesktopPreviewConfigInputSchema = Schema.Struct({
   environmentId: EnvironmentId,
+  projectId: ProjectId,
   /**
    * Browser profile the partition is derived from. Derivation stays in main:
    * `will-attach-webview` only prefix-checks the partition string, so a
@@ -989,7 +990,8 @@ export const DesktopPreviewConfigInputSchema = Schema.Struct({
 
 export const DesktopPreviewClearDataInputSchema = Schema.Struct({
   environmentId: EnvironmentId,
-  /** Omit to clear every profile; otherwise only this profile's partition. */
+  projectId: ProjectId,
+  /** Omit to clear the default profile; otherwise only this profile's partition. */
   profileId: Schema.optional(BrowserProfileId),
 });
 
@@ -1176,20 +1178,29 @@ export interface DesktopPreviewBridge {
   setAudioMuted: (tabId: string, audioMuted: boolean) => Promise<void>;
   /** Open the guest webview's DevTools (detached). */
   openDevTools: (tabId: string) => Promise<void>;
-  /** Drop cookies + storage data for the preview partition (all tabs). */
-  clearCookies: (environmentId: EnvironmentId, profileId?: string) => Promise<void>;
-  /** Drop the HTTP cache for the preview partition (all tabs). */
-  clearCache: (environmentId: EnvironmentId, profileId?: string) => Promise<void>;
+  /** Drop cookies + storage data for this environment+project preview partition. */
+  clearCookies: (input: {
+    environmentId: EnvironmentId;
+    projectId: ProjectId;
+    profileId?: string;
+  }) => Promise<void>;
+  /** Drop the HTTP cache for this environment+project preview partition. */
+  clearCache: (input: {
+    environmentId: EnvironmentId;
+    projectId: ProjectId;
+    profileId?: string;
+  }) => Promise<void>;
   /**
    * One-shot config for mounting a preview `<webview>`. Replaces three
    * earlier round-trip calls (`getBrowserPartition`, `getWebviewPreferences`,
    * `getPickPreloadPath`) so adding a new field here only requires touching
    * the contract + main, not the renderer's mount logic.
    */
-  getPreviewConfig: (
-    environmentId: EnvironmentId,
-    profileId?: string,
-  ) => Promise<DesktopPreviewWebviewConfig>;
+  getPreviewConfig: (input: {
+    environmentId: EnvironmentId;
+    projectId: ProjectId;
+    profileId?: string;
+  }) => Promise<DesktopPreviewWebviewConfig>;
   setAnnotationTheme: (theme: DesktopPreviewAnnotationTheme) => Promise<void>;
   /**
    * Activate the in-page element picker for the given tab. Resolves with

--- a/packages/shared/src/preview.test.ts
+++ b/packages/shared/src/preview.test.ts
@@ -14,7 +14,13 @@ describe("previewBrowserScope", () => {
   it("joins environment and project so threads in one project share a partition", () => {
     expect(
       previewBrowserScope(EnvironmentId.make("environment-a"), ProjectId.make("project-1")),
-    ).toBe("environment-a:project-1");
+    ).toBe(JSON.stringify(["environment-a", "project-1"]));
+  });
+
+  it("keeps pairs distinct when ids contain colons", () => {
+    expect(previewBrowserScope(EnvironmentId.make("a:b"), ProjectId.make("c"))).not.toBe(
+      previewBrowserScope(EnvironmentId.make("a"), ProjectId.make("b:c")),
+    );
   });
 });
 

--- a/packages/shared/src/preview.test.ts
+++ b/packages/shared/src/preview.test.ts
@@ -1,3 +1,4 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -5,8 +6,17 @@ import {
   isPreviewableUrl,
   newPreviewTabId,
   normalizePreviewUrl,
+  previewBrowserScope,
   PreviewUrlNormalizationError,
 } from "./preview.ts";
+
+describe("previewBrowserScope", () => {
+  it("joins environment and project so threads in one project share a partition", () => {
+    expect(
+      previewBrowserScope(EnvironmentId.make("environment-a"), ProjectId.make("project-1")),
+    ).toBe("environment-a:project-1");
+  });
+});
 
 describe("newPreviewTabId", () => {
   it("returns a unique tab id every call", () => {

--- a/packages/shared/src/preview.ts
+++ b/packages/shared/src/preview.ts
@@ -7,9 +7,14 @@
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
-/** Persist-partition scope. Threads in one project share a login. */
+/**
+ * Persist-partition scope. Threads in one project share a login.
+ *
+ * Encoded as JSON so ids that contain `:` cannot collide
+ * (`"a:b"+"c"` vs `"a"+"b:c"`).
+ */
 export function previewBrowserScope(environmentId: EnvironmentId, projectId: ProjectId): string {
-  return `${environmentId}:${projectId}`;
+  return JSON.stringify([environmentId, projectId]);
 }
 
 const TAB_ID_PREFIX = "tab_";

--- a/packages/shared/src/preview.ts
+++ b/packages/shared/src/preview.ts
@@ -1,10 +1,16 @@
 /**
- * Pure URL helpers shared between the preview server, desktop main process,
+ * Pure preview helpers shared between the preview server, desktop main process,
  * and web renderer. Centralising these guarantees the four call sites agree
  * on what counts as "loopback" and how to normalise a free-form URL string.
  */
 
+import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
+
+/** Persist-partition scope. Threads in one project share a login. */
+export function previewBrowserScope(environmentId: EnvironmentId, projectId: ProjectId): string {
+  return `${environmentId}:${projectId}`;
+}
 
 const TAB_ID_PREFIX = "tab_";
 let nextPreviewTabSequence = 0;


### PR DESCRIPTION
Two folders on the same machine shared one Chromium persist partition, so logging into a site in project A signed you into project B.

Preview storage is now scoped to environment plus project. Linked workers of one project still share a login. Clear cookies and cache only wipe that project. The first launch after this is a fresh jar per project.

Implemented with Grok 4.6 through Grok CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Electron partition derivation and cookie/storage isolation (auth-sensitive), with a breaking IPC shape for `getPreviewConfig` and intentional per-project cookie reset on upgrade.
> 
> **Overview**
> Fixes preview sessions in the same environment sharing one Chromium persist partition, which let logins and cookies bleed across projects.
> 
> **Partition identity** now includes `projectId` via shared `previewBrowserScope` (JSON-encoded `environmentId` + `projectId`). Desktop `resolvePartitionScope`, `getPreviewConfig`, and clear-cookies/cache IPC take `projectId`; named/incognito profiles still layer on top of the project scope. Clears without `projectId` keep a **legacy** environment-only path so profile maintenance can still wipe old partitions.
> 
> **Renderer** resolves `projectId` from the thread shell or composer draft, skips webview config until it exists, and passes the full tuple through the bridge. Hosted webviews **remount on partition change** (key = partition + generation) and **latch `src`** so React re-renders do not navigate the guest after attach.
> 
> **Profile deletion** clears legacy and project-scoped storage for all environments plus known/remembered projects (refs remembered when a project is removed). Preview chrome only offers per-project clear actions when `projectId` is known.
> 
> **Contract change:** `getPreviewConfig` now requires `projectId` in its input schema. Existing environment-only cookie jars are not migrated—each project gets a fresh partition after upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b299a022b524635b1bce297a696282a39ea0be32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope preview partitions by `projectId` to fix cookie leaks across projects
> - Preview partitions now derive from `environmentId` and `projectId` using JSON tuples via `previewBrowserScope`, preventing cookie and cache leaks between projects in the same environment.
> - Updates IPC contracts, bridge wrappers, and `resolvePartitionScope` to include `projectId`.
> - Renderer webviews resolve `projectId` from the thread shell or composer draft, deferring config load until available, and latch their source across recovery generations.
> - Browser profile cleanup tracks deleted project references in memory to clear both legacy and project-scoped partitions.
> - Behavioral Change: `DesktopPreviewConfigInputSchema` now requires `projectId`, causing `getPreviewConfig` IPC requests without it to fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b299a02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->