### PR TITLE
fix(desktop): stop granting preview content clipboard-read and geolocation

### DIFF
--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -63,7 +63,7 @@ describe("BrowserSession", () => {
     }).pipe(Effect.provide(layer)),
   );
 
-  it.effect("grants clipboard-sanitized-write through both the request and check handlers", () =>
+  it.effect("grants only write-direction clipboard access through both handlers", () =>
     Effect.gen(function* () {
       const browserSessions = yield* BrowserSession.BrowserSession;
       const partition = yield* browserSessions.getPartition("scope-a");
@@ -86,12 +86,7 @@ describe("BrowserSession", () => {
         return granted;
       };
 
-      for (const permission of [
-        "clipboard-read",
-        "clipboard-sanitized-write",
-        "notifications",
-        "geolocation",
-      ]) {
+      for (const permission of ["clipboard-sanitized-write", "notifications"]) {
         assert.isTrue(requestAllows(permission), `request handler should allow ${permission}`);
         assert.isTrue(
           checkHandler(null, permission) as boolean,
@@ -102,7 +97,11 @@ describe("BrowserSession", () => {
       // `clipboard-write` is not a real Electron permission — the async write API
       // uses `clipboard-sanitized-write` — so the stale name must not be granted,
       // and unrelated permissions stay denied.
-      for (const permission of ["clipboard-write", "midi"]) {
+      //
+      // `clipboard-read` and `geolocation` are denied deliberately: preview tabs
+      // load arbitrary sites, and the agent can evaluate script inside them, so
+      // neither may be granted without the user seeing a prompt.
+      for (const permission of ["clipboard-write", "midi", "clipboard-read", "geolocation"]) {
         assert.isFalse(requestAllows(permission), `request handler should deny ${permission}`);
         assert.isFalse(
           checkHandler(null, permission) as boolean,

--- a/apps/desktop/src/preview/BrowserSession.ts
+++ b/apps/desktop/src/preview/BrowserSession.ts
@@ -19,10 +19,18 @@ const PREVIEW_PARTITION_PREFIX = "persist:t3code-preview-";
 // buttons — e.g. the Next.js / Vercel error overlay — fail with
 // `Failed to execute 'writeText' on 'Clipboard': Write permission denied`.
 const ALLOWED_PREVIEW_PERMISSIONS: ReadonlySet<string> = new Set([
-  "clipboard-read",
   "clipboard-sanitized-write",
   "notifications",
-  "geolocation",
+  // Deliberately NOT clipboard-read: that is the read direction of the
+  // clipboard, and the copy buttons this list exists for only ever write.
+  // Preview tabs load arbitrary sites and the agent can evaluate script in
+  // them, so granting it would hand whatever the user last copied - a
+  // password, an API key, a one-time code - to any page or injected
+  // instruction that asks for it.
+  //
+  // Deliberately NOT geolocation: nothing in the preview needs the user's
+  // physical location, and it is granted here to every site the agent opens.
+  //
   // Deliberately NOT local-fonts: preview sessions run untrusted web content,
   // and silently granting it would hand every page the user's installed-font
   // fingerprint (and font file bytes via FontData.blob()). The app's own font


### PR DESCRIPTION
## Problem

Every preview partition auto-approves a fixed permission set through both the request handler and the check handler, with no prompt and no origin restriction:

```ts
const ALLOWED_PREVIEW_PERMISSIONS: ReadonlySet<string> = new Set([
  "clipboard-read",
  "clipboard-sanitized-write",
  "notifications",
  "geolocation",
```

The comment above the set explains the list exists so built-in "Copy" buttons — the Next.js / Vercel error overlay — keep working. Those only ever *write*. `clipboard-read` is the read direction, and in Electron it reads the real OS clipboard.

Preview tabs accept any absolute `http(s)` URL, so arbitrary sites land in this partition, and the agent can evaluate script inside them via `preview_evaluate`. That gives two paths to the same disclosure: a hostile page calling `navigator.clipboard.readText()` where Chrome would normally prompt, and an injected agent reading the clipboard into its own context. Either way the user's clipboard contents are readable without them being asked.

`geolocation` was granted the same way, to every site the agent opens, and nothing in the preview needs it.

## Fix

Drop `clipboard-read` and `geolocation`. Keep `clipboard-sanitized-write` and `notifications`, so the copy buttons the list was added for keep working. Comments record why each is deliberately absent, in the same style as the existing `local-fonts` note.

Tests now assert both are denied by both handlers.

## Note for reviewers

`evaluateWithDebugger` sends every `Runtime.evaluate` with `userGesture: true`, which manufactures the transient user activation that permission-gated APIs check. That is a separate concern with ~10 call sites, some of which may rely on it, so it is not touched here.

## Verification

- `vp test run apps/desktop/src/preview/BrowserSession.test.ts` — 6 passed
- `vp run --filter @t3tools/desktop typecheck` — clean
- `vp fmt --check`, `vp lint`, `git diff --check` on the changed files — clean

Found during a security review of the repository.

Model: Claude Opus 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows permission auto-approval in preview sessions with targeted test coverage; copy-to-clipboard for overlays should remain via clipboard-sanitized-write.
> 
> **Overview**
> Tightens **auto-granted Electron permissions** for desktop preview browser partitions so untrusted preview URLs and agent-injected script cannot read the OS clipboard or access geolocation without a user prompt.
> 
> **`ALLOWED_PREVIEW_PERMISSIONS`** now only includes **`clipboard-sanitized-write`** and **`notifications`** (dropped **`clipboard-read`** and **`geolocation`**). Inline comments document why read-direction clipboard and location are excluded, matching the existing **`local-fonts`** rationale. **`BrowserSession.test.ts`** is updated to expect allow for write clipboard + notifications and explicit deny for **`clipboard-read`**, **`geolocation`**, and other unrelated permissions on both the request and check handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3c4c9ce5ef0be63e537756a00abc1bc4192223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `clipboard-read` and `geolocation` from preview permissions in `BrowserSession`
> Trims the `ALLOWED_PREVIEW_PERMISSIONS` constant in [BrowserSession.ts](https://github.com/pingdotgg/t3code/pull/8291/files#diff-17a3bda9cc115ba14d32576e0f787fbd4488b05312afb31216156b1616efee0f) so only `clipboard-sanitized-write` and `notifications` remain granted. Comments explain why read-direction clipboard and geolocation are excluded. Tests in [BrowserSession.test.ts](https://github.com/pingdotgg/t3code/pull/8291/files#diff-bfb816daf00b721b7015b3d41241ae829ecb9997ff6ddf8a6fde1d746df58182) are updated to assert denial of both removed permissions.
> - Behavioral Change: preview permission handlers now deny `clipboard-read` and `geolocation` where they previously allowed them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a3c4c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->