### PR TITLE
fix: strip terminal title escape from `opencode agent list` output

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -255,6 +255,47 @@ describe("parseAgentListCliOutput", () => {
     NodeAssert.equal(result[0]!.hidden, true);
     NodeAssert.equal(result[1]!.hidden, false);
   });
+
+  it("strips terminal OSC title sequences from agent headers (regression for #7716)", () => {
+    // `opencode agent list` intermittently prefixes the first line with a terminal
+    // title OSC `ESC ]0;user: cwd BEL` (e.g. `\x1b]0;heinrich: ready\x07`) on macOS.
+    // The parser must sanitize before applying AGENT_HEADER_RE or it creates a
+    // polluted agent id `]0;heinrich: ready build` that blocks build mode.
+    const stdout = [
+      "\u001b]0;heinrich: ready\u0007build (primary)",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+      "plan (primary)",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.equal(result.length, 2);
+    NodeAssert.equal(result[0]!.name, "build");
+    NodeAssert.equal(result[0]!.mode, "primary");
+    NodeAssert.equal(result[1]!.name, "plan");
+  });
+
+  it("strips ANSI color sequences from agent headers", () => {
+    const stdout = [
+      "\u001b[36mbuild\u001b[0m (primary)",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.equal(result.length, 1);
+    NodeAssert.equal(result[0]!.name, "build");
+  });
+
+  it("handles OSC terminated with ST (ESC \\)", () => {
+    const stdout = [
+      "\u001b]0;heinrich: ready\u001b\\build (primary)",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.equal(result.length, 1);
+    NodeAssert.equal(result[0]!.name, "build");
+  });
 });
 
 describe("parseSkillsCliOutput", () => {

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -199,6 +199,19 @@ function parseServerUrlFromOutput(output: string): string | null {
 const SLUG_LINE_RE = /^(\S+\/\S+)\s*$/;
 const AGENT_HEADER_RE = /^(.+)\s+\((\S+)\)\s*$/;
 
+/**
+ * Strip terminal escape sequences that can leak into CLI stdout on macOS.
+ * `opencode agent list` intermittently prefixes the first line with an OSC
+ * title `ESC ]0;user: cwd BEL` / `ESC ]0;... ESC \` or ANSI color `ESC[...m`.
+ * Without sanitizing, `AGENT_HEADER_RE` captures the polluted prefix as the
+ * agent name (`]0;heinrich: ready build` — #7716).
+ */
+function stripTerminalEscapes(input: string): string {
+  return input
+    .replace(/\x1B\][^\x07\x1B]*(\x07|\x1B\\)/g, "")
+    .replace(/\x1B\[[0-9:;?]*[ -/]*[@-~]/g, "");
+}
+
 // Agents that are always hidden in OpenCode but the CLI "agent list" command
 // does not expose the hidden flag. Keep in sync with OpenCode agent
 // definitions (in the OpenCode repo: packages/opencode/src/agent/agent.ts).
@@ -269,7 +282,7 @@ export function parseModelsCliOutput(stdout: string): {
 /** @internal */
 export function parseAgentListCliOutput(stdout: string): ReadonlyArray<Agent> {
   const agents: Array<Agent> = [];
-  const lines = stdout.split("\n");
+  const lines = stripTerminalEscapes(stdout).split("\n");
   let currentHeader: { name: string; mode: string } | null = null;
   const blockLines: Array<string> = [];
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
Previously, whenever `opencode agent list` tried to change the terminal title with an escape, it would stop you from switching to build mode since the parser would parse it as "\x1b]0;usernamehere: ready\x07".

A test was added to fix the parsing problem, and a function was added to strip it of terminal escapes.

## Why
Instead of trying to stop it from ever sending the code (unreliable on macOS), we just strip them off the answer, so `]0;heinrich: ready build` becomes `build` again.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x]  N/A I included before/after screenshots for any UI changes
- [x] N/A I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI output sanitization for agent list parsing, with regression tests and no auth or data-path impact.
> 
> **Overview**
> Fixes **#7716**, where macOS `opencode agent list` stdout sometimes prefixes the first agent line with a terminal title OSC (`ESC ]0;…`) or ANSI color codes. **`parseAgentListCliOutput`** now runs stdout through **`stripTerminalEscapes`** before line splitting and header matching, so agent names stay correct (e.g. `build` instead of `]0;heinrich: ready build`) and build mode selection works again.
> 
> **`stripTerminalEscapes`** removes OSC sequences (BEL or ST termination) and standard CSI ANSI sequences. Regression tests cover OSC-prefixed headers, colored headers, and OSC terminated with `ESC \`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c88685b606c5efd9108e809f6c9318e2364f455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip terminal escape sequences from `parseAgentListCliOutput` stdout
> Adds a `stripTerminalEscapes` utility in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/8302/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) that removes OSC window title sequences (terminated by BEL or ST) and ANSI SGR color codes from text. `parseAgentListCliOutput` now runs stdout through this sanitizer before splitting into lines, so agent headers parse into clean name/mode values instead of polluted or skipped entries. Tests in [opencodeRuntime.cliParsers.test.ts](https://github.com/pingdotgg/t3code/pull/8302/files#diff-89a1591aef6b6557b8380e6b6169a55f61d0231dd60973e337aa2af824bde0f9) cover OSC-with-BEL, OSC-with-ST, and ANSI color cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c88685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->