### PR TITLE
fix(chat): show turn diffs after work completes

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -767,6 +767,64 @@ describe("CheckpointReactor", () => {
     expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
   });
 
+  it("captures a completion after the read model advances to a follow-up turn", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const completedTurnId = asTurnId("turn-completed");
+    const completedAt = "2026-01-01T00:00:10.000Z";
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-before-follow-up"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId,
+      turnId: completedTurnId,
+    });
+    await waitForGitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0));
+
+    await harness.dispatch({
+      type: "thread.session.set",
+      commandId: CommandId.make("cmd-session-advanced-to-follow-up"),
+      threadId,
+      session: {
+        threadId,
+        status: "running",
+        providerName: "codex",
+        runtimeMode: "approval-required",
+        activeTurnId: asTurnId("turn-follow-up"),
+        lastError: null,
+        updatedAt: "2026-01-01T00:00:20.000Z",
+      },
+      createdAt: "2026-01-01T00:00:20.000Z",
+    });
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "completed turn\n", "utf8");
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-after-follow-up-started"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId: completedTurnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(
+      harness.engine,
+      (event) => event.type === "thread.turn-diff-completed" && event.occurredAt === completedAt,
+    );
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.checkpoints[0]?.completedAt === completedAt,
+    );
+
+    expect(thread.checkpoints).toHaveLength(1);
+    expect(
+      gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "README.md"),
+    ).toBe("completed turn\n");
+  });
+
   it("captures pre-turn and completion checkpoints for claude runtime events", async () => {
     const harness = await createHarness({
       seedFilesystemCheckpoints: false,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -87,6 +87,7 @@ function createProviderServiceHarness(
   const rollbackConversation = vi.fn(
     (_input: { readonly threadId: ThreadId; readonly numTurns: number }) => Effect.void,
   );
+  let activeTurnId: TurnId | undefined;
 
   const unsupported = <A>() =>
     Effect.die(new Error("Unsupported provider call in test")) as Effect.Effect<A, never>;
@@ -101,6 +102,7 @@ function createProviderServiceHarness(
             cwd: sessionCwd,
             createdAt: now,
             updatedAt: now,
+            ...(activeTurnId ? { activeTurnId } : {}),
           },
         ] satisfies ReadonlyArray<ProviderSession>)
       : Effect.succeed([] as ReadonlyArray<ProviderSession>);
@@ -139,6 +141,9 @@ function createProviderServiceHarness(
     service,
     rollbackConversation,
     emit,
+    setActiveTurnId: (turnId: TurnId | undefined) => {
+      activeTurnId = turnId;
+    },
   };
 }
 
@@ -342,6 +347,7 @@ describe("CheckpointReactor", () => {
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(RuntimeReceiptBusLive),
+      Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(vcsStatusBroadcasterLayer),
       Layer.provideMerge(CheckpointStore.layer.pipe(Layer.provide(VcsDriverRegistry.layer))),
@@ -765,6 +771,130 @@ describe("CheckpointReactor", () => {
       (entry) => entry.latestTurn?.turnId === "turn-main" && entry.checkpoints.length === 1,
     );
     expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+  });
+
+  it("preserves the active turn when a stale turn.started event arrives", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const activeTurnId = asTurnId("turn-active");
+    const completedAt = "2026-01-01T00:00:10.000Z";
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-active"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId,
+      turnId: activeTurnId,
+    });
+    await waitForGitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0));
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-stale"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:05.000Z",
+      threadId,
+      turnId: asTurnId("turn-stale"),
+    });
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "active turn\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-active-after-stale-start"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId: activeTurnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(
+      harness.engine,
+      (event) => event.type === "thread.turn-diff-completed" && event.occurredAt === completedAt,
+    );
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.checkpoints[0]?.completedAt === completedAt,
+    );
+    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+  });
+
+  it("tracks a new turn when an accepted steer supersedes the active turn", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const oldTurnId = asTurnId("turn-steered-over");
+    const newTurnId = asTurnId("turn-from-steer");
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    const completedAt = "2026-01-01T00:00:10.000Z";
+
+    await harness.dispatch({
+      type: "thread.session.set",
+      commandId: CommandId.make("cmd-session-set-before-steer"),
+      threadId,
+      session: {
+        threadId,
+        status: "running",
+        providerName: "codex",
+        runtimeMode: "approval-required",
+        activeTurnId: oldTurnId,
+        lastError: null,
+        updatedAt: createdAt,
+      },
+      createdAt,
+    });
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-before-steer"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt,
+      threadId,
+      turnId: oldTurnId,
+    });
+    await waitForGitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0));
+
+    await harness.dispatch({
+      type: "thread.turn.start",
+      commandId: CommandId.make("cmd-turn-start-steer"),
+      threadId,
+      message: {
+        messageId: MessageId.make("msg-steer"),
+        role: "user",
+        text: "Use the new direction",
+        attachments: [],
+      },
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      runtimeMode: "approval-required",
+      createdAt: "2026-01-01T00:00:05.000Z",
+    });
+    harness.provider.setActiveTurnId(newTurnId);
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-from-steer"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:05.000Z",
+      threadId,
+      turnId: newTurnId,
+    });
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "steered turn\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-from-steer"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId: newTurnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(
+      harness.engine,
+      (event) => event.type === "thread.turn-diff-completed" && event.occurredAt === completedAt,
+    );
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.checkpoints[0]?.completedAt === completedAt,
+    );
+    expect(thread.latestTurn?.turnId).toBe(newTurnId);
   });
 
   it("captures a completion after the read model advances to a follow-up turn", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -147,13 +147,16 @@ async function waitForThread(
     readonly threads: ReadonlyArray<{
       readonly id: ThreadId;
       readonly latestTurn: { readonly turnId: string } | null;
-      readonly checkpoints: ReadonlyArray<{ readonly checkpointTurnCount: number }>;
+      readonly checkpoints: ReadonlyArray<{
+        readonly checkpointTurnCount: number;
+        readonly completedAt: string;
+      }>;
       readonly activities: ReadonlyArray<{ readonly kind: string }>;
     }>;
   }>,
   predicate: (thread: {
     latestTurn: { turnId: string } | null;
-    checkpoints: ReadonlyArray<{ checkpointTurnCount: number }>;
+    checkpoints: ReadonlyArray<{ checkpointTurnCount: number; completedAt: string }>;
     activities: ReadonlyArray<{ kind: string }>;
   }) => boolean,
   timeoutMs = 15_000,
@@ -161,7 +164,7 @@ async function waitForThread(
   const deadline = (await Effect.runPromise(Clock.currentTimeMillis)) + timeoutMs;
   const poll = async (): Promise<{
     latestTurn: { turnId: string } | null;
-    checkpoints: ReadonlyArray<{ checkpointTurnCount: number }>;
+    checkpoints: ReadonlyArray<{ checkpointTurnCount: number; completedAt: string }>;
     activities: ReadonlyArray<{ kind: string }>;
   }> => {
     const snapshot = await readModel();
@@ -180,7 +183,7 @@ async function waitForThread(
 
 async function waitForEvent(
   engine: OrchestrationEngineShape,
-  predicate: (event: { type: string }) => boolean,
+  predicate: (event: { type: string; occurredAt: string }) => boolean,
   timeoutMs = 15_000,
 ) {
   const deadline = (await Effect.runPromise(Clock.currentTimeMillis)) + timeoutMs;
@@ -449,6 +452,7 @@ describe("CheckpointReactor", () => {
       engine,
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
+      checkpointStore,
       cwd,
       drain,
     };
@@ -528,6 +532,66 @@ describe("CheckpointReactor", () => {
         "README.md",
       ),
     ).toBe("v2\n");
+  });
+
+  it("replaces a legacy mid-turn checkpoint with the filesystem state at completion", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const turnId = asTurnId("turn-1");
+    const checkpointRef = checkpointRefForThreadTurn(threadId, 1);
+    const midTurnAt = "2026-01-01T00:00:10.000Z";
+    const completedAt = "2026-01-01T00:00:30.000Z";
+
+    await Effect.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+      }),
+    );
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "mid-turn\n", "utf8");
+    await Effect.runPromise(
+      harness.checkpointStore.captureCheckpoint({ cwd: harness.cwd, checkpointRef }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-legacy-mid-turn-diff"),
+        threadId,
+        turnId,
+        completedAt: midTurnAt,
+        checkpointRef,
+        status: "ready",
+        files: [{ path: "README.md", kind: "modified", additions: 1, deletions: 1 }],
+        checkpointTurnCount: 1,
+        createdAt: midTurnAt,
+      }),
+    );
+    await harness.drain();
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("mid-turn\n");
+
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "final\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-after-legacy-checkpoint"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(
+      harness.engine,
+      (event) => event.type === "thread.turn-diff-completed" && event.occurredAt === completedAt,
+    );
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.checkpoints.length === 1 && entry.checkpoints[0]?.completedAt === completedAt,
+    );
+
+    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("final\n");
   });
 
   it("refreshes local git status state on turn completion using the session cwd", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -45,6 +45,8 @@ import { RuntimeReceiptBusLive } from "./RuntimeReceiptBus.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
+import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import {
   OrchestrationEngineService,
   type OrchestrationEngineShape,
@@ -260,7 +262,8 @@ describe("CheckpointReactor", () => {
     | OrchestrationEngineService
     | CheckpointReactor
     | CheckpointStore.CheckpointStore
-    | ProjectionSnapshotQuery,
+    | ProjectionSnapshotQuery
+    | ProjectionTurnRepository,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -343,7 +346,7 @@ describe("CheckpointReactor", () => {
       streamStatus: () => Stream.empty,
     });
 
-    const layer = CheckpointReactorLive.pipe(
+    const layer = Layer.merge(CheckpointReactorLive, ProjectionTurnRepositoryLive).pipe(
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(RuntimeReceiptBusLive),
@@ -370,6 +373,7 @@ describe("CheckpointReactor", () => {
     const checkpointStore = await runtime.runPromise(
       Effect.service(CheckpointStore.CheckpointStore),
     );
+    const projectionTurns = await runtime.runPromise(Effect.service(ProjectionTurnRepository));
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
     const drain = () => Effect.runPromise(reactor.drain);
@@ -377,6 +381,38 @@ describe("CheckpointReactor", () => {
       runtime!.runPromise(checkpointStore.captureCheckpoint(input));
     const dispatch = (command: Parameters<OrchestrationEngineShape["dispatch"]>[0]) =>
       runtime!.runPromise(engine.dispatch(command));
+    const projectRunningTurn = (input: {
+      readonly threadId: ThreadId;
+      readonly turnId: TurnId;
+      readonly messageId: MessageId;
+      readonly at: string;
+    }) =>
+      runtime!.runPromise(
+        projectionTurns
+          .upsertByTurnId({
+            threadId: input.threadId,
+            turnId: input.turnId,
+            pendingMessageId: input.messageId,
+            sourceProposedPlanThreadId: null,
+            sourceProposedPlanId: null,
+            assistantMessageId: null,
+            state: "running",
+            requestedAt: input.at,
+            startedAt: input.at,
+            completedAt: null,
+            checkpointTurnCount: null,
+            checkpointRef: null,
+            checkpointStatus: null,
+            checkpointFiles: [],
+          })
+          .pipe(
+            Effect.andThen(
+              projectionTurns.deletePendingTurnStartByThreadId({
+                threadId: input.threadId,
+              }),
+            ),
+          ),
+      );
 
     const createdAt = "2026-01-01T00:00:00.000Z";
     await Effect.runPromise(
@@ -464,6 +500,7 @@ describe("CheckpointReactor", () => {
       provider,
       captureCheckpoint,
       dispatch,
+      projectRunningTurn,
       cwd,
       drain,
     };
@@ -819,7 +856,7 @@ describe("CheckpointReactor", () => {
     expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
   });
 
-  it("tracks a new turn when an accepted steer supersedes the active turn", async () => {
+  it("tracks an accepted steer after its pending start is projected", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const threadId = ThreadId.make("thread-1");
     const oldTurnId = asTurnId("turn-steered-over");
@@ -865,6 +902,12 @@ describe("CheckpointReactor", () => {
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
       runtimeMode: "approval-required",
       createdAt: "2026-01-01T00:00:05.000Z",
+    });
+    await harness.projectRunningTurn({
+      threadId,
+      turnId: newTurnId,
+      messageId: MessageId.make("msg-steer"),
+      at: "2026-01-01T00:00:05.000Z",
     });
     harness.provider.setActiveTurnId(newTurnId);
     harness.provider.emit({
@@ -953,6 +996,71 @@ describe("CheckpointReactor", () => {
     expect(
       gitShowFileAtRef(harness.cwd, checkpointRefForThreadTurn(threadId, 1), "README.md"),
     ).toBe("completed turn\n");
+  });
+
+  it("tracks the turn before a baseline capture failure", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const completedTurnId = asTurnId("turn-baseline-failed");
+    const gitDir = NodePath.join(harness.cwd, ".git");
+    const gitDirMode = NodeFS.statSync(gitDir).mode;
+    const completedAt = "2026-01-01T00:00:10.000Z";
+
+    NodeFS.chmodSync(gitDir, 0o555);
+    try {
+      harness.provider.emit({
+        type: "turn.started",
+        eventId: EventId.make("evt-turn-started-baseline-failed"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        threadId,
+        turnId: completedTurnId,
+      });
+      await harness.drain();
+    } finally {
+      NodeFS.chmodSync(gitDir, gitDirMode);
+    }
+    expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0))).toBe(false);
+
+    await harness.dispatch({
+      type: "thread.session.set",
+      commandId: CommandId.make("cmd-session-advanced-after-baseline-failure"),
+      threadId,
+      session: {
+        threadId,
+        status: "running",
+        providerName: "codex",
+        runtimeMode: "approval-required",
+        activeTurnId: asTurnId("turn-follow-up"),
+        lastError: null,
+        updatedAt: "2026-01-01T00:00:20.000Z",
+      },
+      createdAt: "2026-01-01T00:00:20.000Z",
+    });
+    await harness.captureCheckpoint({
+      cwd: harness.cwd,
+      checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+    });
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "completed turn\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-after-baseline-failure"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId: completedTurnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(
+      harness.engine,
+      (event) => event.type === "thread.turn-diff-completed" && event.occurredAt === completedAt,
+    );
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.checkpoints[0]?.completedAt === completedAt,
+    );
+    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
   });
 
   it("captures pre-turn and completion checkpoints for claude runtime events", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -367,6 +367,10 @@ describe("CheckpointReactor", () => {
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
     const drain = () => Effect.runPromise(reactor.drain);
+    const captureCheckpoint = (input: CheckpointStore.CaptureCheckpointInput) =>
+      runtime!.runPromise(checkpointStore.captureCheckpoint(input));
+    const dispatch = (command: Parameters<OrchestrationEngineShape["dispatch"]>[0]) =>
+      runtime!.runPromise(engine.dispatch(command));
 
     const createdAt = "2026-01-01T00:00:00.000Z";
     await Effect.runPromise(
@@ -452,7 +456,8 @@ describe("CheckpointReactor", () => {
       engine,
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
-      checkpointStore,
+      captureCheckpoint,
+      dispatch,
       cwd,
       drain,
     };
@@ -542,30 +547,24 @@ describe("CheckpointReactor", () => {
     const midTurnAt = "2026-01-01T00:00:10.000Z";
     const completedAt = "2026-01-01T00:00:30.000Z";
 
-    await Effect.runPromise(
-      harness.checkpointStore.captureCheckpoint({
-        cwd: harness.cwd,
-        checkpointRef: checkpointRefForThreadTurn(threadId, 0),
-      }),
-    );
+    await harness.captureCheckpoint({
+      cwd: harness.cwd,
+      checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+    });
     NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "mid-turn\n", "utf8");
-    await Effect.runPromise(
-      harness.checkpointStore.captureCheckpoint({ cwd: harness.cwd, checkpointRef }),
-    );
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-legacy-mid-turn-diff"),
-        threadId,
-        turnId,
-        completedAt: midTurnAt,
-        checkpointRef,
-        status: "ready",
-        files: [{ path: "README.md", kind: "modified", additions: 1, deletions: 1 }],
-        checkpointTurnCount: 1,
-        createdAt: midTurnAt,
-      }),
-    );
+    await harness.captureCheckpoint({ cwd: harness.cwd, checkpointRef });
+    await harness.dispatch({
+      type: "thread.turn.diff.complete",
+      commandId: CommandId.make("cmd-legacy-mid-turn-diff"),
+      threadId,
+      turnId,
+      completedAt: midTurnAt,
+      checkpointRef,
+      status: "ready",
+      files: [{ path: "README.md", kind: "modified", additions: 1, deletions: 1 }],
+      checkpointTurnCount: 1,
+      createdAt: midTurnAt,
+    });
     await harness.drain();
     expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("mid-turn\n");
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -369,13 +369,16 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      // Only skip if a real (non-placeholder) checkpoint already exists for this turn.
-      // ProviderRuntimeIngestion may insert placeholder entries with status "missing"
-      // before this reactor runs; those must not prevent real git capture.
+      const existingCheckpoint = thread.checkpoints.find(
+        (checkpoint) => checkpoint.turnId === turnId,
+      );
+      // A replayed completion event must not recapture an already-final checkpoint.
+      // Older servers could capture on a mid-turn diff update, so a checkpoint
+      // timestamped before the completion event still needs to be replaced.
       if (
-        thread.checkpoints.some(
-          (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
-        )
+        existingCheckpoint &&
+        existingCheckpoint.status !== "missing" &&
+        existingCheckpoint.completedAt === event.createdAt
       ) {
         return;
       }
@@ -391,18 +394,11 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      // If a placeholder checkpoint exists for this turn, reuse its turn count
-      // instead of incrementing past it.
-      const existingPlaceholder = thread.checkpoints.find(
-        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status === "missing",
-      );
       const currentTurnCount = thread.checkpoints.reduce(
         (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
         0,
       );
-      const nextTurnCount = existingPlaceholder
-        ? existingPlaceholder.checkpointTurnCount
-        : currentTurnCount + 1;
+      const nextTurnCount = existingCheckpoint?.checkpointTurnCount ?? currentTurnCount + 1;
 
       yield* captureAndDispatchCheckpoint({
         threadId: thread.id,
@@ -416,68 +412,6 @@ const make = Effect.gen(function* () {
       });
     },
   );
-
-  // Captures a real git checkpoint when a placeholder checkpoint (status "missing")
-  // is detected via a domain event. This replaces the placeholder with a real
-  // git-ref-based checkpoint.
-  //
-  // ProviderRuntimeIngestion creates placeholder checkpoints on turn.diff.updated
-  // events from the Codex runtime. This handler fires when the corresponding
-  // domain event arrives, allowing the reactor to capture the actual filesystem
-  // state into a git ref and dispatch a replacement checkpoint.
-  const captureCheckpointFromPlaceholder = Effect.fn("captureCheckpointFromPlaceholder")(function* (
-    event: Extract<OrchestrationEvent, { type: "thread.turn-diff-completed" }>,
-  ) {
-    const { threadId, turnId, checkpointTurnCount, status } = event.payload;
-
-    // Only replace placeholders; skip events from our own real captures.
-    if (status !== "missing") {
-      return;
-    }
-
-    const thread = yield* resolveThreadDetail(threadId);
-    if (!thread) {
-      yield* Effect.logWarning("checkpoint capture from placeholder skipped: thread not found", {
-        threadId,
-      });
-      return;
-    }
-
-    // If a real checkpoint already exists for this turn, skip.
-    if (
-      thread.checkpoints.some(
-        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
-      )
-    ) {
-      yield* Effect.logDebug(
-        "checkpoint capture from placeholder skipped: real checkpoint already exists",
-        { threadId, turnId },
-      );
-      return;
-    }
-
-    const projects = yield* resolveThreadProjects(thread.projectId);
-    const checkpointCwd = yield* resolveCheckpointCwd({
-      threadId,
-      thread,
-      projects,
-      preferSessionRuntime: true,
-    });
-    if (!checkpointCwd) {
-      return;
-    }
-
-    yield* captureAndDispatchCheckpoint({
-      threadId,
-      turnId,
-      thread,
-      cwd: checkpointCwd,
-      turnCount: checkpointTurnCount,
-      status: "ready",
-      assistantMessageId: event.payload.assistantMessageId ?? undefined,
-      createdAt: event.payload.completedAt,
-    });
-  });
 
   const ensurePreTurnBaselineFromTurnStart = Effect.fn("ensurePreTurnBaselineFromTurnStart")(
     function* (event: Extract<ProviderRuntimeEvent, { type: "turn.started" }>) {
@@ -838,26 +772,6 @@ const make = Effect.gen(function* () {
       );
       return;
     }
-
-    // When ProviderRuntimeIngestion creates a placeholder checkpoint (status "missing")
-    // from a turn.diff.updated runtime event, capture the real git checkpoint to
-    // replace it. The providerService.streamEvents PubSub does not reliably deliver
-    // turn.completed runtime events to this reactor (shared subscription), so
-    // reacting to the domain event is the reliable path.
-    if (event.type === "thread.turn-diff-completed") {
-      yield* captureCheckpointFromPlaceholder(event).pipe(
-        Effect.catch((error) =>
-          Effect.flatMap(nowIso, (createdAt) =>
-            appendCaptureFailureActivity({
-              threadId: event.payload.threadId,
-              turnId: event.payload.turnId,
-              detail: error.message,
-              createdAt,
-            }).pipe(Effect.catch(() => Effect.void)),
-          ),
-        ),
-      );
-    }
   });
 
   const processRuntimeEvent = Effect.fn("processRuntimeEvent")(function* (
@@ -918,8 +832,7 @@ const make = Effect.gen(function* () {
         if (
           event.type !== "thread.turn-start-requested" &&
           event.type !== "thread.message-sent" &&
-          event.type !== "thread.checkpoint-revert-requested" &&
-          event.type !== "thread.turn-diff-completed"
+          event.type !== "thread.checkpoint-revert-requested"
         ) {
           return Effect.void;
         }

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -27,6 +27,8 @@ import {
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import * as CheckpointStore from "../../checkpointing/CheckpointStore.ts";
+import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
+import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { CheckpointReactor, type CheckpointReactorShape } from "../Services/CheckpointReactor.ts";
 import { forkParked } from "../../serverActivation.ts";
@@ -84,6 +86,7 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
+  const projectionTurnRepository = yield* ProjectionTurnRepository;
   const checkpointStore = yield* CheckpointStore.CheckpointStore;
   const receiptBus = yield* RuntimeReceiptBus;
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
@@ -417,6 +420,40 @@ const make = Effect.gen(function* () {
       });
     },
   );
+
+  const rememberRuntimeTurnStart = Effect.fn("rememberRuntimeTurnStart")(function* (
+    event: Extract<ProviderRuntimeEvent, { type: "turn.started" }>,
+  ) {
+    const turnId = toTurnId(event.turnId);
+    if (!turnId) {
+      return;
+    }
+
+    const activeRuntimeTurnId = activeRuntimeTurnByThread.get(event.threadId);
+    if (!activeRuntimeTurnId || sameId(activeRuntimeTurnId, turnId)) {
+      activeRuntimeTurnByThread.set(event.threadId, turnId);
+      return;
+    }
+
+    const thread = yield* resolveThreadDetail(event.threadId);
+    if (sameId(thread?.session?.activeTurnId, turnId)) {
+      activeRuntimeTurnByThread.set(event.threadId, turnId);
+      return;
+    }
+
+    const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+      threadId: event.threadId,
+    });
+    if (Option.isNone(pendingTurnStart)) {
+      return;
+    }
+
+    const sessions = yield* providerService.listSessions();
+    const providerSession = sessions.find((session) => session.threadId === event.threadId);
+    if (sameId(providerSession?.activeTurnId, turnId)) {
+      activeRuntimeTurnByThread.set(event.threadId, turnId);
+    }
+  });
 
   const ensurePreTurnBaselineFromTurnStart = Effect.fn("ensurePreTurnBaselineFromTurnStart")(
     function* (event: Extract<ProviderRuntimeEvent, { type: "turn.started" }>) {
@@ -783,11 +820,8 @@ const make = Effect.gen(function* () {
     event: ProviderRuntimeEvent,
   ) {
     if (event.type === "turn.started") {
-      const turnId = toTurnId(event.turnId);
-      if (turnId) {
-        activeRuntimeTurnByThread.set(event.threadId, turnId);
-      }
       yield* ensurePreTurnBaselineFromTurnStart(event);
+      yield* rememberRuntimeTurnStart(event);
       return;
     }
 
@@ -869,4 +903,6 @@ const make = Effect.gen(function* () {
   } satisfies CheckpointReactorShape;
 });
 
-export const CheckpointReactorLive = Layer.effect(CheckpointReactor, make);
+export const CheckpointReactorLive = Layer.effect(CheckpointReactor, make).pipe(
+  Layer.provide(ProjectionTurnRepositoryLive),
+);

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -441,6 +441,15 @@ const make = Effect.gen(function* () {
       return;
     }
 
+    const projectedTurn = yield* projectionTurnRepository.getByTurnId({
+      threadId: event.threadId,
+      turnId,
+    });
+    if (Option.isSome(projectedTurn) && projectedTurn.value.state === "running") {
+      activeRuntimeTurnByThread.set(event.threadId, turnId);
+      return;
+    }
+
     const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
       threadId: event.threadId,
     });
@@ -820,8 +829,8 @@ const make = Effect.gen(function* () {
     event: ProviderRuntimeEvent,
   ) {
     if (event.type === "turn.started") {
-      yield* ensurePreTurnBaselineFromTurnStart(event);
       yield* rememberRuntimeTurnStart(event);
+      yield* ensurePreTurnBaselineFromTurnStart(event);
       return;
     }
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -88,6 +88,7 @@ const make = Effect.gen(function* () {
   const receiptBus = yield* RuntimeReceiptBus;
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
+  const activeRuntimeTurnByThread = new Map<ThreadId, TurnId>();
 
   const appendRevertFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -353,7 +354,10 @@ const make = Effect.gen(function* () {
 
   // Captures a real git checkpoint when a turn completes via a runtime event.
   const captureCheckpointFromTurnCompletion = Effect.fn("captureCheckpointFromTurnCompletion")(
-    function* (event: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>) {
+    function* (
+      event: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>,
+      activeRuntimeTurnId: TurnId | undefined,
+    ) {
       const turnId = toTurnId(event.turnId);
       if (!turnId) {
         return;
@@ -365,7 +369,8 @@ const make = Effect.gen(function* () {
       }
 
       // When a primary turn is active, only that turn may produce completion checkpoints.
-      if (thread.session?.activeTurnId && !sameId(thread.session.activeTurnId, turnId)) {
+      const primaryTurnId = activeRuntimeTurnId ?? thread.session?.activeTurnId;
+      if (primaryTurnId && !sameId(primaryTurnId, turnId)) {
         return;
       }
 
@@ -778,14 +783,18 @@ const make = Effect.gen(function* () {
     event: ProviderRuntimeEvent,
   ) {
     if (event.type === "turn.started") {
+      const turnId = toTurnId(event.turnId);
+      if (turnId) {
+        activeRuntimeTurnByThread.set(event.threadId, turnId);
+      }
       yield* ensurePreTurnBaselineFromTurnStart(event);
       return;
     }
 
     if (event.type === "turn.completed") {
       const turnId = toTurnId(event.turnId);
-      yield* refreshLocalGitStatusFromTurnCompletion(event);
-      yield* captureCheckpointFromTurnCompletion(event).pipe(
+      const activeRuntimeTurnId = activeRuntimeTurnByThread.get(event.threadId);
+      yield* captureCheckpointFromTurnCompletion(event, activeRuntimeTurnId).pipe(
         Effect.catch((error) =>
           Effect.flatMap(nowIso, (createdAt) =>
             appendCaptureFailureActivity({
@@ -797,6 +806,10 @@ const make = Effect.gen(function* () {
           ),
         ),
       );
+      if (turnId && activeRuntimeTurnId && sameId(activeRuntimeTurnId, turnId)) {
+        activeRuntimeTurnByThread.delete(event.threadId);
+      }
+      yield* refreshLocalGitStatusFromTurnCompletion(event);
       return;
     }
   });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -171,7 +171,6 @@ type ProviderRuntimeTestThread = ProviderRuntimeTestReadModel["threads"][number]
 type ProviderRuntimeTestMessage = ProviderRuntimeTestThread["messages"][number];
 type ProviderRuntimeTestProposedPlan = ProviderRuntimeTestThread["proposedPlans"][number];
 type ProviderRuntimeTestActivity = ProviderRuntimeTestThread["activities"][number];
-type ProviderRuntimeTestCheckpoint = ProviderRuntimeTestThread["checkpoints"][number];
 
 async function waitForThread(
   readModel: () => Promise<ProviderRuntimeTestReadModel>,
@@ -2856,7 +2855,7 @@ describe("ProviderRuntimeIngestion", () => {
     });
   });
 
-  it("consumes P1 runtime events into thread metadata, diff checkpoints, and activities", async () => {
+  it("consumes P1 runtime events without checkpointing mid-turn diff updates", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -2906,19 +2905,6 @@ describe("ProviderRuntimeIngestion", () => {
     });
 
     harness.emit({
-      type: "runtime.warning",
-      eventId: asEventId("evt-runtime-warning"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-1"),
-      turnId: asTurnId("turn-p1"),
-      payload: {
-        message: "Provider got slow",
-        detail: { latencyMs: 1500 },
-      },
-    });
-
-    harness.emit({
       type: "turn.diff.updated",
       eventId: asEventId("evt-turn-diff-updated"),
       provider: ProviderDriverKind.make("codex"),
@@ -2928,6 +2914,19 @@ describe("ProviderRuntimeIngestion", () => {
       itemId: asItemId("item-p1-assistant"),
       payload: {
         unifiedDiff: "diff --git a/file.txt b/file.txt\n+hello\n",
+      },
+    });
+
+    harness.emit({
+      type: "runtime.warning",
+      eventId: asEventId("evt-runtime-warning"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-p1"),
+      payload: {
+        message: "Provider got slow",
+        detail: { latencyMs: 1500 },
       },
     });
 
@@ -2943,9 +2942,6 @@ describe("ProviderRuntimeIngestion", () => {
         ) &&
         entry.activities.some(
           (activity: ProviderRuntimeTestActivity) => activity.kind === "runtime.warning",
-        ) &&
-        entry.checkpoints.some(
-          (checkpoint: ProviderRuntimeTestCheckpoint) => checkpoint.turnId === "turn-p1",
         ),
     );
 
@@ -2983,12 +2979,7 @@ describe("ProviderRuntimeIngestion", () => {
     expect(warning?.kind).toBe("runtime.warning");
     expect(warningPayload?.message).toBe("Provider got slow");
 
-    const checkpoint = thread.checkpoints.find(
-      (entry: ProviderRuntimeTestCheckpoint) => entry.turnId === "turn-p1",
-    );
-    expect(checkpoint?.status).toBe("missing");
-    expect(checkpoint?.assistantMessageId).toBe("assistant:item-p1-assistant");
-    expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
+    expect(thread.checkpoints).toEqual([]);
   });
 
   it("mirrors a provider title only while the thread still has the default title", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -6,14 +6,12 @@ import {
   type OrchestrationEvent,
   type OrchestrationMessage,
   type OrchestrationProposedPlanId,
-  CheckpointRef,
   classifyTaskAgentKind,
   EventId,
   isToolLifecycleItemType,
   ThreadId,
   type ThreadTokenUsageSnapshot,
   TurnId,
-  type OrchestrationCheckpointSummary,
   type OrchestrationProposedPlan,
   type OrchestrationThread,
   type OrchestrationThreadActivity,
@@ -32,7 +30,6 @@ import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
-import { isGitRepository } from "../../git/Utils.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ThreadBackgroundLivenessService } from "../ThreadBackgroundLiveness.ts";
 import { ThreadPlanProgressService } from "../ThreadPlanProgress.ts";
@@ -180,31 +177,6 @@ function findProposedPlanById(
     }
   }
   return undefined;
-}
-
-function hasCheckpointForTurn(
-  checkpoints: ReadonlyArray<OrchestrationCheckpointSummary>,
-  turnId: TurnId,
-): boolean {
-  for (let index = 0; index < checkpoints.length; index += 1) {
-    if (checkpoints[index]?.turnId === turnId) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function maxCheckpointTurnCount(
-  checkpoints: ReadonlyArray<OrchestrationCheckpointSummary>,
-): number {
-  let maxTurnCount = 0;
-  for (let index = 0; index < checkpoints.length; index += 1) {
-    const checkpoint = checkpoints[index];
-    if (checkpoint && checkpoint.checkpointTurnCount > maxTurnCount) {
-      maxTurnCount = checkpoint.checkpointTurnCount;
-    }
-  }
-  return maxTurnCount;
 }
 
 function truncateDetail(value: string, limit = 180): string {
@@ -1920,43 +1892,6 @@ const make = Effect.gen(function* () {
             threadId: thread.id,
             title: event.payload.name,
           });
-        }
-      }
-
-      if (event.type === "turn.diff.updated") {
-        const turnId = toTurnId(event.turnId);
-        const checkpointContext = turnId
-          ? yield* projectionSnapshotQuery
-              .getThreadCheckpointContext(thread.id)
-              .pipe(Effect.map(Option.getOrUndefined))
-          : undefined;
-        const workspaceCwd =
-          checkpointContext?.worktreePath ?? checkpointContext?.workspaceRoot ?? undefined;
-        if (turnId && checkpointContext && workspaceCwd && isGitRepository(workspaceCwd)) {
-          // Skip if a checkpoint already exists for this turn. A real
-          // (non-placeholder) capture from CheckpointReactor should not
-          // be clobbered, and dispatching a duplicate placeholder for the
-          // same turnId would produce an unstable checkpointTurnCount.
-          if (hasCheckpointForTurn(checkpointContext.checkpoints, turnId)) {
-            // Already tracked; no-op.
-          } else {
-            const assistantMessageId = MessageId.make(
-              `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
-            );
-            yield* orchestrationEngine.dispatch({
-              type: "thread.turn.diff.complete",
-              commandId: yield* providerCommandId(event, "thread-turn-diff-complete"),
-              threadId: thread.id,
-              turnId,
-              completedAt: now,
-              checkpointRef: CheckpointRef.make(`provider-diff:${event.eventId}`),
-              status: "missing",
-              files: [],
-              assistantMessageId,
-              checkpointTurnCount: maxCheckpointTurnCount(checkpointContext.checkpoints) + 1,
-              createdAt: now,
-            });
-          }
         }
       }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2711,13 +2711,12 @@ function ChatViewContent(props: ChatViewProps) {
   ] = useDraftHeroLayoutTransition(isDraftHeroState);
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
-  const turnDiffSummaryByAssistantMessageId = useMemo(() => {
-    const byMessageId = new Map<MessageId, TurnDiffSummary>();
+  const turnDiffSummaryByTurnId = useMemo(() => {
+    const byTurnId = new Map<TurnId, TurnDiffSummary>();
     for (const summary of turnDiffSummaries) {
-      if (!summary.assistantMessageId) continue;
-      byMessageId.set(summary.assistantMessageId, summary);
+      byTurnId.set(summary.turnId, summary);
     }
-    return byMessageId;
+    return byTurnId;
   }, [turnDiffSummaries]);
   const revertTurnCountByUserMessageId = useMemo(() => {
     const byUserMessageId = new Map<MessageId, number>();
@@ -2735,7 +2734,9 @@ function ChatViewContent(props: ChatViewProps) {
         if (nextEntry.message.role === "user") {
           break;
         }
-        const summary = turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
+        const summary = nextEntry.message.turnId
+          ? turnDiffSummaryByTurnId.get(nextEntry.message.turnId)
+          : undefined;
         if (!summary) {
           continue;
         }
@@ -2750,7 +2751,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     return byUserMessageId;
-  }, [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByAssistantMessageId]);
+  }, [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByTurnId]);
 
   const gitCwd = activeProject
     ? projectScriptCwd({
@@ -6921,7 +6922,7 @@ function ChatViewContent(props: ChatViewProps) {
                 timelineEntries={timelineEntries}
                 latestTurn={activeLatestTurn}
                 runningTurnId={activeRunningTurnId}
-                turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
+                turnDiffSummaryByTurnId={turnDiffSummaryByTurnId}
                 activeThreadEnvironmentId={activeThread.environmentId}
                 routeThreadKey={routeThreadKey}
                 onOpenTurnDiff={onOpenTurnDiff}

--- a/apps/web/src/components/chat/ChangedFilesTree.tsx
+++ b/apps/web/src/components/chat/ChangedFilesTree.tsx
@@ -28,6 +28,7 @@ import {
 const EMPTY_DIRECTORY_OVERRIDES: Record<string, boolean> = {};
 
 export const ChangedFilesCard = memo(function ChangedFilesCard(props: {
+  className?: string;
   turnId: TurnId;
   files: ReadonlyArray<TurnDiffFileChange>;
   expanded: boolean;
@@ -39,6 +40,7 @@ export const ChangedFilesCard = memo(function ChangedFilesCard(props: {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
 }) {
   const {
+    className,
     turnId,
     files,
     expanded,
@@ -56,7 +58,10 @@ export const ChangedFilesCard = memo(function ChangedFilesCard(props: {
 
   return (
     <div
-      className="@container/changed-files mt-4 rounded-2xl border border-border/70 bg-secondary p-2 dark:border-transparent dark:bg-input/32"
+      className={cn(
+        "@container/changed-files mt-4 rounded-2xl border border-border/70 bg-secondary p-2 dark:border-transparent dark:bg-input/32",
+        className,
+      )}
       data-changed-files-state={
         expanded ? "expanded" : compactPreviewVisible ? "preview" : "collapsed"
       }

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -322,7 +322,7 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -376,7 +376,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -389,8 +389,8 @@ describe("deriveMessagesTimelineRows", () => {
     expect(assistantRows[1]?.assistantCopyStreaming).toBe(true);
   });
 
-  it("projects assistant diff summaries and user revert counts onto the affected rows", () => {
-    const assistantTurnDiffSummary = {
+  it("places turn diffs after the turn's tool rows and withholds them while unsettled", () => {
+    const turnDiffSummary = {
       turnId: "turn-1" as never,
       completedAt: "2026-01-01T00:00:30Z",
       assistantMessageId: "assistant-1" as never,
@@ -400,42 +400,56 @@ describe("deriveMessagesTimelineRows", () => {
       files: [{ path: "src/index.ts", kind: "modified", additions: 3, deletions: 1 }],
     };
 
-    const rows = deriveMessagesTimelineRows({
-      timelineEntries: [
-        {
-          id: "user-entry",
-          kind: "message",
+    const timelineEntries = [
+      {
+        id: "user-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:00Z",
+        message: {
+          id: "user-1" as never,
+          role: "user" as const,
+          text: "Do the thing",
+          turnId: null,
           createdAt: "2026-01-01T00:00:00Z",
-          message: {
-            id: "user-1" as never,
-            role: "user",
-            text: "Do the thing",
-            turnId: null,
-            createdAt: "2026-01-01T00:00:00Z",
-            updatedAt: "2026-01-01T00:00:00Z",
-            streaming: false,
-          },
+          updatedAt: "2026-01-01T00:00:00Z",
+          streaming: false,
         },
-        {
-          id: "assistant-entry",
-          kind: "message",
+      },
+      {
+        id: "assistant-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:20Z",
+        message: {
+          id: "assistant-1" as never,
+          role: "assistant" as const,
+          text: "Done",
+          turnId: "turn-1" as never,
           createdAt: "2026-01-01T00:00:20Z",
-          message: {
-            id: "assistant-1" as never,
-            role: "assistant",
-            text: "Done",
-            turnId: "turn-1" as never,
-            createdAt: "2026-01-01T00:00:20Z",
-            updatedAt: "2026-01-01T00:00:30Z",
-            streaming: false,
-          },
+          updatedAt: "2026-01-01T00:00:30Z",
+          streaming: false,
         },
-      ],
+      },
+      {
+        id: "tool-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:25Z",
+        entry: {
+          id: "tool-1",
+          createdAt: "2026-01-01T00:00:25Z",
+          turnId: "turn-1" as never,
+          label: "Ran tests",
+          tone: "tool" as const,
+          toolLifecycleStatus: "completed" as const,
+        },
+      },
+    ];
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map([
-        ["assistant-1" as never, assistantTurnDiffSummary],
-      ]),
+      turnDiffSummaryByTurnId: new Map([["turn-1" as never, turnDiffSummary]]),
       revertTurnCountByUserMessageId: new Map([["user-1" as never, 1]]),
     });
 
@@ -443,13 +457,33 @@ describe("deriveMessagesTimelineRows", () => {
       (row): row is Extract<(typeof rows)[number], { kind: "message" }> =>
         row.kind === "message" && row.message.role === "user",
     );
-    const assistantRow = rows.find(
-      (row): row is Extract<(typeof rows)[number], { kind: "message" }> =>
-        row.kind === "message" && row.message.role === "assistant",
+    const diffRow = rows.find(
+      (row): row is Extract<(typeof rows)[number], { kind: "turn-diff" }> =>
+        row.kind === "turn-diff",
     );
+    const toolRowIndex = rows.findIndex((row) => row.kind === "work-toggle");
+    const diffRowIndex = rows.findIndex((row) => row.kind === "turn-diff");
 
     expect(userRow?.revertTurnCount).toBe(1);
-    expect(assistantRow?.assistantTurnDiffSummary).toBe(assistantTurnDiffSummary);
+    expect(diffRow?.turnSummary).toBe(turnDiffSummary);
+    expect(toolRowIndex).toBeGreaterThanOrEqual(0);
+    expect(diffRowIndex).toBeGreaterThan(toolRowIndex);
+
+    const unsettledRows = deriveMessagesTimelineRows({
+      timelineEntries,
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByTurnId: new Map([["turn-1" as never, turnDiffSummary]]),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(unsettledRows.some((row) => row.kind === "turn-diff")).toBe(false);
   });
 
   it("keeps the first and terminal assistant messages visible around settled work", () => {
@@ -514,7 +548,7 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -538,7 +572,7 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -604,7 +638,7 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -699,7 +733,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:14Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -736,7 +770,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -804,7 +838,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -856,7 +890,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -925,7 +959,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -996,7 +1030,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1063,7 +1097,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1110,7 +1144,7 @@ describe("deriveMessagesTimelineRows", () => {
       latestTurn: null,
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1171,7 +1205,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1207,7 +1241,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1269,7 +1303,7 @@ describe("deriveMessagesTimelineRows", () => {
       runningTurnId: "turn-2" as never,
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:01:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1314,7 +1348,7 @@ describe("deriveMessagesTimelineRows", () => {
       expandedTurnIds: new Set(["turn-1" as never]),
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1352,7 +1386,7 @@ describe("deriveMessagesTimelineRows", () => {
       },
       isWorking: true,
       activeTurnStartedAt: "2026-01-01T00:00:00Z",
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1409,7 +1443,7 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     };
     const collapsedRows = deriveMessagesTimelineRows(baseInput);
@@ -1460,7 +1494,7 @@ describe("deriveMessagesTimelineRows", () => {
       timelineEntries,
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1507,7 +1541,7 @@ describe("deriveMessagesTimelineRows", () => {
         timelineEntries,
         isWorking: false,
         activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
+        turnDiffSummaryByTurnId: new Map(),
         revertTurnCountByUserMessageId: new Map(),
       });
 
@@ -1558,7 +1592,7 @@ describe("computeStableMessagesTimelineRows", () => {
       ],
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 
@@ -1607,7 +1641,7 @@ describe("computeStableMessagesTimelineRows", () => {
         ],
         isWorking: false,
         activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
+        turnDiffSummaryByTurnId: new Map(),
         revertTurnCountByUserMessageId: new Map(),
       });
 
@@ -1663,7 +1697,7 @@ describe("computeStableMessagesTimelineRows", () => {
       ],
       isWorking: false,
       activeTurnStartedAt: null,
-      turnDiffSummaryByAssistantMessageId: new Map(),
+      turnDiffSummaryByTurnId: new Map(),
       revertTurnCountByUserMessageId: new Map(),
     });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -199,6 +199,7 @@ export type MessagesTimelineRow =
       kind: "work-toggle";
       id: string;
       createdAt: string;
+      turnId: TurnId | null;
       groupId: string;
       hiddenCount: number;
       expanded: boolean;
@@ -216,6 +217,12 @@ export type MessagesTimelineRow =
       expanded: boolean;
     }
   | {
+      kind: "turn-diff";
+      id: string;
+      createdAt: string;
+      turnSummary: TurnDiffSummary;
+    }
+  | {
       kind: "message";
       id: string;
       createdAt: string;
@@ -224,7 +231,6 @@ export type MessagesTimelineRow =
       showAssistantMeta: boolean;
       showAssistantCopyButton: boolean;
       assistantCopyStreaming: boolean;
-      assistantTurnDiffSummary?: TurnDiffSummary | undefined;
       revertTurnCount?: number | undefined;
     }
   | {
@@ -520,6 +526,75 @@ function timelineEntryTurnId(entry: TimelineEntry): TurnId | null {
   return entry.kind === "work" ? (entry.entry.turnId ?? null) : null;
 }
 
+function timelineRowTurnId(row: MessagesTimelineRow): TurnId | null {
+  switch (row.kind) {
+    case "work":
+      return row.groupedEntries.findLast((entry) => entry.turnId !== undefined)?.turnId ?? null;
+    case "work-live":
+      return row.entry.turnId ?? null;
+    case "work-toggle":
+    case "turn-fold":
+      return row.turnId;
+    case "turn-diff":
+      return row.turnSummary.turnId;
+    case "message":
+      return row.message.role === "assistant" ? (row.message.turnId ?? null) : null;
+    case "proposed-plan":
+      return row.proposedPlan.turnId;
+    case "turn-plan":
+      return row.turnPlan.turnId;
+    case "working":
+      return null;
+  }
+}
+
+function appendTurnDiffRows(input: {
+  rows: MessagesTimelineRow[];
+  turnDiffSummaryByTurnId: ReadonlyMap<TurnId, TurnDiffSummary>;
+  unsettledTurnId: TurnId | null;
+}): MessagesTimelineRow[] {
+  const lastRowIndexByTurnId = new Map<TurnId, number>();
+  for (let index = 0; index < input.rows.length; index += 1) {
+    const row = input.rows[index];
+    if (!row) continue;
+    const turnId = timelineRowTurnId(row);
+    if (turnId !== null) {
+      lastRowIndexByTurnId.set(turnId, index);
+    }
+  }
+
+  const summaryByAnchorIndex = new Map<number, TurnDiffSummary>();
+  for (const summary of input.turnDiffSummaryByTurnId.values()) {
+    if (summary.turnId === input.unsettledTurnId || summary.files.length === 0) {
+      continue;
+    }
+    const anchorIndex = lastRowIndexByTurnId.get(summary.turnId);
+    if (anchorIndex !== undefined) {
+      summaryByAnchorIndex.set(anchorIndex, summary);
+    }
+  }
+  if (summaryByAnchorIndex.size === 0) {
+    return input.rows;
+  }
+
+  const rowsWithDiffs: MessagesTimelineRow[] = [];
+  for (let index = 0; index < input.rows.length; index += 1) {
+    const row = input.rows[index];
+    if (!row) continue;
+    rowsWithDiffs.push(row);
+    const turnSummary = summaryByAnchorIndex.get(index);
+    if (turnSummary) {
+      rowsWithDiffs.push({
+        kind: "turn-diff",
+        id: `turn-diff:${turnSummary.turnId}`,
+        createdAt: turnSummary.completedAt,
+        turnSummary,
+      });
+    }
+  }
+  return rowsWithDiffs;
+}
+
 /**
  * Settled turns keep their first and terminal assistant messages visible.
  * Everything between them folds behind a "Worked for ..." row anchored at
@@ -665,7 +740,7 @@ export function deriveMessagesTimelineRows(input: {
   expandedWorkGroupIds?: ReadonlySet<string>;
   isWorking: boolean;
   activeTurnStartedAt: string | null;
-  turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
+  turnDiffSummaryByTurnId: ReadonlyMap<TurnId, TurnDiffSummary>;
   revertTurnCountByUserMessageId: ReadonlyMap<MessageId, number>;
 }): MessagesTimelineRow[] {
   const nextRows: MessagesTimelineRow[] = [];
@@ -893,6 +968,7 @@ export function deriveMessagesTimelineRows(input: {
             kind: "work-toggle",
             id: `work-toggle:${timelineEntry.id}`,
             createdAt: timelineEntry.createdAt,
+            turnId: timelineEntry.entry.turnId ?? null,
             groupId,
             hiddenCount: visibleGroupedEntries.length,
             expanded,
@@ -959,6 +1035,7 @@ export function deriveMessagesTimelineRows(input: {
               kind: "work-toggle",
               id: `work-toggle:${timelineEntry.id}`,
               createdAt: timelineEntry.createdAt,
+              turnId: timelineEntry.entry.turnId ?? null,
               groupId,
               hiddenCount: hiddenEntries.length,
               expanded,
@@ -1022,10 +1099,6 @@ export function deriveMessagesTimelineRows(input: {
       showAssistantMeta,
       showAssistantCopyButton: showAssistantMeta,
       assistantCopyStreaming: timelineEntry.message.streaming || assistantTurnStillInProgress,
-      assistantTurnDiffSummary:
-        timelineEntry.message.role === "assistant"
-          ? input.turnDiffSummaryByAssistantMessageId.get(timelineEntry.message.id)
-          : undefined,
       revertTurnCount:
         timelineEntry.message.role === "user"
           ? input.revertTurnCountByUserMessageId.get(timelineEntry.message.id)
@@ -1037,7 +1110,11 @@ export function deriveMessagesTimelineRows(input: {
     appendWorkingRow();
   }
 
-  return nextRows;
+  return appendTurnDiffRows({
+    rows: nextRows,
+    turnDiffSummaryByTurnId: input.turnDiffSummaryByTurnId,
+    unsettledTurnId,
+  });
 }
 
 export function computeStableMessagesTimelineRows(
@@ -1075,6 +1152,9 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
       return a.createdAt === bf.createdAt && a.label === bf.label && a.expanded === bf.expanded;
     }
 
+    case "turn-diff":
+      return a.turnSummary === (b as typeof a).turnSummary;
+
     case "proposed-plan":
       return a.proposedPlan === (b as typeof a).proposedPlan;
 
@@ -1109,6 +1189,7 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
       const bw = b as typeof a;
       return (
         a.createdAt === bw.createdAt &&
+        a.turnId === bw.turnId &&
         a.groupId === bw.groupId &&
         a.hiddenCount === bw.hiddenCount &&
         a.expanded === bw.expanded &&
@@ -1127,7 +1208,6 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
         a.showAssistantMeta === bm.showAssistantMeta &&
         a.showAssistantCopyButton === bm.showAssistantCopyButton &&
         a.assistantCopyStreaming === bm.assistantCopyStreaming &&
-        a.assistantTurnDiffSummary === bm.assistantTurnDiffSummary &&
         a.revertTurnCount === bm.revertTurnCount
       );
     }

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -415,7 +415,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Open diff"');
     expect(markup).toContain("1 changed file");
     expect(markup).toContain('data-timeline-row-kind="turn-fold"');
-    expect(markup).toContain('data-timeline-row-kind="turn-diff"><div class="px-1">');
+    expect(markup).toContain('data-timeline-row-kind="turn-diff"><div class="min-w-0 px-1">');
     expect(markup).toMatch(/class="[^"]*@container\/changed-files[^"]*mt-0[^"]*"/u);
     expect(markup.indexOf('data-timeline-row-kind="turn-diff"')).toBeGreaterThan(
       markup.indexOf('data-timeline-row-kind="turn-fold"'),

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -181,7 +181,7 @@ function buildProps() {
     listRef: createRef<LegendListRef | null>(),
     latestTurn: null,
     runningTurnId: null,
-    turnDiffSummaryByAssistantMessageId: new Map(),
+    turnDiffSummaryByTurnId: new Map(),
     routeThreadKey: "environment-local:thread-1",
     onOpenTurnDiff: () => {},
     revertTurnCountByUserMessageId: new Map(),
@@ -346,7 +346,7 @@ describe("MessagesTimeline", () => {
     expect(fadedMarkup).toContain("topbar-scroll-fade");
   });
 
-  it("keeps assistant changed-files headers sticky below the thread header", () => {
+  it("keeps changed files after the turn's folded work with a sticky header", () => {
     const assistantMessageId = MessageId.make("message-assistant-with-files");
     const turnId = TurnId.make("turn-with-files");
     const markup = renderToStaticMarkup(
@@ -373,11 +373,24 @@ describe("MessagesTimeline", () => {
               streaming: false,
             },
           },
+          {
+            id: "entry-tool-after-assistant",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:29.000Z",
+            entry: {
+              id: "tool-after-assistant",
+              createdAt: "2026-03-17T19:12:29.000Z",
+              turnId,
+              label: "Ran tests",
+              tone: "tool",
+              toolLifecycleStatus: "completed",
+            },
+          },
         ]}
-        turnDiffSummaryByAssistantMessageId={
+        turnDiffSummaryByTurnId={
           new Map([
             [
-              assistantMessageId,
+              turnId,
               {
                 turnId,
                 checkpointTurnCount: 1,
@@ -401,6 +414,10 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Collapse all folders"');
     expect(markup).toContain('aria-label="Open diff"');
     expect(markup).toContain("1 changed file");
+    expect(markup).toContain('data-timeline-row-kind="turn-fold"');
+    expect(markup.indexOf('data-timeline-row-kind="turn-diff"')).toBeGreaterThan(
+      markup.indexOf('data-timeline-row-kind="turn-fold"'),
+    );
   });
 
   it("treats only the strict list end as the live edge", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -415,6 +415,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Open diff"');
     expect(markup).toContain("1 changed file");
     expect(markup).toContain('data-timeline-row-kind="turn-fold"');
+    expect(markup).toContain('data-timeline-row-kind="turn-diff"><div class="px-1">');
+    expect(markup).toMatch(/class="[^"]*@container\/changed-files[^"]*mt-0[^"]*"/u);
     expect(markup.indexOf('data-timeline-row-kind="turn-diff"')).toBeGreaterThan(
       markup.indexOf('data-timeline-row-kind="turn-fold"'),
     );

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1633,7 +1633,7 @@ function TurnDiffTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
   const expanded = persistedExpanded ?? (isLatestTurn && autoExpanded);
 
   return (
-    <div className="px-1">
+    <div className="min-w-0 px-1">
       <ChangedFilesCard
         className="mt-0"
         turnId={turnSummary.turnId}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -213,7 +213,7 @@ interface MessagesTimelineProps {
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   latestTurn: TimelineLatestTurn | null;
   runningTurnId: TurnId | null;
-  turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
+  turnDiffSummaryByTurnId: Map<TurnId, TurnDiffSummary>;
   routeThreadKey: string;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   revertTurnCountByUserMessageId: Map<MessageId, number>;
@@ -258,7 +258,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   timelineEntries,
   latestTurn,
   runningTurnId,
-  turnDiffSummaryByAssistantMessageId,
+  turnDiffSummaryByTurnId,
   routeThreadKey,
   onOpenTurnDiff,
   revertTurnCountByUserMessageId,
@@ -414,7 +414,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         expandedWorkGroupIds,
         isWorking,
         activeTurnStartedAt,
-        turnDiffSummaryByAssistantMessageId,
+        turnDiffSummaryByTurnId,
         revertTurnCountByUserMessageId,
       }),
     [
@@ -425,7 +425,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       expandedWorkGroupIds,
       isWorking,
       activeTurnStartedAt,
-      turnDiffSummaryByAssistantMessageId,
+      turnDiffSummaryByTurnId,
       revertTurnCountByUserMessageId,
     ],
   );
@@ -974,6 +974,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       {row.kind === "work-live" ? <LiveWorkEntryTimelineRow row={row} /> : null}
       {row.kind === "work-toggle" ? <WorkGroupToggleTimelineRow row={row} /> : null}
       {row.kind === "turn-fold" ? <TurnFoldTimelineRow row={row} /> : null}
+      {row.kind === "turn-diff" ? <TurnDiffTimelineRow row={row} /> : null}
       {row.kind === "message" && row.message.role === "user" ? <UserTimelineRow row={row} /> : null}
       {row.kind === "message" && row.message.role === "assistant" ? (
         <AssistantTimelineRow row={row} />
@@ -1148,12 +1149,6 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           isStreaming={Boolean(row.message.streaming)}
           lineBreaks={shouldPreserveAssistantLineBreaks(messageText)}
           skills={ctx.skills}
-        />
-        <AssistantChangedFilesSection
-          turnSummary={row.assistantTurnDiffSummary}
-          routeThreadKey={ctx.routeThreadKey}
-          resolvedTheme={ctx.resolvedTheme}
-          onOpenTurnDiff={ctx.onOpenTurnDiff}
         />
         {row.showAssistantMeta ? (
           <div className="mt-1.5 flex items-center gap-2 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover/assistant:opacity-100">
@@ -1621,53 +1616,14 @@ function WorkGroupToggleTimelineRow({
   );
 }
 
-/** Subscribes directly to the UI state store for expand/collapse state,
- *  so toggling re-renders only this component — not the entire list. */
-const AssistantChangedFilesSection = memo(function AssistantChangedFilesSection({
-  turnSummary,
-  routeThreadKey,
-  resolvedTheme,
-  onOpenTurnDiff,
-}: {
-  turnSummary: TurnDiffSummary | undefined;
-  routeThreadKey: string;
-  resolvedTheme: "light" | "dark";
-  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-}) {
-  if (!turnSummary) return null;
-  const checkpointFiles = turnSummary.files;
-  if (checkpointFiles.length === 0) return null;
-
-  return (
-    <AssistantChangedFilesSectionInner
-      turnSummary={turnSummary}
-      checkpointFiles={checkpointFiles}
-      routeThreadKey={routeThreadKey}
-      resolvedTheme={resolvedTheme}
-      onOpenTurnDiff={onOpenTurnDiff}
-    />
-  );
-});
-
-/** Inner component that only mounts when there are actual changed files,
- *  so the store subscription is unconditional (no hooks after early return). */
-function AssistantChangedFilesSectionInner({
-  turnSummary,
-  checkpointFiles,
-  routeThreadKey,
-  resolvedTheme,
-  onOpenTurnDiff,
-}: {
-  turnSummary: TurnDiffSummary;
-  checkpointFiles: TurnDiffSummary["files"];
-  routeThreadKey: string;
-  resolvedTheme: "light" | "dark";
-  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-}) {
+function TurnDiffTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-diff" }> }) {
+  const ctx = use(TimelineRowCtx);
   const activity = use(TimelineRowActivityCtx);
+  const turnSummary = row.turnSummary;
+  const checkpointFiles = turnSummary.files;
   const isLatestTurn = activity.latestTurnId === turnSummary.turnId;
   const persistedExpanded = useUiStateStore(
-    (store) => store.threadChangedFilesExpandedById[routeThreadKey]?.[turnSummary.turnId],
+    (store) => store.threadChangedFilesExpandedById[ctx.routeThreadKey]?.[turnSummary.turnId],
   );
   const setExpanded = useUiStateStore((store) => store.setThreadChangedFilesExpanded);
   const [autoExpanded] = useState(() =>
@@ -1683,12 +1639,12 @@ function AssistantChangedFilesSectionInner({
       expanded={expanded}
       showCompactPreview={isLatestTurn}
       allDirectoriesExpanded={allDirectoriesExpanded}
-      resolvedTheme={resolvedTheme}
+      resolvedTheme={ctx.resolvedTheme}
       onExpandedChange={(nextExpanded) =>
-        setExpanded(routeThreadKey, turnSummary.turnId, nextExpanded)
+        setExpanded(ctx.routeThreadKey, turnSummary.turnId, nextExpanded)
       }
       onToggleAllDirectories={() => setAllDirectoriesExpanded((current) => !current)}
-      onOpenTurnDiff={onOpenTurnDiff}
+      onOpenTurnDiff={ctx.onOpenTurnDiff}
     />
   );
 }

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1633,19 +1633,22 @@ function TurnDiffTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
   const expanded = persistedExpanded ?? (isLatestTurn && autoExpanded);
 
   return (
-    <ChangedFilesCard
-      turnId={turnSummary.turnId}
-      files={checkpointFiles}
-      expanded={expanded}
-      showCompactPreview={isLatestTurn}
-      allDirectoriesExpanded={allDirectoriesExpanded}
-      resolvedTheme={ctx.resolvedTheme}
-      onExpandedChange={(nextExpanded) =>
-        setExpanded(ctx.routeThreadKey, turnSummary.turnId, nextExpanded)
-      }
-      onToggleAllDirectories={() => setAllDirectoriesExpanded((current) => !current)}
-      onOpenTurnDiff={ctx.onOpenTurnDiff}
-    />
+    <div className="px-1">
+      <ChangedFilesCard
+        className="mt-0"
+        turnId={turnSummary.turnId}
+        files={checkpointFiles}
+        expanded={expanded}
+        showCompactPreview={isLatestTurn}
+        allDirectoriesExpanded={allDirectoriesExpanded}
+        resolvedTheme={ctx.resolvedTheme}
+        onExpandedChange={(nextExpanded) =>
+          setExpanded(ctx.routeThreadKey, turnSummary.turnId, nextExpanded)
+        }
+        onToggleAllDirectories={() => setAllDirectoriesExpanded((current) => !current)}
+        onOpenTurnDiff={ctx.onOpenTurnDiff}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
The changed-files card could appear as soon as Codex emitted a mid-turn diff update, even when the same turn continued with more tool calls. The checkpoint was also stale because it captured the filesystem before the turn finished.

This waits for the provider's turn-completed event before capturing the checkpoint. It also renders changed files as a settled turn row after the turn's final visible work row, and replaces checkpoints created by older versions if completion arrives later.

Tests:
- `vp test run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts apps/server/src/orchestration/Layers/CheckpointReactor.test.ts`
- `vp test run apps/web/src/components/chat/MessagesTimeline.logic.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx`
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/web typecheck`
- focused lint and formatting checks for the changed files

Built with gpt-5.6-sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration checkpoint timing and turn identity logic; mis-tracked turns could skip or replace checkpoints, though extensive new reactor tests cover steer, stale events, and legacy mid-turn data.
> 
> **Overview**
> Turn checkpoints and changed-files UI no longer react to mid-turn Codex diff updates. **Checkpoint capture** waits for `turn.completed`, and **ProviderRuntimeIngestion** stops emitting placeholder `thread.turn.diff.complete` events on `turn.diff.updated`.
> 
> **CheckpointReactor** tracks the primary turn per thread at runtime (`rememberRuntimeTurnStart`, projection turns, provider `activeTurnId`) so completion git capture ignores auxiliary or stale turns but still runs when the session has already advanced. It drops the `thread.turn-diff-completed` domain handler and **re-captures** when an older mid-turn checkpoint’s `completedAt` does not match the completion event.
> 
> **Chat timeline** keys diff summaries by `turnId`, adds a `turn-diff` row after the turn’s last visible row (including folded work), and hides changed files while the turn is still unsettled. The changed-files card moves out of assistant message bubbles into that row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe5f8cd57032918d257a03ae209fa44fc0572a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show turn diffs in dedicated timeline rows after work completes and gate checkpoint capture to active turn
> - Moves changed-files display from assistant message rows into a new `turn-diff` row kind in `MessagesTimeline`, placed after a turn's final work row when the turn is settled and has file changes. Renames the prop `turnDiffSummaryByAssistantMessageId` to `turnDiffSummaryByTurnId` across [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/8315/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8315/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), and [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/8315/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe). The new `TurnDiffTimelineRow` persists expand/collapse state keyed by route and turn.
> - Reworks checkpoint capture in [CheckpointReactor.ts](https://github.com/pingdotgg/t3code/pull/8315/files#diff-79dc41615f79575ae1404bd102df915797fb24ba34989557f80e229d305521fb): completion checkpoints are now gated to the thread's primary active runtime turn (tracked via `rememberRuntimeTurnStart`), duplicate completions with matching `completedAt` are skipped, and legacy mid-turn placeholder captures are replaced on completion. The reactor stops subscribing to `thread.turn-diff-completed` domain events.
> - Removes mid-turn diff placeholder checkpoint dispatch from [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/8315/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7); `turn.diff.updated` events no longer produce checkpoint entries.
> - Behavioral Change: `MessagesTimelineRow` type removes `assistantTurnDiffSummary` from the `message` variant and adds `turnId` to `work-toggle` rows; `deriveMessagesTimelineRows` no longer annotates assistant messages with diff summaries. Checkpoint capture now requires an active runtime turn match, so stale or non-primary turns will not produce completion checkpoints.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe5f8cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->