### PR TITLE
fix(server): explain invalid GitHub repository paths

### DIFF
--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -117,6 +117,33 @@ it.effect("looks up repositories through the requested provider without search",
   }).pipe(Effect.provide(makeLayer({ provider })));
 });
 
+it.effect("rejects GitHub repository names without an owner", () => {
+  let lookupCalls = 0;
+  const provider = makeProvider({
+    getRepositoryCloneUrls: () =>
+      Effect.sync(() => {
+        lookupCalls += 1;
+        return CLONE_URLS;
+      }),
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+    const error = yield* Effect.flip(
+      service.lookupRepository({
+        provider: "github",
+        repository: "t3code",
+        cwd: "/workspace",
+      }),
+    );
+
+    assert.strictEqual(error.provider, "github");
+    assert.strictEqual(error.operation, "lookupRepository");
+    assert.strictEqual(error.detail, "Enter a GitHub repository as owner/repo.");
+    assert.strictEqual(lookupCalls, 0);
+  }).pipe(Effect.provide(makeLayer({ provider })));
+});
+
 it.effect("preserves provider failures without deriving the repository message from them", () => {
   const providerCause = new SourceControlProviderError({
     provider: "github",

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -118,10 +118,19 @@ export const make = Effect.gen(function* () {
       operation: "lookupRepository",
       provider: input.provider,
     });
+    const repository = input.repository.trim();
+    if (providerKind === "github" && !/^[^/\s]+\/[^/\s]+$/u.test(repository)) {
+      return yield* new SourceControlRepositoryError({
+        operation: "lookupRepository",
+        provider: providerKind,
+        detail: "Enter a GitHub repository as owner/repo.",
+      });
+    }
+
     const provider = yield* providers.get(providerKind);
     const urls = yield* provider.getRepositoryCloneUrls({
       cwd: input.cwd ?? config.cwd,
-      repository: input.repository.trim(),
+      repository,
     });
     return toRepositoryInfo(providerKind, urls);
   });


### PR DESCRIPTION
## What Changed

Validate GitHub repository lookup input at the server boundary before invoking the provider. Bare names and other malformed values now return an actionable `Enter a GitHub repository as owner/repo.` error, while valid paths continue through the existing provider lookup.

Added a focused regression test that verifies malformed input never reaches the provider.

## Why

The GitHub project picker asks for `owner/repo`, but a bare value such as `bacii` was forwarded to `gh repo view`. GitHub rejected the inferred repository, and T3 intentionally replaced the CLI detail with a generic transport-safe error. That left users with no indication that the input format was wrong.

Validating the documented input shape before the external CLI call fixes the message for every client without exposing arbitrary provider stderr or duplicating validation in web and mobile.

## Verification

- `vp test run apps/server/src/sourceControl/SourceControlRepositoryService.test.ts` (8 passed)
- `vp lint apps/server/src/sourceControl/SourceControlRepositoryService.ts apps/server/src/sourceControl/SourceControlRepositoryService.test.ts --report-unused-disable-directives`
- `vp run --filter t3 typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable; this changes server-side validation and error detail
- [x] Animation video is not applicable

Built with Codex (GPT-5) via the T3 Code triage harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds input validation and a clearer error path only; no changes to auth, cloning, or provider credential handling.
> 
> **Overview**
> **GitHub repository lookup** now rejects malformed names at the server boundary before any provider or `gh` CLI call.
> 
> In `lookupRepository`, trimmed input for `github` must match `owner/repo` (single slash, no whitespace). Bare names like `t3code` return `Enter a GitHub repository as owner/repo.` instead of a generic transport-safe error after GitHub rejects the inferred repo.
> 
> A regression test confirms malformed input never invokes `getRepositoryCloneUrls`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf3f9e4d58d35b3a3d584ec18b3025d681016b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject invalid GitHub repository paths in `SourceControlRepositoryService.lookupRepository`
> Adds a regex check (`^[^/\s]+/[^/\s]+$`) for GitHub providers in `lookupRepository`; values not in `owner/repo` format fail with a `SourceControlRepositoryError` and the provider is never called. The repository string is now trimmed before use. Risk: GitHub-only validation is new — callers passing a bare repo name will now receive an error instead of a provider lookup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cf3f9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->