### PR TITLE
fix(preview): let overlay-timeout errors reach automation callers

### DIFF
--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -1068,7 +1068,7 @@ it.effect("routes a wait budget that leaves the host room to report a failure", 
       yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 200 });
       yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 1 });
 
-      expect(routedRequests.map((request) => request.timeoutMs)).toEqual([14_000, 180, 0]);
+      expect(routedRequests.map((request) => request.timeoutMs)).toEqual([14_000, 180, 1]);
     }),
   ),
 );

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -7,6 +7,7 @@ import {
   PreviewAutomationMalformedResponseError,
   PreviewAutomationNoAvailableHostError,
   PreviewAutomationTargetNotEditableError,
+  PreviewAutomationTimeoutError,
   PreviewTabId,
   ProviderInstanceId,
   ThreadId,
@@ -14,11 +15,13 @@ import {
   type PreviewAutomationRequest,
   type PreviewAutomationStreamEvent,
 } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
 import * as Fiber from "effect/Fiber";
 import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 
 import * as PreviewAutomationBroker from "./PreviewAutomationBroker.ts";
 
@@ -1039,6 +1042,109 @@ it.effect("accepts responses only from the host that received the request", () =
 
       const result = yield* broker.invoke<string>({ scope, operation: "status", input: {} });
       expect(result).toBe("owner");
+    }),
+  ),
+);
+
+it.effect("routes a wait budget that leaves the host room to report a failure", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const requests = requestsFrom(yield* broker.connect(makeHost()));
+      const routedRequests: RoutedRequest[] = [];
+      yield* Stream.runForEach(requests, (request) => {
+        routedRequests.push(request);
+        return broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: true,
+          result: "done",
+        });
+      }).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 15_000 });
+      yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 200 });
+
+      expect(routedRequests.map((request) => request.timeoutMs)).toEqual([14_000, 180]);
+    }),
+  ),
+);
+
+it.effect("reports why a host gave up when it spends its whole wait budget", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const requests = requestsFrom(yield* broker.connect(makeHost()));
+      const routed = yield* Deferred.make<RoutedRequest>();
+      yield* Stream.runForEach(requests, (request) => Deferred.succeed(routed, request)).pipe(
+        Effect.forkScoped,
+      );
+
+      const pending = yield* broker
+        .invoke<void>({ scope, operation: "snapshot", input: {}, timeoutMs: 15_000 })
+        .pipe(Effect.flip, Effect.forkScoped);
+      const request = yield* Deferred.await(routed);
+
+      // The host waits out every millisecond it was given before it reports the
+      // overlay it never got. That answer has to beat the abandon deadline.
+      yield* TestClock.adjust(Duration.millis(request.timeoutMs));
+      yield* broker.respond({
+        clientId: "client-1",
+        connectionId: request.connectionId,
+        requestId: request.requestId,
+        ok: false,
+        error: {
+          _tag: "PreviewAutomationTimeoutError",
+          message: `Preview webview for request ${request.requestId} did not register within ${request.timeoutMs}ms.`,
+          detail: { timeoutStage: "overlay" },
+        },
+      });
+
+      const error = yield* Fiber.join(pending);
+      expect(error).toBeInstanceOf(PreviewAutomationTimeoutError);
+      expect(error).toMatchObject({
+        operation: "snapshot",
+        requestId: "preview-0",
+        timeoutMs: 15_000,
+        timeoutStage: "overlay",
+        remoteTag: "PreviewAutomationTimeoutError",
+      });
+      expect(error.message).toBe(
+        "Preview automation snapshot timed out after 15000ms waiting for the preview overlay to become available.",
+      );
+    }),
+  ).pipe(Effect.provide(TestClock.layer())),
+);
+
+it.effect("ignores a timeout stage the host did not send", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const requests = requestsFrom(yield* broker.connect(makeHost()));
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: false,
+          error: {
+            _tag: "PreviewAutomationTimeoutError",
+            message: "remote timeout",
+            detail: { timeoutStage: "not-a-stage" },
+          },
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const error = yield* broker
+        .invoke<void>({ scope, operation: "evaluate", input: {}, timeoutMs: 15_000 })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewAutomationTimeoutError);
+      expect("timeoutStage" in error).toBe(false);
+      expect(error.message).toBe("Preview automation evaluate timed out after 15000ms.");
     }),
   ),
 );

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -1066,8 +1066,9 @@ it.effect("routes a wait budget that leaves the host room to report a failure", 
 
       yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 15_000 });
       yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 200 });
