### PR TITLE
fix(web): keep review badges at their display size

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -289,3 +289,24 @@ describe("ChatMarkdown Windows file links", () => {
     expect(html).not.toContain("chat-markdown-file-link");
   });
 });
+
+describe("ChatMarkdown image sizing", () => {
+  it("keeps Cursor review buttons at their requested display widths", () => {
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/repo"
+        text={`<div><a href="https://cursor.com/open"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-cursor-light.png"><img alt="Fix in Cursor" width="115" height="28" src="https://cursor.com/assets/images/fix-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-web-light.png"><img alt="Fix in Web" width="99" height="28" src="https://cursor.com/assets/images/fix-in-web-dark.png"></picture></a></div>`}
+      />,
+    );
+
+    expect(markup).toMatch(
+      /<img(?=[^>]*alt="Fix in Cursor")(?=[^>]*width="115")(?=[^>]*height="28")[^>]*>/u,
+    );
+    expect(markup).toMatch(
+      /<img(?=[^>]*alt="Fix in Web")(?=[^>]*width="99")(?=[^>]*height="28")[^>]*>/u,
+    );
+    expect(markup).not.toContain("w-auto");
+    expect(markup).toContain('media="(prefers-color-scheme: dark)"');
+    expect(markup).toContain('media="(prefers-color-scheme: light)"');
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1045,8 +1045,10 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
   );
 });
 
+// `w-auto` would override an HTML width attribute, which review bots use to size high-density
+// button images below their intrinsic raster width.
 const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME =
-  "h-auto w-auto max-h-[30rem] max-w-[min(100%,30rem)] object-contain";
+  "h-auto max-h-[30rem] max-w-[min(100%,30rem)] object-contain";
 
 // block! outranks the unlayered `.chat-markdown img { display: inline-block }`
 // rule, keeping workspace images on the same block layout as their placeholder.


### PR DESCRIPTION
## Problem

PR review bots can supply high-density button images with explicit HTML widths. The shared Markdown image class applied `w-auto`, which overrode those widths and rendered Cursor review buttons at their 3x source size.

## Fix

Remove the width override while keeping the existing height and maximum-size constraints. Add regression coverage using the full two-button Cursor markup, including its light and dark picture sources.

## Visual comparison

| Before | After |
| --- | --- |
| ![Cursor review badge rendered at its source size](https://gist.githubusercontent.com/MohtashamMurshid/4144d4843c57d0af37637fffcb028719/raw/3611776b43aaa42cfd32eb6eeb3ac9eb9a155ceb/before.png) | ![Cursor review badge rendered at its requested display size](https://gist.githubusercontent.com/MohtashamMurshid/4144d4843c57d0af37637fffcb028719/raw/3611776b43aaa42cfd32eb6eeb3ac9eb9a155ceb/after.png) |

The after state was captured from the live comment on [oikina PR #183](https://github.com/MohtashamMurshid/oikina/pull/183). The 345x84 source now displays at its requested 115x28 size.

## Verification

- `pnpm exec vp test run apps/web/src/components/ChatMarkdown.test.tsx`
- `pnpm exec vp lint --report-unused-disable-directives apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx`
- `pnpm exec vp fmt --check apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx`
- `pnpm exec vp run --filter @t3tools/web typecheck`

Built with gpt-5.6-sol through the Codex harness in T3 Code.