### PR TITLE
feat(usage): add OpenCode as a usage provider

### DIFF
--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,11 +5,12 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "opencode"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  opencode: "OpenCode",
 };
 
 /**
@@ -21,5 +22,6 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
   return {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
+    opencode: "#8b5cf6",
   };
 }

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -37,6 +37,7 @@ import { ServerConfig } from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+import { listOpenCodeDatabaseFiles, readOpenCodeRecords } from "./opencodeTranscriptReader.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -218,10 +219,14 @@ export const make = Effect.gen(function* () {
     const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
     const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    // OpenCode keeps no T3-visible home setting; its store follows XDG.
+    const opencodeDataHome =
+      process.env.XDG_DATA_HOME?.trim() || path.join(NodeOS.homedir(), ".local", "share");
 
     return [
       { provider: "claude" as const, dir: claudeDir },
       { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      { provider: "opencode" as const, dir: path.join(opencodeDataHome, "opencode") },
     ];
   });
 
@@ -277,7 +282,11 @@ export const make = Effect.gen(function* () {
         return cached.records;
       }
 
-      const parsed = yield* Effect.promise(() => readTranscriptRecords(filePath, provider));
+      const parsed = yield* Effect.promise(() =>
+        provider === "opencode"
+          ? readOpenCodeRecords(filePath)
+          : readTranscriptRecords(filePath, provider),
+      );
       // A read failure is not an empty transcript: caching it under this
       // (size, mtime) would silently drop the file's usage until it changes.
       if (parsed === null) return [];
@@ -373,7 +382,12 @@ export const make = Effect.gen(function* () {
       }
 
       walkedRoots.push(dir);
-      const files = yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
+      // OpenCode keeps every message in one sqlite database rather than a
+      // directory of transcripts, so it contributes at most one pseudo-file.
+      const files =
+        provider === "opencode"
+          ? listOpenCodeDatabaseFiles(dir, windowStartMs)
+          : yield* Effect.promise(() => listTranscriptFiles(dir, windowStartMs));
       let scannedFiles = 0;
       let skippedFiles = 0;
       // Distinct per directory. Buckets carry per-cell session counts, but a

--- a/apps/server/src/usage/opencodeTranscriptReader.test.ts
+++ b/apps/server/src/usage/opencodeTranscriptReader.test.ts
@@ -54,6 +54,8 @@ beforeAll(() => {
   database
     .prepare("INSERT INTO message VALUES (?, ?, ?)")
     .run("msg_3", "ses_b", messageData({ output: 5 }));
+  // A malformed payload must cost its own row, never the whole scan.
+  database.prepare("INSERT INTO message VALUES (?, ?, ?)").run("msg_4", "ses_c", "not json {");
 });
 
 afterAll(() => {

--- a/apps/server/src/usage/opencodeTranscriptReader.test.ts
+++ b/apps/server/src/usage/opencodeTranscriptReader.test.ts
@@ -1,0 +1,97 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import { afterAll, beforeAll, describe, expect, it } from "@effect/vitest";
+
+import {
+  listOpenCodeDatabaseFiles,
+  readOpenCodeRecords,
+  statOpenCodeDatabase,
+} from "./opencodeTranscriptReader.ts";
+
+let dataDir: string;
+let database: NodeSqlite.DatabaseSync;
+
+const messageData = (overrides: {
+  role?: string;
+  input?: number;
+  output?: number;
+  modelID?: string;
+}) =>
+  JSON.stringify({
+    role: overrides.role ?? "assistant",
+    cost: 0.01,
+    tokens:
+      "input" in overrides || "output" in overrides
+        ? {
+            input: overrides.input ?? 0,
+            output: overrides.output ?? 0,
+            reasoning: 0,
+            cache: { write: 0, read: 0 },
+          }
+        : undefined,
+    modelID: overrides.modelID ?? "claude-fable-5",
+    providerID: "anthropic",
+    time: { created: 1_780_114_618_934 },
+  });
+
+beforeAll(() => {
+  dataDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "opencode-usage-"));
+  database = new NodeSqlite.DatabaseSync(NodePath.join(dataDir, "opencode.db"));
+  database.exec(
+    "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL)",
+  );
+  database
+    .prepare("INSERT INTO message VALUES (?, ?, ?)")
+    .run("msg_1", "ses_a", messageData({ input: 100, output: 20 }));
+  // User rows carry no tokens and must never surface.
+  database
+    .prepare("INSERT INTO message VALUES (?, ?, ?)")
+    .run("msg_2", "ses_a", messageData({ role: "user" }));
+  database
+    .prepare("INSERT INTO message VALUES (?, ?, ?)")
+    .run("msg_3", "ses_b", messageData({ output: 5 }));
+});
+
+afterAll(() => {
+  database.close();
+  NodeFS.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("statOpenCodeDatabase", () => {
+  it("reports the database as one pseudo-file", () => {
+    const file = statOpenCodeDatabase(dataDir);
+
+    expect(file?.path).toBe(NodePath.join(dataDir, "opencode.db"));
+    expect(file?.size).toBeGreaterThan(0);
+    expect(file?.mtimeMs).toBeGreaterThan(0);
+  });
+
+  it("returns null when there is no database", () => {
+    expect(statOpenCodeDatabase(NodePath.join(dataDir, "absent"))).toBeNull();
+  });
+});
+
+describe("listOpenCodeDatabaseFiles", () => {
+  it("applies the same mtime window as the transcript walk", () => {
+    expect(listOpenCodeDatabaseFiles(dataDir, Number.MAX_SAFE_INTEGER)).toEqual([]);
+    expect(listOpenCodeDatabaseFiles(dataDir, 0)).toHaveLength(1);
+  });
+});
+
+describe("readOpenCodeRecords", () => {
+  it("reads every billable assistant row and nothing else", async () => {
+    const records = await readOpenCodeRecords(NodePath.join(dataDir, "opencode.db"));
+
+    expect(records?.length).toBe(2);
+    expect(records?.map((record) => record.sessionId)).toEqual(["ses_a", "ses_b"]);
+    expect(records?.[0]?.totals).toMatchObject({ uncachedInputTokens: 100, outputTokens: 20 });
+  });
+
+  it("returns null for an unreadable store", async () => {
+    expect(await readOpenCodeRecords(NodePath.join(dataDir, "absent", "opencode.db"))).toBeNull();
+  });
+});

--- a/apps/server/src/usage/opencodeTranscriptReader.ts
+++ b/apps/server/src/usage/opencodeTranscriptReader.ts
@@ -84,12 +84,16 @@ export async function readOpenCodeRecords(dbPath: string): Promise<readonly Usag
 
   try {
     // JSON1 extraction prunes user messages and error stubs before their
-    // (potentially large) `data` payloads reach JavaScript.
+    // (potentially large) `data` payloads reach JavaScript. json_valid guards
+    // the extraction: a malformed row must cost itself, not throw out of the
+    // iterator and void the whole scan.
     const statement = database.prepare(
       `SELECT session_id, data FROM message
-       WHERE json_extract(data, '$.role') = 'assistant'
+       WHERE json_valid(data)
+         AND json_extract(data, '$.role') = 'assistant'
          AND json_extract(data, '$.tokens') IS NOT NULL`,
     );
+    let scanned = 0;
     for (const row of statement.iterate()) {
       try {
         const record = parseOpenCodeMessage(JSON.parse(String(row.data)), String(row.session_id));
@@ -97,6 +101,10 @@ export async function readOpenCodeRecords(dbPath: string): Promise<readonly Usag
       } catch {
         // A malformed row drops itself rather than failing the scan.
       }
+      // The sqlite iteration is fully synchronous, unlike the readline walk
+      // over JSONL transcripts. Yield periodically so a cold scan of a large
+      // store cannot stall the server's other requests.
+      if (++scanned % 2048 === 0) await new Promise<void>((resolve) => setImmediate(resolve));
     }
   } catch {
     return null;

--- a/apps/server/src/usage/opencodeTranscriptReader.ts
+++ b/apps/server/src/usage/opencodeTranscriptReader.ts
@@ -1,0 +1,108 @@
+// @effect-diagnostics nodeBuiltinImport:off
+/**
+ * Raw access to OpenCode's sqlite session store.
+ *
+ * Isolated here so the rest of the usage code stays on Effect's `FileSystem`,
+ * following the same split as `usageTranscriptReader`. OpenCode keeps every
+ * message in one database (`opencode.db` plus its `-wal`/`-shm` siblings), so
+ * instead of walking a directory of transcripts we treat the database as a
+ * single pseudo-file and stream rows out of it.
+ *
+ * The connection is opened read-only. OpenCode runs in WAL mode, so a
+ * concurrent server never blocks us and we never checkpoint on top of it.
+ *
+ * @module opencodeTranscriptReader
+ */
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import { parseOpenCodeMessage, type UsageRecord } from "./usageTranscripts.ts";
+
+export const OPENCODE_DB_FILENAME = "opencode.db";
+
+export interface OpenCodeDatabaseFile {
+  readonly path: string;
+  readonly size: number;
+  readonly mtimeMs: number;
+}
+
+/**
+ * Stats the database as one cacheable unit.
+ *
+ * The scan cache keys parsed records by `(size, mtime)`, but a live OpenCode
+ * process writes recent messages into `-wal` without touching the main file,
+ * so all three siblings contribute to both figures. Returns `null` when the
+ * database itself is absent, which callers report as a missing source.
+ */
+export function statOpenCodeDatabase(dataDir: string): OpenCodeDatabaseFile | null {
+  const dbPath = NodePath.join(dataDir, OPENCODE_DB_FILENAME);
+  let size = 0;
+  let mtimeMs = 0;
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      const stats = NodeFS.statSync(dbPath + suffix);
+      size += stats.size;
+      mtimeMs = Math.max(mtimeMs, stats.mtimeMs);
+    } catch {
+      // The main file must exist; wal/shm are optional between checkpoints.
+      if (suffix === "") return null;
+    }
+  }
+  return { path: dbPath, size, mtimeMs };
+}
+
+/** Same mtime gate the transcript walk applies, so windows behave identically. */
+export function listOpenCodeDatabaseFiles(
+  dataDir: string,
+  sinceMs: number,
+): readonly OpenCodeDatabaseFile[] {
+  const file = statOpenCodeDatabase(dataDir);
+  if (file === null || file.mtimeMs < sinceMs) return [];
+  return [file];
+}
+
+/**
+ * Reads every billable assistant message out of the database.
+ *
+ * Async signature keeps it interchangeable with the transcript reader behind
+ * `Effect.promise`, though the work itself is synchronous.
+ *
+ * Returns `null` when the database could not be opened or read; like the
+ * transcript reader, the distinction matters because only a genuinely empty
+ * store may be memoised under its `(size, mtime)` key.
+ */
+export async function readOpenCodeRecords(dbPath: string): Promise<readonly UsageRecord[] | null> {
+  const records: UsageRecord[] = [];
+
+  let database: NodeSqlite.DatabaseSync;
+  try {
+    database = new NodeSqlite.DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return null;
+  }
+
+  try {
+    // JSON1 extraction prunes user messages and error stubs before their
+    // (potentially large) `data` payloads reach JavaScript.
+    const statement = database.prepare(
+      `SELECT session_id, data FROM message
+       WHERE json_extract(data, '$.role') = 'assistant'
+         AND json_extract(data, '$.tokens') IS NOT NULL`,
+    );
+    for (const row of statement.iterate()) {
+      try {
+        const record = parseOpenCodeMessage(JSON.parse(String(row.data)), String(row.session_id));
+        if (record !== null) records.push(record);
+      } catch {
+        // A malformed row drops itself rather than failing the scan.
+      }
+    }
+  } catch {
+    return null;
+  } finally {
+    database.close();
+  }
+
+  return records;
+}

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -50,6 +50,26 @@ describe("scan cache round trip", () => {
     expect(restored.get("/b.jsonl")).toEqual(original.get("/b.jsonl"));
   });
 