+      yield* broker.invoke<string>({ scope, operation: "snapshot", input: {}, timeoutMs: 1 });
 
-      expect(routedRequests.map((request) => request.timeoutMs)).toEqual([14_000, 180]);
+      expect(routedRequests.map((request) => request.timeoutMs)).toEqual([14_000, 180, 0]);
     }),
   ),
 );

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -182,7 +182,7 @@ const HOST_RESPONSE_MARGIN_MS = 1_000;
  * reported into a request nobody was waiting on any more.
  */
 const hostResponseBudgetMs = (timeoutMs: number): number =>
-  Math.max(1, timeoutMs - Math.min(HOST_RESPONSE_MARGIN_MS, Math.ceil(timeoutMs / 10)));
+  Math.max(0, timeoutMs - Math.min(HOST_RESPONSE_MARGIN_MS, Math.ceil(timeoutMs / 10)));
 
 const isPreviewAutomationTimeoutStage = Schema.is(PreviewAutomationTimeoutStage);
 

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -12,6 +12,7 @@ import {
   PreviewAutomationTabNotFoundError,
   PreviewAutomationTargetNotEditableError,
   PreviewAutomationTimeoutError,
+  PreviewAutomationTimeoutStage,
   PreviewAutomationUnsupportedClientError,
   PreviewTabId,
   type PreviewAutomationError,
@@ -166,6 +167,31 @@ const supportsOperation = (
   operation: PreviewAutomationOperation,
 ): boolean => connection.supportedOperations.has(operation);
 
+/**
+ * Headroom the broker keeps between the host's budget and its own deadline, so
+ * a host that gives up still has time to say why over the wire. A tenth of the
+ * request keeps small budgets usable and the cap keeps large ones from wasting
+ * seconds of a wait that could still succeed.
+ */
+const HOST_RESPONSE_MARGIN_MS = 1_000;
+
+/**
+ * The wait budget handed to the host. It stays strictly below the broker's
+ * abandon deadline: sharing one deadline made every host-side readiness failure
+ * lose the race to `PreviewAutomationTimeoutError`, so the specific reason was
+ * reported into a request nobody was waiting on any more.
+ */
+const hostResponseBudgetMs = (timeoutMs: number): number =>
+  Math.max(1, timeoutMs - Math.min(HOST_RESPONSE_MARGIN_MS, Math.ceil(timeoutMs / 10)));
+
+const isPreviewAutomationTimeoutStage = Schema.is(PreviewAutomationTimeoutStage);
+
+const remoteTimeoutStage = (detail: unknown): PreviewAutomationTimeoutStage | undefined => {
+  if (typeof detail !== "object" || detail === null || !("timeoutStage" in detail))
+    return undefined;
+  return isPreviewAutomationTimeoutStage(detail.timeoutStage) ? detail.timeoutStage : undefined;
+};
+
 type RemoteDetailKind = "null" | "array" | "object" | "string" | "number" | "boolean";
 
 function remoteDetailKind(detail: unknown): RemoteDetailKind {
@@ -209,11 +235,14 @@ const classifyResponseError = (
         ...context,
         ...remoteDiagnostics,
       });
-    case "PreviewAutomationTimeoutError":
+    case "PreviewAutomationTimeoutError": {
+      const timeoutStage = remoteTimeoutStage(error.detail);
       return new PreviewAutomationTimeoutError({
         ...context,
         ...remoteDiagnostics,
+        ...(timeoutStage === undefined ? {} : { timeoutStage }),
       });
+    }
     case "PreviewAutomationControlInterruptedError":
       return new PreviewAutomationControlInterruptedError({
         ...context,
@@ -534,7 +563,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
           tabIdExplicit: input.tabId !== undefined,
           operation: input.operation,
           input: input.input,
-          timeoutMs,
+          timeoutMs: hostResponseBudgetMs(timeoutMs),
         },
       });
       if (!offered) {

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -179,10 +179,14 @@ const HOST_RESPONSE_MARGIN_MS = 1_000;
  * The wait budget handed to the host. It stays strictly below the broker's
  * abandon deadline: sharing one deadline made every host-side readiness failure
  * lose the race to `PreviewAutomationTimeoutError`, so the specific reason was
- * reported into a request nobody was waiting on any more.
+ * reported into a request nobody was waiting on any more. The wire schema
+ * requires a positive budget, so the broker deadline is clamped to 2ms
+ * (`MINIMUM_BROKER_TIMEOUT_MS`) instead of ever putting 0 on the wire.
  */
+const MINIMUM_BROKER_TIMEOUT_MS = 2;
+
 const hostResponseBudgetMs = (timeoutMs: number): number =>
-  Math.max(0, timeoutMs - Math.min(HOST_RESPONSE_MARGIN_MS, Math.ceil(timeoutMs / 10)));
+  Math.max(1, timeoutMs - Math.min(HOST_RESPONSE_MARGIN_MS, Math.ceil(timeoutMs / 10)));
 
 const isPreviewAutomationTimeoutStage = Schema.is(PreviewAutomationTimeoutStage);
 
@@ -455,7 +459,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
   const invoke = Effect.fn("PreviewAutomationBroker.invoke")(function* <A = unknown>(
     input: Parameters<PreviewAutomationBroker["Service"]["invoke"]>[0],
   ): Effect.fn.Return<A, PreviewAutomationError> {
-    const timeoutMs = input.timeoutMs ?? 15_000;
+    const timeoutMs = Math.max(MINIMUM_BROKER_TIMEOUT_MS, input.timeoutMs ?? 15_000);
     const deferred = yield* Deferred.make<unknown, PreviewAutomationError>();
     const route = yield* SynchronizedRef.modify(state, (current) => {
       const assignments = new Map(

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -76,6 +76,14 @@ import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
 
 const PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS = 500;
 
+/**
+ * A per-operation timeout is the caller's whole request budget, which outlives
+ * the response budget the broker hands this host. Waiting past that budget
+ * reports the reason into a request the broker has already abandoned.
+ */
+const waitBudgetMs = (requestedMs: number | undefined, responseBudgetMs: number): number =>
+  requestedMs === undefined ? responseBudgetMs : Math.min(requestedMs, responseBudgetMs);
+
 const waitForPreviewPresentation = async (runtimeTabId: string): Promise<void> => {
   const deadline = Date.now() + PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS;
   while (Date.now() <= deadline) {
@@ -489,7 +497,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               ready.runtimeTabId,
               request.operation,
               input.readiness ?? "load",
-              input.timeoutMs ?? request.timeoutMs,
+              waitBudgetMs(input.timeoutMs, request.timeoutMs),
             );
             return await currentStatus(threadRef, ready.tabId);
           }
@@ -530,7 +538,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 ready.tabId,
                 ready.runtimeTabId,
                 setting,
-                input.timeoutMs ?? request.timeoutMs,
+                waitBudgetMs(input.timeoutMs, request.timeoutMs),
                 {
                   requestId: request.requestId,
                   operation: request.operation,

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -31,6 +31,10 @@ export class PreviewAutomationOverlayTimeoutError extends Schema.TaggedErrorClas
     return "PreviewAutomationTimeoutError" as const;
   }
 
+  get timeoutStage() {
+    return "overlay" as const;
+  }
+
   override get message(): string {
     return `Preview webview for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} did not register within ${this.timeoutMs}ms.`;
   }
@@ -51,6 +55,10 @@ export class PreviewAutomationNavigationTimeoutError extends Schema.TaggedErrorC
     return "PreviewAutomationTimeoutError" as const;
   }
 
+  get timeoutStage() {
+    return "navigation" as const;
+  }
+
   override get message(): string {
     return `Preview navigation for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} tab ${this.tabId} did not reach ${this.readiness} readiness within ${this.timeoutMs}ms.`;
   }
@@ -68,6 +76,10 @@ export class PreviewAutomationViewportTimeoutError extends Schema.TaggedErrorCla
 ) {
   get responseTag() {
     return "PreviewAutomationTimeoutError" as const;
+  }
+
+  get timeoutStage() {
+    return "viewport" as const;
   }
 
   override get message(): string {
@@ -218,15 +230,27 @@ export type PreviewAutomationHostError = typeof PreviewAutomationHostError.Type;
 
 export const isPreviewAutomationHostError = Schema.is(PreviewAutomationHostError);
 
+/**
+ * Timeouts all collapse onto the wire's single timeout tag, so the stage a host
+ * gave up in rides along in the detail. It is what lets the server tell "the
+ * overlay never registered" apart from a generic expiry.
+ */
 export function serializePreviewAutomationHostError(
   error: PreviewAutomationHostError,
 ): NonNullable<PreviewAutomationResponse["error"]> {
-  const detail = Object.fromEntries(
-    Object.entries(error).filter(
-      ([key]) =>
-        key !== "_tag" && key !== "cause" && key !== "name" && key !== "message" && key !== "stack",
+  const detail = {
+    ...Object.fromEntries(
+      Object.entries(error).filter(
+        ([key]) =>
+          key !== "_tag" &&
+          key !== "cause" &&
+          key !== "name" &&
+          key !== "message" &&
+          key !== "stack",
+      ),
     ),
-  );
+    ...("timeoutStage" in error ? { timeoutStage: error.timeoutStage } : {}),
+  };
   return {
     _tag: error.responseTag,
     message: error.message,

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -10,6 +10,7 @@ import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  PreviewAutomationOverlayTimeoutError,
   PreviewAutomationRecordingNotActiveError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationViewportTimeoutError,
@@ -265,6 +266,28 @@ describe("previewAutomationRequestConsumer", () => {
     ).toMatchObject({
       _tag: "PreviewAutomationExecutionError",
       detail: { tabId: null },
+    });
+  });
+
+  it("names the stage an overlay timeout gave up in", () => {
+    const error = new PreviewAutomationOverlayTimeoutError({
+      requestId: "request-snapshot",
+      environmentId,
+      threadId,
+      timeoutMs: 14_000,
+    });
+
+    expect(
+      serializePreviewAutomationError(error, {
+        requestId: "request-snapshot",
+        operation: "snapshot",
+        environmentId,
+        threadId,
+        tabId,
+      }),
+    ).toMatchObject({
+      _tag: "PreviewAutomationTimeoutError",
+      detail: { timeoutStage: "overlay", timeoutMs: 14_000 },
     });
   });
 

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -726,16 +726,33 @@ export class PreviewAutomationTabNotFoundError extends Schema.TaggedErrorClass<P
   }
 }
 
+/**
+ * What the host was waiting for when it ran out of budget. Hosts collapse their
+ * own timeout errors onto the wire's timeout tag, so this closed vocabulary is
+ * what carries the reason back to the caller without echoing remote text.
+ */
+export const PreviewAutomationTimeoutStage = Schema.Literals(["overlay", "navigation", "viewport"]);
+export type PreviewAutomationTimeoutStage = typeof PreviewAutomationTimeoutStage.Type;
+
+const previewAutomationTimeoutStageSummary = {
+  overlay: "waiting for the preview overlay to become available",
+  navigation: "waiting for the page to finish loading",
+  viewport: "waiting for the viewport to render at the requested size",
+} as const satisfies Record<PreviewAutomationTimeoutStage, string>;
+
 export class PreviewAutomationTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationTimeoutError>()(
   "PreviewAutomationTimeoutError",
   {
     ...PreviewAutomationRequestErrorFields,
     ...PreviewAutomationOptionalRemoteDiagnosticFields,
+    timeoutStage: Schema.optional(PreviewAutomationTimeoutStage),
   },
 ) {
   override get message(): string {
-    const summary = `Preview automation ${this.operation} timed out after ${this.timeoutMs}ms.`;
-    return summary;
+    const summary = `Preview automation ${this.operation} timed out after ${this.timeoutMs}ms`;
+    return this.timeoutStage === undefined
+      ? `${summary}.`
+      : `${summary} ${previewAutomationTimeoutStageSummary[this.timeoutStage]}.`;
   }
 }
 


### PR DESCRIPTION
`waitForDesktopOverlay` waited for the desktop preview overlay using `request.timeoutMs`, the exact deadline the broker uses to abandon the request, so both expired at the same instant: the broker always fired its generic `PreviewAutomationTimeoutError` first and dropped the deferred, and the host's precise overlay error was reported into a request nobody was listening to. Agents retried doomed calls because "Preview automation evaluate timed out after 15000ms." says nothing about the overlay never becoming available.

The broker now hands the host a wait budget below its own deadline (`timeoutMs` minus a tenth, capped at 1s — 14000ms for the default 15000ms request), so a host that gives up still has room to say why over the wire. Caller-facing semantics are unchanged: the broker still abandons at the full `timeoutMs` and still reports that number.

Landing the response in time is only half of it: `PreviewAutomationTimeoutError.message` ignored the remote message, so the reason would still have been invisible. Host timeouts now carry a closed `timeoutStage` vocabulary (`overlay`, `navigation`, `viewport`) in the response detail — no remote text is echoed, matching the existing structured-diagnostics policy — and the caller's message reads `Preview automation snapshot timed out after 15000ms waiting for the preview overlay to become available.` Per-operation `input.timeoutMs` on navigate/resize is clamped to the wire budget so it cannot re-open the same race.

Fixes #8257

Not addressed here, both filed as separate concerns in the issue's "supporting observations": `preview_snapshot` still flattens every failure to `"Preview snapshot failed."` in `content` (its reason now reaches `structuredContent`/logs but the fixed text was a deliberate hardening against `Cause.pretty` leakage, so changing it is its own decision), and these calls still record as `Success` spans. The desktop `waitFor` deadline in `apps/desktop/src/preview/Manager.ts` shares the same collision with `input.timeoutMs`, untouched here.

Verification:
- `vp test run apps/server/src/mcp/ apps/web/src/components/preview/` — 28 files, 144 tests pass.
- Both new broker tests fail on the unfixed code (`expected [ 15000, 200 ] to deeply equal [ 14000, 180 ]`, and the caller receiving a stage-less generic timeout), so they pin the regression rather than the implementation.
- `vp run --filter @t3tools/contracts typecheck`, `--filter t3 typecheck`, `--filter @t3tools/web typecheck` clean (server prints only pre-existing suggestions in unrelated files).
- `vp lint` and `vp fmt --check` clean on the six touched files.
- No dev server or browser was launched; the desktop overlay path itself is not exercised by automated tests.

Implemented with Claude Opus via the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview automation timeout semantics (hosts get less wall time) and error shaping on a critical agent-facing path; behavior is covered by new broker tests but desktop overlay timing is not fully exercised in CI.
> 
> **Overview**
> Fixes a race where the broker and preview host shared the same deadline, so the broker’s generic `PreviewAutomationTimeoutError` usually won before the host could report *why* (e.g. overlay never registered).
> 
> The broker now routes a **shorter wait budget** to hosts (`hostResponseBudgetMs`: caller timeout minus min(1000ms, 10%)) while still abandoning the caller at the full `timeoutMs`. Host navigate/resize waits use `waitBudgetMs` so per-operation `input.timeoutMs` cannot exceed that wire budget.
> 
> Host timeout failures carry a closed **`timeoutStage`** (`overlay`, `navigation`, `viewport`) in response detail; the broker validates and maps it onto `PreviewAutomationTimeoutError`, with stage-specific caller messages. Unknown stages are dropped. Contracts, host error serialization, and broker tests cover budget routing and stage forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fac6348db56fb3be5a4456283b1e4b0f26e238e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `PreviewAutomationTimeoutError` with `timeoutStage` to automation callers
> - Broker now sends the host a reduced timeout (`hostResponseBudgetMs`) so the host can report failures before the broker's own deadline; broker-side timeout is clamped to a minimum of 2ms via `MINIMUM_BROKER_TIMEOUT_MS`
> - Host timeout error classes (`PreviewAutomationOverlayTimeoutError`, `PreviewAutomationNavigationTimeoutError`, `PreviewAutomationViewportTimeoutError`) now expose a `timeoutStage` getter, and `serializePreviewAutomationHostError` includes it in the wire detail
> - `classifyResponseError` in `PreviewAutomationBroker` parses the remote `timeoutStage` and attaches it to the surfaced `PreviewAutomationTimeoutError`; unrecognized stages are ignored and yield a generic timeout message
> - Host per-operation waits (navigation readiness, viewport render) are now capped by `waitBudgetMs`, the smaller of the per-operation timeout and the broker-supplied budget
> - Behavioral Change: the host receives a strictly smaller timeout than the broker's overall invoke timeout; `PreviewAutomationTimeoutError` may now carry an optional `timeoutStage` field of type `PreviewAutomationTimeoutStage` (closed literal: `overlay`, `navigation`, `viewport`) and produces a stage-specific message when present
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fac634.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->