### PR TITLE
fix(server): stage only changed checkpoint paths

### DIFF
--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -246,6 +246,24 @@ describe("runProcess", () => {
     }),
   );
 
+  it.effect("preserves raw stdout bytes when requested", () =>
+    Effect.gen(function* () {
+      const stdoutBytes = new Uint8Array([0x66, 0x80, 0x6f]);
+      const spawner = makeSpawner(() =>
+        Effect.succeed(makeHandle({ stdout: Stream.make(stdoutBytes) })),
+      );
+
+      const result = yield* runWith(spawner)({
+        command: "fake",
+        args: ["raw-stdout"],
+        captureStdoutBytes: true,
+      });
+
+      expect(result.stdoutInvalidUtf8).toBe(true);
+      expect(Array.from(result.stdoutBytes ?? [])).toEqual(Array.from(stdoutBytes));
+    }),
+  );
+
   it.effect("fails fast on output limit before timeout for long-running output", () =>
     Effect.gen(function* () {
       const textChunk = "x".repeat(64);
@@ -316,6 +334,32 @@ describe("runProcess", () => {
 
       expect(result.stdout).toBe("stdin payload");
       expect(result.code).toBe(0);
+    }),
+  );
+
+  it.effect("writes raw stdin bytes without UTF-8 encoding", () =>
+    Effect.gen(function* () {
+      const stdinBytes = new Uint8Array([0x66, 0x80, 0x6f]);
+      const receivedBytes: number[] = [];
+      const spawner = makeSpawner(() =>
+        Effect.succeed(
+          makeHandle({
+            stdin: Sink.forEach((chunk: Uint8Array) =>
+              Effect.sync(() => {
+                receivedBytes.push(...chunk);
+              }),
+            ),
+          }),
+        ),
+      );
+
+      yield* runWith(spawner)({
+        command: "fake",
+        args: ["raw-stdin"],
+        stdin: stdinBytes,
+      });
+
+      expect(receivedBytes).toEqual(Array.from(stdinBytes));
     }),
   );
 

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -24,7 +24,8 @@ export interface ProcessRunInput {
   readonly spawnCwd?: string | undefined;
   readonly timeout?: Duration.Input | undefined;
   readonly env?: NodeJS.ProcessEnv | undefined;
-  readonly stdin?: string | undefined;
+  readonly stdin?: string | Uint8Array | undefined;
+  readonly captureStdoutBytes?: boolean | undefined;
   readonly maxOutputBytes?: number | undefined;
   readonly outputMode?: "error" | "truncate" | undefined;
   readonly truncatedMarker?: string | undefined;
@@ -44,6 +45,7 @@ export interface ProcessRunOutput {
   readonly stderrTruncated: boolean;
   readonly stdoutInvalidUtf8: boolean;
   readonly stderrInvalidUtf8: boolean;
+  readonly stdoutBytes?: Uint8Array;
 }
 
 const ProcessInvocationFields = {
@@ -182,6 +184,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
   readonly maxOutputBytes: number;
   readonly outputMode: "error" | "truncate";
   readonly truncatedMarker: string;
+  readonly preserveBytes: boolean;
 }) {
   const stream = input.stream.pipe(
     Stream.mapError(
@@ -202,6 +205,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
       stream,
       maxBytes: input.maxOutputBytes,
       truncatedMarker: input.truncatedMarker,
+      preserveBytes: input.preserveBytes,
     });
   }
 
@@ -239,13 +243,15 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
         });
       },
     ),
-    Effect.map(
-      (state): CollectedUint8StreamText => ({
-        ...decodeUtf8(Buffer.concat(state.chunks, state.bytes)),
+    Effect.map((state): CollectedUint8StreamText => {
+      const rawBytes = Buffer.concat(state.chunks, state.bytes);
+      return {
+        ...decodeUtf8(rawBytes),
         bytes: state.bytes,
         truncated: false,
-      }),
-    ),
+        ...(input.preserveBytes ? { rawBytes } : {}),
+      };
+    }),
   );
 });
 
@@ -335,7 +341,10 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
   const writeStdin =
     stdin === undefined
       ? Effect.void
