### PR TITLE
feat(web): save model options with favorites

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8,6 +8,7 @@ import {
   type ProjectScript,
   type ProjectId,
   type ProviderApprovalDecision,
+  type ProviderOptionSelection,
   type PreviewAnnotationPayload,
   ProviderInstanceId,
   type ServerProvider,
@@ -6511,7 +6512,11 @@ function ChatViewContent(props: ChatViewProps) {
   );
 
   const onProviderModelSelect = useCallback(
-    (instanceId: ProviderInstanceId, model: string) => {
+    (
+      instanceId: ProviderInstanceId,
+      model: string,
+      savedOptions?: ReadonlyArray<ProviderOptionSelection>,
+    ) => {
       if (!activeThread) return;
       // Look up the configured instance so model normalization and custom
       // model lookup stay scoped to that exact instance. Unknown instance ids
@@ -6549,10 +6554,7 @@ function ChatViewContent(props: ChatViewProps) {
         scheduleComposerFocus();
         return;
       }
-      const nextModelSelection: ModelSelection = {
-        instanceId,
-        model: resolvedModel,
-      };
+      const nextModelSelection = createModelSelection(instanceId, resolvedModel, savedOptions);
       const modelChangeBlockReason = getStartedThreadModelChangeBlockReason({
         providers: providerStatuses,
         hasStartedSession: activeThread.session !== null,
@@ -6572,6 +6574,7 @@ function ChatViewContent(props: ChatViewProps) {
       setComposerDraftModelSelection(
         scopeThreadRef(activeThread.environmentId, activeThread.id),
         nextModelSelection,
+        { replaceOptions: savedOptions !== undefined },
       );
       setStickyComposerModelSelection(nextModelSelection);
       scheduleComposerFocus();

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -5,6 +5,7 @@ import type {
   PreviewAnnotationPayload,
   ProviderApprovalDecision,
   ProviderInteractionMode,
+  ProviderOptionSelection,
   ResolvedKeybindingsConfig,
   RuntimeMode,
   ScopedThreadRef,
@@ -653,7 +654,11 @@ export interface ChatComposerProps {
     cursorAdjacentToMention: boolean,
   ) => void;
 
-  onProviderModelSelect: (instanceId: ProviderInstanceId, model: string) => void;
+  onProviderModelSelect: (
+    instanceId: ProviderInstanceId,
+    model: string,
+    savedOptions?: ReadonlyArray<ProviderOptionSelection>,
+  ) => void;
   getModelDisabledReason: (instanceId: ProviderInstanceId, model: string) => string | null;
   toggleInteractionMode: () => void;
   handleRuntimeModeChange: (mode: RuntimeMode) => void;
@@ -3495,6 +3500,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       instanceEntries={providerInstanceEntries}
                       keybindings={keybindings}
                       modelOptionsByInstance={modelOptionsByInstance}
+                      selectionOptions={selectedModelOptionsForDispatch ?? []}
                       triggerClassName="-ms-2.5"
                       terminalOpen={terminalOpen}
                       open={isComposerModelPickerOpen}

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -35,6 +35,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
   useTriggerLabel?: boolean;
   showNewBadge?: boolean;
   jumpLabel?: string | null;
+  favoriteConfigurationLabel?: string | null;
   disabledReason?: string | null;
   onToggleFavorite: () => void;
 }) {
@@ -82,6 +83,14 @@ export const ModelListRow = memo(function ModelListRow(props: {
             <span className="truncate text-xs font-normal leading-snug text-muted-foreground/70">
               {providerLabel}
             </span>
+            {props.favoriteConfigurationLabel ? (
+              <>
+                <span className="text-xs text-muted-foreground/50">·</span>
+                <span className="shrink-0 text-xs font-medium leading-snug text-muted-foreground">
+                  {props.favoriteConfigurationLabel}
+                </span>
+              </>
+            ) : null}
           </div>
         )}
       </div>

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -1,6 +1,7 @@
 import {
   type ProviderInstanceId,
   type ProviderDriverKind,
+  type ProviderOptionSelection,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
@@ -41,6 +42,11 @@ import {
   type ProviderInstanceEntry,
 } from "../../providerInstances";
 import { providerModelKey, sortProviderModelItems } from "../../modelOrdering";
+import {
+  findModelFavorite,
+  getModelFavoriteEffortLabel,
+  toggleModelFavorite,
+} from "../../modelFavorites";
 
 type ModelPickerItem = {
   slug: string;
@@ -88,10 +94,15 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
    * model set but are free to diverge via customModels).
    */
   modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
+  selectionOptions: ReadonlyArray<ProviderOptionSelection>;
   terminalOpen: boolean;
   onRequestClose?: () => void;
   getModelDisabledReason?: (instanceId: ProviderInstanceId, model: string) => string | null;
-  onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+  onInstanceModelChange: (
+    instanceId: ProviderInstanceId,
+    model: string,
+    savedOptions?: ReadonlyArray<ProviderOptionSelection>,
+  ) => void;
 }) {
   const {
     keybindings: providedKeybindings,
@@ -169,6 +180,16 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   const favoritesSet = useMemo(() => {
     return new Set(favorites.map((fav) => providerModelKey(fav.provider, fav.model)));
   }, [favorites]);
+  const favoriteByKey = useMemo(
+    () =>
+      new Map(
+        favorites.map((favorite) => [
+          providerModelKey(favorite.provider, favorite.model),
+          favorite,
+        ]),
+      ),
+    [favorites],
+  );
 
   /**
    * Lookup table keyed by `instanceId`. Used for display name + driver
@@ -434,24 +455,31 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       // normalization rules, so pass the driver kind here.
       const resolvedModel = resolveSelectableModel(entry.driverKind, modelSlug, options);
       if (resolvedModel) {
-        onInstanceModelChange(instanceId, resolvedModel);
+        const favorite = findModelFavorite(favorites, instanceId, modelSlug);
+        onInstanceModelChange(instanceId, resolvedModel, favorite?.options);
       }
     },
-    [entryByInstanceId, getModelDisabledReason, modelOptionsByInstance, onInstanceModelChange],
+    [
+      entryByInstanceId,
+      favorites,
+      getModelDisabledReason,
+      modelOptionsByInstance,
+      onInstanceModelChange,
+    ],
   );
 
   const toggleFavorite = useCallback(
     (instanceId: ProviderInstanceId, model: string) => {
-      const newFavorites = [...favorites];
-      const index = newFavorites.findIndex((f) => f.provider === instanceId && f.model === model);
-      if (index >= 0) {
-        newFavorites.splice(index, 1);
-      } else {
-        newFavorites.push({ provider: instanceId, model });
-      }
-      updateSettings({ favorites: newFavorites });
+      const isActiveModel = instanceId === props.activeInstanceId && model === props.model;
+      updateSettings({
+        favorites: toggleModelFavorite(favorites, {
+          instanceId,
+          model,
+          options: isActiveModel ? props.selectionOptions : [],
+        }),
+      });
     },
-    [favorites, updateSettings],
+    [favorites, props.activeInstanceId, props.model, props.selectionOptions, updateSettings],
   );
 
   const modelJumpCommandByKey = useMemo(() => {
@@ -769,6 +797,9 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                         useTriggerLabel={false}
                         showNewBadge={isModelPickerNewModel(model.driverKind, model.slug)}
                         jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
+                        favoriteConfigurationLabel={getModelFavoriteEffortLabel(
+                          favoriteByKey.get(providerModelKey(model.instanceId, model.slug)),
+                        )}
                         disabledReason={disabledReason}
                         onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}
                       />

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -45,7 +45,7 @@ import { providerModelKey, sortProviderModelItems } from "../../modelOrdering";
 import {
   findModelFavorite,
   getModelFavoriteEffortLabel,
-  toggleModelFavorite,
+  toggleModelFavoriteForSelection,
 } from "../../modelFavorites";
 
 type ModelPickerItem = {
@@ -470,16 +470,27 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
 
   const toggleFavorite = useCallback(
     (instanceId: ProviderInstanceId, model: string) => {
-      const isActiveModel = instanceId === props.activeInstanceId && model === props.model;
+      const entry = entryByInstanceId.get(instanceId);
+      if (!entry) {
+        return;
+      }
       updateSettings({
-        favorites: toggleModelFavorite(favorites, {
-          instanceId,
-          model,
-          options: isActiveModel ? props.selectionOptions : [],
+        favorites: toggleModelFavoriteForSelection(favorites, {
+          selection: { instanceId, model },
+          activeSelection: { instanceId: props.activeInstanceId, model: props.model },
+          activeOptions: props.selectionOptions,
+          models: entry.models,
         }),
       });
     },
-    [favorites, props.activeInstanceId, props.model, props.selectionOptions, updateSettings],
+    [
+      entryByInstanceId,
+      favorites,
+      props.activeInstanceId,
+      props.model,
+      props.selectionOptions,
+      updateSettings,
+    ],
   );
 
   const modelJumpCommandByKey = useMemo(() => {
@@ -799,6 +810,9 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                         jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
                         favoriteConfigurationLabel={getModelFavoriteEffortLabel(
                           favoriteByKey.get(providerModelKey(model.instanceId, model.slug)),
+                          entryByInstanceId
+                            .get(model.instanceId)
+                            ?.models.find((candidate) => candidate.slug === model.slug),
                         )}
                         disabledReason={disabledReason}
                         onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -1,6 +1,7 @@
 import {
   type ProviderInstanceId,
   type ProviderDriverKind,
+  type ProviderOptionSelection,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { memo, useEffect, useMemo, useState } from "react";
@@ -32,6 +33,8 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   instanceEntries: ReadonlyArray<ProviderInstanceEntry>;
   keybindings?: ResolvedKeybindingsConfig;
   modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
+  /** Complete option snapshot for the active model, saved when it is favorited. */
+  selectionOptions?: ReadonlyArray<ProviderOptionSelection>;
   activeProviderIconClassName?: string;
   compact?: boolean;
   disabled?: boolean;
@@ -42,7 +45,11 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   triggerAriaLabel?: string;
   onOpenChange?: (open: boolean) => void;
   getModelDisabledReason?: (instanceId: ProviderInstanceId, model: string) => string | null;
-  onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+  onInstanceModelChange: (
+    instanceId: ProviderInstanceId,
+    model: string,
+    savedOptions?: ReadonlyArray<ProviderOptionSelection>,
+  ) => void;
 }) {
   const [uncontrolledIsMenuOpen, setUncontrolledIsMenuOpen] = useState(false);
   const isMenuOpen = props.open ?? uncontrolledIsMenuOpen;
@@ -125,9 +132,13 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     };
   }, [isMenuOpen]);
 
-  const handleInstanceModelChange = (instanceId: ProviderInstanceId, model: string) => {
+  const handleInstanceModelChange = (
+    instanceId: ProviderInstanceId,
+    model: string,
+    savedOptions?: ReadonlyArray<ProviderOptionSelection>,
+  ) => {
     if (props.disabled) return;
-    props.onInstanceModelChange(instanceId, model);
+    props.onInstanceModelChange(instanceId, model, savedOptions);
     setIsMenuOpen(false);
   };
 
@@ -197,6 +208,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           instanceEntries={props.instanceEntries}
           {...(props.keybindings ? { keybindings: props.keybindings } : {})}
           modelOptionsByInstance={props.modelOptionsByInstance}
+          selectionOptions={props.selectionOptions ?? []}
           terminalOpen={props.terminalOpen ?? false}
           onRequestClose={() => setIsMenuOpen(false)}
           {...(props.getModelDisabledReason

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -61,6 +61,7 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { getCustomModelOptionsByInstance } from "../../modelSelection";
+import { buildModelFavoriteOptions } from "../../modelFavorites";
 import {
   buildSidebarProjectSnapshots,
   type SidebarProjectGroupMember,
@@ -431,6 +432,10 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const activeEntry = instanceEntries.find(
     (entry) => entry.instanceId === resolvedSelection?.instanceId,
   );
+  const favoriteSelectionOptions =
+    resolvedSelection && activeEntry
+      ? buildModelFavoriteOptions(resolvedSelection, activeEntry.models)
+      : [];
   const setDefaultModel = useCallback(
     (selection: ModelSelection | null) =>
       void updateAllMembers({ defaultModelSelection: selection }, "Failed to update default model"),
@@ -846,10 +851,11 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                     lockedProvider={null}
                     instanceEntries={instanceEntries}
                     modelOptionsByInstance={modelOptionsByInstance}
+                    selectionOptions={favoriteSelectionOptions}
                     triggerVariant="outline"
                     triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
-                    onInstanceModelChange={(instanceId, model) => {
-                      setDefaultModel(createModelSelection(instanceId, model));
+                    onInstanceModelChange={(instanceId, model, savedOptions) => {
+                      setDefaultModel(createModelSelection(instanceId, model, savedOptions));
                     }}
                   />
                   <TraitsPicker

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -14,7 +14,7 @@ import {
   type ProviderInstanceId,
   resolveProviderInstanceEnabled,
 } from "@t3tools/contracts";
-import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { DEFAULT_UNIFIED_SETTINGS, type ModelFavorite } from "@t3tools/contracts/settings";
 import {
   getBackgroundActivityPresetSettings,
   resolveServerBackgroundActivitySettings,
@@ -110,7 +110,7 @@ function withoutProviderInstanceKey<V>(
 }
 
 function withoutProviderInstanceFavorites(
-  favorites: ReadonlyArray<{ readonly provider: ProviderInstanceId; readonly model: string }>,
+  favorites: ReadonlyArray<ModelFavorite>,
   instanceId: ProviderInstanceId,
 ) {
   return favorites.filter((favorite) => favorite.provider !== instanceId);
@@ -640,10 +640,17 @@ export function EnvironmentProviderSettings({
         }),
       ),
     ];
+    const existingFavorites = new Map(
+      (settings.favorites ?? [])
+        .filter((favorite) => favorite.provider === instanceId)
+        .map((favorite) => [favorite.model, favorite]),
+    );
     updateSettings({
       favorites: [
         ...withoutProviderInstanceFavorites(settings.favorites ?? [], instanceId),
-        ...favoriteModels.map((model) => ({ provider: instanceId, model })),
+        ...favoriteModels.map(
+          (model) => existingFavorites.get(model) ?? { provider: instanceId, model },
+        ),
       ],
     });
   };

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -72,6 +72,7 @@ import {
   resolveAppModelSelectionState,
   withoutPlanAgentSelection,
 } from "../../modelSelection";
+import { buildModelFavoriteOptions } from "../../modelFavorites";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -1882,6 +1883,9 @@ export function GeneralSettingsPanel() {
   );
   const textGenProvider: ProviderDriverKind =
     textGenInstanceEntry?.driverKind ?? DEFAULT_DRIVER_KIND;
+  const textGenFavoriteOptions = textGenInstanceEntry
+    ? buildModelFavoriteOptions(textGenerationModelSelection, textGenInstanceEntry.models)
+    : [];
   const textGenerationModelOptionsByInstance = getCustomModelOptionsByInstance(
     settings,
     serverProviders,
@@ -2420,14 +2424,19 @@ export function GeneralSettingsPanel() {
                 lockedProvider={null}
                 instanceEntries={textGenerationModelInstanceEntries}
                 modelOptionsByInstance={textGenerationModelOptionsByInstance}
+                selectionOptions={textGenFavoriteOptions}
                 triggerVariant="outline"
                 triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
-                onInstanceModelChange={(instanceId, model) => {
+                onInstanceModelChange={(instanceId, model, savedOptions) => {
                   updateSettings({
                     textGenerationModelSelection: resolveAppModelSelectionState(
                       {
                         ...settings,
-                        textGenerationModelSelection: createModelSelection(instanceId, model),
+                        textGenerationModelSelection: createModelSelection(
+                          instanceId,
+                          model,
+                          savedOptions,
+                        ),
                       },
                       serverProviders,
                     ),

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -15,6 +15,7 @@ import {
   getCustomModelOptionsByInstance,
   resolveAppModelSelectionState,
 } from "../../modelSelection";
+import { buildModelFavoriteOptions } from "../../modelFavorites";
 import { primaryServerProvidersAtom } from "../../state/server";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
@@ -69,6 +70,12 @@ export function SourceControlWritingSettingsSection() {
     activeSelection.instanceId,
     activeSelection.model,
   );
+  const activeInstanceEntry = instanceEntries.find(
+    (entry) => entry.instanceId === activeSelection.instanceId,
+  );
+  const favoriteSelectionOptions = activeInstanceEntry
+    ? buildModelFavoriteOptions(activeSelection, activeInstanceEntry.models)
+    : [];
 
   return (
     <SettingsSection title="Text generation">
@@ -180,12 +187,17 @@ export function SourceControlWritingSettingsSection() {
                 lockedProvider={null}
                 instanceEntries={instanceEntries}
                 modelOptionsByInstance={modelOptionsByInstance}
+                selectionOptions={favoriteSelectionOptions}
                 triggerVariant="outline"
                 triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                 triggerAriaLabel="Source control writer model"
-                onInstanceModelChange={(instanceId, model) => {
+                onInstanceModelChange={(instanceId, model, savedOptions) => {
                   updateSettings({
-                    sourceControlWriterModelSelection: createModelSelection(instanceId, model),
+                    sourceControlWriterModelSelection: createModelSelection(
+                      instanceId,
+                      model,
+                      savedOptions,
+                    ),
                   });
                 }}
               />

--- a/apps/web/src/modelFavorites.test.ts
+++ b/apps/web/src/modelFavorites.test.ts
@@ -6,6 +6,7 @@ import {
   findModelFavorite,
   getModelFavoriteEffortLabel,
   toggleModelFavorite,
+  toggleModelFavoriteForSelection,
 } from "./modelFavorites";
 
 const CODEX = ProviderInstanceId.make("codex");
@@ -51,6 +52,86 @@ describe("model favorites", () => {
       },
     ]);
     expect(getModelFavoriteEffortLabel(favorites[0])).toBe("High");
+  });
+
+  it("snapshots an inactive model's defaults instead of the active model's options", () => {
+    const favorites = toggleModelFavoriteForSelection([], {
+      selection: { instanceId: CODEX, model: "gpt-5.6-sol" },
+      activeSelection: { instanceId: CODEX, model: "gpt-5.6-terra" },
+      activeOptions: [],
+      models: [
+        {
+          slug: "gpt-5.6-sol",
+          name: "GPT-5.6-Sol",
+          isCustom: false,
+          capabilities: {
+            optionDescriptors: [
+              {
+                id: "reasoningEffort",
+                label: "Reasoning effort",
+                type: "select",
+                options: [
+                  { id: "medium", label: "Medium", isDefault: true },
+                  { id: "high", label: "High" },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(favorites).toEqual([
+      {
+        provider: CODEX,
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "medium" }],
+      },
+    ]);
+  });
+
+  it("uses the provider's label for saved effort values", () => {
+    expect(
+      getModelFavoriteEffortLabel(
+        {
+          provider: CODEX,
+          model: "gpt-5.6-sol",
+          options: [{ id: "reasoningEffort", value: "xhigh" }],
+        },
+        {
+          slug: "gpt-5.6-sol",
+          name: "GPT-5.6-Sol",
+          isCustom: false,
+          capabilities: {
+            optionDescriptors: [
+              {
+                id: "reasoningEffort",
+                label: "Reasoning effort",
+                type: "select",
+                options: [{ id: "xhigh", label: "Extra High", isDefault: true }],
+              },
+            ],
+          },
+        },
+      ),
+    ).toBe("Extra High");
+  });
+
+  it("formats supported effort values when provider metadata is unavailable", () => {
+    expect(
+      getModelFavoriteEffortLabel({
+        provider: CODEX,
+        model: "claude-opus",
+        options: [{ id: "effort", value: "ultrathink" }],
+      }),
+    ).toBe("Ultrathink");
+    expect(
+      getModelFavoriteEffortLabel({
+        provider: CODEX,
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "ultra" }],
+      }),
+    ).toBe("Ultra");
   });
 
   it("keeps model-only legacy favorites selectable without inventing options", () => {

--- a/apps/web/src/modelFavorites.test.ts
+++ b/apps/web/src/modelFavorites.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vite-plus/test";
+import { ProviderInstanceId } from "@t3tools/contracts";
+
+import {
+  buildModelFavoriteOptions,
+  findModelFavorite,
+  getModelFavoriteEffortLabel,
+  toggleModelFavorite,
+} from "./modelFavorites";
+
+const CODEX = ProviderInstanceId.make("codex");
+
+describe("model favorites", () => {
+  it("materializes a model's default reasoning effort for a favorite snapshot", () => {
+    expect(
+      buildModelFavoriteOptions({ instanceId: CODEX, model: "gpt-5.6-sol" }, [
+        {
+          slug: "gpt-5.6-sol",
+          name: "GPT-5.6-Sol",
+          isCustom: false,
+          capabilities: {
+            optionDescriptors: [
+              {
+                id: "reasoningEffort",
+                label: "Reasoning effort",
+                type: "select",
+                options: [
+                  { id: "medium", label: "Medium", isDefault: true },
+                  { id: "high", label: "High" },
+                ],
+              },
+            ],
+          },
+        },
+      ]),
+    ).toEqual([{ id: "reasoningEffort", value: "medium" }]);
+  });
+
+  it("snapshots reasoning effort when a model is favorited", () => {
+    const favorites = toggleModelFavorite([], {
+      instanceId: CODEX,
+      model: "gpt-5.6-sol",
+      options: [{ id: "reasoningEffort", value: "high" }],
+    });
+
+    expect(favorites).toEqual([
+      {
+        provider: CODEX,
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "high" }],
+      },
+    ]);
+    expect(getModelFavoriteEffortLabel(favorites[0])).toBe("High");
+  });
+
+  it("keeps model-only legacy favorites selectable without inventing options", () => {
+    const favorite = findModelFavorite(
+      [{ provider: CODEX, model: "gpt-5.6-sol" }],
+      CODEX,
+      "gpt-5.6-sol",
+    );
+
+    expect(favorite?.options).toBeUndefined();
+    expect(getModelFavoriteEffortLabel(favorite)).toBeNull();
+  });
+
+  it("removes an existing favorite regardless of its saved configuration", () => {
+    const favorites = toggleModelFavorite(
+      [
+        {
+          provider: CODEX,
+          model: "gpt-5.6-sol",
+          options: [{ id: "reasoningEffort", value: "high" }],
+        },
+      ],
+      {
+        instanceId: CODEX,
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "low" }],
+      },
+    );
+
+    expect(favorites).toEqual([]);
+  });
+});

--- a/apps/web/src/modelFavorites.ts
+++ b/apps/web/src/modelFavorites.ts
@@ -1,0 +1,78 @@
+import type {
+  ModelSelection,
+  ProviderInstanceId,
+  ProviderOptionSelection,
+  ServerProviderModel,
+} from "@t3tools/contracts";
+import type { ModelFavorite } from "@t3tools/contracts/settings";
+import {
+  buildProviderOptionSelectionsFromDescriptors,
+  getModelSelectionOptionDescriptors,
+} from "@t3tools/shared/model";
+
+const EFFORT_OPTION_IDS = new Set(["reasoningEffort", "effort", "reasoning", "variant"]);
+const EFFORT_LABELS: Readonly<Record<string, string>> = {
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "XHigh",
+  max: "Max",
+  adaptive: "Adaptive",
+};
+
+export function findModelFavorite(
+  favorites: ReadonlyArray<ModelFavorite>,
+  instanceId: ProviderInstanceId,
+  model: string,
+): ModelFavorite | undefined {
+  return favorites.find((favorite) => favorite.provider === instanceId && favorite.model === model);
+}
+
+export function buildModelFavoriteOptions(
+  selection: ModelSelection,
+  models: ReadonlyArray<ServerProviderModel>,
+): ReadonlyArray<ProviderOptionSelection> {
+  const model = models.find((candidate) => candidate.slug === selection.model);
+  return (
+    buildProviderOptionSelectionsFromDescriptors(
+      getModelSelectionOptionDescriptors(selection, model?.capabilities),
+    ) ?? []
+  );
+}
+
+export function toggleModelFavorite(
+  favorites: ReadonlyArray<ModelFavorite>,
+  input: {
+    readonly instanceId: ProviderInstanceId;
+    readonly model: string;
+    readonly options: ReadonlyArray<ProviderOptionSelection>;
+  },
+): ModelFavorite[] {
+  const existingIndex = favorites.findIndex(
+    (favorite) => favorite.provider === input.instanceId && favorite.model === input.model,
+  );
+  if (existingIndex >= 0) {
+    return favorites.filter((_, index) => index !== existingIndex);
+  }
+  return [
+    ...favorites,
+    {
+      provider: input.instanceId,
+      model: input.model,
+      // Keep an empty array to distinguish a new snapshot that intentionally
+      // uses provider defaults from a legacy favorite with no saved options.
+      options: input.options.map((option) => ({ ...option })),
+    },
+  ];
+}
+
+export function getModelFavoriteEffortLabel(favorite: ModelFavorite | undefined): string | null {
+  const effort = favorite?.options?.find(
+    (selection) => EFFORT_OPTION_IDS.has(selection.id) && typeof selection.value === "string",
+  );
+  if (!effort || typeof effort.value !== "string") {
+    return null;
+  }
+  return EFFORT_LABELS[effort.value] ?? effort.value;
+}

--- a/apps/web/src/modelFavorites.ts
+++ b/apps/web/src/modelFavorites.ts
@@ -16,9 +16,13 @@ const EFFORT_LABELS: Readonly<Record<string, string>> = {
   low: "Low",
   medium: "Medium",
   high: "High",
-  xhigh: "XHigh",
+  xhigh: "Extra High",
   max: "Max",
   adaptive: "Adaptive",
+  ultra: "Ultra",
+  ultracode: "Ultracode",
+  ultrathink: "Ultrathink",
+  none: "None",
 };
 
 export function findModelFavorite(
@@ -67,12 +71,46 @@ export function toggleModelFavorite(
   ];
 }
 
-export function getModelFavoriteEffortLabel(favorite: ModelFavorite | undefined): string | null {
+export function toggleModelFavoriteForSelection(
+  favorites: ReadonlyArray<ModelFavorite>,
+  input: {
+    readonly selection: ModelSelection;
+    readonly activeSelection: ModelSelection;
+    readonly activeOptions: ReadonlyArray<ProviderOptionSelection>;
+    readonly models: ReadonlyArray<ServerProviderModel>;
+  },
+): ModelFavorite[] {
+  const { selection } = input;
+  const isActiveModel =
+    selection.instanceId === input.activeSelection.instanceId &&
+    selection.model === input.activeSelection.model;
+
+  return toggleModelFavorite(favorites, {
+    instanceId: selection.instanceId,
+    model: selection.model,
+    options: isActiveModel
+      ? input.activeOptions
+      : buildModelFavoriteOptions(selection, input.models),
+  });
+}
+
+export function getModelFavoriteEffortLabel(
+  favorite: ModelFavorite | undefined,
+  model?: ServerProviderModel,
+): string | null {
   const effort = favorite?.options?.find(
     (selection) => EFFORT_OPTION_IDS.has(selection.id) && typeof selection.value === "string",
   );
   if (!effort || typeof effort.value !== "string") {
     return null;
+  }
+  const providerLabel = model?.capabilities?.optionDescriptors
+    ?.flatMap((descriptor) =>
+      descriptor.type === "select" && descriptor.id === effort.id ? descriptor.options : [],
+    )
+    .find((option) => option.id === effort.value)?.label;
+  if (providerLabel) {
+    return providerLabel;
   }
   return EFFORT_LABELS[effort.value] ?? effort.value;
 }

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -12,9 +12,10 @@ the composer or paste them into a message.
 
 ## Favorite model configurations
 
-The star beside a model saves the active model configuration, including reasoning effort and other
-model options. Selecting that favorite later restores the saved options along with the model. To
-replace a saved configuration, remove the favorite, choose the options you want, and add it again.
+The star beside the selected model saves its active configuration, including reasoning effort and
+other model options. Starring a different model saves that model's current defaults. Selecting a
+favorite later restores the saved options along with the model. To replace a saved configuration,
+remove the favorite, choose the options you want, and add it again.
 
 Favorites created by an older version of T3 Code remain model-only and keep the current options when
 selected.

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -10,6 +10,15 @@ becomes available after every upload finishes. Failed uploads can be retried or 
 On web and desktop, HEIC and HEIF photos are automatically converted to JPEG when you drag them into
 the composer or paste them into a message.
 
+## Favorite model configurations
+
+The star beside a model saves the active model configuration, including reasoning effort and other
+model options. Selecting that favorite later restores the saved options along with the model. To
+replace a saved configuration, remove the favorite, choose the options you want, and add it again.
+
+Favorites created by an older version of T3 Code remain model-only and keep the current options when
+selected.
+
 ## Commands and skills
 
 Type `/` to open the command menu. Type `$` to find and add a skill. Skill rows show their source,

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -1,4 +1,12 @@
-# Customize a project icon
+# Project settings
+
+## Choose the default model for new threads
+
+Open **Project settings** from the command palette, then use **New threads → Model** to choose the
+model and its reasoning options. Picking a saved favorite applies its saved reasoning effort to the
+project default too.
+
+## Customize a project icon
 
 T3 Code selects a project icon automatically. It checks `t3.json`, common favicon and app icon
 paths, and icon links in project HTML files.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -66,6 +66,32 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings model favorites", () => {
+  it("keeps legacy model-only favorites valid", () => {
+    expect(
+      decodeClientSettings({ favorites: [{ provider: "codex", model: "gpt-5.6-sol" }] }).favorites,
+    ).toEqual([{ provider: ProviderInstanceId.make("codex"), model: "gpt-5.6-sol" }]);
+  });
+
+  it("decodes saved reasoning options in settings and patches", () => {
+    const favorite = {
+      provider: "codex",
+      model: "gpt-5.6-sol",
+      options: { reasoningEffort: "high" },
+    };
+    const expected = [
+      {
+        provider: ProviderInstanceId.make("codex"),
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "high" }],
+      },
+    ];
+
+    expect(decodeClientSettings({ favorites: [favorite] }).favorites).toEqual(expected);
+    expect(decodeClientSettingsPatch({ favorites: [favorite] }).favorites).toEqual(expected);
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -125,6 +125,19 @@ export type EnvironmentIdentificationMode = typeof EnvironmentIdentificationMode
 export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationMode = "artwork";
 
 /**
+ * A model-picker favorite. `options` is optional so favorites written before
+ * configuration snapshots were introduced continue to decode as model-only
+ * favorites. New favorites include the complete provider option bundle,
+ * including reasoning effort, so selecting one can restore the configuration.
+ */
+export const ModelFavorite = Schema.Struct({
+  provider: ProviderInstanceId,
+  model: TrimmedNonEmptyString,
+  options: Schema.optionalKey(ProviderOptionSelections),
+});
+export type ModelFavorite = typeof ModelFavorite.Type;
+
+/**
  * A user-chosen font family (a single name or a comma-separated list). Empty
  * means "use the app default"; clients compose their own fallback stacks.
  */
@@ -206,12 +219,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // default instance for their kind (because `defaultInstanceIdForDriver(kind)`
   // uses the same slug). The field name is kept as `provider` for storage
   // stability; new call sites should treat the value as an instance id.
-  favorites: Schema.Array(
-    Schema.Struct({
-      provider: ProviderInstanceId,
-      model: TrimmedNonEmptyString,
-    }),
-  ).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  favorites: Schema.Array(ModelFavorite).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
   providerModelPreferences: Schema.Record(
     ProviderInstanceId,
     Schema.Struct({
@@ -917,14 +925,7 @@ export const ClientSettingsPatch = Schema.Struct({
   fontFamilySans: Schema.optionalKey(FontFamilyPreference),
   fontFamilyTerminal: Schema.optionalKey(FontFamilyPreference),
   fontSmoothing: Schema.optionalKey(Schema.Boolean),
-  favorites: Schema.optionalKey(
-    Schema.Array(
-      Schema.Struct({
-        provider: ProviderInstanceId,
-        model: TrimmedNonEmptyString,
-      }),
-    ),
-  ),
+  favorites: Schema.optionalKey(Schema.Array(ModelFavorite)),
   providerModelPreferences: Schema.optionalKey(
     Schema.Record(
       ProviderInstanceId,


### PR DESCRIPTION
## Problem

Model favorites only persist the provider instance and model slug, so choosing a favorite can silently keep a different reasoning effort from the one the user intended to save.

## Fix

- Snapshot the model's canonical provider options when it is favorited, including defaults and reasoning effort.
- Restore saved options when the favorite is chosen in the composer or in a default-model picker.
- Show the saved effort in favorite rows, while keeping existing model-only favorites backward compatible.
- Preserve saved option snapshots when favorites are managed from Provider settings.

## Evidence

| Before | After |
| --- | --- |
| ![A favorite row without its active High effort](https://github.com/aflekkas/t3code/releases/download/pr-evidence-model-favorites/t3-model-effort-before.png) | ![A favorite row displaying its saved High effort](https://github.com/aflekkas/t3code/releases/download/pr-evidence-model-favorites/t3-model-effort-favorite-saved.png) |

The browser integration pass also changed the composer from High to Low and confirmed that choosing the favorite restored High. The same pass changed a project's new-thread default from High to Low and confirmed that choosing the favorite restored the saved High default.

## Verification

- `vp test run packages/contracts/src/settings.test.ts apps/web/src/modelFavorites.test.ts` (59 tests)
- Targeted `@t3tools/contracts` and `@t3tools/web` typechecks
- Targeted lint and formatting checks
- Integrated browser pass against an isolated T3 home

Built with GPT-5.6-Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and client settings shape change with backward-compatible decoding; no auth or server turn logic changes beyond applying stored model selections.
> 
> **Overview**
> **Model favorites now store and restore full provider option snapshots** (e.g. reasoning effort), not just instance + model slug.
> 
> The `ModelFavorite` settings schema gains optional `options`, with legacy model-only favorites still decoding unchanged. New `modelFavorites` helpers snapshot options when starring (active model uses current composer options; other models use defaults), show saved effort on picker rows, and pass `savedOptions` through `onProviderModelSelect` / `createModelSelection`. Choosing a favorite in the composer or default-model pickers applies those options; composer draft updates use `replaceOptions` when restoring from a favorite. **Provider settings** no longer drops saved option snapshots when rewriting an instance’s favorite list.
> 
> User docs cover favorite configurations and project default model behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1119dced22826f16618fab978c71d6429a9faeba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Save and restore provider model options with favorites in web app
> - Introduces `ModelFavorite` schema with optional `options` field in [settings.ts](https://github.com/pingdotgg/t3code/pull/8287/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), allowing favorites to persist provider option snapshots (e.g. reasoning effort) while remaining backward-compatible with legacy model-only favorites
> - Adds utilities in [modelFavorites.ts](https://github.com/pingdotgg/t3code/pull/8287/files#diff-2bd0dc136a3f417376283650ac5df2b035d7645fa1f44ff602f967ab2a556887): `buildModelFavoriteOptions` to materialize option snapshots, `toggleModelFavoriteForSelection` to snapshot active options when favoriting the active model or defaults for other models, and `getModelFavoriteEffortLabel` for human-readable labels
> - Updates `ProviderModelPicker`, `ChatComposer`, `ChatView`, and all settings panels to pass `selectionOptions` and forward `savedOptions` so selecting a favorite restores its saved configuration
> - Displays a configuration label (e.g. reasoning effort) next to favorited models in `ModelListRow`
> - Fixes `EnvironmentProviderSettings.updateInstanceFavorites` in [ProviderSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/8287/files#diff-f12e4babdd78afe45c2a0146ab2c0ef5a097d301ebed3350f53de81fc57349d3) to preserve existing option snapshots when editing an instance's favorites rather than dropping them
> - Risk: `ModelFavorite` schema replaces the inline favorites element struct in both `ClientSettingsSchema` and `ClientSettingsPatch`; legacy favorites without `options` still decode but any out-of-tree consumers expecting the old inline struct shape will need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1119dce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->