### PR TITLE
fix(settings): keep the rest of settings.json when one provider instance is malformed

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -985,6 +985,68 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  // `providerInstances` is a Record schema, so one bad key fails the whole
+  // settings decode. Reverting every unrelated setting because of a typo in a
+  // hand-added second provider is not an acceptable blast radius.
+  it.effect("keeps unrelated settings when one provider instance is malformed", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        // Leading digit on the second key fails the instance-id slug pattern.
+        '{"providers":{"claudeAgent":{"binaryPath":"/tmp/claude"}},' +
+          '"providerInstances":{"claudeAgent_work":{"driver":"claudeAgent",' +
+          '"config":{"homePath":"/tmp/work"}},"2claude_broken":{"driver":"claudeAgent"}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.strictEqual(settings.providers.claudeAgent.binaryPath, "/tmp/claude");
+      assert.deepEqual(Object.keys(settings.providerInstances), ["claudeAgent_work"]);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  // The in-memory settings are what the next write persists, so a file we could
+  // not read has to survive somewhere before that write lands.
+  it.effect("quarantines a settings file it cannot read", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const original = '{"providers":{"claudeAgent":{"binaryPath":42}}}';
+
+      yield* fileSystem.writeFileString(serverConfig.settingsPath, original);
+
+      const settings = yield* serverSettings.getSettings;
+      assert.strictEqual(settings.providers.claudeAgent.binaryPath, "claude");
+
+      const quarantined = yield* fileSystem.readFileString(`${serverConfig.settingsPath}.invalid`);
+      assert.strictEqual(quarantined, original);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  // The Record schema trims instance-id keys on decode, so a key with stray
+  // whitespace is valid. Salvage must not classify it as malformed and drop it.
+  it.effect("keeps an instance whose key has surrounding whitespace", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providerInstances":{"  claudeAgent_work  ":{"driver":"claudeAgent"},' +
+          '"2claude_broken":{"driver":"claudeAgent"}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+      assert.deepEqual(Object.keys(settings.providerInstances), ["claudeAgent_work"]);
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("stores sensitive provider instance environment values outside settings.json", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_SERVER_SETTINGS,
   type ModelSelection,
   type ProviderInstanceConfig,
+  ProviderInstanceConfig as ProviderInstanceConfigSchema,
   type ProviderInstanceEnvironmentVariable,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -292,6 +293,74 @@ function restoreUsedProviders(
   };
 }
 
+const decodeLenientJsonValueExit = Schema.decodeUnknownExit(fromLenientJson(Schema.Unknown));
+const decodeServerSettingsExit = Schema.decodeUnknownExit(ServerSettings);
+const decodeProviderInstanceConfigExit = Schema.decodeUnknownExit(ProviderInstanceConfigSchema);
+const decodeProviderInstanceIdExit = Schema.decodeUnknownExit(ProviderInstanceId);
+
+/**
+ * Drop the `providerInstances` entries that cannot decode, keeping the rest of
+ * the document.
+ *
+ * `providerInstances` is a `Schema.Record(ProviderInstanceId, ...)`, so one
+ * malformed key or a missing `driver` fails the *whole* settings decode — and a
+ * whole-document failure means every unrelated setting silently reverts to
+ * defaults. Hand-editing this map is a documented way to configure a second
+ * provider instance, so a typo there must not cost the user their keybindings,
+ * projects, and provider paths.
+ *
+ * Returns `undefined` when there is nothing to prune, so the caller does not
+ * retry a decode that is failing for some other reason.
+ */
+function pruneUndecodableProviderInstances(
+  document: unknown,
+): { readonly document: unknown; readonly droppedKeys: ReadonlyArray<string> } | undefined {
+  if (typeof document !== "object" || document === null) return undefined;
+  const record = document as Record<string, unknown>;
+  const instances = record["providerInstances"];
+  if (typeof instances !== "object" || instances === null) return undefined;
+
+  const kept: Record<string, unknown> = {};
+  const droppedKeys: string[] = [];
+  for (const [key, value] of Object.entries(instances as Record<string, unknown>)) {
+    // Decode rather than `Schema.is`: `ProviderInstanceId` trims on decode, so
+    // a key like `"  codex_work  "` is accepted by the Record but rejected by
+    // a type check on the raw string. Getting that wrong would drop a valid
+    // instance during salvage — the exact loss this function exists to prevent.
+    if (
+      decodeProviderInstanceIdExit(key)._tag === "Success" &&
+      decodeProviderInstanceConfigExit(value)._tag === "Success"
+    ) {
+      kept[key] = value;
+    } else {
+      droppedKeys.push(key);
+    }
+  }
+
+  if (droppedKeys.length === 0) return undefined;
+  return { document: { ...record, providerInstances: kept }, droppedKeys };
+}
+
+/**
+ * Re-decode a settings document after dropping the `providerInstances` entries
+ * that cannot decode. Returns `undefined` when there was nothing to drop, or
+ * when the document still fails for some other reason.
+ */
+function salvageSettingsWithoutMalformedInstances(
+  raw: string,
+): { readonly settings: ServerSettings; readonly droppedKeys: ReadonlyArray<string> } | undefined {
+  const parsed = decodeLenientJsonValueExit(raw);
+  if (parsed._tag !== "Success") return undefined;
+
+  const pruned = pruneUndecodableProviderInstances(parsed.value);
+  if (!pruned) return undefined;
+
+  const salvaged = decodeServerSettingsExit(pruned.document);
+  if (salvaged._tag !== "Success") return undefined;
+
+  return { settings: salvaged.value, droppedKeys: pruned.droppedKeys };
+}
+
 function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings {
   return isModelSelectionProviderEnabled(settings, settings.textGenerationModelSelection)
     ? settings
@@ -410,6 +479,44 @@ const make = Effect.gen(function* () {
     ),
   );
 
+  // Sibling of settings.json rather than a timestamped file: reloads happen on
+  // every watcher tick while the file is broken, and one recoverable copy is
+  // the useful outcome — not a directory full of them.
+  const quarantinePath = `${settingsPath}.invalid`;
+
+  /**
+   * Preserve a settings file the server could not read.
+   *
+   * A failed decode leaves the in-memory settings holding defaults (or a
+   * salvaged subset), and the next `updateSettings` writes that back over
+   * settings.json. Without this copy the user's real configuration is gone with
+   * only a log line to show for it. Failures here are logged and swallowed: a
+   * settings file we cannot back up is still a settings file the server has to
+   * boot with.
+   */
+  // True once this episode of unreadable settings has been preserved. Reset when
+  // the file decodes again, so a later, unrelated breakage still gets a copy.
+  let quarantinedThisEpisode = false;
+
+  const quarantineUnreadableSettings = (raw: string) =>
+    Effect.suspend(() => {
+      // Keep the *first* copy of each episode. Reloads fire on every watcher
+      // tick while the file is broken, and a half-saved buffer landing a second
+      // later must not overwrite the last good configuration.
+      if (quarantinedThisEpisode) return Effect.void;
+      quarantinedThisEpisode = true;
+      return writeFileStringAtomically({ filePath: quarantinePath, contents: raw });
+    }).pipe(
+      Effect.provideService(FileSystem.FileSystem, fs),
+      Effect.provideService(Path.Path, pathService),
+      Effect.catchCause((cause) =>
+        Effect.logWarning("could not quarantine unreadable settings.json", {
+          path: quarantinePath,
+          cause,
+        }),
+      ),
+    );
+
   const loadSettingsFromDisk = Effect.gen(function* () {
     let settings = DEFAULT_SERVER_SETTINGS;
     let persisted: typeof PersistedOptionalProviderSettings.Type = {};
@@ -423,15 +530,36 @@ const make = Effect.gen(function* () {
       }
       if (decoded._tag === "Failure" || persistedSettings._tag === "Failure") {
         const failure = decoded._tag === "Failure" ? decoded : persistedSettings;
-        if (failure._tag === "Failure") {
+
+        // Whatever happens next, the in-memory settings no longer match the
+        // file, and the next settings change rewrites the file from that
+        // in-memory copy. Keep a copy first so a typo is never the reason a
+        // configuration is destroyed.
+        yield* quarantineUnreadableSettings(raw);
+
+        const salvaged = salvageSettingsWithoutMalformedInstances(raw);
+        if (salvaged) {
+          settings = salvaged.settings;
+          yield* Effect.logWarning(
+            "dropped malformed provider instances from settings.json, kept every other setting",
+            {
+              path: settingsPath,
+              droppedInstanceIds: salvaged.droppedKeys,
+              quarantinePath,
+              ...(failure._tag === "Failure" ? { issues: Cause.pretty(failure.cause) } : {}),
+            },
+          );
+        } else if (failure._tag === "Failure") {
           yield* Effect.logWarning("failed to parse settings.json, using defaults", {
             path: settingsPath,
+            quarantinePath,
             issues: Cause.pretty(failure.cause),
             cause: failure.cause,
           });
         }
       } else {
         settings = decoded.value;
+        quarantinedThisEpisode = false;
       }
     }
 


### PR DESCRIPTION
## Problem

One malformed `providerInstances` entry silently resets **every** setting, and the next settings change makes that permanent.

`providerInstances` is a `Schema.Record(ProviderInstanceId, ProviderInstanceConfig)`, so a key that fails the slug pattern, or an entry missing `driver`, fails the whole `ServerSettings` decode. `loadSettingsFromDisk` logs a warning and returns `DEFAULT_SERVER_SETTINGS`. From the UI this looks like every setting spontaneously reverted. Then `updateSettings` computes the next state from that defaulted `current` and calls `writeSettingsAtomically`, so the first subsequent change — a provider toggle is enough — overwrites `settings.json` with defaults. Keybindings, projects, provider paths, and any other instances are gone, with a log line as the only trace.

`fromLenientJson` is lenient about JSON syntax, not about schema errors, so this is reachable from an ordinary typo. Hand-editing this map is a documented way to configure a second provider instance (`docs/user/providers-claude.md`), which makes the typo a realistic one.

To reproduce: add `"providerInstances": { "2claude_work": { "driver": "claudeAgent" } }` to `settings.json` (leading digit fails `PROVIDER_SLUG_PATTERN`), let the watcher reload, then toggle any provider in Settings.

## Fix

Two independent guards:

1. **Salvage.** On a decode failure, re-decode with the undecodable `providerInstances` entries dropped. If that succeeds, keep every other setting and name the dropped ids in the warning. Returns early when there is nothing to prune, so a document failing for some other reason is not retried pointlessly.
2. **Quarantine.** Before the in-memory copy can be written back, copy the unreadable file to `settings.json.invalid`. A stable name rather than a timestamp, since reloads fire on every watcher tick while the file is broken and one recoverable copy is the useful outcome. Failures here are logged and swallowed — a settings file we cannot back up is still one the server has to boot with.

Behaviour on a clean file is unchanged: the success path returns before either guard.

## Tests

Two added to `serverSettings.test.ts`: unrelated settings surviving a malformed instance, and an unreadable file being quarantined byte-for-byte.

`vp test run apps/server/src/serverSettings.test.ts` — 33 passed. Typecheck and lint clean.

Also verified against a running server: injecting a bad instance kept the rest of the config live, wrote `settings.json.invalid` with the bad entry intact, and a subsequent provider toggle persisted without losing anything.

---
Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes critical settings load/persist behavior on decode failure; quarantine write failures are logged and swallowed, so users could still lose recoverability on restricted filesystems.
> 
> **Overview**
> When `settings.json` fails schema decode, the server no longer throws away the whole file and falls back to defaults (which the next `updateSettings` could persist over the user’s config).
> 
> **Salvage:** On decode failure, it prunes only `providerInstances` entries whose keys or values fail `ProviderInstanceId` / `ProviderInstanceConfig` decode (using schema decode so trimmed keys like `"  claudeAgent_work  "` stay valid), then re-decodes the rest. Unrelated fields such as `providers.*` are kept; dropped instance ids are logged.
> 
> **Quarantine:** Before applying defaults or salvaged state, the raw file is copied once per “broken file” episode to `${settingsPath}.invalid` so a later settings write cannot erase the last on-disk config. The flag resets when the file decodes successfully again.
> 
> Tests cover malformed instance + preserved provider paths, full-file quarantine on type errors, and whitespace-padded instance keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6a9721153cd033a34e5b8a841f369ec4f7946e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep valid settings when one provider instance in settings.json is malformed
> - On decode failure in `make`, the server now backs up the raw file to `<settingsPath>.invalid` via `quarantineUnreadableSettings` before attempting recovery
> - `salvageSettingsWithoutMalformedInstances` leniently parses the JSON and drops only the `providerInstances` entries that fail to decode as `ProviderInstanceId` or `ProviderInstanceConfig`, preserving the rest of the document
> - If salvage still fails, the server logs a warning with the dropped keys and quarantine path, then falls back to in-memory defaults
> - Behavioral Change: a module-local `quarantinedThisEpisode` flag suppresses repeated `.invalid` overwrites until the next successful decode; the flag is reset on success in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/8277/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d6a972.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->