### PR TITLE
fix(mobile): hide worktrees outside git repos

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -63,6 +63,7 @@ import { useCreateProjectThread } from "./use-project-actions";
 import { resolveDraftProjectSelection } from "./new-task-project-selection";
 import {
   resolveNewTaskBranchLabel,
+  resolveNewTaskWorkspaceMode,
   resolveNewTaskWorkspaceLabel,
 } from "./new-task-context-presentation";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
@@ -651,10 +652,16 @@ export function NewTaskDraftScreen(props: {
         selectedEnvironmentServerConfig,
         draft.modelSelection ?? null,
       ) ?? flow.selectedModel;
-    const workspaceMode = draft.workspaceSelection?.mode ?? flow.workspaceMode;
-    const selectedBranchName = draft.workspaceSelection?.branch ?? flow.selectedBranchName;
-    const selectedWorktreePath =
-      draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath;
+    const workspaceMode = resolveNewTaskWorkspaceMode({
+      requestedMode: draft.workspaceSelection?.mode ?? flow.workspaceMode,
+      isGitRepo: flow.isGitRepo,
+    });
+    const selectedBranchName = flow.isGitRepo
+      ? (draft.workspaceSelection?.branch ?? flow.selectedBranchName)
+      : null;
+    const selectedWorktreePath = flow.isGitRepo
+      ? (draft.workspaceSelection?.worktreePath ?? flow.selectedWorktreePath)
+      : null;
     const startFromOrigin = draft.workspaceSelection?.startFromOrigin ?? flow.startFromOrigin;
     const runtimeMode = draft.runtimeMode ?? flow.runtimeMode;
     const interactionMode = flow.planModeEnabled
@@ -924,7 +931,7 @@ export function NewTaskDraftScreen(props: {
     </View>
   );
 
-  const workspaceControls = (
+  const workspaceControls = flow.isGitRepo ? (
     <View className="flex-row items-center gap-1 px-2">
       <ComposerInlineControl
         accessibilityHint={`Switches to ${flow.workspaceMode === "local" ? "a new worktree" : "the current checkout"}`}
@@ -952,11 +959,11 @@ export function NewTaskDraftScreen(props: {
         onPress={() => openContextPicker("NewTaskBranch")}
       />
     </View>
-  );
+  ) : null;
 
   const composerDock = (
     <View className="bg-sheet px-4 pt-1" style={{ paddingBottom: controlsBottomPadding }}>
-      <View className="pb-1">{workspaceControls}</View>
+      {workspaceControls ? <View className="pb-1">{workspaceControls}</View> : null}
 
       <ComposerSurface
         animateLayout={false}

--- a/apps/mobile/src/features/threads/new-task-context-presentation.test.ts
+++ b/apps/mobile/src/features/threads/new-task-context-presentation.test.ts
@@ -4,7 +4,19 @@ import {
   resolveNewTaskBranchWorktreePath,
   resolveNewTaskBranchLabel,
   resolveNewTaskLocalWorkspaceSelection,
+  resolveNewTaskWorkspaceMode,
 } from "./new-task-context-presentation";
+
+describe("resolveNewTaskWorkspaceMode", () => {
+  it("allows new worktrees only in Git repositories", () => {
+    expect(resolveNewTaskWorkspaceMode({ requestedMode: "worktree", isGitRepo: true })).toBe(
+      "worktree",
+    );
+    expect(resolveNewTaskWorkspaceMode({ requestedMode: "worktree", isGitRepo: false })).toBe(
+      "local",
+    );
+  });
+});
 
 describe("resolveNewTaskLocalWorkspaceSelection", () => {
   it("waits for refs instead of carrying a worktree base into Current checkout", () => {

--- a/apps/mobile/src/features/threads/new-task-context-presentation.ts
+++ b/apps/mobile/src/features/threads/new-task-context-presentation.ts
@@ -1,5 +1,12 @@
 type WorkspaceMode = "local" | "worktree";
 
+export function resolveNewTaskWorkspaceMode(input: {
+  readonly requestedMode: WorkspaceMode;
+  readonly isGitRepo: boolean;
+}): WorkspaceMode {
+  return input.isGitRepo ? input.requestedMode : "local";
+}
+
 export function resolveNewTaskWorkspaceLabel(input: {
   readonly workspaceMode: WorkspaceMode;
   readonly worktreePath: string | null;

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -81,6 +81,7 @@ import { useLegacyPlanModeState } from "./use-legacy-plan-mode-enabled";
 import {
   resolveNewTaskBranchWorktreePath,
   resolveNewTaskLocalWorkspaceSelection,
+  resolveNewTaskWorkspaceMode,
 } from "./new-task-context-presentation";
 
 type WorkspaceMode = "local" | "worktree";
@@ -126,6 +127,7 @@ type NewTaskFlowContextValue = {
   readonly selectedProjectKey: string | null;
   readonly selectedModelKey: string | null;
   readonly workspaceMode: WorkspaceMode;
+  readonly isGitRepo: boolean;
   readonly selectedBranchName: string | null;
   readonly selectedWorktreePath: string | null;
   readonly startFromOrigin: boolean;
@@ -360,6 +362,17 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const selectedProjectDraft = useComposerDraft(selectedProjectDraftKey);
   const prompt = selectedProjectDraft.text;
   const attachments = selectedProjectDraft.attachments;
+  const projectGitStatus = useEnvironmentQuery(
+    selectedProject !== null && selectedProject.workspaceRoot !== ""
+      ? vcsEnvironment.status({
+          environmentId: selectedProject.environmentId,
+          input: { cwd: selectedProject.workspaceRoot },
+        })
+      : null,
+  );
+  // Default true while status loads so Git repositories do not flash from
+  // Current checkout to their configured New worktree default.
+  const isGitRepo = projectGitStatus.data?.isRepo ?? true;
   // Default mode until the user picks one explicitly — same resolution web
   // uses for new draft threads: per-project setting, then the repo's
   // checked-in t3.json, then the server's configured default.
@@ -389,9 +402,16 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     projectSetting: selectedProject?.defaultThreadEnvMode,
     projectFilePending: t3ProjectFileQuery.isPending,
   });
-  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode;
-  const selectedBranchName = selectedProjectDraft.workspaceSelection?.branch ?? null;
-  const selectedWorktreePath = selectedProjectDraft.workspaceSelection?.worktreePath ?? null;
+  const workspaceMode = resolveNewTaskWorkspaceMode({
+    requestedMode: selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode,
+    isGitRepo,
+  });
+  const selectedBranchName = isGitRepo
+    ? (selectedProjectDraft.workspaceSelection?.branch ?? null)
+    : null;
+  const selectedWorktreePath = isGitRepo
+    ? (selectedProjectDraft.workspaceSelection?.worktreePath ?? null)
+    : null;
   // Keep the user's explicit choice separate from the resolved display value:
   // only the explicit flag is ever written back to the draft, so the resolved
   // value keeps tracking the server setting when the config loads late.
@@ -562,14 +582,6 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   // against. Detached HEAD and non-repository projects report no ref, so this
   // stays null instead of fabricating a branch. The status family is
   // deduplicated per (environmentId, cwd) with the thread rows.
-  const projectGitStatus = useEnvironmentQuery(
-    branchTarget.environmentId !== null && branchTarget.cwd !== null
-      ? vcsEnvironment.status({
-          environmentId: branchTarget.environmentId,
-          input: { cwd: branchTarget.cwd },
-        })
-      : null,
-  );
   const currentCheckoutBranchName = projectGitStatus.data?.refName ?? null;
 
   const filteredBranches = useMemo(() => {
@@ -632,13 +644,14 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   );
 
   const setWorkspaceMode = useCallback(
-    (mode: WorkspaceMode) => {
+    (requestedMode: WorkspaceMode) => {
       if (!selectedProjectDraftKey) {
         return;
       }
       if (!selectedProject) {
         return;
       }
+      const mode = resolveNewTaskWorkspaceMode({ requestedMode, isGitRepo });
       const localSelection = resolveNewTaskLocalWorkspaceSelection({
         branches: availableBranches,
         projectCwd: selectedProject.workspaceRoot,
@@ -660,6 +673,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [
       availableBranches,
       draftStartFromOrigin,
+      isGitRepo,
       selectedBranchName,
       selectedProject,
       selectedProjectDraftKey,
@@ -845,7 +859,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       const workspaceSelection = draft.workspaceSelection;
       // Fall back to the resolved mode (server default) so queued tasks drain
       // with the same mode the composer displayed.
-      const mode = workspaceSelection?.mode ?? workspaceMode;
+      const mode = resolveNewTaskWorkspaceMode({
+        requestedMode: workspaceSelection?.mode ?? workspaceMode,
+        isGitRepo,
+      });
       // When the selection is the stand-in built from the queued snapshot,
       // persist the original (possibly absent) snapshot values — the
       // stand-in's placeholder title/workspaceRoot must never be written back
@@ -881,8 +898,9 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           // queued local task drains days later against whatever is checked
           // out then, so recording a queue-time guess would pin a stale label
           // to a thread that ran somewhere else.
-          branch: workspaceSelection?.branch ?? null,
-          worktreePath: mode === "worktree" ? null : (workspaceSelection?.worktreePath ?? null),
+          branch: isGitRepo ? (workspaceSelection?.branch ?? null) : null,
+          worktreePath:
+            isGitRepo && mode === "local" ? (workspaceSelection?.worktreePath ?? null) : null,
           // The draft only carries the flag when the user touched it; fall
           // back to the resolved default (server settings) so queued tasks
           // drain with the same origin mode the composer displayed.
@@ -896,6 +914,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     [
       editingPendingProject,
       editingPendingTask,
+      isGitRepo,
       selectedEnvironmentServerConfig,
       selectedModel,
       selectedProject,
@@ -1004,6 +1023,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedProjectKey,
       selectedModelKey,
       workspaceMode,
+      isGitRepo,
       selectedBranchName,
       selectedWorktreePath,
       startFromOrigin,
@@ -1073,6 +1093,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       filteredBranches,
       finishEditingPendingTask,
       interactionMode,
+      isGitRepo,
       planModeEnabled,
       loadBranches,
       loadMoreBranches,


### PR DESCRIPTION
The mobile new-task composer offered worktree and branch controls for folders that were not Git repositories. This PR uses the existing VCS status stream and hides those controls when the selected folder is not a Git repository.

Confirmed non-Git folders are normalized to the current checkout with no branch or worktree metadata.

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Mobile implementation | 3 | +57 | -22 |
| Focused tests | 1 | +12 | -0 |
| **Total** | **4** | **+69** | **-22** |

## Proof

Matched iPhone 17 Pro simulator captures use the same non-Git project, backend, light theme, and viewport.

| Before: direct base | After: PR |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ea88040a-3d50-4af1-853c-d57b3e6add28" width="320" alt="Before: a non-Git folder incorrectly shows New worktree and Choose branch"> | <img src="https://github.com/user-attachments/assets/4c9c2aa4-062f-4d49-8209-2656720c4a73" width="320" alt="After: the same non-Git folder has no worktree or branch controls"> |

## How to verify

1. Add a project whose root is a normal folder without a `.git` directory.
2. Open the mobile new-task composer for that project.
3. Confirm that worktree and branch controls are absent and the task uses the current checkout.
4. Open a Git project and confirm the existing checkout, worktree, and branch controls still appear.

## Implementation note

This reuses the existing status subscription. It adds no RPCs, contracts, server routes, or compatibility machinery.

Built with gpt-5.6-sol in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile new-task UI and workspace resolution only; no server or auth changes, with a unit test for the mode guard.
> 
> **Overview**
> The mobile **new-task** composer no longer shows worktree or branch controls when the selected project folder is **not a Git repository**. Detection reuses the existing **`vcsEnvironment.status`** subscription; **`isGitRepo`** is exposed on the new-task flow (defaulting to Git while status loads to avoid a flash).
> 
> **`resolveNewTaskWorkspaceMode`** forces **`local`** when `isRepo` is false, and branch/worktree draft fields are cleared on submit, queue, and workspace changes so non-Git tasks always start as **current checkout** with no branch or worktree metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851bf2498d1db692704614f858668d8a161e1e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide workspace controls in `NewTaskDraftScreen` for non-Git repos
> - Adds `resolveNewTaskWorkspaceMode` to force workspace mode to `local` when the selected project is not a Git repository
> - `NewTaskFlowProvider` fetches VCS status, clears branch and worktree selections for non-Git projects, and omits them from queued messages
> - `NewTaskDraftScreen` only renders workspace controls when `isGitRepo` is true
> - Risk: `NewTaskFlowProvider` defaults `isGitRepo` to `true` while the VCS status query loads, potentially flashing Git-only UI before it resolves
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 851bf24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->