### PR TITLE
feat(server): add Atomic and Pi RPC providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # T3 Code
 
-T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps provider CLIs (Codex, Claude Code, Cursor, Grok, OpenCode) and serves web, desktop, and mobile clients.
+T3 Code is a minimal GUI for coding agents. A Node WebSocket server wraps provider CLIs and serves web, desktop, and mobile clients. The current built-in provider inventory lives in `docs/internals/providers.md`.
 
 You can think of T3 Code as an open source "bring-your-own-subscription" alternative to apps like Claude Desktop, Codex App, Cursor Glass and Conductor.
 
@@ -68,7 +68,7 @@ The most common defect in this repo is a change that works on the path you teste
 
 - **Entry points.** A behavior reachable from the chat view is usually also reachable from Settings, the command palette, and a keybinding. Fixing one is not fixing the feature.
 - **Clients.** Web, desktop (wraps web, adds Electron shell/IPC), and mobile (React Native, separate navigation). Shared logic lives in `packages/client-runtime`
-- **Providers.** Codex, Claude, Cursor, Grok, and OpenCode each have an adapter. Provider-shaped features need a decision per adapter, even if the decision is "not supported here".
+- **Providers.** Every built-in provider has an adapter. Provider-shaped features need a decision per adapter, even if the decision is "not supported here". See `docs/internals/providers.md` for the current inventory.
 - **Contracts.** Anything crossing the wire is typed in `packages/contracts`. Change the schema and the server, web, mobile, and desktop all follow.
 - **Reverse states.** If you added a way in, add the way out and the way to see it. Snooze needs unsnooze. Close needs reopen. A one-way door is a bug.
 - **Connection modes.** Local, remote/relay, and tunnel behave differently. Multi-device and multi-environment cases are real.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 T3 Code is an "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app ([iOS](https://apps.apple.com/us/app/t3-code-remote-claude-more/id6787819824), [Android](https://play.google.com/store/apps/details?id=com.t3tools.t3code)), [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
 
-Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, and OpenCode. If they're set up on your computer, T3 Code can control them.
+Works with subscriptions and model credentials configured in supported provider CLIs. See
+[Install and first run](./docs/user/install.md#providers) for the current provider list and setup.
 
 ## "Wait, what are you selling me?"
 
@@ -13,13 +14,9 @@ We wanted something performant, remote-ready, and truly open. If we ever go the 
 ## Installation
 
 > [!WARNING]
-> T3 Code currently supports Codex, Claude, Cursor, Grok Build and OpenCode. Install and authenticate at least one provider before use:
->
-> - Codex: install [Codex CLI](https://developers.openai.com/codex/cli) and run `codex login`
-> - Claude: install [Claude Code](https://claude.com/product/claude-code) and run `claude auth login`
-> - Cursor: install [Cursor CLI](https://cursor.com/cli) and run `agent login`
-> - Grok Build: install [Grok Build CLI](https://x.ai/cli) and run `grok login`
-> - OpenCode: install [OpenCode](https://opencode.ai) and run `opencode auth login`
+> Install and authenticate at least one supported provider CLI before use. The current provider
+> list, setup commands, binary discovery, and Early Access defaults are in
+> [Install T3 Code](./docs/user/install.md#providers).
 
 ### Try it out (install-free)
 

--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -20,6 +20,7 @@ import { ControlPill } from "../../components/ControlPill";
 import { cn } from "../../lib/cn";
 import { useThemeColor } from "../../lib/useThemeColor";
 import {
+  getPendingUserInputCustomAnswer,
   isPendingUserInputOptionSelected,
   type PendingUserInput,
   type PendingUserInputDraftAnswer,
@@ -301,7 +302,7 @@ export function PendingUserInputCard(props: PendingUserInputCardProps) {
                 })}
               </View>
               <TextInput
-                value={draft?.customAnswer ?? ""}
+                value={getPendingUserInputCustomAnswer(question, draft)}
                 onChangeText={(value) =>
                   props.onChangeCustomAnswer(props.pendingUserInput.requestId, question.id, value)
                 }

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -16,7 +16,9 @@ import {
   buildPendingUserInputAnswers,
   buildThreadFeed,
   derivePendingApprovals,
+  derivePendingUserInputs,
   deriveThreadFeedPresentation,
+  getPendingUserInputCustomAnswer,
   isPendingUserInputOptionSelected,
   setPendingUserInputCustomAnswer,
   togglePendingUserInputOptionSelection,
@@ -140,6 +142,38 @@ describe("pending user input answers", () => {
         "  Orders  ",
       ),
     ).toBe(false);
+  });
+
+  it("preserves provider defaults for display and unchanged submission", () => {
+    const requested = makeActivity({
+      id: EventId.make("user-input-default"),
+      kind: "user-input.requested",
+      summary: "User input requested",
+      createdAt: "2026-08-25T00:00:00.000Z",
+      payload: {
+        requestId: "request-default",
+        questions: [
+          {
+            id: "editor",
+            header: "Editor",
+            question: "Review this value",
+            defaultValue: "ORIGINAL_WORKFLOW_VALUE",
+            options: [{ label: "Custom", description: "Enter a custom value" }],
+            multiSelect: false,
+          },
+        ],
+      },
+    });
+
+    const pending = derivePendingUserInputs([requested]);
+    const question = pending[0]?.questions[0];
+    expect(question?.defaultValue).toBe("ORIGINAL_WORKFLOW_VALUE");
+    expect(question && getPendingUserInputCustomAnswer(question, undefined)).toBe(
+      "ORIGINAL_WORKFLOW_VALUE",
+    );
+    expect(question && buildPendingUserInputAnswers([question], {})).toEqual({
+      editor: "ORIGINAL_WORKFLOW_VALUE",
+    });
   });
 });
 

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -223,6 +223,9 @@ function parseUserInputQuestions(
         id: question.id,
         header: question.header,
         question: question.question,
+        ...(typeof question.defaultValue === "string"
+          ? { defaultValue: question.defaultValue }
+          : {}),
         options,
         multiSelect: question.multiSelect === true,
       };
@@ -256,7 +259,7 @@ function resolvePendingUserInputAnswer(
   question: UserInputQuestion,
   draft: PendingUserInputDraftAnswer | undefined,
 ): string | ReadonlyArray<string> | null {
-  const customAnswer = normalizeDraftAnswer(draft?.customAnswer);
+  const customAnswer = normalizeDraftAnswer(getPendingUserInputCustomAnswer(question, draft));
   if (customAnswer) {
     return customAnswer;
   }
@@ -1467,6 +1470,13 @@ export function derivePendingUserInputs(
   }
 
   return Arr.sortWith(openByRequestId.values(), (s) => new Date(s.createdAt), Order.Date);
+}
+
+export function getPendingUserInputCustomAnswer(
+  question: UserInputQuestion,
+  draft: PendingUserInputDraftAnswer | undefined,
+): string {
+  return draft?.customAnswer ?? question.defaultValue ?? "";
 }
 
 export function setPendingUserInputCustomAnswer(

--- a/apps/server/src/orchestration/workflowScriptQuery.test.ts
+++ b/apps/server/src/orchestration/workflowScriptQuery.test.ts
@@ -14,6 +14,11 @@ NodeFS.writeFileSync(scriptPath, "export const meta = {};\n");
 const outside = NodePath.join(NodeOS.tmpdir(), "wf-outside.js");
 NodeFS.writeFileSync(outside, "evil\n");
 const link = NodePath.join(root, "sneaky.js");
+const atomicWorkspace = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "atomic-workflow-view-"));
+const atomicRoot = NodePath.join(atomicWorkspace, ".atomic", "workflows");
+const atomicScriptPath = NodePath.join(atomicRoot, "generated-workflow.ts");
+NodeFS.mkdirSync(atomicRoot, { recursive: true });
+NodeFS.writeFileSync(atomicScriptPath, "export default { name: 'generated-workflow' };\n");
 try {
   NodeFS.symlinkSync(outside, link);
 } catch (error) {
@@ -31,6 +36,7 @@ if (!NodeFS.lstatSync(link).isSymbolicLink()) {
 afterAll(() => {
   NodeFS.rmSync(root, { recursive: true, force: true });
   NodeFS.rmSync(outside, { force: true });
+  NodeFS.rmSync(atomicWorkspace, { recursive: true, force: true });
 });
 
 describe("readWorkflowScript containment", () => {
@@ -42,12 +48,23 @@ describe("readWorkflowScript containment", () => {
     }),
   );
 
+  effectIt.effect("serves a TypeScript workflow from the thread's Atomic directory", () =>
+    Effect.gen(function* () {
+      const result = yield* readWorkflowScript({
+        scriptPath: atomicScriptPath,
+        workspaceRoot: atomicWorkspace,
+      });
+      assert.include(result.contents, "generated-workflow");
+      assert.equal(result.truncated, false);
+    }),
+  );
+
   effectIt.effect("rejects relative and non-js paths", () =>
     Effect.gen(function* () {
       const relative = yield* Effect.exit(readWorkflowScript({ scriptPath: "run.js" }));
       assert.equal(relative._tag, "Failure");
       const nonJs = yield* Effect.exit(
-        readWorkflowScript({ scriptPath: scriptPath.replace(".js", ".ts") }),
+        readWorkflowScript({ scriptPath: scriptPath.replace(".js", ".txt") }),
       );
       assert.equal(nonJs._tag, "Failure");
     }),

--- a/apps/server/src/orchestration/workflowScriptQuery.test.ts
+++ b/apps/server/src/orchestration/workflowScriptQuery.test.ts
@@ -19,6 +19,17 @@ const atomicRoot = NodePath.join(atomicWorkspace, ".atomic", "workflows");
 const atomicScriptPath = NodePath.join(atomicRoot, "generated-workflow.ts");
 NodeFS.mkdirSync(atomicRoot, { recursive: true });
 NodeFS.writeFileSync(atomicScriptPath, "export default { name: 'generated-workflow' };\n");
+const escapedAtomicWorkspace = NodeFS.mkdtempSync(
+  NodePath.join(NodeOS.tmpdir(), "atomic-workflow-escaped-view-"),
+);
+const escapedAtomicTarget = NodeFS.mkdtempSync(
+  NodePath.join(NodeOS.tmpdir(), "atomic-workflow-escaped-target-"),
+);
+const escapedAtomicRoot = NodePath.join(escapedAtomicWorkspace, ".atomic", "workflows");
+const escapedAtomicScript = NodePath.join(escapedAtomicTarget, "escaped-workflow.ts");
+NodeFS.mkdirSync(NodePath.dirname(escapedAtomicRoot), { recursive: true });
+NodeFS.writeFileSync(escapedAtomicScript, "export default { escaped: true };\n");
+NodeFS.symlinkSync(escapedAtomicTarget, escapedAtomicRoot, "dir");
 try {
   NodeFS.symlinkSync(outside, link);
 } catch (error) {
@@ -37,6 +48,8 @@ afterAll(() => {
   NodeFS.rmSync(root, { recursive: true, force: true });
   NodeFS.rmSync(outside, { force: true });
   NodeFS.rmSync(atomicWorkspace, { recursive: true, force: true });
+  NodeFS.rmSync(escapedAtomicWorkspace, { recursive: true, force: true });
+  NodeFS.rmSync(escapedAtomicTarget, { recursive: true, force: true });
 });
 
 describe("readWorkflowScript containment", () => {
@@ -87,6 +100,19 @@ describe("readWorkflowScript containment", () => {
       if (sneaky._tag === "Success") {
         assert.equal(sneaky.value, "outside-root");
       }
+    }),
+  );
+
+  effectIt.effect("rejects an Atomic workflow root symlinked outside its workspace", () =>
+    Effect.gen(function* () {
+      const escaped = yield* readWorkflowScript({
+        scriptPath: escapedAtomicScript,
+        workspaceRoot: escapedAtomicWorkspace,
+      }).pipe(
+        Effect.flip,
+        Effect.map((error) => error.reason),
+      );
+      assert.equal(escaped, "outside-root");
     }),
   );
 });

--- a/apps/server/src/orchestration/workflowScriptQuery.ts
+++ b/apps/server/src/orchestration/workflowScriptQuery.ts
@@ -47,6 +47,7 @@ export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(
       ? [
           {
             path: NodePath.resolve(input.workspaceRoot, ".atomic", "workflows"),
+            workspaceRoot: NodePath.resolve(input.workspaceRoot),
             extensions: new Set([".js", ".ts"]),
           },
         ]
@@ -57,7 +58,17 @@ export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(
       const resolved = await Promise.all(
         configuredRoots.map(async (root) => {
           try {
-            return { ...root, path: await NodeFSP.realpath(root.path) };
+            const resolvedRoot = await NodeFSP.realpath(root.path);
+            if ("workspaceRoot" in root) {
+              const resolvedWorkspace = await NodeFSP.realpath(root.workspaceRoot);
+              if (
+                resolvedRoot !== resolvedWorkspace &&
+                !resolvedRoot.startsWith(`${resolvedWorkspace}${NodePath.sep}`)
+              ) {
+                return null;
+              }
+            }
+            return { ...root, path: resolvedRoot };
           } catch {
             return null;
           }

--- a/apps/server/src/orchestration/workflowScriptQuery.ts
+++ b/apps/server/src/orchestration/workflowScriptQuery.ts
@@ -4,10 +4,9 @@
  * "{} script" affordance.
  *
  * Containment rules (lifted from the reviewed #3650 inspection service):
- * - the resolved realpath must live under ~/.claude/projects (where the
- *   Claude harness persists workflow scripts) — realpath re-containment
- *   defeats symlink escapes, including a symlinked leaf file;
- * - only .js leaf files are served;
+ * - the resolved realpath must live under ~/.claude/projects (Claude) or the
+ *   current thread workspace's .atomic/workflows directory;
+ * - only .js files are served from Claude and .js/.ts from Atomic;
  * - reads are size-capped rather than failed, with a truncation marker.
  *
  * The client-supplied path is a hint from the workflow's runHandles; it is
@@ -22,23 +21,50 @@ import * as Effect from "effect/Effect";
 
 const SCRIPT_BYTE_CAP = 256 * 1024;
 
-function scriptsRoot(): string {
+function claudeScriptsRoot(): string {
   return NodePath.join(NodeOS.homedir(), ".claude", "projects");
 }
 
 export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(function* (input: {
   readonly scriptPath: string;
+  readonly workspaceRoot?: string;
 }) {
   const requested = input.scriptPath;
+  const requestedExtension = NodePath.extname(requested);
 
-  if (!NodePath.isAbsolute(requested) || NodePath.extname(requested) !== ".js") {
+  if (
+    !NodePath.isAbsolute(requested) ||
+    (requestedExtension !== ".js" && requestedExtension !== ".ts")
+  ) {
     return yield* Effect.fail(
       new OrchestrationGetWorkflowScriptError({ reason: "invalid-path", scriptPath: requested }),
     );
   }
 
-  const root = yield* Effect.tryPromise({
-    try: () => NodeFSP.realpath(scriptsRoot()),
+  const configuredRoots = [
+    { path: claudeScriptsRoot(), extensions: new Set([".js"]) },
+    ...(input.workspaceRoot
+      ? [
+          {
+            path: NodePath.resolve(input.workspaceRoot, ".atomic", "workflows"),
+            extensions: new Set([".js", ".ts"]),
+          },
+        ]
+      : []),
+  ];
+  const roots = yield* Effect.tryPromise({
+    try: async () => {
+      const resolved = await Promise.all(
+        configuredRoots.map(async (root) => {
+          try {
+            return { ...root, path: await NodeFSP.realpath(root.path) };
+          } catch {
+            return null;
+          }
+        }),
+      );
+      return resolved.filter((root): root is NonNullable<typeof root> => root !== null);
+    },
     catch: (cause) =>
       new OrchestrationGetWorkflowScriptError({
         reason: "root-unavailable",
@@ -46,6 +72,12 @@ export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(
         cause,
       }),
   });
+  if (roots.length === 0) {
+    return yield* new OrchestrationGetWorkflowScriptError({
+      reason: "root-unavailable",
+      scriptPath: requested,
+    });
+  }
 
   // Realpath the FILE itself (not just its directory): a symlink named
   // like a script inside a contained directory must not escape.
@@ -59,12 +91,15 @@ export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(
       }),
   });
 
-  if (resolved !== root && !resolved.startsWith(`${root}${NodePath.sep}`)) {
+  const containingRoot = roots.find(
+    (root) => resolved === root.path || resolved.startsWith(`${root.path}${NodePath.sep}`),
+  );
+  if (!containingRoot) {
     return yield* Effect.fail(
       new OrchestrationGetWorkflowScriptError({ reason: "outside-root", scriptPath: resolved }),
     );
   }
-  if (NodePath.extname(resolved) !== ".js") {
+  if (!containingRoot.extensions.has(NodePath.extname(resolved))) {
     return yield* Effect.fail(
       new OrchestrationGetWorkflowScriptError({ reason: "not-js", scriptPath: resolved }),
     );

--- a/apps/server/src/orchestration/workflowScriptQuery.ts
+++ b/apps/server/src/orchestration/workflowScriptQuery.ts
@@ -36,9 +36,10 @@ export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(
     !NodePath.isAbsolute(requested) ||
     (requestedExtension !== ".js" && requestedExtension !== ".ts")
   ) {
-    return yield* Effect.fail(
-      new OrchestrationGetWorkflowScriptError({ reason: "invalid-path", scriptPath: requested }),
-    );
+    return yield* new OrchestrationGetWorkflowScriptError({
+      reason: "invalid-path",
+      scriptPath: requested,
+    });
   }
 
   const configuredRoots = [
@@ -106,14 +107,16 @@ export const readWorkflowScript = Effect.fn("orchestration.readWorkflowScript")(
     (root) => resolved === root.path || resolved.startsWith(`${root.path}${NodePath.sep}`),
   );
   if (!containingRoot) {
-    return yield* Effect.fail(
-      new OrchestrationGetWorkflowScriptError({ reason: "outside-root", scriptPath: resolved }),
-    );
+    return yield* new OrchestrationGetWorkflowScriptError({
+      reason: "outside-root",
+      scriptPath: resolved,
+    });
   }
   if (!containingRoot.extensions.has(NodePath.extname(resolved))) {
-    return yield* Effect.fail(
-      new OrchestrationGetWorkflowScriptError({ reason: "not-js", scriptPath: resolved }),
-    );
+    return yield* new OrchestrationGetWorkflowScriptError({
+      reason: "not-js",
+      scriptPath: resolved,
+    });
   }
 
   // TOCTOU-safe read (review finding): open FIRST, then verify what was

--- a/apps/server/src/provider/Drivers/AtomicDriver.ts
+++ b/apps/server/src/provider/Drivers/AtomicDriver.ts
@@ -1,0 +1,179 @@
+import {
+  AtomicSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  TextGenerationError,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import type * as TextGeneration from "../../textGeneration/TextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeAtomicAdapter } from "../Layers/AtomicAdapter.ts";
+import {
+  buildInitialAtomicProviderSnapshot,
+  checkAtomicProviderStatus,
+} from "../Layers/AtomicProvider.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeAtomicSettings = Schema.decodeSync(AtomicSettings);
+const DRIVER_KIND = ProviderDriverKind.make("atomic");
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: "@bastani/atomic",
+  }),
+);
+
+export type AtomicDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | Path.Path
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+function makeUnsupportedTextGeneration(): TextGeneration.TextGeneration["Service"] {
+  const unsupported = (
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle",
+  ) =>
+    Effect.fail(
+      new TextGenerationError({
+        operation,
+        detail:
+          "Atomic is available for agent sessions, but auxiliary title and Git text generation are not implemented yet.",
+      }),
+    );
+  return {
+    generateCommitMessage: () => unsupported("generateCommitMessage"),
+    generatePrContent: () => unsupported("generatePrContent"),
+    generateBranchName: () => unsupported("generateBranchName"),
+    generateThreadTitle: () => unsupported("generateThreadTitle"),
+  };
+}
+
+export const AtomicDriver: ProviderDriver<AtomicSettings, AtomicDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Atomic",
+    supportsMultipleInstances: true,
+  },
+  configSchema: AtomicSettings,
+  defaultConfig: (): AtomicSettings => decodeAtomicSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const serverConfig = yield* ServerConfig;
+      const serverSettings = yield* ServerSettingsService;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies AtomicSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+      const adapter = yield* makeAtomicAdapter(effectiveConfig, {
+        instanceId,
+        environment: processEnv,
+      });
+      const checkProvider = checkAtomicProviderStatus(
+        effectiveConfig,
+        serverConfig.cwd,
+        processEnv,
+      ).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<AtomicSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialAtomicProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Atomic snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration: makeUnsupportedTextGeneration(),
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Drivers/PiDriver.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.ts
@@ -1,0 +1,176 @@
+import {
+  PiSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  TextGenerationError,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import type * as TextGeneration from "../../textGeneration/TextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makePiAdapter } from "../Layers/PiAdapter.ts";
+import { buildInitialPiProviderSnapshot, checkPiProviderStatus } from "../Layers/PiProvider.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodePiSettings = Schema.decodeSync(PiSettings);
+const DRIVER_KIND = ProviderDriverKind.make("pi");
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: "@earendil-works/pi-coding-agent",
+  }),
+);
+
+export type PiDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | Path.Path
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+function makeUnsupportedTextGeneration(): TextGeneration.TextGeneration["Service"] {
+  const unsupported = (
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle",
+  ) =>
+    Effect.fail(
+      new TextGenerationError({
+        operation,
+        detail:
+          "Pi is available for agent sessions, but auxiliary title and Git text generation are not implemented yet.",
+      }),
+    );
+  return {
+    generateCommitMessage: () => unsupported("generateCommitMessage"),
+    generatePrContent: () => unsupported("generatePrContent"),
+    generateBranchName: () => unsupported("generateBranchName"),
+    generateThreadTitle: () => unsupported("generateThreadTitle"),
+  };
+}
+
+export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Pi",
+    supportsMultipleInstances: true,
+  },
+  configSchema: PiSettings,
+  defaultConfig: (): PiSettings => decodePiSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const serverConfig = yield* ServerConfig;
+      const serverSettings = yield* ServerSettingsService;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies PiSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+      const adapter = yield* makePiAdapter(effectiveConfig, {
+        instanceId,
+        environment: processEnv,
+      });
+      const checkProvider = checkPiProviderStatus(
+        effectiveConfig,
+        serverConfig.cwd,
+        processEnv,
+      ).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<PiSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialPiProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Pi snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration: makeUnsupportedTextGeneration(),
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/AtomicAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.test.ts
@@ -243,6 +243,33 @@ describe("AtomicAdapter", () => {
           awaitingInput?.type === "task.progress" ? awaitingInput.payload.summary : undefined,
           "Approve the synthesized result?",
         );
+        assert.isDefined(
+          events.find(
+            (event) =>
+              event.type === "task.progress" &&
+              event.payload.taskId === "workflow-run-1" &&
+              event.payload.status === "waiting" &&
+              event.payload.summary === "Provide workflow inputs.",
+          ),
+        );
+        const resumedStage = events.find(
+          (event) =>
+            event.type === "task.updated" &&
+            event.payload.taskId === "workflow-run-1:wf:approve" &&
+            event.payload.status === "running",
+        );
+        assert.equal(
+          resumedStage?.type === "task.updated" ? resumedStage.payload.role : undefined,
+          "workflow stage",
+        );
+        const completedStage = events.find(
+          (event) =>
+            event.type === "task.completed" && event.payload.taskId === "workflow-run-1:wf:approve",
+        );
+        assert.equal(
+          completedStage?.type === "task.completed" ? completedStage.payload.role : undefined,
+          "workflow stage",
+        );
         const completed = events.find(
           (event) => event.type === "task.completed" && event.payload.taskId === "workflow-run-1",
         );
@@ -373,6 +400,126 @@ describe("AtomicAdapter", () => {
       yield* Fiber.join(sendFiber);
       const completed = yield* Fiber.join(completedFiber).pipe(Effect.map(Option.getOrThrow));
       assert.equal(completed.type, "turn.completed");
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("stops a session while its prompt request is awaiting user input", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter();
+      const threadId = ThreadId.make("atomic-stop-awaiting-input");
+      const requestedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "user-input.requested"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendFiber = yield* adapter
+        .sendTurn({ threadId, input: "/t3-ui-wait", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Fiber.join(requestedFiber).pipe(Effect.map(Option.getOrThrow));
+
+      yield* adapter.stopSession(threadId);
+
+      const sendResult = yield* Fiber.join(sendFiber).pipe(Effect.result);
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(sendResult._tag, "Failure");
+      assert.isFalse(yield* adapter.hasSession(threadId));
+      assert.isDefined(
+        events.find(
+          (event) => event.type === "turn.completed" && event.payload.state === "interrupted",
+        ),
+      );
+      assert.isDefined(events.find((event) => event.type === "user-input.resolved"));
+      assert.equal(events.at(-1)?.type, "session.exited");
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("fails and retires a session when the prompt request is rejected", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter();
+      const threadId = ThreadId.make("atomic-prompt-rejected");
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const result = yield* adapter
+        .sendTurn({ threadId, input: "/t3-prompt-rejected", attachments: [] })
+        .pipe(Effect.result);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(result._tag, "Failure");
+      assert.isFalse(yield* adapter.hasSession(threadId));
+      assert.isDefined(
+        events.find((event) => event.type === "turn.completed" && event.payload.state === "failed"),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("drains acknowledged tool events before completing an interruption", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter();
+      const threadId = ThreadId.make("atomic-abort-drain");
+      const toolStartedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "item.started" &&
+            event.payload.itemType === "dynamic_tool_call" &&
+            event.itemId === "abort-tool-1",
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "/t3-abort-drain", attachments: [] });
+      yield* Fiber.join(toolStartedFiber).pipe(Effect.map(Option.getOrThrow));
+      yield* adapter.interruptTurn(threadId);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const toolCompletedIndex = events.findIndex(
+        (event) =>
+          event.type === "item.completed" &&
+          event.payload.itemType === "dynamic_tool_call" &&
+          event.itemId === "abort-tool-1",
+      );
+      const turnCompletedIndex = events.findIndex((event) => event.type === "turn.completed");
+      assert.isAtLeast(toolCompletedIndex, 0);
+      assert.isTrue(toolCompletedIndex < turnCompletedIndex);
+      assert.equal(
+        events[turnCompletedIndex]?.type === "turn.completed"
+          ? events[turnCompletedIndex].payload.state
+          : undefined,
+        "interrupted",
+      );
     }).pipe(Effect.scoped),
   );
 });

--- a/apps/server/src/provider/Layers/AtomicAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.test.ts
@@ -391,6 +391,9 @@ describe("AtomicAdapter", () => {
         "Edit this value before the workflow continues.",
       );
       assert.equal(requested.payload.questions[0]?.defaultValue, "ORIGINAL_WORKFLOW_VALUE");
+      if (requested.requestId === undefined) {
+        return assert.fail("Expected the Atomic user-input request to have an id.");
+      }
 
       // Deliberately cross the ordinary command deadline before the user answers.
       yield* Effect.sleep(Duration.millis(80));

--- a/apps/server/src/provider/Layers/AtomicAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.test.ts
@@ -1,0 +1,378 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import {
+  ApprovalRequestId,
+  AtomicSettings,
+  ProviderDriverKind,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { assert, describe } from "vite-plus/test";
+
+import { ServerConfig } from "../../config.ts";
+import { makeAtomicAdapter } from "./AtomicAdapter.ts";
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockPeer = NodePath.join(__dirname, "../testFixtures/piRpcMockPeer.mjs");
+const decodeAtomicSettings = Schema.decodeSync(AtomicSettings);
+
+function writeMockWrapper(): string {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "atomic-adapter-test-"));
+  const wrapper = NodePath.join(dir, "mock-atomic.sh");
+  NodeFS.writeFileSync(
+    wrapper,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(mockPeer)} "$@"\n`,
+    "utf8",
+  );
+  NodeFS.chmodSync(wrapper, 0o755);
+  return wrapper;
+}
+
+function makeAdapter(options?: { readonly requestTimeout?: Duration.Input }) {
+  return makeAtomicAdapter(
+    decodeAtomicSettings({ enabled: true, binaryPath: writeMockWrapper() }),
+    options,
+  ).pipe(
+    Effect.provide(
+      ServerConfig.layerTest(process.cwd(), { prefix: "atomic-adapter-test-" }).pipe(
+        Layer.provideMerge(NodeServices.layer),
+      ),
+    ),
+  );
+}
+
+describe("AtomicAdapter", () => {
+  it.live("keeps the Pi-derived process alive and completes only after agent_settled", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter();
+      const threadId = ThreadId.make("atomic-chat-lifecycle");
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "Reply with PI_RPC_OK", attachments: [] });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const assistantStarts = events.filter(
+        (event) => event.type === "item.started" && event.payload.itemType === "assistant_message",
+      );
+      assert.lengthOf(
+        assistantStarts,
+        2,
+        "user messages must not become assistant messages, but queued assistant runs must remain visible",
+      );
+      assert.include(
+        events
+          .filter((event) => event.type === "content.delta")
+          .map((event) => (event.type === "content.delta" ? event.payload.delta : "")),
+        "Check the shared Pi event stream.",
+      );
+      assert.include(
+        events
+          .filter((event) => event.type === "content.delta")
+          .map((event) => (event.type === "content.delta" ? event.payload.delta : "")),
+        "PI_RPC_OK",
+      );
+      assert.include(
+        events
+          .filter((event) => event.type === "content.delta")
+          .map((event) => (event.type === "content.delta" ? event.payload.delta : "")),
+        "QUEUED_FOLLOW_UP",
+      );
+      const toolUpdate = events.find(
+        (event) => event.type === "item.updated" && event.payload.itemType === "dynamic_tool_call",
+      );
+      assert.equal(
+        toolUpdate?.type === "item.updated" ? toolUpdate.payload.detail : undefined,
+        "partial tool output",
+      );
+      const usage = events.find((event) => event.type === "thread.token-usage.updated");
+      assert.deepInclude(usage?.type === "thread.token-usage.updated" ? usage.payload.usage : {}, {
+        usedTokens: 1500,
+        totalProcessedTokens: 1900,
+        maxTokens: 200000,
+        toolUses: 1,
+      });
+      assert.equal(events.at(-1)?.type, "turn.completed");
+    }).pipe(Effect.scoped),
+  );
+
+  it.live(
+    "renders slash-command feedback and keeps background workflow events after the turn",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* makeAdapter();
+        const threadId = ThreadId.make("atomic-workflow-lifecycle");
+        const cwd = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "atomic-workflow-cwd-"));
+        const workflowDir = NodePath.join(cwd, ".atomic", "workflows");
+        NodeFS.mkdirSync(workflowDir, { recursive: true });
+        const scriptPath = NodePath.join(workflowDir, "classify-and-act.ts");
+        NodeFS.writeFileSync(scriptPath, "export default {};\n", "utf8");
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil(
+            (event) => event.type === "task.completed" && event.payload.taskId === "workflow-run-1",
+          ),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          threadId,
+          provider: ProviderDriverKind.make("atomic"),
+          cwd,
+          runtimeMode: "full-access",
+        });
+        yield* adapter.sendTurn({ threadId, input: "/workflow list", attachments: [] });
+
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        assert.isDefined(events.find((event) => event.type === "turn.completed"));
+        assert.isDefined(
+          events.find(
+            (event) =>
+              event.type === "content.delta" &&
+              event.payload.delta.includes("Workflow classify-and-act started"),
+          ),
+        );
+        const workflowStarted = events.find(
+          (event) => event.type === "task.started" && event.payload.taskId === "workflow-run-1",
+        );
+        assert.lengthOf(
+          events.filter(
+            (event) => event.type === "task.started" && event.payload.taskId === "workflow-run-1",
+          ),
+          1,
+          "the same lifecycle notice can arrive on both Pi event surfaces",
+        );
+        assert.equal(
+          workflowStarted?.type === "task.started" ? workflowStarted.payload.taskType : undefined,
+          "local_workflow",
+        );
+        assert.equal(
+          workflowStarted?.type === "task.started"
+            ? workflowStarted.payload.runHandles?.runId
+            : undefined,
+          "workflow-run-1",
+        );
+        assert.equal(
+          workflowStarted?.type === "task.started"
+            ? workflowStarted.payload.runHandles?.scriptPath
+            : undefined,
+          scriptPath,
+        );
+        const stageStarted = events.find(
+          (event) =>
+            event.type === "task.started" && event.payload.taskId === "workflow-run-1:wf:classify",
+        );
+        assert.equal(
+          stageStarted?.type === "task.started" ? stageStarted.payload.parentAgentId : undefined,
+          "workflow-run-1",
+        );
+        assert.equal(
+          stageStarted?.type === "task.started" ? stageStarted.payload.phaseIndex : undefined,
+          0,
+        );
+        assert.equal(
+          stageStarted?.type === "task.started" ? stageStarted.payload.phaseTitle : undefined,
+          "Stage 1",
+        );
+        assert.equal(
+          stageStarted?.type === "task.started" ? stageStarted.payload.timelineBypass : undefined,
+          true,
+        );
+        assert.isDefined(
+          events.find(
+            (event) =>
+              event.type === "task.completed" &&
+              event.payload.taskId === "workflow-run-1:wf:classify" &&
+              event.payload.parentAgentId === "workflow-run-1" &&
+              event.payload.phaseIndex === 0,
+          ),
+        );
+        const parallelStage = events.find(
+          (event) =>
+            event.type === "task.started" && event.payload.taskId === "workflow-run-1:wf:inspect",
+        );
+        assert.isDefined(parallelStage, "Atomic stage identity must survive the adapter");
+        assert.equal(
+          parallelStage?.type === "task.started" ? parallelStage.payload.phaseIndex : undefined,
+          0,
+          "independent roots belong to the same workflow layer",
+        );
+        const dependentStage = events.find(
+          (event) =>
+            event.type === "task.started" &&
+            event.payload.taskId === "workflow-run-1:wf:synthesize",
+        );
+        assert.deepEqual(
+          dependentStage?.type === "task.started"
+            ? (dependentStage.payload as unknown as Record<string, unknown>).dependsOnTaskIds
+            : undefined,
+          ["workflow-run-1:wf:classify", "workflow-run-1:wf:inspect"],
+        );
+        assert.equal(
+          dependentStage?.type === "task.started" ? dependentStage.payload.phaseIndex : undefined,
+          1,
+        );
+        const awaitingInput = events.find(
+          (event) =>
+            event.type === "task.progress" &&
+            event.payload.taskId === "workflow-run-1:wf:approve" &&
+            event.payload.status === "waiting",
+        );
+        assert.equal(
+          awaitingInput?.type === "task.progress" ? awaitingInput.payload.summary : undefined,
+          "Approve the synthesized result?",
+        );
+        const completed = events.find(
+          (event) => event.type === "task.completed" && event.payload.taskId === "workflow-run-1",
+        );
+        assert.lengthOf(
+          events.filter(
+            (event) => event.type === "task.completed" && event.payload.taskId === "workflow-run-1",
+          ),
+          1,
+        );
+        assert.equal(
+          completed?.type === "task.completed" ? completed.payload.summary : undefined,
+          "WORKFLOW_OK",
+        );
+      }).pipe(Effect.scoped),
+  );
+
+  it.live("treats an extension load failure as recoverable when Pi keeps running", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter();
+      const threadId = ThreadId.make("atomic-recoverable-extension-error");
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/t3-recoverable-extension-error",
+        attachments: [],
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.isUndefined(events.find((event) => event.type === "runtime.error"));
+      assert.isDefined(events.find((event) => event.type === "runtime.warning"));
+      assert.isDefined(
+        events.find(
+          (event) =>
+            event.type === "content.delta" &&
+            event.payload.delta === "RECOVERED_AFTER_EXTENSION_ERROR",
+        ),
+      );
+      assert.equal(events.at(-1)?.type, "turn.completed");
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("fails a turn when the final Pi assistant outcome is an error", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter();
+      const threadId = ThreadId.make("atomic-terminal-assistant-error");
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "/t3-terminal-assistant-error",
+        attachments: [],
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(
+        events.find((event) => event.type === "runtime.error")?.payload.message,
+        "The model request failed permanently.",
+      );
+      const completed = events.at(-1);
+      assert.equal(completed?.type, "turn.completed");
+      assert.equal(
+        completed?.type === "turn.completed" ? completed.payload.state : undefined,
+        "failed",
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("keeps an interactive prompt alive beyond the ordinary RPC deadline", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makeAdapter({ requestTimeout: Duration.millis(30) });
+      const threadId = ThreadId.make("atomic-long-lived-ui-request");
+      const requestFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "user-input.requested"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("atomic"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendFiber = yield* adapter
+        .sendTurn({ threadId, input: "/t3-ui-wait", attachments: [] })
+        .pipe(Effect.forkChild);
+      const requested = yield* Fiber.join(requestFiber).pipe(Effect.map(Option.getOrThrow));
+      if (requested.type !== "user-input.requested") {
+        return assert.fail("Expected an Atomic user-input request.");
+      }
+      assert.equal(
+        requested.payload.questions[0]?.question,
+        "Edit this value before the workflow continues.",
+      );
+      assert.equal(requested.payload.questions[0]?.defaultValue, "ORIGINAL_WORKFLOW_VALUE");
+
+      // Deliberately cross the ordinary command deadline before the user answers.
+      yield* Effect.sleep(Duration.millis(80));
+      yield* adapter.respondToUserInput(threadId, ApprovalRequestId.make(requested.requestId), {
+        "ui-editor-1:answer": "EDITED_WORKFLOW_VALUE",
+      });
+      yield* Fiber.join(sendFiber);
+      const completed = yield* Fiber.join(completedFiber).pipe(Effect.map(Option.getOrThrow));
+      assert.equal(completed.type, "turn.completed");
+    }).pipe(Effect.scoped),
+  );
+});

--- a/apps/server/src/provider/Layers/AtomicAdapter.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.ts
@@ -10,6 +10,7 @@ import {
   ProviderItemId,
   RuntimeItemId,
   RuntimeRequestId,
+  RuntimeTaskId,
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -17,6 +18,7 @@ import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { tokenizeCliArgs } from "@t3tools/shared/cliArgs";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
@@ -42,11 +44,11 @@ import {
 import {
   type AtomicRpcEvent,
   type AtomicRpcProcess,
+  atomicRpcEventSequence,
   makeAtomicRpcProcess,
 } from "../atomic/AtomicRpcProcess.ts";
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 
-const PROVIDER = ProviderDriverKind.make("atomic");
 const RESUME_VERSION = 1 as const;
 const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown);
 const isRecord = Schema.is(UnknownRecord);
@@ -65,6 +67,7 @@ const AtomicStateData = Schema.Struct({
   thinkingLevel: Schema.optional(Schema.String),
   sessionFile: Schema.optional(Schema.String),
   sessionId: Schema.optional(Schema.String),
+  isStreaming: Schema.optional(Schema.Boolean),
 });
 const decodeState = Schema.decodeUnknownOption(AtomicStateData);
 const AtomicResumeCursor = Schema.Struct({
@@ -80,6 +83,20 @@ interface PendingUiRequest {
   readonly questionId: string;
 }
 
+interface AtomicWorkflowStageContext {
+  readonly id: string;
+  readonly index: number;
+  name: string;
+  parentIds: ReadonlyArray<string>;
+  awaitingInput: boolean;
+}
+
+interface AtomicWorkflowRunContext {
+  name: string;
+  scriptPath: string | undefined;
+  readonly stages: Map<string, AtomicWorkflowStageContext>;
+}
+
 interface AtomicSessionContext {
   readonly threadId: ThreadId;
   readonly scope: Scope.Closeable;
@@ -88,15 +105,42 @@ interface AtomicSessionContext {
   activeTurnId: TurnId | undefined;
   assistantItemId: RuntimeItemId | undefined;
   reasoningItemId: RuntimeItemId | undefined;
+  messageSequence: number;
+  assistantText: string;
+  reasoningText: string;
+  pendingAssistantError: string | undefined;
+  sawAgentActivity: boolean;
   readonly pendingUi: Map<ApprovalRequestId, PendingUiRequest>;
+  readonly workflowRuns: Map<string, AtomicWorkflowRunContext>;
+  readonly workflowLifecycleSignatures: Map<string, string>;
+  mappedEventSequence: number;
   turns: Array<{ id: TurnId; items: Array<unknown> }>;
   stopped: boolean;
 }
 
-export interface AtomicAdapterOptions {
+export interface PiCompatibleAdapterOptions {
   readonly environment?: NodeJS.ProcessEnv;
   readonly instanceId?: ProviderInstanceId;
+  /** Internal process budget override. Primarily used by focused adapter tests. */
+  readonly startupTimeout?: Duration.Input;
+  /** Internal process budget override. Primarily used by focused adapter tests. */
+  readonly requestTimeout?: Duration.Input;
 }
+
+export interface PiCompatibleSettings {
+  readonly binaryPath: string;
+  readonly agentDir: string;
+  readonly launchArgs: string;
+}
+
+export interface PiCompatibleAdapterDefinition {
+  readonly provider: ProviderDriverKind;
+  readonly displayName: string;
+  readonly agentDirEnvironmentVariable: "ATOMIC_CODING_AGENT_DIR" | "PI_CODING_AGENT_DIR";
+  readonly rawSource: "atomic.rpc" | "pi.rpc";
+}
+
+export type AtomicAdapterOptions = PiCompatibleAdapterOptions;
 
 function parseModelSlug(
   slug: string | undefined,
@@ -113,22 +157,116 @@ function field(record: Readonly<Record<string, unknown>>, name: string): string 
   return isString(value) && value.trim().length > 0 ? value : undefined;
 }
 
-function dataText(value: unknown): string | undefined {
-  if (isString(value)) return value;
-  if (!isRecord(value)) return undefined;
-  return field(value, "text") ?? field(value, "content") ?? field(value, "output");
+function stringField(record: Readonly<Record<string, unknown>>, name: string): string | undefined {
+  const value = record[name];
+  return isString(value) ? value : undefined;
 }
 
-function atomicEnvironment(
-  settings: AtomicSettings,
+function workflowStageTaskId(runId: string, stageId: string): string {
+  return `${runId}:wf:${stageId}`;
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function atomicSessionUsage(data: unknown) {
+  if (!isRecord(data)) return undefined;
+  const tokens = isRecord(data.tokens) ? data.tokens : undefined;
+  const contextUsage = isRecord(data.contextUsage) ? data.contextUsage : undefined;
+  const usedTokens = nonNegativeNumber(contextUsage?.tokens) ?? nonNegativeNumber(tokens?.total);
+  if (usedTokens === undefined) return undefined;
+  const maxTokens = nonNegativeNumber(contextUsage?.contextWindow);
+  const inputTokens = nonNegativeNumber(tokens?.input);
+  const cachedInputTokens = nonNegativeNumber(tokens?.cacheRead);
+  const outputTokens = nonNegativeNumber(tokens?.output);
+  const totalProcessedTokens = nonNegativeNumber(tokens?.total);
+  const toolUses = nonNegativeNumber(data.toolCalls);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined && maxTokens > 0 ? { maxTokens } : {}),
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(cachedInputTokens === undefined ? {} : { cachedInputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+    ...(totalProcessedTokens === undefined ? {} : { totalProcessedTokens }),
+    ...(toolUses === undefined ? {} : { toolUses }),
+  };
+}
+
+function workflowStageDepth(
+  run: AtomicWorkflowRunContext,
+  stage: AtomicWorkflowStageContext,
+  visiting: ReadonlySet<string> = new Set(),
+): number {
+  if (stage.parentIds.length === 0 || visiting.has(stage.id)) return 0;
+  const nextVisiting = new Set(visiting).add(stage.id);
+  return (
+    1 +
+    Math.max(
+      ...stage.parentIds.map((parentId) => {
+        const parent = run.stages.get(parentId);
+        return parent ? workflowStageDepth(run, parent, nextVisiting) : 0;
+      }),
+    )
+  );
+}
+
+function dataText(value: unknown): string | undefined {
+  if (isString(value)) return value;
+  if (Array.isArray(value)) {
+    const text = value
+      .map(dataText)
+      .filter((entry): entry is string => entry !== undefined)
+      .join("");
+    return text.length > 0 ? text : undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  return (
+    stringField(value, "text") ??
+    stringField(value, "thinking") ??
+    dataText(value.content) ??
+    dataText(value.output) ??
+    dataText(value.result)
+  );
+}
+
+function messageContent(message: Readonly<Record<string, unknown>>, blockType: string): string {
+  if (!Array.isArray(message.content)) return "";
+  return message.content
+    .filter((block): block is Readonly<Record<string, unknown>> => isRecord(block))
+    .filter((block) => field(block, "type") === blockType)
+    .map((block) =>
+      blockType === "thinking"
+        ? (stringField(block, "thinking") ?? stringField(block, "text") ?? "")
+        : (stringField(block, "text") ?? ""),
+    )
+    .join("");
+}
+
+function visibleMessageText(message: Readonly<Record<string, unknown>>): string | undefined {
+  const text = dataText(message.content);
+  if (!text) return undefined;
+  // Atomic's terminal chat surfaces sometimes include ANSI styling. T3 owns
+  // presentation, so retain the content while removing terminal escapes.
+  // eslint-disable-next-line no-control-regex -- ANSI CSI begins with ESC.
+  const clean = text.replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, "").trim();
+  return clean.length > 0 ? clean : undefined;
+}
+
+function piCompatibleEnvironment(
+  settings: PiCompatibleSettings,
+  definition: PiCompatibleAdapterDefinition,
   environment: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
   return settings.agentDir
-    ? { ...environment, ATOMIC_CODING_AGENT_DIR: settings.agentDir }
+    ? { ...environment, [definition.agentDirEnvironmentVariable]: settings.agentDir }
     : environment;
 }
 
-function sessionArgs(settings: AtomicSettings, title: string | undefined): ReadonlyArray<string> {
+function sessionArgs(
+  settings: PiCompatibleSettings,
+  title: string | undefined,
+): ReadonlyArray<string> {
   const configured = [...tokenizeCliArgs(settings.launchArgs)];
   const hasTrustFlag = configured.some((arg) => arg === "--approve" || arg === "--no-approve");
   return [
@@ -138,17 +276,23 @@ function sessionArgs(settings: AtomicSettings, title: string | undefined): Reado
   ];
 }
 
-export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
-  settings: AtomicSettings,
-  options?: AtomicAdapterOptions,
+export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(function* (
+  settings: PiCompatibleSettings,
+  definition: PiCompatibleAdapterDefinition,
+  options?: PiCompatibleAdapterOptions,
 ) {
+  const PROVIDER = definition.provider;
   const crypto = yield* Crypto.Crypto;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const serverConfig = yield* ServerConfig;
-  const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("atomic");
-  const environment = atomicEnvironment(settings, options?.environment ?? process.env);
+  const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make(PROVIDER);
+  const environment = piCompatibleEnvironment(
+    settings,
+    definition,
+    options?.environment ?? process.env,
+  );
   const sessions = new Map<ThreadId, AtomicSessionContext>();
   const locks = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
   const runtimeEvents = yield* PubSub.unbounded<ProviderRuntimeEvent>();
@@ -159,7 +303,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
         new ProviderAdapterRequestError({
           provider: PROVIDER,
           method: "crypto/randomUUIDv4",
-          detail: "Failed to generate an Atomic runtime identifier.",
+          detail: `Failed to generate a ${definition.displayName} runtime identifier.`,
           cause,
         }),
     ),
@@ -168,6 +312,19 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
     Effect.all({ eventId: Effect.map(randomId, EventId.make), createdAt: nowIso });
   const publish = (event: ProviderRuntimeEvent) =>
     PubSub.publish(runtimeEvents, event).pipe(Effect.asVoid);
+
+  const awaitMappedEvents = (context: AtomicSessionContext, target: number) => {
+    const wait = (): Effect.Effect<void> =>
+      context.mappedEventSequence >= target
+        ? Effect.void
+        : Effect.sleep(Duration.millis(1)).pipe(Effect.flatMap(wait));
+    return wait().pipe(
+      Effect.timeout(Duration.seconds(5)),
+      Effect.catch(() =>
+        Effect.logWarning(`Timed out draining ${definition.displayName} events through ${target}.`),
+      ),
+    );
+  };
 
   const getLock = (threadId: string) =>
     SynchronizedRef.modifyEffect(locks, (current) => {
@@ -194,7 +351,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
   };
 
   const raw = (payload: AtomicRpcEvent, method?: string) => ({
-    source: "atomic.rpc" as const,
+    source: definition.rawSource,
     ...(method ? { method } : {}),
     payload,
   });
@@ -211,6 +368,10 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
       context.activeTurnId = undefined;
       context.assistantItemId = undefined;
       context.reasoningItemId = undefined;
+      context.assistantText = "";
+      context.reasoningText = "";
+      context.pendingAssistantError = undefined;
+      context.sawAgentActivity = false;
       context.session = { ...rest, status: "ready", updatedAt: yield* nowIso };
       yield* publish({
         type: "turn.completed",
@@ -233,9 +394,12 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
       if (!atomicRequestId || !method) return;
       if (method === "notify") {
         const message = field(event, "message");
-        if (message) {
+        const notifyType = field(event, "notifyType") ?? "info";
+        // Informational notices are terminal UI chrome in Pi (for example
+        // "Obsidian: 2 vaults discovered"), not warnings in a chat transcript.
+        if (message && notifyType !== "info") {
           yield* publish({
-            type: field(event, "notifyType") === "error" ? "runtime.error" : "runtime.warning",
+            type: "runtime.warning",
             ...(yield* eventStamp()),
             provider: PROVIDER,
             providerInstanceId: boundInstanceId,
@@ -243,9 +407,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
             payload: {
               message,
-              ...(field(event, "notifyType") === "error"
-                ? { errorClass: "provider_error" as const }
-                : {}),
+              detail: { kind: "extension_notification", notifyType },
             },
             raw: raw(event, "extension_ui_request"),
           });
@@ -255,8 +417,9 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
       if (!["select", "confirm", "input", "editor"].includes(method)) return;
       const requestId = ApprovalRequestId.make(atomicRequestId);
       const questionId = `${atomicRequestId}:answer`;
-      const title = field(event, "title") ?? "Atomic needs input";
+      const title = field(event, "title") ?? `${definition.displayName} needs input`;
       const question = field(event, "message") ?? title;
+      const defaultValue = stringField(event, "prefill") ?? stringField(event, "initialValue");
       const selectOptions = isStringArray(event.options) ? event.options : [];
       const optionsForQuestion =
         method === "confirm"
@@ -287,6 +450,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
               id: questionId,
               header: title,
               question,
+              ...(defaultValue === undefined ? {} : { defaultValue }),
               options: optionsForQuestion,
               multiSelect: false,
             },
@@ -294,6 +458,292 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
         },
         raw: raw(event, "extension_ui_request"),
       });
+    });
+
+  const startProviderTurn = (context: AtomicSessionContext) =>
+    Effect.gen(function* () {
+      if (context.activeTurnId) return context.activeTurnId;
+      const turnId = TurnId.make(yield* randomId);
+      context.activeTurnId = turnId;
+      context.session = {
+        ...context.session,
+        status: "running",
+        activeTurnId: turnId,
+        updatedAt: yield* nowIso,
+      };
+      context.turns.push({ id: turnId, items: [] });
+      yield* publish({
+        type: "turn.started",
+        ...(yield* eventStamp()),
+        provider: PROVIDER,
+        providerInstanceId: boundInstanceId,
+        threadId: context.threadId,
+        turnId,
+        payload: {},
+      });
+      return turnId;
+    });
+
+  const resolveAbandonedUiRequests = (context: AtomicSessionContext) =>
+    Effect.gen(function* () {
+      for (const requestId of context.pendingUi.keys()) {
+        yield* publish({
+          type: "user-input.resolved",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          requestId: RuntimeRequestId.make(requestId),
+          payload: { answers: {} },
+        });
+      }
+      context.pendingUi.clear();
+    });
+
+  const handleWorkflowEntry = (context: AtomicSessionContext, event: AtomicRpcEvent) =>
+    Effect.gen(function* () {
+      const entry = isRecord(event.entry)
+        ? event.entry
+        : isRecord(event.message)
+          ? event.message
+          : undefined;
+      if (!entry) return false;
+      const customType = field(entry, "customType");
+      let data = isRecord(entry.data)
+        ? entry.data
+        : isRecord(entry.details)
+          ? entry.details
+          : entry;
+      let entryType =
+        customType ??
+        (field(entry, "type")?.startsWith("workflow.") ? field(entry, "type") : undefined);
+      if (customType === "workflows:lifecycle-notice") {
+        const kind = field(data, "kind");
+        const scope = field(data, "scope");
+        entryType =
+          kind === "started"
+            ? `workflow.${scope}.start`
+            : kind === "awaiting_input"
+              ? `workflow.${scope}.waiting`
+              : kind === "paused"
+                ? `workflow.${scope}.paused`
+                : kind === "resumed"
+                  ? `workflow.${scope}.resumed`
+                  : ["completed", "failed", "blocked", "quit"].includes(kind ?? "")
+                    ? `workflow.${scope}.end`
+                    : undefined;
+        data = { ...data, ...(field(data, "status") ? {} : { status: kind }) };
+      }
+      if (!entryType?.startsWith("workflow.")) return false;
+      const runId = field(data, "runId");
+      if (!runId) return true;
+      const stageId = field(data, "stageId");
+      const lifecycleTarget = `${runId}:${stageId ?? "run"}`;
+      const lifecycleSignature = [
+        entryType,
+        field(data, "status") ?? "",
+        field(data, "promptMessage") ?? "",
+        dataText(data.result) ?? "",
+      ].join("\u0000");
+      if (context.workflowLifecycleSignatures.get(lifecycleTarget) === lifecycleSignature) {
+        return true;
+      }
+      context.workflowLifecycleSignatures.set(lifecycleTarget, lifecycleSignature);
+      const isRunEntry = entryType === "workflow.run.start" || entryType === "workflow.run.end";
+      const eventWorkflowName =
+        field(data, "workflowName") ?? (isRunEntry ? field(data, "name") : undefined);
+      let workflowRun = context.workflowRuns.get(runId);
+      if (!workflowRun) {
+        workflowRun = {
+          name: eventWorkflowName ?? `${definition.displayName} workflow`,
+          scriptPath: undefined,
+          stages: new Map(),
+        };
+        context.workflowRuns.set(runId, workflowRun);
+      } else if (eventWorkflowName) {
+        workflowRun.name = eventWorkflowName;
+      }
+      const workflowName = workflowRun.name;
+      if (workflowRun.scriptPath === undefined && /^[a-zA-Z0-9._-]+$/u.test(workflowName)) {
+        for (const extension of ["ts", "js"] as const) {
+          const candidate = path.resolve(
+            context.session.cwd,
+            ".atomic",
+            "workflows",
+            `${workflowName}.${extension}`,
+          );
+          if (yield* fileSystem.exists(candidate).pipe(Effect.orElseSucceed(() => false))) {
+            workflowRun.scriptPath = candidate;
+            break;
+          }
+        }
+      }
+      let stage: AtomicWorkflowStageContext | undefined;
+      if (stageId) {
+        const eventStageName = field(data, "stageName") ?? field(data, "name");
+        const eventParentIds = isStringArray(data.parentIds) ? data.parentIds : undefined;
+        const replayKey = field(data, "replayKey");
+        stage = workflowRun.stages.get(stageId);
+        if (!stage) {
+          stage = {
+            id: stageId,
+            index: workflowRun.stages.size,
+            name: eventStageName ?? stageId,
+            parentIds: eventParentIds ?? [],
+            awaitingInput:
+              replayKey?.startsWith("prompt:") === true || entryType === "workflow.stage.waiting",
+          };
+          workflowRun.stages.set(stageId, stage);
+        } else {
+          if (eventStageName) stage.name = eventStageName;
+          if (eventParentIds) stage.parentIds = eventParentIds;
+          if (replayKey?.startsWith("prompt:") === true || entryType === "workflow.stage.waiting") {
+            stage.awaitingInput = true;
+          }
+        }
+      }
+      const stageName = stage?.name;
+      const source = raw(event, field(event, "type") ?? "workflow_lifecycle");
+      const taskId = RuntimeTaskId.make(stage ? workflowStageTaskId(runId, stage.id) : runId);
+      const phaseIndex = stage ? workflowStageDepth(workflowRun, stage) : undefined;
+      const linkage = stage
+        ? ({
+            taskType: "local_agent",
+            workflowName,
+            workflowStageId: stage.id,
+            title: stage.name,
+            role: stage.awaitingInput ? "human input" : "workflow stage",
+            ...(field(data, "model") ? { model: field(data, "model") } : {}),
+            parentAgentId: runId,
+            dependsOnTaskIds: stage.parentIds.map((parentId) =>
+              RuntimeTaskId.make(workflowStageTaskId(runId, parentId)),
+            ),
+            agentIndex: stage.index,
+            phaseIndex,
+            phaseTitle: `Stage ${phaseIndex! + 1}`,
+            timelineBypass: true,
+          } as const)
+        : ({
+            taskType: "local_workflow",
+            workflowName,
+            title: workflowName,
+            runHandles: {
+              runId,
+              ...(workflowRun.scriptPath ? { scriptPath: workflowRun.scriptPath } : {}),
+            },
+          } as const);
+
+      if (entryType === "workflow.run.start" || entryType === "workflow.stage.start") {
+        yield* publish({
+          type: "task.started",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          payload: {
+            taskId,
+            description:
+              entryType === "workflow.run.start"
+                ? `Running ${workflowName}`
+                : `Running ${stageName ?? "workflow stage"}`,
+            ...linkage,
+          },
+          raw: source,
+        });
+        if (entryType === "workflow.stage.start" && stage?.awaitingInput) {
+          yield* publish({
+            type: "task.updated",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+            payload: {
+              taskId,
+              status: "waiting",
+              description: `Awaiting input for ${stage.name}`,
+              ...linkage,
+            },
+            raw: source,
+          });
+        }
+        return true;
+      }
+
+      if (entryType === "workflow.stage.end" || entryType === "workflow.run.end") {
+        const status = field(data, "status");
+        const terminalStatus =
+          status === "failed" || status === "blocked"
+            ? "failed"
+            : status === "cancelled" || status === "interrupted" || status === "quit"
+              ? "stopped"
+              : "completed";
+        const summary =
+          dataText(data.result) ?? field(data, "summary") ?? field(data, "error") ?? undefined;
+        yield* publish({
+          type: "task.completed",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          payload: {
+            taskId,
+            status: terminalStatus,
+            ...(summary ? { summary } : {}),
+            ...linkage,
+          },
+          raw: source,
+        });
+        return true;
+      }
+      if (entryType === "workflow.stage.waiting" && stage) {
+        const prompt = field(data, "promptMessage") ?? `Awaiting input for ${stage.name}`;
+        yield* publish({
+          type: "task.progress",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          payload: {
+            taskId,
+            status: "waiting",
+            description: prompt,
+            summary: prompt,
+            ...linkage,
+          },
+          raw: source,
+        });
+        return true;
+      }
+      if (
+        entryType === "workflow.stage.paused" ||
+        entryType === "workflow.run.paused" ||
+        entryType === "workflow.stage.resumed" ||
+        entryType === "workflow.run.resumed"
+      ) {
+        const resumed = entryType.endsWith(".resumed");
+        yield* publish({
+          type: "task.updated",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          payload: {
+            taskId,
+            status: resumed ? "running" : "idle",
+            description: `${stageName ?? workflowName} ${resumed ? "resumed" : "paused"}`,
+            ...linkage,
+          },
+          raw: source,
+        });
+        return true;
+      }
+      return true;
     });
 
   const handleEvent = (
@@ -306,11 +756,95 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
       if (type === "extension_ui_request") {
         return yield* handleExtensionUi(context, event);
       }
+      if (type === "entry_appended" && (yield* handleWorkflowEntry(context, event))) return;
+      if (type === "message_end") {
+        yield* handleWorkflowEntry(context, event);
+      }
+      if (type === "extension_error") {
+        yield* publish({
+          // Pi treats extension loading as best-effort: one incompatible
+          // extension can fail while the agent and every other extension keep
+          // running. Preserve that recoverability in T3. Transport failures
+          // and assistant message errors still use runtime.error below.
+          type: "runtime.warning",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          payload: {
+            message:
+              field(event, "error") ??
+              field(event, "message") ??
+              `${definition.displayName} extension failed.`,
+            detail: {
+              kind: "extension_error",
+              ...(field(event, "extensionPath")
+                ? { extensionPath: field(event, "extensionPath") }
+                : {}),
+            },
+          },
+          raw: raw(event, type),
+        });
+        return;
+      }
+      if (type === "auto_retry_start" || type === "summarization_retry_scheduled") {
+        const attempt = nonNegativeNumber(event.attempt);
+        const maxAttempts = nonNegativeNumber(event.maxAttempts);
+        const delayMs = nonNegativeNumber(event.delayMs);
+        yield* publish({
+          type: "runtime.warning",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          payload: {
+            message: `${definition.displayName} is retrying${attempt === undefined ? "" : ` (attempt ${attempt}${maxAttempts === undefined ? "" : ` of ${maxAttempts}`})`}${delayMs === undefined ? "." : ` in ${Math.ceil(delayMs / 1000)}s.`}`,
+            detail: event,
+          },
+          raw: raw(event, type),
+        });
+        return;
+      }
+      if (type === "auto_retry_end") {
+        if (event.success === false) {
+          yield* publish({
+            type: "runtime.warning",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+            payload: {
+              message:
+                field(event, "finalError") ?? `${definition.displayName} exhausted its retries.`,
+              detail: event,
+            },
+            raw: raw(event, type),
+          });
+        }
+        return;
+      }
+      if (type === "agent_start") {
+        context.sawAgentActivity = true;
+        yield* startProviderTurn(context);
+        return;
+      }
       const turnId = context.activeTurnId;
       if (!turnId) return;
       const source = raw(event, type);
       if (type === "message_start") {
-        context.assistantItemId = RuntimeItemId.make(`${turnId}:assistant`);
+        const message = isRecord(event.message) ? event.message : undefined;
+        if (message && field(message, "role") !== "assistant") return;
+        context.sawAgentActivity = true;
+        context.messageSequence += 1;
+        context.assistantItemId = RuntimeItemId.make(
+          `${turnId}:assistant:${context.messageSequence}`,
+        );
+        context.reasoningItemId = undefined;
+        context.assistantText = "";
+        context.reasoningText = "";
         yield* publish({
           type: "item.started",
           ...(yield* eventStamp()),
@@ -329,11 +863,26 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           ? event.assistantMessageEvent
           : undefined;
         const updateType = update ? field(update, "type") : undefined;
-        const delta = update ? field(update, "delta") : undefined;
-        if (!delta || (updateType !== "text_delta" && updateType !== "thinking_delta")) return;
+        if (updateType === "error") {
+          const error = update && isRecord(update.error) ? update.error : undefined;
+          context.pendingAssistantError =
+            (update && field(update, "error")) ??
+            (error && field(error, "errorMessage")) ??
+            `${definition.displayName} assistant stream failed.`;
+          return;
+        }
+        const delta = update ? stringField(update, "delta") : undefined;
+        if (
+          delta === undefined ||
+          (updateType !== "text_delta" && updateType !== "thinking_delta")
+        ) {
+          return;
+        }
         const isThinking = updateType === "thinking_delta";
         if (isThinking && !context.reasoningItemId) {
-          context.reasoningItemId = RuntimeItemId.make(`${turnId}:reasoning`);
+          context.reasoningItemId = RuntimeItemId.make(
+            `${turnId}:reasoning:${context.messageSequence}`,
+          );
           yield* publish({
             type: "item.started",
             ...(yield* eventStamp()),
@@ -347,8 +896,26 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           });
         }
         if (!isThinking && !context.assistantItemId) {
-          context.assistantItemId = RuntimeItemId.make(`${turnId}:assistant`);
+          context.messageSequence += 1;
+          context.assistantItemId = RuntimeItemId.make(
+            `${turnId}:assistant:${context.messageSequence}`,
+          );
+          yield* publish({
+            type: "item.started",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            itemId: context.assistantItemId,
+            payload: { itemType: "assistant_message", status: "inProgress" },
+            raw: source,
+          });
         }
+        const itemId = isThinking ? context.reasoningItemId : context.assistantItemId;
+        if (!itemId) return;
+        if (isThinking) context.reasoningText += delta;
+        else context.assistantText += delta;
         yield* publish({
           type: "content.delta",
           ...(yield* eventStamp()),
@@ -356,13 +923,95 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           providerInstanceId: boundInstanceId,
           threadId: context.threadId,
           turnId,
-          itemId: isThinking ? context.reasoningItemId : context.assistantItemId,
+          itemId,
           payload: { streamKind: isThinking ? "reasoning_text" : "assistant_text", delta },
           raw: source,
         });
         return;
       }
       if (type === "message_end") {
+        const message = isRecord(event.message) ? event.message : undefined;
+        const role = message ? field(message, "role") : undefined;
+        if (role === "custom" && message) {
+          if (isBoolean(message.display) && !message.display) return;
+          const text = visibleMessageText(message);
+          if (!text) return;
+          context.messageSequence += 1;
+          const itemId = RuntimeItemId.make(`${turnId}:custom:${context.messageSequence}`);
+          yield* publish({
+            type: "item.started",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            itemId,
+            payload: { itemType: "assistant_message", status: "inProgress" },
+            raw: source,
+          });
+          yield* publish({
+            type: "content.delta",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            itemId,
+            payload: { streamKind: "assistant_text", delta: text },
+            raw: source,
+          });
+          yield* publish({
+            type: "item.completed",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            itemId,
+            payload: { itemType: "assistant_message", status: "completed" },
+            raw: source,
+          });
+          return;
+        }
+        if (role !== undefined && role !== "assistant") return;
+        if (message) {
+          const stopReason = field(message, "stopReason");
+          if (stopReason === "error") {
+            context.pendingAssistantError =
+              field(message, "errorMessage") ??
+              context.pendingAssistantError ??
+              `${definition.displayName} assistant stream failed.`;
+          } else if (stopReason !== "aborted") {
+            // Pi may recover from one failed model/tool-extension cycle and
+            // continue the same agent turn. Only the last assistant outcome at
+            // agent_settled is terminal for T3's thread lifecycle.
+            context.pendingAssistantError = undefined;
+          }
+          const authoritativeReasoning = messageContent(message, "thinking");
+          const authoritativeText = messageContent(message, "text");
+          for (const [itemId, streamKind, current, final] of [
+            [
+              context.reasoningItemId,
+              "reasoning_text",
+              context.reasoningText,
+              authoritativeReasoning,
+            ],
+            [context.assistantItemId, "assistant_text", context.assistantText, authoritativeText],
+          ] as const) {
+            if (!itemId || final.length <= current.length || !final.startsWith(current)) continue;
+            yield* publish({
+              type: "content.delta",
+              ...(yield* eventStamp()),
+              provider: PROVIDER,
+              providerInstanceId: boundInstanceId,
+              threadId: context.threadId,
+              turnId,
+              itemId,
+              payload: { streamKind, delta: final.slice(current.length) },
+              raw: source,
+            });
+          }
+        }
         for (const [itemId, itemType] of [
           [context.reasoningItemId, "reasoning"],
           [context.assistantItemId, "assistant_message"],
@@ -380,6 +1029,10 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             raw: source,
           });
         }
+        context.assistantItemId = undefined;
+        context.reasoningItemId = undefined;
+        context.assistantText = "";
+        context.reasoningText = "";
         return;
       }
       if (
@@ -389,7 +1042,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
       ) {
         const toolCallId = field(event, "toolCallId") ?? field(event, "id") ?? `${turnId}:tool`;
         const itemId = RuntimeItemId.make(toolCallId);
-        const toolName = field(event, "toolName") ?? "Atomic tool";
+        const toolName = field(event, "toolName") ?? `${definition.displayName} tool`;
         const lifecycle =
           type === "tool_execution_start"
             ? "item.started"
@@ -397,6 +1050,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
               ? "item.updated"
               : "item.completed";
         const isError = isBoolean(event.isError) ? event.isError : false;
+        const detail = dataText(event.partialResult ?? event.result);
         yield* publish({
           type: lifecycle,
           ...(yield* eventStamp()),
@@ -411,19 +1065,55 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             status:
               lifecycle === "item.completed" ? (isError ? "failed" : "completed") : "inProgress",
             title: toolName,
-            ...(dataText(event.partialResult ?? event.result)
-              ? { detail: dataText(event.partialResult ?? event.result) }
-              : {}),
+            ...(detail ? { detail } : {}),
             data: event,
           },
           raw: source,
         });
         return;
       }
-      if (type === "agent_end") {
-        yield* completeActiveTurn(context, "completed");
+      if (type === "agent_settled") {
+        const statsResult = yield* context.rpc
+          .request({ type: "get_session_stats" })
+          .pipe(Effect.result);
+        if (statsResult._tag === "Success") {
+          const usage = atomicSessionUsage(statsResult.success.data);
+          if (usage) {
+            yield* publish({
+              type: "thread.token-usage.updated",
+              ...(yield* eventStamp()),
+              provider: PROVIDER,
+              providerInstanceId: boundInstanceId,
+              threadId: context.threadId,
+              turnId,
+              payload: { usage },
+              raw: source,
+            });
+          }
+        }
+        yield* resolveAbandonedUiRequests(context);
+        const terminalError = context.pendingAssistantError;
+        if (terminalError) {
+          yield* publish({
+            type: "runtime.error",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            payload: { message: terminalError, class: "provider_error" },
+            raw: source,
+          });
+          yield* completeActiveTurn(context, "failed", terminalError);
+        } else {
+          yield* completeActiveTurn(context, "completed");
+        }
         return;
       }
+      // agent_end is the end of one low-level Pi run. Atomic may still retry,
+      // compact, or deliver queued workflow follow-ups; agent_settled is the
+      // only terminal lifecycle signal.
+      if (type === "agent_end") return;
       if (type === "compaction_start" || type === "compaction_end") {
         const itemId = RuntimeItemId.make(`${turnId}:compaction`);
         yield* publish({
@@ -477,8 +1167,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           return yield* new ProviderAdapterValidationError({
             provider: PROVIDER,
             operation: "startSession",
-            issue:
-              "Atomic RPC does not expose approval callbacks. Choose Full access for Atomic sessions.",
+            issue: `${definition.displayName} RPC does not expose approval callbacks. Choose Full access for ${definition.displayName} sessions.`,
           });
         }
         const existing = sessions.get(input.threadId);
@@ -489,9 +1178,16 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           const cwd = input.cwd ?? serverConfig.cwd;
           const rpc = yield* makeAtomicRpcProcess({
             binaryPath: settings.binaryPath,
+            runtimeName: definition.displayName,
             args: sessionArgs(settings, input.title),
             cwd,
             environment,
+            ...(options?.startupTimeout === undefined
+              ? {}
+              : { startupTimeout: options.startupTimeout }),
+            ...(options?.requestTimeout === undefined
+              ? {}
+              : { requestTimeout: options.requestTimeout }),
           }).pipe(
             Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
             Effect.provideService(FileSystem.FileSystem, fileSystem),
@@ -591,18 +1287,34 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             activeTurnId: undefined,
             assistantItemId: undefined,
             reasoningItemId: undefined,
+            messageSequence: 0,
+            assistantText: "",
+            reasoningText: "",
+            pendingAssistantError: undefined,
+            sawAgentActivity: false,
             pendingUi: new Map(),
+            workflowRuns: new Map(),
+            workflowLifecycleSignatures: new Map(),
+            mappedEventSequence: 0,
             turns: [],
             stopped: false,
           };
           yield* rpc.events.pipe(
-            Stream.runForEach((event) =>
-              handleEvent(context, event).pipe(
+            Stream.runForEach((event) => {
+              const sequence = atomicRpcEventSequence(event);
+              return handleEvent(context, event).pipe(
                 Effect.catch((cause) =>
-                  Effect.logWarning("Failed to map an Atomic RPC event.", { cause }),
+                  Effect.logWarning(`Failed to map a ${definition.displayName} RPC event.`, {
+                    cause,
+                  }),
                 ),
-              ),
-            ),
+                Effect.tap(() =>
+                  Effect.sync(() => {
+                    if (sequence !== undefined) context.mappedEventSequence = sequence;
+                  }),
+                ),
+              );
+            }),
             Effect.forkIn(sessionScope),
           );
           sessions.set(input.threadId, context);
@@ -613,7 +1325,10 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             provider: PROVIDER,
             providerInstanceId: boundInstanceId,
             threadId: input.threadId,
-            payload: { message: "Atomic RPC session ready", resume: session.resumeCursor },
+            payload: {
+              message: `${definition.displayName} RPC session ready`,
+              resume: session.resumeCursor,
+            },
           });
           yield* publish({
             type: "session.state.changed",
@@ -621,7 +1336,10 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             provider: PROVIDER,
             providerInstanceId: boundInstanceId,
             threadId: input.threadId,
-            payload: { state: "ready", reason: "Atomic RPC session ready" },
+            payload: {
+              state: "ready",
+              reason: `${definition.displayName} RPC session ready`,
+            },
           });
           yield* publish({
             type: "thread.started",
@@ -634,7 +1352,9 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           return session;
         }).pipe(
           Effect.ensuring(
-            transferred ? Effect.void : Effect.ignore(Scope.close(sessionScope, Exit.void)),
+            Effect.suspend(() =>
+              transferred ? Effect.void : Effect.ignore(Scope.close(sessionScope, Exit.void)),
+            ),
           ),
         );
       }),
@@ -718,6 +1438,8 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
         const turnId = context.activeTurnId ?? TurnId.make(yield* randomId);
         if (!steering) {
           context.activeTurnId = turnId;
+          context.pendingAssistantError = undefined;
+          context.sawAgentActivity = false;
           context.session = {
             ...context.session,
             status: "running",
@@ -742,13 +1464,16 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             },
           });
         }
-        yield* context.rpc
-          .request({
-            type: "prompt",
-            message: text ?? "Please inspect the attached image.",
-            ...(images.length > 0 ? { images } : {}),
-            ...(steering ? { streamingBehavior: "steer" } : {}),
-          })
+        const promptResponse = yield* context.rpc
+          .request(
+            {
+              type: "prompt",
+              message: text ?? "Please inspect the attached image.",
+              ...(images.length > 0 ? { images } : {}),
+              ...(steering ? { streamingBehavior: "steer" } : {}),
+            },
+            Duration.infinity,
+          )
           .pipe(
             Effect.mapError(
               (cause) =>
@@ -760,6 +1485,43 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
                 }),
             ),
           );
+        // Atomic writes custom/workflow events before the prompt response, but
+        // the transport and adapter consume on separate fibers. Drain those
+        // already-read events before deciding an extension-only turn was idle.
+        yield* awaitMappedEvents(context, promptResponse.precedingEventSequence);
+        // Dialogs with provider-side timeouts resolve without a separate RPC
+        // callback. Once the owning prompt has returned, any remaining cards
+        // are stale and must not leave T3 permanently awaiting input.
+        yield* resolveAbandonedUiRequests(context);
+        if (!steering && context.activeTurnId === turnId && !context.sawAgentActivity) {
+          const stateResponse = yield* context.rpc.request({ type: "get_state" }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "get_state",
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          // get_state may report idle immediately after Pi has emitted
+          // agent_settled while the adapter fiber is still mapping that event.
+          // Drain everything already observed by the transport before using
+          // the extension-only fallback, or a genuine terminal error can be
+          // overwritten by a synthetic successful completion.
+          yield* awaitMappedEvents(context, stateResponse.precedingEventSequence);
+          if (context.activeTurnId !== turnId) return;
+          const state = Option.getOrUndefined(decodeState(stateResponse.data));
+          // Extension commands such as `/workflow list` can emit custom chat
+          // messages without ever starting a Pi agent run. Their prompt
+          // response is accepted and get_state reports idle, so settle the T3
+          // turn explicitly instead of waiting for an agent event that will
+          // never arrive.
+          if (state?.isStreaming === false) {
+            yield* completeActiveTurn(context, "completed");
+          }
+        }
         return { threadId: input.threadId, turnId, resumeCursor: context.session.resumeCursor };
       }),
     );
@@ -778,6 +1540,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
             }),
         ),
       );
+      yield* resolveAbandonedUiRequests(context);
       yield* completeActiveTurn(context, "interrupted");
     });
 
@@ -790,7 +1553,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
       new ProviderAdapterRequestError({
         provider: PROVIDER,
         method: "respondToRequest",
-        detail: "Atomic RPC does not expose approval requests.",
+        detail: `${definition.displayName} RPC does not expose approval requests.`,
       }),
     );
 
@@ -806,7 +1569,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
         return yield* new ProviderAdapterRequestError({
           provider: PROVIDER,
           method: "extension_ui_response",
-          detail: `Unknown Atomic UI request: ${requestId}`,
+          detail: `Unknown ${definition.displayName} UI request: ${requestId}`,
         });
       }
       const answer = answers[pending.questionId];
@@ -883,7 +1646,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
         return yield* new ProviderAdapterRequestError({
           provider: PROVIDER,
           method: "fork",
-          detail: "Atomic session rollback is not available in this first integration.",
+          detail: `${definition.displayName} session rollback is not available in this first integration.`,
         });
       }),
     stopAll: () =>
@@ -898,3 +1661,14 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
   };
   return adapter;
 });
+
+const ATOMIC_ADAPTER_DEFINITION: PiCompatibleAdapterDefinition = {
+  provider: ProviderDriverKind.make("atomic"),
+  displayName: "Atomic",
+  agentDirEnvironmentVariable: "ATOMIC_CODING_AGENT_DIR",
+  rawSource: "atomic.rpc",
+};
+
+export function makeAtomicAdapter(settings: AtomicSettings, options?: AtomicAdapterOptions) {
+  return makePiCompatibleAdapter(settings, ATOMIC_ADAPTER_DEFINITION, options);
+}

--- a/apps/server/src/provider/Layers/AtomicAdapter.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.ts
@@ -7,6 +7,7 @@ import {
   type ProviderSession,
   ProviderDriverKind,
   ProviderInstanceId,
+  ProviderItemId,
   RuntimeItemId,
   RuntimeRequestId,
   type ThreadId,
@@ -404,7 +405,7 @@ export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
           threadId: context.threadId,
           turnId,
           itemId,
-          providerRefs: { providerItemId: toolCallId },
+          providerRefs: { providerItemId: ProviderItemId.make(toolCallId) },
           payload: {
             itemType: "dynamic_tool_call",
             status:

--- a/apps/server/src/provider/Layers/AtomicAdapter.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.ts
@@ -603,6 +603,9 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
           }
         }
       }
+      if (stage && (entryType === "workflow.stage.resumed" || entryType === "workflow.stage.end")) {
+        stage.awaitingInput = false;
+      }
       const stageName = stage?.name;
       const source = raw(event, field(event, "type") ?? "workflow_lifecycle");
       const taskId = RuntimeTaskId.make(stage ? workflowStageTaskId(runId, stage.id) : runId);
@@ -699,8 +702,9 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
         });
         return true;
       }
-      if (entryType === "workflow.stage.waiting" && stage) {
-        const prompt = field(data, "promptMessage") ?? `Awaiting input for ${stage.name}`;
+      if (entryType === "workflow.stage.waiting" || entryType === "workflow.run.waiting") {
+        const prompt =
+          field(data, "promptMessage") ?? `Awaiting input for ${stage?.name ?? workflowName}`;
         yield* publish({
           type: "task.progress",
           ...(yield* eventStamp()),
@@ -1138,9 +1142,12 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
       if (context.stopped) return;
       context.stopped = true;
       yield* context.rpc.kill;
+      yield* resolveAbandonedUiRequests(context);
+      yield* completeActiveTurn(context, "interrupted", "Session stopped.");
       yield* Effect.ignore(Scope.close(context.scope, Exit.void));
-      sessions.delete(context.threadId);
-      if (emitExit) {
+      const ownsSession = sessions.get(context.threadId) === context;
+      if (ownsSession) sessions.delete(context.threadId);
+      if (emitExit && ownsSession) {
         yield* publish({
           type: "session.exited",
           ...(yield* eventStamp()),
@@ -1484,6 +1491,14 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
                   cause,
                 }),
             ),
+            Effect.tapError((cause) =>
+              context.stopped
+                ? Effect.void
+                : Effect.gen(function* () {
+                    yield* completeActiveTurn(context, "failed", cause.message);
+                    yield* stopSessionInternal(context, false);
+                  }),
+            ),
           );
         // Atomic writes custom/workflow events before the prompt response, but
         // the transport and adapter consume on separate fibers. Drain those
@@ -1529,7 +1544,7 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
   const interruptTurn: ProviderAdapterShape<ProviderAdapterError>["interruptTurn"] = (threadId) =>
     Effect.gen(function* () {
       const context = yield* requireSession(threadId);
-      yield* context.rpc.request({ type: "abort" }).pipe(
+      const response = yield* context.rpc.request({ type: "abort" }).pipe(
         Effect.mapError(
           (cause) =>
             new ProviderAdapterRequestError({
@@ -1540,6 +1555,7 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
             }),
         ),
       );
+      yield* awaitMappedEvents(context, response.precedingEventSequence);
       yield* resolveAbandonedUiRequests(context);
       yield* completeActiveTurn(context, "interrupted");
     });
@@ -1621,10 +1637,7 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
     respondToRequest,
     respondToUserInput,
     stopSession: (threadId) =>
-      withThreadLock(
-        threadId,
-        Effect.flatMap(requireSession(threadId), (context) => stopSessionInternal(context, true)),
-      ),
+      Effect.flatMap(requireSession(threadId), (context) => stopSessionInternal(context, true)),
     listSessions: () => Effect.sync(() => Array.from(sessions.values(), ({ session }) => session)),
     hasSession: (threadId) =>
       Effect.sync(() => {

--- a/apps/server/src/provider/Layers/AtomicAdapter.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.ts
@@ -568,7 +568,7 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
       if (workflowRun.scriptPath === undefined && /^[a-zA-Z0-9._-]+$/u.test(workflowName)) {
         for (const extension of ["ts", "js"] as const) {
           const candidate = path.resolve(
-            context.session.cwd,
+            context.session.cwd!,
             ".atomic",
             "workflows",
             `${workflowName}.${extension}`,

--- a/apps/server/src/provider/Layers/AtomicAdapter.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.ts
@@ -1526,7 +1526,9 @@ export const makePiCompatibleAdapter = Effect.fn("makePiCompatibleAdapter")(func
           // the extension-only fallback, or a genuine terminal error can be
           // overwritten by a synthetic successful completion.
           yield* awaitMappedEvents(context, stateResponse.precedingEventSequence);
-          if (context.activeTurnId !== turnId) return;
+          if (context.activeTurnId !== turnId) {
+            return { threadId: input.threadId, turnId, resumeCursor: context.session.resumeCursor };
+          }
           const state = Option.getOrUndefined(decodeState(stateResponse.data));
           // Extension commands such as `/workflow list` can emit custom chat
           // messages without ever starting a Pi agent run. Their prompt

--- a/apps/server/src/provider/Layers/AtomicAdapter.ts
+++ b/apps/server/src/provider/Layers/AtomicAdapter.ts
@@ -1,0 +1,899 @@
+import {
+  ApprovalRequestId,
+  type AtomicSettings,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeItemId,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { tokenizeCliArgs } from "@t3tools/shared/cliArgs";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as Semaphore from "effect/Semaphore";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import {
+  type AtomicRpcEvent,
+  type AtomicRpcProcess,
+  makeAtomicRpcProcess,
+} from "../atomic/AtomicRpcProcess.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+
+const PROVIDER = ProviderDriverKind.make("atomic");
+const RESUME_VERSION = 1 as const;
+const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown);
+const isRecord = Schema.is(UnknownRecord);
+const isString = Schema.is(Schema.String);
+const isBoolean = Schema.is(Schema.Boolean);
+const isStringArray = Schema.is(Schema.Array(Schema.String));
+const AtomicStateData = Schema.Struct({
+  model: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        provider: Schema.String,
+        id: Schema.String,
+      }),
+    ),
+  ),
+  thinkingLevel: Schema.optional(Schema.String),
+  sessionFile: Schema.optional(Schema.String),
+  sessionId: Schema.optional(Schema.String),
+});
+const decodeState = Schema.decodeUnknownOption(AtomicStateData);
+const AtomicResumeCursor = Schema.Struct({
+  schemaVersion: Schema.Literal(RESUME_VERSION),
+  sessionFile: Schema.optional(Schema.String),
+  sessionId: Schema.optional(Schema.String),
+});
+const decodeResumeCursor = Schema.decodeUnknownOption(AtomicResumeCursor);
+
+interface PendingUiRequest {
+  readonly atomicRequestId: string;
+  readonly method: string;
+  readonly questionId: string;
+}
+
+interface AtomicSessionContext {
+  readonly threadId: ThreadId;
+  readonly scope: Scope.Closeable;
+  readonly rpc: AtomicRpcProcess;
+  session: ProviderSession;
+  activeTurnId: TurnId | undefined;
+  assistantItemId: RuntimeItemId | undefined;
+  reasoningItemId: RuntimeItemId | undefined;
+  readonly pendingUi: Map<ApprovalRequestId, PendingUiRequest>;
+  turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  stopped: boolean;
+}
+
+export interface AtomicAdapterOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly instanceId?: ProviderInstanceId;
+}
+
+function parseModelSlug(
+  slug: string | undefined,
+): { provider: string; modelId: string } | undefined {
+  const value = slug?.trim();
+  if (!value) return undefined;
+  const separator = value.indexOf("/");
+  if (separator <= 0 || separator === value.length - 1) return undefined;
+  return { provider: value.slice(0, separator), modelId: value.slice(separator + 1) };
+}
+
+function field(record: Readonly<Record<string, unknown>>, name: string): string | undefined {
+  const value = record[name];
+  return isString(value) && value.trim().length > 0 ? value : undefined;
+}
+
+function dataText(value: unknown): string | undefined {
+  if (isString(value)) return value;
+  if (!isRecord(value)) return undefined;
+  return field(value, "text") ?? field(value, "content") ?? field(value, "output");
+}
+
+function atomicEnvironment(
+  settings: AtomicSettings,
+  environment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return settings.agentDir
+    ? { ...environment, ATOMIC_CODING_AGENT_DIR: settings.agentDir }
+    : environment;
+}
+
+function sessionArgs(settings: AtomicSettings, title: string | undefined): ReadonlyArray<string> {
+  const configured = [...tokenizeCliArgs(settings.launchArgs)];
+  const hasTrustFlag = configured.some((arg) => arg === "--approve" || arg === "--no-approve");
+  return [
+    ...(hasTrustFlag ? [] : ["--no-approve"]),
+    ...configured,
+    ...(title ? ["--name", title] : []),
+  ];
+}
+
+export const makeAtomicAdapter = Effect.fn("makeAtomicAdapter")(function* (
+  settings: AtomicSettings,
+  options?: AtomicAdapterOptions,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const serverConfig = yield* ServerConfig;
+  const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("atomic");
+  const environment = atomicEnvironment(settings, options?.environment ?? process.env);
+  const sessions = new Map<ThreadId, AtomicSessionContext>();
+  const locks = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+  const runtimeEvents = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+  const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+  const randomId = crypto.randomUUIDv4.pipe(
+    Effect.mapError(
+      (cause) =>
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "crypto/randomUUIDv4",
+          detail: "Failed to generate an Atomic runtime identifier.",
+          cause,
+        }),
+    ),
+  );
+  const eventStamp = () =>
+    Effect.all({ eventId: Effect.map(randomId, EventId.make), createdAt: nowIso });
+  const publish = (event: ProviderRuntimeEvent) =>
+    PubSub.publish(runtimeEvents, event).pipe(Effect.asVoid);
+
+  const getLock = (threadId: string) =>
+    SynchronizedRef.modifyEffect(locks, (current) => {
+      const existing = current.get(threadId);
+      if (existing) return Effect.succeed([existing, current] as const);
+      return Semaphore.make(1).pipe(
+        Effect.map((semaphore) => {
+          const next = new Map(current);
+          next.set(threadId, semaphore);
+          return [semaphore, next] as const;
+        }),
+      );
+    });
+  const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+    Effect.flatMap(getLock(threadId), (lock) => lock.withPermit(effect));
+
+  const requireSession = (
+    threadId: ThreadId,
+  ): Effect.Effect<AtomicSessionContext, ProviderAdapterSessionNotFoundError> => {
+    const context = sessions.get(threadId);
+    return context && !context.stopped
+      ? Effect.succeed(context)
+      : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
+  };
+
+  const raw = (payload: AtomicRpcEvent, method?: string) => ({
+    source: "atomic.rpc" as const,
+    ...(method ? { method } : {}),
+    payload,
+  });
+
+  const completeActiveTurn = (
+    context: AtomicSessionContext,
+    state: "completed" | "failed" | "interrupted" | "cancelled",
+    errorMessage?: string,
+  ) =>
+    Effect.gen(function* () {
+      const turnId = context.activeTurnId;
+      if (!turnId) return;
+      const { activeTurnId: _activeTurnId, ...rest } = context.session;
+      context.activeTurnId = undefined;
+      context.assistantItemId = undefined;
+      context.reasoningItemId = undefined;
+      context.session = { ...rest, status: "ready", updatedAt: yield* nowIso };
+      yield* publish({
+        type: "turn.completed",
+        ...(yield* eventStamp()),
+        provider: PROVIDER,
+        providerInstanceId: boundInstanceId,
+        threadId: context.threadId,
+        turnId,
+        payload: { state, ...(errorMessage ? { errorMessage } : {}), stopReason: state },
+      });
+    });
+
+  const handleExtensionUi = (
+    context: AtomicSessionContext,
+    event: AtomicRpcEvent,
+  ): Effect.Effect<void, ProviderAdapterError> =>
+    Effect.gen(function* () {
+      const atomicRequestId = field(event, "id");
+      const method = field(event, "method");
+      if (!atomicRequestId || !method) return;
+      if (method === "notify") {
+        const message = field(event, "message");
+        if (message) {
+          yield* publish({
+            type: field(event, "notifyType") === "error" ? "runtime.error" : "runtime.warning",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+            payload: {
+              message,
+              ...(field(event, "notifyType") === "error"
+                ? { errorClass: "provider_error" as const }
+                : {}),
+            },
+            raw: raw(event, "extension_ui_request"),
+          });
+        }
+        return;
+      }
+      if (!["select", "confirm", "input", "editor"].includes(method)) return;
+      const requestId = ApprovalRequestId.make(atomicRequestId);
+      const questionId = `${atomicRequestId}:answer`;
+      const title = field(event, "title") ?? "Atomic needs input";
+      const question = field(event, "message") ?? title;
+      const selectOptions = isStringArray(event.options) ? event.options : [];
+      const optionsForQuestion =
+        method === "confirm"
+          ? [
+              { label: "Yes", description: "Confirm this action." },
+              { label: "No", description: "Decline this action." },
+            ]
+          : method === "select"
+            ? selectOptions.map((label) => ({ label, description: `Choose ${label}.` }))
+            : [
+                {
+                  label: "Enter a custom answer",
+                  description: "Use the custom response field for your answer.",
+                },
+              ];
+      context.pendingUi.set(requestId, { atomicRequestId, method, questionId });
+      yield* publish({
+        type: "user-input.requested",
+        ...(yield* eventStamp()),
+        provider: PROVIDER,
+        providerInstanceId: boundInstanceId,
+        threadId: context.threadId,
+        ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+        requestId: RuntimeRequestId.make(requestId),
+        payload: {
+          questions: [
+            {
+              id: questionId,
+              header: title,
+              question,
+              options: optionsForQuestion,
+              multiSelect: false,
+            },
+          ],
+        },
+        raw: raw(event, "extension_ui_request"),
+      });
+    });
+
+  const handleEvent = (
+    context: AtomicSessionContext,
+    event: AtomicRpcEvent,
+  ): Effect.Effect<void, ProviderAdapterError> =>
+    Effect.gen(function* () {
+      const type = field(event, "type");
+      if (!type) return;
+      if (type === "extension_ui_request") {
+        return yield* handleExtensionUi(context, event);
+      }
+      const turnId = context.activeTurnId;
+      if (!turnId) return;
+      const source = raw(event, type);
+      if (type === "message_start") {
+        context.assistantItemId = RuntimeItemId.make(`${turnId}:assistant`);
+        yield* publish({
+          type: "item.started",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          turnId,
+          itemId: context.assistantItemId,
+          payload: { itemType: "assistant_message", status: "inProgress" },
+          raw: source,
+        });
+        return;
+      }
+      if (type === "message_update") {
+        const update = isRecord(event.assistantMessageEvent)
+          ? event.assistantMessageEvent
+          : undefined;
+        const updateType = update ? field(update, "type") : undefined;
+        const delta = update ? field(update, "delta") : undefined;
+        if (!delta || (updateType !== "text_delta" && updateType !== "thinking_delta")) return;
+        const isThinking = updateType === "thinking_delta";
+        if (isThinking && !context.reasoningItemId) {
+          context.reasoningItemId = RuntimeItemId.make(`${turnId}:reasoning`);
+          yield* publish({
+            type: "item.started",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            itemId: context.reasoningItemId,
+            payload: { itemType: "reasoning", status: "inProgress" },
+            raw: source,
+          });
+        }
+        if (!isThinking && !context.assistantItemId) {
+          context.assistantItemId = RuntimeItemId.make(`${turnId}:assistant`);
+        }
+        yield* publish({
+          type: "content.delta",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          turnId,
+          itemId: isThinking ? context.reasoningItemId : context.assistantItemId,
+          payload: { streamKind: isThinking ? "reasoning_text" : "assistant_text", delta },
+          raw: source,
+        });
+        return;
+      }
+      if (type === "message_end") {
+        for (const [itemId, itemType] of [
+          [context.reasoningItemId, "reasoning"],
+          [context.assistantItemId, "assistant_message"],
+        ] as const) {
+          if (!itemId) continue;
+          yield* publish({
+            type: "item.completed",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: context.threadId,
+            turnId,
+            itemId,
+            payload: { itemType, status: "completed" },
+            raw: source,
+          });
+        }
+        return;
+      }
+      if (
+        type === "tool_execution_start" ||
+        type === "tool_execution_update" ||
+        type === "tool_execution_end"
+      ) {
+        const toolCallId = field(event, "toolCallId") ?? field(event, "id") ?? `${turnId}:tool`;
+        const itemId = RuntimeItemId.make(toolCallId);
+        const toolName = field(event, "toolName") ?? "Atomic tool";
+        const lifecycle =
+          type === "tool_execution_start"
+            ? "item.started"
+            : type === "tool_execution_update"
+              ? "item.updated"
+              : "item.completed";
+        const isError = isBoolean(event.isError) ? event.isError : false;
+        yield* publish({
+          type: lifecycle,
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          turnId,
+          itemId,
+          providerRefs: { providerItemId: toolCallId },
+          payload: {
+            itemType: "dynamic_tool_call",
+            status:
+              lifecycle === "item.completed" ? (isError ? "failed" : "completed") : "inProgress",
+            title: toolName,
+            ...(dataText(event.partialResult ?? event.result)
+              ? { detail: dataText(event.partialResult ?? event.result) }
+              : {}),
+            data: event,
+          },
+          raw: source,
+        });
+        return;
+      }
+      if (type === "agent_end") {
+        yield* completeActiveTurn(context, "completed");
+        return;
+      }
+      if (type === "compaction_start" || type === "compaction_end") {
+        const itemId = RuntimeItemId.make(`${turnId}:compaction`);
+        yield* publish({
+          type: type === "compaction_start" ? "item.started" : "item.completed",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          turnId,
+          itemId,
+          payload: {
+            itemType: "context_compaction",
+            status: type === "compaction_start" ? "inProgress" : "completed",
+          },
+          raw: source,
+        });
+      }
+    });
+
+  const stopSessionInternal = (context: AtomicSessionContext, emitExit: boolean) =>
+    Effect.gen(function* () {
+      if (context.stopped) return;
+      context.stopped = true;
+      yield* context.rpc.kill;
+      yield* Effect.ignore(Scope.close(context.scope, Exit.void));
+      sessions.delete(context.threadId);
+      if (emitExit) {
+        yield* publish({
+          type: "session.exited",
+          ...(yield* eventStamp()),
+          provider: PROVIDER,
+          providerInstanceId: boundInstanceId,
+          threadId: context.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      }
+    });
+
+  const startSession: ProviderAdapterShape<ProviderAdapterError>["startSession"] = (input) =>
+    withThreadLock(
+      input.threadId,
+      Effect.gen(function* () {
+        if (input.provider !== undefined && input.provider !== PROVIDER) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+          });
+        }
+        if (input.runtimeMode !== "full-access") {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue:
+              "Atomic RPC does not expose approval callbacks. Choose Full access for Atomic sessions.",
+          });
+        }
+        const existing = sessions.get(input.threadId);
+        if (existing) yield* stopSessionInternal(existing, false);
+        const sessionScope = yield* Scope.make();
+        let transferred = false;
+        return yield* Effect.gen(function* () {
+          const cwd = input.cwd ?? serverConfig.cwd;
+          const rpc = yield* makeAtomicRpcProcess({
+            binaryPath: settings.binaryPath,
+            args: sessionArgs(settings, input.title),
+            cwd,
+            environment,
+          }).pipe(
+            Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, path),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          const resume = Option.getOrUndefined(decodeResumeCursor(input.resumeCursor));
+          if (resume?.sessionFile) {
+            yield* rpc.request({ type: "switch_session", sessionPath: resume.sessionFile }).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "switch_session",
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            );
+          }
+          const selection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const model = parseModelSlug(selection?.model);
+          if (model) {
+            yield* rpc.request({ type: "set_model", ...model }).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "set_model",
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            );
+          }
+          const thinkingLevel = getModelSelectionStringOptionValue(selection, "reasoningEffort");
+          if (thinkingLevel) {
+            yield* rpc.request({ type: "set_thinking_level", level: thinkingLevel }).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "set_thinking_level",
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            );
+          }
+          const stateResponse = yield* rpc.request({ type: "get_state" }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "get_state",
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          const state = Option.getOrUndefined(decodeState(stateResponse.data));
+          const now = yield* nowIso;
+          const selectedModel = state?.model
+            ? `${state.model.provider}/${state.model.id}`
+            : selection?.model;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            ...(selectedModel ? { model: selectedModel } : {}),
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: RESUME_VERSION,
+              ...(state?.sessionFile ? { sessionFile: state.sessionFile } : {}),
+              ...(state?.sessionId ? { sessionId: state.sessionId } : {}),
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+          const context: AtomicSessionContext = {
+            threadId: input.threadId,
+            scope: sessionScope,
+            rpc,
+            session,
+            activeTurnId: undefined,
+            assistantItemId: undefined,
+            reasoningItemId: undefined,
+            pendingUi: new Map(),
+            turns: [],
+            stopped: false,
+          };
+          yield* rpc.events.pipe(
+            Stream.runForEach((event) =>
+              handleEvent(context, event).pipe(
+                Effect.catch((cause) =>
+                  Effect.logWarning("Failed to map an Atomic RPC event.", { cause }),
+                ),
+              ),
+            ),
+            Effect.forkIn(sessionScope),
+          );
+          sessions.set(input.threadId, context);
+          transferred = true;
+          yield* publish({
+            type: "session.started",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: input.threadId,
+            payload: { message: "Atomic RPC session ready", resume: session.resumeCursor },
+          });
+          yield* publish({
+            type: "session.state.changed",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Atomic RPC session ready" },
+          });
+          yield* publish({
+            type: "thread.started",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: input.threadId,
+            payload: { providerThreadId: state?.sessionId },
+          });
+          return session;
+        }).pipe(
+          Effect.ensuring(
+            transferred ? Effect.void : Effect.ignore(Scope.close(sessionScope, Exit.void)),
+          ),
+        );
+      }),
+    );
+
+  const sendTurn: ProviderAdapterShape<ProviderAdapterError>["sendTurn"] = (input) =>
+    withThreadLock(
+      input.threadId,
+      Effect.gen(function* () {
+        const context = yield* requireSession(input.threadId);
+        const text = input.input?.trim();
+        const images = yield* Effect.forEach(input.attachments ?? [], (attachment) =>
+          Effect.gen(function* () {
+            const attachmentPath = resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            });
+            if (!attachmentPath) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "prompt",
+                detail: `Invalid attachment id '${attachment.id}'.`,
+              });
+            }
+            const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "prompt",
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            );
+            return {
+              type: "image",
+              data: Buffer.from(bytes).toString("base64"),
+              mimeType: attachment.mimeType,
+            };
+          }),
+        );
+        if (!text && images.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Turn requires non-empty text or attachments.",
+          });
+        }
+        const selection =
+          input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+        const selectedModel = parseModelSlug(selection?.model);
+        if (selectedModel && selection?.model !== context.session.model) {
+          yield* context.rpc.request({ type: "set_model", ...selectedModel }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "set_model",
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+        }
+        const thinkingLevel = getModelSelectionStringOptionValue(selection, "reasoningEffort");
+        if (thinkingLevel) {
+          yield* context.rpc.request({ type: "set_thinking_level", level: thinkingLevel }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "set_thinking_level",
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+        }
+        const steering = context.activeTurnId !== undefined;
+        const turnId = context.activeTurnId ?? TurnId.make(yield* randomId);
+        if (!steering) {
+          context.activeTurnId = turnId;
+          context.session = {
+            ...context.session,
+            status: "running",
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+            ...(selection?.model ? { model: selection.model } : {}),
+          };
+          context.turns.push({
+            id: turnId,
+            items: [{ input: text, attachments: input.attachments }],
+          });
+          yield* publish({
+            type: "turn.started",
+            ...(yield* eventStamp()),
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            threadId: input.threadId,
+            turnId,
+            payload: {
+              ...(selection?.model ? { model: selection.model } : {}),
+              ...(thinkingLevel ? { effort: thinkingLevel } : {}),
+            },
+          });
+        }
+        yield* context.rpc
+          .request({
+            type: "prompt",
+            message: text ?? "Please inspect the attached image.",
+            ...(images.length > 0 ? { images } : {}),
+            ...(steering ? { streamingBehavior: "steer" } : {}),
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "prompt",
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+        return { threadId: input.threadId, turnId, resumeCursor: context.session.resumeCursor };
+      }),
+    );
+
+  const interruptTurn: ProviderAdapterShape<ProviderAdapterError>["interruptTurn"] = (threadId) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      yield* context.rpc.request({ type: "abort" }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "abort",
+              detail: cause.message,
+              cause,
+            }),
+        ),
+      );
+      yield* completeActiveTurn(context, "interrupted");
+    });
+
+  const respondToRequest = (
+    _threadId: ThreadId,
+    _requestId: ApprovalRequestId,
+    _decision: ProviderApprovalDecision,
+  ): Effect.Effect<void, ProviderAdapterError> =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "respondToRequest",
+        detail: "Atomic RPC does not expose approval requests.",
+      }),
+    );
+
+  const respondToUserInput: ProviderAdapterShape<ProviderAdapterError>["respondToUserInput"] = (
+    threadId,
+    requestId,
+    answers,
+  ) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      const pending = context.pendingUi.get(requestId);
+      if (!pending) {
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "extension_ui_response",
+          detail: `Unknown Atomic UI request: ${requestId}`,
+        });
+      }
+      const answer = answers[pending.questionId];
+      const value = isString(answer) ? answer : isStringArray(answer) ? answer[0] : undefined;
+      const response =
+        pending.method === "confirm"
+          ? value === undefined
+            ? { cancelled: true }
+            : { confirmed: value.toLowerCase() === "yes" }
+          : value === undefined
+            ? { cancelled: true }
+            : { value };
+      yield* context.rpc
+        .notify({
+          type: "extension_ui_response",
+          id: pending.atomicRequestId,
+          ...response,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "extension_ui_response",
+                detail: cause.message,
+                cause,
+              }),
+          ),
+        );
+      context.pendingUi.delete(requestId);
+      yield* publish({
+        type: "user-input.resolved",
+        ...(yield* eventStamp()),
+        provider: PROVIDER,
+        providerInstanceId: boundInstanceId,
+        threadId,
+        ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+        requestId: RuntimeRequestId.make(requestId),
+        payload: { answers },
+      });
+    });
+
+  const adapter: ProviderAdapterShape<ProviderAdapterError> = {
+    provider: PROVIDER,
+    capabilities: { sessionModelSwitch: "in-session" },
+    startSession,
+    sendTurn,
+    interruptTurn,
+    respondToRequest,
+    respondToUserInput,
+    stopSession: (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.flatMap(requireSession(threadId), (context) => stopSessionInternal(context, true)),
+      ),
+    listSessions: () => Effect.sync(() => Array.from(sessions.values(), ({ session }) => session)),
+    hasSession: (threadId) =>
+      Effect.sync(() => {
+        const context = sessions.get(threadId);
+        return context !== undefined && !context.stopped;
+      }),
+    readThread: (threadId) =>
+      Effect.map(requireSession(threadId), (context) => ({ threadId, turns: context.turns })),
+    rollbackThread: (threadId, numTurns) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "fork",
+          detail: "Atomic session rollback is not available in this first integration.",
+        });
+      }),
+    stopAll: () =>
+      Effect.forEach(
+        Array.from(sessions.values()),
+        (context) => stopSessionInternal(context, true),
+        {
+          discard: true,
+        },
+      ),
+    streamEvents: Stream.fromPubSub(runtimeEvents),
+  };
+  return adapter;
+});

--- a/apps/server/src/provider/Layers/AtomicProvider.ts
+++ b/apps/server/src/provider/Layers/AtomicProvider.ts
@@ -53,7 +53,6 @@ const decodeState = Schema.decodeUnknownOption(AtomicStateData);
 const decodeCommands = Schema.decodeUnknownOption(AtomicCommandsData);
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
-const RPC_PROBE_TIMEOUT = Duration.seconds(15);
 
 const PRESENTATION = {
   displayName: "Atomic",
@@ -260,9 +259,11 @@ export const checkAtomicProviderStatus = Effect.fn("checkAtomicProviderStatus")(
     });
     const [stateResponse, modelsResponse, commandsResponse] = yield* Effect.all(
       [
-        rpc.request({ type: "get_state" }, RPC_PROBE_TIMEOUT),
-        rpc.request({ type: "get_available_models" }, RPC_PROBE_TIMEOUT),
-        rpc.request({ type: "get_commands" }, RPC_PROBE_TIMEOUT),
+        // No explicit timeout: these are the first commands on a freshly
+        // spawned process, so they inherit the RPC startup budget.
+        rpc.request({ type: "get_state" }),
+        rpc.request({ type: "get_available_models" }),
+        rpc.request({ type: "get_commands" }),
       ],
       { concurrency: "unbounded" },
     );
@@ -271,8 +272,10 @@ export const checkAtomicProviderStatus = Effect.fn("checkAtomicProviderStatus")(
     const commandData = Option.getOrUndefined(decodeCommands(commandsResponse.data));
     const models = modelsFromRpc({
       models: modelData?.models ?? [],
-      defaultModel: state?.model,
-      thinkingLevel: state?.thinkingLevel,
+      defaultModel: state?.model ?? null,
+      // exactOptionalPropertyTypes: an absent thinking level must be omitted
+      // rather than passed as undefined.
+      ...(state?.thinkingLevel === undefined ? {} : { thinkingLevel: state.thinkingLevel }),
     });
     return { models, ...commandsFromRpc(commandData?.commands ?? []) };
   }).pipe(Effect.scoped, Effect.result);

--- a/apps/server/src/provider/Layers/AtomicProvider.ts
+++ b/apps/server/src/provider/Layers/AtomicProvider.ts
@@ -54,19 +54,37 @@ const decodeCommands = Schema.decodeUnknownOption(AtomicCommandsData);
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
-const PRESENTATION = {
-  displayName: "Atomic",
-  badgeLabel: "Early Access",
-  showInteractionModeToggle: false,
-  requiresNewThreadForModelChange: false,
-} as const;
+export interface PiCompatibleProviderSettings {
+  readonly enabled: boolean;
+  readonly binaryPath: string;
+  readonly agentDir: string;
+  readonly customModels: ReadonlyArray<string>;
+}
 
-function atomicEnvironment(
-  settings: AtomicSettings,
+export interface PiCompatibleProviderDefinition {
+  readonly displayName: string;
+  readonly agentDirEnvironmentVariable: "ATOMIC_CODING_AGENT_DIR" | "PI_CODING_AGENT_DIR";
+  readonly versionStatus?: (
+    version: string | null,
+  ) => { readonly status: "ready" | "warning" | "error"; readonly message: string } | undefined;
+}
+
+function presentation(definition: PiCompatibleProviderDefinition) {
+  return {
+    displayName: definition.displayName,
+    badgeLabel: "Early Access",
+    showInteractionModeToggle: false,
+    requiresNewThreadForModelChange: false,
+  } as const;
+}
+
+function piCompatibleEnvironment(
+  settings: PiCompatibleProviderSettings,
+  definition: PiCompatibleProviderDefinition,
   environment: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
   return settings.agentDir
-    ? { ...environment, ATOMIC_CODING_AGENT_DIR: settings.agentDir }
+    ? { ...environment, [definition.agentDirEnvironmentVariable]: settings.agentDir }
     : environment;
 }
 
@@ -157,12 +175,13 @@ function commandsFromRpc(commands: ReadonlyArray<typeof AtomicCommand.Type>): {
   return { slashCommands, skills };
 }
 
-export function buildInitialAtomicProviderSnapshot(
-  settings: AtomicSettings,
+export function buildInitialPiCompatibleProviderSnapshot(
+  settings: PiCompatibleProviderSettings,
+  definition: PiCompatibleProviderDefinition,
 ): Effect.Effect<ServerProviderDraft> {
   return Effect.map(DateTime.now, (now) =>
     buildServerProvider({
-      presentation: PRESENTATION,
+      presentation: presentation(definition),
       enabled: settings.enabled,
       checkedAt: DateTime.formatIso(now),
       models: providerModelsFromSettings([], settings.customModels, EMPTY_CAPABILITIES),
@@ -172,151 +191,178 @@ export function buildInitialAtomicProviderSnapshot(
         status: "warning",
         auth: { status: "unknown" },
         message: settings.enabled
-          ? "Checking Atomic CLI availability..."
-          : "Atomic is disabled in T3 Code settings.",
+          ? `Checking ${definition.displayName} CLI availability...`
+          : `${definition.displayName} is disabled in T3 Code settings.`,
       },
     }),
   );
 }
 
-export const checkAtomicProviderStatus = Effect.fn("checkAtomicProviderStatus")(function* (
+export const checkPiCompatibleProviderStatus = Effect.fn("checkPiCompatibleProviderStatus")(
+  function* (
+    settings: PiCompatibleProviderSettings,
+    definition: PiCompatibleProviderDefinition,
+    cwd: string,
+    environment: NodeJS.ProcessEnv = process.env,
+  ) {
+    const checkedAt = DateTime.formatIso(yield* DateTime.now);
+    const fallbackModels = providerModelsFromSettings(
+      [],
+      settings.customModels,
+      EMPTY_CAPABILITIES,
+    );
+    if (!settings.enabled) {
+      return yield* buildInitialPiCompatibleProviderSnapshot(settings, definition);
+    }
+
+    const env = piCompatibleEnvironment(settings, definition, environment);
+    const spawnCommand = yield* resolveSpawnCommand(settings.binaryPath, ["--version"], { env });
+    const versionResult = yield* spawnAndCollect(
+      settings.binaryPath,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env,
+        shell: spawnCommand.shell,
+      }),
+    ).pipe(Effect.timeoutOption(Duration.seconds(4)), Effect.result);
+
+    if (Result.isFailure(versionResult)) {
+      return buildServerProvider({
+        presentation: presentation(definition),
+        enabled: true,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: !isCommandMissingCause(versionResult.failure),
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: isCommandMissingCause(versionResult.failure)
+            ? `${definition.displayName} CLI (${settings.binaryPath}) is not installed or not on PATH.`
+            : `Failed to execute the ${definition.displayName} CLI health check.`,
+        },
+      });
+    }
+    if (Option.isNone(versionResult.success)) {
+      return buildServerProvider({
+        presentation: presentation(definition),
+        enabled: true,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: `${definition.displayName} CLI timed out while running --version.`,
+        },
+      });
+    }
+    const versionOutput = versionResult.success.value;
+    const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+    if (versionOutput.code !== 0) {
+      return buildServerProvider({
+        presentation: presentation(definition),
+        enabled: true,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: `${definition.displayName} CLI is installed but failed to run.`,
+        },
+      });
+    }
+
+    const discovery = yield* Effect.gen(function* () {
+      const rpc = yield* makeAtomicRpcProcess({
+        binaryPath: settings.binaryPath,
+        runtimeName: definition.displayName,
+        args: ["--no-session", "--no-approve"],
+        cwd,
+        environment: env,
+      });
+      const [stateResponse, modelsResponse, commandsResponse] = yield* Effect.all(
+        [
+          // No explicit timeout: these are the first commands on a freshly
+          // spawned process, so they inherit the RPC startup budget.
+          rpc.request({ type: "get_state" }),
+          rpc.request({ type: "get_available_models" }),
+          rpc.request({ type: "get_commands" }),
+        ],
+        { concurrency: "unbounded" },
+      );
+      const state = Option.getOrUndefined(decodeState(stateResponse.data));
+      const modelData = Option.getOrUndefined(decodeModels(modelsResponse.data));
+      const commandData = Option.getOrUndefined(decodeCommands(commandsResponse.data));
+      const models = modelsFromRpc({
+        models: modelData?.models ?? [],
+        defaultModel: state?.model ?? null,
+        // exactOptionalPropertyTypes: an absent thinking level must be omitted
+        // rather than passed as undefined.
+        ...(state?.thinkingLevel === undefined ? {} : { thinkingLevel: state.thinkingLevel }),
+      });
+      return { models, ...commandsFromRpc(commandData?.commands ?? []) };
+    }).pipe(Effect.scoped, Effect.result);
+
+    if (Result.isFailure(discovery)) {
+      return buildServerProvider({
+        presentation: presentation(definition),
+        enabled: true,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: `${definition.displayName} RPC model discovery failed. Check ${definition.displayName} configuration and credentials.`,
+        },
+      });
+    }
+    const discovered = discovery.success;
+    const models = providerModelsFromSettings(
+      discovered.models,
+      settings.customModels,
+      EMPTY_CAPABILITIES,
+    );
+    const versionStatus = definition.versionStatus?.(version);
+    return buildServerProvider({
+      presentation: presentation(definition),
+      enabled: true,
+      checkedAt,
+      models,
+      slashCommands: discovered.slashCommands,
+      skills: discovered.skills,
+      probe: {
+        installed: true,
+        version,
+        status: versionStatus?.status ?? (models.length > 0 ? "ready" : "warning"),
+        auth: { status: models.length > 0 ? "authenticated" : "unknown" },
+        message:
+          versionStatus?.message ??
+          (models.length > 0
+            ? `${definition.displayName} RPC is ready.`
+            : `${definition.displayName} is installed, but it reported no configured models.`),
+      },
+    });
+  },
+);
+
+const ATOMIC_PROVIDER_DEFINITION: PiCompatibleProviderDefinition = {
+  displayName: "Atomic",
+  agentDirEnvironmentVariable: "ATOMIC_CODING_AGENT_DIR",
+};
+
+export function buildInitialAtomicProviderSnapshot(settings: AtomicSettings) {
+  return buildInitialPiCompatibleProviderSnapshot(settings, ATOMIC_PROVIDER_DEFINITION);
+}
+
+export function checkAtomicProviderStatus(
   settings: AtomicSettings,
   cwd: string,
   environment: NodeJS.ProcessEnv = process.env,
 ) {
-  const checkedAt = DateTime.formatIso(yield* DateTime.now);
-  const fallbackModels = providerModelsFromSettings([], settings.customModels, EMPTY_CAPABILITIES);
-  if (!settings.enabled) {
-    return yield* buildInitialAtomicProviderSnapshot(settings);
-  }
-
-  const env = atomicEnvironment(settings, environment);
-  const spawnCommand = yield* resolveSpawnCommand(settings.binaryPath, ["--version"], { env });
-  const versionResult = yield* spawnAndCollect(
-    settings.binaryPath,
-    ChildProcess.make(spawnCommand.command, spawnCommand.args, {
-      env,
-      shell: spawnCommand.shell,
-    }),
-  ).pipe(Effect.timeoutOption(Duration.seconds(4)), Effect.result);
-
-  if (Result.isFailure(versionResult)) {
-    return buildServerProvider({
-      presentation: PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: !isCommandMissingCause(versionResult.failure),
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: isCommandMissingCause(versionResult.failure)
-          ? "Atomic CLI (`atomic`) is not installed or not on PATH."
-          : "Failed to execute the Atomic CLI health check.",
-      },
-    });
-  }
-  if (Option.isNone(versionResult.success)) {
-    return buildServerProvider({
-      presentation: PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Atomic CLI timed out while running `atomic --version`.",
-      },
-    });
-  }
-  const versionOutput = versionResult.success.value;
-  const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
-  if (versionOutput.code !== 0) {
-    return buildServerProvider({
-      presentation: PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Atomic CLI is installed but failed to run.",
-      },
-    });
-  }
-
-  const discovery = yield* Effect.gen(function* () {
-    const rpc = yield* makeAtomicRpcProcess({
-      binaryPath: settings.binaryPath,
-      args: ["--no-session", "--no-approve"],
-      cwd,
-      environment: env,
-    });
-    const [stateResponse, modelsResponse, commandsResponse] = yield* Effect.all(
-      [
-        // No explicit timeout: these are the first commands on a freshly
-        // spawned process, so they inherit the RPC startup budget.
-        rpc.request({ type: "get_state" }),
-        rpc.request({ type: "get_available_models" }),
-        rpc.request({ type: "get_commands" }),
-      ],
-      { concurrency: "unbounded" },
-    );
-    const state = Option.getOrUndefined(decodeState(stateResponse.data));
-    const modelData = Option.getOrUndefined(decodeModels(modelsResponse.data));
-    const commandData = Option.getOrUndefined(decodeCommands(commandsResponse.data));
-    const models = modelsFromRpc({
-      models: modelData?.models ?? [],
-      defaultModel: state?.model ?? null,
-      // exactOptionalPropertyTypes: an absent thinking level must be omitted
-      // rather than passed as undefined.
-      ...(state?.thinkingLevel === undefined ? {} : { thinkingLevel: state.thinkingLevel }),
-    });
-    return { models, ...commandsFromRpc(commandData?.commands ?? []) };
-  }).pipe(Effect.scoped, Effect.result);
-
-  if (Result.isFailure(discovery)) {
-    return buildServerProvider({
-      presentation: PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Atomic RPC model discovery failed. Check Atomic configuration and credentials.",
-      },
-    });
-  }
-  const discovered = discovery.success;
-  const models = providerModelsFromSettings(
-    discovered.models,
-    settings.customModels,
-    EMPTY_CAPABILITIES,
-  );
-  return buildServerProvider({
-    presentation: PRESENTATION,
-    enabled: true,
-    checkedAt,
-    models,
-    slashCommands: discovered.slashCommands,
-    skills: discovered.skills,
-    probe: {
-      installed: true,
-      version,
-      status: models.length > 0 ? "ready" : "warning",
-      auth: { status: models.length > 0 ? "authenticated" : "unknown" },
-      message:
-        models.length > 0
-          ? "Atomic RPC is ready."
-          : "Atomic is installed, but it reported no configured models.",
-    },
-  });
-});
+  return checkPiCompatibleProviderStatus(settings, ATOMIC_PROVIDER_DEFINITION, cwd, environment);
+}

--- a/apps/server/src/provider/Layers/AtomicProvider.ts
+++ b/apps/server/src/provider/Layers/AtomicProvider.ts
@@ -1,0 +1,319 @@
+import {
+  type AtomicSettings,
+  type ModelCapabilities,
+  type ServerProviderModel,
+  type ServerProviderSkill,
+  type ServerProviderSlashCommand,
+} from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import { ChildProcess } from "effect/unstable/process";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import { makeAtomicRpcProcess } from "../atomic/AtomicRpcProcess.ts";
+
+const AtomicModel = Schema.Struct({
+  id: Schema.String,
+  name: Schema.optional(Schema.String),
+  provider: Schema.String,
+  reasoning: Schema.optional(Schema.Boolean),
+  thinkingLevelMap: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+});
+type AtomicModel = typeof AtomicModel.Type;
+
+const AtomicModelsData = Schema.Struct({ models: Schema.Array(AtomicModel) });
+const AtomicStateData = Schema.Struct({
+  model: Schema.optional(Schema.NullOr(AtomicModel)),
+  thinkingLevel: Schema.optional(Schema.String),
+});
+const AtomicCommand = Schema.Struct({
+  name: Schema.String,
+  description: Schema.optional(Schema.String),
+  source: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+  path: Schema.optional(Schema.String),
+});
+const AtomicCommandsData = Schema.Struct({ commands: Schema.Array(AtomicCommand) });
+
+const decodeModels = Schema.decodeUnknownOption(AtomicModelsData);
+const decodeState = Schema.decodeUnknownOption(AtomicStateData);
+const decodeCommands = Schema.decodeUnknownOption(AtomicCommandsData);
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const RPC_PROBE_TIMEOUT = Duration.seconds(15);
+
+const PRESENTATION = {
+  displayName: "Atomic",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: false,
+  requiresNewThreadForModelChange: false,
+} as const;
+
+function atomicEnvironment(
+  settings: AtomicSettings,
+  environment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return settings.agentDir
+    ? { ...environment, ATOMIC_CODING_AGENT_DIR: settings.agentDir }
+    : environment;
+}
+
+function supportedThinkingLevels(model: AtomicModel): ReadonlyArray<string> {
+  if (model.reasoning !== true) return ["off"];
+  return THINKING_LEVELS.filter((level) => {
+    const mapped = model.thinkingLevelMap?.[level];
+    if (mapped === null) return false;
+    if ((level === "xhigh" || level === "max") && mapped === undefined) return false;
+    return true;
+  });
+}
+
+function capabilitiesForModel(
+  model: AtomicModel,
+  currentThinkingLevel?: string,
+): ModelCapabilities {
+  const levels = supportedThinkingLevels(model);
+  if (levels.length <= 1) return EMPTY_CAPABILITIES;
+  const selected = levels.includes(currentThinkingLevel ?? "") ? currentThinkingLevel : undefined;
+  return createModelCapabilities({
+    optionDescriptors: [
+      {
+        id: "reasoningEffort",
+        label: "Thinking",
+        type: "select",
+        options: levels.map((level) => ({
+          id: level,
+          label: level === "xhigh" ? "Extra high" : level[0]!.toUpperCase() + level.slice(1),
+          ...(level === selected ? { isDefault: true } : {}),
+        })),
+        ...(selected ? { currentValue: selected } : {}),
+      },
+    ],
+  });
+}
+
+function modelSlug(model: AtomicModel): string {
+  return `${model.provider}/${model.id}`;
+}
+
+function modelsFromRpc(input: {
+  readonly models: ReadonlyArray<AtomicModel>;
+  readonly defaultModel?: AtomicModel | null;
+  readonly thinkingLevel?: string;
+}): ReadonlyArray<ServerProviderModel> {
+  const defaultSlug = input.defaultModel ? modelSlug(input.defaultModel) : undefined;
+  const seen = new Set<string>();
+  const models: ServerProviderModel[] = [];
+  for (const model of input.models) {
+    const slug = modelSlug(model);
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    models.push({
+      slug,
+      name: model.name?.trim() || model.id,
+      subProvider: model.provider,
+      isCustom: false,
+      ...(slug === defaultSlug ? { isDefault: true } : {}),
+      capabilities: capabilitiesForModel(model, input.thinkingLevel),
+    });
+  }
+  return models;
+}
+
+function commandsFromRpc(commands: ReadonlyArray<typeof AtomicCommand.Type>): {
+  readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
+} {
+  const slashCommands = commands
+    .filter((command) => command.name.trim().length > 0)
+    .map((command) => ({
+      name: command.name.trim(),
+      ...(command.description?.trim() ? { description: command.description.trim() } : {}),
+    }));
+  const skills = commands
+    .filter(
+      (command): command is typeof command & { readonly path: string } =>
+        command.source === "skill" && typeof command.path === "string" && command.path.length > 0,
+    )
+    .map((command) => ({
+      name: command.name.replace(/^skill:/, ""),
+      ...(command.description?.trim() ? { description: command.description.trim() } : {}),
+      path: command.path,
+      ...(command.location ? { scope: command.location } : {}),
+      enabled: true,
+    }));
+  return { slashCommands, skills };
+}
+
+export function buildInitialAtomicProviderSnapshot(
+  settings: AtomicSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.map(DateTime.now, (now) =>
+    buildServerProvider({
+      presentation: PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt: DateTime.formatIso(now),
+      models: providerModelsFromSettings([], settings.customModels, EMPTY_CAPABILITIES),
+      probe: {
+        installed: settings.enabled,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: settings.enabled
+          ? "Checking Atomic CLI availability..."
+          : "Atomic is disabled in T3 Code settings.",
+      },
+    }),
+  );
+}
+
+export const checkAtomicProviderStatus = Effect.fn("checkAtomicProviderStatus")(function* (
+  settings: AtomicSettings,
+  cwd: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const fallbackModels = providerModelsFromSettings([], settings.customModels, EMPTY_CAPABILITIES);
+  if (!settings.enabled) {
+    return yield* buildInitialAtomicProviderSnapshot(settings);
+  }
+
+  const env = atomicEnvironment(settings, environment);
+  const spawnCommand = yield* resolveSpawnCommand(settings.binaryPath, ["--version"], { env });
+  const versionResult = yield* spawnAndCollect(
+    settings.binaryPath,
+    ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+      env,
+      shell: spawnCommand.shell,
+    }),
+  ).pipe(Effect.timeoutOption(Duration.seconds(4)), Effect.result);
+
+  if (Result.isFailure(versionResult)) {
+    return buildServerProvider({
+      presentation: PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: !isCommandMissingCause(versionResult.failure),
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: isCommandMissingCause(versionResult.failure)
+          ? "Atomic CLI (`atomic`) is not installed or not on PATH."
+          : "Failed to execute the Atomic CLI health check.",
+      },
+    });
+  }
+  if (Option.isNone(versionResult.success)) {
+    return buildServerProvider({
+      presentation: PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "Atomic CLI timed out while running `atomic --version`.",
+      },
+    });
+  }
+  const versionOutput = versionResult.success.value;
+  const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+  if (versionOutput.code !== 0) {
+    return buildServerProvider({
+      presentation: PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "Atomic CLI is installed but failed to run.",
+      },
+    });
+  }
+
+  const discovery = yield* Effect.gen(function* () {
+    const rpc = yield* makeAtomicRpcProcess({
+      binaryPath: settings.binaryPath,
+      args: ["--no-session", "--no-approve"],
+      cwd,
+      environment: env,
+    });
+    const [stateResponse, modelsResponse, commandsResponse] = yield* Effect.all(
+      [
+        rpc.request({ type: "get_state" }, RPC_PROBE_TIMEOUT),
+        rpc.request({ type: "get_available_models" }, RPC_PROBE_TIMEOUT),
+        rpc.request({ type: "get_commands" }, RPC_PROBE_TIMEOUT),
+      ],
+      { concurrency: "unbounded" },
+    );
+    const state = Option.getOrUndefined(decodeState(stateResponse.data));
+    const modelData = Option.getOrUndefined(decodeModels(modelsResponse.data));
+    const commandData = Option.getOrUndefined(decodeCommands(commandsResponse.data));
+    const models = modelsFromRpc({
+      models: modelData?.models ?? [],
+      defaultModel: state?.model,
+      thinkingLevel: state?.thinkingLevel,
+    });
+    return { models, ...commandsFromRpc(commandData?.commands ?? []) };
+  }).pipe(Effect.scoped, Effect.result);
+
+  if (Result.isFailure(discovery)) {
+    return buildServerProvider({
+      presentation: PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "Atomic RPC model discovery failed. Check Atomic configuration and credentials.",
+      },
+    });
+  }
+  const discovered = discovery.success;
+  const models = providerModelsFromSettings(
+    discovered.models,
+    settings.customModels,
+    EMPTY_CAPABILITIES,
+  );
+  return buildServerProvider({
+    presentation: PRESENTATION,
+    enabled: true,
+    checkedAt,
+    models,
+    slashCommands: discovered.slashCommands,
+    skills: discovered.skills,
+    probe: {
+      installed: true,
+      version,
+      status: models.length > 0 ? "ready" : "warning",
+      auth: { status: models.length > 0 ? "authenticated" : "unknown" },
+      message:
+        models.length > 0
+          ? "Atomic RPC is ready."
+          : "Atomic is installed, but it reported no configured models.",
+    },
+  });
+});

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -1,0 +1,80 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import { PiSettings, ProviderDriverKind, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { assert, describe } from "vite-plus/test";
+
+import { ServerConfig } from "../../config.ts";
+import { makePiAdapter } from "./PiAdapter.ts";
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockPeer = NodePath.join(__dirname, "../testFixtures/piRpcMockPeer.mjs");
+const decodePiSettings = Schema.decodeSync(PiSettings);
+
+function writeMockWrapper(): string {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "pi-adapter-test-"));
+  const wrapper = NodePath.join(dir, "mock-pi.sh");
+  NodeFS.writeFileSync(
+    wrapper,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(mockPeer)} "$@"\n`,
+    "utf8",
+  );
+  NodeFS.chmodSync(wrapper, 0o755);
+  return wrapper;
+}
+
+describe("PiAdapter", () => {
+  it.live("uses the shared Pi lifecycle for thinking, tools, queued runs, and completion", () =>
+    Effect.gen(function* () {
+      const adapter = yield* makePiAdapter(
+        decodePiSettings({ enabled: true, binaryPath: writeMockWrapper() }),
+      ).pipe(
+        Effect.provide(
+          ServerConfig.layerTest(process.cwd(), { prefix: "pi-adapter-test-" }).pipe(
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      );
+      const threadId = ThreadId.make("pi-chat-lifecycle");
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("pi"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "Reply with PI_RPC_OK", attachments: [] });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(events.at(-1)?.type, "turn.completed");
+      assert.isDefined(
+        events.find(
+          (event) => event.type === "content.delta" && event.payload.delta === "PI_RPC_OK",
+        ),
+      );
+      assert.isDefined(
+        events.find(
+          (event) => event.type === "content.delta" && event.payload.delta === "QUEUED_FOLLOW_UP",
+        ),
+      );
+      assert.isTrue(events.every((event) => event.provider === "pi"));
+      const raw = events.find((event) => event.raw)?.raw;
+      assert.equal(raw?.source, "pi.rpc");
+    }).pipe(Effect.scoped),
+  );
+});

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1,0 +1,23 @@
+import { type PiSettings, ProviderDriverKind } from "@t3tools/contracts";
+
+import {
+  makePiCompatibleAdapter,
+  type PiCompatibleAdapterOptions,
+  type PiCompatibleAdapterDefinition,
+} from "./AtomicAdapter.ts";
+
+const PI_ADAPTER_DEFINITION: PiCompatibleAdapterDefinition = {
+  provider: ProviderDriverKind.make("pi"),
+  displayName: "Pi",
+  agentDirEnvironmentVariable: "PI_CODING_AGENT_DIR",
+  rawSource: "pi.rpc",
+};
+
+/**
+ * Pi and Atomic intentionally share one RPC lifecycle reducer. Atomic is a Pi
+ * distribution with additional extensions; keeping one adapter seam makes
+ * ordinary chat, thinking, tools, queueing, and settlement behave identically.
+ */
+export function makePiAdapter(settings: PiSettings, options?: PiCompatibleAdapterOptions) {
+  return makePiCompatibleAdapter(settings, PI_ADAPTER_DEFINITION, options);
+}

--- a/apps/server/src/provider/Layers/PiProvider.test.ts
+++ b/apps/server/src/provider/Layers/PiProvider.test.ts
@@ -1,0 +1,55 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import { PiSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { assert, describe } from "vite-plus/test";
+
+import { checkPiProviderStatus } from "./PiProvider.ts";
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockPeer = NodePath.join(__dirname, "../testFixtures/piRpcMockPeer.mjs");
+const decodePiSettings = Schema.decodeSync(PiSettings);
+
+function writeMockWrapper(version: string): string {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "pi-provider-test-"));
+  const wrapper = NodePath.join(dir, "mock-pi.sh");
+  NodeFS.writeFileSync(
+    wrapper,
+    `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '${version}\\n'
+  exit 0
+fi
+exec ${JSON.stringify(process.execPath)} ${JSON.stringify(mockPeer)} "$@"
+`,
+    "utf8",
+  );
+  NodeFS.chmodSync(wrapper, 0o755);
+  return wrapper;
+}
+
+describe("PiProvider", () => {
+  it.effect("keeps the compatible 0.84.1 shim range selectable with an upgrade advisory", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkPiProviderStatus(
+        decodePiSettings({ enabled: true, binaryPath: writeMockWrapper("0.84.1") }),
+        process.cwd(),
+      );
+      assert.equal(snapshot.displayName, "Pi");
+      assert.equal(snapshot.version, "0.84.1");
+      assert.equal(snapshot.status, "ready");
+      assert.deepEqual(
+        snapshot.models.map((model) => model.slug),
+        ["openai-codex/gpt-5.4"],
+      );
+      assert.match(snapshot.message ?? "", /0\.84\.3/u);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/Layers/PiProvider.ts
+++ b/apps/server/src/provider/Layers/PiProvider.ts
@@ -1,0 +1,62 @@
+import type { PiSettings } from "@t3tools/contracts";
+
+import {
+  buildInitialPiCompatibleProviderSnapshot,
+  checkPiCompatibleProviderStatus,
+  type PiCompatibleProviderDefinition,
+} from "./AtomicProvider.ts";
+
+function parseVersion(version: string | null): readonly [number, number, number] | undefined {
+  if (!version) return undefined;
+  const match = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function piVersionStatus(version: string | null) {
+  const parsed = parseVersion(version);
+  if (!parsed) {
+    return {
+      status: "warning" as const,
+      message:
+        "Pi RPC responded, but its version could not be verified. Pi 0.84.3 or newer is recommended.",
+    };
+  }
+  const [major, minor, patch] = parsed;
+  if (major === 0 && minor < 84) {
+    return {
+      status: "error" as const,
+      message:
+        "This Pi release predates the supported RPC lifecycle. Upgrade to Pi 0.84.3 or newer.",
+    };
+  }
+  if (major === 0 && minor === 84 && patch < 3) {
+    return {
+      // T3 treats provider warning status as unavailable in the model picker.
+      // Pi 0.84.0-0.84.2 is usable through the compatibility reducer, so keep
+      // the provider selectable and carry the upgrade guidance in the message.
+      status: "ready" as const,
+      message:
+        "Pi RPC is available through the 0.84 compatibility shim. Upgrade to Pi 0.84.3 or newer for complete tool and usage metadata.",
+    };
+  }
+  return { status: "ready" as const, message: "Pi RPC is ready." };
+}
+
+const PI_PROVIDER_DEFINITION: PiCompatibleProviderDefinition = {
+  displayName: "Pi",
+  agentDirEnvironmentVariable: "PI_CODING_AGENT_DIR",
+  versionStatus: piVersionStatus,
+};
+
+export function buildInitialPiProviderSnapshot(settings: PiSettings) {
+  return buildInitialPiCompatibleProviderSnapshot(settings, PI_PROVIDER_DEFINITION);
+}
+
+export function checkPiProviderStatus(
+  settings: PiSettings,
+  cwd: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  return checkPiCompatibleProviderStatus(settings, PI_PROVIDER_DEFINITION, cwd, environment);
+}

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1743,6 +1743,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               );
 
               assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
+                "atomic",
                 "claudeAgent",
                 "codex",
                 "cursor",

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1749,6 +1749,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 "cursor",
                 "grok",
                 "opencode",
+                "pi",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);
               assert.strictEqual(cursorProvider?.status, "disabled");

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.test.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.test.ts
@@ -50,6 +50,16 @@ process.stdin.on("data", (chunk) => {
   return wrapper;
 };
 
+const writeMockAtomicScript = (source: string) => {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "atomic-rpc-test-"));
+  const script = NodePath.join(dir, "mock-atomic.mjs");
+  NodeFS.writeFileSync(script, source, "utf8");
+  const wrapper = NodePath.join(dir, "mock-atomic.sh");
+  NodeFS.writeFileSync(wrapper, `#!/bin/sh\nexec ${process.execPath} ${script}\n`, "utf8");
+  NodeFS.chmodSync(wrapper, 0o755);
+  return wrapper;
+};
+
 const REPLY_DELAY = 300;
 
 describe("AtomicRpcProcess", () => {
@@ -93,6 +103,27 @@ describe("AtomicRpcProcess", () => {
         .request({ type: "get_state" }, Duration.millis(20))
         .pipe(Effect.result);
       assert.strictEqual(result._tag, "Failure");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("fails pending requests immediately when stdout closes cleanly", () =>
+    Effect.gen(function* () {
+      const rpc = yield* makeAtomicRpcProcess({
+        binaryPath: writeMockAtomicScript(
+          `process.stdin.once("data", () => setTimeout(() => process.exit(0), 50));\nsetInterval(() => {}, 1000);\n`,
+        ),
+        startupTimeout: Duration.seconds(10),
+      });
+      const result = yield* rpc
+        .request({ type: "get_state" })
+        .pipe(Effect.timeout(Duration.millis(500)), Effect.result);
+      assert.strictEqual(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "AtomicRpcError");
+        if (result.failure._tag === "AtomicRpcError") {
+          assert.strictEqual(result.failure.operation, "read");
+        }
+      }
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.test.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.test.ts
@@ -116,7 +116,10 @@ describe("AtomicRpcProcess", () => {
       });
       const result = yield* rpc
         .request({ type: "get_state" })
-        .pipe(Effect.timeout(Duration.millis(500)), Effect.result);
+        // The budget includes spawning the mock Node process. Under the normal
+        // parallel suite load, process startup alone can exceed 500ms. Two
+        // seconds still proves EOF beats the 10-second RPC request timeout.
+        .pipe(Effect.timeout(Duration.seconds(2)), Effect.result);
       assert.strictEqual(result._tag, "Failure");
       if (result._tag === "Failure") {
         assert.strictEqual(result.failure._tag, "AtomicRpcError");

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.test.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Guards the RPC timeout budgets. Atomic does network work before answering its
+ * first command (OAuth refresh, model-catalog fetch), so a cold start measured
+ * ~28s against a fast connection while warm starts land near 0.7s. The first
+ * command therefore gets a much larger budget than steady-state commands.
+ */
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import { assert, describe } from "vite-plus/test";
+
+import { makeAtomicRpcProcess } from "./AtomicRpcProcess.ts";
+
+// Mock Atomic: answers every command after `delayMs`, standing in for a runtime
+// whose first reply is slow. Launched through a shell wrapper because
+// makeAtomicRpcProcess always prepends `--mode rpc`, which node itself rejects.
+const writeMockAtomic = (delayMs: number) => {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "atomic-rpc-test-"));
+  const script = NodePath.join(dir, "mock-atomic.mjs");
+  NodeFS.writeFileSync(
+    script,
+    `let buf = "";
+process.stdin.on("data", (chunk) => {
+  buf += chunk.toString("utf8");
+  let i;
+  while ((i = buf.indexOf("\\n")) !== -1) {
+    const line = buf.slice(0, i);
+    buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    const command = JSON.parse(line);
+    setTimeout(() => {
+      process.stdout.write(
+        JSON.stringify({ id: command.id, type: "response", command: command.type, success: true }) + "\\n",
+      );
+    }, ${delayMs});
+  }
+});
+`,
+    "utf8",
+  );
+  const wrapper = NodePath.join(dir, "mock-atomic.sh");
+  NodeFS.writeFileSync(wrapper, `#!/bin/sh\nexec ${process.execPath} ${script}\n`, "utf8");
+  NodeFS.chmodSync(wrapper, 0o755);
+  return wrapper;
+};
+
+const REPLY_DELAY = 300;
+
+describe("AtomicRpcProcess", () => {
+  it.live("gives the first command the startup budget, not the steady-state one", () =>
+    Effect.gen(function* () {
+      // The steady-state budget is far too small for the mock's reply delay, so
+      // a success here can only come from the startup budget.
+      const rpc = yield* makeAtomicRpcProcess({
+        binaryPath: writeMockAtomic(REPLY_DELAY),
+        startupTimeout: Duration.seconds(10),
+        requestTimeout: Duration.millis(20),
+      });
+      const response = yield* rpc.request({ type: "get_state" });
+      assert.strictEqual(response.success, true);
+      assert.strictEqual(response.command, "get_state");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("falls back to the steady-state budget once Atomic has answered", () =>
+    Effect.gen(function* () {
+      const rpc = yield* makeAtomicRpcProcess({
+        binaryPath: writeMockAtomic(REPLY_DELAY),
+        startupTimeout: Duration.seconds(10),
+        requestTimeout: Duration.millis(20),
+      });
+      yield* rpc.request({ type: "get_state" });
+      // Same reply delay, now measured against the steady-state budget.
+      const result = yield* rpc.request({ type: "get_state" }).pipe(Effect.result);
+      assert.strictEqual(result._tag, "Failure");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("honors an explicit per-request timeout over both budgets", () =>
+    Effect.gen(function* () {
+      const rpc = yield* makeAtomicRpcProcess({
+        binaryPath: writeMockAtomic(REPLY_DELAY),
+        startupTimeout: Duration.seconds(10),
+        requestTimeout: Duration.seconds(10),
+      });
+      const result = yield* rpc
+        .request({ type: "get_state" }, Duration.millis(20))
+        .pipe(Effect.result);
+      assert.strictEqual(result._tag, "Failure");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.ts
@@ -1,0 +1,178 @@
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as Ndjson from "effect/unstable/encoding/Ndjson";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+const AtomicRpcResponse = Schema.Struct({
+  id: Schema.optional(Schema.String),
+  type: Schema.Literal("response"),
+  command: Schema.String,
+  success: Schema.Boolean,
+  data: Schema.optional(Schema.Unknown),
+  error: Schema.optional(Schema.String),
+});
+export type AtomicRpcResponse = typeof AtomicRpcResponse.Type;
+
+const AtomicRpcEvent = Schema.Record(Schema.String, Schema.Unknown);
+export type AtomicRpcEvent = typeof AtomicRpcEvent.Type;
+
+const isAtomicRpcResponse = Schema.is(AtomicRpcResponse);
+const isAtomicRpcEvent = Schema.is(AtomicRpcEvent);
+const encodeCommand = Schema.encodeUnknown(Schema.fromJsonString(Schema.Unknown));
+
+export class AtomicRpcError extends Schema.TaggedErrorClass<AtomicRpcError>()("AtomicRpcError", {
+  operation: Schema.String,
+  detail: Schema.String,
+  cause: Schema.optional(Schema.Defect()),
+}) {
+  override get message(): string {
+    return `Atomic RPC ${this.operation} failed: ${this.detail}`;
+  }
+}
+
+export interface AtomicRpcProcess {
+  readonly request: (
+    command: Readonly<Record<string, unknown>>,
+    timeout?: Duration.DurationInput,
+  ) => Effect.Effect<AtomicRpcResponse, AtomicRpcError>;
+  readonly notify: (
+    command: Readonly<Record<string, unknown>>,
+  ) => Effect.Effect<void, AtomicRpcError>;
+  readonly events: Stream.Stream<AtomicRpcEvent>;
+  readonly kill: Effect.Effect<void>;
+}
+
+export interface AtomicRpcProcessOptions {
+  readonly binaryPath: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly cwd?: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+const DEFAULT_REQUEST_TIMEOUT = Duration.seconds(15);
+
+export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* (
+  options: AtomicRpcProcessOptions,
+) {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const environment = options.environment ?? process.env;
+  const args = ["--mode", "rpc", ...(options.args ?? [])];
+  const spawnCommand = yield* resolveSpawnCommand(options.binaryPath, args, { env: environment });
+  const command = ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    env: environment,
+    shell: spawnCommand.shell,
+    stdin: { stream: "pipe", endOnDone: false },
+    stdout: "pipe",
+    stderr: "pipe",
+    killSignal: "SIGTERM",
+    forceKillAfter: Duration.seconds(2),
+  });
+  const handle = yield* Effect.acquireRelease(
+    spawner.spawn(command).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AtomicRpcError({
+            operation: "spawn",
+            detail: `Could not start '${options.binaryPath}'.`,
+            cause,
+          }),
+      ),
+    ),
+    (child) => child.kill().pipe(Effect.ignore),
+  );
+  const events = yield* PubSub.unbounded<AtomicRpcEvent>();
+  const pending = new Map<string, Deferred.Deferred<AtomicRpcResponse, AtomicRpcError>>();
+  const writeMutex = yield* Semaphore.make(1);
+  let requestSequence = 0;
+
+  const write = (value: Readonly<Record<string, unknown>>) =>
+    writeMutex.withPermits(1)(
+      encodeCommand(value).pipe(
+        Effect.map((encoded) => `${encoded}\n`),
+        Effect.flatMap((encoded) =>
+          Stream.run(Stream.encodeText(Stream.make(encoded)), handle.stdin),
+        ),
+        Effect.mapError(
+          (cause) =>
+            new AtomicRpcError({
+              operation: typeof value.type === "string" ? value.type : "write",
+              detail: "Could not write to Atomic stdin.",
+              cause,
+            }),
+        ),
+      ),
+    );
+
+  yield* handle.stdout.pipe(
+    Stream.pipeThroughChannel(Ndjson.decode({ ignoreEmptyLines: true })),
+    Stream.runForEach((value) => {
+      if (isAtomicRpcResponse(value)) {
+        const deferred = value.id ? pending.get(value.id) : undefined;
+        if (!deferred) return Effect.void;
+        pending.delete(value.id!);
+        return value.success
+          ? Deferred.succeed(deferred, value).pipe(Effect.asVoid)
+          : Deferred.fail(
+              deferred,
+              new AtomicRpcError({
+                operation: value.command,
+                detail: value.error ?? "Atomic returned an unsuccessful response.",
+              }),
+            ).pipe(Effect.asVoid);
+      }
+      return isAtomicRpcEvent(value)
+        ? PubSub.publish(events, value).pipe(Effect.asVoid)
+        : Effect.logWarning("Ignored malformed Atomic RPC frame.");
+    }),
+    Effect.catchCause((cause) =>
+      Effect.gen(function* () {
+        const error = new AtomicRpcError({
+          operation: "read",
+          detail: "Atomic RPC output closed or could not be decoded.",
+          cause,
+        });
+        for (const deferred of pending.values()) {
+          yield* Deferred.fail(deferred, error);
+        }
+        pending.clear();
+      }),
+    ),
+    Effect.forkScoped,
+  );
+  yield* handle.stderr.pipe(Stream.runDrain, Effect.ignore, Effect.forkScoped);
+
+  const notify: AtomicRpcProcess["notify"] = write;
+  const request: AtomicRpcProcess["request"] = (input, timeout = DEFAULT_REQUEST_TIMEOUT) =>
+    Effect.gen(function* () {
+      const id = `t3-${++requestSequence}`;
+      const deferred = yield* Deferred.make<AtomicRpcResponse, AtomicRpcError>();
+      pending.set(id, deferred);
+      yield* write({ ...input, id }).pipe(
+        Effect.tapError(() => Effect.sync(() => pending.delete(id))),
+      );
+      const response = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(timeout));
+      if (Option.isNone(response)) {
+        pending.delete(id);
+        return yield* new AtomicRpcError({
+          operation: typeof input.type === "string" ? input.type : "request",
+          detail: `Timed out after ${Duration.toMillis(Duration.decode(timeout))}ms.`,
+        });
+      }
+      return response.value;
+    });
+
+  return {
+    request,
+    notify,
+    events: Stream.fromPubSub(events),
+    kill: handle.kill().pipe(Effect.ignore),
+  } satisfies AtomicRpcProcess;
+});

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.ts
@@ -65,14 +65,14 @@ export interface AtomicRpcProcessOptions {
   readonly args?: ReadonlyArray<string>;
   readonly cwd?: string;
   readonly environment?: NodeJS.ProcessEnv;
-  /** Budget for the first command, which pays Atomic's startup network cost. */
+  /** Budget for commands issued before the first response, which pay the startup network cost. */
   readonly startupTimeout?: Duration.Input;
-  /** Budget for every command after Atomic has answered once. */
+  /** Budget for every command after the runtime has answered once. */
   readonly requestTimeout?: Duration.Input;
 }
 
 const DEFAULT_REQUEST_TIMEOUT = Duration.seconds(15);
-// Atomic performs network work before it answers its first command: it
+// Atomic performs network work before it sends its first response: it
 // refreshes OAuth credentials and fetches the model catalog, rewriting
 // auth.json and models-store.json. Measured cold start is ~28s against a
 // fast connection and warm start ~0.7s, so the first round trip gets a much
@@ -118,7 +118,7 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
   const writeMutex = yield* Semaphore.make(1);
   let requestSequence = 0;
   let eventSequence = 0;
-  // False until Atomic answers its first command, i.e. until startup network
+  // False until Atomic sends its first response, i.e. until startup network
   // work has finished. Gates which timeout `request` applies.
   let settled = false;
 

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.ts
@@ -25,7 +25,6 @@ export type AtomicRpcEvent = typeof AtomicRpcEvent.Type;
 
 const isAtomicRpcResponse = Schema.is(AtomicRpcResponse);
 const isAtomicRpcEvent = Schema.is(AtomicRpcEvent);
-const encodeCommand = Schema.encodeUnknown(Schema.fromJsonString(Schema.Unknown));
 
 export class AtomicRpcError extends Schema.TaggedErrorClass<AtomicRpcError>()("AtomicRpcError", {
   operation: Schema.String,
@@ -40,7 +39,7 @@ export class AtomicRpcError extends Schema.TaggedErrorClass<AtomicRpcError>()("A
 export interface AtomicRpcProcess {
   readonly request: (
     command: Readonly<Record<string, unknown>>,
-    timeout?: Duration.DurationInput,
+    timeout?: Duration.Input,
   ) => Effect.Effect<AtomicRpcResponse, AtomicRpcError>;
   readonly notify: (
     command: Readonly<Record<string, unknown>>,
@@ -54,15 +53,28 @@ export interface AtomicRpcProcessOptions {
   readonly args?: ReadonlyArray<string>;
   readonly cwd?: string;
   readonly environment?: NodeJS.ProcessEnv;
+  /** Budget for the first command, which pays Atomic's startup network cost. */
+  readonly startupTimeout?: Duration.Input;
+  /** Budget for every command after Atomic has answered once. */
+  readonly requestTimeout?: Duration.Input;
 }
 
 const DEFAULT_REQUEST_TIMEOUT = Duration.seconds(15);
+// Atomic performs network work before it answers its first command: it
+// refreshes OAuth credentials and fetches the model catalog, rewriting
+// auth.json and models-store.json. Measured cold start is ~28s against a
+// fast connection and warm start ~0.7s, so the first round trip gets a much
+// larger budget than steady-state commands. Corporate proxies make the cold
+// case slower still.
+const STARTUP_REQUEST_TIMEOUT = Duration.seconds(90);
 
 export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* (
   options: AtomicRpcProcessOptions,
 ) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const environment = options.environment ?? process.env;
+  const startupTimeout = options.startupTimeout ?? STARTUP_REQUEST_TIMEOUT;
+  const requestTimeout = options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT;
   const args = ["--mode", "rpc", ...(options.args ?? [])];
   const spawnCommand = yield* resolveSpawnCommand(options.binaryPath, args, { env: environment });
   const command = ChildProcess.make(spawnCommand.command, spawnCommand.args, {
@@ -92,14 +104,13 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
   const pending = new Map<string, Deferred.Deferred<AtomicRpcResponse, AtomicRpcError>>();
   const writeMutex = yield* Semaphore.make(1);
   let requestSequence = 0;
+  // False until Atomic answers its first command, i.e. until startup network
+  // work has finished. Gates which timeout `request` applies.
+  let settled = false;
 
   const write = (value: Readonly<Record<string, unknown>>) =>
     writeMutex.withPermits(1)(
-      encodeCommand(value).pipe(
-        Effect.map((encoded) => `${encoded}\n`),
-        Effect.flatMap((encoded) =>
-          Stream.run(Stream.encodeText(Stream.make(encoded)), handle.stdin),
-        ),
+      Stream.run(Stream.encodeText(Stream.make(`${JSON.stringify(value)}\n`)), handle.stdin).pipe(
         Effect.mapError(
           (cause) =>
             new AtomicRpcError({
@@ -108,6 +119,7 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
               cause,
             }),
         ),
+        Effect.asVoid,
       ),
     );
 
@@ -115,6 +127,7 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
     Stream.pipeThroughChannel(Ndjson.decode({ ignoreEmptyLines: true })),
     Stream.runForEach((value) => {
       if (isAtomicRpcResponse(value)) {
+        settled = true;
         const deferred = value.id ? pending.get(value.id) : undefined;
         if (!deferred) return Effect.void;
         pending.delete(value.id!);
@@ -150,20 +163,21 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
   yield* handle.stderr.pipe(Stream.runDrain, Effect.ignore, Effect.forkScoped);
 
   const notify: AtomicRpcProcess["notify"] = write;
-  const request: AtomicRpcProcess["request"] = (input, timeout = DEFAULT_REQUEST_TIMEOUT) =>
+  const request: AtomicRpcProcess["request"] = (input, timeout) =>
     Effect.gen(function* () {
+      const effectiveTimeout = timeout ?? (settled ? requestTimeout : startupTimeout);
       const id = `t3-${++requestSequence}`;
       const deferred = yield* Deferred.make<AtomicRpcResponse, AtomicRpcError>();
       pending.set(id, deferred);
       yield* write({ ...input, id }).pipe(
         Effect.tapError(() => Effect.sync(() => pending.delete(id))),
       );
-      const response = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(timeout));
+      const response = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(effectiveTimeout));
       if (Option.isNone(response)) {
         pending.delete(id);
         return yield* new AtomicRpcError({
           operation: typeof input.type === "string" ? input.type : "request",
-          detail: `Timed out after ${Duration.toMillis(Duration.decode(timeout))}ms.`,
+          detail: `Timed out after ${Duration.toMillis(effectiveTimeout)}ms.`,
         });
       }
       return response.value;

--- a/apps/server/src/provider/atomic/AtomicRpcProcess.ts
+++ b/apps/server/src/provider/atomic/AtomicRpcProcess.ts
@@ -18,10 +18,21 @@ const AtomicRpcResponse = Schema.Struct({
   data: Schema.optional(Schema.Unknown),
   error: Schema.optional(Schema.String),
 });
-export type AtomicRpcResponse = typeof AtomicRpcResponse.Type;
+type AtomicRpcWireResponse = typeof AtomicRpcResponse.Type;
+export type AtomicRpcResponse = AtomicRpcWireResponse & {
+  /** Number of unsolicited events read before this response frame. */
+  readonly precedingEventSequence: number;
+};
 
 const AtomicRpcEvent = Schema.Record(Schema.String, Schema.Unknown);
 export type AtomicRpcEvent = typeof AtomicRpcEvent.Type;
+
+const eventSequences = new WeakMap<object, number>();
+
+/** Ordered transport cursor attached out-of-band so it never pollutes raw provider data. */
+export function atomicRpcEventSequence(event: AtomicRpcEvent): number | undefined {
+  return eventSequences.get(event);
+}
 
 const isAtomicRpcResponse = Schema.is(AtomicRpcResponse);
 const isAtomicRpcEvent = Schema.is(AtomicRpcEvent);
@@ -50,6 +61,7 @@ export interface AtomicRpcProcess {
 
 export interface AtomicRpcProcessOptions {
   readonly binaryPath: string;
+  readonly runtimeName?: string;
   readonly args?: ReadonlyArray<string>;
   readonly cwd?: string;
   readonly environment?: NodeJS.ProcessEnv;
@@ -72,6 +84,7 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
   options: AtomicRpcProcessOptions,
 ) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const runtimeName = options.runtimeName ?? "Atomic";
   const environment = options.environment ?? process.env;
   const startupTimeout = options.startupTimeout ?? STARTUP_REQUEST_TIMEOUT;
   const requestTimeout = options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT;
@@ -93,7 +106,7 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
         (cause) =>
           new AtomicRpcError({
             operation: "spawn",
-            detail: `Could not start '${options.binaryPath}'.`,
+            detail: `Could not start ${runtimeName} from '${options.binaryPath}'.`,
             cause,
           }),
       ),
@@ -104,6 +117,7 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
   const pending = new Map<string, Deferred.Deferred<AtomicRpcResponse, AtomicRpcError>>();
   const writeMutex = yield* Semaphore.make(1);
   let requestSequence = 0;
+  let eventSequence = 0;
   // False until Atomic answers its first command, i.e. until startup network
   // work has finished. Gates which timeout `request` applies.
   let settled = false;
@@ -115,13 +129,27 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
           (cause) =>
             new AtomicRpcError({
               operation: typeof value.type === "string" ? value.type : "write",
-              detail: "Could not write to Atomic stdin.",
+              detail: `Could not write to ${runtimeName} stdin.`,
               cause,
             }),
         ),
         Effect.asVoid,
       ),
     );
+
+  const failPending = (cause?: unknown) =>
+    Effect.gen(function* () {
+      if (pending.size === 0) return;
+      const error = new AtomicRpcError({
+        operation: "read",
+        detail: `${runtimeName} RPC output closed or could not be decoded.`,
+        ...(cause === undefined ? {} : { cause }),
+      });
+      for (const deferred of pending.values()) {
+        yield* Deferred.fail(deferred, error);
+      }
+      pending.clear();
+    });
 
   yield* handle.stdout.pipe(
     Stream.pipeThroughChannel(Ndjson.decode({ ignoreEmptyLines: true })),
@@ -132,32 +160,29 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
         if (!deferred) return Effect.void;
         pending.delete(value.id!);
         return value.success
-          ? Deferred.succeed(deferred, value).pipe(Effect.asVoid)
+          ? Deferred.succeed(deferred, {
+              ...value,
+              precedingEventSequence: eventSequence,
+            }).pipe(Effect.asVoid)
           : Deferred.fail(
               deferred,
               new AtomicRpcError({
                 operation: value.command,
-                detail: value.error ?? "Atomic returned an unsuccessful response.",
+                detail: value.error ?? `${runtimeName} returned an unsuccessful response.`,
               }),
             ).pipe(Effect.asVoid);
       }
-      return isAtomicRpcEvent(value)
-        ? PubSub.publish(events, value).pipe(Effect.asVoid)
-        : Effect.logWarning("Ignored malformed Atomic RPC frame.");
+      if (!isAtomicRpcEvent(value)) {
+        return Effect.logWarning(`Ignored malformed ${runtimeName} RPC frame.`);
+      }
+      eventSequence += 1;
+      eventSequences.set(value, eventSequence);
+      return PubSub.publish(events, value).pipe(Effect.asVoid);
     }),
-    Effect.catchCause((cause) =>
-      Effect.gen(function* () {
-        const error = new AtomicRpcError({
-          operation: "read",
-          detail: "Atomic RPC output closed or could not be decoded.",
-          cause,
-        });
-        for (const deferred of pending.values()) {
-          yield* Deferred.fail(deferred, error);
-        }
-        pending.clear();
-      }),
-    ),
+    Effect.catchCause((cause) => failPending(cause)),
+    // A clean EOF is just as terminal as a decode failure. Without this
+    // finalizer, requests wait for their full timeout after the child exits.
+    Effect.ensuring(failPending()),
     Effect.forkScoped,
   );
   yield* handle.stderr.pipe(Stream.runDrain, Effect.ignore, Effect.forkScoped);
@@ -169,12 +194,16 @@ export const makeAtomicRpcProcess = Effect.fn("makeAtomicRpcProcess")(function* 
       const id = `t3-${++requestSequence}`;
       const deferred = yield* Deferred.make<AtomicRpcResponse, AtomicRpcError>();
       pending.set(id, deferred);
-      yield* write({ ...input, id }).pipe(
-        Effect.tapError(() => Effect.sync(() => pending.delete(id))),
+      const response = yield* Effect.gen(function* () {
+        yield* write({ ...input, id });
+        return yield* Deferred.await(deferred);
+      }).pipe(
+        // The deadline covers both the stdin write and the response wait. A
+        // dead child can otherwise leave a pipe write suspended forever.
+        Effect.timeoutOption(effectiveTimeout),
+        Effect.ensuring(Effect.sync(() => pending.delete(id))),
       );
-      const response = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(effectiveTimeout));
       if (Option.isNone(response)) {
-        pending.delete(id);
         return yield* new AtomicRpcError({
           operation: typeof input.type === "string" ? input.type : "request",
           detail: `Timed out after ${Duration.toMillis(effectiveTimeout)}ms.`,

--- a/apps/server/src/provider/builtInDrivers.test.ts
+++ b/apps/server/src/provider/builtInDrivers.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { BUILT_IN_DRIVERS } from "./builtInDrivers.ts";
+
+describe("BUILT_IN_DRIVERS", () => {
+  it("ships Pi as a first-class provider driver", () => {
+    expect(BUILT_IN_DRIVERS.map((driver) => driver.driverKind)).toContain("pi");
+  });
+});

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -26,6 +26,7 @@ import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
+import { PiDriver, type PiDriverEnv } from "./Drivers/PiDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
 /**
@@ -39,7 +40,8 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | PiDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -48,6 +50,7 @@ export type BuiltInDriversEnv =
  */
 export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv>> = [
   AtomicDriver,
+  PiDriver,
   CodexDriver,
   ClaudeDriver,
   CursorDriver,

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -21,6 +21,7 @@
  * @module provider/builtInDrivers
  */
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
+import { AtomicDriver, type AtomicDriverEnv } from "./Drivers/AtomicDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
@@ -33,6 +34,7 @@ import type { AnyProviderDriver } from "./ProviderDriver.ts";
  * layer must provide every service in this union.
  */
 export type BuiltInDriversEnv =
+  | AtomicDriverEnv
   | ClaudeDriverEnv
   | CodexDriverEnv
   | CursorDriverEnv
@@ -45,6 +47,7 @@ export type BuiltInDriversEnv =
  * iteration order has no functional effect on instance lookup.
  */
 export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv>> = [
+  AtomicDriver,
   CodexDriver,
   ClaudeDriver,
   CursorDriver,

--- a/apps/server/src/provider/testFixtures/piRpcMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/piRpcMockPeer.mjs
@@ -1,6 +1,7 @@
 let buffer = "";
 let isStreaming = false;
 let pendingUiPrompt;
+let abortableTurnActive = false;
 
 const write = (value) => {
   process.stdout.write(`${JSON.stringify(value)}\n`);
@@ -13,6 +14,16 @@ const response = (command, data) => {
     command: command.type,
     success: true,
     ...(data === undefined ? {} : { data }),
+  });
+};
+
+const failureResponse = (command, error) => {
+  write({
+    id: command.id,
+    type: "response",
+    command: command.type,
+    success: false,
+    error,
   });
 };
 
@@ -138,6 +149,21 @@ const runWorkflowCommand = (command) => {
       details: { kind: "dispatch", workflowName: "classify-and-act", runId },
     },
   });
+  write({
+    type: "message_end",
+    message: {
+      role: "custom",
+      customType: "workflows:lifecycle-notice",
+      display: false,
+      details: {
+        kind: "awaiting_input",
+        scope: "run",
+        runId,
+        workflowName: "classify-and-act",
+        promptMessage: "Provide workflow inputs.",
+      },
+    },
+  });
   response(command);
   setTimeout(() => {
     write({
@@ -245,6 +271,22 @@ const runWorkflowCommand = (command) => {
           promptId: "prompt-approve-1",
           promptKind: "confirm",
           promptMessage: "Approve the synthesized result?",
+        },
+      },
+    });
+    write({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "workflows:lifecycle-notice",
+        display: false,
+        details: {
+          kind: "resumed",
+          scope: "stage",
+          runId,
+          workflowName: "classify-and-act",
+          stageId: "approve",
+          stageName: "Approve",
         },
       },
     });
@@ -368,6 +410,19 @@ const requestLongLivedUi = (command) => {
   });
 };
 
+const runAbortableTurn = (command) => {
+  isStreaming = true;
+  abortableTurnActive = true;
+  response(command);
+  write({ type: "agent_start" });
+  write({
+    type: "tool_execution_start",
+    toolCallId: "abort-tool-1",
+    toolName: "read",
+    args: { path: "README.md" },
+  });
+};
+
 const handle = (command) => {
   switch (command.type) {
     case "get_state":
@@ -404,6 +459,10 @@ const handle = (command) => {
         runRecoverableExtensionErrorTurn(command);
       } else if (command.message === "/t3-terminal-assistant-error") {
         runTerminalAssistantErrorTurn(command);
+      } else if (command.message === "/t3-prompt-rejected") {
+        failureResponse(command, "The prompt transport rejected the request.");
+      } else if (command.message === "/t3-abort-drain") {
+        runAbortableTurn(command);
       } else if (command.message === "/t3-ui-wait") {
         requestLongLivedUi(command);
       } else if (String(command.message).startsWith("/workflow")) {
@@ -411,6 +470,29 @@ const handle = (command) => {
       } else {
         runChatTurn(command);
       }
+      return;
+    case "abort":
+      if (abortableTurnActive) {
+        write({
+          type: "entry_appended",
+          entry: {
+            type: "custom",
+            customType: "workflow.run.start",
+            data: { runId: "abort-drain-workflow", name: "abort-drain-workflow" },
+          },
+        });
+        write({
+          type: "tool_execution_end",
+          toolCallId: "abort-tool-1",
+          toolName: "read",
+          args: { path: "README.md" },
+          result: { content: [{ type: "text", text: "abort tool output" }] },
+          isError: false,
+        });
+        abortableTurnActive = false;
+        isStreaming = false;
+      }
+      response(command);
       return;
     case "extension_ui_response":
       if (pendingUiPrompt && command.id === "ui-editor-1") {

--- a/apps/server/src/provider/testFixtures/piRpcMockPeer.mjs
+++ b/apps/server/src/provider/testFixtures/piRpcMockPeer.mjs
@@ -1,0 +1,437 @@
+let buffer = "";
+let isStreaming = false;
+let pendingUiPrompt;
+
+const write = (value) => {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+};
+
+const response = (command, data) => {
+  write({
+    id: command.id,
+    type: "response",
+    command: command.type,
+    success: true,
+    ...(data === undefined ? {} : { data }),
+  });
+};
+
+const assistantMessage = {
+  role: "assistant",
+  content: [
+    { type: "thinking", thinking: "Check the shared Pi event stream." },
+    { type: "text", text: "PI_RPC_OK" },
+  ],
+};
+
+const runChatTurn = (command) => {
+  isStreaming = true;
+  response(command);
+  write({ type: "agent_start" });
+  write({
+    type: "message_start",
+    message: { role: "user", content: [{ type: "text", text: command.message }] },
+  });
+  write({
+    type: "message_end",
+    message: { role: "user", content: [{ type: "text", text: command.message }] },
+  });
+  write({ type: "message_start", message: { role: "assistant", content: [] } });
+  write({
+    type: "message_update",
+    assistantMessageEvent: {
+      type: "thinking_delta",
+      contentIndex: 0,
+      delta: "Check the shared Pi event stream.",
+    },
+  });
+  write({
+    type: "message_update",
+    assistantMessageEvent: {
+      type: "text_delta",
+      contentIndex: 1,
+      delta: "PI_RPC_OK",
+    },
+  });
+  write({
+    type: "tool_execution_start",
+    toolCallId: "tool-1",
+    toolName: "read",
+    args: { path: "README.md" },
+  });
+  write({
+    type: "tool_execution_update",
+    toolCallId: "tool-1",
+    toolName: "read",
+    args: { path: "README.md" },
+    partialResult: { content: [{ type: "text", text: "partial tool output" }] },
+  });
+  write({
+    type: "tool_execution_end",
+    toolCallId: "tool-1",
+    toolName: "read",
+    args: { path: "README.md" },
+    result: { content: [{ type: "text", text: "complete tool output" }] },
+    isError: false,
+  });
+  write({ type: "message_end", message: assistantMessage });
+  write({ type: "agent_end", messages: [assistantMessage] });
+  setTimeout(() => {
+    const followUp = {
+      role: "assistant",
+      content: [{ type: "text", text: "QUEUED_FOLLOW_UP" }],
+    };
+    write({ type: "agent_start" });
+    write({ type: "message_start", message: { role: "assistant", content: [] } });
+    write({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "QUEUED_FOLLOW_UP" },
+    });
+    write({ type: "message_end", message: followUp });
+    write({ type: "agent_end", messages: [followUp] });
+    isStreaming = false;
+    write({ type: "agent_settled" });
+  }, 15);
+};
+
+const runWorkflowCommand = (command) => {
+  const runId = "workflow-run-1";
+  write({
+    type: "message_start",
+    message: {
+      role: "custom",
+      customType: "workflows:chat-surface",
+      content: "Workflow classify-and-act started.",
+      display: true,
+      details: {
+        kind: "dispatch",
+        workflowName: "classify-and-act",
+        runId,
+        inputs: { prompt: "Return WORKFLOW_OK" },
+      },
+    },
+  });
+  write({
+    type: "entry_appended",
+    entry: {
+      type: "custom",
+      customType: "workflow.run.start",
+      data: { runId, name: "classify-and-act", inputs: { prompt: "Return WORKFLOW_OK" } },
+    },
+  });
+  write({
+    type: "message_end",
+    message: {
+      role: "custom",
+      customType: "workflow.run.start",
+      display: false,
+      details: { runId, name: "classify-and-act", inputs: { prompt: "Return WORKFLOW_OK" } },
+    },
+  });
+  write({
+    type: "message_end",
+    message: {
+      role: "custom",
+      customType: "workflows:chat-surface",
+      content: "Workflow classify-and-act started.",
+      display: true,
+      details: { kind: "dispatch", workflowName: "classify-and-act", runId },
+    },
+  });
+  response(command);
+  setTimeout(() => {
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.start",
+        data: { runId, stageId: "classify", name: "Classify", parentIds: [] },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.start",
+        data: { runId, stageId: "inspect", name: "Inspect", parentIds: [] },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.end",
+        data: {
+          runId,
+          stageId: "classify",
+          name: "Classify",
+          status: "completed",
+          summary: "Classification complete",
+        },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.end",
+        data: {
+          runId,
+          stageId: "inspect",
+          name: "Inspect",
+          parentIds: [],
+          status: "completed",
+          summary: "Inspection complete",
+        },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.start",
+        data: {
+          runId,
+          stageId: "synthesize",
+          name: "Synthesize",
+          parentIds: ["classify", "inspect"],
+        },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.end",
+        data: {
+          runId,
+          stageId: "synthesize",
+          name: "Synthesize",
+          parentIds: ["classify", "inspect"],
+          status: "completed",
+          summary: "Synthesis complete",
+        },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.start",
+        data: {
+          runId,
+          stageId: "approve",
+          name: "Approve",
+          parentIds: ["synthesize"],
+          replayKey: "prompt:confirm:approve",
+        },
+      },
+    });
+    write({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "workflows:lifecycle-notice",
+        content: "Workflow is awaiting approval.",
+        display: true,
+        details: {
+          kind: "awaiting_input",
+          scope: "stage",
+          runId,
+          workflowName: "classify-and-act",
+          status: "waiting",
+          stageId: "approve",
+          stageName: "Approve",
+          promptId: "prompt-approve-1",
+          promptKind: "confirm",
+          promptMessage: "Approve the synthesized result?",
+        },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.stage.end",
+        data: {
+          runId,
+          stageId: "approve",
+          name: "Approve",
+          parentIds: ["synthesize"],
+          status: "completed",
+          summary: "Approved",
+        },
+      },
+    });
+    write({
+      type: "entry_appended",
+      entry: {
+        type: "custom",
+        customType: "workflow.run.end",
+        data: {
+          runId,
+          name: "classify-and-act",
+          status: "completed",
+          result: "WORKFLOW_OK",
+        },
+      },
+    });
+    write({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "workflow.run.end",
+        display: false,
+        details: {
+          runId,
+          name: "classify-and-act",
+          status: "completed",
+          result: "WORKFLOW_OK",
+        },
+      },
+    });
+  }, 20);
+};
+
+const runRecoverableExtensionErrorTurn = (command) => {
+  isStreaming = true;
+  response(command);
+  write({ type: "agent_start" });
+  write({
+    type: "extension_error",
+    extensionPath: "/tmp/incompatible-extension.mjs",
+    error: "Optional extension uses an older Pi API.",
+  });
+  const failedMessage = {
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "Optional extension intercepted an incompatible tool result.",
+  };
+  write({ type: "message_start", message: { role: "assistant", content: [] } });
+  write({
+    type: "message_update",
+    assistantMessageEvent: { type: "error", reason: "error", error: failedMessage },
+  });
+  write({ type: "message_end", message: failedMessage });
+  const message = {
+    role: "assistant",
+    content: [{ type: "text", text: "RECOVERED_AFTER_EXTENSION_ERROR" }],
+    stopReason: "stop",
+  };
+  write({ type: "message_start", message: { role: "assistant", content: [] } });
+  write({
+    type: "message_update",
+    assistantMessageEvent: {
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "RECOVERED_AFTER_EXTENSION_ERROR",
+    },
+  });
+  write({ type: "message_end", message });
+  write({ type: "agent_end", messages: [message] });
+  isStreaming = false;
+  write({ type: "agent_settled" });
+};
+
+const runTerminalAssistantErrorTurn = (command) => {
+  isStreaming = true;
+  response(command);
+  write({ type: "agent_start" });
+  const failedMessage = {
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "The model request failed permanently.",
+  };
+  write({ type: "message_start", message: { role: "assistant", content: [] } });
+  write({
+    type: "message_update",
+    assistantMessageEvent: { type: "error", reason: "error", error: failedMessage },
+  });
+  write({ type: "message_end", message: failedMessage });
+  write({ type: "agent_end", messages: [failedMessage] });
+  isStreaming = false;
+  write({ type: "agent_settled" });
+};
+
+const requestLongLivedUi = (command) => {
+  isStreaming = true;
+  pendingUiPrompt = command;
+  write({
+    type: "extension_ui_request",
+    id: "ui-editor-1",
+    method: "editor",
+    title: "Review workflow input",
+    message: "Edit this value before the workflow continues.",
+    prefill: "ORIGINAL_WORKFLOW_VALUE",
+  });
+};
+
+const handle = (command) => {
+  switch (command.type) {
+    case "get_state":
+      response(command, {
+        model: { provider: "openai-codex", id: "gpt-5.4" },
+        thinkingLevel: "high",
+        sessionId: "pi-rpc-mock-session",
+        sessionFile: "/tmp/pi-rpc-mock-session.jsonl",
+        isStreaming,
+      });
+      return;
+    case "get_available_models":
+      response(command, {
+        models: [{ provider: "openai-codex", id: "gpt-5.4", name: "GPT-5.4", reasoning: true }],
+      });
+      return;
+    case "get_commands":
+      response(command, { commands: [] });
+      return;
+    case "get_session_stats":
+      response(command, {
+        sessionFile: "/tmp/pi-rpc-mock-session.jsonl",
+        sessionId: "pi-rpc-mock-session",
+        userMessages: 1,
+        assistantMessages: 2,
+        toolCalls: 1,
+        totalMessages: 5,
+        tokens: { input: 1200, output: 300, cacheRead: 400, cacheWrite: 0, total: 1900 },
+        contextUsage: { tokens: 1500, contextWindow: 200000, percent: 0.75 },
+      });
+      return;
+    case "prompt":
+      if (command.message === "/t3-recoverable-extension-error") {
+        runRecoverableExtensionErrorTurn(command);
+      } else if (command.message === "/t3-terminal-assistant-error") {
+        runTerminalAssistantErrorTurn(command);
+      } else if (command.message === "/t3-ui-wait") {
+        requestLongLivedUi(command);
+      } else if (String(command.message).startsWith("/workflow")) {
+        runWorkflowCommand(command);
+      } else {
+        runChatTurn(command);
+      }
+      return;
+    case "extension_ui_response":
+      if (pendingUiPrompt && command.id === "ui-editor-1") {
+        const prompt = pendingUiPrompt;
+        pendingUiPrompt = undefined;
+        response(prompt);
+        isStreaming = false;
+      }
+      return;
+    default:
+      response(command);
+  }
+};
+
+process.stdin.on("data", (chunk) => {
+  buffer += chunk.toString("utf8");
+  let newline;
+  while ((newline = buffer.indexOf("\n")) !== -1) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    handle(JSON.parse(line));
+  }
+});

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -249,6 +249,29 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("skips session-only providers when healing text generation selection", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const next = yield* serverSettings.updateSettings({
+        providers: {
+          atomic: { enabled: true },
+          pi: { enabled: true },
+          codex: { enabled: false },
+          claudeAgent: { enabled: true },
+        },
+        textGenerationModelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection.model,
+        },
+      });
+
+      assert.deepEqual(next.textGenerationModelSelection, {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-haiku-4-5",
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("buffers changes after a subscription is acquired but before it is consumed", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -299,7 +299,14 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
 }
 
 function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const fallbackEntry = Object.entries(settings.providers).find(([, provider]) => provider.enabled);
+  const fallbackEntry = Object.entries(settings.providers).find(([driver, provider]) => {
+    const providerKind = ProviderDriverKind.make(driver);
+    return (
+      provider.enabled &&
+      (DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[providerKind] ??
+        DEFAULT_MODEL_BY_PROVIDER[providerKind]) !== undefined
+    );
+  });
   const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
   if (!fallback) {
     return settings;

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -8,7 +8,13 @@ import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstance
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import type { TextGenerationPolicy } from "./TextGenerationPolicy.ts";
 
-export type TextGenerationProvider = "codex" | "claudeAgent" | "cursor" | "grok" | "opencode";
+export type TextGenerationProvider =
+  | "atomic"
+  | "codex"
+  | "claudeAgent"
+  | "cursor"
+  | "grok"
+  | "opencode";
 
 export interface CommitMessageGenerationInput {
   cwd: string;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -34,6 +34,7 @@ import {
   OrchestrationGetSnapshotError,
   OrchestrationSearchThreadsError,
   OrchestrationGetTurnDiffError,
+  OrchestrationGetWorkflowScriptError,
   ORCHESTRATION_WS_METHODS,
   type ProjectId,
   type ProjectEntriesFailure,
@@ -1274,7 +1275,30 @@ const makeWsRpcLayer = (
         [ORCHESTRATION_WS_METHODS.getWorkflowScript]: (input) =>
           observeRpcEffect(
             ORCHESTRATION_WS_METHODS.getWorkflowScript,
-            readWorkflowScript({ scriptPath: input.scriptPath }),
+            Effect.gen(function* () {
+              const projectionFailure = (cause: unknown) =>
+                new OrchestrationGetWorkflowScriptError({
+                  reason: "root-unavailable",
+                  scriptPath: input.scriptPath,
+                  cause,
+                });
+              const thread = yield* projectionSnapshotQuery
+                .getThreadShellById(input.threadId)
+                .pipe(Effect.mapError(projectionFailure));
+              if (Option.isNone(thread)) {
+                return yield* projectionFailure(`Thread ${input.threadId} was not found.`);
+              }
+              const project = yield* projectionSnapshotQuery
+                .getProjectShellById(thread.value.projectId)
+                .pipe(Effect.mapError(projectionFailure));
+              if (Option.isNone(project)) {
+                return yield* projectionFailure(`Project ${thread.value.projectId} was not found.`);
+              }
+              return yield* readWorkflowScript({
+                scriptPath: input.scriptPath,
+                workspaceRoot: thread.value.worktreePath ?? project.value.workspaceRoot,
+              });
+            }),
             { "rpc.aggregate": "orchestration" },
           ),
         [ORCHESTRATION_WS_METHODS.getTurnDiff]: (input) =>

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -31,15 +31,14 @@ import { ScrollArea } from "~/components/ui/scroll-area";
 import { Button } from "~/components/ui/button";
 
 /**
- * In-flight states all present as Working (one steady state, per the
- * monitoring-pill design: detail belongs in the activity sub-line, and a
- * stalled/waiting/queued subagent is still the fleet doing its job, not a
- * user problem). Only settled states differentiate.
+ * Waiting is deliberately distinct: Atomic workflow HIL can pause indefinitely
+ * until a person answers, so presenting that state as generic work hides the
+ * one thing the user needs to act on.
  */
 const STATUS_VISUALS: Record<RuntimeSubagent["status"], { dotClass: string; label: string }> = {
   pending: { dotClass: "bg-info", label: "Working" },
   running: { dotClass: "bg-info", label: "Working" },
-  waiting: { dotClass: "bg-info", label: "Working" },
+  waiting: { dotClass: "bg-warning", label: "Awaiting input" },
   // Idle reads as settled (muted, not sky): a resting Codex child looks done
   // unless resumed — live-test: sky idle dots read as stuck in-progress.
   idle: { dotClass: "bg-muted-foreground/50", label: "Idle · resumable" },
@@ -205,52 +204,73 @@ function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeS
 }
 
 /**
- * Phase rail: the run's shape at a glance. One segment per phase in order,
- * separated by chevrons; each segment shows title + one dot per member.
- * The whole arc (done → live → pending) is visible without scrolling the
- * member list.
+ * Workflow topology: one row per dependency layer and one node per stage.
+ * Atomic supplies stable stage IDs and parent IDs, so parallel roots share a
+ * row and dependent stages identify the exact nodes they follow.
  */
-function PhaseRail({ group }: { group: AgentPanelWorkflowGroup }) {
+function WorkflowGraph({ group }: { group: AgentPanelWorkflowGroup }) {
   if (group.phases.length === 0) {
     return null;
   }
+  const members = workflowMembers(group);
+  const membersById = new Map(members.map((member) => [member.id, member]));
   return (
-    <div className="flex flex-wrap items-center gap-x-1 gap-y-1 px-1.5 pb-1 pt-1.5">
+    <div className="mx-1.5 mt-1.5 rounded-md border border-border/50 bg-background/35 px-2 py-2">
+      <div className="mb-1.5 flex items-center gap-1.5 font-mono text-[.6rem] uppercase tracking-wider text-muted-foreground/70">
+        <Braces aria-hidden className="size-3" />
+        Live workflow graph
+      </div>
       {group.phases.map((phase, index) => (
-        <div key={phase.index} className="flex items-center gap-1">
-          {index > 0 ? (
-            <ChevronRight aria-hidden className="size-3 text-muted-foreground/40" />
-          ) : null}
-          <div
-            className={cn(
-              "flex items-center gap-1 rounded-sm border px-1.5 py-0.5",
-              phase.state === "running"
-                ? "border-info/40"
-                : phase.state === "done"
-                  ? "border-success/30"
-                  : "border-border/50",
-            )}
-          >
-            <span
-              className={cn(
-                "font-mono text-[.65rem]",
-                phase.state === "running"
-                  ? "text-info-foreground"
-                  : phase.state === "done"
-                    ? "text-success-foreground"
-                    : "text-muted-foreground/70",
-              )}
-            >
-              {phase.state === "done" ? "✓ " : ""}
+        <div key={phase.index}>
+          {index > 0 ? <div className="ml-[1.55rem] h-3 w-px bg-border/70" aria-hidden /> : null}
+          <div className="grid min-w-0 grid-cols-[3.1rem_minmax(0,1fr)] items-start gap-1.5">
+            <span className="pt-1.5 font-mono text-[.6rem] uppercase text-muted-foreground/60">
               {phase.title}
             </span>
-            <span className="flex items-center gap-0.5">
+            <div className="flex min-w-0 flex-wrap gap-1.5">
               {phase.members.length === 0 ? (
-                <span className="font-mono text-[.6rem] text-muted-foreground/50">–</span>
+                <span className="rounded border border-dashed border-border/60 px-2 py-1 font-mono text-[.65rem] text-muted-foreground/60">
+                  Pending
+                </span>
               ) : (
-                phase.members.map((member) => <StatusDot key={member.id} status={member.status} />)
+                phase.members.map((member) => {
+                  const dependencies = (member.dependsOnTaskIds ?? []).map(
+                    (taskId) =>
+                      membersById.get(taskId)?.title ?? taskId.split(":wf:").at(-1) ?? taskId,
+                  );
+                  return (
+                    <div
+                      key={member.id}
+                      className={cn(
+                        "min-w-28 max-w-full rounded border px-2 py-1",
+                        member.status === "waiting"
+                          ? "border-warning/45 bg-warning/5"
+                          : member.status === "failed"
+                            ? "border-destructive/45 bg-destructive/5"
+                            : member.status === "running" || member.status === "pending"
+                              ? "border-info/40 bg-info/5"
+                              : member.status === "completed"
+                                ? "border-success/30 bg-success/5"
+                                : "border-border/60",
+                      )}
+                    >
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <StatusDot status={member.status} />
+                        <span className="truncate text-xs font-medium">{member.title}</span>
+                        <span className="ml-auto shrink-0 font-mono text-[.58rem] text-muted-foreground/70">
+                          {STATUS_VISUALS[member.status].label}
+                        </span>
+                      </div>
+                      {dependencies.length > 0 ? (
+                        <div className="mt-0.5 truncate font-mono text-[.58rem] text-muted-foreground/65">
+                          after {dependencies.join(" + ")}
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })
               )}
-            </span>
+            </div>
           </div>
         </div>
       ))}
@@ -373,7 +393,7 @@ function PhaseSection({
   );
 }
 
-/** Expanded workflow: phase rail + full phase tree. */
+/** Expanded workflow: live topology + full stage tree. */
 function ExpandedWorkflowSection({
   group,
   environmentId,
@@ -428,7 +448,7 @@ function ExpandedWorkflowSection({
           <ChevronDown aria-hidden className="size-3" />
         </Button>
       </div>
-      <PhaseRail group={group} />
+      <WorkflowGraph group={group} />
       {scriptOpen && canShowScript ? (
         <WorkflowScriptView
           environmentId={environmentId}
@@ -568,10 +588,11 @@ export function AgentsPanel({
       </ScrollArea>
       <footer className="flex items-center justify-between border-t border-border/60 px-3 py-1.5 font-mono text-[.7rem] text-muted-foreground">
         <span className="flex items-center gap-2">
-          {model.runningCount + model.waitingCount > 0 ? (
-            <span className="text-info-foreground">
-              ● {model.runningCount + model.waitingCount} working
-            </span>
+          {model.runningCount > 0 ? (
+            <span className="text-info-foreground">● {model.runningCount} working</span>
+          ) : null}
+          {model.waitingCount > 0 ? (
+            <span className="text-warning">● {model.waitingCount} awaiting input</span>
           ) : null}
           {model.idleCount > 0 ? <span>{model.idleCount} idle</span> : null}
           {model.settledCount > 0 ? <span>{model.settledCount} settled</span> : null}

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -666,6 +666,16 @@ export const OpenCodeIcon: Icon = (props) => (
   </svg>
 );
 
+export const AtomicIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="32" height="32" rx="7" fill="#1E1E2E" />
+    <path d="M9 9h14v5h-9v9H9V9Z" fill="#45475A" opacity=".72" />
+    <path d="M14 9h9v14h-5v-9h-4V9Z" fill="#89B4FA" />
+    <rect x="10" y="10" width="3" height="3" rx=".5" fill="#B4BEFE" />
+    <rect x="19" y="19" width="3" height="3" rx=".5" fill="#74C7EC" />
+  </svg>
+);
+
 export const GithubCopilotIcon: Icon = ({ className, ...props }) => (
   <svg
     {...props}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2559,9 +2559,13 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
   // stalled agents read as working; only settled states differentiate.
   const working = running + waiting;
   const dotClass = live ? "bg-info" : failed > 0 ? "bg-destructive" : "bg-success";
-  const lead = live
-    ? `Kicked off ${agentCount} subagent${agentCount === 1 ? "" : "s"}`
-    : `Ran ${agentCount} subagent${agentCount === 1 ? "" : "s"}`;
+  const lead = spawn.workflowId
+    ? live
+      ? "Workflow running"
+      : "Workflow finished"
+    : live
+      ? `Kicked off ${agentCount} subagent${agentCount === 1 ? "" : "s"}`
+      : `Ran ${agentCount} subagent${agentCount === 1 ? "" : "s"}`;
   const status = live
     ? livePhase
       ? `${livePhase.title} · ${livePhase.activeCount} working`
@@ -2589,7 +2593,15 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
         {totalTokens > 0 ? (
           <span className="tabular-nums">Σ {formatSubagentTokenCount(totalTokens)}</span>
         ) : null}
-        <span className="text-info-foreground">{live ? "Open Agents ▸" : "View ▸"}</span>
+        <span className="text-info-foreground">
+          {spawn.workflowId
+            ? live
+              ? "Open stages ▸"
+              : "View stages ▸"
+            : live
+              ? "Open Agents ▸"
+              : "View ▸"}
+        </span>
       </span>
     </button>
   );

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,9 +1,19 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { AtomicIcon, ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AtomicIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+  PiAgentIcon,
+} from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
   [ProviderDriverKind.make("atomic")]: AtomicIcon,
+  [ProviderDriverKind.make("pi")]: PiAgentIcon,
   [ProviderDriverKind.make("codex")]: OpenAI,
   [ProviderDriverKind.make("claudeAgent")]: ClaudeAI,
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,8 +1,9 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { AtomicIcon, ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
+  [ProviderDriverKind.make("atomic")]: AtomicIcon,
   [ProviderDriverKind.make("codex")]: OpenAI,
   [ProviderDriverKind.make("claudeAgent")]: ClaudeAI,
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -5,6 +5,7 @@ import {
   CursorSettings,
   GrokSettings,
   OpenCodeSettings,
+  PiSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
@@ -16,6 +17,7 @@ import {
   type Icon,
   OpenAI,
   OpenCodeIcon,
+  PiAgentIcon,
 } from "../Icons";
 
 type ProviderSettingsSchema = {
@@ -50,6 +52,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: AtomicIcon,
     badgeLabel: "Early Access",
     settingsSchema: AtomicSettings,
+  },
+  {
+    value: ProviderDriverKind.make("pi"),
+    label: "Pi",
+    icon: PiAgentIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: PiSettings,
   },
   {
     value: ProviderDriverKind.make("codex"),

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,4 +1,5 @@
 import {
+  AtomicSettings,
   ClaudeSettings,
   CodexSettings,
   CursorSettings,
@@ -7,7 +8,15 @@ import {
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AtomicIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -35,6 +44,13 @@ export interface ProviderClientDefinition {
 }
 
 export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = [
+  {
+    value: ProviderDriverKind.make("atomic"),
+    label: "Atomic",
+    icon: AtomicIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: AtomicSettings,
+  },
   {
     value: ProviderDriverKind.make("codex"),
     label: "Codex",

--- a/apps/web/src/pendingUserInput.test.ts
+++ b/apps/web/src/pendingUserInput.test.ts
@@ -41,6 +41,19 @@ const multiSelectQuestion = {
 } as const;
 
 describe("resolvePendingUserInputAnswer", () => {
+  it("uses a provider editor's default value until the user changes it", () => {
+    const question = {
+      ...singleSelectQuestion,
+      id: "editor",
+      defaultValue: "ORIGINAL_WORKFLOW_VALUE",
+    };
+
+    expect(resolvePendingUserInputAnswer(question, undefined)).toBe("ORIGINAL_WORKFLOW_VALUE");
+    expect(derivePendingUserInputProgress([question], {}, 0).customAnswer).toBe(
+      "ORIGINAL_WORKFLOW_VALUE",
+    );
+  });
+
   it("prefers a custom answer over selected options", () => {
     expect(
       resolvePendingUserInputAnswer(singleSelectQuestion, {

--- a/apps/web/src/pendingUserInput.ts
+++ b/apps/web/src/pendingUserInput.ts
@@ -49,7 +49,7 @@ export function resolvePendingUserInputAnswer(
   question: UserInputQuestion,
   draft: PendingUserInputDraftAnswer | undefined,
 ): string | string[] | null {
-  const customAnswer = normalizeDraftAnswer(draft?.customAnswer);
+  const customAnswer = normalizeDraftAnswer(draft?.customAnswer ?? question.defaultValue);
   if (customAnswer) {
     return customAnswer;
   }
@@ -151,7 +151,7 @@ export function derivePendingUserInputProgress(
   const resolvedAnswer = activeQuestion
     ? resolvePendingUserInputAnswer(activeQuestion, activeDraft)
     : null;
-  const customAnswer = activeDraft?.customAnswer ?? "";
+  const customAnswer = activeDraft?.customAnswer ?? activeQuestion?.defaultValue ?? "";
   const answeredQuestionCount = countAnsweredPendingUserInputQuestions(questions, draftAnswers);
   const isLastQuestion =
     questions.length === 0 ? true : normalizedQuestionIndex >= questions.length - 1;

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -41,6 +41,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("pi"),
+    label: "Pi",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
   { value: ProviderDriverKind.make("codex"), label: "Codex", available: true },
   { value: ProviderDriverKind.make("claudeAgent"), label: "Claude", available: true },
   {
@@ -523,6 +529,9 @@ function parseUserInputQuestions(
         id: question.id,
         header: question.header,
         question: question.question,
+        ...(typeof question.defaultValue === "string"
+          ? { defaultValue: question.defaultValue }
+          : {}),
         options,
         multiSelect: question.multiSelect === true,
       };

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -35,6 +35,12 @@ export const PROVIDER_OPTIONS: Array<{
   /** Shown on the model picker sidebar when relevant */
   pickerSidebarBadge?: "new" | "soon";
 }> = [
+  {
+    value: ProviderDriverKind.make("atomic"),
+    label: "Atomic",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
   { value: ProviderDriverKind.make("codex"), label: "Codex", available: true },
   { value: ProviderDriverKind.make("claudeAgent"), label: "Claude", available: true },
   {

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -94,7 +94,7 @@ The live backend agent implementation and its event stream. The main service is 
 
 #### Provider
 
-The backend agent runtime that actually performs work. Five drivers ship built in: Codex, Claude, Cursor, Grok, and OpenCode. See [ProviderService.ts][14], [ProviderAdapter.ts][15], and [CodexAdapter.ts][17] as a representative adapter.
+The backend agent runtime that actually performs work. The current built-in driver inventory is in [providers.md][16]. See [ProviderService.ts][14], [ProviderAdapter.ts][15], and [CodexAdapter.ts][17] as a representative adapter.
 
 #### Session
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -18,13 +18,12 @@ there, never in the client.
 ┌──────────────────▼─────────────────────────────┐
 │ apps/server                                    │
 │  orchestration engine (event-sourced)          │
-│  provider driver registry (5 built-in drivers) │
+│  provider driver registry (built-in drivers)   │
 │  checkpointing, VCS, terminals, filesystem     │
 └──────────────────┬─────────────────────────────┘
                    │ per-driver transport
 ┌──────────────────▼─────────────────────────────┐
-│ Agent CLIs: Codex, Claude, Cursor, Grok,       │
-│ OpenCode                                       │
+│ Agent CLIs (see provider architecture)         │
 └────────────────────────────────────────────────┘
 ```
 
@@ -106,11 +105,11 @@ build production behavior on receipts.
 
 ## Provider drivers
 
-Five drivers ship built in, registered in [`builtInDrivers.ts`][drivers] as `BUILT_IN_DRIVERS`:
-Codex, Claude, Cursor, Grok, and OpenCode. A driver declares its kind and config schema and creates a
-scoped adapter; `ProviderInstanceRegistry` owns live instances and `ProviderAdapterRegistry` resolves
-an instance to its adapter, so `ProviderService` routes session and turn operations without knowing
-which agent is behind them. See [providers.md](./providers.md).
+Built-in drivers are registered in [`builtInDrivers.ts`][drivers] as `BUILT_IN_DRIVERS`. A driver
+declares its kind and config schema and creates a scoped adapter; `ProviderInstanceRegistry` owns
+live instances and `ProviderAdapterRegistry` resolves an instance to its adapter, so
+`ProviderService` routes session and turn operations without knowing which agent is behind them.
+The current inventory and provider architecture are in [providers.md](./providers.md).
 
 ## Checkpointing
 

--- a/docs/internals/providers-pi-atomic.md
+++ b/docs/internals/providers-pi-atomic.md
@@ -1,0 +1,191 @@
+# Pi and Atomic providers
+
+> For maintainers. For installation and binary discovery, see
+> [Install T3 Code](../user/install.md#providers).
+
+T3 Code integrates Pi and Atomic as separate built-in providers over their shared RPC protocol.
+Pi is the compatibility baseline. Atomic uses the same chat lifecycle and adds extension events for
+workflows and interactive UI.
+
+This document records the adapter contract so the implementation can be maintained in this fork or
+proposed upstream without rediscovering the protocol and lifecycle decisions.
+
+## Supported user experience
+
+| Capability                                             | Pi                   | Atomic |
+| ------------------------------------------------------ | -------------------- | ------ |
+| Create, resume, interrupt, and stop a session          | Yes                  | Yes    |
+| Stream assistant text and thinking                     | Yes                  | Yes    |
+| Show tool start, updates, results, and failures        | Yes                  | Yes    |
+| Discover models, thinking levels, commands, and skills | Yes                  | Yes    |
+| Show retries, extension failures, and terminal errors  | Yes                  | Yes    |
+| Show context and token usage after a turn              | Yes                  | Yes    |
+| Ask select, confirm, input, and editor questions       | Yes                  | Yes    |
+| Preserve editor prefill text                           | Yes                  | Yes    |
+| Show workflow runs, stages, dependencies, and status   | Protocol events only | Yes    |
+| Open contained workflow source from the Agents panel   | No                   | Yes    |
+
+Both providers are Early Access and disabled by default. Pi 0.84.3 or newer is recommended. Pi
+0.84.0 through 0.84.2 can use the compatibility reducer, but may omit complete tool or usage
+metadata.
+
+## Driver and adapter split
+
+The provider drivers remain separate because they have distinct settings, update packages, labels,
+icons, raw-event source names, and agent-directory environment variables:
+
+| Concern                  | Pi                                | Atomic                    |
+| ------------------------ | --------------------------------- | ------------------------- |
+| Driver kind              | `pi`                              | `atomic`                  |
+| Default binary           | `pi`                              | `atomic`                  |
+| Package                  | `@earendil-works/pi-coding-agent` | `@bastani/atomic`         |
+| Agent directory variable | `PI_CODING_AGENT_DIR`             | `ATOMIC_CODING_AGENT_DIR` |
+| Raw event source         | `pi.rpc`                          | `atomic.rpc`              |
+
+The lifecycle reducer is shared in
+[`AtomicAdapter.ts`](../../apps/server/src/provider/Layers/AtomicAdapter.ts) through
+`makePiCompatibleAdapter`. [`PiAdapter.ts`](../../apps/server/src/provider/Layers/PiAdapter.ts) and
+the Atomic wrapper supply small provider definitions instead of duplicating event handling.
+
+Provider discovery follows the same shape. The shared logic in
+[`AtomicProvider.ts`](../../apps/server/src/provider/Layers/AtomicProvider.ts) checks the binary,
+starts a temporary no-session RPC peer, and requests state, models, and commands. Pi-specific
+version guidance stays in
+[`PiProvider.ts`](../../apps/server/src/provider/Layers/PiProvider.ts).
+
+This is intentionally a deep adapter boundary: differences that affect presentation or process
+configuration stay in definitions, while ordering, session ownership, and terminal lifecycle rules
+have one implementation.
+
+## Process and framing contract
+
+[`AtomicRpcProcess.ts`](../../apps/server/src/provider/atomic/AtomicRpcProcess.ts) owns one child
+process and exposes request, notification, event-stream, and kill operations.
+
+- The child starts as `<binary> --mode rpc`. Session processes also receive `--no-approve` unless
+  launch arguments explicitly contain `--approve` or `--no-approve`.
+- Requests and notifications are JSON objects framed by an ASCII LF (`\n`). JSON strings may contain
+  Unicode line separator U+2028; it is data, not an RPC frame boundary.
+- Standard input remains open for the lifetime of the session. Closing it after the first command
+  terminates interactive RPC operation.
+- Responses are correlated by generated request IDs. Unsolicited events are published separately.
+- The first request has a 90-second budget because Atomic can refresh credentials and fetch model
+  metadata before replying. Later requests use a 15-second budget.
+- A clean output EOF fails pending requests immediately rather than making them wait for a timeout.
+
+Each response carries an out-of-band `precedingEventSequence`. The adapter waits until all earlier
+events have been mapped before it treats a response as proof that a turn is idle or settled. This
+barrier prevents a synthetic success from racing ahead of a terminal event already emitted by the
+CLI.
+
+The session owns a closeable Effect scope. Ownership must move to the live session context before
+`startSession` returns; otherwise the child process and event consumer are finalized and a later
+turn appears to dispatch successfully while producing no output.
+
+## RPC lifecycle mapping
+
+The shared reducer maps Pi-compatible events into provider runtime events:
+
+| RPC event                         | T3 runtime behavior                                         |
+| --------------------------------- | ----------------------------------------------------------- |
+| `agent_start`                     | Starts the provider turn                                    |
+| `message_start`                   | Opens assistant and, when needed, reasoning items           |
+| `message_update`                  | Streams text or thinking deltas                             |
+| `message_end`                     | Reconciles authoritative content and closes message items   |
+| `tool_execution_start/update/end` | Starts, updates, and completes a dynamic tool item          |
+| `auto_retry_start/end`            | Shows nonfatal retry warnings                               |
+| `compaction_start/end`            | Shows context compaction work                               |
+| `agent_end`                       | No terminal action; a retry or queued run may follow        |
+| `agent_settled`                   | Reads session statistics and completes or fails the T3 turn |
+
+`agent_settled`, not `agent_end`, is authoritative. Atomic may compact, retry, or execute a queued
+follow-up after a low-level agent run ends. Treating `agent_end` as terminal truncates that work and
+can leave workflow output invisible.
+
+Assistant-cycle errors are held until settlement. A later successful assistant message clears a
+recoverable error; an error still present at `agent_settled` becomes a runtime error and failed turn.
+An `extension_error` is only a warning because Pi extensions are best-effort and one incompatible
+extension does not imply that the agent failed.
+
+After settlement, `get_session_stats` is mapped to T3 context-window, input, cached-input, output,
+total-token, and tool-use fields when the CLI supplies them.
+
+## Extension UI requests
+
+An unsolicited `extension_ui_request` is mapped to structured T3 user input:
+
+- `select` becomes one question with the supplied choices.
+- `confirm` becomes Yes and No choices.
+- `input` and `editor` become free-text questions.
+- Pi's `prefill` becomes the question's initial value.
+- `notify` with warning or error severity becomes a runtime warning; informational terminal chrome
+  is not copied into chat.
+
+Prompt RPC calls do not use the ordinary command timeout because a person may take an arbitrary
+amount of time to respond. When a turn settles, any unanswered request is resolved as abandoned so
+stale prompts do not remain in the composer.
+
+## Atomic workflow projection
+
+Atomic emits workflow lifecycle data as `entry_appended` records and as custom message content.
+The adapter normalizes both forms and deduplicates identical state transitions. Supported lifecycle
+records include run and stage start/end, waiting, pause, and resume.
+
+The projection preserves Atomic's run UUID, stage UUID, stage ordering, and parent-stage UUIDs.
+Stable T3 task IDs are derived from the run and stage IDs, and dependency IDs become
+`dependsOnTaskIds`. This lets the Agents panel render dependency layers instead of presenting a
+workflow as an unrelated flat list. Waiting stages receive an explicit **Awaiting input** state.
+
+Workflow source is an inspection feature, not arbitrary file access. A script link is served only
+when all of these checks pass:
+
+1. The requested path is absolute.
+2. The file resolves under the current thread workspace's `.atomic/workflows` directory.
+3. The resolved leaf is a regular `.js` or `.ts` file, including after symlink resolution.
+4. The read stays within the size cap and the file does not change during inspection.
+
+Claude's existing contained `.js` workflow source behavior remains unchanged. Atomic source is
+displayed in the existing Agents-panel script viewer through the same orchestration query.
+
+## Configuration and continuation
+
+Each provider instance supports:
+
+- an explicit binary path for CLIs outside the server process's `PATH`;
+- an optional isolated agent directory;
+- additional tokenized launch arguments; and
+- multiple independently configured provider instances.
+
+Models use the CLI's `provider/model` identity. Thinking choices come from the model's reported
+capabilities. Model changes do not require a new T3 thread, but continuation identity remains scoped
+to the configured provider instance.
+
+Pi and Atomic currently support agent sessions only. They do not implement T3's auxiliary commit
+message, pull-request text, branch-name, or thread-title generation operations.
+
+## Known boundary
+
+The parent Atomic RPC process exposes workflow lifecycle and summary records, but it does not expose
+private child-stage reasoning/tool streams or a complete stage-chat and human-in-the-loop response
+transport. T3 therefore shows honest stage status, dependencies, summaries, and source without
+inventing child transcripts.
+
+Attached stage transcripts, stage steering and follow-ups, first-class run controls, and complete
+workflow human-in-the-loop answers require a narrow Atomic workflow-store/SDK bridge or a new
+upstream JSON-safe RPC API. That bridge should preserve the current provider runtime contract rather
+than coupling the web client directly to Atomic storage.
+
+## Focused verification
+
+Changes to this adapter should exercise the smallest relevant suites:
+
+- RPC framing, startup budget, response correlation, EOF, and event ordering in
+  `AtomicRpcProcess.test.ts`;
+- shared chat, thinking, tools, settlement, prompts, retries, errors, usage, and workflow projection
+  in `AtomicAdapter.test.ts`;
+- Pi provider definitions and compatibility in `PiAdapter.test.ts` and `PiProvider.test.ts`;
+- driver registration, contracts, workflow-source containment, pending input, and subagent runtime
+  projection in their adjacent focused tests.
+
+Use a temporary or repo-local T3 home for visible acceptance. Never point a development server at a
+user's normal T3 data directory.

--- a/docs/internals/providers-pi-atomic.md
+++ b/docs/internals/providers-pi-atomic.md
@@ -69,8 +69,8 @@ process and exposes request, notification, event-stream, and kill operations.
 - Standard input remains open for the lifetime of the session. Closing it after the first command
   terminates interactive RPC operation.
 - Responses are correlated by generated request IDs. Unsolicited events are published separately.
-- The first request has a 90-second budget because Atomic can refresh credentials and fetch model
-  metadata before replying. Later requests use a 15-second budget.
+- Requests issued before the first response have a 90-second budget because Atomic can refresh
+  credentials and fetch model metadata before replying. Later requests use a 15-second budget.
 - A clean output EOF fails pending requests immediately rather than making them wait for a timeout.
 
 Each response carries an out-of-band `precedingEventSequence`. The adapter waits until all earlier
@@ -142,7 +142,7 @@ when all of these checks pass:
 1. The requested path is absolute.
 2. The file resolves under the current thread workspace's `.atomic/workflows` directory.
 3. The resolved leaf is a regular `.js` or `.ts` file, including after symlink resolution.
-4. The read stays within the size cap and the file does not change during inspection.
+4. The read stays within the size cap, and the opened inode still matches the resolved leaf.
 
 Claude's existing contained `.js` workflow source behavior remains unchanged. Atomic source is
 displayed in the existing Agents-panel script viewer through the same orchestration query.

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -38,8 +38,9 @@ Two registries separate configuration from live processes:
 [`ProviderService`][service] sits on top. It combines the adapter registry with the provider session
 directory to route session and turn operations for a thread, so callers name a thread, not an agent.
 
-Adding a driver means writing the driver plus adapter and adding it to `BUILT_IN_DRIVERS`. No
-orchestration, contract, or client change is required for the common case.
+Adding a built-in driver also requires its settings schema and default-instance hydration plus its
+client presentation metadata. The orchestration model remains provider-agnostic; change its
+contracts only when the provider introduces a capability that must cross the wire.
 
 Pi and Atomic share a Pi-RPC lifecycle adapter, while Atomic adds workflow lifecycle projection and
 workflow source inspection. See [Pi and Atomic providers](./providers-pi-atomic.md) for the protocol

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -7,10 +7,12 @@ orchestration layer does not know which one is behind a thread.
 
 ## Built-in drivers
 
-[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with five entries:
+[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with seven entries:
 
 | Driver kind   | Driver source                           |
 | ------------- | --------------------------------------- |
+| `atomic`      | [`Drivers/AtomicDriver.ts`][atomic]     |
+| `pi`          | [`Drivers/PiDriver.ts`][pi]             |
 | `codex`       | [`Drivers/CodexDriver.ts`][codex]       |
 | `claudeAgent` | [`Drivers/ClaudeDriver.ts`][claude]     |
 | `cursor`      | [`Drivers/CursorDriver.ts`][cursor]     |
@@ -38,6 +40,10 @@ directory to route session and turn operations for a thread, so callers name a t
 
 Adding a driver means writing the driver plus adapter and adding it to `BUILT_IN_DRIVERS`. No
 orchestration, contract, or client change is required for the common case.
+
+Pi and Atomic share a Pi-RPC lifecycle adapter, while Atomic adds workflow lifecycle projection and
+workflow source inspection. See [Pi and Atomic providers](./providers-pi-atomic.md) for the protocol
+contract, event mappings, extension UI behavior, and known boundaries.
 
 ## Model manifest
 
@@ -88,6 +94,8 @@ when a request opens (approval) or user input is requested, via
 `flushBufferedAssistantMessagesForTurn`.
 
 [drivers]: ../../apps/server/src/provider/builtInDrivers.ts
+[atomic]: ../../apps/server/src/provider/Drivers/AtomicDriver.ts
+[pi]: ../../apps/server/src/provider/Drivers/PiDriver.ts
 [codex]: ../../apps/server/src/provider/Drivers/CodexDriver.ts
 [claude]: ../../apps/server/src/provider/Drivers/ClaudeDriver.ts
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -54,16 +54,28 @@ yay -S t3code-nightly-bin
 T3 Code drives provider CLIs; it does not ship them. Install the CLI for each provider you want
 to use, then authenticate it.
 
-| Provider   | CLI                                                   | Default binary | Log in with           |
-| ---------- | ----------------------------------------------------- | -------------- | --------------------- |
-| Codex      | [Codex CLI](https://developers.openai.com/codex/cli)  | `codex`        | `codex login`         |
-| Claude     | [Claude Code](https://claude.com/product/claude-code) | `claude`       | `claude auth login`   |
-| Cursor     | [Cursor CLI](https://cursor.com/cli)                  | `cursor-agent` | `agent login`         |
-| Grok Build | [Grok Build CLI](https://x.ai/cli)                    | `grok`         | `grok login`          |
-| OpenCode   | [OpenCode](https://opencode.ai)                       | `opencode`     | `opencode auth login` |
+| Provider   | CLI                                                     | Default binary | Log in with                |
+| ---------- | ------------------------------------------------------- | -------------- | -------------------------- |
+| Atomic     | [Atomic](https://github.com/bastani-inc/atomic)         | `atomic`       | Model provider credentials |
+| Pi         | [Pi coding agent](https://github.com/earendil-works/pi) | `pi`           | Model provider credentials |
+| Codex      | [Codex CLI](https://developers.openai.com/codex/cli)    | `codex`        | `codex login`              |
+| Claude     | [Claude Code](https://claude.com/product/claude-code)   | `claude`       | `claude auth login`        |
+| Cursor     | [Cursor CLI](https://cursor.com/cli)                    | `cursor-agent` | `agent login`              |
+| Grok Build | [Grok Build CLI](https://x.ai/cli)                      | `grok`         | `grok login`               |
+| OpenCode   | [OpenCode](https://opencode.ai)                         | `opencode`     | `opencode auth login`      |
 
-Codex and Claude are on by default. Cursor, Grok Build, and OpenCode are off by default; turn
-them on in **Settings** → the provider's card when you want to use them.
+Codex and Claude are on by default. Atomic, Pi, Cursor, Grok Build, and OpenCode are off by default;
+turn them on in **Settings** → the provider's card when you want to use them.
+
+Install the Pi-compatible providers with npm when you want either of them:
+
+```bash
+npm install --global @earendil-works/pi-coding-agent
+npm install --global @bastani/atomic
+```
+
+Pi 0.84.3 or newer is recommended. Atomic and Pi discover the models and credentials configured in
+their own agent directories. T3 Code does not copy or manage those credentials.
 
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
 T3 Code looks for, but authenticate with `agent login`, not `cursor-agent login`.

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -77,6 +77,16 @@ npm install --global @bastani/atomic
 Pi 0.84.3 or newer is recommended. Atomic and Pi discover the models and credentials configured in
 their own agent directories. T3 Code does not copy or manage those credentials.
 
+### Atomic Workflow Visibility
+
+In the web and desktop clients, Atomic workflow runs appear in the **Agents** panel with live stage
+status, dependency order, summaries, and an **Awaiting input** state. When the workflow has a `.js`
+or `.ts` script in the current workspace's `.atomic/workflows` directory, **{} script** opens its
+contained, read-only source.
+
+Atomic's parent RPC stream does not include private child-stage reasoning or tool transcripts, so
+T3 Code reports only the workflow lifecycle and summary details Atomic publishes.
+
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
 T3 Code looks for, but authenticate with `agent login`, not `cursor-agent login`.
 
@@ -94,8 +104,8 @@ started T3 Code.
 
 Provider auth is required before you start a session with that provider, not before you start
 T3 Code. You can install T3 Code, open it, and add providers afterwards. A provider that is not
-authenticated shows its status in **Settings** and fails at session start with the login command
-to run.
+authenticated shows its status in **Settings** and reports its authentication or configuration
+guidance if a session cannot start.
 
 For multi-account setups, see [Codex](./providers-codex.md) and [Claude](./providers-claude.md).
 

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -300,6 +300,23 @@ describe("foldSubagentActivities", () => {
     expect(member?.parentAgentId).toBe("wf-1");
   });
 
+  it("preserves provider workflow stage identity and dependency edges", () => {
+    const [member] = fold([
+      activity("task.started", {
+        taskId: "run-1:wf:synthesize",
+        taskType: "local_agent",
+        parentAgentId: "run-1",
+        workflowStageId: "synthesize",
+        dependsOnTaskIds: ["run-1:wf:classify", "run-1:wf:inspect"],
+        phaseIndex: 1,
+        phaseTitle: "Stage 2",
+      }),
+    ]);
+
+    expect(member?.workflowStageId).toBe("synthesize");
+    expect(member?.dependsOnTaskIds).toEqual(["run-1:wf:classify", "run-1:wf:inspect"]);
+  });
+
   it("a workflow member retry (attempt bump) is a reactivation of the same slot", () => {
     const agents = fold([
       activity("task.progress", {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -77,6 +77,8 @@ export interface RuntimeSubagent {
   readonly phaseTitle: string | null;
   readonly attempt: number | null;
   readonly workflowName: string | null;
+  readonly workflowStageId?: string | null;
+  readonly dependsOnTaskIds?: ReadonlyArray<string>;
   readonly phases: ReadonlyArray<SubagentWorkflowPhase>;
   readonly runHandles: SubagentRunHandles | null;
   readonly recentActivity: ReadonlyArray<SubagentActivityEntry>;
@@ -144,6 +146,14 @@ function asString(value: unknown): string | undefined {
 
 function asCount(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function asStringArray(value: unknown): ReadonlyArray<string> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.flatMap((entry) => {
+    const parsed = asString(entry);
+    return parsed ? [parsed] : [];
+  });
 }
 
 function asUsage(value: unknown): SubagentUsage | undefined {
@@ -246,6 +256,8 @@ interface MutableAgent {
   phaseTitle: string | null;
   attempt: number | null;
   workflowName: string | null;
+  workflowStageId: string | null;
+  dependsOnTaskIds: ReadonlyArray<string>;
   phases: ReadonlyArray<SubagentWorkflowPhase>;
   runHandles: SubagentRunHandles | null;
   recentActivity: ReadonlyArray<SubagentActivityEntry>;
@@ -300,6 +312,8 @@ function getOrCreate(
     phaseTitle: asString(payload.phaseTitle) ?? null,
     attempt: asCount(payload.attempt) ?? null,
     workflowName: asString(payload.workflowName) ?? null,
+    workflowStageId: asString(payload.workflowStageId) ?? null,
+    dependsOnTaskIds: asStringArray(payload.dependsOnTaskIds) ?? [],
     phases: [],
     runHandles: null,
     recentActivity: [],
@@ -329,6 +343,10 @@ function fillMetadata(agent: MutableAgent, payload: Record<string, unknown>): vo
   }
   const workflowName = asString(payload.workflowName);
   if (workflowName) agent.workflowName = workflowName;
+  const workflowStageId = asString(payload.workflowStageId);
+  if (workflowStageId) agent.workflowStageId = workflowStageId;
+  const dependsOnTaskIds = asStringArray(payload.dependsOnTaskIds);
+  if (dependsOnTaskIds) agent.dependsOnTaskIds = dependsOnTaskIds;
   if (asString(payload.taskType) === "local_workflow") agent.kind = "workflow";
   const agentIndex = asCount(payload.agentIndex);
   if (agentIndex !== undefined) agent.agentIndex = agentIndex;

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ATOMIC_DRIVER_KIND = ProviderDriverKind.make("atomic");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -212,6 +213,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [ATOMIC_DRIVER_KIND]: {},
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -222,4 +224,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ATOMIC_DRIVER_KIND]: "Atomic",
 };

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1668,11 +1668,11 @@ export const OrchestrationGetWorkflowScriptResult = Schema.Struct({
 export type OrchestrationGetWorkflowScriptResult = typeof OrchestrationGetWorkflowScriptResult.Type;
 
 const WORKFLOW_SCRIPT_ERROR_MESSAGES = {
-  "invalid-path": "Workflow scripts must be absolute .js paths.",
+  "invalid-path": "Workflow scripts must be absolute .js or .ts paths.",
   "root-unavailable": "Script root unavailable.",
   "not-found": "Script not found.",
   "outside-root": "Script path is outside the workflow scripts root.",
-  "not-js": "Resolved script is not a .js file.",
+  "not-js": "Resolved workflow file type is unsupported.",
   "not-regular-file": "Script is not a regular file.",
   "changed-during-read": "Script changed between resolution and open.",
   "read-failed": "Script read failed.",

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -181,6 +181,30 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.usage.maxTokens).toBe(200000);
     expect(parsed.payload.usage.usedTokens).toBe(31251);
   });
+
+  it("preserves workflow stage identity and dependency edges", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "task.started",
+      eventId: "event-workflow-stage-1",
+      provider: "atomic",
+      createdAt: "2026-02-28T00:00:05.000Z",
+      threadId: "thread-1",
+      payload: {
+        taskId: "run-1:wf:synthesize",
+        taskType: "local_agent",
+        parentAgentId: "run-1",
+        workflowStageId: "synthesize",
+        dependsOnTaskIds: ["run-1:wf:classify", "run-1:wf:inspect"],
+      },
+    });
+
+    expect(parsed.type).toBe("task.started");
+    if (parsed.type !== "task.started") {
+      throw new Error("expected task.started");
+    }
+    expect(parsed.payload.workflowStageId).toBe("synthesize");
+    expect(parsed.payload.dependsOnTaskIds).toEqual(["run-1:wf:classify", "run-1:wf:inspect"]);
+  });
 });
 
 describe("classifyTaskAgentKind", () => {

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -27,6 +27,7 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("claude.sdk.permission"),
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
+  Schema.Literal("atomic.rpc"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -28,6 +28,7 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
   Schema.Literal("atomic.rpc"),
+  Schema.Literal("pi.rpc"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);
@@ -457,6 +458,8 @@ export const UserInputQuestion = Schema.Struct({
   id: TrimmedNonEmptyStringSchema,
   header: TrimmedNonEmptyStringSchema,
   question: TrimmedNonEmptyStringSchema,
+  /** Initial editor/input value supplied by a provider extension. */
+  defaultValue: Schema.optional(Schema.String),
   options: Schema.Array(UserInputQuestionOption),
   multiSelect: Schema.optional(Schema.Boolean).pipe(
     Schema.withConstructorDefault(Effect.succeed(false)),
@@ -573,6 +576,10 @@ const taskAgentLinkageFields = {
   toolUseId: Schema.optional(TrimmedNonEmptyStringSchema),
   parentAgentId: Schema.optional(TrimmedNonEmptyStringSchema),
   workflowName: Schema.optional(TrimmedNonEmptyStringSchema),
+  /** Provider-stable workflow stage identity (distinct from the T3 task id). */
+  workflowStageId: Schema.optional(TrimmedNonEmptyStringSchema),
+  /** Canonical task ids that must settle before this task can run. */
+  dependsOnTaskIds: Schema.optional(Schema.Array(RuntimeTaskId)),
   agentIndex: Schema.optional(NonNegativeInt),
   phaseIndex: Schema.optional(NonNegativeInt),
   phaseTitle: Schema.optional(TrimmedNonEmptyStringSchema),

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -234,12 +234,15 @@ describe("provider enabled defaults", () => {
     expect(decoded.providers.cursor.enabled).toBe(false);
     expect(decoded.providers.grok.enabled).toBe(false);
     expect(decoded.providers.opencode.enabled).toBe(false);
+    expect(decoded.providers.pi.enabled).toBe(false);
+    expect(decoded.providers.pi.binaryPath).toBe("pi");
   });
 
   it("derives per-driver defaults from the settings schemas", () => {
     expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("cursor"))).toBe(false);
     expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("pi"))).toBe(false);
     // Unknown fork drivers stay enabled; their own build decides otherwise.
     expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
   });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -588,6 +588,44 @@ export const AtomicSettings = makeProviderSettingsSchema(
 );
 export type AtomicSettings = typeof AtomicSettings.Type;
 
+export const PiSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("pi").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Pi coding agent CLI used by this instance.",
+        providerSettingsForm: { placeholder: "pi", clearWhenEmpty: "omit" },
+      }),
+    ),
+    agentDir: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Pi agent directory",
+        description: "Optional PI_CODING_AGENT_DIR for isolated Pi configuration.",
+        providerSettingsForm: { placeholder: "~/.pi/agent", clearWhenEmpty: "omit" },
+      }),
+    ),
+    launchArgs: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Launch arguments",
+        description: "Additional CLI arguments passed to Pi RPC sessions.",
+        providerSettingsForm: { placeholder: "e.g. --approve", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  { order: ["binaryPath", "agentDir", "launchArgs"] },
+);
+export type PiSettings = typeof PiSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -726,6 +764,7 @@ export const ServerSettings = Schema.Struct({
   // is removed entirely.
   providers: Schema.Struct({
     atomic: AtomicSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    pi: PiSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     codex: CodexSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
@@ -892,6 +931,14 @@ const AtomicSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const PiSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  agentDir: Schema.optionalKey(TrimmedString),
+  launchArgs: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
@@ -929,6 +976,7 @@ export const ServerSettingsPatch = Schema.Struct({
   providers: Schema.optionalKey(
     Schema.Struct({
       atomic: Schema.optionalKey(AtomicSettingsPatch),
+      pi: Schema.optionalKey(PiSettingsPatch),
       codex: Schema.optionalKey(CodexSettingsPatch),
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -550,6 +550,44 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const AtomicSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("atomic").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Atomic CLI binary used by this instance.",
+        providerSettingsForm: { placeholder: "atomic", clearWhenEmpty: "omit" },
+      }),
+    ),
+    agentDir: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Atomic agent directory",
+        description: "Optional ATOMIC_CODING_AGENT_DIR for isolated Atomic configuration.",
+        providerSettingsForm: { placeholder: "~/.atomic", clearWhenEmpty: "omit" },
+      }),
+    ),
+    launchArgs: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Launch arguments",
+        description: "Additional CLI arguments passed to Atomic RPC sessions.",
+        providerSettingsForm: { placeholder: "e.g. --approve", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  { order: ["binaryPath", "agentDir", "launchArgs"] },
+);
+export type AtomicSettings = typeof AtomicSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -687,6 +725,7 @@ export const ServerSettings = Schema.Struct({
   // owns its config in its own package, this struct shrinks to nothing and
   // is removed entirely.
   providers: Schema.Struct({
+    atomic: AtomicSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     codex: CodexSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
@@ -845,6 +884,14 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const AtomicSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  agentDir: Schema.optionalKey(TrimmedString),
+  launchArgs: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
@@ -881,6 +928,7 @@ export const ServerSettingsPatch = Schema.Struct({
   ),
   providers: Schema.optionalKey(
     Schema.Struct({
+      atomic: Schema.optionalKey(AtomicSettingsPatch),
       codex: Schema.optionalKey(CodexSettingsPatch),
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,86 @@
 import "vite-plus/test/config";
 import { defineConfig } from "vite-plus";
+import * as NodePath from "node:path";
 import * as NodeURL from "node:url";
+
+const repositoryRoot = NodeURL.fileURLToPath(new URL(".", import.meta.url));
+const stagedCheckExtensions = new Set([
+  ".astro",
+  ".cjs",
+  ".css",
+  ".html",
+  ".js",
+  ".json",
+  ".jsonc",
+  ".jsx",
+  ".md",
+  ".mdx",
+  ".mjs",
+  ".scss",
+  ".ts",
+  ".tsx",
+  ".yaml",
+  ".yml",
+]);
+const stagedIgnoredSegments = new Set([
+  ".alchemy",
+  ".reference",
+  ".repos",
+  "dist",
+  "dist-electron",
+  "node_modules",
+]);
+const mobileNativeConfigPaths = new Set([
+  ".github/workflows/ci.yml",
+  "apps/mobile/.editorconfig",
+  "apps/mobile/.swiftlint.yml",
+  "apps/mobile/Brewfile",
+  "apps/mobile/detekt.yml",
+  "package.json",
+  "scripts/mobile-native-static-check.ts",
+]);
+
+function stagedPath(file: string): string {
+  return (NodePath.isAbsolute(file) ? NodePath.relative(repositoryRoot, file) : file).replaceAll(
+    NodePath.sep,
+    "/",
+  );
+}
+
+function isIgnoredStagedPath(file: string): boolean {
+  const segments = file.split("/");
+  return (
+    segments.some((segment) => stagedIgnoredSegments.has(segment) || segment.endsWith(".icon")) ||
+    file === "pnpm-lock.yaml" ||
+    file.endsWith(".tsbuildinfo") ||
+    file.endsWith("/routeTree.gen.ts") ||
+    file === "routeTree.gen.ts" ||
+    file.startsWith("apps/mobile/android/") ||
+    file.startsWith("apps/mobile/ios/") ||
+    file === "apps/web/public/mockServiceWorker.js" ||
+    file === "apps/web/src/lib/vendor/qrcodegen.ts" ||
+    file === "apps/mobile/uniwind-types.d.ts"
+  );
+}
+
+function shellQuote(file: string): string {
+  return `'${file.replaceAll("'", `'"'"'`)}'`;
+}
+
+function isResourceMonitorPath(file: string): boolean {
+  return (
+    file === "native/resource-monitor/Cargo.toml" ||
+    file === "native/resource-monitor/Cargo.lock" ||
+    (file.startsWith("native/resource-monitor/src/") && file.endsWith(".rs"))
+  );
+}
+
+function isMobileNativePath(file: string): boolean {
+  return (
+    mobileNativeConfigPaths.has(file) ||
+    (file.startsWith("apps/mobile/") && [".swift", ".kt", ".kts"].includes(NodePath.extname(file)))
+  );
+}
 
 export default defineConfig({
   resolve: {
@@ -20,9 +100,23 @@ export default defineConfig({
     hookTimeout: 60_000,
     testTimeout: 60_000,
   },
-  staged: {
-    // Formatter only for now — no lint or typecheck on commit.
-    "*": "vp fmt",
+  staged: (files) => {
+    const paths = files.map(stagedPath);
+    const checkedPaths = paths.filter(
+      (file) => stagedCheckExtensions.has(NodePath.extname(file)) && !isIgnoredStagedPath(file),
+    );
+    const commands: string[] = [];
+    if (checkedPaths.length > 0) {
+      commands.push(`vp check --fix ${checkedPaths.map(shellQuote).join(" ")}`);
+    }
+    if (paths.some(isResourceMonitorPath)) {
+      commands.push("cargo fmt --manifest-path native/resource-monitor/Cargo.toml -- --check");
+      commands.push("vp run test:resource-monitor");
+    }
+    if (paths.some(isMobileNativePath)) {
+      commands.push("vp run lint:mobile");
+    }
+    return commands;
   },
   fmt: {
     ignorePatterns: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off
 import "vite-plus/test/config";
 import { defineConfig } from "vite-plus";
 import * as NodePath from "node:path";


### PR DESCRIPTION
## Intent

Deliver the best working Atomic experience in the T3 Code fork, add Pi as the shared RPC compatibility provider, expose honest workflow progress and source to users, document the adapter for maintainers and possible upstreaming, synchronize with upstream main, and prepare the atomic branch for a PR into the fork's dev/next-release branch while leaving the isolated dev app running.

## What Changed

- Register Atomic and Pi as configurable Early Access providers backed by a shared RPC adapter, including discovery, session lifecycle, streaming, tool activity, usage, and interactive prompts.
- Project Atomic workflows into dependency-aware stages with waiting and terminal states, and expose workspace-contained `.js`/`.ts` source in the web Agents view while carrying related state through shared contracts and clients.
- Add focused provider coverage plus installation and maintainer documentation for configuration, protocol behavior, capabilities, and current limitations.

## Risk Assessment

🚨 High: The change still has a reachable workspace-containment escape, incomplete turn/session lifecycle invariants, and deterministic unsupported choices across user-facing surfaces.

## Testing

After mapping the target to the supplied upstream baseline and resolving a shell PATH setup issue, I fixed the load-sensitive EOF regression test, passed the focused Atomic/Pi/workflow/client checks, probed both installed CLIs in isolated directories, and verified the Atomic workflow/source and Pi turn end-to-end with persisted state and three visual artifacts; no actionable issue remains, and the isolated app is still running.

- Evidence: Atomic workflow progress and dependency stages (local file: <code>/var/folders/56/9gldf4zd5l526h1c7r293fzr0000gn/T/no-mistakes-evidence/01M0Y63ERDYSNNX7TQ81WYNZ0E/atomic-workflow-progress.jpg</code>)
- Evidence: Contained Atomic workflow source (local file: <code>/var/folders/56/9gldf4zd5l526h1c7r293fzr0000gn/T/no-mistakes-evidence/01M0Y63ERDYSNNX7TQ81WYNZ0E/atomic-workflow-source.jpg</code>)
- Evidence: Pi shared-RPC turn (local file: <code>/var/folders/56/9gldf4zd5l526h1c7r293fzr0000gn/T/no-mistakes-evidence/01M0Y63ERDYSNNX7TQ81WYNZ0E/pi-shared-rpc-turn.jpg</code>)
<details>
<summary>Evidence: Installed-binary RPC compatibility</summary>

```text
Atomic and Pi each returned successful get_state and get_available_models RPC responses from their installed binaries using isolated agent directories. No credentials or models were present, as expected.
```
</details>
<details>
<summary>Evidence: Persisted provider and workflow state</summary>

```text
Atomic workflow session: ready, provider_instance_id=atomic, last_error=null. Pi compatibility session: ready, provider_instance_id=pi, last_error=null. Atomic's persisted approval stage transitioned waiting → running → completed.
```
</details>
<details>
<summary>Evidence: Retained isolated dev app</summary>

Source: [Retained isolated dev app](http://localhost:6235/)

```text
The isolated dev server remains running and the retained browser tab is open on the Atomic workflow source surface.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 8 issues (6 errors, 2 warnings)</summary>

- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1364` - `sendTurn` holds the per-thread mutex while awaiting the unbounded interactive `prompt` request. If Atomic is waiting for editor/input, `stopSession` waits on the same mutex and cannot kill the child, so deletion, reaping, or an explicit session stop can hang indefinitely. Limit the lock to state setup or allow teardown to bypass it.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1467` - A new turn is marked active before the prompt request, but prompt write/EOF/rejection failures return without clearing that state or stopping the RPC process. The reactor records an error while `hasSession` remains true; the next message is consequently sent as `streamingBehavior: &#34;steer&#34;` to the failed or dead turn. Fail and clear the turn, then retire the unusable transport at this boundary.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1532` - The abort response&#39;s `precedingEventSequence` is discarded before `completeActiveTurn` clears `activeTurnId`. If the transport has read `tool_execution_end` or `agent_settled` but the mapper is behind, those events are subsequently dropped and tool activity remains `inProgress`. Drain the acknowledged event sequence before synthesizing interruption completion.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:702` - This contradicts the required criterion to “expose honest workflow progress”: run-scoped `awaiting_input` normalizes to `workflow.run.waiting`, but only stage waiting is handled, leaving the coordinator running. Additionally, a resumed stage never clears `awaitingInput`, so its linkage remains `human input`. Handle run and stage waiting and clear the marker before resumed or terminal linkage is built.
- 🚨 `packages/contracts/src/providerRuntime.ts:462` - The new provider-supplied `defaultValue` is only propagated by web. Mobile&#39;s question parser drops it and its resolver/input default to empty, so Atomic/Pi editor prefill disappears and cannot be submitted unchanged. This conflicts with the “best working Atomic experience” criterion and the documented cross-provider prefill support; propagate and resolve `defaultValue` in the mobile path too.
- 🚨 `packages/contracts/src/settings.ts:766` - Putting Atomic and Pi first changes the existing “first enabled provider” text-generation fallback. Both new drivers explicitly reject every auxiliary text-generation operation, so when the configured selection is disabled and Atomic/Pi plus a capable provider are enabled, fallback selects a provider guaranteed to fail titles and Git text. Filter fallback candidates by actual text-generation support rather than settings key order.
- 🚨 `apps/server/src/orchestration/workflowScriptQuery.ts:60` - Realpathing `.atomic/workflows` directly makes a symlinked workflow directory&#39;s external target a trusted root. A checkout can therefore point that directory outside the workspace and expose arbitrary external `.js`/`.ts` files through the workflow-source RPC, contrary to the documented containment boundary. Realpath the workspace and reject an Atomic root that escapes it before trusting the root.
- 🚨 `apps/server/src/provider/Layers/ProviderRegistry.test.ts:1745` - Pi is now registered in `BUILT_IN_DRIVERS`, and legacy settings hydration synthesizes its default instance, but this updated registry assertion still omits `pi`. The focused ProviderRegistry test will deterministically fail; add `pi` to the expected sorted instance list.

🔧 Fix: Fix Atomic lifecycle, workflow, mobile, and staged checks
8 issues (6 errors, 2 warnings) still open:
- 🚨 `apps/server/src/orchestration/workflowScriptQuery.ts:127` - The workspace-containment fix remains raceable: after the realpath checks, replacing `.atomic/workflows` with an external symlink makes both `open(resolved)` and the subsequent `lstat(resolved)` traverse to the same outside inode, so arbitrary external workflow source is returned. Anchor the read to stable contained directory/file handles with no-follow semantics and validate the object actually opened.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1512` - The durable active-turn cleanup only covers `prompt` rejection. If an extension-only prompt succeeds but `get_state` fails or times out, `sendTurn` returns an error while the turn remains active and the next message is sent as steering. Settle the turn and retire the transport on every failure after turn activation.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1639` - Removing `stopSession` from the turn mutex introduces a startup race: a stop before session installation is lost, while a stop after `sessions.set` can kill the new context before `startSession` publishes ready events and returns that dead session. Add a separate per-thread lifecycle generation/lock that coordinates start and stop without covering the interactive prompt.
- 🚨 `apps/web/src/components/chat/MessagesTimeline.tsx:2560` - This contradicts the required criterion to “expose honest workflow progress”: the primary timeline deliberately counts `waiting` stages as `working`, rendering “Workflow running” while Atomic is blocked on human input; the expanded panel can also retain “Live workflow graph” after completion. Derive these labels from waiting and terminal state instead of folding waiting into running.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1173` - Atomic/Pi reject every runtime mode except `full-access`, but web and mobile still offer Supervised, Auto-accept, and Auto without provider filtering. Selecting one and starting or restarting a session deterministically fails, conflicting with the required “best working Atomic experience.” Expose supported runtime modes through the shared provider contract and consume them on both clients, or explicitly force full access.
- 🚨 `apps/server/src/provider/Drivers/AtomicDriver.ts:176` - Atomic and Pi register text-generation implementations that always fail, yet the generic text-generation and source-control model pickers include enabled Atomic/Pi instances and preserve an explicit selection. Choosing either therefore breaks titles and Git text. Add a shared text-generation capability and filter selection candidates, including persisted selections.
- ⚠️ `apps/server/src/provider/Layers/AtomicAdapter.ts:261` - The settings UI advertises `~/.atomic` and `~/.pi/agent`, but both provider environment builders pass `agentDir` verbatim; spawned environment values receive no shell tilde expansion, so these paths can resolve incorrectly. Apply the repository&#39;s `expandHomePath` helper before setting both environment variables.
- ⚠️ `apps/mobile/src/components/ProviderIcon.tsx:62` - Mobile has no Atomic or Pi icon cases, so both new first-class providers fall through to the Codex glyph in model and thread rows while web identifies them distinctly. Add provider-specific mobile icons or an intentionally neutral fallback.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git log --oneline --decorate --no-merges b0a0281269156295e2202d31198829bd3b500bdf..f220f7187ea11bd38734e8ae7bb5bcda0a0c50c2` and `git diff --stat/--name-status`</code>
- <code>`git merge-base --is-ancestor origin/main f220f7187ea11bd38734e8ae7bb5bcda0a0c50c2 &amp;&amp; git rev-list --left-right --count origin/main...f220f7187ea11bd38734e8ae7bb5bcda0a0c50c2` (supplied origin/main is an ancestor; target is four commits ahead)</code>
- <code>`vp test run &lt;focused Atomic/Pi/workflow/client files&gt;` (documented launcher absent from shell PATH; retried with the worktree-local binary)</code>
- `./node_modules/.bin/vp test run apps/server/src/provider/atomic/AtomicRpcProcess.test.ts apps/server/src/provider/Layers/AtomicAdapter.test.ts apps/server/src/provider/Layers/PiAdapter.test.ts apps/server/src/provider/Layers/PiProvider.test.ts apps/server/src/provider/Layers/ProviderRegistry.test.ts apps/server/src/provider/builtInDrivers.test.ts apps/server/src/orchestration/workflowScriptQuery.test.ts apps/server/src/serverSettings.test.ts apps/mobile/src/lib/threadActivity.test.ts apps/web/src/pendingUserInput.test.ts packages/client-runtime/src/state/subagentRuntime.test.ts packages/contracts/src/providerRuntime.test.ts packages/contracts/src/settings.test.ts`
- `Two-file Atomic process/adapter regression loop repeated ten times after the test fix`
- <code>Installed `/opt/homebrew/bin/atomic` and `/Users/taylor/.local/bin/pi` RPC probes: `get_state` and `get_available_models` with worktree-local agent directories</code>
- `node apps/server/src/bin.ts project add --base-dir <worktree>/.t3 --title 'Atomic Acceptance' <worktree>/.t3/e2e-workspace`
- <code>Authenticated browser flow: select Atomic GPT-5.4 → send `/workflow list` → open Agents → expand stages → open contained TypeScript source</code>
- <code>Authenticated browser flow: select Pi GPT-5.4 → send compatibility prompt → verify `PI_RPC_OK`, reasoning/tool work, queued follow-up, context usage, and settled composer</code>
- `Read-only SQLite verification of projected provider sessions and Atomic workflow task transitions`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.test.ts:397` - TS2345: AtomicAdapter.test.ts passes an optional requestId to ApprovalRequestId.make without narrowing; this phase cannot modify tests.
- 🚨 `apps/server/src/provider/Layers/AtomicAdapter.ts:1371` - TS2375: Atomic sendTurn can return undefined when event settlement wins the response-order race; correcting it requires a functional behavior change outside this phase.

🔧 Fix: Fix Atomic adapter typecheck errors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new provider stack (child processes, RPC timeouts, turn/session locking) plus workflow script reads from workspace paths—areas called out in review for containment races and lifecycle edge cases.
> 
> **Overview**
> Adds **Atomic** and **Pi** as Early Access built-in providers on a shared Pi-compatible RPC adapter (sessions, streaming, tools, extension UI prompts, workflow lifecycle → task events). **Atomic**-specific behavior includes workspace `.atomic/workflows` script viewing with expanded containment rules; the orchestration RPC now resolves **workspace root** from the thread before reading scripts.
> 
> **Mobile** pending user-input cards honor provider **`defaultValue`** for prefill and unchanged submit (via `getPendingUserInputCustomAnswer`). **Web** Agents/timeline surfaces distinguish **awaiting input** from generic “working,” show a dependency-aware **workflow graph**, and adjust workflow spawn affordances. **README/AGENTS** defer the provider inventory to user docs.
> 
> Text-generation fallback in server settings skips enabled providers that have no configured auxiliary model; Atomic/Pi drivers still return explicit failures for title/Git generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 709283915562105056a7a5f5a41319a594d53829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `atomic` and `pi` provider drivers with shared RPC adapter
> - Introduces `atomic` and `pi` provider drivers, settings schemas, and UI definitions in [builtInDrivers.ts](https://github.com/pingdotgg/t3code/pull/8262/files#diff-7bd5dca89e0c2be78fa6adf17c285d16f158d8c8b671b62245d46b910a665c39), [settings.ts](https://github.com/pingdotgg/t3code/pull/8262/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), and [providerDriverMeta.ts](https://github.com/pingdotgg/t3code/pull/8262/files#diff-85c0e0270187750635f7fedc543a86f3a11511b2709940b62774f268dbfb5c57).
> - Adds a shared `AtomicRpcProcess` transport and `AtomicAdapter` to handle session lifecycle, phased timeouts, and event streaming for both providers.
> - Extends [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/8262/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7) schemas to accept `atomic.rpc`/`pi.rpc` sources, workflow stage linkage fields (`workflowStageId`, `dependsOnTaskIds`), and `defaultValue` on user input questions.
> - Updates [readWorkflowScript](https://github.com/pingdotgg/t3code/pull/8262/files#diff-46a22110c4a8339703e84cdd2ec6655b7e688fce9b1e3032032a737b2bc335a1) to serve `.ts` workflow files from a workspace's `.atomic/workflows` directory and prevent symlink escapes outside the workspace root.
> - Risk: `fallbackTextGenerationProvider` now skips providers without a default text-generation model, so `atomic` and `pi` are no longer chosen as fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7092839. 35 files reviewed, 15 issues evaluated, 4 issues filtered, 11 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/AgentsPanel.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 221](https://github.com/pingdotgg/t3code/blob/709283915562105056a7a5f5a41319a594d53829/apps/web/src/components/AgentsPanel.tsx#L221): `WorkflowGraph` is retained while an expanded live workflow settles (the parent intentionally keeps it open), but its heading is always `Live workflow graph`. Thus any workflow that completes, fails, or is cancelled while open is still presented as live until the user collapses it, giving an incorrect status cue. <b>[ Already posted ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/pendingUserInput.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 52](https://github.com/pingdotgg/t3code/blob/709283915562105056a7a5f5a41319a594d53829/apps/web/src/pendingUserInput.ts#L52): `resolvePendingUserInputAnswer` treats `defaultValue` as a custom answer even after an option is selected. `togglePendingUserInputOptionSelection` deliberately writes `customAnswer: ""` plus `selectedOptionLabels`, but `"" ?? question.defaultValue` selects the default first, so a question such as the tested editor question (which has both a default and options) always submits the default rather than the user's selected option. <b>[ Cross-file consolidated ]</b>
> - [line 154](https://github.com/pingdotgg/t3code/blob/709283915562105056a7a5f5a41319a594d53829/apps/web/src/pendingUserInput.ts#L154): `derivePendingUserInputProgress` restores `defaultValue` when an option click has created a draft with `customAnswer: ""`. Option toggling uses that empty string to mean “use the selected labels”; this fallback instead makes `usingCustomAnswer` true, so the UI suppresses the selected-option state and continues presenting the provider default after the user chose an option. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/contracts/src/settings.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 571](https://github.com/pingdotgg/t3code/blob/709283915562105056a7a5f5a41319a594d53829/packages/contracts/src/settings.ts#L571): The advertised `~/.atomic` agent directory is stored verbatim, while the adapter passes `settings.agentDir` directly as `ATOMIC_CODING_AGENT_DIR`. Spawned processes do not shell-expand environment-variable values, so selecting the shown `~/.atomic` value makes Atomic receive a relative literal-tilde path rather than the user's home directory and prevents the promised isolated configuration from being used. Expand `~` before constructing the environment (and apply the same correction to Pi). <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->