### PR TITLE
feat(github): add advisory contribution checks for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,17 +17,38 @@ we may close it without merging it, or never review it.
 
 ## Why
 
-<!-- Explain the problem being solved and why this approach is the right one. -->
+<!-- Explain what users observed, the cause, and why this boundary is the right one. -->
+
+## Owning Context
+
+<!-- Link the bug issue, Ideas discussion, or stacked PR when one exists. For maintainer-directed work without a public link, state that without adding private routing details. -->
+
+## Scope and Non-Goals
+
+<!-- Name what this PR intentionally leaves unchanged or defers. -->
+
+## Affected Areas
+
+<!-- Name the affected clients, providers, platforms, contracts, and connection modes. Say which are not applicable or unsupported. -->
+
+## Validation
+
+<!-- List exact focused commands or direct checks and their results. Do not describe a skipped or partial check as passing. -->
+
+## Risks and Untested Paths
+
+<!-- State known limitations and anything you could not exercise. Use "None known" only when accurate. -->
 
 ## UI Changes
 
 <!-- If this PR changes UI, include clear before/after screenshots.
-     If the change involves motion or interaction, include a short video.
-     Delete this section if not applicable. -->
+     If the change involves motion or interaction, include a labelled "Video:" link.
+     If neither applies, keep this section and state "No visual or interaction changes." -->
 
 ## Checklist
 
 - [ ] This PR is small and focused
 - [ ] I explained what changed and why
+- [ ] I documented scope, affected areas, validation, and untested paths
 - [ ] I included before/after screenshots for any UI changes
 - [ ] I included a video for animation/interaction changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,27 +17,11 @@ we may close it without merging it, or never review it.
 
 ## Why
 
-<!-- Explain what users observed, the cause, and why this boundary is the right one. -->
+<!-- Explain the problem being solved and why this approach is the right one. -->
 
 ## Owning Context
 
 <!-- Link the bug issue, Ideas discussion, or stacked PR when one exists. For maintainer-directed work without a public link, state that without adding private routing details. -->
-
-## Scope and Non-Goals
-
-<!-- Name what this PR intentionally leaves unchanged or defers. -->
-
-## Affected Areas
-
-<!-- Name the affected clients, providers, platforms, contracts, and connection modes. Say which are not applicable or unsupported. -->
-
-## Validation
-
-<!-- List exact focused commands or direct checks and their results. Do not describe a skipped or partial check as passing. -->
-
-## Risks and Untested Paths
-
-<!-- State known limitations and anything you could not exercise. Use "None known" only when accurate. -->
 
 ## UI Changes
 
@@ -49,6 +33,5 @@ we may close it without merging it, or never review it.
 
 - [ ] This PR is small and focused
 - [ ] I explained what changed and why
-- [ ] I documented scope, affected areas, validation, and untested paths
 - [ ] I included before/after screenshots for any UI changes
 - [ ] I included a video for animation/interaction changes