+  it("restores opencode entries so a restart does not rescan the store", () => {
+    const original: ScanCache = new Map([
+      [
+        "/home/u/.local/share/opencode/opencode.db",
+        {
+          size: 40,
+          mtimeMs: 300,
+          provider: "opencode",
+          records: [record({ provider: "opencode", dedupeKey: null })],
+        },
+      ],
+    ]);
+
+    const restored = decodeScanCache(JSON.parse(JSON.stringify(encodeScanCache(original))));
+
+    expect(restored.get("/home/u/.local/share/opencode/opencode.db")).toEqual(
+      original.get("/home/u/.local/share/opencode/opencode.db"),
+    );
+  });
+
   it("interns repeated model and session strings", () => {
     const encoded = encodeScanCache(
       cacheWith([["/a.jsonl", 100, [record(), record({ dedupeKey: "msg_2:" }), record()]]]),

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -134,7 +134,7 @@ export function decodeScanCache(document: unknown): ScanCache {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
-    if (entry.p !== "claude" && entry.p !== "codex") continue;
+    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "opencode") continue;
     if (!isRecordArray(entry.r)) continue;
 
     const provider: UsageProviderKind = entry.p;

--- a/apps/server/src/usage/usageTranscripts.test.ts
+++ b/apps/server/src/usage/usageTranscripts.test.ts
@@ -4,6 +4,7 @@ import {
   initialCodexScanState,
   parseClaudeLine,
   parseCodexLine,
+  parseOpenCodeMessage,
   totalTokens,
 } from "./usageTranscripts.ts";
 
@@ -247,5 +248,94 @@ describe("totalTokens", () => {
         reasoningTokens: 25,
       }),
     ).toBe(100);
+  });
+});
+
+/** Shaped after a real OpenCode `message` row payload. */
+function opencodeMessage(overrides: {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  cost?: number;
+  modelID?: string;
+  createdMs?: number;
+}): object {
+  return {
+    role: "assistant",
+    mode: "build",
+    agent: "build",
+    cost: overrides.cost ?? 0,
+    tokens: {
+      // OpenCode's own total treats reasoning as disjoint from output.
+      total:
+        (overrides.input ?? 0) +
+        (overrides.output ?? 0) +
+        (overrides.reasoning ?? 0) +
+        (overrides.cacheRead ?? 0) +
+        (overrides.cacheWrite ?? 0),
+      input: overrides.input ?? 0,
+      output: overrides.output ?? 0,
+      reasoning: overrides.reasoning ?? 0,
+      cache: { write: overrides.cacheWrite ?? 0, read: overrides.cacheRead ?? 0 },
+    },
+    modelID: overrides.modelID ?? "claude-fable-5",
+    providerID: "anthropic",
+    time: { created: overrides.createdMs ?? 1_780_114_618_934, completed: 1_780_114_624_274 },
+    finish: "stop",
+  };
+}
+
+describe("parseOpenCodeMessage", () => {
+  it("extracts token totals and trusts the stored cost", () => {
+    const record = parseOpenCodeMessage(
+      opencodeMessage({
+        input: 8505,
+        output: 178,
+        reasoning: 64,
+        cacheRead: 1200,
+        cacheWrite: 300,
+        cost: 0.042,
+      }),
+      "ses_123",
+    );
+
+    expect(record).not.toBeNull();
+    expect(record?.provider).toBe("opencode");
+    expect(record?.model).toBe("claude-fable-5");
+    expect(record?.sessionId).toBe("ses_123");
+    expect(record?.totals).toEqual({
+      uncachedInputTokens: 8505,
+      cachedInputTokens: 1200,
+      cacheCreationTokens: 300,
+      // Reasoning is disjoint from output in the store, so output absorbs it
+      // to reconcile with OpenCode's own grand total.
+      outputTokens: 178 + 64,
+      reasoningTokens: 64,
+    });
+    expect(record?.reportedCostUsd).toBe(0.042);
+    // One row is one billed request; there is nothing to de-duplicate.
+    expect(record?.dedupeKey).toBeNull();
+  });
+
+  it("treats a stored zero cost as a real answer from a free provider", () => {
+    const record = parseOpenCodeMessage(opencodeMessage({ input: 10, output: 5 }), "ses_1");
+
+    expect(record?.reportedCostUsd).toBe(0);
+  });
+
+  it("drops user rows, rows without tokens, unknown models, and empty totals", () => {
+    const user = { ...opencodeMessage({ input: 10, output: 5 }), role: "user" };
+    expect(parseOpenCodeMessage(user, "ses_1")).toBeNull();
+
+    const noTokens = { ...opencodeMessage({ input: 10, output: 5 }), tokens: undefined };
+    expect(parseOpenCodeMessage(noTokens, "ses_1")).toBeNull();
+
+    const noModel = opencodeMessage({ modelID: "" });
+    expect(parseOpenCodeMessage(noModel, "ses_1")).toBeNull();
+
+    const empty = opencodeMessage({});
+    expect(parseOpenCodeMessage(empty, "ses_1")).toBeNull();
   });
 });

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -297,4 +297,77 @@ export function parseCodexLine(line: string, state: CodexScanState): UsageRecord
   };
 }
 
