### PR TITLE
fix(web): pull request surface offers the checkout's PR

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4406,12 +4406,12 @@ function ChatViewContent(props: ChatViewProps) {
     linkedPullRequest: linkedThreadPullRequest,
     linkedPullRequestStatus,
   });
-  // The right panel offers the thread's own change request, else the checkout's: the same one
-  // the git menu's "View PR" opens in this panel. A shared checkout keeps the recorded thread
-  // branch strict (#4460), so an agent that branches and opens a PR mid-thread leaves the thread
-  // without one while the checkout has it. Without either the picker says so rather than
+  // The right panel offers the thread's own change request, else the checkout's open one: the
+  // same one the git menu's "View PR" opens in this panel. A shared checkout keeps the recorded
+  // thread branch strict (#4460), so an agent that branches and opens a PR mid-thread leaves the
+  // thread without one while the checkout has it. Without either the picker says so rather than
   // opening an empty panel.
-  const checkoutPr = gitStatusQuery.data?.pr ?? null;
+  const checkoutPr = gitStatusQuery.data?.pr?.state === "open" ? gitStatusQuery.data.pr : null;
   const addPullRequestSurface = useCallback(() => {
     if (activeThreadPr !== null) {
       openThreadPullRequest(activeThreadPr.number);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4406,14 +4406,24 @@ function ChatViewContent(props: ChatViewProps) {
     linkedPullRequest: linkedThreadPullRequest,
     linkedPullRequestStatus,
   });
-  // The right panel offers the thread's own change request, so it can only offer it once the
-  // branch has one; until then the picker says so rather than opening an empty panel.
+  // The right panel offers the thread's own change request, else the checkout's: the same one
+  // the git menu's "View PR" opens in this panel. A shared checkout keeps the recorded thread
+  // branch strict (#4460), so an agent that branches and opens a PR mid-thread leaves the thread
+  // without one while the checkout has it. Without either the picker says so rather than
+  // opening an empty panel.
+  const checkoutPr = gitStatusQuery.data?.pr ?? null;
   const addPullRequestSurface = useCallback(() => {
-    if (activeThreadPr === null) return;
-    openThreadPullRequest(activeThreadPr.number);
-  }, [activeThreadPr, openThreadPullRequest]);
+    if (activeThreadPr !== null) {
+      openThreadPullRequest(activeThreadPr.number);
+    } else if (checkoutPr !== null) {
+      openProjectPullRequest(checkoutPr.number);
+    }
+  }, [activeThreadPr, checkoutPr, openProjectPullRequest, openThreadPullRequest]);
   const pullRequestSurfaceAvailable =
-    supportsPullRequests && activeThreadPr !== null && threadRepository !== null;
+    supportsPullRequests &&
+    (activeThreadPr !== null
+      ? threadRepository !== null
+      : checkoutPr !== null && activeProjectRepository !== null);
   // Primitive slice of the displayed PR for the settle-rule memos below:
   // resolveDisplayedThreadPr returns a fresh object every render, so memoize
   // on the fields the rules read instead of the object identity.

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4409,9 +4409,13 @@ function ChatViewContent(props: ChatViewProps) {
   // The right panel offers the thread's own change request, else the checkout's open one: the
   // same one the git menu's "View PR" opens in this panel. A shared checkout keeps the recorded
   // thread branch strict (#4460), so an agent that branches and opens a PR mid-thread leaves the
-  // thread without one while the checkout has it. Without either the picker says so rather than
-  // opening an empty panel.
-  const checkoutPr = gitStatusQuery.data?.pr?.state === "open" ? gitStatusQuery.data.pr : null;
+  // thread without one while the checkout has it. A linked PR is the thread's own even while
+  // its detail is still loading, so the checkout never stands in for it. Without either the
+  // picker says so rather than opening an empty panel.
+  const checkoutPr =
+    linkedThreadPullRequest === null && gitStatusQuery.data?.pr?.state === "open"
+      ? gitStatusQuery.data.pr
+      : null;
   const addPullRequestSurface = useCallback(() => {
     if (activeThreadPr !== null) {
       openThreadPullRequest(activeThreadPr.number);

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -99,7 +99,7 @@ const SURFACE_DISABLED_REASONS = {
   terminal: "Terminal surfaces are only available from a project thread.",
   files: "Files are only available when a project is open.",
   diff: "Diff is only available for server threads in Git repositories.",
-  pullRequest: "This thread's branch has no pull request yet.",
+  pullRequest: "This branch has no pull request yet.",
   agents: "Agents are only available from a thread.",
 } as const;
 


### PR DESCRIPTION
## Problem

On a thread whose checkout has an open pull request, the git menu shows **View PR** and opens that PR in the right panel, yet the right panel's own **Pull request** card is disabled with "No pull request on this branch yet." Two entry points to the same panel disagree about whether a PR exists.

The card only offered the thread's *own* PR, which requires the recorded thread branch to match the checkout. On a shared (non-worktree) checkout that recorded branch deliberately stays strict (#4460), so the common flow of an agent running `git checkout -b` and `gh pr create` mid-thread leaves the thread without an attributed PR while the checkout clearly has one.

Closes #8265

## Solution

The card now falls back to the checkout's PR, opened against the project repository with the same gate **View PR** already uses. The thread's own PR still wins when it has one, and thread attribution (sidebar badge, composer footer, auto-settle) is unchanged. The menu's disabled reason now reads "This branch has no pull request yet." to match.

## Before

Reporter's screenshot: View PR enabled, Pull request card disabled.

<img width="823" alt="View PR enabled while the Pull request card says no PR" src="https://github.com/user-attachments/assets/f25235cc-bc86-4fec-8594-43f84db040f5" />

## After

The card is enabled whenever View PR would open a PR in the panel, and opens the same one.

## Verification

- `vp run typecheck` for `apps/web`
- `vp lint` and `vp fmt --check` on the two changed files
- `vp test run apps/web/src/components/RightPanelTabs.test.tsx`

---
Made with Claude Fable 5 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only fallback for opening an existing checkout PR in the right panel; thread PR resolution and attribution logic are unchanged.
> 
> **Overview**
> Aligns the right panel **Pull request** card with the git menu **View PR** when a thread has no attributed PR but the checkout has an open one.
> 
> **ChatView** now derives `checkoutPr` from git status (open PR only, and only when there is no linked thread PR) and enables the surface when either the thread PR or that checkout PR exists. Opening the surface prefers the thread PR via `openThreadPullRequest`; otherwise it opens the checkout PR with `openProjectPullRequest`, matching **View PR**.
> 
> **RightPanelTabs** updates the disabled copy to *"This branch has no pull request yet."* so it is not thread-specific when the fallback applies. Thread attribution elsewhere is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d2dc7d2f089923892108ea0870c41b9a1385cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Offer checkout PR on Pull Request surface when thread has no PR
> - Derives `checkoutPr` from `gitStatusQuery` in `ChatViewContent` so the PR surface shows an open checkout PR even when the thread has no linked PR
> - Opens the thread PR when one exists; otherwise opens the project's checkout PR via `openProjectPullRequest`
> - `pullRequestSurfaceAvailable` is now true when either the thread has a PR and `threadRepository` is present, or the checkout has an open PR and `activeProjectRepository` is present
> - Updates the disabled-reason text in [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/8273/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) from "This thread's branch has no pull request yet." to "This branch has no pull request yet."
> - Behavioral Change: the PR surface now activates for branches with an open checkout PR regardless of thread PR state, which may surface PRs that were previously hidden
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21d2dc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->