-      : Stream.run(Stream.encodeText(Stream.make(stdin)), child.stdin).pipe(
+      : Stream.run(
+          typeof stdin === "string" ? Stream.encodeText(Stream.make(stdin)) : Stream.make(stdin),
+          child.stdin,
+        ).pipe(
           Effect.mapError(
             (cause) =>
               new ProcessStdinError({
@@ -343,7 +352,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
                 argumentCount: input.args.length,
                 cwd: input.cwd,
                 spawnCwd: input.spawnCwd,
-                stdinBytes: Buffer.byteLength(stdin),
+                stdinBytes: typeof stdin === "string" ? Buffer.byteLength(stdin) : stdin.byteLength,
                 cause,
               }),
           ),
@@ -361,6 +370,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
         maxOutputBytes,
         outputMode,
         truncatedMarker,
+        preserveBytes: input.captureStdoutBytes === true,
       }),
       collectText({
         command: input.command,
@@ -372,6 +382,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
         maxOutputBytes,
         outputMode,
         truncatedMarker,
+        preserveBytes: false,
       }),
       writeStdin,
     ],
@@ -401,6 +412,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
     stderrTruncated: stderr.truncated,
     stdoutInvalidUtf8: stdout.invalidUtf8,
     stderrInvalidUtf8: stderr.invalidUtf8,
+    ...(stdout.rawBytes !== undefined ? { stdoutBytes: stdout.rawBytes } : {}),
   } satisfies ProcessRunOutput;
 });
 

