### PR TITLE
fix(server): terminate git clone arguments with --

### DIFF
--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -176,9 +176,52 @@ it.effect("clones a looked-up repository into the requested destination", () =>
       assert.deepStrictEqual(cloneCalls, [
         {
           cwd: parent,
-          args: ["clone", CLONE_URLS.url, "t3code"],
+          args: ["clone", "--", CLONE_URLS.url, "t3code"],
         },
       ]);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          git: {
+            execute: (input) =>
+              Effect.sync(() => {
+                cloneCalls.push({ cwd: input.cwd, args: input.args });
+                return processOutput();
+              }),
+          },
+        }),
+      ),
+    );
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("passes a dash-leading destination name to git as a path, not an option", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const parent = yield* fs.makeTempDirectoryScoped({
+      prefix: "t3-source-control-clone-dash-",
+    });
+    // Reachable from the mobile add-project deep link, which supplies both the
+    // remote URL and the final path segment.
+    const destinationPath = `${parent}/--upload-pack=touch pwned`;
+    const cloneCalls: Array<{ cwd: string; args: ReadonlyArray<string> }> = [];
+
+    yield* Effect.gen(function* () {
+      const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      yield* service.cloneRepository({
+        remoteUrl: CLONE_URLS.url,
+        destinationPath,
+      });
+
+      assert.deepStrictEqual(cloneCalls, [
+        {
+          cwd: parent,
+          args: ["clone", "--", CLONE_URLS.url, "--upload-pack=touch pwned"],
+        },
+      ]);
+      const [call] = cloneCalls;
+      assert.isDefined(call);
+      assert.strictEqual(call.args[1], "--", "every positional must follow the -- terminator");
     }).pipe(
       Effect.provide(
         makeLayer({

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -206,7 +206,12 @@ export const make = Effect.gen(function* () {
     yield* git.execute({
       operation: "SourceControlRepositoryService.cloneRepository",
       cwd: preparedDestination.parentPath,
-      args: ["clone", remoteUrl, preparedDestination.directoryName],
+      // `--` is required: git clone permutes options and positionals, so a
+      // remote URL or a destination directory whose name begins with a dash
+      // would otherwise be read as an option. `--upload-pack=<cmd>` is the
+      // dangerous one - git hands its value to a shell for local and ssh
+      // transports.
+      args: ["clone", "--", remoteUrl, preparedDestination.directoryName],
       timeoutMs: 120_000,
       maxOutputBytes: 256 * 1024,
     });


### PR DESCRIPTION
## Problem

`SourceControlRepositoryService.cloneRepository` passed the remote URL and the destination directory name to `git clone` as bare positionals:

```ts
args: ["clone", remoteUrl, preparedDestination.directoryName],
```

`git clone` permutes options and positionals, so a value beginning with a dash is parsed as an option rather than a path. `--upload-pack=<cmd>` is the dangerous one — git hands its value to a shell for the local and ssh transports. Reproduced against git 2.50.1: `git clone <local repo> '--upload-pack=touch pwned'` fails to clone *and* creates `pwned`.

The destination basename is reachable from outside the app. `apps/mobile/src/Stack.tsx` registers `add-project/destination` as a deep link under the `t3code://` schemes, and `AddProjectScreen` uses the `repositoryName` route param as the pinned final path segment, with `remoteUrl` from another param. A crafted link prefills both positionals, and one Clone tap runs the command on the paired host.

## Fix

Add the `--` terminator, which ends option parsing and covers both positionals at once. One line, no behavior change for valid input.

Regression test clones into a `--upload-pack=touch pwned` directory name and asserts every positional lands after `--`.

## Verification

- `vp test run apps/server/src/sourceControl/SourceControlRepositoryService.test.ts` — 8 passed
- `vp run --filter t3 typecheck` — clean
- `vp fmt --check`, `vp lint`, `git diff --check` on the changed files — clean

Found during a security review of the repository.

Model: Claude Opus 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for git argument parsing that could execute shell commands when clone destination or URL starts with `-`; reachable via mobile deep-link params.
> 
> **Overview**
> Fixes a **command-injection / argument-smuggling** risk in `SourceControlRepositoryService.cloneRepository` by inserting `--` before the remote URL and destination directory when invoking `git clone`.
> 
> Without the terminator, `git` can treat dash-prefixed destination names (or URLs) as options—e.g. `--upload-pack=<cmd>`—which can run arbitrary shell commands on local/SSH transports. That matters because mobile add-project deep links can supply both the clone URL and the final path segment, so a crafted destination could reach this code path.
> 
> Existing clone tests now expect `clone -- <url> <dir>`, and a new regression test clones into a directory named `--upload-pack=touch pwned` and asserts all positionals follow `--`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3026919361512546ba3453a48d8b42b8b279acaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Terminate 'git clone' arguments with '--' in 'make.cloneRepository'
> Inserts the `--` option terminator before positional arguments in [SourceControlRepositoryService.ts](apps/server/src/sourceControl/SourceControlRepositoryService.ts). This prevents git from parsing dash-leading remote URLs or destination names as command-line options. Adds a test case for dash-leading destination names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3026919.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->