+/* -------------------------------------------------------------------------- */
+/* OpenCode                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Parses one row of OpenCode's `message` table into a usage record.
+ *
+ * OpenCode keeps one row per assistant response in `opencode.db`, with the
+ * message JSON in `data` and the session id on the column. Each row is exactly
+ * one billed request, so unlike the Claude and Codex formats there is nothing
+ * to de-duplicate or suppress; rows are never re-emitted.
+ *
+ * `tokens.input` is exclusive of cached tokens (the cache read/write counts are
+ * separate fields), so it maps straight to `uncachedInputTokens`.
+ *
+ * Unlike the other providers, OpenCode treats reasoning as disjoint from
+ * output: its own `total` is `input + output + cache + reasoning`. Output
+ * absorbs reasoning here, which keeps the contract's "reasoning is a subset of
+ * output" invariant while still reconciling with the stored grand total.
+ *
+ * `cost` is what OpenCode itself priced via models.dev at request time. A
+ * stored `0` is a real answer for free providers, so any finite non-negative
+ * figure is trusted as provider-reported rather than falling back to the rate
+ * table.
+ */
+export function parseOpenCodeMessage(data: unknown, sessionId: string): UsageRecord | null {
+  if (typeof data !== "object" || data === null) return null;
+  const record = data as Record<string, unknown>;
+
+  if (record["role"] !== "assistant") return null;
+
+  const tokens = record["tokens"];
+  if (typeof tokens !== "object" || tokens === null) return null;
+  const tokensRecord = tokens as Record<string, unknown>;
+  const cache =
+    typeof tokensRecord["cache"] === "object" && tokensRecord["cache"] !== null
+      ? (tokensRecord["cache"] as Record<string, unknown>)
+      : {};
+
+  const model = typeof record["modelID"] === "string" ? record["modelID"] : "";
+  if (model.length === 0) return null;
+
+  const created = record["time"];
+  const timestampMs =
+    typeof created === "object" && created !== null
+      ? int((created as Record<string, unknown>)["created"])
+      : 0;
+  if (timestampMs === 0) return null;
+
+  const reasoningTokens = int(tokensRecord["reasoning"]);
+  const totals: UsageTokenTotals = {
+    uncachedInputTokens: int(tokensRecord["input"]),
+    cachedInputTokens: int(cache["read"]),
+    cacheCreationTokens: int(cache["write"]),
+    outputTokens: int(tokensRecord["output"]) + reasoningTokens,
+    reasoningTokens,
+  };
+
+  if (totalTokens(totals) === 0) return null;
+
+  const cost = record["cost"];
+
+  return {
+    provider: "opencode",
+    timestampMs,
+    model,
+    sessionId,
+    totals,
+    reportedCostUsd: typeof cost === "number" && Number.isFinite(cost) && cost >= 0 ? cost : null,
+    dedupeKey: null,
+  };
+}
+
 export { EMPTY_TOTALS };

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -23,6 +23,12 @@ export const PROVIDER_PRESENTATION = {
     label: "Claude Code",
     color: "#d97757",
     mark: ClaudeAI,
+  },
+  opencode: {
+    label: "OpenCode",
+    // Saturated enough to hold against both themes without flipping.
+    color: "#8b5cf6",
+    mark: OpenCodeIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,9 +1,9 @@
 # Review usage
 
-The Usage page combines Codex and Claude Code activity from your connected environments. It reads
-the providers' local session history and shows API-equivalent token cost, processed tokens, cache
-savings, provider shares, and model breakdowns. Subscription billing is separate from the raw token
-cost shown here.
+The Usage page combines Codex, Claude Code, and OpenCode activity from your connected environments.
+It reads the providers' local session history and shows API-equivalent token cost, processed tokens,
+cache savings, provider shares, and model breakdowns. Subscription billing is separate from the raw
+token cost shown here.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -2,8 +2,9 @@
  * Usage reporting contract.
  *
  * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`) rather than
- * relying on T3 Code's own orchestration projections, so usage stays complete
+ * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`, OpenCode's
+ * sqlite store at `${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db`) rather
+ * than relying on T3 Code's own orchestration projections, so usage stays complete
  * even for turns that were never driven through T3 Code. This mirrors the
  * approach `ccusage` takes.
  *