--- a/.github/scripts/pr-guideline-review.cjs
+++ b/.github/scripts/pr-guideline-review.cjs
@@ -350,7 +350,14 @@ function evaluatePull({
 
   const nonProductAreas = new Set(["docs", "GitHub automation"]);
   const onlyNonProductAreas = areas.length > 0 && areas.every((area) => nonProductAreas.has(area));
-  if (!trustedPull && isFeaturePull(pull.title) && !onlyNonProductAreas && !discussionLink) {
+  const onlyTestFiles = files.length > 0 && files.every((file) => isTestFile(file.filename));
+  if (
+    !trustedPull &&
+    isFeaturePull(pull.title) &&
+    !onlyNonProductAreas &&
+    !onlyTestFiles &&
+    !discussionLink
+  ) {
     if (maintainerContext) {
       findings.push(
         finding(

--- a/.github/scripts/pr-guideline-review.cjs
+++ b/.github/scripts/pr-guideline-review.cjs
@@ -36,11 +36,43 @@ function stripComments(markdown) {
 }
 
 function section(markdown, heading) {
-  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = markdown.match(
-    new RegExp(`^##[ \\t]+${escaped}[ \\t]*\\r?\\n([^]*?)(?=^##[ \\t]+|(?![^]))`, "im"),
-  );
-  return stripComments(match?.[1] ?? "");
+  const lines = markdown.split(/\r?\n/);
+  const content = [];
+  let fence;
+  let collecting = false;
+
+  for (const line of lines) {
+    if (fence) {
+      if (collecting) content.push(line);
+      const closingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
+      if (
+        closingFence &&
+        closingFence[1][0] === fence.character &&
+        closingFence[1].length >= fence.length
+      ) {
+        fence = undefined;
+      }
+      continue;
+    }
+
+    const openingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+    if (openingFence && (openingFence[1][0] === "~" || !openingFence[2].includes("`"))) {
+      if (collecting) content.push(line);
+      fence = { character: openingFence[1][0], length: openingFence[1].length };
+      continue;
+    }
+
+    const levelTwoHeading = line.match(/^##[ \t]+(.+?)[ \t]*$/);
+    if (levelTwoHeading) {
+      if (collecting) break;
+      collecting = levelTwoHeading[1].toLowerCase() === heading.toLowerCase();
+      continue;
+    }
+
+    if (collecting) content.push(line);
+  }
+
+  return stripComments(content.join("\n"));
 }
 
 function sectionAny(markdown, headings) {
@@ -78,15 +110,24 @@ function isDefiniteUiFile(file) {
 
 function imageCount(markdown) {
   const markdownImages = markdown.match(/!\[[^\]]*\]\([^\s)]+(?:\s+"[^"]*")?\)/gi) ?? [];
-  const htmlImages = markdown.match(/<img\b[^>]*>/gi) ?? [];
+  const htmlImages = (markdown.match(/<img\b[^>]*>/gi) ?? []).filter((tag) =>
+    hasNonEmptySrc(tag, "img"),
+  );
   const remaining = markdown.replace(/!\[[^\]]*\]\([^)]*\)/g, "").replace(/<img\b[^>]*>/gi, "");
   const bareImageUrls =
     remaining.match(/https?:\/\/[^\s)]+\.(?:avif|gif|jpe?g|png|webp)(?:\?[^\s)]*)?/gi) ?? [];
   return markdownImages.length + htmlImages.length + bareImageUrls.length;
 }
 
+function hasNonEmptySrc(markdown, tagName) {
+  const tags = markdown.match(new RegExp(`<${tagName}\\b[^>]*>`, "gi")) ?? [];
+  return tags.some((tag) => /\bsrc\s*=\s*(?:"[^"\s][^"]*"|'[^'\s][^']*'|[^\s"'=<>]+)/i.test(tag));
+}
+
 function hasVideo(markdown) {
-  if (/<video\b[^>]*>/i.test(markdown)) return true;
+  if (hasNonEmptySrc(markdown, "video")) return true;
+  const videoBlocks = markdown.match(/<video\b[^>]*>[^]*?<\/video\s*>/gi) ?? [];
+  if (videoBlocks.some((block) => hasNonEmptySrc(block, "source"))) return true;
   if (/https?:\/\/[^\s)]+\.(?:mov|mp4|webm)(?:\?[^\s)]*)?/i.test(markdown)) return true;
 
   const withoutImages = markdown.replace(/!\[[^\]]*\]\([^)]*\)/g, "").replace(/<img\b[^>]*>/gi, "");
@@ -108,7 +149,13 @@ function hasDiscussionLink(markdown, repository) {
 }
 
 function isFeaturePull(title) {
-  return /^(?:feat|feature)(?:\([^)]*\))?[!:]/i.test(title.trim());
+  const normalized = title.trim();
+  return (
+    /^(?:feat|feature)(?:\([^)]*\))?[!:]/i.test(normalized) ||
+    /^(?:(?:add|create|implement|introduce|launch)\s+(?:a|an|the|new)\b|(?:enable|support)\b)/i.test(
+      normalized,
+    )
+  );
 }
 
 function hasMaintainerContextStatement(markdown) {
@@ -206,14 +253,16 @@ function evaluatePull({
   const lines = effectiveChangedLines(files);
   const lineKind = lines.nonTest === 0 && lines.test > 0 ? "test" : "non-test";
   const areas = changedAreas(files);
-  const contextLink = hasRepositoryContextLink(body, repository);
-  const discussionLink = hasDiscussionLink(body, repository);
-  const maintainerContext = hasMaintainerContextStatement(body);
+  const visibleBody = stripComments(body);
+  const contextLink = hasRepositoryContextLink(visibleBody, repository);
+  const discussionLink = hasDiscussionLink(visibleBody, repository);
+  const maintainerContext = hasMaintainerContextStatement(visibleBody);
   const uiCandidates = files.filter((file) => isUiCandidate(file.filename));
   const uiFiles = uiCandidates.filter((file) => isDefiniteUiFile(file));
   const uninspectableUiFiles = uiCandidates.filter((file) => file.patch === undefined);
   const trustedPull = isTrustedPull(pull, vouchedUsers);
   const hasMotionChange = uiFiles.some((file) => MOTION_PATTERN.test(changedPatch(file)));
+  const uiEvidence = section(body, "UI Changes");
   const findings = [];
 
   if (!whatChanged) {
@@ -279,7 +328,7 @@ function evaluatePull({
       ),
     );
   }
-  if (uiFiles.length > 0 && imageCount(body) < 2 && !explainsNoVisualChange(body)) {
+  if (uiFiles.length > 0 && imageCount(uiEvidence) < 2 && !explainsNoVisualChange(body)) {
     findings.push(
       finding(
         "missing-ui-images",
@@ -288,7 +337,7 @@ function evaluatePull({
       ),
     );
   }
-  if (hasMotionChange && !hasVideo(body) && !explainsNoInteractionChange(body)) {
+  if (hasMotionChange && !hasVideo(uiEvidence) && !explainsNoInteractionChange(body)) {
     findings.push(
       finding(
         "missing-interaction-video",

--- a/.github/scripts/pr-guideline-review.cjs
+++ b/.github/scripts/pr-guideline-review.cjs
@@ -1,0 +1,542 @@
+const COMMENT_MARKER = "<!-- t3-pr-guideline-review -->";
+
+const TEST_FILE_PATTERNS = [
+  /^apps\/server\/integration\//,
+  /(^|\/)__tests__(\/|$)/,
+  /(^|\/)tests?(\/|$)/,
+  /\.test\.[^/]+$/,
+  /\.spec\.[^/]+$/,
+  /\.browser\.[^/]+$/,
+  /\.integration\.[^/]+$/,
+];
+
+const UI_FILE_PATTERNS = [
+  /^apps\/web\/src\/.*\.(?:css|jsx|scss|tsx)$/,
+  /^apps\/mobile\/.*\.(?:css|jsx|scss|tsx)$/,
+  /^apps\/desktop\/src\/.*\.(?:css|jsx|scss|tsx)$/,
+];
+
+const MOTION_PATTERN =
+  /(?:@keyframes|\banimation(?:-duration|-name)?\s*:|\btransition(?:-duration|-property)?\s*:|\bLayoutAnimation\b|\bAnimated\.(?:decay|event|loop|parallel|sequence|spring|stagger|timing)\s*\(|\bwithTiming\s*\(|\buseAnimatedStyle\s*\(|\bmotion\.)/i;
+
+const AREA_PATTERNS = [
+  [/^apps\/web\//, "web"],
+  [/^apps\/mobile\//, "mobile"],
+  [/^apps\/desktop\//, "desktop"],
+  [/^apps\/server\//, "server"],
+  [/^packages\/contracts\//, "contracts"],
+  [/^packages\/client-runtime\//, "client runtime"],
+  [/^packages\//, "shared package"],
+  [/^docs\//, "docs"],
+  [/^\.github\//, "GitHub automation"],
+];
+
+function stripComments(markdown) {
+  return markdown.replace(/<!--[^]*?-->/g, "").trim();
+}
+
+function section(markdown, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = markdown.match(
+    new RegExp(`^##[ \\t]+${escaped}[ \\t]*\\r?\\n([^]*?)(?=^##[ \\t]+|(?![^]))`, "im"),
+  );
+  return stripComments(match?.[1] ?? "");
+}
+
+function sectionAny(markdown, headings) {
+  return headings.map((heading) => section(markdown, heading)).find(Boolean) ?? "";
+}
+
+function isTestFile(filename) {
+  return TEST_FILE_PATTERNS.some((pattern) => pattern.test(filename));
+}
+
+function isUiCandidate(filename) {
+  return !isTestFile(filename) && UI_FILE_PATTERNS.some((pattern) => pattern.test(filename));
+}
+
+function changedPatch(file) {
+  return (file.patch ?? "")
+    .split("\n")
+    .filter(
+      (line) =>
+        (line.startsWith("+") && !line.startsWith("+++")) ||
+        (line.startsWith("-") && !line.startsWith("---")),
+    )
+    .join("\n");
+}
+
+function isDefiniteUiFile(file) {
+  if (!isUiCandidate(file.filename)) return false;
+  if (/\.(?:css|scss)$/.test(file.filename)) return true;
+  const patch = changedPatch(file);
+  return (
+    /(?:<[A-Za-z][^>]*\/>|\bclassName\s*=|\bstyle\s*=|\baria-[a-z-]+\s*=|\brole\s*=)/.test(patch) ||
+    MOTION_PATTERN.test(patch)
+  );
+}
+
+function imageCount(markdown) {
+  const markdownImages = markdown.match(/!\[[^\]]*\]\([^\s)]+(?:\s+"[^"]*")?\)/gi) ?? [];
+  const htmlImages = markdown.match(/<img\b[^>]*>/gi) ?? [];
+  const remaining = markdown.replace(/!\[[^\]]*\]\([^)]*\)/g, "").replace(/<img\b[^>]*>/gi, "");
+  const bareImageUrls =
+    remaining.match(/https?:\/\/[^\s)]+\.(?:avif|gif|jpe?g|png|webp)(?:\?[^\s)]*)?/gi) ?? [];
+  return markdownImages.length + htmlImages.length + bareImageUrls.length;
+}
+
+function hasVideo(markdown) {
+  if (/<video\b[^>]*>/i.test(markdown)) return true;
+  if (/https?:\/\/[^\s)]+\.(?:mov|mp4|webm)(?:\?[^\s)]*)?/i.test(markdown)) return true;
+
+  const withoutImages = markdown.replace(/!\[[^\]]*\]\([^)]*\)/g, "").replace(/<img\b[^>]*>/gi, "");
+  return /\b(?:demo|recording|video)\b[^\n]{0,80}https:\/\/github\.com\/user-attachments\/assets\/[a-z0-9-]+/i.test(
+    withoutImages,
+  );
+}
+
+function hasRepositoryContextLink(markdown, repository) {
+  const escaped = repository.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`https://github\\.com/${escaped}/(?:issues|discussions)/\\d+`, "i").test(
+    markdown,
+  );
+}
+
+function hasDiscussionLink(markdown, repository) {
+  const escaped = repository.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`https://github\\.com/${escaped}/discussions/\\d+`, "i").test(markdown);
+}
+
+function isFeaturePull(title) {
+  return /^(?:feat|feature)(?:\([^)]*\))?[!:]/i.test(title.trim());
+}
+
+function hasMaintainerContextStatement(markdown) {
+  return /\b(?:maintainer[- ](?:approved|directed|requested)|requested by (?:a )?maintainer)\b/i.test(
+    markdown,
+  );
+}
+
+function parseVouchedUsers(contents) {
+  return new Set(
+    contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^github:[^\s#]+$/i.test(line))
+      .map((line) => line.slice("github:".length).toLowerCase()),
+  );
+}
+
+function isTrustedPull(pull, vouchedUsers) {
+  if (["COLLABORATOR", "MEMBER", "OWNER"].includes(pull.author_association)) return true;
+  if (pull.labels?.some((label) => label.name === "vouch:trusted")) return true;
+  return vouchedUsers.has(pull.user?.login?.toLowerCase());
+}
+
+function isBotPull(pull) {
+  return pull.user?.type === "Bot" || pull.user?.login?.endsWith("[bot]");
+}
+
+function explainsNoVisualChange(markdown) {
+  const evidence = section(markdown, "UI Changes");
+  return /\b(?:no (?:user-facing |visible )?(?:UI|visual)(?: or interaction)? changes?|(?:screenshots?|UI changes?) (?:are |is )?not applicable)\b/i.test(
+    evidence,
+  );
+}
+
+function explainsNoInteractionChange(markdown) {
+  const evidence = section(markdown, "UI Changes");
+  return (
+    /\b(?:no (?:visual or )?(?:motion|interaction) changes?|(?:motion|interaction)(?:s| UI)? (?:is|are) unchanged)\b/i.test(
+      evidence,
+    ) || /\bvideo is not applicable\b/i.test(evidence)
+  );
+}
+
+function effectiveChangedLines(files) {
+  const totals = files.reduce(
+    (result, file) => {
+      const changed = (file.additions ?? 0) + (file.deletions ?? 0);
+      if (isTestFile(file.filename)) result.test += changed;
+      else result.nonTest += changed;
+      return result;
+    },
+    { nonTest: 0, test: 0 },
+  );
+
+  return {
+    ...totals,
+    effective: totals.nonTest === 0 ? totals.test : totals.nonTest,
+  };
+}
+
+function changedAreas(files) {
+  const areas = new Set();
+  for (const file of files) {
+    if (isTestFile(file.filename)) continue;
+    const match = AREA_PATTERNS.find(([pattern]) => pattern.test(file.filename));
+    if (match) areas.add(match[1]);
+  }
+  return [...areas];
+}
+
+function finding(code, severity, message) {
+  return { code, severity, message };
+}
+
+function evaluatePull({
+  pull,
+  files,
+  repository,
+  vouchedUsers = new Set(),
+  vouchedStandardAvailable = false,
+}) {
+  const body = pull.body ?? "";
+  const whatChanged = section(body, "What Changed");
+  const why = section(body, "Why");
+  const scopeAndNonGoals = section(body, "Scope and Non-Goals");
+  const affectedAreas = section(body, "Affected Areas");
+  const validation = section(body, "Validation");
+  const risksAndUntested = sectionAny(body, [
+    "Risks and Untested Paths",
+    "Risks and Limitations",
+    "Risks",
+    "Limitations",
+  ]);
+  const lines = effectiveChangedLines(files);
+  const lineKind = lines.nonTest === 0 && lines.test > 0 ? "test" : "non-test";
+  const areas = changedAreas(files);
+  const contextLink = hasRepositoryContextLink(body, repository);
+  const discussionLink = hasDiscussionLink(body, repository);
+  const maintainerContext = hasMaintainerContextStatement(body);
+  const uiCandidates = files.filter((file) => isUiCandidate(file.filename));
+  const uiFiles = uiCandidates.filter((file) => isDefiniteUiFile(file));
+  const uninspectableUiFiles = uiCandidates.filter((file) => file.patch === undefined);
+  const trustedPull = isTrustedPull(pull, vouchedUsers);
+  const hasMotionChange = uiFiles.some((file) => MOTION_PATTERN.test(changedPatch(file)));
+  const findings = [];
+
+  if (!whatChanged) {
+    findings.push(
+      finding(
+        "missing-what-changed",
+        "blocking",
+        "Fill in `## What Changed` with the exact behavior this PR changes.",
+      ),
+    );
+  }
+  if (!why) {
+    findings.push(
+      finding(
+        "missing-why",
+        "blocking",
+        "Fill in `## Why` with the concrete problem and why this change should exist.",
+      ),
+    );
+  }
+
+  if (trustedPull && vouchedStandardAvailable && !scopeAndNonGoals) {
+    findings.push(
+      finding(
+        "missing-scope-and-non-goals",
+        "blocking",
+        "The vouched-contributor handoff requires explicit scope. Fill in `## Scope and Non-Goals` with what this PR intentionally leaves unchanged or defers.",
+      ),
+    );
+  }
+  const surfaceEvidence = `${scopeAndNonGoals}\n${risksAndUntested}`;
+  if (
+    trustedPull &&
+    vouchedStandardAvailable &&
+    !affectedAreas &&
+    !/\b(?:clients?|providers?|platforms?|contracts?|connection modes?|surfaces?)\b/i.test(
+      surfaceEvidence,
+    )
+  ) {
+    findings.push(
+      finding(
+        "missing-affected-areas",
+        "blocking",
+        "Name the applicable clients, providers, platforms, contracts, and connection modes in `## Affected Areas` or the scope/risk sections; include unsupported paths.",
+      ),
+    );
+  }
+  if (trustedPull && vouchedStandardAvailable && !validation) {
+    findings.push(
+      finding(
+        "missing-validation",
+        "blocking",
+        "Fill in `## Validation` with the exact focused commands or direct checks and their results.",
+      ),
+    );
+  }
+  if (trustedPull && vouchedStandardAvailable && !risksAndUntested) {
+    findings.push(
+      finding(
+        "missing-risks-and-untested",
+        "blocking",
+        "Fill in `## Risks and Untested Paths`; say `None known` only when that is the honest result.",
+      ),
+    );
+  }
+  if (uiFiles.length > 0 && imageCount(body) < 2 && !explainsNoVisualChange(body)) {
+    findings.push(
+      finding(
+        "missing-ui-images",
+        "blocking",
+        "This diff touches visible client files. Add both a before image and an after image to `## UI Changes`.",
+      ),
+    );
+  }
+  if (hasMotionChange && !hasVideo(body) && !explainsNoInteractionChange(body)) {
+    findings.push(
+      finding(
+        "missing-interaction-video",
+        "blocking",
+        "The diff contains motion or transition code. Add a short interaction video.",
+      ),
+    );
+  }
+
+  const nonProductAreas = new Set(["docs", "GitHub automation"]);
+  const onlyNonProductAreas = areas.length > 0 && areas.every((area) => nonProductAreas.has(area));
+  if (!trustedPull && isFeaturePull(pull.title) && !onlyNonProductAreas && !discussionLink) {
+    if (maintainerContext) {
+      findings.push(
+        finding(
+          "private-feature-context",
+          "advisory",
+          "This feature is described as maintainer-directed without a public Ideas link. A maintainer must verify that context.",
+        ),
+      );
+    } else {
+      findings.push(
+        finding(
+          "missing-feature-discussion",
+          "blocking",
+          "Feature proposals belong in an Ideas discussion. Link the repository discussion where this direction was raised, or state that a maintainer directed the work without adding private routing details.",
+        ),
+      );
+    }
+  } else if (!trustedPull && lines.effective >= 100 && !contextLink) {
+    findings.push(
+      finding(
+        "missing-nontrivial-context",
+        "advisory",
+        `This change has ${lines.effective.toLocaleString("en-US")} ${lineKind} changed lines. Link the repository bug issue or Ideas discussion that established the scope first.`,
+      ),
+    );
+  }
+
+  if (lines.effective >= 1_000) {
+    findings.push(
+      finding(
+        "xxl-change",
+        "advisory",
+        "The contribution guide says 1,000+ line PRs are likely to be closed quickly. A maintainer must decide whether the change can be split.",
+      ),
+    );
+  } else if (lines.effective >= 100) {
+    findings.push(
+      finding(
+        "large-change",
+        "advisory",
+        `This change has ${lines.effective.toLocaleString("en-US")} ${lineKind} changed lines, outside the project's preferred small-PR range. A maintainer should confirm that the scope is still reviewable.`,
+      ),
+    );
+  }
+
+  if (areas.length >= 3) {
+    findings.push(
+      finding(
+        "many-areas",
+        "advisory",
+        `The diff crosses ${areas.length} project areas. Check that it still delivers one outcome without unrelated fixes.`,
+      ),
+    );
+  }
+
+  if (Number.isSafeInteger(pull.changed_files) && pull.changed_files > files.length) {
+    findings.push(
+      finding(
+        "incomplete-file-list",
+        "advisory",
+        `GitHub returned ${files.length.toLocaleString("en-US")} of ${pull.changed_files.toLocaleString("en-US")} changed files. A maintainer must inspect the full diff.`,
+      ),
+    );
+  }
+
+  if (uninspectableUiFiles.length > 0) {
+    findings.push(
+      finding(
+        "uninspectable-ui-patch",
+        "advisory",
+        `GitHub omitted patch text for ${uninspectableUiFiles.length.toLocaleString("en-US")} client file${uninspectableUiFiles.length === 1 ? "" : "s"}. A maintainer must check whether visual or interaction evidence applies.`,
+      ),
+    );
+  }
+
+  const hasBlocking = findings.some((entry) => entry.severity === "blocking");
+  const hasAdvisory = findings.some((entry) => entry.severity === "advisory");
+  const status = hasBlocking ? "needs_work" : hasAdvisory ? "manual_review" : "pass";
+
+  return {
+    status,
+    findings,
+    metrics: {
+      effectiveChangedLines: lines.effective,
+      nonTestChangedLines: lines.nonTest,
+      testChangedLines: lines.test,
+      lineKind,
+      areas,
+      uiFileCount: uiFiles.length,
+      hasMotionChange,
+      trustedPull,
+    },
+  };
+}
+
+function renderComment(result, { repository, policyRevision, vouchedStandardAvailable = false }) {
+  const policyUrl = `https://github.com/${repository}/blob/${policyRevision}/CONTRIBUTING.md`;
+  const vouchedPolicyUrl = `https://github.com/${repository}/blob/${policyRevision}/CONTRIBUTING_VOUCHED.md`;
+  const title = {
+    needs_work: "Needs work before maintainer review",
+    manual_review: "Human judgment needed",
+    pass: "Looks ready for a maintainer to inspect",
+  }[result.status];
+  const icon = { blocking: "❌", advisory: "⚠️" };
+  const detail =
+    result.findings.length === 0
+      ? ["- ✅ The objective checks found no missing explanation, context, size, or evidence item."]
+      : result.findings.map((entry) => `- ${icon[entry.severity]} ${entry.message}`);
+  const areas = result.metrics.areas.length > 0 ? result.metrics.areas.join(", ") : "uncategorized";
+  const policies =
+    result.metrics.trustedPull && vouchedStandardAvailable
+      ? `[CONTRIBUTING.md](${policyUrl}) and [CONTRIBUTING_VOUCHED.md](${vouchedPolicyUrl})`
+      : `[CONTRIBUTING.md](${policyUrl})`;
+
+  return [
+    COMMENT_MARKER,
+    "## Contribution sniff test",
+    "",
+    `### ${title}`,
+    "",
+    ...detail,
+    "",
+    `Observed by this advisory check: ${result.metrics.effectiveChangedLines.toLocaleString("en-US")} ${result.metrics.lineKind} changed lines, ${areas}. The repository's \`size:*\` workflow may report fewer lines because it also ignores whitespace-only changes.`,
+    "",
+    `This advisory check applies ${policies}. It does not approve, reject, or replace maintainer review. It deliberately leaves product direction, whether the PR mixes concerns, and whether the implementation is correct to a person.`,
+  ].join("\n");
+}
+
+async function upsertComment(github, context, pullNumber, body) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...context.repo,
+    issue_number: pullNumber,
+    per_page: 100,
+  });
+  const existing = comments.find(
+    (comment) =>
+      comment.user?.login === "github-actions[bot]" && comment.body?.includes(COMMENT_MARKER),
+  );
+
+  if (existing?.body === body) return "unchanged";
+  if (existing) {
+    await github.rest.issues.updateComment({
+      ...context.repo,
+      comment_id: existing.id,
+      body,
+    });
+    return "updated";
+  }
+
+  await github.rest.issues.createComment({
+    ...context.repo,
+    issue_number: pullNumber,
+    body,
+  });
+  return "created";
+}
+
+async function reviewPull({
+  github,
+  context,
+  core,
+  policyRevision = context.sha,
+  vouchedUsers = new Set(),
+  vouchedStandardAvailable = false,
+}) {
+  const eventPull = context.payload.pull_request;
+  const expectedHeadSha = eventPull.head.sha;
+  const { owner, repo } = context.repo;
+  const pullNumber = eventPull.number;
+  const { data: pull } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+
+  if (pull.head.sha !== expectedHeadSha) {
+    core.info(`Skipping stale PR head ${expectedHeadSha}; current head is ${pull.head.sha}.`);
+    return { published: false, reason: "stale" };
+  }
+
+  if (isBotPull(pull)) {
+    core.info(`Skipping bot-authored PR from ${pull.user.login}.`);
+    return { published: false, reason: "bot" };
+  }
+
+  if (pull.draft) {
+    core.info(`Skipping draft PR #${pullNumber}.`);
+    return { published: false, reason: "draft" };
+  }
+
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+  const result = evaluatePull({
+    pull,
+    files,
+    repository: `${owner}/${repo}`,
+    vouchedUsers,
+    vouchedStandardAvailable,
+  });
+  const body = renderComment(result, {
+    repository: `${owner}/${repo}`,
+    policyRevision: policyRevision ?? pull.base.sha,
+    vouchedStandardAvailable,
+  });
+
+  const { data: currentPull } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  if (currentPull.head.sha !== expectedHeadSha) {
+    core.info(
+      `Skipping stale PR head ${expectedHeadSha}; current head is ${currentPull.head.sha}.`,
+    );
+    return { published: false, reason: "stale" };
+  }
+
+  const publication = await upsertComment(github, context, pullNumber, body);
+  core.info(`PR #${pullNumber}: ${result.status}; comment ${publication}.`);
+  return { published: true, publication, result };
+}
+
+module.exports = {
+  COMMENT_MARKER,
+  effectiveChangedLines,
+  evaluatePull,
+  hasVideo,
+  imageCount,
+  parseVouchedUsers,
+  renderComment,
+  reviewPull,
+  section,
+  sectionAny,
+  upsertComment,
+};

--- a/.github/scripts/pr-guideline-review.cjs
+++ b/.github/scripts/pr-guideline-review.cjs
@@ -62,7 +62,7 @@ function section(markdown, heading) {
       continue;
     }
 
-    const levelTwoHeading = line.match(/^##[ \t]+(.+?)[ \t]*$/);
+    const levelTwoHeading = line.match(/^##[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/);
     if (levelTwoHeading) {
       if (collecting) break;
       collecting = levelTwoHeading[1].toLowerCase() === heading.toLowerCase();
@@ -109,7 +109,8 @@ function isDefiniteUiFile(file) {
 }
 
 function imageCount(markdown) {
-  const markdownImages = markdown.match(/!\[[^\]]*\]\([^\s)]+(?:\s+"[^"]*")?\)/gi) ?? [];
+  const markdownImages =
+    markdown.match(/!\[[^\]]*\]\([^\s)]+(?:\s+(?:"[^"]*"|'[^']*'))?\)/gi) ?? [];
   const htmlImages = (markdown.match(/<img\b[^>]*>/gi) ?? []).filter((tag) =>
     hasNonEmptySrc(tag, "img"),
   );
@@ -121,7 +122,7 @@ function imageCount(markdown) {
 
 function hasNonEmptySrc(markdown, tagName) {
   const tags = markdown.match(new RegExp(`<${tagName}\\b[^>]*>`, "gi")) ?? [];
-  return tags.some((tag) => /\bsrc\s*=\s*(?:"[^"\s][^"]*"|'[^'\s][^']*'|[^\s"'=<>]+)/i.test(tag));
+  return tags.some((tag) => /\ssrc\s*=\s*(?:"[^"\s][^"]*"|'[^'\s][^']*'|[^\s"'=<>]+)/i.test(tag));
 }
 
 function hasVideo(markdown) {
@@ -507,6 +508,25 @@ async function upsertComment(github, context, pullNumber, body) {
   return "created";
 }
 
+async function removeComment(github, context, pullNumber) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...context.repo,
+    issue_number: pullNumber,
+    per_page: 100,
+  });
+  const existing = comments.find(
+    (comment) =>
+      comment.user?.login === "github-actions[bot]" && comment.body?.includes(COMMENT_MARKER),
+  );
+
+  if (!existing) return "absent";
+  await github.rest.issues.deleteComment({
+    ...context.repo,
+    comment_id: existing.id,
+  });
+  return "removed";
+}
+
 async function reviewPull({
   github,
   context,
@@ -536,8 +556,9 @@ async function reviewPull({
   }
 
   if (pull.draft) {
-    core.info(`Skipping draft PR #${pullNumber}.`);
-    return { published: false, reason: "draft" };
+    const removal = await removeComment(github, context, pullNumber);
+    core.info(`Skipping draft PR #${pullNumber}; prior comment ${removal}.`);
+    return { published: false, reason: "draft", removal };
   }
 
   const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -584,6 +605,7 @@ module.exports = {
   imageCount,
   parseVouchedUsers,
   renderComment,
+  removeComment,
   reviewPull,
   section,
   sectionAny,

--- a/.github/scripts/pr-guideline-review.cjs
+++ b/.github/scripts/pr-guideline-review.cjs
@@ -100,6 +100,7 @@ function isDefiniteUiFile(file) {
   const patch = changedPatch(file);
   return (
     /(?:<[A-Za-z][^>]*\/>|\bclassName\s*=|\bstyle\s*=|\baria-[a-z-]+\s*=|\brole\s*=)/.test(patch) ||
+    /<([A-Za-z][\w.]*)(?:\s[^>]*)?>[^]*?<\/\1\s*>/.test(patch) ||
     MOTION_PATTERN.test(patch)
   );
 }

--- a/.github/scripts/pr-guideline-review.cjs
+++ b/.github/scripts/pr-guideline-review.cjs
@@ -75,10 +75,6 @@ function section(markdown, heading) {
   return stripComments(content.join("\n"));
 }
 
-function sectionAny(markdown, headings) {
-  return headings.map((heading) => section(markdown, heading)).find(Boolean) ?? "";
-}
-
 function isTestFile(filename) {
   return TEST_FILE_PATTERNS.some((pattern) => pattern.test(filename));
 }
@@ -232,25 +228,10 @@ function finding(code, severity, message) {
   return { code, severity, message };
 }
 
-function evaluatePull({
-  pull,
-  files,
-  repository,
-  vouchedUsers = new Set(),
-  vouchedStandardAvailable = false,
-}) {
+function evaluatePull({ pull, files, repository, vouchedUsers = new Set() }) {
   const body = pull.body ?? "";
   const whatChanged = section(body, "What Changed");
   const why = section(body, "Why");
-  const scopeAndNonGoals = section(body, "Scope and Non-Goals");
-  const affectedAreas = section(body, "Affected Areas");
-  const validation = section(body, "Validation");
-  const risksAndUntested = sectionAny(body, [
-    "Risks and Untested Paths",
-    "Risks and Limitations",
-    "Risks",
-    "Limitations",
-  ]);
   const lines = effectiveChangedLines(files);
   const lineKind = lines.nonTest === 0 && lines.test > 0 ? "test" : "non-test";
   const areas = changedAreas(files);
@@ -285,50 +266,6 @@ function evaluatePull({
     );
   }
 
-  if (trustedPull && vouchedStandardAvailable && !scopeAndNonGoals) {
-    findings.push(
-      finding(
-        "missing-scope-and-non-goals",
-        "blocking",
-        "The vouched-contributor handoff requires explicit scope. Fill in `## Scope and Non-Goals` with what this PR intentionally leaves unchanged or defers.",
-      ),
-    );
-  }
-  const surfaceEvidence = `${scopeAndNonGoals}\n${risksAndUntested}`;
-  if (
-    trustedPull &&
-    vouchedStandardAvailable &&
-    !affectedAreas &&
-    !/\b(?:clients?|providers?|platforms?|contracts?|connection modes?|surfaces?)\b/i.test(
-      surfaceEvidence,
-    )
-  ) {
-    findings.push(
-      finding(
-        "missing-affected-areas",
-        "blocking",
-        "Name the applicable clients, providers, platforms, contracts, and connection modes in `## Affected Areas` or the scope/risk sections; include unsupported paths.",
-      ),
-    );
-  }
-  if (trustedPull && vouchedStandardAvailable && !validation) {
-    findings.push(
-      finding(
-        "missing-validation",
-        "blocking",
-        "Fill in `## Validation` with the exact focused commands or direct checks and their results.",
-      ),
-    );
-  }
-  if (trustedPull && vouchedStandardAvailable && !risksAndUntested) {
-    findings.push(
-      finding(
-        "missing-risks-and-untested",
-        "blocking",
-        "Fill in `## Risks and Untested Paths`; say `None known` only when that is the honest result.",
-      ),
-    );
-  }
   if (uiFiles.length > 0 && imageCount(uiEvidence) < 2 && !explainsNoVisualChange(body)) {
     findings.push(
       finding(
@@ -453,9 +390,8 @@ function evaluatePull({
   };
 }
 
-function renderComment(result, { repository, policyRevision, vouchedStandardAvailable = false }) {
+function renderComment(result, { repository, policyRevision }) {
   const policyUrl = `https://github.com/${repository}/blob/${policyRevision}/CONTRIBUTING.md`;
-  const vouchedPolicyUrl = `https://github.com/${repository}/blob/${policyRevision}/CONTRIBUTING_VOUCHED.md`;
   const title = {
     needs_work: "Needs work before maintainer review",
     manual_review: "Human judgment needed",
@@ -467,11 +403,6 @@ function renderComment(result, { repository, policyRevision, vouchedStandardAvai
       ? ["- ✅ The objective checks found no missing explanation, context, size, or evidence item."]
       : result.findings.map((entry) => `- ${icon[entry.severity]} ${entry.message}`);
   const areas = result.metrics.areas.length > 0 ? result.metrics.areas.join(", ") : "uncategorized";
-  const policies =
-    result.metrics.trustedPull && vouchedStandardAvailable
-      ? `[CONTRIBUTING.md](${policyUrl}) and [CONTRIBUTING_VOUCHED.md](${vouchedPolicyUrl})`
-      : `[CONTRIBUTING.md](${policyUrl})`;
-
   return [
     COMMENT_MARKER,
     "## Contribution sniff test",
@@ -482,7 +413,7 @@ function renderComment(result, { repository, policyRevision, vouchedStandardAvai
     "",
     `Observed by this advisory check: ${result.metrics.effectiveChangedLines.toLocaleString("en-US")} ${result.metrics.lineKind} changed lines, ${areas}. The repository's \`size:*\` workflow may report fewer lines because it also ignores whitespace-only changes.`,
     "",
-    `This advisory check applies ${policies}. It does not approve, reject, or replace maintainer review. It deliberately leaves product direction, whether the PR mixes concerns, and whether the implementation is correct to a person.`,
+    `This advisory check applies [CONTRIBUTING.md](${policyUrl}). It does not approve, reject, or replace maintainer review. It deliberately leaves product direction, whether the PR mixes concerns, and whether the implementation is correct to a person.`,
   ].join("\n");
 }
 
@@ -540,7 +471,6 @@ async function reviewPull({
   core,
   policyRevision = context.sha,
   vouchedUsers = new Set(),
-  vouchedStandardAvailable = false,
 }) {
   const eventPull = context.payload.pull_request;
   const expectedHeadSha = eventPull.head.sha;
@@ -579,12 +509,10 @@ async function reviewPull({
     files,
     repository: `${owner}/${repo}`,
     vouchedUsers,
-    vouchedStandardAvailable,
   });
   const body = renderComment(result, {
     repository: `${owner}/${repo}`,
     policyRevision: policyRevision ?? pull.base.sha,
-    vouchedStandardAvailable,
   });
 
   const { data: currentPull } = await github.rest.pulls.get({
@@ -615,6 +543,5 @@ module.exports = {
   removeComment,
   reviewPull,
   section,
-  sectionAny,
   upsertComment,
 };

--- a/.github/scripts/pr-guideline-review.test.cjs
+++ b/.github/scripts/pr-guideline-review.test.cjs
@@ -1,0 +1,624 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  COMMENT_MARKER,
+  effectiveChangedLines,
+  evaluatePull,
+  hasVideo,
+  imageCount,
+  parseVouchedUsers,
+  renderComment,
+  reviewPull,
+  upsertComment,
+} = require("./pr-guideline-review.cjs");
+
+const completeBody = `
+## What Changed
+
+Stops the server from retrying a completed receipt.
+
+## Why
+
+The retry duplicates a completed side effect.
+
+## Checklist
+
+- [x] This PR is small and focused
+- [x] I explained what changed and why
+- [x] I included before/after screenshots for any UI changes
+- [x] I included a video for animation/interaction changes
+`;
+
+function evaluate(overrides = {}) {
+  const files = overrides.files ?? [
+    { filename: "apps/server/src/receipts.ts", additions: 8, deletions: 2, patch: "+return;" },
+    { filename: "apps/server/src/receipts.test.ts", additions: 20, deletions: 0 },
+  ];
+  return evaluatePull({
+    pull: {
+      title: "fix(server): do not retry completed receipts",
+      body: completeBody,
+      changed_files: files.length,
+      ...overrides.pull,
+    },
+    files,
+    repository: "pingdotgg/t3code",
+    vouchedUsers: overrides.vouchedUsers,
+    vouchedStandardAvailable: overrides.vouchedStandardAvailable,
+  });
+}
+
+test("passes a small focused non-UI fix", () => {
+  const result = evaluate();
+
+  assert.equal(result.status, "pass");
+  assert.deepEqual(result.findings, []);
+  assert.equal(result.metrics.effectiveChangedLines, 10);
+  assert.equal(result.metrics.testChangedLines, 20);
+});
+
+test("reports missing template content with direct fixes", () => {
+  const result = evaluate({
+    pull: {
+      body: `
+## What Changed
+<!-- Describe the change clearly and keep scope tight. -->
+## Why
+<!-- Explain the problem being solved. -->
+## Checklist
+- [ ] This PR is small and focused
+- [ ] I explained what changed and why
+`,
+    },
+  });
+
+  assert.equal(result.status, "needs_work");
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-what-changed", "missing-why"],
+  );
+});
+
+test("applies the richer handoff to collaborators and vouched contributors", () => {
+  const collaborator = evaluate({
+    pull: {
+      body: completeBody,
+      author_association: "COLLABORATOR",
+    },
+    vouchedStandardAvailable: true,
+  });
+
+  assert.equal(collaborator.status, "needs_work");
+  assert.deepEqual(
+    collaborator.findings.map((entry) => entry.code),
+    [
+      "missing-scope-and-non-goals",
+      "missing-affected-areas",
+      "missing-validation",
+      "missing-risks-and-untested",
+    ],
+  );
+
+  const vouched = evaluate({
+    pull: {
+      user: { login: "VouchedPerson", type: "User" },
+      body: `${completeBody}
+## Scope and Non-Goals
+Only receipt retry state changes; UI behavior is unchanged.
+## Affected Areas
+Server receipts only. No client, provider, contract, or remote-path change.
+## Validation
+\`node --test receipts.test.ts\`: passed.
+## Risks and Untested Paths
+None known.`,
+    },
+    vouchedUsers: new Set(["vouchedperson"]),
+    vouchedStandardAvailable: true,
+  });
+
+  assert.equal(vouched.status, "pass");
+  assert.deepEqual(vouched.findings, []);
+  assert.equal(vouched.metrics.trustedPull, true);
+});
+
+test("parses only active GitHub entries from the vouch file", () => {
+  assert.deepEqual(
+    [...parseVouchedUsers("# comment\ngithub:Alice\n-github:Blocked reason\ngithub:bob\n")],
+    ["alice", "bob"],
+  );
+});
+
+test("accepts equivalent vouched-guide headings and surface evidence", () => {
+  const result = evaluate({
+    pull: {
+      author_association: "MEMBER",
+      body: `${completeBody}
+## Scope and Non-Goals
+Documentation only. No client, provider, platform, contract, or connection behavior changes.
+## Validation
+\`vp fmt guide.md --check\`: passed.
+## Risks and Limitations
+The guide will need updates when policy changes. No runtime path was exercised.`,
+    },
+    vouchedStandardAvailable: true,
+  });
+
+  assert.equal(result.status, "pass");
+  assert.deepEqual(result.findings, []);
+});
+
+test("requires images and video for a visible motion change", () => {
+  const result = evaluate({
+    files: [
+      {
+        filename: "apps/web/src/components/sidebar.tsx",
+        additions: 12,
+        deletions: 2,
+        patch: "+transition: opacity 120ms ease;",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "needs_work");
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-ui-images", "missing-interaction-video"],
+  );
+});
+
+test("accepts GitHub image and video evidence", () => {
+  const result = evaluate({
+    pull: {
+      body: `${completeBody}\n![Before](https://github.com/user-attachments/assets/before)\n![After](https://github.com/user-attachments/assets/after)\nVideo: https://github.com/user-attachments/assets/demo-video`,
+    },
+    files: [
+      {
+        filename: "apps/mobile/src/sidebar.tsx",
+        additions: 8,
+        deletions: 2,
+        patch: "+const style = useAnimatedStyle(() => ({}));",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "pass");
+  assert.equal(
+    imageCount(
+      "![Before](https://github.com/user-attachments/assets/before)\n![After](https://github.com/user-attachments/assets/after)",
+    ),
+    2,
+  );
+  assert.equal(hasVideo("Video: https://github.com/user-attachments/assets/demo-video"), true);
+});
+
+test("accepts an explicit explanation that client behavior is unchanged", () => {
+  const result = evaluate({
+    pull: {
+      body: `${completeBody}\n## UI Changes\nNo visual change. Existing interactions are unchanged.`,
+    },
+    files: [
+      {
+        filename: "apps/mobile/src/thread-work-log.tsx",
+        additions: 5,
+        deletions: 4,
+        patch: "+transition: existingBehavior;",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "pass");
+  assert.deepEqual(result.findings, []);
+});
+
+test("does not infer a visual change from TSX logic, generics, handlers, or closing tags", () => {
+  const result = evaluate({
+    files: [
+      {
+        filename: "apps/mobile/src/Animated.tsx",
+        additions: 2,
+        deletions: 1,
+        patch:
+          "+const selected = useState<boolean>(false);\n+const onSelect = () => selected;\n+</Panel>;\n+const View = Animated.View;",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "pass");
+  assert.deepEqual(result.findings, []);
+});
+
+test("detects a self-closing JSX element as a visible change", () => {
+  const result = evaluate({
+    files: [
+      {
+        filename: "apps/web/src/sidebar.tsx",
+        additions: 1,
+        deletions: 0,
+        patch: "+<Button />",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "needs_work");
+  assert.equal(result.findings.at(-1).code, "missing-ui-images");
+});
+
+test("accepts the exact no-UI phrase documented by the template", () => {
+  const result = evaluate({
+    pull: { body: `${completeBody}\n## UI Changes\nNo visual or interaction changes.` },
+    files: [
+      {
+        filename: "apps/web/src/sidebar.tsx",
+        additions: 2,
+        deletions: 1,
+        patch: "+style={{ transition: 'opacity 120ms' }};",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "pass");
+  assert.deepEqual(result.findings, []);
+});
+
+test("does not treat an HTML image attachment as video evidence", () => {
+  const image = '<img src="https://github.com/user-attachments/assets/screenshot">';
+  assert.equal(imageCount(image), 1);
+  assert.equal(hasVideo(image), false);
+  assert.equal(hasVideo("https://github.com/user-attachments/assets/unlabelled-still"), false);
+  assert.equal(hasVideo("Video: https://github.com/user-attachments/assets/demo"), true);
+});
+
+test("requires prior repository context for features and large changes", () => {
+  const feature = evaluate({
+    pull: {
+      title: "feat(web): add a new dashboard",
+      body: `${completeBody}\nBug: https://github.com/pingdotgg/t3code/issues/1234`,
+    },
+  });
+  assert.equal(feature.status, "needs_work");
+  assert.equal(feature.findings.at(-1).code, "missing-feature-discussion");
+
+  const discussedFeature = evaluate({
+    pull: {
+      title: "feat(web): add a new dashboard",
+      body: `${completeBody}\nProposal: https://github.com/pingdotgg/t3code/discussions/1234`,
+    },
+  });
+  assert.equal(discussedFeature.status, "pass");
+
+  const directedFeature = evaluate({
+    pull: {
+      title: "feat(web): add a new dashboard",
+      body: `${completeBody}\nMaintainer-directed work; no public routing link exists.`,
+    },
+  });
+  assert.equal(directedFeature.status, "manual_review");
+  assert.equal(directedFeature.findings.at(-1).code, "private-feature-context");
+
+  const docsFeature = evaluate({
+    pull: { title: "feat(docs): explain dashboards" },
+    files: [{ filename: "docs/user/dashboard.md", additions: 20, deletions: 0 }],
+  });
+  assert.equal(docsFeature.status, "pass");
+
+  const large = evaluate({
+    pull: { body: `${completeBody}\nContext: https://github.com/pingdotgg/t3code/issues/1234` },
+    files: [{ filename: "apps/server/src/receipts.ts", additions: 120, deletions: 0 }],
+  });
+  assert.equal(large.status, "manual_review");
+  assert.deepEqual(
+    large.findings.map((entry) => entry.code),
+    ["large-change"],
+  );
+});
+
+test("treats missing context on a large external fix as maintainer judgment", () => {
+  const result = evaluate({
+    files: [{ filename: "apps/server/src/receipts.ts", additions: 120, deletions: 0 }],
+  });
+
+  assert.equal(result.status, "manual_review");
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-nontrivial-context", "large-change"],
+  );
+});
+
+test("flags an XXL change and a diff crossing many project areas", () => {
+  const result = evaluate({
+    pull: {
+      body: `${completeBody}\nContext: https://github.com/pingdotgg/t3code/discussions/1234`,
+    },
+    files: [
+      { filename: "apps/server/src/a.ts", additions: 400, deletions: 0 },
+      { filename: "packages/contracts/src/a.ts", additions: 350, deletions: 0 },
+      { filename: "packages/client-runtime/src/a.ts", additions: 300, deletions: 0 },
+    ],
+  });
+
+  assert.equal(result.status, "manual_review");
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["xxl-change", "many-areas"],
+  );
+});
+
+test("requires human judgment when GitHub truncates the changed-file list", () => {
+  const result = evaluate({ pull: { changed_files: 3_001 } });
+
+  assert.equal(result.status, "manual_review");
+  assert.equal(result.findings.at(-1).code, "incomplete-file-list");
+});
+
+test("requires human judgment when GitHub omits a client patch", () => {
+  const result = evaluate({
+    files: [
+      {
+        filename: "apps/web/src/components/sidebar.tsx",
+        additions: 2_000,
+        deletions: 0,
+      },
+    ],
+  });
+
+  assert.equal(result.status, "manual_review");
+  assert.equal(result.findings.at(-1).code, "uninspectable-ui-patch");
+});
+
+test("uses test lines only for a test-only PR", () => {
+  assert.deepEqual(
+    effectiveChangedLines([
+      { filename: "apps/server/src/a.test.ts", additions: 40, deletions: 2 },
+      { filename: "apps/server/tests/fixture.ts", additions: 8, deletions: 0 },
+      { filename: "apps/server/integration/fixture.ts", additions: 7, deletions: 0 },
+    ]),
+    { nonTest: 0, test: 57, effective: 57 },
+  );
+});
+
+test("renders an advisory comment without claiming approval", () => {
+  const comment = renderComment(evaluate(), {
+    repository: "pingdotgg/t3code",
+    policyRevision: "base-sha",
+  });
+
+  assert.match(comment, new RegExp(COMMENT_MARKER));
+  assert.match(comment, /Looks ready for a maintainer to inspect/);
+  assert.match(comment, /does not approve, reject, or replace maintainer review/);
+  assert.match(comment, /CONTRIBUTING\.md/);
+  assert.match(comment, /blob\/base-sha\/CONTRIBUTING\.md/);
+  assert.match(comment, /size:\*.*ignores whitespace-only changes/);
+});
+
+test("links the pinned vouched standard when it is active", () => {
+  const result = evaluate({
+    pull: { author_association: "COLLABORATOR" },
+    vouchedStandardAvailable: true,
+  });
+  const comment = renderComment(result, {
+    repository: "pingdotgg/t3code",
+    policyRevision: "base-sha",
+    vouchedStandardAvailable: true,
+  });
+
+  assert.match(comment, /blob\/base-sha\/CONTRIBUTING_VOUCHED\.md/);
+});
+
+test("does not publish stale results", async () => {
+  let listedFiles = false;
+  const result = await reviewPull({
+    github: {
+      paginate: async () => {
+        listedFiles = true;
+        return [];
+      },
+      rest: {
+        pulls: {
+          get: async () => ({ data: { head: { sha: "new-sha" } } }),
+          listFiles: () => {},
+        },
+      },
+    },
+    context: {
+      repo: { owner: "pingdotgg", repo: "t3code" },
+      payload: {
+        pull_request: { number: 7, head: { sha: "old-sha" } },
+        repository: { default_branch: "main" },
+      },
+    },
+    core: { info: () => {}, setOutput: () => {} },
+  });
+
+  assert.deepEqual(result, { published: false, reason: "stale" });
+  assert.equal(listedFiles, false);
+});
+
+test("does not comment on bot-authored PRs", async () => {
+  let listedFiles = false;
+  const pull = {
+    number: 7,
+    head: { sha: "head-sha" },
+    user: { login: "dependabot[bot]", type: "Bot" },
+  };
+  const result = await reviewPull({
+    github: {
+      paginate: async () => {
+        listedFiles = true;
+        return [];
+      },
+      rest: {
+        pulls: {
+          get: async () => ({ data: pull }),
+          listFiles: () => {},
+        },
+      },
+    },
+    context: {
+      repo: { owner: "pingdotgg", repo: "t3code" },
+      payload: { pull_request: pull, repository: { default_branch: "main" } },
+    },
+    core: { info: () => {}, setOutput: () => {} },
+  });
+
+  assert.deepEqual(result, { published: false, reason: "bot" });
+  assert.equal(listedFiles, false);
+});
+
+test("does not comment on draft PRs", async () => {
+  let listedFiles = false;
+  const pull = {
+    number: 7,
+    head: { sha: "head-sha" },
+    draft: true,
+    user: { login: "contributor", type: "User" },
+  };
+  const result = await reviewPull({
+    github: {
+      paginate: async () => {
+        listedFiles = true;
+        return [];
+      },
+      rest: {
+        pulls: {
+          get: async () => ({ data: pull }),
+          listFiles: () => {},
+        },
+      },
+    },
+    context: {
+      repo: { owner: "pingdotgg", repo: "t3code" },
+      payload: { pull_request: pull, repository: { default_branch: "main" } },
+    },
+    core: { info: () => {}, setOutput: () => {} },
+  });
+
+  assert.deepEqual(result, { published: false, reason: "draft" });
+  assert.equal(listedFiles, false);
+});
+
+test("does not publish after the head changes during file collection", async () => {
+  const listFiles = () => {};
+  let pullRead = 0;
+  let listedComments = false;
+  const result = await reviewPull({
+    github: {
+      paginate: async (method) => {
+        if (method === listFiles) return [];
+        listedComments = true;
+        return [];
+      },
+      rest: {
+        issues: { listComments: () => {} },
+        pulls: {
+          get: async () => ({
+            data: {
+              number: 7,
+              head: { sha: pullRead++ === 0 ? "head-sha" : "new-sha" },
+              base: { sha: "base-sha" },
+              title: "fix: example",
+              body: completeBody,
+            },
+          }),
+          listFiles,
+        },
+      },
+    },
+    context: {
+      repo: { owner: "pingdotgg", repo: "t3code" },
+      payload: {
+        pull_request: { number: 7, head: { sha: "head-sha" } },
+        repository: { default_branch: "main" },
+      },
+    },
+    core: { info: () => {}, setOutput: () => {} },
+  });
+
+  assert.deepEqual(result, { published: false, reason: "stale" });
+  assert.equal(listedComments, false);
+});
+
+test("leaves an unchanged bot comment alone and ignores an attacker marker", async () => {
+  const body = `${COMMENT_MARKER}\ncurrent result`;
+  let wrote = false;
+  const publication = await upsertComment(
+    {
+      paginate: async () => [
+        { id: 1, user: { login: "contributor" }, body: COMMENT_MARKER },
+        { id: 2, user: { login: "github-actions[bot]" }, body },
+      ],
+      rest: {
+        issues: {
+          listComments: () => {},
+          createComment: async () => {
+            wrote = true;
+          },
+          updateComment: async () => {
+            wrote = true;
+          },
+        },
+      },
+    },
+    { repo: { owner: "pingdotgg", repo: "t3code" } },
+    7,
+    body,
+  );
+
+  assert.equal(publication, "unchanged");
+  assert.equal(wrote, false);
+});
+
+test("updates one existing bot comment in place", async () => {
+  const calls = [];
+  const listFiles = () => {};
+  const listComments = () => {};
+  const pull = {
+    number: 7,
+    head: { sha: "head-sha" },
+    title: "fix(server): do not retry completed receipts",
+    body: completeBody,
+    changed_files: 1,
+    base: { sha: "base-sha" },
+  };
+  const result = await reviewPull({
+    github: {
+      paginate: async (method) => {
+        if (method === listFiles) {
+          return [{ filename: "apps/server/src/receipts.ts", additions: 8, deletions: 2 }];
+        }
+        assert.equal(method, listComments);
+        return [
+          {
+            id: 99,
+            user: { login: "github-actions[bot]" },
+            body: `${COMMENT_MARKER}\nold result`,
+          },
+        ];
+      },
+      rest: {
+        issues: {
+          listComments,
+          createComment: async (input) => calls.push(["create", input]),
+          updateComment: async (input) => calls.push(["update", input]),
+        },
+        pulls: {
+          get: async () => ({ data: pull }),
+          listFiles,
+        },
+      },
+    },
+    context: {
+      repo: { owner: "pingdotgg", repo: "t3code" },
+      payload: { pull_request: pull, repository: { default_branch: "main" } },
+    },
+    core: { info: () => {}, setOutput: () => {} },
+  });
+
+  assert.equal(result.published, true);
+  assert.equal(result.publication, "updated");
+  assert.deepEqual(
+    calls.map(([kind]) => kind),
+    ["update"],
+  );
+  assert.equal(calls[0][1].comment_id, 99);
+});

--- a/.github/scripts/pr-guideline-review.test.cjs
+++ b/.github/scripts/pr-guideline-review.test.cjs
@@ -170,7 +170,7 @@ test("requires images and video for a visible motion change", () => {
 test("accepts GitHub image and video evidence", () => {
   const result = evaluate({
     pull: {
-      body: `${completeBody}\n![Before](https://github.com/user-attachments/assets/before)\n![After](https://github.com/user-attachments/assets/after)\nVideo: https://github.com/user-attachments/assets/demo-video`,
+      body: `${completeBody}\n## UI Changes\n![Before](https://github.com/user-attachments/assets/before)\n![After](https://github.com/user-attachments/assets/after)\nVideo: https://github.com/user-attachments/assets/demo-video`,
     },
     files: [
       {
@@ -269,6 +269,42 @@ test("does not treat an HTML image attachment as video evidence", () => {
   assert.equal(hasVideo("Video: https://github.com/user-attachments/assets/demo"), true);
 });
 
+test("requires non-empty HTML evidence sources", () => {
+  assert.equal(imageCount("<img><img src=''>"), 0);
+  assert.equal(imageCount('<img src="before.png"><img src="after.png">'), 2);
+  assert.equal(hasVideo("<video></video>"), false);
+  assert.equal(hasVideo("<video><source src=''></video>"), false);
+  assert.equal(hasVideo('<video src="demo.mp4"></video>'), true);
+  assert.equal(hasVideo('<video><source src="demo.webm"></video>'), true);
+});
+
+test("counts UI evidence only in the UI Changes section", () => {
+  const result = evaluate({
+    pull: {
+      body: `${completeBody}
+## UI Changes
+Changed the sidebar layout.
+## Validation
+![Unrelated](https://github.com/user-attachments/assets/unrelated)
+![Also unrelated](https://github.com/user-attachments/assets/also-unrelated)
+Video: https://github.com/user-attachments/assets/unrelated-video`,
+    },
+    files: [
+      {
+        filename: "apps/web/src/sidebar.tsx",
+        additions: 3,
+        deletions: 1,
+        patch: "+transition: opacity 120ms ease;",
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-ui-images", "missing-interaction-video"],
+  );
+});
+
 test("requires prior repository context for features and large changes", () => {
   const feature = evaluate({
     pull: {
@@ -310,6 +346,92 @@ test("requires prior repository context for features and large changes", () => {
   assert.deepEqual(
     large.findings.map((entry) => entry.code),
     ["large-change"],
+  );
+});
+
+test("recognizes a plain-language feature title", () => {
+  const result = evaluate({
+    pull: { title: "Add a dashboard" },
+    files: [
+      {
+        filename: "apps/web/src/dashboard.tsx",
+        additions: 20,
+        deletions: 0,
+        patch: "+export const dashboardEnabled = true;",
+      },
+    ],
+  });
+
+  assert.equal(result.status, "needs_work");
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-feature-discussion"],
+  );
+});
+
+test("ignores repository links hidden in HTML comments", () => {
+  const feature = evaluate({
+    pull: {
+      title: "feat(web): add a dashboard",
+      body: `${completeBody}\n<!-- https://github.com/pingdotgg/t3code/discussions/1234 -->`,
+    },
+  });
+  assert.equal(feature.findings.at(-1).code, "missing-feature-discussion");
+
+  const large = evaluate({
+    pull: {
+      body: `${completeBody}\n<!-- https://github.com/pingdotgg/t3code/issues/1234 -->`,
+    },
+    files: [{ filename: "apps/server/src/receipts.ts", additions: 120, deletions: 0 }],
+  });
+  assert.deepEqual(
+    large.findings.map((entry) => entry.code),
+    ["missing-nontrivial-context", "large-change"],
+  );
+
+  const hiddenMaintainerContext = evaluate({
+    pull: {
+      title: "feat(web): add a dashboard",
+      body: `${completeBody}\n<!-- Maintainer-directed work. -->`,
+    },
+  });
+  assert.equal(hiddenMaintainerContext.findings.at(-1).code, "missing-feature-discussion");
+});
+
+test("ignores section headings inside fenced code blocks", () => {
+  const result = evaluate({
+    pull: {
+      body: `
+\`\`\`markdown
+## What Changed
+Pretend change.
+## Why
+Pretend reason.
+\`\`\`
+`,
+    },
+  });
+
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-what-changed", "missing-why"],
+  );
+
+  const tildeFence = evaluate({
+    pull: {
+      body: `
+~~~\`markdown
+## What Changed
+Pretend change.
+## Why
+Pretend reason.
+~~~
+`,
+    },
+  });
+  assert.deepEqual(
+    tildeFence.findings.map((entry) => entry.code),
+    ["missing-what-changed", "missing-why"],
   );
 });
 

--- a/.github/scripts/pr-guideline-review.test.cjs
+++ b/.github/scripts/pr-guideline-review.test.cjs
@@ -380,6 +380,22 @@ test("recognizes a plain-language feature title", () => {
   );
 });
 
+test("does not classify a test-only PR as a feature", () => {
+  const result = evaluate({
+    pull: { title: "Add a test for receipt retries" },
+    files: [
+      {
+        filename: "apps/server/src/receipts.test.ts",
+        additions: 12,
+        deletions: 0,
+      },
+    ],
+  });
+
+  assert.equal(result.status, "pass");
+  assert.deepEqual(result.findings, []);
+});
+
 test("ignores repository links hidden in HTML comments", () => {
   const feature = evaluate({
     pull: {

--- a/.github/scripts/pr-guideline-review.test.cjs
+++ b/.github/scripts/pr-guideline-review.test.cjs
@@ -271,11 +271,22 @@ test("does not treat an HTML image attachment as video evidence", () => {
 
 test("requires non-empty HTML evidence sources", () => {
   assert.equal(imageCount("<img><img src=''>"), 0);
+  assert.equal(imageCount('<img data-src="deferred.png">'), 0);
   assert.equal(imageCount('<img src="before.png"><img src="after.png">'), 2);
   assert.equal(hasVideo("<video></video>"), false);
   assert.equal(hasVideo("<video><source src=''></video>"), false);
+  assert.equal(hasVideo('<video data-src="deferred.mp4"></video>'), false);
   assert.equal(hasVideo('<video src="demo.mp4"></video>'), true);
   assert.equal(hasVideo('<video><source src="demo.webm"></video>'), true);
+});
+
+test("accepts single-quoted Markdown image titles", () => {
+  assert.equal(
+    imageCount(
+      "![Before](https://example.com/before.png 'before')\n![After](https://example.com/after.png 'after')",
+    ),
+    2,
+  );
 });
 
 test("counts UI evidence only in the UI Changes section", () => {
@@ -435,6 +446,21 @@ Pretend reason.
   );
 });
 
+test("accepts section headings with closing hashes", () => {
+  const result = evaluate({
+    pull: {
+      body: `
+## What Changed ##
+Stops a duplicate retry.
+## Why ###
+The retry repeats a side effect.
+`,
+    },
+  });
+
+  assert.deepEqual(result.findings, []);
+});
+
 test("treats missing context on a large external fix as maintainer judgment", () => {
   const result = evaluate({
     files: [{ filename: "apps/server/src/receipts.ts", additions: 120, deletions: 0 }],
@@ -587,8 +613,11 @@ test("does not comment on bot-authored PRs", async () => {
   assert.equal(listedFiles, false);
 });
 
-test("does not comment on draft PRs", async () => {
+test("removes a stale bot comment when a PR becomes a draft", async () => {
   let listedFiles = false;
+  let deletedComment;
+  const listFiles = () => {};
+  const listComments = () => {};
   const pull = {
     number: 7,
     head: { sha: "head-sha" },
@@ -597,14 +626,29 @@ test("does not comment on draft PRs", async () => {
   };
   const result = await reviewPull({
     github: {
-      paginate: async () => {
+      paginate: async (method) => {
+        if (method === listComments) {
+          return [
+            {
+              id: 99,
+              user: { login: "github-actions[bot]" },
+              body: `${COMMENT_MARKER}\nold result`,
+            },
+          ];
+        }
         listedFiles = true;
         return [];
       },
       rest: {
+        issues: {
+          listComments,
+          deleteComment: async (input) => {
+            deletedComment = input.comment_id;
+          },
+        },
         pulls: {
           get: async () => ({ data: pull }),
-          listFiles: () => {},
+          listFiles,
         },
       },
     },
@@ -615,8 +659,9 @@ test("does not comment on draft PRs", async () => {
     core: { info: () => {}, setOutput: () => {} },
   });
 
-  assert.deepEqual(result, { published: false, reason: "draft" });
+  assert.deepEqual(result, { published: false, reason: "draft", removal: "removed" });
   assert.equal(listedFiles, false);
+  assert.equal(deletedComment, 99);
 });
 
 test("does not publish after the head changes during file collection", async () => {

--- a/.github/scripts/pr-guideline-review.test.cjs
+++ b/.github/scripts/pr-guideline-review.test.cjs
@@ -194,6 +194,24 @@ test("detects a self-closing JSX element as a visible change", () => {
   assert.equal(result.findings.at(-1).code, "missing-ui-images");
 });
 
+test("detects a paired JSX element as a visible change", () => {
+  const result = evaluate({
+    files: [
+      {
+        filename: "apps/web/src/components/SaveButton.tsx",
+        additions: 1,
+        deletions: 0,
+        patch: "+return <button>Save</button>;",
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    result.findings.map((entry) => entry.code),
+    ["missing-ui-images"],
+  );
+});
+
 test("accepts the exact no-UI phrase documented by the template", () => {
   const result = evaluate({
     pull: { body: `${completeBody}\n## UI Changes\nNo visual or interaction changes.` },

--- a/.github/scripts/pr-guideline-review.test.cjs
+++ b/.github/scripts/pr-guideline-review.test.cjs
@@ -45,7 +45,6 @@ function evaluate(overrides = {}) {
     files,
     repository: "pingdotgg/t3code",
     vouchedUsers: overrides.vouchedUsers,
-    vouchedStandardAvailable: overrides.vouchedStandardAvailable,
   });
 }
 
@@ -80,46 +79,16 @@ test("reports missing template content with direct fixes", () => {
   );
 });
 
-test("applies the richer handoff to collaborators and vouched contributors", () => {
-  const collaborator = evaluate({
-    pull: {
-      body: completeBody,
-      author_association: "COLLABORATOR",
-    },
-    vouchedStandardAvailable: true,
-  });
-
-  assert.equal(collaborator.status, "needs_work");
-  assert.deepEqual(
-    collaborator.findings.map((entry) => entry.code),
-    [
-      "missing-scope-and-non-goals",
-      "missing-affected-areas",
-      "missing-validation",
-      "missing-risks-and-untested",
-    ],
-  );
-
+test("treats collaborators and vouched contributors as trusted", () => {
+  const collaborator = evaluate({ pull: { author_association: "COLLABORATOR" } });
   const vouched = evaluate({
-    pull: {
-      user: { login: "VouchedPerson", type: "User" },
-      body: `${completeBody}
-## Scope and Non-Goals
-Only receipt retry state changes; UI behavior is unchanged.
-## Affected Areas
-Server receipts only. No client, provider, contract, or remote-path change.
-## Validation
-\`node --test receipts.test.ts\`: passed.
-## Risks and Untested Paths
-None known.`,
-    },
+    pull: { user: { login: "VouchedPerson", type: "User" } },
     vouchedUsers: new Set(["vouchedperson"]),
-    vouchedStandardAvailable: true,
   });
 
-  assert.equal(vouched.status, "pass");
-  assert.deepEqual(vouched.findings, []);
+  assert.equal(collaborator.metrics.trustedPull, true);
   assert.equal(vouched.metrics.trustedPull, true);
+  assert.equal(evaluate().metrics.trustedPull, false);
 });
 
 test("parses only active GitHub entries from the vouch file", () => {
@@ -127,25 +96,6 @@ test("parses only active GitHub entries from the vouch file", () => {
     [...parseVouchedUsers("# comment\ngithub:Alice\n-github:Blocked reason\ngithub:bob\n")],
     ["alice", "bob"],
   );
-});
-
-test("accepts equivalent vouched-guide headings and surface evidence", () => {
-  const result = evaluate({
-    pull: {
-      author_association: "MEMBER",
-      body: `${completeBody}
-## Scope and Non-Goals
-Documentation only. No client, provider, platform, contract, or connection behavior changes.
-## Validation
-\`vp fmt guide.md --check\`: passed.
-## Risks and Limitations
-The guide will need updates when policy changes. No runtime path was exercised.`,
-    },
-    vouchedStandardAvailable: true,
-  });
-
-  assert.equal(result.status, "pass");
-  assert.deepEqual(result.findings, []);
 });
 
 test("requires images and video for a visible motion change", () => {
@@ -555,20 +505,6 @@ test("renders an advisory comment without claiming approval", () => {
   assert.match(comment, /size:\*.*ignores whitespace-only changes/);
 });
 
-test("links the pinned vouched standard when it is active", () => {
-  const result = evaluate({
-    pull: { author_association: "COLLABORATOR" },
-    vouchedStandardAvailable: true,
-  });
-  const comment = renderComment(result, {
-    repository: "pingdotgg/t3code",
-    policyRevision: "base-sha",
-    vouchedStandardAvailable: true,
-  });
-
-  assert.match(comment, /blob\/base-sha\/CONTRIBUTING_VOUCHED\.md/);
-});
-
 test("does not publish stale results", async () => {
   let listedFiles = false;
   const result = await reviewPull({
@@ -804,4 +740,28 @@ test("updates one existing bot comment in place", async () => {
     ["update"],
   );
   assert.equal(calls[0][1].comment_id, 99);
+});
+
+test("creates a bot comment when none exists", async () => {
+  const calls = [];
+  const publication = await upsertComment(
+    {
+      paginate: async () => [{ id: 5, user: { login: "someone" }, body: COMMENT_MARKER }],
+      rest: {
+        issues: {
+          listComments: () => {},
+          createComment: async (input) => calls.push(["create", input]),
+          updateComment: async (input) => calls.push(["update", input]),
+        },
+      },
+    },
+    { repo: { owner: "pingdotgg", repo: "t3code" } },
+    7,
+    "body",
+  );
+
+  assert.equal(publication, "created");
+  assert.deepEqual(calls, [
+    ["create", { owner: "pingdotgg", repo: "t3code", issue_number: 7, body: "body" }],
+  ]);
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Test nightly release checks
         run: node --test .github/scripts/check-nightly-release.test.cjs
 
+      - name: Test contribution sniff test
+        run: node --test .github/scripts/pr-guideline-review.test.cjs
+
       - name: Test
         run: vp run --parallel --concurrency-limit 4 --filter '!t3' --filter '!@t3tools/monorepo' test
 

--- a/.github/workflows/pr-guideline-review.yml
+++ b/.github/workflows/pr-guideline-review.yml
@@ -2,13 +2,23 @@ name: PR Guideline Review
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, ready_for_review]
+    types: [opened, reopened, edited, synchronize, ready_for_review, converted_to_draft]
     paths:
       - .github/scripts/pr-guideline-review.cjs
       - .github/scripts/pr-guideline-review.test.cjs
       - .github/workflows/pr-guideline-review.yml
   pull_request_target:
-    types: [opened, reopened, edited, synchronize, ready_for_review]
+    types:
+      [
+        opened,
+        reopened,
+        edited,
+        synchronize,
+        ready_for_review,
+        converted_to_draft,
+        labeled,
+        unlabeled,
+      ]
 
 permissions: {}
 
@@ -25,7 +35,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download proposed reviewer
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require("node:fs");
@@ -68,7 +78,7 @@ jobs:
             }
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.13.1
 
@@ -96,7 +106,7 @@ jobs:
       # the trusted base-branch reviewer. PR files are API data and are never
       # checked out or executed.
       - name: Checkout trusted reviewer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -107,7 +117,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Update contribution sniff test
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require("node:fs");
@@ -132,4 +142,5 @@ jobs:
               });
             } catch (error) {
               core.warning(`Advisory contribution review was unavailable: ${error instanceof Error ? error.message : String(error)}`);
+              throw error;
             }

--- a/.github/workflows/pr-guideline-review.yml
+++ b/.github/workflows/pr-guideline-review.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Test proposed reviewer
         run: |
+          set -o pipefail
           node --test --test-reporter=tap .github/scripts/pr-guideline-review.test.cjs | tee tap.log
           grep -Eq '^# pass [1-9][0-9]*$' tap.log
 
@@ -81,8 +82,7 @@ jobs:
     name: Review contribution guidelines
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.base.repo.full_name == github.repository &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch
+      github.event.pull_request.base.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/pr-guideline-review.yml
+++ b/.github/workflows/pr-guideline-review.yml
@@ -1,0 +1,135 @@
+name: PR Guideline Review
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+    paths:
+      - .github/scripts/pr-guideline-review.cjs
+      - .github/scripts/pr-guideline-review.test.cjs
+      - .github/workflows/pr-guideline-review.yml
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate contribution reviewer
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: pr-guideline-validate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Download proposed reviewer
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const pull = context.payload.pull_request;
+            const source = pull.head.repo?.full_name ?? context.payload.repository.full_name;
+            const [owner, repo] = source.split("/");
+            const files = [
+              ".github/scripts/pr-guideline-review.cjs",
+              ".github/scripts/pr-guideline-review.test.cjs",
+            ];
+
+            for (const file of files) {
+              let data;
+              try {
+                ({ data } = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: file,
+                  ref: pull.head.sha,
+                }));
+              } catch (error) {
+                throw new Error(
+                  `Could not load ${file} at ${pull.head.sha}: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              }
+              if (
+                Array.isArray(data) ||
+                data.type !== "file" ||
+                data.encoding !== "base64" ||
+                !data.content
+              ) {
+                throw new Error(
+                  `Expected ${file} at ${pull.head.sha} to be a base64 file within GitHub's 1 MB inline-content limit.`,
+                );
+              }
+
+              fs.mkdirSync(path.dirname(file), { recursive: true });
+              fs.writeFileSync(file, Buffer.from(data.content, "base64"));
+            }
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.13.1
+
+      - name: Test proposed reviewer
+        run: |
+          node --test --test-reporter=tap .github/scripts/pr-guideline-review.test.cjs | tee tap.log
+          grep -Eq '^# pass [1-9][0-9]*$' tap.log
+
+  review:
+    name: Review contribution guidelines
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.base.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    concurrency:
+      group: pr-guideline-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      # pull_request_target has a write-capable token for fork PRs. Load only
+      # the trusted base-branch reviewer. PR files are API data and are never
+      # checked out or executed.
+      - name: Checkout trusted reviewer
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts
+            .github/VOUCHED.td
+            CONTRIBUTING_VOUCHED.md
+          sparse-checkout-cone-mode: false
+
+      - name: Update contribution sniff test
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("node:fs");
+            const reviewer = require("./.github/scripts/pr-guideline-review.cjs");
+            try {
+              let vouchedUsers = new Set();
+              try {
+                vouchedUsers = reviewer.parseVouchedUsers(
+                  fs.readFileSync(".github/VOUCHED.td", "utf8"),
+                );
+              } catch (error) {
+                core.warning(`Trusted contributor list was unavailable; using PR association and labels: ${error instanceof Error ? error.message : String(error)}`);
+              }
+              const vouchedStandardAvailable = fs.existsSync("CONTRIBUTING_VOUCHED.md");
+              await reviewer.reviewPull({
+                github,
+                context,
+                core,
+                policyRevision: context.sha,
+                vouchedUsers,
+                vouchedStandardAvailable,
+              });
+            } catch (error) {
+              core.warning(`Advisory contribution review was unavailable: ${error instanceof Error ? error.message : String(error)}`);
+            }

--- a/.github/workflows/pr-guideline-review.yml
+++ b/.github/workflows/pr-guideline-review.yml
@@ -1,12 +1,6 @@
 name: PR Guideline Review
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize, ready_for_review, converted_to_draft]
-    paths:
-      - .github/scripts/pr-guideline-review.cjs
-      - .github/scripts/pr-guideline-review.test.cjs
-      - .github/workflows/pr-guideline-review.yml
   pull_request_target:
     types:
       [
@@ -23,76 +17,9 @@ on:
 permissions: {}
 
 jobs:
-  validate:
-    name: Validate contribution reviewer
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
-    concurrency:
-      group: pr-guideline-validate-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    permissions:
-      contents: read
-    timeout-minutes: 5
-    steps:
-      - name: Download proposed reviewer
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const fs = require("node:fs");
-            const path = require("node:path");
-            const pull = context.payload.pull_request;
-            const source = pull.head.repo?.full_name ?? context.payload.repository.full_name;
-            const [owner, repo] = source.split("/");
-            const files = [
-              ".github/scripts/pr-guideline-review.cjs",
-              ".github/scripts/pr-guideline-review.test.cjs",
-            ];
-
-            for (const file of files) {
-              let data;
-              try {
-                ({ data } = await github.rest.repos.getContent({
-                  owner,
-                  repo,
-                  path: file,
-                  ref: pull.head.sha,
-                }));
-              } catch (error) {
-                throw new Error(
-                  `Could not load ${file} at ${pull.head.sha}: ${error instanceof Error ? error.message : String(error)}`,
-                );
-              }
-              if (
-                Array.isArray(data) ||
-                data.type !== "file" ||
-                data.encoding !== "base64" ||
-                !data.content
-              ) {
-                throw new Error(
-                  `Expected ${file} at ${pull.head.sha} to be a base64 file within GitHub's 1 MB inline-content limit.`,
-                );
-              }
-
-              fs.mkdirSync(path.dirname(file), { recursive: true });
-              fs.writeFileSync(file, Buffer.from(data.content, "base64"));
-            }
-
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 24.13.1
-
-      - name: Test proposed reviewer
-        run: |
-          set -o pipefail
-          node --test --test-reporter=tap .github/scripts/pr-guideline-review.test.cjs | tee tap.log
-          grep -Eq '^# pass [1-9][0-9]*$' tap.log
-
   review:
     name: Review contribution guidelines
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.base.repo.full_name == github.repository
+    if: github.event.pull_request.base.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -113,7 +40,6 @@ jobs:
           sparse-checkout: |
             .github/scripts
             .github/VOUCHED.td
-            CONTRIBUTING_VOUCHED.md
           sparse-checkout-cone-mode: false
 
       - name: Update contribution sniff test
@@ -131,14 +57,12 @@ jobs:
               } catch (error) {
                 core.warning(`Trusted contributor list was unavailable; using PR association and labels: ${error instanceof Error ? error.message : String(error)}`);
               }
-              const vouchedStandardAvailable = fs.existsSync("CONTRIBUTING_VOUCHED.md");
               await reviewer.reviewPull({
                 github,
                 context,
                 core,
                 policyRevision: context.sha,
                 vouchedUsers,
-                vouchedStandardAvailable,
               });
             } catch (error) {
               core.warning(`Advisory contribution review was unavailable: ${error instanceof Error ? error.message : String(error)}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ If that sounds annoying, that is because it is. This project is still early and 
 
 PRs are automatically labeled with a `vouch:*` trust status and a `size:*` diff size based on changed lines.
 
+PRs also receive an advisory contribution sniff test that explains objective guideline gaps. It does not accept, reject, or replace maintainer review.
+
+When `CONTRIBUTING_VOUCHED.md` is present on the target branch, trusted contributors receive its additional handoff checks for scope, affected surfaces, validation, risks, and untested paths.
+
 If you are an external contributor, expect `vouch:unvouched` until we explicitly add you to [.github/VOUCHED.td](.github/VOUCHED.td).
 
 ## What We Are Most Likely To Accept

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,6 @@ PRs are automatically labeled with a `vouch:*` trust status and a `size:*` diff 
 
 PRs also receive an advisory contribution sniff test that explains objective guideline gaps. It does not accept, reject, or replace maintainer review.
 
-When `CONTRIBUTING_VOUCHED.md` is present on the target branch, trusted contributors receive its additional handoff checks for scope, affected surfaces, validation, risks, and untested paths.
-
 If you are an external contributor, expect `vouch:unvouched` until we explicitly add you to [.github/VOUCHED.td](.github/VOUCHED.td).
 
 ## What We Are Most Likely To Accept


### PR DESCRIPTION
## What Changed

Adds an advisory contribution check that points out missing PR explanations, context, and UI evidence before a maintainer reviews the change. It creates or updates one GitHub Actions comment, without approving, rejecting, or labeling the PR.

The check reads `What Changed`, `Why`, and `UI Changes`; flags missing before/after images for detected visible client changes and missing video for detected motion changes; and highlights external feature proposals without a repository discussion, large changes without context, broad diffs, and incomplete API diffs for human review. Explicit explanations that visuals or interactions are unchanged are accepted.

The PR template adds owning context and clarifies evidence wording. CONTRIBUTING.md explains the advisory check. Tests run in the existing CI Test job using the repository's CommonJS/Node test convention.

## Why

The contribution guide already asks for these explanations and evidence, but authors often learn about gaps only when a maintainer reads the PR. This check supplies early, concrete feedback while leaving product direction, scope, and correctness to maintainers.

The change is not superseded by the Cursor hygiene forwarder (#9518, adjusted in #9527): that workflow forwards events to an external service; it does not implement these template and evidence checks.

## Owning Context

No prior maintainer alignment. Maintainers must decide whether to adopt this proposed advisory policy and write-capable workflow.

## Trust boundary

The `pull_request_target` job executes only the trusted base revision from `github.sha`, with sparse checkout, disabled credential persistence, and actions pinned to full commit SHAs. PR files are fetched as API data and never executed. Permissions are limited to `contents: read` and `pull-requests: write`. Draft PRs have prior advisory comments removed; bot PRs are skipped. The head is checked before evaluation and again before publication.

## Validation

Rebased cleanly onto `origin/main` at `b1e223e2b0`; all six commits remain patch-equivalent to the previous head.

- `node --test .github/scripts/pr-guideline-review.test.cjs`: 34 passed, 0 failed.
- `node --check` on the reviewer and its test: passed.
- `vp fmt --check` on all six changed files and `vp lint` on both CommonJS files: passed.
- `git diff --check origin/main...HEAD`: passed. No TypeScript files or application runtime behavior changed.
- Independent read-only Codex CLI review using GPT-6 Astra, medium reasoning: exit 0, no actionable findings in `origin/main...469a878d7d`. The reviewer independently reran all 34 tests. This was a same-provider review, as explicitly requested through codex-review.

Live advisory publication remains unverified until the workflow is on a trusted base branch; mocked GitHub API tests cover comment creation, update, unchanged results, draft removal, bot exclusion, and stale-head checks.

## UI Changes

No visual or interaction changes to web, desktop, or mobile clients. This is GitHub automation and contributor guidance; client screenshots and videos do not demonstrate its behavior.

Coordination trace: T3 thread 809de8ee-7ea5-4b23-92cb-12730950e082

Model and harness: GPT-6 in Codex/T3 Code; independent review by GPT-6 Astra (medium) in Codex CLI. Existing implementation and previous worker fixes preserved.
