### PR TITLE
fix(codex): accept current ChatGPT workspace plans

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -85,14 +85,18 @@ function codexAccountAuthLabel(account: CodexSchema.V2GetAccountResponse["accoun
     case "prolite":
       return "ChatGPT Pro 5x Subscription";
     case "team":
-      return "ChatGPT Team Subscription";
+    case "self_serve_business_prolite":
     case "self_serve_business_usage_based":
     case "business":
       return "ChatGPT Business Subscription";
+    case "ent26":
+    case "enterprise_cbp_automation":
     case "enterprise_cbp_usage_based":
     case "enterprise":
       return "ChatGPT Enterprise Subscription";
     case "edu":
+    case "edu_plus":
+    case "edu_pro":
       return "ChatGPT Edu Subscription";
     case "unknown":
       return "ChatGPT Subscription";

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -392,6 +392,43 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
+      it.effect("classifies current workspace plan values by product family", () =>
+        Effect.gen(function* () {
+          const expectedLabels = [
+            ["team", "ChatGPT Business Subscription"],
+            ["self_serve_business_prolite", "ChatGPT Business Subscription"],
+            ["self_serve_business_usage_based", "ChatGPT Business Subscription"],
+            ["business", "ChatGPT Business Subscription"],
+            ["ent26", "ChatGPT Enterprise Subscription"],
+            ["enterprise_cbp_automation", "ChatGPT Enterprise Subscription"],
+            ["enterprise_cbp_usage_based", "ChatGPT Enterprise Subscription"],
+            ["enterprise", "ChatGPT Enterprise Subscription"],
+            ["edu", "ChatGPT Edu Subscription"],
+            ["edu_plus", "ChatGPT Edu Subscription"],
+            ["edu_pro", "ChatGPT Edu Subscription"],
+          ] as const;
+
+          for (const [planType, expectedLabel] of expectedLabels) {
+            const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+              Effect.succeed(
+                makeCodexProbeSnapshot({
+                  account: {
+                    account: {
+                      type: "chatgpt",
+                      email: "test@example.com",
+                      planType,
+                    },
+                    requiresOpenaiAuth: false,
+                  },
+                }),
+              ),
+            );
+
+            assert.strictEqual(status.auth.label, expectedLabel);
+          }
+        }),
+      );
+
       it.effect("passes configured launch args to the Codex provider probe", () =>
         Effect.gen(function* () {
           let observedLaunchArgs: string | undefined;

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -18,6 +18,34 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const UPSTREAM_REF = "678157acaa819d5510adfe359abb5d0392cfe461";
+// Keep account decoding compatible with newer Codex binaries without pulling
+// unrelated protocol changes into the pinned schema snapshot.
+const ACCOUNT_PLAN_TYPES = [
+  "free",
+  "go",
+  "plus",
+  "pro",
+  "prolite",
+  "team",
+  "self_serve_business_prolite",
+  "self_serve_business_usage_based",
+  "business",
+  "ent26",
+  "enterprise_cbp_automation",
+  "enterprise_cbp_usage_based",
+  "enterprise",
+  "edu",
+  "edu_plus",
+  "edu_pro",
+  "unknown",
+] as const;
+const ACCOUNT_PLAN_TYPE_SCHEMA_NAMES = new Set([
+  "ServerNotification__PlanType",
+  "V2AccountRateLimitsUpdatedNotification__PlanType",
+  "V2AccountUpdatedNotification__PlanType",
+  "V2GetAccountRateLimitsResponse__PlanType",
+  "V2GetAccountResponse__PlanType",
+]);
 const USER_AGENT = "effect-codex-app-server-generator";
 const GITHUB_API_BASE =
   "https://api.github.com/repos/openai/codex/contents/codex-rs/app-server-protocol";
@@ -279,6 +307,27 @@ function stripNullDefaults(value: Schema.Json): Schema.Json {
       .filter(([key, child]) => !(key === "default" && child === null))
       .map(([key, child]) => [key, stripNullDefaults(child)]),
   ) as Schema.Json;
+}
+
+function includeNewerPlanTypes(name: string, schema: Schema.Json): Schema.Json {
+  if (
+    !ACCOUNT_PLAN_TYPE_SCHEMA_NAMES.has(name) ||
+    schema === null ||
+    Array.isArray(schema) ||
+    typeof schema !== "object"
+  ) {
+    return schema;
+  }
+
+  const schemaObject = schema as Record<string, Schema.Json>;
+  if (!Array.isArray(schemaObject.enum)) {
+    return schema;
+  }
+
+  return {
+    ...schemaObject,
+    enum: ACCOUNT_PLAN_TYPES,
+  };
 }
 
 function toPascalCaseMethod(method: string) {
@@ -597,7 +646,7 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
   for (const [name, schema] of Object.entries(aggregateSchemas).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    generator.addSchema(name, schema as never);
+    generator.addSchema(name, includeNewerPlanTypes(name, schema) as never);
   }
 
   const generatedEntries = new Map<string, string>();

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -2411,11 +2411,16 @@ export type ServerNotification__PlanType =
   | "pro"
   | "prolite"
   | "team"
+  | "self_serve_business_prolite"
   | "self_serve_business_usage_based"
   | "business"
+  | "ent26"
+  | "enterprise_cbp_automation"
   | "enterprise_cbp_usage_based"
   | "enterprise"
   | "edu"
+  | "edu_plus"
+  | "edu_pro"
   | "unknown";
 export const ServerNotification__PlanType = Schema.Literals([
   "free",
@@ -2424,11 +2429,16 @@ export const ServerNotification__PlanType = Schema.Literals([
   "pro",
   "prolite",
   "team",
+  "self_serve_business_prolite",
   "self_serve_business_usage_based",
   "business",
+  "ent26",
+  "enterprise_cbp_automation",
   "enterprise_cbp_usage_based",
   "enterprise",
   "edu",
+  "edu_plus",
+  "edu_pro",
   "unknown",
 ]);
 
@@ -3243,11 +3253,16 @@ export type V2AccountRateLimitsUpdatedNotification__PlanType =
   | "pro"
   | "prolite"
   | "team"
+  | "self_serve_business_prolite"
   | "self_serve_business_usage_based"
   | "business"
+  | "ent26"
+  | "enterprise_cbp_automation"
   | "enterprise_cbp_usage_based"
   | "enterprise"
   | "edu"
+  | "edu_plus"
+  | "edu_pro"
   | "unknown";
 export const V2AccountRateLimitsUpdatedNotification__PlanType = Schema.Literals([
   "free",
@@ -3256,11 +3271,16 @@ export const V2AccountRateLimitsUpdatedNotification__PlanType = Schema.Literals(
   "pro",
   "prolite",
   "team",
+  "self_serve_business_prolite",
   "self_serve_business_usage_based",
   "business",
+  "ent26",
+  "enterprise_cbp_automation",
   "enterprise_cbp_usage_based",
   "enterprise",
   "edu",
+  "edu_plus",
+  "edu_pro",
   "unknown",
 ]);
 
@@ -3331,11 +3351,16 @@ export type V2AccountUpdatedNotification__PlanType =
   | "pro"
   | "prolite"
   | "team"
+  | "self_serve_business_prolite"
   | "self_serve_business_usage_based"
   | "business"
+  | "ent26"
+  | "enterprise_cbp_automation"
   | "enterprise_cbp_usage_based"
   | "enterprise"
   | "edu"
+  | "edu_plus"
+  | "edu_pro"
   | "unknown";
 export const V2AccountUpdatedNotification__PlanType = Schema.Literals([
   "free",
@@ -3344,11 +3369,16 @@ export const V2AccountUpdatedNotification__PlanType = Schema.Literals([
   "pro",
   "prolite",
   "team",
+  "self_serve_business_prolite",
   "self_serve_business_usage_based",
   "business",
+  "ent26",
+  "enterprise_cbp_automation",
   "enterprise_cbp_usage_based",
   "enterprise",
   "edu",
+  "edu_plus",
+  "edu_pro",
   "unknown",
 ]);
 
@@ -4135,11 +4165,16 @@ export type V2GetAccountRateLimitsResponse__PlanType =
   | "pro"
   | "prolite"
   | "team"
+  | "self_serve_business_prolite"
   | "self_serve_business_usage_based"
   | "business"
+  | "ent26"
+  | "enterprise_cbp_automation"
   | "enterprise_cbp_usage_based"
   | "enterprise"
   | "edu"
+  | "edu_plus"
+  | "edu_pro"
   | "unknown";
 export const V2GetAccountRateLimitsResponse__PlanType = Schema.Literals([
   "free",
@@ -4148,11 +4183,16 @@ export const V2GetAccountRateLimitsResponse__PlanType = Schema.Literals([
   "pro",
   "prolite",
   "team",
+  "self_serve_business_prolite",
   "self_serve_business_usage_based",
   "business",
+  "ent26",
+  "enterprise_cbp_automation",
   "enterprise_cbp_usage_based",
   "enterprise",
   "edu",
+  "edu_plus",
+  "edu_pro",
   "unknown",
 ]);
 
@@ -4223,11 +4263,16 @@ export type V2GetAccountResponse__PlanType =
   | "pro"
   | "prolite"
   | "team"
+  | "self_serve_business_prolite"
   | "self_serve_business_usage_based"
   | "business"
+  | "ent26"
+  | "enterprise_cbp_automation"
   | "enterprise_cbp_usage_based"
   | "enterprise"
   | "edu"
+  | "edu_plus"
+  | "edu_pro"
   | "unknown";
 export const V2GetAccountResponse__PlanType = Schema.Literals([
   "free",
@@ -4236,11 +4281,16 @@ export const V2GetAccountResponse__PlanType = Schema.Literals([
   "pro",
   "prolite",
   "team",
+  "self_serve_business_prolite",
   "self_serve_business_usage_based",
   "business",
+  "ent26",
+  "enterprise_cbp_automation",
   "enterprise_cbp_usage_based",
   "enterprise",
   "edu",
+  "edu_plus",
+  "edu_pro",
   "unknown",
 ]);
 

--- a/packages/effect-codex-app-server/src/_internal/shared.test.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.test.ts
@@ -149,3 +149,59 @@ it.effect("retains the full notification payload decode cause chain", () =>
     assert.isTrue(Schema.isSchemaError(error.cause.cause));
   }),
 );
+
+it("leaves unrelated and opaque planType fields untouched", () => {
+  const opaque = { planType: "application_specific" };
+  const payload = { planType: "custom", arguments: opaque };
+
+  assert.strictEqual(Shared.normalizeAccountPlanTypes("thread/read", payload), payload);
+
+  const normalizedAccount = Shared.normalizeAccountPlanTypes("account/read", {
+    account: { type: "chatgpt", planType: "future_plan", metadata: opaque },
+  });
+  assert.deepEqual(normalizedAccount, {
+    account: { type: "chatgpt", planType: "unknown", metadata: opaque },
+  });
+  assert.strictEqual(
+    (normalizedAccount as { account: { metadata: unknown } }).account.metadata,
+    opaque,
+  );
+});
+
+it("normalizes only plan-bearing rate-limit fields", () => {
+  const opaque = { planType: "application_specific" };
+  const normalized = Shared.normalizeAccountPlanTypes("account/rateLimits/read", {
+    rateLimits: { planType: "future_plan", opaque },
+    rateLimitsByLimitId: {
+      first: { planType: "another_future_plan" },
+      second: { planType: "plus" },
+    },
+  });
+
+  assert.deepEqual(normalized, {
+    rateLimits: { planType: "unknown", opaque },
+    rateLimitsByLimitId: {
+      first: { planType: "unknown" },
+      second: { planType: "plus" },
+    },
+  });
+  assert.strictEqual((normalized as { rateLimits: { opaque: unknown } }).rateLimits.opaque, opaque);
+});
+
+it("normalizes account plan notifications without walking unrelated fields", () => {
+  const opaque = { planType: "application_specific" };
+
+  assert.deepEqual(
+    Shared.normalizeAccountPlanTypes("account/updated", {
+      planType: "future_plan",
+      opaque,
+    }),
+    { planType: "unknown", opaque },
+  );
+  assert.deepEqual(
+    Shared.normalizeAccountPlanTypes("account/rateLimits/updated", {
+      rateLimits: { planType: "future_plan", opaque },
+    }),
+    { rateLimits: { planType: "unknown", opaque } },
+  );
+});

--- a/packages/effect-codex-app-server/src/_internal/shared.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.ts
@@ -17,6 +17,90 @@ export const JsonRpcResponseEnvelope = Schema.Struct({
   error: Schema.optional(JsonRpcError),
 });
 
+const PINNED_PLAN_TYPES = new Set<string>([
+  "free",
+  "go",
+  "plus",
+  "pro",
+  "prolite",
+  "team",
+  "self_serve_business_prolite",
+  "self_serve_business_usage_based",
+  "business",
+  "ent26",
+  "enterprise_cbp_automation",
+  "enterprise_cbp_usage_based",
+  "enterprise",
+  "edu",
+  "edu_plus",
+  "edu_pro",
+  "unknown",
+]);
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const normalizePlanTypeField = (value: unknown): unknown => {
+  if (
+    !isObject(value) ||
+    typeof value.planType !== "string" ||
+    PINNED_PLAN_TYPES.has(value.planType)
+  ) {
+    return value;
+  }
+  return { ...value, planType: "unknown" };
+};
+
+const normalizeField = (
+  value: unknown,
+  field: string,
+  normalize: (child: unknown) => unknown,
+): unknown => {
+  if (!isObject(value)) {
+    return value;
+  }
+  const current = value[field];
+  const normalized = normalize(current);
+  return normalized === current ? value : { ...value, [field]: normalized };
+};
+
+const normalizeRateLimitsById = (value: unknown): unknown => {
+  if (!isObject(value)) {
+    return value;
+  }
+
+  let normalized: JsonObject | undefined;
+  for (const [limitId, snapshot] of Object.entries(value)) {
+    const normalizedSnapshot = normalizePlanTypeField(snapshot);
+    if (normalizedSnapshot !== snapshot) {
+      normalized ??= { ...value };
+      normalized[limitId] = normalizedSnapshot;
+    }
+  }
+  return normalized ?? value;
+};
+
+export const normalizeAccountPlanTypes = (method: string, raw: unknown): unknown => {
+  switch (method) {
+    case "account/read":
+      return normalizeField(raw, "account", normalizePlanTypeField);
+    case "account/rateLimits/read":
+      return normalizeField(
+        normalizeField(raw, "rateLimits", normalizePlanTypeField),
+        "rateLimitsByLimitId",
+        normalizeRateLimitsById,
+      );
+    case "account/updated":
+      return normalizePlanTypeField(raw);
+    case "account/rateLimits/updated":
+      return normalizeField(raw, "rateLimits", normalizePlanTypeField);
+    default:
+      return raw;
+  }
+};
+
 export const decodeOptionalPayload = <A, I>(
   method: string,
   schema: Schema.Codec<A, I> | undefined,
@@ -31,7 +115,7 @@ export const decodeOptionalPayload = <A, I>(
     );
   }
 
-  return Schema.decodeUnknownEffect(schema)(raw).pipe(
+  return Schema.decodeUnknownEffect(schema)(normalizeAccountPlanTypes(method, raw)).pipe(
     Effect.mapError((error) =>
       CodexError.CodexAppServerRequestError.invalidPayload(method, "decode-payload", error),
     ),

--- a/packages/effect-codex-app-server/src/client.test.ts
+++ b/packages/effect-codex-app-server/src/client.test.ts
@@ -11,6 +11,14 @@ import { assert, it } from "@effect/vitest";
 
 import * as CodexClient from "./client.ts";
 
+const currentPlanTypes = [
+  "self_serve_business_prolite",
+  "ent26",
+  "enterprise_cbp_automation",
+  "edu_plus",
+  "edu_pro",
+] as const;
+
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/codex-app-server-mock-peer.ts"),
 );
@@ -152,6 +160,50 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
       );
 
       assert.equal(initialized.userAgent, "mock-codex-app-server");
+    }),
+  );
+
+  for (const planType of currentPlanTypes) {
+    it.effect(`reads accounts with the ${planType} plan`, () =>
+      Effect.gen(function* () {
+        const handle = yield* makeHandle({
+          CODEX_APP_SERVER_TEST_ACCOUNT_PLAN_TYPE: planType,
+        });
+        const scope = yield* Scope.make();
+        const clientLayer = CodexClient.layerChildProcess(handle);
+        const context = yield* Layer.buildWithScope(clientLayer, scope);
+
+        const account = yield* Effect.gen(function* () {
+          const client = yield* CodexClient.CodexAppServerClient;
+          return yield* client.request("account/read", {});
+        }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+        assert.equal(account.account?.type, "chatgpt");
+        if (account.account?.type === "chatgpt") {
+          assert.equal(account.account.planType, planType);
+        }
+      }),
+    );
+  }
+
+  it.effect("maps future account plans to unknown", () =>
+    Effect.gen(function* () {
+      const handle = yield* makeHandle({
+        CODEX_APP_SERVER_TEST_ACCOUNT_PLAN_TYPE: "future_plan",
+      });
+      const scope = yield* Scope.make();
+      const clientLayer = CodexClient.layerChildProcess(handle);
+      const context = yield* Layer.buildWithScope(clientLayer, scope);
+
+      const account = yield* Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        return yield* client.request("account/read", {});
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+      assert.equal(account.account?.type, "chatgpt");
+      if (account.account?.type === "chatgpt") {
+        assert.equal(account.account.planType, "unknown");
+      }
     }),
   );
 });

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -26,6 +26,15 @@ const decodeAccountTokenUsageResponse = Schema.decodeUnknownEffect(
 const decodeAccountRateLimitsResponse = Schema.decodeUnknownEffect(
   CodexRpc.CLIENT_REQUEST_RESPONSES["account/rateLimits/read"],
 );
+const decodeAccountResponse = Schema.decodeUnknownEffect(
+  CodexRpc.CLIENT_REQUEST_RESPONSES["account/read"],
+);
+const decodeAccountUpdated = Schema.decodeUnknownEffect(
+  CodexRpc.SERVER_NOTIFICATION_PARAMS["account/updated"],
+);
+const decodeAccountRateLimitsUpdated = Schema.decodeUnknownEffect(
+  CodexRpc.SERVER_NOTIFICATION_PARAMS["account/rateLimits/updated"],
+);
 const decodeConsumeRateLimitResetCreditParams = Schema.decodeUnknownEffect(
   CodexRpc.CLIENT_REQUEST_PARAMS["account/rateLimitResetCredit/consume"],
 );
@@ -34,6 +43,37 @@ const decodeConsumeRateLimitResetCreditResponse = Schema.decodeUnknownEffect(
 );
 
 it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
+  it.effect("decodes every current Codex account plan", () =>
+    Effect.gen(function* () {
+      const planTypes = [
+        "self_serve_business_prolite",
+        "ent26",
+        "enterprise_cbp_automation",
+        "edu_plus",
+        "edu_pro",
+      ] as const;
+
+      for (const planType of planTypes) {
+        const account = yield* decodeAccountResponse({
+          account: { type: "chatgpt", email: null, planType },
+          requiresOpenaiAuth: false,
+        });
+        assert.equal(account.account?.type, "chatgpt");
+        if (account.account?.type === "chatgpt") {
+          assert.equal(account.account.planType, planType);
+        }
+
+        assert.deepEqual(yield* decodeAccountRateLimitsResponse({ rateLimits: { planType } }), {
+          rateLimits: { planType },
+        });
+        assert.deepEqual(yield* decodeAccountUpdated({ planType }), { planType });
+        assert.deepEqual(yield* decodeAccountRateLimitsUpdated({ rateLimits: { planType } }), {
+          rateLimits: { planType },
+        });
+      }
+    }),
+  );
+
   it.effect("maps account usage responses to the upstream token usage schema", () =>
     Effect.gen(function* () {
       assert.strictEqual(

--- a/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
+++ b/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
@@ -75,7 +75,7 @@ const handleMethod = (message: Record<string, unknown>) => {
         account: {
           type: "chatgpt",
           email: "mock@example.com",
-          planType: "plus",
+          planType: process.env.CODEX_APP_SERVER_TEST_ACCOUNT_PLAN_TYPE ?? "plus",
         },
         requiresOpenaiAuth: false,
       });


### PR DESCRIPTION
## What Changed

- Add all five plan values emitted by current Codex but missing from T3 Code's pinned schemas: `self_serve_business_prolite`, `ent26`, `enterprise_cbp_automation`, `edu_plus`, and `edu_pro`.
- Keep the schema generator reproducible without pulling unrelated protocol changes from a newer upstream snapshot.
- Normalize future unknown plans only at the plan-bearing paths for `account/read`, `account/rateLimits/read`, `account/updated`, and `account/rateLimits/updated`.
- Classify legacy and current wire values using current product families: Business, Enterprise, and Edu. In particular, the legacy `team` wire value now displays as ChatGPT Business.
- Add protocol, mock-peer, forward-compatibility, opaque-payload, and provider-label regression coverage.

## Why

Codex 0.149.1 can return account plan values that T3 Code's pinned protocol schema does not recognize. Schema decoding then rejects `account/read` during the provider probe and prevents the Codex provider from starting.

PR #7869 is an incomplete fix. It is framed around Edu Plus, does not add all five current values to the schema, and recursively rewrites every field named `planType` in every protocol payload. Its automated reviews correctly identified two problems with that approach: it can corrupt opaque tool or structured-content data, and it traverses and reallocates large unrelated payloads.

This change recognizes every plan in Codex's current `PlanType` enum and keeps a forward-compatible fallback constrained to the four account methods and their exact plan-bearing fields. Unrelated payloads retain object identity and opaque nested `planType` fields remain untouched.

ChatGPT for Teachers is a current offering, but Codex does not currently define a distinct Teachers/K–12 wire value. This PR deliberately does not invent one; any future distinct value safely decodes as `unknown` until the pinned schema is updated.

Fixes #8292.
Also resolves #7828.

## UI Changes

No frontend component or layout changes. The existing provider status UI receives corrected account-family labels from the server, including ChatGPT Business for the legacy `team` wire value. This mapping is covered by a focused provider-status test.

## Verification

- `vp test run packages/effect-codex-app-server/src/_internal/shared.test.ts packages/effect-codex-app-server/src/client.test.ts packages/effect-codex-app-server/src/protocol.test.ts apps/server/src/provider/Layers/ProviderRegistry.test.ts` — 72 tests passed
- `vp run --filter effect-codex-app-server typecheck` — passed
- `vp run --filter t3 typecheck` — passed
- Targeted `vp lint` and `vp fmt` for all changed source and test files — passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No frontend component or layout changes require screenshots
- [x] No animation or interaction changes require video

GPT-5 via Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex account protocol decoding and provider probe behavior on a critical startup path, but scope is limited to plan-type enums and targeted normalization rather than broad payload rewriting.
> 
> **Overview**
> Fixes Codex provider startup when newer binaries return **account `planType` values** that the pinned app-server schema did not recognize (e.g. Codex 0.149.1), which caused `account/read` decoding to fail during the provider probe.
> 
> The pinned **`PlanType` enums** in generated schemas are expanded for five current wire values (`self_serve_business_prolite`, `ent26`, `enterprise_cbp_automation`, `edu_plus`, `edu_pro`), and the schema **generator** overrides selected plan-type definitions with a fixed list so decoding stays compatible without bumping the whole upstream protocol snapshot.
> 
> **Forward compatibility:** before decode, `normalizeAccountPlanTypes` maps unrecognized `planType` strings to `unknown` only on account-related methods and specific fields (`account`, `rateLimits`, `rateLimitsByLimitId`), leaving unrelated payloads and nested opaque `planType` fields unchanged.
> 
> On the server, **`codexAccountAuthLabel`** groups legacy and new workspace values into Business, Enterprise, and Edu families (including mapping legacy **`team`** to ChatGPT Business). Regression tests cover protocol decoding, client `account/read`, normalization behavior, and provider status labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc1578bea00b3ec1305f454d555f880ef1b4904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept current ChatGPT workspace `planType` values in Codex provider
> - Expands `planType` enums across account schemas in [schema.gen.ts](https://github.com/pingdotgg/t3code/pull/8294/files#diff-c283b8cf9097ca9d1030e7acabd5d3c70e2a5ca2bfaf229f79512ba96ed58296) to include `team`, `self_serve_business_prolite`, `ent26`, `enterprise_cbp_automation`, `edu_plus`, `edu_pro`, and other current workspace plan variants.
> - Introduces `normalizeAccountPlanTypes` in [shared.ts](https://github.com/pingdotgg/t3code/pull/8294/files#diff-082b3e69a506286c6688439b14dd2ee72dffcd995aeb34fd03f517ac162e4d5a) which coerces unrecognized future `planType` values to `'unknown'` for targeted methods (`account/read`, `account/rateLimits/read`, `account/updated`, `account/rateLimits/updated`) before schema decoding, preventing decode failures on future plan types.
> - Updates `codexAccountAuthLabel` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/8294/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) to map the new plan variants to Business, Enterprise, and Edu subscription labels.
> - Pins `ACCOUNT_PLAN_TYPES` in [generate.ts](https://github.com/pingdotgg/t3code/pull/8294/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) so the generator overrides selected `planType` enums with a fixed list, decoupling decoding from unrelated upstream schema changes.
> - Behavioral Change: payloads with `planType` values not in the pinned set are normalized to `'unknown'` rather than causing decode failures; unrelated/opaque fields in those payloads are preserved by reference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fc1578.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->