### PR TITLE
fix(web): renumber project picker jump shortcuts to match filtered results

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -9,6 +9,7 @@ import {
   filterPinnedBrowseEntries,
   filterCommandPaletteGroups,
   reduceCommandPaletteUiState,
+  type CommandPaletteActionItem,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -136,6 +137,73 @@ describe("enumerateCommandPaletteItems", () => {
       "thread.jump.9",
       undefined,
     ]);
+  });
+});
+
+describe("filterCommandPaletteGroups shortcut enumeration", () => {
+  function makeProjectItem(value: string, title: string): CommandPaletteActionItem {
+    return {
+      kind: "action",
+      value,
+      searchTerms: [title],
+      title,
+      icon: null,
+      run: async () => undefined,
+    };
+  }
+
+  const enumeratedGroup: CommandPaletteGroup = {
+    value: "projects",
+    label: "Projects",
+    enumerateShortcuts: true,
+    items: [
+      makeProjectItem("project-alpha", "Alpha"),
+      makeProjectItem("project-beta", "Beta"),
+      makeProjectItem("project-gamma", "Gamma"),
+      makeProjectItem("project-lol", "Lol"),
+    ],
+  };
+
+  it("assigns positional shortcuts to enumerated groups when the query is empty", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [enumeratedGroup],
+      query: "",
+      isInSubmenu: true,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.shortcutCommand)).toEqual([
+      "thread.jump.1",
+      "thread.jump.2",
+      "thread.jump.3",
+      "thread.jump.4",
+    ]);
+  });
+
+  it("renumbers shortcuts to match visible positions after filtering", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [enumeratedGroup],
+      query: "lol",
+      isInSubmenu: true,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["project-lol"]);
+    expect(groups[0]?.items[0]?.shortcutCommand).toBe("thread.jump.1");
+  });
+
+  it("leaves groups without enumerateShortcuts untouched", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [{ ...enumeratedGroup, enumerateShortcuts: false }],
+      query: "lol",
+      isInSubmenu: true,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items[0]?.shortcutCommand).toBeUndefined();
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -9,7 +9,6 @@ import {
   filterPinnedBrowseEntries,
   filterCommandPaletteGroups,
   reduceCommandPaletteUiState,
-  type CommandPaletteActionItem,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -137,73 +136,6 @@ describe("enumerateCommandPaletteItems", () => {
       "thread.jump.9",
       undefined,
     ]);
-  });
-});
-
-describe("filterCommandPaletteGroups shortcut enumeration", () => {
-  function makeProjectItem(value: string, title: string): CommandPaletteActionItem {
-    return {
-      kind: "action",
-      value,
-      searchTerms: [title],
-      title,
-      icon: null,
-      run: async () => undefined,
-    };
-  }
-
-  const enumeratedGroup: CommandPaletteGroup = {
-    value: "projects",
-    label: "Projects",
-    enumerateShortcuts: true,
-    items: [
-      makeProjectItem("project-alpha", "Alpha"),
-      makeProjectItem("project-beta", "Beta"),
-      makeProjectItem("project-gamma", "Gamma"),
-      makeProjectItem("project-lol", "Lol"),
-    ],
-  };
-
-  it("assigns positional shortcuts to enumerated groups when the query is empty", () => {
-    const groups = filterCommandPaletteGroups({
-      activeGroups: [enumeratedGroup],
-      query: "",
-      isInSubmenu: true,
-      projectSearchItems: [],
-      threadSearchItems: [],
-    });
-
-    expect(groups[0]?.items.map((item) => item.shortcutCommand)).toEqual([
-      "thread.jump.1",
-      "thread.jump.2",
-      "thread.jump.3",
-      "thread.jump.4",
-    ]);
-  });
-
-  it("renumbers shortcuts to match visible positions after filtering", () => {
-    const groups = filterCommandPaletteGroups({
-      activeGroups: [enumeratedGroup],
-      query: "lol",
-      isInSubmenu: true,
-      projectSearchItems: [],
-      threadSearchItems: [],
-    });
-
-    expect(groups[0]?.items.map((item) => item.value)).toEqual(["project-lol"]);
-    expect(groups[0]?.items[0]?.shortcutCommand).toBe("thread.jump.1");
-  });
-
-  it("leaves groups without enumerateShortcuts untouched", () => {
-    const groups = filterCommandPaletteGroups({
-      activeGroups: [{ ...enumeratedGroup, enumerateShortcuts: false }],
-      query: "lol",
-      isInSubmenu: true,
-      projectSearchItems: [],
-      threadSearchItems: [],
-    });
-
-    expect(groups[0]?.items[0]?.shortcutCommand).toBeUndefined();
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -115,6 +115,7 @@ export interface CommandPaletteSubmenuItem extends CommandPaletteItem {
 export interface CommandPaletteGroup {
   readonly value: string;
   readonly label: string;
+  readonly enumerateShortcuts?: boolean;
   readonly items: ReadonlyArray<CommandPaletteActionItem | CommandPaletteSubmenuItem>;
 }
 
@@ -125,8 +126,8 @@ export interface CommandPaletteView {
 }
 
 export function enumerateCommandPaletteItems(
-  items: ReadonlyArray<CommandPaletteActionItem>,
-): CommandPaletteActionItem[] {
+  items: CommandPaletteGroup["items"],
+): Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> {
   return items.map((item, index) => {
     const shortcutCommand = THREAD_JUMP_KEYBINDING_COMMANDS[index];
     if (shortcutCommand) return { ...item, shortcutCommand };
@@ -134,6 +135,11 @@ export function enumerateCommandPaletteItems(
     const { shortcutCommand: _shortcutCommand, ...itemWithoutShortcut } = item;
     return itemWithoutShortcut;
   });
+}
+
+function withEnumeratedShortcuts(group: CommandPaletteGroup): CommandPaletteGroup {
+  if (!group.enumerateShortcuts) return group;
+  return { ...group, items: enumerateCommandPaletteItems(group.items) };
 }
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
@@ -303,7 +309,7 @@ export function filterCommandPaletteGroups(input: {
     if (isActionsFilter) {
       return input.activeGroups.filter((group) => group.value === "actions");
     }
-    return [...input.activeGroups];
+    return input.activeGroups.map(withEnumeratedShortcuts);
   }
 
   let baseGroups = [...input.activeGroups];
@@ -351,7 +357,7 @@ export function filterCommandPaletteGroups(input: {
       return [];
     }
 
-    return [{ value: group.value, label: group.label, items }];
+    return [withEnumeratedShortcuts({ ...group, items })];
   });
 }
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -117,7 +117,6 @@ import {
   buildProjectActionItems,
   buildRootGroups,
   buildThreadActionItems,
-  enumerateCommandPaletteItems,
   type CommandPaletteActionItem,
   type CommandPaletteOpenIntent,
   type CommandPaletteSubmenuItem,
@@ -1023,55 +1022,53 @@ function OpenCommandPaletteDialog(props: {
 
   const projectThreadItems = useMemo(
     () =>
-      enumerateCommandPaletteItems(
-        buildProjectActionItems({
-          projects: pickerProjects,
-          valuePrefix: "new-thread-in",
-          searchTerms: (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            const location = projectEnvironmentLocationById.get(project.environmentId);
-            return [
-              ...(group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ??
-                []),
-              ...(location ? [location.label] : []),
-            ];
-          },
-          renderDescription: (project) => {
-            const location = projectEnvironmentLocationById.get(project.environmentId) ?? {
-              kind: "remote",
-              label: "Remote",
-            };
-            return (
-              <span className="flex min-w-0 items-center gap-1">
-                <span className="inline-flex min-w-0 items-center gap-1">
-                  {location.kind === "remote" ? (
-                    <ServerIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
-                  ) : null}
-                  <span className="truncate">{location.label}</span>
-                </span>
-                <CommandPaletteMetaDot />
-                <span className="truncate">{project.workspaceRoot}</span>
+      buildProjectActionItems({
+        projects: pickerProjects,
+        valuePrefix: "new-thread-in",
+        searchTerms: (project) => {
+          const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
+          const location = projectEnvironmentLocationById.get(project.environmentId);
+          return [
+            ...(group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ??
+              []),
+            ...(location ? [location.label] : []),
+          ];
+        },
+        renderDescription: (project) => {
+          const location = projectEnvironmentLocationById.get(project.environmentId) ?? {
+            kind: "remote",
+            label: "Remote",
+          };
+          return (
+            <span className="flex min-w-0 items-center gap-1">
+              <span className="inline-flex min-w-0 items-center gap-1">
+                {location.kind === "remote" ? (
+                  <ServerIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
+                ) : null}
+                <span className="truncate">{location.label}</span>
               </span>
+              <CommandPaletteMetaDot />
+              <span className="truncate">{project.workspaceRoot}</span>
+            </span>
+          );
+        },
+        icon: projectFavicon,
+        runProject: async (project) => {
+          const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
+          const contextualRefBelongsToGroup =
+            contextualProjectRef !== null &&
+            group?.memberProjectRefs.some(
+              (projectRef) =>
+                projectRef.environmentId === contextualProjectRef.environmentId &&
+                projectRef.projectId === contextualProjectRef.projectId,
             );
-          },
-          icon: projectFavicon,
-          runProject: async (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            const contextualRefBelongsToGroup =
-              contextualProjectRef !== null &&
-              group?.memberProjectRefs.some(
-                (projectRef) =>
-                  projectRef.environmentId === contextualProjectRef.environmentId &&
-                  projectRef.projectId === contextualProjectRef.projectId,
-              );
-            await handleNewThread(
-              contextualRefBelongsToGroup
-                ? contextualProjectRef
-                : scopeProjectRef(project.environmentId, project.id),
-            );
-          },
-        }),
-      ),
+          await handleNewThread(
+            contextualRefBelongsToGroup
+              ? contextualProjectRef
+              : scopeProjectRef(project.environmentId, project.id),
+          );
+        },
+      }),
     [
       contextualProjectRef,
       handleNewThread,
@@ -1470,7 +1467,8 @@ function OpenCommandPaletteDialog(props: {
         {
           value: "projects",
           label: "Projects",
-          items: enumerateCommandPaletteItems(prioritized),
+          enumerateShortcuts: true,
+          items: prioritized,
         },
       ],
     });
@@ -1521,7 +1519,14 @@ function OpenCommandPaletteDialog(props: {
       title: "New thread in...",
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+      groups: [
+        {
+          value: "projects",
+          label: "Projects",
+          enumerateShortcuts: true,
+          items: projectThreadItems,
+        },
+      ],
     });
   }
 


### PR DESCRIPTION
## What Changed

In the "New Thread" project picker (and the "New thread in..." command palette submenu), the ⌘1–⌘9 jump shortcut hints were assigned from each project's position in the **unfiltered** list, at view-construction time. After typing in the search box, the visible rows kept their original numbers — the only remaining result could still show ⌘4 — and pressing ⌘1 did nothing if the item that owned `thread.jump.1` had been filtered out. The filter's rank-based re-sorting caused the same mismatch even when no rows were dropped.

This PR moves the enumeration out of view construction and into `filterCommandPaletteGroups`, which runs on every query change: groups that opt in via a new `enumerateShortcuts` flag get `thread.jump.N` assigned after filtering and ranking.

- `apps/web/src/components/CommandPalette.logic.ts` — `CommandPaletteGroup.enumerateShortcuts` flag; enumeration applied in `filterCommandPaletteGroups` (both the empty-query and filtered paths)
- `apps/web/src/components/CommandPalette.tsx` — stop baking shortcuts into `projectThreadItems`; mark the two picker groups with `enumerateShortcuts: true`

Most of the `CommandPalette.tsx` diff is re-indentation from removing the `enumerateCommandPaletteItems(...)` wrapper — with whitespace ignored the change is 20(+) / 9(−) lines.

## Why

Shortcut hints and their handlers should always follow **visible** positions. Enumerating after the filter runs makes that hold by construction: the keydown handler already resolves items from the displayed groups, so hints and handlers can no longer disagree with what is on screen. Other palette items with static shortcuts (`chat.new`, `filePicker.toggle`, …) are untouched.

## UI Changes

Projects: Alpha ⌘1, Beta ⌘2, Gamma ⌘3, Delta ⌘4. Typing "delta" leaves a single visible row.

### Before

The row still shows the stale **⌘4**, and pressing ⌘1 does nothing (the item owning `thread.jump.1` was filtered out):

<img width="1600" alt="before: filtered row still shows cmd-4" src="https://raw.githubusercontent.com/kacpergumieniuk/t3code/bebf77085b57f31939985b0f34395c9fe32d659a/before-filtered-cmd4.png" />

Video: [before-bug.mp4](https://github.com/kacpergumieniuk/t3code/raw/bebf77085b57f31939985b0f34395c9fe32d659a/before-bug.mp4)

### After

The filtered row renumbers to **⌘1**, and pressing ⌘1 opens a new thread in Delta:

<img width="1600" alt="after: filtered row renumbered to cmd-1" src="https://raw.githubusercontent.com/kacpergumieniuk/t3code/bebf77085b57f31939985b0f34395c9fe32d659a/after-filtered-cmd1.png" />

Video: [after-fix.mp4](https://github.com/kacpergumieniuk/t3code/raw/bebf77085b57f31939985b0f34395c9fe32d659a/after-fix.mp4)

## Verification

- `vp run test` in `apps/web`: full suite passes (2859 tests / 281 files)
- `vp run typecheck` (apps/web), `vp lint`, `vp fmt --check` clean
- Verified manually in an isolated dev environment (recordings above): the filtered picker renumbers to ⌘1 and ⌘1 executes the visible item; on `main` the same flow shows the stale hint and a dead ⌘1

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Made with Claude Fable 5 in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix command palette jump shortcuts to match filtered project results
> - Moves shortcut enumeration from component build-time to filtering time via a new `enumerateShortcuts` group flag and `withEnumeratedShortcuts` helper, so jump keybindings (`THREAD_JUMP_KEYBINDING_COMMANDS`) are assigned after filtering and match the visible results
> - Broadens `enumerateCommandPaletteItems` to accept both `CommandPaletteActionItem` and `CommandPaletteSubmenuItem` arrays
> - `OpenCommandPaletteDialog` no longer pre-enumerates `projectThreadItems`; the Projects view and New-thread submenu groups now set `enumerateShortcuts: true` and pass raw items
> - Risk: groups that previously relied on pre-enumerated shortcuts from the component must now opt in via `enumerateShortcuts: true` in [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/8268/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e), otherwise their items will have no shortcuts
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f589a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->