### PR TITLE
perf(pull-requests): load the first page faster

### DIFF
--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -2557,6 +2557,7 @@ it.effect("carries every repository of a slice on from the oldest row in it", ()
 it.effect("verifies an unseen repository when a batched search reaches its end", () =>
   Effect.gen(function* () {
     const separately: string[] = [];
+    const separateCursors: unknown[] = [];
     const service = yield* makeService({
       projects: [
         project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" }),
@@ -2564,10 +2565,14 @@ it.effect("verifies an unseen repository when a batched search reaches its end",
       ],
       providers: [
         fakeProvider("github", {
-          listChangeRequests: ({ repository }) => {
+          listChangeRequests: ({ repository, cursor }) => {
             separately.push(repository);
+            separateCursors.push(cursor);
             return Effect.succeed({
-              items: repository === "acme/docs" ? [changeRequest(2, "2026-07-01T00:00:00Z")] : [],
+              items:
+                repository === "acme/docs" && cursor === undefined
+                  ? [changeRequest(2, "2026-07-04T00:00:00Z")]
+                  : [],
               truncated: false,
               continues: true,
             });
@@ -2591,8 +2596,10 @@ it.effect("verifies an unseen repository when a batched search reaches its end",
     const second = yield* service.list({ state: "open", cursors: first.nextCursors });
 
     // The first page stays one host request. If the search never produces a row for `acme/docs`,
-    // the final slice still checks it directly so a search-index gap cannot hide its pull request.
+    // the final slice still checks it directly from the repository head. Its pull request is
+    // newer than the batch boundary, so forwarding that cursor would hide it.
     assert.deepStrictEqual(separately, ["acme/docs"]);
+    assert.deepStrictEqual(separateCursors, [undefined]);
     assert.deepStrictEqual(
       second.entries.map((entry) => [entry.repository, entry.number]),
       [["acme/docs", 2]],

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -2513,6 +2513,7 @@ it.effect("reads a host's repositories in one search, and files the rows back un
 );
 it.effect("carries every repository of a slice on from the oldest row in it", () =>
   Effect.gen(function* () {
+    const separately: string[] = [];
     const service = yield* makeService({
       projects: [
         project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
@@ -2521,6 +2522,10 @@ it.effect("carries every repository of a slice on from the oldest row in it", ()
       ],
       providers: [
         fakeProvider("github", {
+          listChangeRequests: ({ repository }) => {
+            separately.push(repository);
+            return Effect.succeed({ items: [], truncated: false, continues: true });
+          },
           listChangeRequestsAcross: () =>
             Effect.succeed({
               items: [
@@ -2538,13 +2543,60 @@ it.effect("carries every repository of a slice on from the oldest row in it", ()
 
     // The boundary is the oldest row of the whole slice, not of each repository: `acme/web` has
     // been read past its newest row, so only the rows sent at the boundary are named for it.
-    // `acme/docs`, which the slice holds nothing of, is not believed on silence alone — it is
-    // read on its own, and that read is what says whether it has anything at all.
+    // `acme/docs` has no row in this full slice. That only says its rows are older, so it carries
+    // on from the shared boundary instead of making the first page wait on a separate CLI call.
+    assert.deepStrictEqual(separately, []);
     assert.isTrue(result.truncated);
     assert.deepStrictEqual(result.nextCursors, {
       "github.com pingdotgg/t3code": "2026-07-02T00:00:00Z|1|2",
       "github.com acme/web": "2026-07-02T00:00:00Z|2|3",
+      "github.com acme/docs": "2026-07-02T00:00:00Z|0|",
     });
+  }),
+);
+it.effect("verifies an unseen repository when a batched search reaches its end", () =>
+  Effect.gen(function* () {
+    const separately: string[] = [];
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" }),
+        project({ id: "p2", title: "docs", workspaceRoot: "/b", repository: "acme/docs" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          listChangeRequests: ({ repository }) => {
+            separately.push(repository);
+            return Effect.succeed({
+              items: repository === "acme/docs" ? [changeRequest(2, "2026-07-01T00:00:00Z")] : [],
+              truncated: false,
+              continues: true,
+            });
+          },
+          listChangeRequestsAcross: (input) =>
+            Effect.succeed(
+              input.cursor === undefined
+                ? {
+                    items: [batchedChangeRequest(1, "acme/web", "2026-07-03T00:00:00Z")],
+                    truncated: true,
+                  }
+                : { items: [], truncated: false },
+            ),
+        }),
+      ],
+    });
+
+    const first = yield* service.list({ state: "open" });
+    assert.deepStrictEqual(separately, []);
+
+    const second = yield* service.list({ state: "open", cursors: first.nextCursors });
+
+    // The first page stays one host request. If the search never produces a row for `acme/docs`,
+    // the final slice still checks it directly so a search-index gap cannot hide its pull request.
+    assert.deepStrictEqual(separately, ["acme/docs"]);
+    assert.deepStrictEqual(
+      second.entries.map((entry) => [entry.repository, entry.number]),
+      [["acme/docs", 2]],
+    );
   }),
 );
 it.effect("carries a slice on without sending the rows it already sent", () =>

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1003,7 +1003,9 @@ export const make = Effect.gen(function* () {
         const first = chunk[0]!;
         const readAcross = first.api.listChangeRequestsAcross;
         const separately = () =>
-          Effect.forEach(chunk, readRepository, { concurrency: REPOSITORY_CONCURRENCY });
+          Effect.forEach(chunk, (project) => readRepository(project), {
+            concurrency: REPOSITORY_CONCURRENCY,
+          });
         if (readAcross === undefined) return separately();
         const viewer = viewers[first.host]!;
         const cursor = cursorOf(first);

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1037,18 +1037,24 @@ export const make = Effect.gen(function* () {
               chunk,
               (project): Effect.Effect<RepositoryBatch> => {
                 const fetched = rows.get(project.repository.trim().toLowerCase()) ?? [];
-                // GitHub does not index every repository for search — a renamed one answers for
-                // its old name with silence rather than with an error — so a repository the
-                // search said nothing at all about is read on its own, once, before it is
-                // believed. Only on its first slice: after that it has a boundary to carry on
-                // from, and silence past one means the rows are older rather than absent. That
-                // keeps a search-invisible repository from disappearing on a busy host, at the
-                // price of one request per repository with nothing in the first slice — which
-                // run together, and only there.
-                if (fetched.length === 0 && cursorOf(project) === undefined) {
+                const cursorHere = cursorOf(project);
+                // GitHub does not index every repository for search. A renamed repository can
+                // answer with silence rather than an error, so a repository that never appeared
+                // is eventually read on its own before that silence is believed.
+                //
+                // A full cross-repository slice cannot make that claim yet: the repository's
+                // newest row may simply be older than the slice. Reading every absent repository
+                // here turned one fast host search into one CLI call per quiet repository. Carry
+                // all of them to the slice boundary instead, and verify only the repositories
+                // still unseen once the search reaches its end. A truncated page with no decoded
+                // boundary cannot be continued safely, so it keeps the fallback.
+                if (
+                  fetched.length === 0 &&
+                  (cursorHere?.delivered ?? 0) === 0 &&
+                  (!page.truncated || boundary === null)
+                ) {
                   return readRepository(project);
                 }
-                const cursorHere = cursorOf(project);
                 const items =
                   cursorHere === undefined
                     ? fetched

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -912,11 +912,14 @@ export const make = Effect.gen(function* () {
        * One repository asked on its own. What every host without a search across repositories
        * does, and what a batched read falls back to for a repository it could not answer for.
        */
-      const readRepository = (project: SupportedProject): Effect.Effect<RepositoryBatch> => {
+      const readRepository = (
+        project: SupportedProject,
+        options?: { readonly fromStart: boolean },
+      ): Effect.Effect<RepositoryBatch> => {
         {
           const viewer = viewers[project.host]!;
           const key = listCursorKey(project.host, project.repository);
-          const cursor = cursorOf(project);
+          const cursor = options?.fromStart === true ? undefined : cursorOf(project);
           return project.api
             .listChangeRequests({
               cwd: project.project.workspaceRoot,
@@ -1053,7 +1056,10 @@ export const make = Effect.gen(function* () {
                   (cursorHere?.delivered ?? 0) === 0 &&
                   (!page.truncated || boundary === null)
                 ) {
-                  return readRepository(project);
+                  // This verifies whether the repository was absent from search, not whether it
+                  // has rows older than the batch boundary. Start at its head so an index gap
+                  // cannot hide newer rows behind the cursor that brought the batch here.
+                  return readRepository(project, { fromStart: true });
                 }
                 const items =
                   cursorHere === undefined

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -157,11 +157,12 @@ const SEARCH_DEBOUNCE_MS = 250;
 /** What `scorePullRequestMatch` gives a row none of whose own fields carry the search text. */
 const MATCHED_ELSEWHERE_SCORE = 10;
 /**
- * One whole page from the host and no more: every provider asks for one row beyond the page as
- * its "is there more" probe, and GitHub serves a hundred per request — so asking for ninety-nine
- * costs one round trip where a hundred costs two.
+ * Enough rows to fill the view without making first paint wait on GitHub's hundred-row worst
+ * case. Providers ask for one extra row as their "is there more" probe, so this reads 31 and lets
+ * the existing scroll pagination fetch the rest. Measured with the listing's GitHub fields: 31
+ * rows took 3.6–4.4s while 100 timed out after 11.1s.
  */
-const PAGE_SIZE = 99;
+const PAGE_SIZE = 30;
 /** The largest page the listing accepts; past it the request is refused outright. */
 const MAX_PAGE_SIZE = 500;
 /** Stable empty map so the memos below do not see a new object on every render. */
@@ -662,15 +663,20 @@ function PullRequestsRouteView() {
   const baselineQuery = usePullRequestList(baselineTargets);
   // The priority groups' own reads. The feed below is paginated by recency, so an older authored
   // or review-requested row can be missing from its first page; partitioned from these
-  // server-filtered reads instead, the priority view is complete up front and a continuation can
-  // only ever append below what is already on screen. A search re-ranks the whole list by match,
+  // server-filtered reads instead, the priority view starts with the host's own matching page and
+  // a continuation can only ever append below what is already on screen. A search re-ranks the
   // so no partitions are read for one. These are the same atoms the Authored and Reviewing tabs
   // ask for, so switching to either is answered from cache.
   const partitionsWanted = search.involvement === "all" && typedQuery.length === 0;
+  // Let the feed arrive before spending two more host searches on its priority groups. Those
+  // reads used to start together, and each may fan out to repositories the host search could not
+  // cover. The page can already group the feed locally until these fuller answers arrive, so the
+  // extra work belongs off the first-row path.
+  const partitionsReady = partitionsWanted && baselineQuery.data !== null;
   // Built together so the two reads share one memo, and in the same field order the feed's own
   // input uses: the atoms are keyed by their input, so the Authored tab then reads this answer.
   const partitionTargets = useMemo(() => {
-    if (!partitionsWanted) return { authored: NO_LIST_TARGETS, reviewing: NO_LIST_TARGETS };
+    if (!partitionsReady) return { authored: NO_LIST_TARGETS, reviewing: NO_LIST_TARGETS };
     const targetsFor = (involvement: PullRequestInvolvement) =>
       environmentQueries.map(({ environmentId, projectIds }) => ({
         environmentId,
@@ -688,7 +694,7 @@ function PullRequestsRouteView() {
   }, [
     menuFiltered,
     menuFilters,
-    partitionsWanted,
+    partitionsReady,
     environmentQueries,
     scopedProjectId,
     search.host,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -665,8 +665,8 @@ function PullRequestsRouteView() {
   // or review-requested row can be missing from its first page; partitioned from these
   // server-filtered reads instead, the priority view starts with the host's own matching page and
   // a continuation can only ever append below what is already on screen. A search re-ranks the
-  // so no partitions are read for one. These are the same atoms the Authored and Reviewing tabs
-  // ask for, so switching to either is answered from cache.
+  // whole list by match, so no partitions are read for one. These are the same atoms the Authored
+  // and Reviewing tabs ask for, so switching to either is answered from cache.
   const partitionsWanted = search.involvement === "all" && typedQuery.length === 0;
   // Let the feed arrive before spending two more host searches on its priority groups. Those
   // reads used to start together, and each may fan out to repositories the host search could not


### PR DESCRIPTION
The pull requests page waits for up to 99 rows and starts authored and reviewing searches alongside the main feed. A full cross-repository search can also reread every quiet repository one at a time, putting many GitHub CLI calls on the path to the first rows.

This reduces the first page to 30 rows, waits for the main feed before starting priority-group searches, and carries quiet repositories through the batch cursor when the page is full. Repositories that remain unseen are still verified directly when the batched search reaches its end.

Measurement

- 31 rows with the listing fields: 3.6 to 4.4 seconds
- 100 rows with the listing fields: GitHub returned a 504 after 11.1 seconds

Testing

- `vp test run apps/server/src/pullRequest/PullRequestService.test.ts`
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/web typecheck`
- Targeted formatting and lint

There is no visual change, so before and after screenshots would be identical.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-repository batched listing and cursor continuation; correctness depends on deferred per-repo verification and boundary cursors, with added tests but real host-search edge cases remain.
> 
> **Overview**
> Speeds up the pull requests **first paint** by asking for fewer rows up front and doing less work in parallel with the main feed.
> 
> On the web route, **`PAGE_SIZE` drops from 99 to 30** so the initial list request stays within a faster GitHub listing window; scroll pagination still loads more. **Authored and reviewing partition list queries wait until the baseline feed has data**, so two extra host searches (and their repository fan-out) are not on the critical path to the first rows.
> 
> On the server, **`PullRequestService` no longer issues a per-repository `listChangeRequests` for every repo missing from a truncated cross-repo search slice**. Quiet repos are **carried forward to the shared slice boundary** in `nextCursors` instead. Per-repo verification still happens when the batched search **cannot be continued safely** (non-truncated page or no boundary) or when pagination **reaches the end** and a repo never appeared—using **`readRepository(..., { fromStart: true })`** so newer PRs are not hidden behind a batch cursor. Tests cover boundary cursors for unseen repos and the end-of-search verification path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9888df79c615655837418971cee99dc9be79a805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up first page load of pull-requests feed and defer partition queries
> - Reduces `PAGE_SIZE` from 99 to 30 in [pull-requests.tsx](https://github.com/pingdotgg/t3code/pull/8312/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5) so the initial server request returns faster.
> - Defers the `authored` and `reviewing` partition queries until the baseline feed has data, via the new `partitionsReady` gate.
> - In [PullRequestService.ts](https://github.com/pingdotgg/t3code/pull/8312/files#diff-6dc74968ebcf535ce84fea9f44369080aa5246f4a8c9d10824bf988651c4f0bf), `make.readTogether` no longer issues immediate per-repo reads for repositories absent from the first batched slice. Instead it carries them forward from the slice boundary and only verifies via a head read (`fromStart: true`) once the batched search ends or no boundary can be decoded.
> - Adds tests in [PullRequestService.test.ts](https://github.com/pingdotgg/t3code/pull/8312/files#diff-fc1a61f4e7350891afe9f22cda7ae1a10db35f21fc1dfe74755f13ef665c21ac) covering the deferred-read path and the unseen-repo-at-search-end case.
> - Risk: repositories that have no rows in the first batch now appear with a boundary cursor (`...|0|`) and are not read until continuation; consumers relying on immediate per-repo reads on the first page will see fewer results for those repos initially.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9888df7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->