--- a/apps/server/src/stream/collectUint8StreamText.ts
+++ b/apps/server/src/stream/collectUint8StreamText.ts
@@ -7,6 +7,7 @@ export interface CollectedUint8StreamText {
   readonly truncated: boolean;
   readonly bytes: number;
   readonly invalidUtf8: boolean;
+  readonly rawBytes?: Uint8Array;
 }
 
 export const decodeUtf8 = (
@@ -26,6 +27,7 @@ export const collectUint8StreamText = <E>(input: {
   readonly stream: Stream.Stream<Uint8Array, E>;
   readonly maxBytes?: number | undefined;
   readonly truncatedMarker?: string | null | undefined;
+  readonly preserveBytes?: boolean | undefined;
 }): Effect.Effect<CollectedUint8StreamText, E> => {
   const maxBytes = input.maxBytes ?? Number.POSITIVE_INFINITY;
   const truncatedMarker = input.truncatedMarker ?? "";
@@ -68,7 +70,8 @@ export const collectUint8StreamText = <E>(input: {
       },
     ),
     Effect.map((state): CollectedUint8StreamText => {
-      const decoded = decodeUtf8(Buffer.concat(state.chunks, state.bytes));
+      const rawBytes = Buffer.concat(state.chunks, state.bytes);
+      const decoded = decodeUtf8(rawBytes);
       return {
         text:
           state.truncated && truncatedMarker.length > 0
@@ -77,6 +80,7 @@ export const collectUint8StreamText = <E>(input: {
         bytes: state.bytes,
         truncated: state.truncated,
         invalidUtf8: decoded.invalidUtf8,
+        ...(input.preserveBytes ? { rawBytes } : {}),
       };
     }),
   );

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -112,6 +112,19 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
 it.effect("GitVcsDriver stages only changed paths when capturing a checkpoint", () => {
   const commands: Array<VcsProcess.VcsProcessInput> = [];
   const changedPaths = ["changed.ts", "deleted.ts", "dir/new\nfile.ts", ":literal.ts"];
+  const invalidUtf8Path = new Uint8Array([0xff, ...new TextEncoder().encode(".txt")]);
+  const statusBytes = Buffer.concat([
+    Buffer.from(
+      ` M ${changedPaths[0]}\0 D ${changedPaths[1]}\0?? ${changedPaths[2]}\0?? ${changedPaths[3]}\0?? `,
+    ),
+    invalidUtf8Path,
+    Buffer.from([0]),
+  ]);
+  const expectedPathspec = Buffer.concat([
+    Buffer.from(`${changedPaths.join("\0")}\0`),
+    invalidUtf8Path,
+    Buffer.from([0]),
+  ]);
 
   return Effect.gen(function* () {
     const driver = yield* GitVcsDriver.makeVcsDriverShape();
@@ -134,6 +147,7 @@ it.effect("GitVcsDriver stages only changed paths when capturing a checkpoint", 
       ".",
     ]);
     assert.strictEqual(statusCommand.env?.GIT_OPTIONAL_LOCKS, "0");
+    assert.strictEqual(statusCommand.captureStdoutBytes, true);
 
     const addCommand = commands.find((command) => command.args[3] === "add");
     assert.isDefined(addCommand);
@@ -144,7 +158,8 @@ it.effect("GitVcsDriver stages only changed paths when capturing a checkpoint", 
       "--pathspec-from-file=-",
       "--pathspec-file-nul",
     ]);
-    assert.strictEqual(addCommand.stdin, `${changedPaths.join("\0")}\0`);
+    assert.instanceOf(addCommand.stdin, Uint8Array);
+    assert.deepStrictEqual(addCommand.stdin, expectedPathspec);
   }).pipe(
     Effect.provide(
       Layer.mergeAll(
@@ -156,7 +171,7 @@ it.effect("GitVcsDriver stages only changed paths when capturing a checkpoint", 
               const args = input.args.slice(2);
               const stdout =
                 args[0] === "status"
-                  ? ` M ${changedPaths[0]}\0 D ${changedPaths[1]}\0?? ${changedPaths[2]}\0?? ${changedPaths[3]}\0`
+                  ? new TextDecoder().decode(statusBytes)
                   : args[0] === "rev-parse" && args[1] === "--git-common-dir"
                     ? ".git\n"
                     : args[0] === "rev-parse" && args[1] === "--show-toplevel"
@@ -172,6 +187,7 @@ it.effect("GitVcsDriver stages only changed paths when capturing a checkpoint", 
                 stderr: "",
                 stdoutTruncated: false,
                 stderrTruncated: false,
+                ...(args[0] === "status" ? { stdoutBytes: statusBytes } : {}),
               };
             }),
         }),

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -7,7 +7,7 @@ import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { assert, it } from "@effect/vitest";
 
-import { GitCommandError } from "@t3tools/contracts";
+import { CheckpointRef, GitCommandError } from "@t3tools/contracts";
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -108,3 +108,147 @@ it.effect("GitVcsDriver forwards execute env to the VCS process", () => {
     ),
   );
 });
+
+it.effect("GitVcsDriver stages only changed paths when capturing a checkpoint", () => {
+  const commands: Array<VcsProcess.VcsProcessInput> = [];
+  const changedPaths = ["changed.ts", "deleted.ts", "dir/new\nfile.ts", ":literal.ts"];
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    assert.isDefined(driver.checkpoints);
+
+    yield* driver.checkpoints.captureCheckpoint({
+      cwd: process.cwd(),
+      checkpointRef: CheckpointRef.make("refs/t3/checkpoints/test/turn/1"),
+    });
+
+    const statusCommand = commands.find((command) => command.args[2] === "status");
+    assert.isDefined(statusCommand);
+    assert.deepStrictEqual(statusCommand.args.slice(2), [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--no-renames",
+      "--",
+      ".",
+    ]);
+    assert.strictEqual(statusCommand.env?.GIT_OPTIONAL_LOCKS, "0");
+
+    const addCommand = commands.find((command) => command.args[3] === "add");
+    assert.isDefined(addCommand);
+    assert.deepStrictEqual(addCommand.args.slice(2), [
+      "--literal-pathspecs",
+      "add",
+      "-A",
+      "--pathspec-from-file=-",
+      "--pathspec-file-nul",
+    ]);
+    assert.strictEqual(addCommand.stdin, `${changedPaths.join("\0")}\0`);
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: (input) =>
+            Effect.sync(() => {
+              commands.push(input);
+              const args = input.args.slice(2);
+              const stdout =
+                args[0] === "status"
+                  ? ` M ${changedPaths[0]}\0 D ${changedPaths[1]}\0?? ${changedPaths[2]}\0?? ${changedPaths[3]}\0`
+                  : args[0] === "rev-parse" && args[1] === "--git-common-dir"
+                    ? ".git\n"
+                    : args[0] === "rev-parse" && args[1] === "--show-toplevel"
+                      ? `${process.cwd()}\n`
+                      : args[0] === "write-tree"
+                        ? "tree-oid\n"
+                        : args[0] === "commit-tree"
+                          ? "commit-oid\n"
+                          : "";
+              return {
+                exitCode: ChildProcessSpawner.ExitCode(0),
+                stdout,
+                stderr: "",
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    ),
+  );
+});
+
+it.effect("GitVcsDriver captures scoped working tree changes without changing the real index", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const driver = yield* GitVcsDriver.makeVcsDriverShape();
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-git-checkpoint-paths-",
+      });
+      const scopeCwd = path.join(cwd, "scope");
+      const checkpointRef = CheckpointRef.make("refs/t3/checkpoints/test/turn/1");
+      assert.isDefined(driver.checkpoints);
+
+      const git = (gitCwd: string, args: ReadonlyArray<string>, allowNonZeroExit = false) =>
+        driver.execute({
+          operation: "GitVcsDriver.test.checkpointPaths",
+          cwd: gitCwd,
+          args,
+          allowNonZeroExit,
+          timeoutMs: 10_000,
+        });
+      const write = (relativePath: string, contents: string) =>
+        fileSystem.writeFileString(path.join(cwd, relativePath), contents);
+
+      yield* git(cwd, ["init"]);
+      yield* git(cwd, ["config", "user.email", "test@test.com"]);
+      yield* git(cwd, ["config", "user.name", "Test"]);
+      yield* fileSystem.makeDirectory(scopeCwd);
+      yield* write("scope/changed.txt", "original changed\n");
+      yield* write("scope/deleted.txt", "original deleted\n");
+      yield* write("scope/staged.txt", "original staged\n");
+      yield* write("outside.txt", "original outside\n");
+      yield* git(cwd, ["add", "."]);
+      yield* git(cwd, ["commit", "-m", "initial"]);
+
+      yield* write("scope/staged.txt", "staged version\n");
+      yield* git(cwd, ["add", "scope/staged.txt"]);
+      const indexTreeBefore = (yield* git(cwd, ["write-tree"])).stdout.trim();
+
+      yield* write("scope/changed.txt", "working changed\n");
+      yield* write("scope/staged.txt", "working version\n");
+      yield* write("scope/new file [1].txt", "new file\n");
+      yield* write("outside.txt", "working outside\n");
+      yield* fileSystem.remove(path.join(scopeCwd, "deleted.txt"));
+
+      yield* driver.checkpoints.captureCheckpoint({ cwd: scopeCwd, checkpointRef });
+
+      const indexTreeAfter = (yield* git(cwd, ["write-tree"])).stdout.trim();
+      assert.strictEqual(indexTreeAfter, indexTreeBefore);
+      assert.strictEqual(
+        (yield* git(cwd, ["show", `${checkpointRef}:scope/changed.txt`])).stdout,
+        "working changed\n",
+      );
+      assert.strictEqual(
+        (yield* git(cwd, ["show", `${checkpointRef}:scope/staged.txt`])).stdout,
+        "working version\n",
+      );
+      assert.strictEqual(
+        (yield* git(cwd, ["show", `${checkpointRef}:scope/new file [1].txt`])).stdout,
+        "new file\n",
+      );
+      assert.strictEqual(
+        (yield* git(cwd, ["show", `${checkpointRef}:outside.txt`])).stdout,
+        "original outside\n",
+      );
+      assert.notStrictEqual(
+        (yield* git(cwd, ["cat-file", "-e", `${checkpointRef}:scope/deleted.txt`], true)).exitCode,
+        0,
+      );
+    }).pipe(Effect.provide(GitContractLayer)),
+  ),
+);

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -358,6 +358,12 @@ function splitNullSeparatedPaths(input: string, truncated: boolean): string[] {
   return parts.filter((value) => value.length > 0);
 }
 
