### PR TITLE
fix(server): git status reports the real path for renamed and non-ASCII files

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -160,7 +160,7 @@ it.effect("uses stable diagnostics for every parsed non-repository command", () 
     yield* driver.listRefs({ cwd });
 
     assert.deepStrictEqual(commands, [
-      { args: ["status", "--porcelain=2", "--branch"], lcAll: "C" },
+      { args: ["status", "--porcelain=2", "--branch", "-z"], lcAll: "C" },
       { args: ["rev-parse", "--abbrev-ref", "HEAD"], lcAll: "C" },
       { args: ["rev-parse", "--git-common-dir"], lcAll: "C" },
     ]);
@@ -981,6 +981,152 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           insertions: 1,
           deletions: 0,
         });
+      }),
+    );
+
+    it.effect("reports a directory rename under its real paths", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "src/old/file.ts", "export const value = 1;\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add nested file"]);
+        yield* git(cwd, ["mv", "src/old", "src/new"]);
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["src/new/file.ts", "src/old/file.ts"],
+        );
+      }),
+    );
+
+    it.effect("reports a rename that moves a file up a directory level", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "a/b/deep.txt", "deep\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add deep file"]);
+        yield* git(cwd, ["mv", "a/b/deep.txt", "a/deep.txt"]);
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["a/b/deep.txt", "a/deep.txt"],
+        );
+      }),
+    );
+
+    it.effect("reports both halves of a top-level rename", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "top.txt", "top\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add top file"]);
+        yield* git(cwd, ["mv", "top.txt", "renamed-top.txt"]);
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["renamed-top.txt", "top.txt"],
+        );
+      }),
+    );
+
+    it.effect("omits a rename destination that was deleted from the worktree", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "src.txt", "source\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add source"]);
+        yield* git(cwd, ["mv", "src.txt", "new.txt"]);
+        yield* fileSystem.remove(pathService.join(cwd, "new.txt"));
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["src.txt"],
+        );
+      }),
+    );
+
+    it.effect("reports paths that contain spaces without truncating them", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "my file.txt", "hello\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add spaced file"]);
+        yield* writeTextFile(cwd, "my file.txt", "hello\nworld\n");
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(status.workingTree.files, [
+          { path: "my file.txt", insertions: 1, deletions: 0 },
+        ]);
+      }),
+    );
+
+    it.effect("reports an unmerged path that contains spaces", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "con flict.txt", "base\n");
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add conflict file"]);
+        yield* git(cwd, ["checkout", "-b", "other"]);
+        yield* writeTextFile(cwd, "con flict.txt", "other\n");
+        yield* git(cwd, ["commit", "-am", "other change"]);
+        yield* git(cwd, ["checkout", initialBranch]);
+        yield* writeTextFile(cwd, "con flict.txt", "main\n");
+        yield* git(cwd, ["commit", "-am", "main change"]);
+        yield* git(cwd, ["merge", "other"]).pipe(Effect.ignore);
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["con flict.txt"],
+        );
+      }),
+    );
+
+    it.effect("reports a non-ASCII path without git's quoted escapes", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "caf\u00e9.txt", "espresso\n");
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["caf\u00e9.txt"],
+        );
+      }),
+    );
+
+    it.effect("reports an untracked path that contains spaces", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        yield* writeTextFile(cwd, "new file.txt", "fresh\n");
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
+
+        assert.deepStrictEqual(
+          status.workingTree.files.map((file) => file.path),
+          ["new file.txt"],
+        );
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -162,23 +162,31 @@ function parseBranchAb(value: string): { ahead: number; behind: number } {
   };
 }
 