@@ -21,9 +22,9 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "opencode"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**


### PR DESCRIPTION
## Problem

The Usage page only covers Claude Code and Codex. If you drive OpenCode, every token it spends is invisible there, which makes the page's totals quietly wrong for anyone who uses more than one CLI.

## What changed

OpenCode is now a third usage provider. It does not write JSONL transcripts like the other two CLIs; it stores every message in one WAL-mode sqlite database at `${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db`. The usage scan treats that database as one more source:

- `UsageProviderKind` gains `"opencode"` and `USAGE_CONTRACT_VERSION` bumps 4 → 5, so an older client paired with a newer environment renders partial coverage instead of failing schema decode.
- `apps/server/src/usage/opencodeTranscriptReader.ts` opens the store read-only through `node:sqlite` (already in the server's dependency set) and streams assistant rows out. The db, `-wal`, and `-shm` siblings stat into one `(size, mtime)` identity so the existing scan cache invalidates on live writes.
- Each row is exactly one billed request, so unlike the Claude content-block repeats or Codex re-emitted events there is nothing to dedupe. OpenCode's stored `cost` is trusted as provider-reported (a literal `0` is a real answer from free providers), so most rows skip the LiteLLM fallback entirely.
- OpenCode treats reasoning tokens as disjoint from output; its own `total` sums them. Output absorbs reasoning here to reconcile with that total while keeping the contract's "reasoning is a subset of output" invariant.
- Web and mobile presentation tables gain entries reusing the existing `OpenCodeIcon`.

## Before / after

**Before:**
<img width="1374" height="740" alt="image" src="https://github.com/user-attachments/assets/8f75c67b-84fe-4a42-8545-b3f21b2e3012" />


**After:**
<img width="1374" height="740" alt="image" src="https://github.com/user-attachments/assets/39e5e1a8-d707-41c0-86a9-5e143f9f6d23" />


## Verification

- Focused tests for the new parser and reader (`vp test run src/usage/`): 46 passed, covering cost trust, reasoning absorption, junk-row rejection, mtime gating, and read-only DB access against a real sqlite file.
- Targeted typecheck clean for contracts, server, web, mobile; lint clean on touched files.
- Validated the extraction SQL against a production `opencode.db` (~19.5k billable rows, zero malformed).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches usage aggregation and a contract version bump, but changes are read-only local SQLite access with isolated parsing and no auth or billing paths.
> 
> **Overview**
> Adds **OpenCode** as a third usage source alongside Claude Code and Codex, so Usage charts and totals include its local session spend.
> 
> The shared contract gains `"opencode"` in `UsageProviderKind` and **`USAGE_CONTRACT_VERSION` bumps 4 → 5** so older clients can still render partial coverage. On the server, OpenCode is read from **`opencode.db`** under `${XDG_DATA_HOME:-~/.local/share}/opencode` (not JSONL): a new reader treats the DB plus WAL/SHM as one cacheable pseudo-file, queries assistant rows with tokens via SQLite JSON, and maps them through **`parseOpenCodeMessage`** (provider-reported cost, no dedupe keys, reasoning folded into output for contract invariants). **`UsageService`** routes listing and parsing through that path while reusing the existing scan cache (decode now accepts `opencode` entries). Web and mobile usage UI pick up label, purple styling, and **`OpenCodeIcon`**; user docs mention OpenCode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61975b20a91332137d33d40c8424af01c9774a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `opencode` as a usage provider across server, mobile, and web
> - Introduces [opencodeTranscriptReader.ts](https://github.com/pingdotgg/t3code/pull/8260/files#diff-4b873ebccf9906634d88295337215bba6fb0dcbcbdf722213bdd28fcf1e73d1e) which reads assistant messages from OpenCode's SQLite store, exposing `statOpenCodeDatabase`, `listOpenCodeDatabaseFiles`, and `readOpenCodeRecords`
> - [UsageService.make](https://github.com/pingdotgg/t3code/pull/8260/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) branches on the `opencode` provider to call the new reader instead of the transcript reader; cache keying and dedup remain unchanged
> - [parseOpenCodeMessage](https://github.com/pingdotgg/t3code/pull/8260/files#diff-639e969b22f50fb1c28800a8caacb40faa709fb5b829f6c1e0a06a1be5fd5871) converts OpenCode message JSON into a `UsageRecord`, mapping reasoning tokens into output and trusting stored non-negative costs
> - Mobile and web usage UIs register `opencode` with label `OpenCode` and color `#8b5cf6`; web adds an `OpenCodeIcon` mark
> - Bumps `USAGE_CONTRACT_VERSION` from 4 to 5 and extends `UsageProviderKind` to include `'opencode'` in [usage.ts](https://github.com/pingdotgg/t3code/pull/8260/files#diff-9abc3595e224ffc63bc8ed068d884a2dad83ccb207f0b183e94259fb7f486a13)
> - Risk: consumers pinned to contract version 4 will not recognize the new provider literal and may reject or discard `opencode` entries; [decodeScanCache](https://github.com/pingdotgg/t3code/pull/8260/files#diff-ca3f710ebaf0cd708cedab20134ea19de9a81237223250d0402fa68c37498806) now accepts `'opencode'` so persisted caches round-trip correctly
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61975b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->