### PR TITLE
fix(usage): scan transcripts for every configured provider instance

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -14,7 +14,12 @@
 import * as NodeOS from "node:os";
 
 import {
+  ClaudeSettings,
+  CodexSettings,
+  defaultInstanceIdForDriver,
+  ProviderDriverKind,
   USAGE_CONTRACT_VERSION,
+  type ServerSettings as ServerSettingsDocument,
   type UsageProviderKind,
   type UsageSource,
   type UsageSummary,
@@ -52,6 +57,64 @@ import {
   type ScanCache,
 } from "./usageScanCache.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
+
+/**
+ * A configured provider instance whose CLI writes transcripts this scanner can
+ * read. Cursor, Grok and OpenCode are absent because nothing parses their
+ * session files yet.
+ */
+type ScannableInstance =
+  | { readonly driver: "claudeAgent"; readonly settings: ClaudeSettings }
+  | { readonly driver: "codex"; readonly settings: CodexSettings };
+
+const CLAUDE_DRIVER = ProviderDriverKind.make("claudeAgent");
+const CODEX_DRIVER = ProviderDriverKind.make("codex");
+const decodeClaudeSettings = Schema.decodeUnknownSync(ClaudeSettings);
+const decodeCodexSettings = Schema.decodeUnknownSync(CodexSettings);
+
+function decodeOrUndefined<A>(decode: (input: unknown) => A, input: unknown): A | undefined {
+  try {
+    return decode(input ?? {});
+  } catch {
+    // The provider registry already surfaces undecodable instances as
+    // "unavailable"; usage just skips them rather than failing the whole scan.
+    return undefined;
+  }
+}
+
+/**
+ * Every instance whose transcripts should be scanned.
+ *
+ * Mirrors `deriveProviderInstanceConfigMap`: explicit `providerInstances`
+ * entries win, and a driver whose default instance id is not claimed by one
+ * falls back to the legacy `providers.<kind>` blob. Written here rather than
+ * reused from the provider layer because usage needs decoded per-driver
+ * settings, not the opaque envelopes the registry passes to drivers.
+ */
+export function scannableInstanceConfigs(
+  settings: ServerSettingsDocument,
+): ReadonlyArray<ScannableInstance> {
+  const instances: ScannableInstance[] = [];
+
+  for (const entry of Object.values(settings.providerInstances)) {
+    if (entry.driver === CLAUDE_DRIVER) {
+      const decoded = decodeOrUndefined(decodeClaudeSettings, entry.config);
+      if (decoded) instances.push({ driver: "claudeAgent", settings: decoded });
+    } else if (entry.driver === CODEX_DRIVER) {
+      const decoded = decodeOrUndefined(decodeCodexSettings, entry.config);
+      if (decoded) instances.push({ driver: "codex", settings: decoded });
+    }
+  }
+
+  if (!(defaultInstanceIdForDriver(CLAUDE_DRIVER) in settings.providerInstances)) {
+    instances.push({ driver: "claudeAgent", settings: settings.providers.claudeAgent });
+  }
+  if (!(defaultInstanceIdForDriver(CODEX_DRIVER) in settings.providerInstances)) {
+    instances.push({ driver: "codex", settings: settings.providers.codex });
+  }
+
+  return instances;
+}
 
 const LITELLM_RATES_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -215,14 +278,45 @@ export const make = Effect.gen(function* () {
       ),
     );
 
-    const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
-    const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    // One directory per configured instance, not one per driver: a second
+    // Claude or Codex points at its own home, and scanning only the default
+    // one silently under-reports every turn the other instance ran.
+    const dirs: Array<{ readonly provider: UsageProviderKind; readonly dir: string }> = [];
+    const seenDirs = new Set<string>();
+    const addDir = Effect.fn("UsageService.addTranscriptDir")(function* (
+      provider: UsageProviderKind,
+      dir: string,
+    ) {
+      // Two instances may legitimately share a home (differing only by binary
+      // or launch args), and two spellings can reach the same directory
+      // through a symlink. Either way the records are the same records, and
+      // cross-file de-duplication does not exist — `dedupeWithinFile` is the
+      // only guard — so scanning it twice doubles that home's reported cost.
+      //
+      // Canonicalize before comparing. A directory that does not exist yet has
+      // no real path; fall back to the resolved one, which still catches the
+      // plain duplicate case.
+      const canonical = yield* fileSystem
+        .realPath(dir)
+        .pipe(Effect.catchCause(() => Effect.succeed(dir)));
+      if (seenDirs.has(canonical)) return;
+      seenDirs.add(canonical);
+      // Scan the path we resolved, not the canonical one: the fingerprint a
+      // source reports should be the directory the instance is configured with.
+      dirs.push({ provider, dir });
+    });
 
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
-    ];
+    for (const config of scannableInstanceConfigs(settings)) {
+      if (config.driver === "claudeAgent") {
+        const claudeHome = yield* resolveClaudeHomePath(config.settings);
+        yield* addDir("claude", yield* resolveClaudeTranscriptDir(claudeHome));
+        continue;
+      }
+      const codexLayout = yield* resolveCodexHomeLayout(config.settings);
+      yield* addDir("codex", path.join(codexLayout.sharedHomePath, "sessions"));
+    }
+
+    return dirs;
   });
 
   /**

--- a/apps/server/src/usage/usageInstances.test.ts
+++ b/apps/server/src/usage/usageInstances.test.ts
@@ -1,0 +1,72 @@
+import { ProviderInstanceId, ServerSettings } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { describe, it } from "@effect/vitest";
+import * as NodeAssert from "node:assert/strict";
+
+import { scannableInstanceConfigs } from "./UsageService.ts";
+
+const decodeSettings = Schema.decodeUnknownSync(ServerSettings);
+
+describe("scannableInstanceConfigs", () => {
+  it("falls back to the legacy per-driver settings when no instances are configured", () => {
+    const configs = scannableInstanceConfigs(decodeSettings({}));
+    NodeAssert.deepStrictEqual(
+      configs.map((config) => config.driver),
+      ["claudeAgent", "codex"],
+    );
+  });
+
+  it("includes every configured Claude instance, not just the default one", () => {
+    const settings = decodeSettings({
+      providers: { claudeAgent: { homePath: "~/.claude" } },
+      providerInstances: {
+        [ProviderInstanceId.make("claudeAgent_work")]: {
+          driver: "claudeAgent",
+          config: { homePath: "/tmp/claude-work" },
+        },
+      },
+    });
+
+    const homePaths = scannableInstanceConfigs(settings)
+      .filter((config) => config.driver === "claudeAgent")
+      .map((config) => config.settings.homePath)
+      .sort();
+
+    NodeAssert.deepStrictEqual(homePaths, ["/tmp/claude-work", "~/.claude"]);
+  });
+
+  // An explicit entry under the default id is the user's override of the
+  // legacy blob; hydration lets it win, so the scan must not read both.
+  it("prefers an explicit default-id instance over the legacy blob", () => {
+    const settings = decodeSettings({
+      providers: { claudeAgent: { homePath: "/tmp/legacy" } },
+      providerInstances: {
+        [ProviderInstanceId.make("claudeAgent")]: {
+          driver: "claudeAgent",
+          config: { homePath: "/tmp/explicit" },
+        },
+      },
+    });
+
+    const homePaths = scannableInstanceConfigs(settings)
+      .filter((config) => config.driver === "claudeAgent")
+      .map((config) => config.settings.homePath);
+
+    NodeAssert.deepStrictEqual(homePaths, ["/tmp/explicit"]);
+  });
+
+  // Forks and rollbacks leave entries for drivers this build cannot read.
+  it("ignores instances whose driver has no transcript reader", () => {
+    const settings = decodeSettings({
+      providerInstances: {
+        [ProviderInstanceId.make("opencode_local")]: { driver: "opencode", config: {} },
+        [ProviderInstanceId.make("ollama_local")]: { driver: "ollama", config: {} },
+      },
+    });
+
+    NodeAssert.deepStrictEqual(
+      scannableInstanceConfigs(settings).map((config) => config.driver),
+      ["claudeAgent", "codex"],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The Usage page under-reports whenever more than one instance of Claude or Codex is configured.

`resolveTranscriptDirs` resolves exactly two directories, both from the legacy per-driver blobs:

```ts
const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
```

`settings.providerInstances` is never consulted. A second Claude or Codex points at its own home, so every turn it ran is invisible — the page shows a plausible-looking number that is simply missing that account's spend.

It also misses the default instance's real home once the default row has been edited in Settings: `buildProviderInstanceUpdatePatch` promotes that row into `providerInstances.<kind>` and resets `providers.<kind>` to schema defaults, so the blob this function reads is blank while the instance entry holds the real `homePath`.

## Fix

Derive the directory list from the configured instances, with the same precedence hydration already uses — an explicit `providerInstances` entry wins over the legacy mirror for that driver's default slot, and drivers with no explicit entry fall back to the blob.

Directories are deduped by resolved path, so two instances that differ only by binary or launch args (sharing one home) are not counted twice. Drivers with no transcript reader — cursor, grok, opencode, and anything a fork adds — are skipped, and an instance whose config cannot decode is skipped rather than failing the whole scan, since the provider registry already surfaces those as unavailable.

The scan loop itself was already per-directory and stamps each source with its own `resolvedHomePath` fingerprint, so multiple directories per provider needed no further change.

## Tests

New `usageInstances.test.ts` covers the legacy fallback, several Claude instances, explicit-entry precedence over the legacy blob, and unreadable drivers being ignored.

`vp test run apps/server/src/usage` — 42 passed. Typecheck and lint clean.

---
Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which directories drive usage totals; misconfigured or undecodable instances are skipped silently, so spend can still look low without a scan error.
> 
> **Overview**
> Fixes **under-reported usage** when multiple Claude or Codex instances exist, or when the real home lives only under `providerInstances` after Settings edits.
> 
> **`scannableInstanceConfigs`** builds the scan list from `ServerSettings`: all Claude/Codex `providerInstances` (decoded settings), with legacy `providers.<driver>` only when the default instance id is missing—matching provider hydration precedence. Unreadable instance configs and drivers without transcript parsers are skipped without failing the scan.
> 
> **`resolveTranscriptDirs`** now resolves **one transcript directory per scannable instance** (not one per driver) and **dedupes by `realPath`** so shared homes are not scanned twice and costs are not doubled.
> 
> New **`usageInstances.test.ts`** covers legacy fallback, multiple Claude homes, explicit default-id over legacy blob, and ignored non-scannable drivers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64148a3a648efb8fc54b8c3f4ea083d919cbf1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scan transcripts for every configured Claude and Codex provider instance
> - Replaces fixed per-driver directory resolution with per-instance resolution driven by `scannableInstanceConfigs`, which decodes `claudeAgent` and `Codex` configs from `settings.providerInstances`
> - Falls back to legacy `settings.providers.<kind>` blob when no explicit instance exists under the driver's default id
> - De-duplicates directories by canonical path via `realPath` to avoid double-counting instances that resolve to the same location
> - Adds test coverage in [usageInstances.test.ts](https://github.com/pingdotgg/t3code/pull/8276/files#diff-bc80dfc931095c5fbac66a5df83f6594d8f78b70dfdad9ee32f1553c30a70766) for legacy fallback, non-default instances, default-id preference, and unsupported-driver exclusion
> - Risk: undecodable or unsupported-driver instance configs are silently skipped — check `scannableInstanceConfigs` in [UsageService.ts](https://github.com/pingdotgg/t3code/pull/8276/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) if expected instances are missing from usage scans
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c64148a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->