### PR TITLE
feat(web): surface pull request deployments with one-click preview links

### DIFF
--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -7,6 +7,7 @@ import {
   resolvePullRequestAuthorFilter,
   type PullRequestAction,
   type PullRequestActor,
+  type PullRequestDeployment,
   type PullRequestInvolvement,
   type PullRequestListFilters,
   type PullRequestListState,
@@ -32,6 +33,7 @@ import {
   buildReviewerRequestJson,
   decodeActorAvatarsJson,
   decodePullRequestActivityJson,
+  decodePullRequestDeploymentsJson,
   decodePullRequestDetailJson,
   decodePullRequestFilesJson,
   decodePullRequestListJson,
@@ -51,6 +53,7 @@ import {
   PULL_REQUEST_ACTIVITY_JSON_FIELDS,
   BASE_COMPARISON_GRAPHQL_QUERY,
   decodeBaseComparisonJson,
+  PULL_REQUEST_DEPLOYMENTS_GRAPHQL_QUERY,
   PULL_REQUEST_DETAIL_JSON_FIELDS,
   PULL_REQUEST_LIST_JSON_FIELDS,
   PULL_REQUEST_NODE_ID_GRAPHQL_QUERY,
@@ -382,6 +385,18 @@ export class GitHubPullRequestCli extends Context.Service<
       /** Manual action checks may use the quota held back from automatic reads. */
       readonly allowReserve?: boolean | undefined;
     }) => Effect.Effect<GitHubBaseComparison, GitHubPullRequestCliError>;
+
+    /**
+     * Where the change is running, one row per environment. Its own read because `gh pr view`
+     * reports no deployment of any kind, and one a caller is expected to degrade rather than fail
+     * on: a preview environment is an extra the detail is readable without.
+     */
+    readonly getPullRequestDeployments: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly host: string;
+      readonly number: number;
+    }) => Effect.Effect<ReadonlyArray<PullRequestDeployment>, GitHubPullRequestCliError>;
 
     readonly getPullRequestActivity: (input: {
       readonly cwd: string;
@@ -1370,6 +1385,22 @@ export const make = Effect.gen(function* () {
         ],
         query: BASE_COMPARISON_GRAPHQL_QUERY,
         decode: decodeBaseComparisonJson,
+      });
+    },
+
+    getPullRequestDeployments: (input) => {
+      const { owner, name } = parseRepositorySelector(input.repository);
+      return graphqlRead({
+        cwd: input.cwd,
+        host: input.host,
+        operation: "getPullRequestDeployments",
+        variables: [
+          ["-f", `owner=${owner}`],
+          ["-f", `name=${name}`],
+          ["-F", `number=${input.number}`],
+        ],
+        query: PULL_REQUEST_DEPLOYMENTS_GRAPHQL_QUERY,
+        decode: decodePullRequestDeploymentsJson,
       });
     },
 

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -1,11 +1,43 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type { PullRequestReaction } from "@t3tools/contracts";
+import type { PullRequestDeployment, PullRequestReaction } from "@t3tools/contracts";
 
 import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
 import { gitHubViewerPermissions, loginAvatarUrl, make } from "./GitHubPullRequestProvider.ts";
 import type { GitHubReviewThreadComments } from "./gitHubPullRequestJson.ts";
+
+// Shared by every fixture below that needs a full pull request detail and only overrides the
+// one or two fields its scenario is actually about.
+const openDetail = {
+  authorId: null,
+  number: 7,
+  title: "Pull request 7",
+  url: "https://github.com/acme/web/pull/7",
+  author: null,
+  headRepositoryOwner: "acme",
+  headBranch: "feat/page",
+  baseBranch: "main",
+  state: "open" as const,
+  isDraft: false,
+  mergeability: "mergeable" as const,
+  reviewDecision: null,
+  additions: 1,
+  deletions: 1,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-02T00:00:00Z",
+  reviewRequestLogins: [],
+  hasTeamReviewRequest: false,
+  checksState: null,
+  labels: [],
+  body: "",
+  changedFiles: 1,
+  mergedAt: null,
+  closedAt: null,
+  checks: [],
+  comments: [],
+  commits: [],
+};
 
 describe("gitHubViewerPermissions", () => {
   it("offers everything to a viewer who can write to the repository", () => {
@@ -111,6 +143,7 @@ describe("gitHubViewerPermissions", () => {
             }),
           getViewerAccess: () =>
             Effect.succeed({ canWrite: false, canUpdate: true, didAuthor: false }),
+          getPullRequestDeployments: () => Effect.succeed([]),
         }),
       ),
     ),