+function parseCheckpointStatusPaths(output: string): string[] {
+  return splitNullSeparatedPaths(output, false).flatMap((entry) =>
+    entry.length > 3 && entry[2] === " " ? [entry.slice(3)] : [],
+  );
+}
+
 function chunkPathsForGitCheckIgnore(relativePaths: ReadonlyArray<string>): string[][] {
   const chunks: string[][] = [];
   let chunk: string[] = [];
@@ -708,10 +714,18 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
     });
 
+  const resolveRepositoryRoot = (cwd: string) =>
+    execute({
+      operation: "GitVcsDriver.checkpoints.resolveRepositoryRoot",
+      cwd,
+      args: ["rev-parse", "--show-toplevel"],
+    }).pipe(Effect.map((result) => result.stdout.trim()));
+
   const checkpoints: VcsDriver.VcsCheckpointOps = {
     captureCheckpoint: Effect.fn("GitVcsDriver.checkpoints.captureCheckpoint")(function* (input) {
       const operation = "GitVcsDriver.checkpoints.captureCheckpoint";
       const gitCommonDir = yield* resolveGitCommonDir(input.cwd);
+      const repositoryRoot = yield* resolveRepositoryRoot(input.cwd);
       const tempIndexPath = path.join(
         gitCommonDir,
         `t3-checkpoint-index-${NodeCrypto.randomUUID()}`,
@@ -731,21 +745,57 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
 
       yield* Effect.gen(function* () {
         const headExists = yield* hasHeadCommit(input.cwd);
-        if (headExists) {
-          yield* execute({
-            operation,
-            cwd: input.cwd,
-            args: ["read-tree", "HEAD"],
-            env: commitEnv,
-          });
-        }
-
         yield* execute({
           operation,
           cwd: input.cwd,
-          args: ["add", "-A", "--", "."],
+          args: headExists ? ["read-tree", "HEAD"] : ["read-tree", "--empty"],
           env: commitEnv,
         });
+
+        const statusResult = yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: [
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--no-renames",
+            "--",
+            ".",
+          ],
+          env: {
+            ...process.env,
+            GIT_OPTIONAL_LOCKS: "0",
+          },
+          maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
+        });
+
+        if (statusResult.stdoutTruncated) {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["add", "-A", "--", "."],
+            env: commitEnv,
+          });
+        } else {
+          const changedPaths = parseCheckpointStatusPaths(statusResult.stdout);
+          if (changedPaths.length > 0) {
+            yield* execute({
+              operation,
+              cwd: repositoryRoot,
+              args: [
+                "--literal-pathspecs",
+                "add",
+                "-A",
+                "--pathspec-from-file=-",
+                "--pathspec-file-nul",
+              ],
+              stdin: `${changedPaths.join("\0")}\0`,
+              env: commitEnv,
+            });
+          }
+        }
 
         const writeTreeResult = yield* execute({
           operation,

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -358,10 +358,19 @@ function splitNullSeparatedPaths(input: string, truncated: boolean): string[] {
   return parts.filter((value) => value.length > 0);
 }
 
-function parseCheckpointStatusPaths(output: string): string[] {
-  return splitNullSeparatedPaths(output, false).flatMap((entry) =>
-    entry.length > 3 && entry[2] === " " ? [entry.slice(3)] : [],
-  );
+function parseCheckpointStatusPathspec(output: Uint8Array): Uint8Array {
+  const paths: Uint8Array[] = [];
+  let recordStart = 0;
+  for (let index = 0; index < output.byteLength; index += 1) {
+    if (output[index] !== 0) {
+      continue;
+    }
+    if (index - recordStart > 3 && output[recordStart + 2] === 0x20) {
+      paths.push(output.subarray(recordStart + 3, index + 1));
+    }
+    recordStart = index + 1;
+  }
+  return Buffer.concat(paths);
 }
 
 function chunkPathsForGitCheckIgnore(relativePaths: ReadonlyArray<string>): string[][] {
@@ -432,7 +441,8 @@ const gitCommand = (
   cwd: string,
   args: ReadonlyArray<string>,
   options?: {
-    readonly stdin?: string;
+    readonly stdin?: string | Uint8Array;
+    readonly captureStdoutBytes?: boolean;
     readonly env?: NodeJS.ProcessEnv;
     readonly allowNonZeroExit?: boolean;
     readonly timeoutMs?: number;
@@ -447,6 +457,9 @@ const gitCommand = (
     cwd,
     spawnCwd: globalThis.process.cwd(),
     ...(options?.stdin !== undefined ? { stdin: options.stdin } : {}),
+    ...(options?.captureStdoutBytes !== undefined
+      ? { captureStdoutBytes: options.captureStdoutBytes }
+      : {}),
     ...(options?.env !== undefined ? { env: options.env } : {}),
     ...(options?.allowNonZeroExit !== undefined
       ? { allowNonZeroExit: options.allowNonZeroExit }
@@ -487,6 +500,9 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
   const execute: VcsDriver.VcsDriver["Service"]["execute"] = (input) =>
     gitCommand(vcsProcess, input.operation, input.cwd, input.args, {
       ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+      ...(input.captureStdoutBytes !== undefined
+        ? { captureStdoutBytes: input.captureStdoutBytes }
+        : {}),
       ...(input.env !== undefined ? { env: input.env } : {}),
       ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
@@ -714,12 +730,14 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
     });
 
-  const resolveRepositoryRoot = (cwd: string) =>
-    execute({
+  const resolveRepositoryRoot = Effect.fn("resolveRepositoryRoot")(function* (cwd: string) {
+    const result = yield* execute({
       operation: "GitVcsDriver.checkpoints.resolveRepositoryRoot",
       cwd,
       args: ["rev-parse", "--show-toplevel"],
-    }).pipe(Effect.map((result) => result.stdout.trim()));
+    });
+    return result.stdout.trim();
+  });
 
   const checkpoints: VcsDriver.VcsCheckpointOps = {
     captureCheckpoint: Effect.fn("GitVcsDriver.checkpoints.captureCheckpoint")(function* (input) {
@@ -769,9 +787,10 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             GIT_OPTIONAL_LOCKS: "0",
           },
           maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
+          captureStdoutBytes: true,
         });
 
-        if (statusResult.stdoutTruncated) {
+        if (statusResult.stdoutTruncated || statusResult.stdoutBytes === undefined) {
           yield* execute({
             operation,
             cwd: input.cwd,
@@ -779,8 +798,8 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
             env: commitEnv,
           });
         } else {
-          const changedPaths = parseCheckpointStatusPaths(statusResult.stdout);
-          if (changedPaths.length > 0) {
+          const changedPathspec = parseCheckpointStatusPathspec(statusResult.stdoutBytes);
+          if (changedPathspec.byteLength > 0) {
             yield* execute({
               operation,
               cwd: repositoryRoot,
@@ -791,7 +810,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
                 "--pathspec-from-file=-",
                 "--pathspec-file-nul",
               ],
-              stdin: `${changedPaths.join("\0")}\0`,
+              stdin: changedPathspec,
               env: commitEnv,
             });
           }

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -61,6 +61,23 @@ describe("VcsProcess.run", () => {
     }).pipe(provideLive),
   );
 
+  it.effect("round-trips raw process bytes when requested", () =>
+    Effect.gen(function* () {
+      const rawBytes = new Uint8Array([0x66, 0x80, 0x6f]);
+      const result = yield* run({
+        operation: "test.raw-stdout",
+        command: "node",
+        args: ["-e", "process.stdin.on('data', chunk => process.stdout.write(chunk))"],
+        cwd: process.cwd(),
+        stdin: rawBytes,
+        captureStdoutBytes: true,
+      });
+
+      expect(result.stdoutInvalidUtf8).toBe(true);
+      expect(Array.from(result.stdoutBytes ?? [])).toEqual(Array.from(rawBytes));
+    }).pipe(provideLive),
+  );
+
   it.effect("writes stdin before waiting for exit", () =>
     Effect.gen(function* () {
       const result = yield* run({

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -23,7 +23,8 @@ export interface VcsProcessInput {
   readonly args: ReadonlyArray<string>;
   readonly cwd: string;
   readonly spawnCwd?: string;
-  readonly stdin?: string;
+  readonly stdin?: string | Uint8Array;
+  readonly captureStdoutBytes?: boolean;
   readonly env?: NodeJS.ProcessEnv;
   readonly allowNonZeroExit?: boolean;
   readonly timeoutMs?: number;
@@ -40,6 +41,7 @@ export interface VcsProcessOutput {
   /** Present on real process output; optional so narrow test doubles remain lightweight. */
   readonly stdoutInvalidUtf8?: boolean;
   readonly stderrInvalidUtf8?: boolean;
+  readonly stdoutBytes?: Uint8Array;
 }
 
 export class VcsProcess extends Context.Service<
@@ -117,6 +119,9 @@ export const make = Effect.gen(function* () {
         cwd: input.cwd,
         ...(input.spawnCwd !== undefined ? { spawnCwd: input.spawnCwd } : {}),
         ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+        ...(input.captureStdoutBytes !== undefined
+          ? { captureStdoutBytes: input.captureStdoutBytes }
+          : {}),
         ...(input.env !== undefined ? { env: input.env } : {}),
         timeout: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         maxOutputBytes: input.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
@@ -178,6 +183,7 @@ export const make = Effect.gen(function* () {
       stderrTruncated: result.stderrTruncated,
       stdoutInvalidUtf8: result.stdoutInvalidUtf8 ?? false,
       stderrInvalidUtf8: result.stderrInvalidUtf8 ?? false,
+      ...(result.stdoutBytes !== undefined ? { stdoutBytes: result.stdoutBytes } : {}),
     } satisfies VcsProcessOutput;
   });
 


### PR DESCRIPTION
## What Changed

- Discover checkpoint paths with a scoped, NUL-delimited `git status` using the real index.
- Stage only those paths into the temporary checkpoint index through `--pathspec-from-file`.
- Preserve raw Git pathname bytes from `status -z` output through pathspec stdin, including non-UTF-8 names.
- Preserve workspace-subdirectory scope and leave the user's real index unchanged.
- Fall back to the existing scoped full add only if status output exceeds the preview limit.
- Add focused unit and Git integration coverage for staged, unstaged, deleted, and untracked paths.

## Why

Checkpoint capture currently builds a temporary index with `git add -A -- .`. On repositories with hundreds of thousands of tracked files, that can exceed the 30-second process timeout even when only a few files changed. The missing checkpoint then prevents Latest turn diffs and summaries from loading.

This change keeps the checkpoint content equivalent while limiting temporary-index staging to the paths Git already reports as changed.

Related to #3646. This PR targets large repositories with a small changed-file set. It does not claim to add failure backoff, temporary-pack cleanup, or handling for a single oversized untracked file.

## Testing

- `vp test run apps/server/src/stream/collectUint8StreamText.test.ts apps/server/src/processRunner.test.ts apps/server/src/vcs/VcsProcess.test.ts apps/server/src/vcs/GitVcsDriver.test.ts`
- `vp lint --report-unused-disable-directives apps/server/src/vcs/GitVcsDriver.ts apps/server/src/vcs/GitVcsDriver.test.ts`
- `vp run --filter t3 typecheck`
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core checkpoint staging and relies on porcelain v1 byte parsing; a format mismatch could miss paths until the slower `add -A` fallback runs.
> 
> **Overview**
> **Checkpoint capture** no longer runs `git add -A -- .` on the temporary index for every capture. It runs a scoped, NUL-delimited `git status --porcelain=v1 -z` (with `GIT_OPTIONAL_LOCKS=0`), parses changed paths from the **raw** status bytes, and stages only those paths via `git add --literal-pathspecs … --pathspec-from-file=-` from the repository root. Repositories without `HEAD` seed the temp index with `read-tree --empty`. If status output is truncated or raw bytes are missing, behavior falls back to the previous scoped `git add -A -- .`.
> 
> **Process I/O** gains optional binary-safe plumbing: `stdin` can be `Uint8Array`, `captureStdoutBytes` returns `stdoutBytes` alongside decoded text (with `stdoutInvalidUtf8`), wired through `VcsProcess`, `processRunner`, and `collectUint8StreamText` so NUL-delimited git output and pathspec stdin stay lossless.
> 
> New unit and integration tests cover raw byte round-trips, exact git commands for checkpoint staging (including invalid-UTF-8 paths), and that scoped checkpoints match the working tree without mutating the real index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8cb9a34be39a9ff1e76e37bf9700d2d32cc80a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `captureCheckpoint` to stage only changed paths via binary-safe pathspecs
> - Reworks `captureCheckpoint` in [GitVcsDriver.ts](https://github.com/pingdotgg/t3code/pull/8301/files#diff-51125f02a750f476d151ebf951da622dc9738e642dc72b99dc8bfccf689a1483) to run `git status --porcelain=v1 -z` with `captureStdoutBytes`, parse the raw bytes into a NUL-delimited pathspec, and feed it to `git add --pathspec-from-file=- --pathspec-file-nul` against a temp index — so only changed paths are staged instead of `git add -A`
> - Adds `parseCheckpointStatusPathspec` to extract NUL-terminated paths from porcelain status bytes, handling files with spaces or invalid UTF-8
> - Propagates `Uint8Array` stdin and `captureStdoutBytes` through `VcsProcess` and `ProcessRunner` so raw bytes flow end-to-end without UTF-8 corruption
> - Uses `resolveRepositoryRoot` to run the pathspec-based `git add` at the repo root so paths resolve correctly
> - Risk: `captureCheckpoint` falls back to `git add -A -- .` in the scoped cwd when status output is truncated or raw bytes are unavailable; reviewers should confirm the fallback in `GitVcsDriver.captureCheckpoint` preserves prior behavior under large diffs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f8cb9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->