+/**
+ * Reads `git diff --numstat -z` output. Records are NUL separated, and a rename
+ * or copy leaves the path field empty and follows it with the old path and the
+ * new path as two further records.
+ */
 function parseNumstatEntries(
   stdout: string,
 ): Array<{ path: string; insertions: number; deletions: number }> {
   const entries: Array<{ path: string; insertions: number; deletions: number }> = [];
-  for (const line of stdout.split(/\r?\n/g)) {
-    if (line.trim().length === 0) continue;
-    const [addedRaw, deletedRaw, ...pathParts] = line.split("\t");
-    const rawPath =
-      pathParts.length > 1 ? (pathParts.at(-1) ?? "").trim() : pathParts.join("\t").trim();
-    if (rawPath.length === 0) continue;
+  const records = stdout.split("\0");
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index] ?? "";
+    if (record.length === 0) continue;
+    const [addedRaw, deletedRaw, ...pathParts] = record.split("\t");
+    if (deletedRaw === undefined) continue;
+    let filePath = pathParts.join("\t");
+    if (filePath.length === 0) {
+      index += 2;
+      filePath = records[index] ?? "";
+    }
+    if (filePath.length === 0) continue;
     const added = Number.parseInt(addedRaw ?? "0", 10);
-    const deleted = Number.parseInt(deletedRaw ?? "0", 10);
-    const renameArrowIndex = rawPath.indexOf(" => ");
-    const normalizedPath =
-      renameArrowIndex >= 0 ? rawPath.slice(renameArrowIndex + " => ".length).trim() : rawPath;
+    const deleted = Number.parseInt(deletedRaw, 10);
     entries.push({
-      path: normalizedPath.length > 0 ? normalizedPath : rawPath,
+      path: filePath,
       insertions: Number.isFinite(added) ? added : 0,
       deletions: Number.isFinite(deleted) ? deleted : 0,
     });
@@ -186,25 +194,36 @@ function parseNumstatEntries(
   return entries;
 }
 
-function parsePorcelainPath(line: string): string | null {
-  if (line.startsWith("? ") || line.startsWith("! ")) {
-    const simple = line.slice(2).trim();
-    return simple.length > 0 ? simple : null;
+/**
+ * Reads the `<path>` field out of one `git status --porcelain=2 -z` record.
+ * Paths may contain spaces, so the fields ahead of the path are skipped by
+ * position rather than by splitting the record on whitespace.
+ */
+function parsePorcelainPath(record: string): string | null {
+  if (record.startsWith("? ") || record.startsWith("! ")) {
+    const untracked = record.slice(2);
+    return untracked.length > 0 ? untracked : null;
   }
 
-  if (!(line.startsWith("1 ") || line.startsWith("2 ") || line.startsWith("u "))) {
-    return null;
+  // Ordinary, renamed/copied and unmerged records carry 8, 9 and 10 space
+  // separated fields ahead of <path>.
+  const leadingFields = record.startsWith("1 ")
+    ? 8
+    : record.startsWith("2 ")
+      ? 9
+      : record.startsWith("u ")
+        ? 10
+        : null;
+  if (leadingFields === null) return null;
+
+  let index = 0;
+  for (let field = 0; field < leadingFields; field += 1) {
+    const separator = record.indexOf(" ", index);
+    if (separator < 0) return null;
+    index = separator + 1;
   }
 
-  const tabIndex = line.indexOf("\t");
-  if (tabIndex >= 0) {
-    const fromTab = line.slice(tabIndex + 1);
-    const [filePath] = fromTab.split("\t");
-    return filePath?.trim().length ? filePath.trim() : null;
-  }
-
-  const parts = line.trim().split(/\s+/g);
-  const filePath = parts.at(-1) ?? "";
+  const filePath = record.slice(index);
   return filePath.length > 0 ? filePath : null;
 }
 
@@ -1581,7 +1600,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const statusResult = yield* executeGitWithStableDiagnostics(
       "GitVcsDriver.statusDetails.status",
       cwd,
-      ["status", "--porcelain=2", "--branch"],
+      ["status", "--porcelain=2", "--branch", "-z"],
       {
         allowNonZeroExit: true,
       },
@@ -1604,7 +1623,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         ...gitCommandContext({
           operation: "GitVcsDriver.statusDetails.status",
           cwd,
-          args: ["status", "--porcelain=2", "--branch"],
+          args: ["status", "--porcelain=2", "--branch", "-z"],
         }),
         detail: "Git status failed.",
         exitCode: statusResult.exitCode,
@@ -1622,7 +1641,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         executeGitWithStableDiagnostics(
           "GitVcsDriver.statusDetails.numstat",
           cwd,
-          ["diff", "HEAD", "--numstat", "--"],
+          ["diff", "HEAD", "--numstat", "-z", "--"],
           { allowNonZeroExit: true },
         ).pipe(
           Effect.flatMap((result) => {
@@ -1633,11 +1652,13 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
                   runGitStdout("GitVcsDriver.statusDetails.numstat.unborn", cwd, [
                     "diff",
                     "--numstat",
+                    "-z",
                   ]),
                   runGitStdout("GitVcsDriver.statusDetails.numstat.unborn.staged", cwd, [
                     "diff",
                     "--cached",
                     "--numstat",
+                    "-z",
                   ]),
                 ]),
                 ([unstagedStdout, stagedStdout]) => {
@@ -1655,7 +1676,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
                   }
                   return Array.from(map.entries())
                     .map(([p, s]) => `${s.insertions}\t${s.deletions}\t${p}`)
-                    .join("\n");
+                    .join("\0");
                 },
               );
             }
@@ -1664,7 +1685,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
                 ...gitCommandContext({
                   operation: "GitVcsDriver.statusDetails.numstat",
                   cwd,
-                  args: ["diff", "HEAD", "--numstat", "--"],
+                  args: ["diff", "HEAD", "--numstat", "-z", "--"],
                 }),
                 detail: "git diff HEAD --numstat failed.",
                 exitCode: result.exitCode,
@@ -1693,28 +1714,42 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     let hasWorkingTreeChanges = false;
     const changedFilesWithoutNumstat = new Set<string>();
 
-    for (const line of statusStdout.split(/\r?\n/g)) {
-      if (line.startsWith("# branch.head ")) {
-        const value = line.slice("# branch.head ".length).trim();
+    const statusRecords = statusStdout.split("\0");
+    for (let index = 0; index < statusRecords.length; index += 1) {
+      const record = statusRecords[index] ?? "";
+      if (record.startsWith("# branch.head ")) {
+        const value = record.slice("# branch.head ".length).trim();
         refName = value.startsWith("(") ? null : value;
         continue;
       }
-      if (line.startsWith("# branch.upstream ")) {
-        const value = line.slice("# branch.upstream ".length).trim();
+      if (record.startsWith("# branch.upstream ")) {
+        const value = record.slice("# branch.upstream ".length).trim();
         upstreamRef = value.length > 0 ? value : null;
         continue;
       }
-      if (line.startsWith("# branch.ab ")) {
-        const value = line.slice("# branch.ab ".length).trim();
+      if (record.startsWith("# branch.ab ")) {
+        const value = record.slice("# branch.ab ".length).trim();
         const parsed = parseBranchAb(value);
         aheadCount = parsed.ahead;
         behindCount = parsed.behind;
         continue;
       }
-      if (line.trim().length > 0 && !line.startsWith("#")) {
+      if (record.length > 0 && !record.startsWith("#")) {
         hasWorkingTreeChanges = true;
-        const pathValue = parsePorcelainPath(line);
-        if (pathValue) changedFilesWithoutNumstat.add(pathValue);
+        const isRenameOrCopy = record.startsWith("2 ");
+        // `<XY>` are the two status columns and Y describes the worktree, so a
+        // rename whose destination was then deleted names no file on disk.
+        const destinationDeleted = isRenameOrCopy && record[3] === "D";
+        const pathValue = parsePorcelainPath(record);
+        if (pathValue && !destinationDeleted) changedFilesWithoutNumstat.add(pathValue);
+        // A rename or copy follows its record with the original path. Both halves
+        // stay in the list: they are handed back to `git add` as pathspecs when a
+        // commit selects a subset of files, and `git add` is rename unaware.
+        if (isRenameOrCopy) {
+          index += 1;
+          const originalPath = statusRecords[index] ?? "";
+          if (originalPath.length > 0) changedFilesWithoutNumstat.add(originalPath);
+        }
       }
     }
 


### PR DESCRIPTION
## What Changed

`git status --porcelain=2` and `git diff HEAD --numstat` now run with `-z`, and their two parsers read git's NUL-separated machine format instead of its human-readable one.

## Why

The changed-file list comes from those two commands. Both were parsed as display text, and both display formats are ambiguous:

- **numstat spells a rename with braces.** A directory rename prints `src/{old => new}/file.ts`, and a move up a level prints `a/{b => }/deep.txt`. The parser sliced after the first `" => "`, producing `new}/file.ts` and `}/deep.txt` — paths that name nothing.
- **porcelain v2 separates a rename's two paths with a TAB, and ordinary records have no TAB at all.** The parser took everything after the tab (the *old* path) for renames, and otherwise fell back to `parts.at(-1)`, which truncates any path containing a space: `my file.txt` became `file.txt`.
- **git quotes non-ASCII paths by default** (`core.quotePath`), so `café.txt` arrived as the literal string `"caf\303\251.txt"`.

These paths are not display-only. When a commit selects a subset of files, both clients send them straight back to git as pathspecs (`GitActionsControl.tsx:1537`, `GitCommitSheet.tsx:62`), and `prepareCommitContext` runs `git reset` and then `git --literal-pathspecs add -A -- <paths>`. A mangled path makes that `add` exit 128 — *after* the reset has already unstaged the user's index.

`-z` removes the ambiguity at its source instead of teaching each parser one more spelling: records are NUL-separated, a rename's two paths arrive as two separate records, and git does no quoting.

## Before / After

A repo with a directory rename, a rename up one level, a top-level rename, a rename of a non-ASCII filename, and an edit to a file whose name contains a space.

**Before** — 11 rows, 5 of which name files that do not exist, while `a/deep.txt`, `src/new/file.ts` and `café-renamed.txt` are missing entirely:

```
"caf\303\251-renamed.txt"     <- git's quoting, not a filename
"caf\303\251.txt"             <- git's quoting, not a filename
}/deep.txt                    <- mangled
a/b/deep.txt
file.txt                      <- truncated "my file.txt"
my file.txt
new}/file.ts                  <- mangled
other.txt
renamed-top.txt
src/old/file.ts
top.txt

partial commit (everything except other.txt) stages:
  *** COMMIT FAILED: git exited non-zero ***
```

**After** — 10 rows, every one a real path:

```
a/b/deep.txt
a/deep.txt
café-renamed.txt
café.txt
my file.txt
other.txt
renamed-top.txt
src/new/file.ts
src/old/file.ts
top.txt

partial commit (everything except other.txt) stages:
  R100  a/b/deep.txt       a/deep.txt
  R100  "caf\303\251.txt"  "caf\303\251-renamed.txt"
  M     my file.txt
  R100  top.txt            renamed-top.txt
  R100  src/old/file.ts    src/new/file.ts
```

Both halves of a rename stay in the list deliberately: `git add` is rename-unaware, so a selective commit needs the source path alongside the destination to stage a rename rather than a duplicated file. The one exception is a rename whose destination was then deleted from the worktree (`2 RD`), where the destination names nothing on disk and only the source belongs in the list.

## Scope

Server-side only, so web, desktop and mobile all pick it up; the wire contract is unchanged. `-z` was already load-bearing in this file for `git worktree list --porcelain -z`.

## UI Changes

No pixels change — the same list renders, with correct strings in it. The before/after data above is the observable difference.

## Verification

- `vp test run apps/server/src/vcs` — 110 passed. 8 new cases: 5 fail on `main`, 3 are guards for behavior that must not change (both halves of a rename stay listed; untracked spaced paths; a deleted rename destination stays out).
- `vp test run apps/server/src/git` — 92 passed
- `vp run --filter t3 typecheck` — clean
- `vp lint` and `vp fmt --check` on both changed files — clean

git 2.52.0 on macOS. Exercised against real repos: directory rename, rename up a level, flat rename, rename with the destination deleted, spaces, non-ASCII, unmerged paths with spaces, untracked paths with spaces, binary renames, tabs in filenames, and `diff.renames` / `status.renames` disabled.

## Overlap

#7443 (draft) rewrites `parsePorcelainPath` as part of a Files-tree feature and adds an `unquoteGitPath` helper to undo git's quoting; `-z` makes that unquoting unnecessary at these two call sites, so expect a textual conflict there. #7289 and #8086 touch other regions of this file.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — not applicable; no visual change, before/after data shown above
- [x] I included a video for animation/interaction changes — not applicable

Built with Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VCS status/commit path handling used across platforms; behavior change is intentional but affects selective staging and any UI that depended on the old (broken) path strings.
> 
> **Overview**
> **Git status details** now invoke `git status --porcelain=2 --branch -z` and `git diff HEAD --numstat -z`, and the server parses NUL-separated records instead of line-oriented display output.
> 
> **Parsing changes** fix wrong or unusable paths in the working-tree file list: renames (directory moves, both path halves, omitted destination when deleted from disk), paths with spaces, non-ASCII names without git quoting, and numstat rename records with empty path fields followed by old/new paths.
> 
> Those paths are reused as **literal pathspecs** for partial commits (`prepareCommitContext`); mangled paths could fail `git add` after a reset. The wire contract is unchanged; clients get the same shape with correct strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7496d7f4c1b1dc0adc2180a71f730853cb46a7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `readStatusDetailsLocal` to use `-z` NUL-separated git output for correct path handling
> - Rewrites `parseNumstatEntries` and `parsePorcelainPath` in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/8310/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) to parse NUL-separated (`-z`) records instead of line-based output, preserving spaces and non-ASCII characters in file paths
> - Switches `git status` to `--porcelain=2 -z` and `git diff` to `--numstat -z`; detects rename/copy records and reports both source and destination paths, omitting the destination when it was deleted in the worktree
> - Updates unborn-HEAD fallback to synthesize NUL-separated numstat records compatible with the new parser
> - Risk: `parseNumstatEntries` now treats a missing deleted count field as invalid and skips the record; any caller relying on the old tab-delimited format or ` => ` rename-arrow stripping will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7496d7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->