@@ -118,36 +151,6 @@ describe("gitHubViewerPermissions", () => {
 });
 
 describe("getViewerPermissions", () => {
-  const openDetail = {
-    authorId: null,
-    number: 7,
-    title: "Pull request 7",
-    url: "https://github.com/acme/web/pull/7",
-    author: null,
-    headRepositoryOwner: "acme",
-    headBranch: "feat/page",
-    baseBranch: "main",
-    state: "open" as const,
-    isDraft: false,
-    mergeability: "mergeable" as const,
-    reviewDecision: null,
-    additions: 1,
-    deletions: 1,
-    createdAt: "2026-07-01T00:00:00Z",
-    updatedAt: "2026-07-02T00:00:00Z",
-    reviewRequestLogins: [],
-    hasTeamReviewRequest: false,
-    checksState: null,
-    labels: [],
-    body: "",
-    changedFiles: 1,
-    mergedAt: null,
-    closedAt: null,
-    checks: [],
-    comments: [],
-    commits: [],
-  };
-
   const layerWithComparison = (
     comparison: Effect.Effect<{
       readonly behindBy: number | null;
@@ -240,6 +243,78 @@ describe("getViewerPermissions", () => {
           getViewerAccess: () =>
             Effect.succeed({ canWrite: true, canUpdate: true, didAuthor: false }),
         }),
+      ),
+    ),
+  );
+});
+
+describe("getChangeRequest deployments", () => {
+  // A pull request whose head repository is unknown, so nothing but the deployments is read.
+  const pullRequest = { ...openDetail, headRepositoryOwner: null };
+
+  const detailWithDeployments = (
+    deployments: Effect.Effect<
+      ReadonlyArray<PullRequestDeployment>,
+      GitHubPullRequestCli.GitHubPullRequestCliError
+    >,
+  ) =>
+    Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+      getPullRequestDetail: () => Effect.succeed(pullRequest),
+      getRepositoryAccess: () =>
+        Effect.succeed({
+          canWrite: false,
+          mergeCapabilities: { merge: true, squash: true, rebase: true },
+        }),
+      getViewerAccess: () => Effect.succeed({ canWrite: false, canUpdate: true, didAuthor: false }),
+      getPullRequestDeployments: () => deployments,
+    });
+
+  const preview: PullRequestDeployment = {
+    environment: "Preview",
+    status: "success",
+    url: "https://preview.example.com",
+  };
+
+  it.effect("carries the host's environments on the detail", () =>
+    Effect.gen(function* () {
+      const provider = yield* make;
+      const detail = yield* provider.getChangeRequest({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+      });
+
+      expect(detail.deployments).toEqual([preview]);
+    }).pipe(Effect.provide(detailWithDeployments(Effect.succeed([preview])))),
+  );
+
+  it.effect("leaves the field absent where the deployments could not be read", () =>
+    Effect.gen(function* () {
+      const provider = yield* make;
+      const detail = yield* provider.getChangeRequest({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+      });
+
+      // Absent rather than empty: the rest of the page must survive a read that failed, and
+      // "none" is a claim this answer cannot make.
+      expect(detail.deployments).toBeUndefined();
+      expect(detail.title).toBe("Pull request 7");
+    }).pipe(
+      Effect.provide(
+        detailWithDeployments(
+          Effect.fail(
+            new GitHubPullRequestCli.GitHubPullRequestReadError({
+              command: "gh",
+              cwd: "/w",
+              operation: "getPullRequestDeployments",
+              cause: new Error("unreadable"),
+            }),
+          ),
+        ),
       ),
     ),
   );

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -252,12 +252,16 @@ export const make = Effect.gen(function* () {
           // A small permissions query replaces the deeply paginated review-thread walk on the
           // core path. Writes ask again immediately before mutating, so this is presentation.
           cli.getViewerAccess(input),
+          // Undefined rather than an empty list where the read failed — a rate limit, a token
+          // that may not read deployments — so the page says nothing instead of claiming there
+          // are none.
+          cli.getPullRequestDeployments(input).pipe(Effect.orElseSucceed(() => undefined)),
         ],
-        { concurrency: 3 },
+        { concurrency: 4 },
       ).pipe(
         Effect.mapError(fail("getChangeRequest")),
         Effect.map(
-          ([detail, repository, viewerAccess]): ProviderChangeRequestDetail => ({
+          ([detail, repository, viewerAccess, deployments]): ProviderChangeRequestDetail => ({
             ...detail.pullRequest,
             reviewers: detail.pullRequest.reviewRequestLogins.map((login) => ({
               login,
@@ -278,6 +282,7 @@ export const make = Effect.gen(function* () {
             ...(detail.comparison?.behindBy == null
               ? {}
               : { behindBy: detail.comparison.behindBy }),
+            ...(deployments === undefined ? {} : { deployments }),
           }),
         ),
       ),

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -9,6 +9,7 @@ import type {
   PullRequestCheck,
   PullRequestComment,
   PullRequestCommit,
+  PullRequestDeployment,
   PullRequestInvolvement,
   PullRequestLabel,
   PullRequestListFilters,
@@ -158,6 +159,8 @@ export interface ProviderChangeRequestDetail extends ProviderChangeRequest {
   readonly closedAt: string | null;
   readonly reviewers: ReadonlyArray<PullRequestActor>;
   readonly checks: ReadonlyArray<PullRequestCheck>;
+  /** Where the change is running, newest first. Absent from a read that could not ask. */
+  readonly deployments?: ReadonlyArray<PullRequestDeployment>;
   readonly mergeCapabilities: PullRequestMergeCapabilities;
   readonly viewerPermissions: PullRequestViewerPermissions;
   /** Absent from a host that cannot compare the branch with its base, which is most of them. */

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1172,6 +1172,9 @@ export const make = Effect.gen(function* () {
               reviewers: changeRequest.reviewers,
               labels: changeRequest.labels,
               checks: changeRequest.checks,
+              ...(changeRequest.deployments === undefined
+                ? {}
+                : { deployments: changeRequest.deployments }),
               mergeCapabilities: changeRequest.mergeCapabilities,
               viewerPermissions: changeRequest.viewerPermissions,
               ...(viewer === null || viewer.trim().length === 0 ? {} : { viewer }),

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -6,6 +6,7 @@ import {
   buildReviewerRequestJson,
   decodeBaseComparisonJson,
   decodePullRequestActivityJson,
+  decodePullRequestDeploymentsJson,
   decodePullRequestDetailJson,
   decodePullRequestFilesJson,
   decodePullRequestListJson,
@@ -1359,5 +1360,151 @@ describe("how far a branch trails its base", () => {
 
   it("refuses a body that is not the answer to this question", () => {
     expect(Result.isSuccess(decodeBaseComparisonJson("{"))).toBe(false);
+  });
+});
+
+describe("where the change is running", () => {
+  const deployments = (nodes: ReadonlyArray<unknown>) =>
+    JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: { commits: { nodes: [{ commit: { deployments: { nodes } } }] } },
+        },
+      },
+    });
+
+  const deployment = (entry: Record<string, unknown>) => ({
+    environment: "Preview",
+    latestStatus: {
+      state: "SUCCESS",
+      environmentUrl: "https://preview.example.com",
+      logUrl: "https://logs.example.com",
+    },
+    ...entry,
+  });
+
+  it("reads an environment, where it stands, and where to open it", () => {
+    expect(expectSuccess(decodePullRequestDeploymentsJson(deployments([deployment({})])))).toEqual([
+      { environment: "Preview", status: "success", url: "https://preview.example.com" },
+    ]);
+  });
+
+  it("maps each of GitHub's states onto what a reader is waiting for", () => {
+    const statuses = [
+      "PENDING",
+      "QUEUED",
+      "WAITING",
+      "IN_PROGRESS",
+      "SUCCESS",
+      "FAILURE",
+      "ERROR",
+      "INACTIVE",
+      "DESTROYED",
+      "SOMETHING_NEW",
+    ].map(
+      (state, index) =>
+        expectSuccess(
+          decodePullRequestDeploymentsJson(
+            deployments([deployment({ environment: `env-${index}`, latestStatus: { state } })]),
+          ),
+        )[0]?.status,
+    );
+
+    expect(statuses).toEqual([
+      "pending",
+      "pending",
+      "pending",
+      "in-progress",
+      "success",
+      "failure",
+      "failure",
+      "inactive",
+      "inactive",
+      // A state this build has never heard of is one nothing can be claimed about yet.
+      "pending",
+    ]);
+  });
+
+  it("treats a deployment the host has said nothing about as pending", () => {
+    expect(
+      expectSuccess(
+        decodePullRequestDeploymentsJson(deployments([deployment({ latestStatus: null })])),
+      ),
+    ).toEqual([{ environment: "Preview", status: "pending", url: null }]);
+  });
+
+  it("falls back to the build log where the environment has no address of its own", () => {
+    const [entry] = expectSuccess(
+      decodePullRequestDeploymentsJson(
+        deployments([
+          deployment({
+            latestStatus: {
+              state: "FAILURE",
+              environmentUrl: "",
+              logUrl: "https://logs.example.com",
+            },
+          }),
+        ]),
+      ),
+    );
+
+    expect(entry?.url).toBe("https://logs.example.com");
+  });
+
+  it("never opens a build log for a live deployment, even where it has no address of its own", () => {
+    const [entry] = expectSuccess(
+      decodePullRequestDeploymentsJson(
+        deployments([
+          deployment({
+            latestStatus: {
+              state: "SUCCESS",
+              environmentUrl: "",
+              logUrl: "https://logs.example.com",
+            },
+          }),
+        ]),
+      ),
+    );
+
+    expect(entry?.url).toBeNull();
+  });
+
+  it("keeps the newest deployment of each environment, in the order the host answered", () => {
+    const decoded = expectSuccess(
+      decodePullRequestDeploymentsJson(
+        deployments([
+          // Newest first, which is what the query orders by, so the retry leads the failure it
+          // replaced and the failure is never shown.
+          deployment({ environment: "Preview", latestStatus: { state: "SUCCESS" } }),
+          deployment({ environment: "Preview", latestStatus: { state: "FAILURE" } }),
+          deployment({ environment: "Storybook", latestStatus: { state: "SUCCESS" } }),
+        ]),
+      ),
+    );
+
+    expect(decoded.map((entry) => [entry.environment, entry.status])).toEqual([
+      ["Preview", "success"],
+      ["Storybook", "success"],
+    ]);
+  });
+
+  it("skips a deployment with no environment to name it by", () => {
+    expect(
+      expectSuccess(
+        decodePullRequestDeploymentsJson(deployments([deployment({ environment: "  " }), null])),
+      ),
+    ).toEqual([]);
+  });
+
+  it("answers nothing for a pull request the viewer cannot see", () => {
+    expect(
+      expectSuccess(
+        decodePullRequestDeploymentsJson(JSON.stringify({ data: { repository: null } })),
+      ),
+    ).toEqual([]);
+  });
+
+  it("refuses a body that is not the answer to this question", () => {
+    expect(Result.isSuccess(decodePullRequestDeploymentsJson("{"))).toBe(false);
   });
 });

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -9,6 +9,8 @@ import type {
   PullRequestChecksState,
   PullRequestComment,
   PullRequestCommit,
+  PullRequestDeployment,
+  PullRequestDeploymentStatus,
   PullRequestLabel,
   PullRequestMergeCapabilities,
   PullRequestOmittedFileStat,
@@ -1985,6 +1987,127 @@ export function decodeBaseComparisonJson(
     behindBy: typeof behindBy === "number" && behindBy >= 0 ? behindBy : null,
     viewerCanUpdate: pullRequest?.viewerCanUpdateBranch === true,
   });
+}
+
+/**
+ * Where the change is running, read off its head commit.
+ *
+ * GitHub hangs a deployment on the commit it was built from rather than on the pull request, so
+ * the last commit is the only one whose environments describe the change as it stands now — an
+ * earlier commit's previews were torn down or replaced by this one's. Newest first, which is what
+ * makes the first deployment of an environment the one serving it now.
+ */
+export const PULL_REQUEST_DEPLOYMENTS_GRAPHQL_QUERY = `query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      commits(last: 1) {
+        nodes {
+          commit {
+            deployments(first: ${GRAPHQL_PAGE_SIZE}, orderBy: { field: CREATED_AT, direction: DESC }) {
+              nodes {
+                environment
+                latestStatus { state environmentUrl logUrl }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const RawDeploymentSchema = Schema.Struct({
+  environment: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Null until the deployment's first status lands, which is a deployment nobody has built yet. */
+  latestStatus: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        state: Schema.optional(Schema.NullOr(Schema.String)),
+        environmentUrl: Schema.optional(Schema.NullOr(Schema.String)),
+        logUrl: Schema.optional(Schema.NullOr(Schema.String)),
+      }),
+    ),
+  ),
+});
+
+const RawDeploymentsSchema = Schema.Struct({
+  data: Schema.Struct({
+    /** Null for a repository, or a number, the viewer cannot see — which is no deployments. */
+    repository: Schema.NullOr(
+      Schema.Struct({
+        pullRequest: Schema.NullOr(
+          Schema.Struct({
+            commits: Schema.Struct({
+              nodes: Schema.Array(
+                Schema.NullOr(
+                  Schema.Struct({
+                    commit: Schema.Struct({
+                      deployments: Schema.Struct({
+                        nodes: Schema.Array(Schema.NullOr(RawDeploymentSchema)),
+                      }),
+                    }),
+                  }),
+                ),
+              ),
+            }),
+          }),
+        ),
+      }),
+    ),
+  }),
+});
+
+const decodeDeployments = decodeJsonResult(RawDeploymentsSchema);
+
+/**
+ * Anything GitHub adds, and a deployment with no status at all, reads as pending: a deployment
+ * nobody has heard from is one that has not happened yet.
+ */
+function toDeploymentStatus(state: string | null | undefined): PullRequestDeploymentStatus {
+  switch (state?.trim().toUpperCase()) {
+    case "IN_PROGRESS":
+      return "in-progress";
+    case "ACTIVE":
+    case "SUCCESS":
+      return "success";
+    case "ERROR":
+    case "FAILURE":
+      return "failure";
+    case "ABANDONED":
+    case "DESTROYED":
+    case "INACTIVE":
+      return "inactive";
+    default:
+      return "pending";
+  }
+}
+
+/**
+ * One row per environment rather than one per deployment of it. A commit that was redeployed — a
+ * retried build, a second provider pushing to the same name — carries the same environment several
+ * times over, and the query hands them over newest first, so the first one to name an environment
+ * is the one serving it now.
+ */
+export function decodePullRequestDeploymentsJson(
+  raw: string,
+): Result.Result<ReadonlyArray<PullRequestDeployment>, DecodeFailure> {
+  const decoded = decodeDeployments(raw);
+  if (!Result.isSuccess(decoded)) return Result.fail(decoded.failure);
+  const commits = decoded.success.data.repository?.pullRequest?.commits.nodes ?? [];
+  const latestByEnvironment = new Map<string, PullRequestDeployment>();
+  for (const node of commits.flatMap((commit) => commit?.commit.deployments.nodes ?? [])) {
+    const environment = trimmed(node?.environment);
+    if (environment === null || latestByEnvironment.has(environment)) continue;
+    const status = toDeploymentStatus(node?.latestStatus?.state);
+    const environmentUrl = trimmed(node?.latestStatus?.environmentUrl);
+    // The log fallback is for a deployment worth investigating. A success with no environment
+    // URL has nothing live to open, so it stays null rather than pointing at a build log — the
+    // header button promises a preview, not a log.
+    const url =
+      environmentUrl ?? (status === "success" ? null : trimmed(node?.latestStatus?.logUrl));
+    latestByEnvironment.set(environment, { environment, status, url });
+  }
+  return Result.succeed([...latestByEnvironment.values()]);
 }
 
 export const REVIEWER_CANDIDATES_GRAPHQL_QUERY = `query($owner: String!, $name: String!, $number: Int!) {

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -24,6 +24,7 @@ import {
   GitPullRequestClosedIcon,
   GitPullRequestDraftIcon,
   GitPullRequestIcon,
+  GlobeIcon,
   HammerIcon,
   LayersIcon,
   MessageCircleQuestionIcon,
@@ -1104,6 +1105,15 @@ export function PullRequestDetailPanel({
           (entry) => entry.outcome === "approved" && !entry.stale,
         ).length
       : 0;
+  // Environments that are both live and reachable, since deployments arrive newest first. A
+  // live deployment can still have nothing to open, which is a status rather than a link.
+  const openableDeployments =
+    detail?.deployments?.filter(
+      (deployment): deployment is typeof deployment & { url: string } =>
+        deployment.status === "success" && !!deployment.url,
+    ) ?? [];
+  const soleOpenableDeployment =
+    openableDeployments.length === 1 ? openableDeployments[0] : undefined;
 
   if (detailQuery.isPending && !detail) {
     return <PullRequestDetailGhost />;
@@ -1307,6 +1317,55 @@ export function PullRequestDetailPanel({
                 >
                   {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
                 </Button>
+              ) : null}
+              {soleOpenableDeployment ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        aria-label="Open preview"
+                        className="size-6"
+                        size="icon-xs"
+                        variant="ghost-muted"
+                        onClick={() =>
+                          void readLocalApi()?.shell.openExternal(soleOpenableDeployment.url)
+                        }
+                      />
+                    }
+                  >
+                    <GlobeIcon className="size-4" />
+                  </TooltipTrigger>
+                  <TooltipPopup side="top">Open preview</TooltipPopup>
+                </Tooltip>
+              ) : openableDeployments.length > 1 ? (
+                // Two or more live environments means one button can no longer say which URL it
+                // opens, so it becomes a menu instead. No tooltip here: a tooltip on a menu
+                // trigger fights the popup for the same space.
+                <Menu>
+                  <MenuTrigger
+                    render={
+                      <Button
+                        aria-label="Open preview"
+                        className="size-6"
+                        size="icon-xs"
+                        variant="ghost-muted"
+                      />
+                    }
+                  >
+                    <GlobeIcon className="size-4" />
+                  </MenuTrigger>
+                  <MenuPopup align="end" side="bottom" className="min-w-48">
+                    {openableDeployments.map((deployment) => (
+                      <MenuItem
+                        key={deployment.environment}
+                        onClick={() => void readLocalApi()?.shell.openExternal(deployment.url)}
+                      >
+                        <GlobeIcon className="size-3.5" />
+                        {deployment.environment}
+                      </MenuItem>
+                    ))}
+                  </MenuPopup>
+                </Menu>
               ) : null}
               <Menu>
                 <MenuTrigger

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -33,8 +33,10 @@ import {
   PullRequestActorAvatar,
   PullRequestActorLabel,
   PullRequestCheckStatusIcon,
+  PullRequestDeploymentStatusIcon,
   PullRequestReviewOutcomeBadge,
   pullRequestCheckStatusLabel,
+  pullRequestDeploymentStatusLabel,
   pullRequestReviewOutcomeLabel,
   pullRequestReviewOutcomeRingClassName,
   pullRequestReviewOutcomeStaleLabel,
@@ -748,6 +750,34 @@ export function PullRequestSummaryTab({
           </div>
         )}
       </Section>
+
+      {/* No section at all rather than an empty one: the field is absent from a host that has no
+          deployments to report and from a read that failed, neither of which is a section a
+          reader can ever fill. */}
+      {detail.deployments && detail.deployments.length > 0 ? (
+        <Section title="Deployments" count={detail.deployments.length}>
+          <div className="space-y-0.5">
+            {detail.deployments.map((deployment) => (
+              <button
+                key={deployment.environment}
+                type="button"
+                disabled={!deployment.url}
+                onClick={() => deployment.url && openCheck(deployment.url)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs",
+                  deployment.url ? "hover:bg-accent/60" : "cursor-default",
+                )}
+              >
+                <PullRequestDeploymentStatusIcon status={deployment.status} />
+                <span className="min-w-0 flex-1 truncate">{deployment.environment}</span>
+                <span className="shrink-0 text-muted-foreground">
+                  {pullRequestDeploymentStatusLabel(deployment.status)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </Section>
+      ) : null}
 
       <Section
         title="Comments"

--- a/apps/web/src/components/pullRequest/pullRequestPresentation.tsx
+++ b/apps/web/src/components/pullRequest/pullRequestPresentation.tsx
@@ -3,6 +3,7 @@ import type {
   PullRequestCheck,
   PullRequestCheckStatus,
   PullRequestChecksState,
+  PullRequestDeploymentStatus,
   PullRequestMergeability,
   PullRequestState,
 } from "@t3tools/contracts";
@@ -140,6 +141,55 @@ export function pullRequestCheckStatusLabel(status: PullRequestCheckStatus): str
 
 export function PullRequestCheckStatusIcon({ status }: { status: PullRequestCheckStatus }) {
   const presentation = CHECK_STATUS_PRESENTATION[status];
+  return (
+    <presentation.Icon
+      aria-hidden
+      className={cn("size-3.5 shrink-0", presentation.toneClassName)}
+    />
+  );
+}
+
+/**
+ * The checks' tones, without their spinner: a deployment is read where it stands rather than
+ * watched, so nothing here repaints.
+ */
+const DEPLOYMENT_STATUS_PRESENTATION = {
+  pending: {
+    label: "Pending",
+    Icon: CircleDotIcon,
+    toneClassName: "text-amber-500",
+  },
+  "in-progress": {
+    label: "Deploying",
+    Icon: CircleDotIcon,
+    toneClassName: "text-amber-500",
+  },
+  success: {
+    label: "Live",
+    Icon: CircleCheckIcon,
+    toneClassName: "text-emerald-600 dark:text-emerald-300/90",
+  },
+  failure: { label: "Failed", Icon: CircleXIcon, toneClassName: "text-destructive" },
+  inactive: {
+    label: "Inactive",
+    Icon: CircleDashedIcon,
+    toneClassName: "text-muted-foreground/70",
+  },
+} as const satisfies Record<
+  PullRequestDeploymentStatus,
+  { label: string; Icon: typeof CircleCheckIcon; toneClassName: string }
+>;
+
+export function pullRequestDeploymentStatusLabel(status: PullRequestDeploymentStatus): string {
+  return DEPLOYMENT_STATUS_PRESENTATION[status].label;
+}
+
+export function PullRequestDeploymentStatusIcon({
+  status,
+}: {
+  status: PullRequestDeploymentStatus;
+}) {
+  const presentation = DEPLOYMENT_STATUS_PRESENTATION[status];
   return (
     <presentation.Icon
       aria-hidden

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -45,6 +45,12 @@ T3 Code works with the platforms your team already uses:
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
 
+**See preview deployments**
+
+- If a pull request has preview deployments (for example, Vercel preview environments on GitHub), the review's Summary tab shows a Deployments section listing each environment and its current state
+- A globe button in the review header opens the newest live preview in your browser
+- When there are several environments, the globe button opens a menu so you can pick which one to open
+
 **Fix what you wrote, in place**
 
 - Rewrite a pull request's title and description from the review itself, in Markdown, with a

--- a/packages/contracts/src/pullRequest.test.ts
+++ b/packages/contracts/src/pullRequest.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   PullRequestActionInput,
   PullRequestCapabilities,
+  PullRequestDetail,
   PullRequestListInput,
   PullRequestListResult,
   PullRequestReviewerRequestInput,
@@ -210,6 +211,69 @@ describe("PullRequestCapabilities", () => {
 
   it("decodes a server that says nothing about reactions as a server with none", () => {
     expect(decodeCapabilities(base).reactions).toBeUndefined();
+  });
+});
+
+describe("PullRequestDetail", () => {
+  const decodeDetail = Schema.decodeUnknownSync(PullRequestDetail);
+  const base = {
+    provider: "github",
+    capabilities: {
+      diff: true,
+      comment: true,
+      actions: [],
+      mergeMethods: [],
+      search: true,
+      review: { inlineComment: true, reply: true, resolve: true, verdicts: [] },
+      reviewers: { request: true, listCandidates: true },
+    },
+    viewerPermissions: {
+      actions: [],
+      comment: true,
+      resolve: true,
+      verdicts: [],
+      requestReviewers: true,
+    },
+    projectId: "project-1",
+    projectTitle: "t3code",
+    workspaceRoot: "/w",
+    repository: "acme/web",
+    number: 7,
+    title: "Add a pull requests page",
+    body: "",
+    url: "https://github.com/acme/web/pull/7",
+    author: null,
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    headBranch: "feat/page",
+    baseBranch: "main",
+    createdAt: "2026-07-01T00:00:00Z",
+    updatedAt: "2026-07-02T00:00:00Z",
+    mergedAt: null,
+    closedAt: null,
+    reviewers: [],
+    labels: [],
+    checks: [],
+    mergeCapabilities: { merge: true, squash: true, rebase: true },
+  };
+
+  it("decodes a server that says nothing about deployments as a server that was not asked", () => {
+    expect(decodeDetail(base).deployments).toBeUndefined();
+  });
+
+  it("carries the environments a server does report", () => {
+    expect(
+      decodeDetail({
+        ...base,
+        deployments: [
+          { environment: "Preview", status: "success", url: "https://preview.example.com" },
+        ],
+      }).deployments,
+    ).toEqual([{ environment: "Preview", status: "success", url: "https://preview.example.com" }]);
   });
 });
 

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -148,6 +148,38 @@ export const PullRequestCheck = Schema.Struct({
 export type PullRequestCheck = typeof PullRequestCheck.Type;
 
 /**
+ * Where a deployment of the change stands. "pending" covers everything before the build starts —
+ * queued, waiting on an approval, and a deployment the host has said nothing about yet.
+ * "inactive" is one that was superseded or torn down, so its environment no longer serves this
+ * change.
+ */
+export const PullRequestDeploymentStatus = Schema.Literals([
+  "pending",
+  "in-progress",
+  "success",
+  "failure",
+  "inactive",
+]);
+export type PullRequestDeploymentStatus = typeof PullRequestDeploymentStatus.Type;
+
+/**
+ * One environment the change has been deployed to — a preview build, a staging box — holding that
+ * environment's latest deployment: a push redeploys the same environment, and every build before
+ * the current one is history nobody is going to open.
+ */
+export const PullRequestDeployment = Schema.Struct({
+  environment: TrimmedNonEmptyString,
+  status: PullRequestDeploymentStatus,
+  /**
+   * Where the deployment can be opened, which is the whole point of showing it. The environment's
+   * own address where the host reported one, the build log where it did not, and null where the
+   * deployment has nothing to open yet — a queued build has no address.
+   */
+  url: Schema.NullOr(Schema.String),
+});
+export type PullRequestDeployment = typeof PullRequestDeployment.Type;
+
+/**
  * The reactions a remark can carry. GitHub's eight, which is also what the picker offers: GitLab
  * accepts any emoji as an award, and the ones outside this set are read as nothing rather than
  * shown under a name no other host would recognise.
@@ -668,6 +700,12 @@ export const PullRequestDetail = Schema.Struct({
   reviewers: Schema.Array(PullRequestActor),
   labels: Schema.Array(PullRequestLabel),
   checks: Schema.Array(PullRequestCheck),
+  /**
+   * Where the change is running, most recent first. Absent from a host that does not report
+   * deployments, which is most of them, and from a read that could not ask — neither of which is
+   * the same as the empty list a change that deploys nowhere answers with.
+   */
+  deployments: Schema.optional(Schema.Array(PullRequestDeployment)),
   mergeCapabilities: PullRequestMergeCapabilities,
   /**
    * Who the host says the reader is, which is the one thing a conversation cannot be read without


### PR DESCRIPTION
## What Changed

When a pull request has deployments (for example Vercel preview environments on GitHub), the review now shows them as first-class data instead of generic check rows:

- The Summary tab gains a **Deployments** section — one row per environment with its state (Live / Deploying / Failed / Inactive); clicking a row opens the environment.
- The pane header gains a compact globe **Open preview** button: with one live environment it opens directly, with several it opens a menu naming each environment, newest first.
- Server side, a new read against GitHub's Deployments GraphQL API (head commit, latest deployment per environment) feeds an optional `deployments` field on `PullRequestDetail`. GitHub only; other hosts leave the field absent, following the `updateMethods`/`reactions` pattern. The read goes through the existing GraphQL budget and degrades to an absent field on failure, so it can never break the detail view. It rides the existing detail query — no new RPC, no extra polling.
- A live deployment with no environment URL never falls back to its build log from the preview button; the log fallback applies only to non-successful deployments, where logs are what you want.
- User docs: a short "See preview deployments" entry in the source control guide.

Proposed and discussed in #8258.

## Why

The preview URL is the thing you usually want mid-review, and today it is buried: providers post it as a commit status, so it renders as an indistinguishable "Details" link among lint and test checks. This promotes deployments to a labeled section and a one-click affordance without new machinery — the data rides the existing detail read, refresh, and cache.

## UI Changes

Before — the Vercel preview is two generic "Passed" rows inside Checks:

<img width="900" alt="PR pane Summary tab before: Vercel appears only as generic check rows" src="https://github.com/user-attachments/assets/79c99803-c56c-4fc6-bb3b-eff196a95802" />

After — a Deployments section names the environment and its state:

<img width="900" alt="PR pane Summary tab after: Deployments section with a Preview environment marked Live" src="https://github.com/user-attachments/assets/01359af2-b4de-49f5-acc3-1f54c352b6b2" />

Header "Open preview" button with tooltip:

<img width="900" alt="PR pane header with the Open preview globe button and its tooltip" src="https://github.com/user-attachments/assets/3bdf429c-7f0e-4a16-adfc-799e46bb7afb" />

Multiple environments become a menu (real data: vercel/commerce#1535):

<img width="900" alt="Header globe button open, showing a menu with two preview environments" src="https://github.com/user-attachments/assets/6316875b-05ec-42c8-ab81-0e63a028cb9c" />

Verified end-to-end against live PRs: single environment opens the deployed preview directly; menu entries open their environment's URL.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (no motion added; the icons deliberately avoid spinners per the no-repainting-animation rule)

Built with Claude Fable 5 in the Claude Code harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every GitHub PR detail load gains an extra GraphQL read (budgeted, but raises parallel fan-out from 3 to 4), though deployment fetch failures are isolated from the rest of the detail response.
> 
> **Overview**
> Adds **optional preview deployment data** to pull request detail so reviewers can open live environments without digging through generic check rows.
> 
> **Contracts & API:** Introduces `PullRequestDeployment` / `PullRequestDeploymentStatus` and an optional `deployments` field on `PullRequestDetail` (absent when the host does not report deployments or the read failed—not the same as an empty list).
> 
> **GitHub server path:** New `getPullRequestDeployments` GraphQL read (head commit, newest deployment per environment) with decoding that maps GitHub states, dedupes by environment, and picks environment URL vs build log (logs only for non-success previews). `getChangeRequest` loads deployments in parallel with the existing detail fetches (concurrency **3 → 4**) and **degrades** with `orElseSucceed(() => undefined)` so failures never break the page.
> 
> **UI:** Summary tab **Deployments** section with status labels/icons and clickable URLs when present. Header **globe** opens the sole live preview directly or a menu when multiple environments have URLs.
> 
> **Docs:** Short “See preview deployments” note in the source-control guide. GitHub-only for now; other providers omit the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fdc0d79fd5ec39f7b8227dc4c9fbeb573c988f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pull request deployment preview links to `PullRequestDetail`
> - Adds `PullRequestDeployment` and `PullRequestDeploymentStatus` schemas to contracts, and an optional `deployments` array on `PullRequestDetail` (most recent first)
> - Server fetches deployments via a new GraphQL query in `GitHubPullRequestCli`; `decodePullRequestDeploymentsJson` normalizes the response, maps GitHub states to internal statuses, deduplicates by environment, and skips unnamed entries
> - `GitHubPullRequestProvider.getChangeRequest` includes deployments with `orElseSucceed(() => undefined)` so fetch failures never fail the page; concurrency in `Effect.all` raised from 3 to 4
> - Web UI shows a globe button in the detail header that opens the single live preview or a menu for multiple; the summary tab renders a Deployments section with status icons and clickable URLs
> - Risk: `getChangeRequest` concurrency increase from 3 to 4 in [GitHubPullRequestProvider.ts](https://github.com/pingdotgg/t3code/pull/8261/files#diff-387272edccb4588cc73a89c98619738ef3bb2de960377976b2b9b430eb3fe0dd) may raise GitHub API rate pressure under high load
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1fdc0d7. 10 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->