### PR TITLE
fix(server): bridge Codex Computer Use on Windows

### DIFF
--- a/apps/server/src/provider/CodexComputerUseBridge.test.ts
+++ b/apps/server/src/provider/CodexComputerUseBridge.test.ts
@@ -1,0 +1,385 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeAssert from "node:assert/strict";
+import * as NodeCrypto from "node:crypto";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeNet from "node:net";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import {
+  COMPUTER_USE_SHIM_SHA256,
+  COMPUTER_USE_SHIM_SOURCE,
+  findComputerUseHelper,
+  makeCodexComputerUseBridge,
+  materializeComputerUseShim,
+} from "./CodexComputerUseBridge.ts";
+
+interface ShimPipeRequest {
+  readonly id: number;
+  readonly method: string;
+  readonly params: unknown;
+  readonly meta: Record<string, unknown>;
+}
+
+interface ShimElicitation {
+  readonly message: string;
+  readonly meta: Record<string, unknown>;
+}
+
+interface ShimSky {
+  readonly list_apps: () => Promise<unknown>;
+  readonly get_window_state: (input: {
+    readonly window: { readonly id: number };
+    readonly include_screenshot: boolean;
+    readonly include_text: boolean;
+  }) => Promise<unknown>;
+}
+
+let shimImportId = 0;
+
+async function withExecutableShim(
+  requireApproval: boolean,
+  run: (context: {
+    readonly sky: ShimSky;
+    readonly requests: ReadonlyArray<ShimPipeRequest>;
+    readonly elicitations: ReadonlyArray<ShimElicitation>;
+  }) => Promise<void>,
+): Promise<void> {
+  const previousNodeRepl = Object.getOwnPropertyDescriptor(globalThis, "nodeRepl");
+  const previousPipePath = process.env.T3_CODEX_COMPUTER_USE_PIPE_PATH;
+  const requests: ShimPipeRequest[] = [];
+  const elicitations: ShimElicitation[] = [];
+  let onData: ((chunk: Uint8Array) => void) | undefined;
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const connection = {
+    on(event: string, listener: (value: Uint8Array) => void) {
+      if (event === "data") onData = listener;
+      return connection;
+    },
+    write(chunk: Uint8Array) {
+      const request = JSON.parse(decoder.decode(chunk)) as ShimPipeRequest;
+      requests.push(request);
+      const approved = request.meta["x-oai-cua-approved-app"] === "t3code.exe";
+      const response =
+        requireApproval && !approved
+          ? {
+              id: request.id,
+              ok: false,
+              approvalRequest: {
+                app: "t3code.exe",
+                displayName: "T3 Code",
+                riskLevel: "low",
+              },
+            }
+          : {
+              id: request.id,
+              ok: true,
+              result: requireApproval
+                ? { screenshots: [], text: "approved" }
+                : [{ name: "T3 Code" }],
+            };
+      queueMicrotask(() => onData?.(encoder.encode(`${JSON.stringify(response)}\n`)));
+      return true;
+    },
+  };
+
+  Object.defineProperty(globalThis, "nodeRepl", {
+    configurable: true,
+    value: {
+      requestMeta: { session_id: "session-1", turn_id: "turn-1" },
+      nativePipe: { createConnection: async () => connection },
+      createElicitation: async (request: ShimElicitation) => {
+        elicitations.push(request);
+        return { action: "accept" };
+      },
+      emitImage: async () => undefined,
+    },
+  });
+  process.env.T3_CODEX_COMPUTER_USE_PIPE_PATH = "\\\\.\\pipe\\t3code-cua-test";
+
+  try {
+    const moduleUrl = `data:text/javascript;base64,${Buffer.from(COMPUTER_USE_SHIM_SOURCE).toString("base64")}#executable-shim-${++shimImportId}`;
+    const loaded = (await import(moduleUrl)) as unknown as { readonly sky: ShimSky };
+    await run({ sky: loaded.sky, requests, elicitations });
+  } finally {
+    if (previousNodeRepl) {
+      Object.defineProperty(globalThis, "nodeRepl", previousNodeRepl);
+    } else {
+      Reflect.deleteProperty(globalThis, "nodeRepl");
+    }
+    if (previousPipePath === undefined) {
+      delete process.env.T3_CODEX_COMPUTER_USE_PIPE_PATH;
+    } else {
+      process.env.T3_CODEX_COMPUTER_USE_PIPE_PATH = previousPipePath;
+    }
+  }
+}
+
+function makeHelperSpawner(control: {
+  readonly commands: Array<ChildProcess.Command>;
+  killCount: number;
+}) {
+  return ChildProcessSpawner.make((command) =>
+    Effect.gen(function* () {
+      control.commands.push(command);
+      const output = yield* Queue.unbounded<Uint8Array>();
+      const exited = yield* Deferred.make<ChildProcessSpawner.ExitCode>();
+      const decoder = new TextDecoder();
+      const encoder = new TextEncoder();
+      let receiveBuffer = "";
+      let killed = false;
+
+      const kill = () =>
+        Effect.gen(function* () {
+          if (killed) return;
+          killed = true;
+          control.killCount += 1;
+          yield* Deferred.succeed(exited, ChildProcessSpawner.ExitCode(0));
+          yield* Queue.shutdown(output);
+        });
+      const handle = ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(1234),
+        exitCode: Deferred.await(exited),
+        isRunning: Effect.sync(() => !killed),
+        kill,
+        unref: Effect.succeed(Effect.void),
+        stdin: Sink.forEach((chunk: Uint8Array) => {
+          receiveBuffer += decoder.decode(chunk, { stream: true });
+          const responses: Uint8Array[] = [];
+          for (;;) {
+            const newline = receiveBuffer.indexOf("\n");
+            if (newline < 0) break;
+            const line = receiveBuffer.slice(0, newline).trim();
+            receiveBuffer = receiveBuffer.slice(newline + 1);
+            if (!line) continue;
+            const request = JSON.parse(line) as ShimPipeRequest;
+            responses.push(
+              encoder.encode(
+                `${JSON.stringify({ id: request.id, ok: true, result: [{ name: "T3 Code" }] })}\n`,
+              ),
+            );
+          }
+          return Effect.forEach(responses, (response) => Queue.offer(output, response), {
+            discard: true,
+          });
+        }),
+        stdout: Stream.fromQueue(output),
+        stderr: Stream.empty,
+        all: Stream.empty,
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+      });
+
+      return yield* Effect.acquireRelease(Effect.succeed(handle), kill);
+    }),
+  );
+}
+
+function requestNamedPipe(pipePath: string): Promise<{
+  readonly response: unknown;
+  readonly closed: Promise<void>;
+}> {
+  return new Promise((resolve, reject) => {
+    const socket = NodeNet.createConnection(pipePath);
+    const decoder = new TextDecoder();
+    let receiveBuffer = "";
+    const closed = new Promise<void>((resolveClosed) => socket.once("close", resolveClosed));
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      socket.write(`${JSON.stringify({ id: 1, method: "list_apps", params: {}, meta: {} })}\n`);
+    });
+    socket.on("data", (chunk) => {
+      receiveBuffer += decoder.decode(chunk, { stream: true });
+      const newline = receiveBuffer.indexOf("\n");
+      if (newline < 0) return;
+      resolve({ response: JSON.parse(receiveBuffer.slice(0, newline)), closed });
+    });
+  });
+}
+
+function connectNamedPipe(pipePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = NodeNet.createConnection(pipePath);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve();
+    });
+    socket.once("error", reject);
+  });
+}
+
+describe("CodexComputerUseBridge", () => {
+  it("routes list_apps through the trusted native-pipe shim", () =>
+    withExecutableShim(false, async ({ sky, requests }) => {
+      NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
+      NodeAssert.deepStrictEqual(requests, [
+        {
+          id: 1,
+          method: "list_apps",
+          params: {},
+          meta: {
+            session_id: "session-1",
+            turn_id: "turn-1",
+          },
+        },
+      ]);
+    }));
+
+  it("requests approval and retries the same helper call with approval metadata", () =>
+    withExecutableShim(true, async ({ sky, requests, elicitations }) => {
+      NodeAssert.deepStrictEqual(
+        await sky.get_window_state({
+          window: { id: 7 },
+          include_screenshot: false,
+          include_text: true,
+        }),
+        { screenshots: [], text: "approved" },
+      );
+      NodeAssert.deepStrictEqual(elicitations, [
+        {
+          message: "Allow Codex to use T3 Code?",
+          meta: {
+            codex_approval_kind: "mcp_tool_call",
+            connector_id: "computer-use",
+            connector_name: "Computer Use",
+            persist: ["session", "always"],
+            riskLevel: "low",
+            tool_params: { app: "t3code.exe" },
+            tool_params_display: [{ name: "app", display_name: "App", value: "T3 Code" }],
+          },
+        },
+      ]);
+      NodeAssert.equal(requests.length, 2);
+      NodeAssert.equal(requests[0]?.method, "get_window_state");
+      NodeAssert.deepStrictEqual(requests[1]?.params, requests[0]?.params);
+      NodeAssert.equal(requests[0]?.meta["x-oai-cua-approved-app"], undefined);
+      NodeAssert.equal(requests[1]?.meta["x-oai-cua-approved-app"], "t3code.exe");
+    }));
+
+  it("pins trust to the exact embedded shim bytes", () => {
+    NodeAssert.equal(
+      COMPUTER_USE_SHIM_SHA256,
+      NodeCrypto.createHash("sha256").update(COMPUTER_USE_SHIM_SOURCE).digest("hex"),
+    );
+    NodeAssert.doesNotMatch(COMPUTER_USE_SHIM_SOURCE, /^import\s/m);
+    NodeAssert.match(COMPUTER_USE_SHIM_SOURCE, /Object\.freeze\(sky\)/);
+  });
+
+  it.effect("materializes a content-addressed package", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-cua-shim-"))),
+      (codexHome) =>
+        Effect.gen(function* () {
+          const first = yield* materializeComputerUseShim(codexHome);
+          const second = yield* materializeComputerUseShim(codexHome);
+          NodeAssert.deepStrictEqual(second, first);
+          NodeAssert.equal(
+            yield* Effect.promise(() => NodeFSP.readFile(first.entryPath, "utf8")),
+            COMPUTER_USE_SHIM_SOURCE,
+          );
+        }),
+      (codexHome) => Effect.promise(() => NodeFSP.rm(codexHome, { recursive: true, force: true })),
+    ),
+  );
+
+  it.effect("proxies a named-pipe request and closes the scoped helper", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-cua-bridge-"))),
+      (root) =>
+        Effect.gen(function* () {
+          const nodeModulesRoot = NodePath.join(root, "node_modules");
+          const helperPath = NodePath.join(
+            nodeModulesRoot,
+            "@oai",
+            "sky",
+            "bin",
+            "windows",
+            "codex-computer-use.exe",
+          );
+          yield* Effect.promise(() =>
+            NodeFSP.mkdir(NodePath.dirname(helperPath), { recursive: true }),
+          );
+          yield* Effect.promise(() => NodeFSP.writeFile(helperPath, "helper", "utf8"));
+
+          const control = {
+            commands: [] as Array<ChildProcess.Command>,
+            killCount: 0,
+          };
+          const spawner = makeHelperSpawner(control);
+          const exchange = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const config = yield* makeCodexComputerUseBridge({
+                codexHome: NodePath.join(root, "codex-home"),
+                nodeModuleRoots: [nodeModulesRoot],
+              }).pipe(
+                Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+                Effect.provideService(
+                  HostProcessPlatform,
+                  NodePath.sep === "\\" ? "win32" : "linux",
+                ),
+              );
+              NodeAssert.ok(config);
+
+              const request = yield* Effect.promise(() => requestNamedPipe(config.pipePath));
+              return { ...request, pipePath: config.pipePath };
+            }),
+          );
+
+          NodeAssert.deepStrictEqual(exchange.response, {
+            id: 1,
+            ok: true,
+            result: [{ name: "T3 Code" }],
+          });
+          NodeAssert.equal(control.commands.length, 1);
+          const command = control.commands[0];
+          NodeAssert.equal(command?._tag, "StandardCommand");
+          if (command?._tag === "StandardCommand") {
+            NodeAssert.equal(command.command, helperPath);
+            NodeAssert.deepStrictEqual(command.args, ["--parent-pid", String(process.pid)]);
+            NodeAssert.equal(command.options.stderr, "ignore");
+          }
+          yield* Effect.promise(() => exchange.closed);
+          NodeAssert.equal(control.killCount, 1);
+          yield* Effect.promise(() => NodeAssert.rejects(connectNamedPipe(exchange.pipePath)));
+        }),
+      (root) => Effect.promise(() => NodeFSP.rm(root, { recursive: true, force: true })),
+    ),
+  );
+
+  it.effect("locates the helper under configured node module roots", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-cua-helper-"))),
+      (root) =>
+        Effect.gen(function* () {
+          const helperPath = NodePath.join(
+            root,
+            "@oai",
+            "sky",
+            "bin",
+            "windows",
+            "codex-computer-use.exe",
+          );
+          yield* Effect.promise(() =>
+            NodeFSP.mkdir(NodePath.dirname(helperPath), { recursive: true }),
+          );
+          yield* Effect.promise(() => NodeFSP.writeFile(helperPath, "helper", "utf8"));
+
+          NodeAssert.equal(
+            yield* findComputerUseHelper([NodePath.join(root, "missing"), root]),
+            helperPath,
+          );
+        }),
+      (root) => Effect.promise(() => NodeFSP.rm(root, { recursive: true, force: true })),
+    ),
+  );
+});

--- a/apps/server/src/provider/CodexComputerUseBridge.test.ts
+++ b/apps/server/src/provider/CodexComputerUseBridge.test.ts
@@ -52,6 +52,7 @@ interface ExecutableShimOptions {
   readonly approvalPersistence?: "session" | "always";
   readonly failedConnectionAttempts?: number;
   readonly dropFirstRequestWithPartialResponse?: boolean;
+  readonly closePreviousConnectionOnSecondRequest?: boolean;
 }
 
 async function withExecutableShim(
@@ -61,55 +62,69 @@ async function withExecutableShim(
     readonly requests: ReadonlyArray<ShimPipeRequest>;
     readonly elicitations: ReadonlyArray<ShimElicitation>;
     readonly connectionAttempts: () => number;
+    readonly closeConnection: (index: number) => void;
   }) => Promise<void>,
 ): Promise<void> {
   const previousNodeRepl = Object.getOwnPropertyDescriptor(globalThis, "nodeRepl");
   const previousPipePath = process.env.T3_CODEX_COMPUTER_USE_PIPE_PATH;
   const requests: ShimPipeRequest[] = [];
   const elicitations: ShimElicitation[] = [];
-  let onData: ((chunk: Uint8Array) => void) | undefined;
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   let connectionAttempts = 0;
-  let onClose: (() => void) | undefined;
-  const connection = {
-    on(event: string, listener: (value: Uint8Array) => void) {
-      if (event === "data") onData = listener;
-      if (event === "close") onClose = listener as () => void;
-      return connection;
-    },
-    write(chunk: Uint8Array) {
-      const request = JSON.parse(decoder.decode(chunk)) as ShimPipeRequest;
-      requests.push(request);
-      if (options.dropFirstRequestWithPartialResponse === true && requests.length === 1) {
-        queueMicrotask(() => {
-          onData?.(encoder.encode('{"id":'));
-          onClose?.();
-        });
+  const connections: Array<{ readonly close: () => void }> = [];
+  const makeConnection = () => {
+    const connectionIndex = connections.length;
+    let onData: ((chunk: Uint8Array) => void) | undefined;
+    let onClose: (() => void) | undefined;
+    const connection = {
+      on(event: string, listener: (value: Uint8Array) => void) {
+        if (event === "data") onData = listener;
+        if (event === "close") onClose = listener as () => void;
+        return connection;
+      },
+      write(chunk: Uint8Array) {
+        const request = JSON.parse(decoder.decode(chunk)) as ShimPipeRequest;
+        requests.push(request);
+        if (
+          options.closePreviousConnectionOnSecondRequest === true &&
+          connectionIndex === 1 &&
+          requests.length === 2
+        ) {
+          connections[0]?.close();
+        }
+        if (options.dropFirstRequestWithPartialResponse === true && requests.length === 1) {
+          queueMicrotask(() => {
+            onData?.(encoder.encode('{"id":'));
+            onClose?.();
+          });
+          return true;
+        }
+        const approved = request.meta["x-oai-cua-approved-app"] === "t3code.exe";
+        const response =
+          options.requireApproval && !approved
+            ? {
+                id: request.id,
+                ok: false,
+                approvalRequest: {
+                  app: "t3code.exe",
+                  displayName: "T3 Code",
+                  riskLevel: "low",
+                },
+              }
+            : {
+                id: request.id,
+                ok: true,
+                result: options.requireApproval
+                  ? { screenshots: [], text: "approved" }
+                  : [{ name: "T3 Code" }],
+              };
+        queueMicrotask(() => onData?.(encoder.encode(`${JSON.stringify(response)}\n`)));
         return true;
-      }
-      const approved = request.meta["x-oai-cua-approved-app"] === "t3code.exe";
-      const response =
-        options.requireApproval && !approved
-          ? {
-              id: request.id,
-              ok: false,
-              approvalRequest: {
-                app: "t3code.exe",
-                displayName: "T3 Code",
-                riskLevel: "low",
-              },
-            }
-          : {
-              id: request.id,
-              ok: true,
-              result: options.requireApproval
-                ? { screenshots: [], text: "approved" }
-                : [{ name: "T3 Code" }],
-            };
-      queueMicrotask(() => onData?.(encoder.encode(`${JSON.stringify(response)}\n`)));
-      return true;
-    },
+      },
+    };
+    connections.push({ close: () => onClose?.() });
+    return connection;
   };
 
   Object.defineProperty(globalThis, "nodeRepl", {
@@ -122,7 +137,7 @@ async function withExecutableShim(
           if (connectionAttempts <= (options.failedConnectionAttempts ?? 0)) {
             throw new Error("Computer Use pipe is not ready");
           }
-          return connection;
+          return makeConnection();
         },
       },
       createElicitation: async (request: ShimElicitation) => {
@@ -145,6 +160,7 @@ async function withExecutableShim(
       requests,
       elicitations,
       connectionAttempts: () => connectionAttempts,
+      closeConnection: (index) => connections[index]?.close(),
     });
   } finally {
     if (previousNodeRepl) {
@@ -320,6 +336,17 @@ describe("CodexComputerUseBridge", () => {
         NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
         NodeAssert.equal(connectionAttempts(), 2);
         NodeAssert.equal(requests.length, 2);
+      },
+    ));
+
+  it("ignores a stale close event after reconnecting", () =>
+    withExecutableShim(
+      { requireApproval: false, closePreviousConnectionOnSecondRequest: true },
+      async ({ sky, connectionAttempts, closeConnection }) => {
+        NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
+        closeConnection(0);
+        NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
+        NodeAssert.equal(connectionAttempts(), 2);
       },
     ));
 

--- a/apps/server/src/provider/CodexComputerUseBridge.test.ts
+++ b/apps/server/src/provider/CodexComputerUseBridge.test.ts
@@ -6,6 +6,7 @@ import * as NodeNet from "node:net";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, it } from "@effect/vitest";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Deferred from "effect/Deferred";
@@ -46,12 +47,20 @@ interface ShimSky {
 
 let shimImportId = 0;
 
+interface ExecutableShimOptions {
+  readonly requireApproval: boolean;
+  readonly approvalPersistence?: "session" | "always";
+  readonly failedConnectionAttempts?: number;
+  readonly dropFirstRequestWithPartialResponse?: boolean;
+}
+
 async function withExecutableShim(
-  requireApproval: boolean,
+  options: ExecutableShimOptions,
   run: (context: {
     readonly sky: ShimSky;
     readonly requests: ReadonlyArray<ShimPipeRequest>;
     readonly elicitations: ReadonlyArray<ShimElicitation>;
+    readonly connectionAttempts: () => number;
   }) => Promise<void>,
 ): Promise<void> {
   const previousNodeRepl = Object.getOwnPropertyDescriptor(globalThis, "nodeRepl");
@@ -61,17 +70,27 @@ async function withExecutableShim(
   let onData: ((chunk: Uint8Array) => void) | undefined;
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
+  let connectionAttempts = 0;
+  let onClose: (() => void) | undefined;
   const connection = {
     on(event: string, listener: (value: Uint8Array) => void) {
       if (event === "data") onData = listener;
+      if (event === "close") onClose = listener as () => void;
       return connection;
     },
     write(chunk: Uint8Array) {
       const request = JSON.parse(decoder.decode(chunk)) as ShimPipeRequest;
       requests.push(request);
+      if (options.dropFirstRequestWithPartialResponse === true && requests.length === 1) {
+        queueMicrotask(() => {
+          onData?.(encoder.encode('{"id":'));
+          onClose?.();
+        });
+        return true;
+      }
       const approved = request.meta["x-oai-cua-approved-app"] === "t3code.exe";
       const response =
-        requireApproval && !approved
+        options.requireApproval && !approved
           ? {
               id: request.id,
               ok: false,
@@ -84,7 +103,7 @@ async function withExecutableShim(
           : {
               id: request.id,
               ok: true,
-              result: requireApproval
+              result: options.requireApproval
                 ? { screenshots: [], text: "approved" }
                 : [{ name: "T3 Code" }],
             };
@@ -97,10 +116,21 @@ async function withExecutableShim(
     configurable: true,
     value: {
       requestMeta: { session_id: "session-1", turn_id: "turn-1" },
-      nativePipe: { createConnection: async () => connection },
+      nativePipe: {
+        createConnection: async () => {
+          connectionAttempts += 1;
+          if (connectionAttempts <= (options.failedConnectionAttempts ?? 0)) {
+            throw new Error("Computer Use pipe is not ready");
+          }
+          return connection;
+        },
+      },
       createElicitation: async (request: ShimElicitation) => {
         elicitations.push(request);
-        return { action: "accept" };
+        return {
+          action: "accept",
+          _meta: { persist: options.approvalPersistence ?? "session" },
+        };
       },
       emitImage: async () => undefined,
     },
@@ -110,7 +140,12 @@ async function withExecutableShim(
   try {
     const moduleUrl = `data:text/javascript;base64,${Buffer.from(COMPUTER_USE_SHIM_SOURCE).toString("base64")}#executable-shim-${++shimImportId}`;
     const loaded = (await import(moduleUrl)) as unknown as { readonly sky: ShimSky };
-    await run({ sky: loaded.sky, requests, elicitations });
+    await run({
+      sky: loaded.sky,
+      requests,
+      elicitations,
+      connectionAttempts: () => connectionAttempts,
+    });
   } finally {
     if (previousNodeRepl) {
       Object.defineProperty(globalThis, "nodeRepl", previousNodeRepl);
@@ -220,7 +255,7 @@ function connectNamedPipe(pipePath: string): Promise<void> {
 
 describe("CodexComputerUseBridge", () => {
   it("routes list_apps through the trusted native-pipe shim", () =>
-    withExecutableShim(false, async ({ sky, requests }) => {
+    withExecutableShim({ requireApproval: false }, async ({ sky, requests }) => {
       NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
       NodeAssert.deepStrictEqual(requests, [
         {
@@ -236,7 +271,7 @@ describe("CodexComputerUseBridge", () => {
     }));
 
   it("requests approval and retries the same helper call with approval metadata", () =>
-    withExecutableShim(true, async ({ sky, requests, elicitations }) => {
+    withExecutableShim({ requireApproval: true }, async ({ sky, requests, elicitations }) => {
       NodeAssert.deepStrictEqual(
         await sky.get_window_state({
           window: { id: 7 },
@@ -266,6 +301,47 @@ describe("CodexComputerUseBridge", () => {
       NodeAssert.equal(requests[1]?.meta["x-oai-cua-approved-app"], "t3code.exe");
     }));
 
+  it("retries the native pipe connection after an initial failure", () =>
+    withExecutableShim(
+      { requireApproval: false, failedConnectionAttempts: 1 },
+      async ({ sky, requests, connectionAttempts }) => {
+        await NodeAssert.rejects(sky.list_apps(), /Computer Use pipe is not ready/);
+        NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
+        NodeAssert.equal(connectionAttempts(), 2);
+        NodeAssert.equal(requests.length, 1);
+      },
+    ));
+
+  it("discards partial responses when reconnecting", () =>
+    withExecutableShim(
+      { requireApproval: false, dropFirstRequestWithPartialResponse: true },
+      async ({ sky, requests, connectionAttempts }) => {
+        await NodeAssert.rejects(sky.list_apps(), /Computer Use pipe closed/);
+        NodeAssert.deepStrictEqual(await sky.list_apps(), [{ name: "T3 Code" }]);
+        NodeAssert.equal(connectionAttempts(), 2);
+        NodeAssert.equal(requests.length, 2);
+      },
+    ));
+
+  it("remembers always-allow approval for later calls", () =>
+    withExecutableShim(
+      { requireApproval: true, approvalPersistence: "always" },
+      async ({ sky, requests, elicitations }) => {
+        const input = {
+          window: { id: 7 },
+          include_screenshot: false,
+          include_text: true,
+        };
+        await sky.get_window_state(input);
+        await sky.get_window_state(input);
+
+        NodeAssert.equal(elicitations.length, 1);
+        NodeAssert.equal(requests.length, 4);
+        NodeAssert.equal(requests[1]?.meta["x-oai-cua-approved-app"], "t3code.exe");
+        NodeAssert.equal(requests[3]?.meta["x-oai-cua-approved-app"], "t3code.exe");
+      },
+    ));
+
   it("pins trust to the exact embedded shim bytes", () => {
     NodeAssert.equal(
       COMPUTER_USE_SHIM_SHA256,
@@ -289,7 +365,7 @@ describe("CodexComputerUseBridge", () => {
           );
         }),
       (codexHome) => Effect.promise(() => NodeFSP.rm(codexHome, { recursive: true, force: true })),
-    ),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("proxies a named-pipe request and closes the scoped helper", () =>
@@ -327,6 +403,7 @@ describe("CodexComputerUseBridge", () => {
                   HostProcessPlatform,
                   NodePath.sep === "\\" ? "win32" : "linux",
                 ),
+                Effect.provide(NodeServices.layer),
               );
               NodeAssert.ok(config);
 
@@ -380,6 +457,6 @@ describe("CodexComputerUseBridge", () => {
           );
         }),
       (root) => Effect.promise(() => NodeFSP.rm(root, { recursive: true, force: true })),
-    ),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/provider/CodexComputerUseBridge.ts
+++ b/apps/server/src/provider/CodexComputerUseBridge.ts
@@ -1,0 +1,520 @@
+import * as NodeCrypto from "node:crypto";
+import * as NodeNet from "node:net";
+import * as NodeOS from "node:os";
+
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import * as NodeSink from "@effect/platform-node/NodeSink";
+import * as NodeStream from "@effect/platform-node/NodeStream";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as FiberSet from "effect/FiberSet";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+const COMPUTER_USE_HELPER_PATH_SEGMENTS = [
+  "@oai",
+  "sky",
+  "bin",
+  "windows",
+  "codex-computer-use.exe",
+] as const;
+const COMPUTER_USE_SHIM_PACKAGE_JSON = `${JSON.stringify({
+  name: "@oai/sky",
+  private: true,
+  type: "module",
+  exports: "./index.js",
+})}\n`;
+const ComputerUseFileSystemLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+// Codex trusts this module by its exact SHA-256. Keep it self-contained so
+// importing the shim does not expand the trusted module graph.
+export const COMPUTER_USE_SHIM_SOURCE = String.raw`const nodeRepl = globalThis.nodeRepl;
+const processShim = globalThis.process;
+const pipePath = processShim?.env?.T3_CODEX_COMPUTER_USE_PIPE_PATH;
+if (!nodeRepl?.nativePipe || typeof nodeRepl.nativePipe.createConnection !== "function") {
+  throw new Error("T3 Computer Use trusted native-pipe bridge is unavailable");
+}
+if (typeof pipePath !== "string" || !pipePath.startsWith("\\\\.\\pipe\\t3code-cua-")) {
+  throw new Error("T3 Computer Use pipe configuration is unavailable");
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const pending = new Map();
+const sessionApprovedScopes = new Set();
+let connectionPromise;
+let receiveBuffer = "";
+let nextRequestId = 1;
+let activeTurnKey = null;
+let activeTurnMetadata = null;
+
+const sanitizeError = (value) => {
+  const text = value && typeof value.message === "string" ? value.message : String(value);
+  return text.slice(0, 2000);
+};
+
+const inertClone = (value, label) => {
+  let encoded;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw new TypeError(label + " must be JSON-serializable");
+  }
+  if (typeof encoded !== "string" || encoded.length > 16 * 1024 * 1024) {
+    throw new TypeError(label + " is too large");
+  }
+  return JSON.parse(encoded);
+};
+
+const deepFreeze = (value) => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+};
+
+const currentTurnMetadata = () => {
+  const merged = Object.create(null);
+  const merge = (candidate) => {
+    let value = candidate;
+    if (typeof value === "string") {
+      try { value = JSON.parse(value); } catch { value = null; }
+    }
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      for (const [key, entry] of Object.entries(value)) merged[key] = entry;
+    }
+  };
+  merge(processShim?.env?.NODE_REPL_REQUEST_META);
+  merge(nodeRepl.requestMeta);
+  const nested = merged["x-codex-turn-metadata"];
+  delete merged["x-codex-turn-metadata"];
+  merge(nested);
+  delete merged["x-oai-cua-approved-app"];
+  return inertClone(merged, "Computer Use turn metadata");
+};
+
+const turnKey = (metadata) => {
+  const sessionId = typeof metadata.session_id === "string" ? metadata.session_id : "";
+  const turnId = typeof metadata.turn_id === "string" ? metadata.turn_id : "";
+  return sessionId && turnId ? sessionId + "\u0000" + turnId : null;
+};
+
+const approvalScopeKey = (sessionId, app, method, params) => {
+  const windowTarget =
+    params && typeof params === "object" && !Array.isArray(params) ? params.window : undefined;
+  if (windowTarget && typeof windowTarget === "object" && !Array.isArray(windowTarget)) {
+    const windowId = windowTarget.id;
+    return JSON.stringify(
+      typeof windowId === "number" || typeof windowId === "string"
+        ? { sessionId, app, windowId }
+        : { sessionId, app, window: windowTarget },
+    );
+  }
+  return JSON.stringify({ sessionId, app, method, params });
+};
+
+const handleLine = (line) => {
+  let message;
+  try { message = JSON.parse(line); } catch { return; }
+  if (!message || typeof message.id !== "number") return;
+  const waiter = pending.get(message.id);
+  if (!waiter) return;
+  pending.delete(message.id);
+  clearTimeout(waiter.timeout);
+  waiter.resolve(message);
+};
+
+const getConnection = async () => {
+  if (!connectionPromise) {
+    connectionPromise = nodeRepl.nativePipe.createConnection(pipePath).then((connection) => {
+      connection.on("data", (chunk) => {
+        receiveBuffer += decoder.decode(chunk, { stream: true });
+        for (;;) {
+          const newline = receiveBuffer.indexOf("\n");
+          if (newline < 0) break;
+          const line = receiveBuffer.slice(0, newline).trim();
+          receiveBuffer = receiveBuffer.slice(newline + 1);
+          if (line) handleLine(line);
+        }
+      });
+      const rejectAll = (reason) => {
+        const message = sanitizeError(reason || "Computer Use pipe closed");
+        connectionPromise = undefined;
+        for (const waiter of pending.values()) {
+          clearTimeout(waiter.timeout);
+          waiter.reject(new Error(message));
+        }
+        pending.clear();
+      };
+      connection.on("error", rejectAll);
+      connection.on("close", () => rejectAll("Computer Use pipe closed"));
+      return connection;
+    });
+  }
+  return connectionPromise;
+};
+
+const send = async (method, params, metadata) => {
+  const connection = await getConnection();
+  const id = nextRequestId++;
+  const request = JSON.stringify({ id, method, params, meta: metadata }) + "\n";
+  const response = new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error("Computer Use request timed out: " + method));
+    }, method === "launch_app" ? 15000 : 10000);
+    pending.set(id, { resolve, reject, timeout });
+  });
+  try {
+    connection.write(encoder.encode(request));
+  } catch (error) {
+    const waiter = pending.get(id);
+    if (waiter) clearTimeout(waiter.timeout);
+    pending.delete(id);
+    throw error;
+  }
+  return response;
+};
+
+const invoke = async (method, rawParams) => {
+  const params = inertClone(rawParams ?? {}, "Computer Use input");
+  const metadata = currentTurnMetadata();
+  const nextTurnKey = turnKey(metadata);
+  if (activeTurnKey && activeTurnKey !== nextTurnKey) {
+    try { await send("end_turn", {}, activeTurnMetadata ?? {}); } catch {}
+  }
+  activeTurnKey = nextTurnKey;
+  activeTurnMetadata = metadata;
+
+  let response = await send(method, params, metadata);
+  if (response?.ok !== true && response?.approvalRequest) {
+    const request = response.approvalRequest;
+    const app = typeof request.app === "string" ? request.app.trim() : "";
+    const displayName =
+      typeof request.displayName === "string" && request.displayName.trim()
+        ? request.displayName.trim()
+        : app;
+    if (!app) throw new Error("Computer Use returned an invalid approval request");
+    const approvalScope = approvalScopeKey(metadata.session_id ?? null, app, method, params);
+
+    if (!sessionApprovedScopes.has(approvalScope)) {
+      const createElicitation = nodeRepl.createElicitation;
+      if (typeof createElicitation !== "function") {
+        throw new Error("Computer Use requires app approval but elicitations are unavailable");
+      }
+      const decision = await createElicitation({
+        message: "Allow Codex to use " + displayName + "?",
+        meta: {
+          codex_approval_kind: "mcp_tool_call",
+          connector_id: "computer-use",
+          connector_name: "Computer Use",
+          persist: ["session", "always"],
+          riskLevel: request.riskLevel === "high" ? "high" : "low",
+          tool_params: { app },
+          tool_params_display: [{ name: "app", display_name: "App", value: displayName }],
+        },
+      });
+      if (decision?.action !== "accept") {
+        throw new Error("Computer Use was not approved to use " + displayName);
+      }
+      if (decision?._meta?.persist === "session") sessionApprovedScopes.add(approvalScope);
+    }
+
+    const approvedMetadata = inertClone(metadata, "Computer Use metadata");
+    approvedMetadata["x-oai-cua-approved-app"] = app;
+    response = await send(method, params, approvedMetadata);
+  }
+
+  if (response?.ok !== true) {
+    throw new Error(
+      typeof response?.error === "string"
+        ? response.error.slice(0, 2000)
+        : "Computer Use request failed",
+    );
+  }
+  const result = inertClone(response.result ?? null, "Computer Use result");
+  if (method === "get_window_state" && Array.isArray(result?.screenshots)) {
+    for (const screenshot of result.screenshots) {
+      if (typeof screenshot?.url === "string") await nodeRepl.emitImage(screenshot.url);
+    }
+  }
+  return deepFreeze(result);
+};
+
+const requireRecord = (value, label) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(label + " must be an object");
+  }
+  return value;
+};
+
+const method = (name, map = (value) => requireRecord(value, name + " input")) =>
+  Object.freeze(async (value) => invoke(name, map(value)));
+const noInputMethod = (name) => Object.freeze(async () => invoke(name, {}));
+
+const sky = Object.assign(Object.create(null), {
+  list_windows: noInputMethod("list_windows"),
+  list_apps: noInputMethod("list_apps"),
+  get_window: method("get_window"),
+  activate_window: method("activate_window"),
+  get_window_state: method("get_window_state", (value) => {
+    const input = requireRecord(value, "get_window_state input");
+    return {
+      window: input.window,
+      include_screenshot: input.include_screenshot !== false,
+      include_text: input.include_text === true,
+    };
+  }),
+  click: Object.freeze(async (value) => {
+    const input = requireRecord(value, "click input");
+    const element = input.element_index ?? input.elementIndex ?? input.element;
+    if (element !== undefined) {
+      return invoke("click_element", {
+        window: input.window,
+        element_index: element,
+        click_count: input.click_count ?? 1,
+        mouse_button: input.mouse_button ?? "left",
+      });
+    }
+    return invoke("click", {
+      window: input.window,
+      x: input.x,
+      y: input.y,
+      screenshotId: input.screenshotId,
+      click_count: input.click_count ?? 1,
+      mouse_button: input.mouse_button ?? "left",
+    });
+  }),
+  scroll: method("scroll"),
+  drag: method("drag"),
+  press_key: method("press_key"),
+  type_text: method("type_text"),
+  launch_app: method("launch_app"),
+  perform_secondary_action: method("perform_secondary_action"),
+  set_value: method("set_value"),
+});
+Object.freeze(sky);
+export { sky };
+`;
+
+export const COMPUTER_USE_SHIM_SHA256 = NodeCrypto.createHash("sha256")
+  .update(COMPUTER_USE_SHIM_SOURCE)
+  .digest("hex");
+
+// The native pipe capability is available only to SHA-pinned trusted modules.
+// If the node_repl sandbox ever exposes raw pipe access, this bridge will also
+// need to authenticate clients before forwarding requests to the helper.
+export interface CodexComputerUseBridgeConfig {
+  readonly nodeModulesRoot: string;
+  readonly trustedModuleSha256: string;
+  readonly pipePath: string;
+}
+
+export interface CodexComputerUseBridgeInput {
+  readonly codexHome: string;
+  readonly nodeModuleRoots: ReadonlyArray<string>;
+}
+
+export class CodexComputerUseBridgeError extends Schema.TaggedErrorClass<CodexComputerUseBridgeError>()(
+  "CodexComputerUseBridgeError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to start the T3 Computer Use bridge";
+  }
+}
+
+export const findComputerUseHelper = Effect.fn("findComputerUseHelper")(function* (
+  nodeModuleRoots: ReadonlyArray<string>,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  for (const root of nodeModuleRoots) {
+    const candidate = path.join(root, ...COMPUTER_USE_HELPER_PATH_SEGMENTS);
+    const info = yield* fileSystem.stat(candidate).pipe(Effect.option);
+    if (Option.isSome(info) && info.value.type === "File") return candidate;
+  }
+  return undefined;
+}, Effect.provide(ComputerUseFileSystemLayer));
+
+const writeFileExactly = Effect.fn("writeFileExactly")(function* (
+  filePath: string,
+  content: string,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const existing = yield* fileSystem.readFileString(filePath).pipe(Effect.option);
+  if (Option.isSome(existing)) {
+    if (existing.value !== content) {
+      return yield* new CodexComputerUseBridgeError({
+        cause: `Refusing to use mismatched Computer Use shim: ${filePath}`,
+      });
+    }
+    return;
+  }
+
+  const temporaryPath = `${filePath}.${NodeCrypto.randomUUID()}.tmp`;
+  yield* fileSystem.writeFileString(temporaryPath, content, { flag: "wx" });
+  yield* fileSystem.link(temporaryPath, filePath).pipe(
+    Effect.catchIf(
+      (error) => error.reason._tag === "AlreadyExists",
+      () =>
+        fileSystem.readFileString(filePath).pipe(
+          Effect.flatMap((current) =>
+            current === content
+              ? Effect.void
+              : new CodexComputerUseBridgeError({
+                  cause: `Refusing to use mismatched Computer Use shim: ${filePath}`,
+                }),
+          ),
+        ),
+    ),
+    Effect.ensuring(fileSystem.remove(temporaryPath, { force: true }).pipe(Effect.ignore)),
+  );
+});
+
+export const materializeComputerUseShim = Effect.fn("materializeComputerUseShim")(
+  function* (codexHome: string) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const nodeModulesRoot = path.join(
+      codexHome,
+      "cache",
+      "t3-code",
+      "cua-shim",
+      COMPUTER_USE_SHIM_SHA256,
+      "node_modules",
+    );
+    const packageDirectory = path.join(nodeModulesRoot, "@oai", "sky");
+    yield* fileSystem.makeDirectory(packageDirectory, { recursive: true });
+    const entryPath = path.join(packageDirectory, "index.js");
+    yield* writeFileExactly(entryPath, COMPUTER_USE_SHIM_SOURCE);
+    yield* writeFileExactly(
+      path.join(packageDirectory, "package.json"),
+      COMPUTER_USE_SHIM_PACKAGE_JSON,
+    );
+    return { nodeModulesRoot, entryPath };
+  },
+  Effect.mapError((cause) => new CodexComputerUseBridgeError({ cause })),
+  Effect.provide(ComputerUseFileSystemLayer),
+);
+
+function listenNamedPipe(
+  server: NodeNet.Server,
+  pipePath: string,
+): Effect.Effect<void, CodexComputerUseBridgeError> {
+  return Effect.callback<void, CodexComputerUseBridgeError>((resume) => {
+    const onError = (cause: Error) => {
+      server.off("listening", onListening);
+      resume(Effect.fail(new CodexComputerUseBridgeError({ cause })));
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resume(Effect.void);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(pipePath);
+    return Effect.sync(() => {
+      server.off("error", onError);
+      server.off("listening", onListening);
+    });
+  });
+}
+
+function closeNamedPipe(server: NodeNet.Server, sockets: Set<NodeNet.Socket>): Effect.Effect<void> {
+  return Effect.callback<void>((resume) => {
+    for (const socket of sockets) socket.destroy();
+    if (!server.listening) {
+      resume(Effect.void);
+      return;
+    }
+    server.close(() => resume(Effect.void));
+  });
+}
+
+export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge")(function* (
+  input: CodexComputerUseBridgeInput,
+) {
+  const helperPath = yield* findComputerUseHelper(input.nodeModuleRoots);
+  if (!helperPath) return undefined;
+
+  const shim = yield* materializeComputerUseShim(input.codexHome);
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const hostPlatform = yield* HostProcessPlatform;
+  const runConnection = yield* FiberSet.makeRuntime<never, void, never>();
+  const pipeId = NodeCrypto.randomUUID();
+  const pipePath =
+    hostPlatform === "win32"
+      ? `\\\\.\\pipe\\t3code-cua-${pipeId}`
+      : `${NodeOS.tmpdir().replace(/[\\/]+$/, "")}/t3code-cua-${pipeId}.sock`;
+  const sockets = new Set<NodeNet.Socket>();
+
+  const handleConnection = Effect.fn("CodexComputerUseBridge.handleConnection")(function* (
+    socket: NodeNet.Socket,
+  ) {
+    yield* Effect.acquireRelease(
+      Effect.sync(() => sockets.add(socket)),
+      () =>
+        Effect.sync(() => {
+          sockets.delete(socket);
+          if (!socket.destroyed) socket.destroy();
+        }),
+    );
+
+    const helper = yield* spawner.spawn(
+      ChildProcess.make(helperPath, ["--parent-pid", String(process.pid)], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "ignore",
+        forceKillAfter: "2 seconds",
+      }),
+    );
+    const socketInput = NodeStream.fromReadable<Uint8Array, CodexComputerUseBridgeError>({
+      evaluate: () => socket,
+      closeOnDone: false,
+      onError: (cause) => new CodexComputerUseBridgeError({ cause }),
+    });
+    const socketOutput = NodeSink.fromWritable<CodexComputerUseBridgeError>({
+      evaluate: () => socket,
+      endOnDone: false,
+      onError: (cause) => new CodexComputerUseBridgeError({ cause }),
+    });
+
+    yield* Effect.raceFirst(
+      Effect.all([Stream.run(socketInput, helper.stdin), Stream.run(helper.stdout, socketOutput)], {
+        concurrency: "unbounded",
+        discard: true,
+      }),
+      helper.exitCode,
+    ).pipe(Effect.ignore);
+  });
+
+  const server = NodeNet.createServer((socket) => {
+    runConnection(
+      handleConnection(socket).pipe(
+        Effect.scoped,
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Windows Computer Use bridge connection failed.", { cause }),
+        ),
+      ),
+    );
+  });
+  yield* Effect.acquireRelease(listenNamedPipe(server, pipePath), () =>
+    closeNamedPipe(server, sockets),
+  );
+
+  return {
+    nodeModulesRoot: shim.nodeModulesRoot,
+    trustedModuleSha256: COMPUTER_USE_SHIM_SHA256,
+    pipePath,
+  };
+});

--- a/apps/server/src/provider/CodexComputerUseBridge.ts
+++ b/apps/server/src/provider/CodexComputerUseBridge.ts
@@ -2,18 +2,18 @@ import * as NodeCrypto from "node:crypto";
 import * as NodeNet from "node:net";
 import * as NodeOS from "node:os";
 
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
-import * as NodePath from "@effect/platform-node/NodePath";
 import * as NodeSink from "@effect/platform-node/NodeSink";
 import * as NodeStream from "@effect/platform-node/NodeStream";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as FiberSet from "effect/FiberSet";
-import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
@@ -30,8 +30,6 @@ const COMPUTER_USE_SHIM_PACKAGE_JSON = `${JSON.stringify({
   type: "module",
   exports: "./index.js",
 })}\n`;
-const ComputerUseFileSystemLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
-
 // Codex trusts this module by its exact SHA-256. Keep it self-contained so
 // importing the shim does not expand the trusted module graph.
 export const COMPUTER_USE_SHIM_SOURCE = String.raw`const nodeRepl = globalThis.nodeRepl;
@@ -133,30 +131,37 @@ const handleLine = (line) => {
 
 const getConnection = async () => {
   if (!connectionPromise) {
-    connectionPromise = nodeRepl.nativePipe.createConnection(pipePath).then((connection) => {
-      connection.on("data", (chunk) => {
-        receiveBuffer += decoder.decode(chunk, { stream: true });
-        for (;;) {
-          const newline = receiveBuffer.indexOf("\n");
-          if (newline < 0) break;
-          const line = receiveBuffer.slice(0, newline).trim();
-          receiveBuffer = receiveBuffer.slice(newline + 1);
-          if (line) handleLine(line);
-        }
-      });
-      const rejectAll = (reason) => {
-        const message = sanitizeError(reason || "Computer Use pipe closed");
+    connectionPromise = nodeRepl.nativePipe
+      .createConnection(pipePath)
+      .then((connection) => {
+        connection.on("data", (chunk) => {
+          receiveBuffer += decoder.decode(chunk, { stream: true });
+          for (;;) {
+            const newline = receiveBuffer.indexOf("\n");
+            if (newline < 0) break;
+            const line = receiveBuffer.slice(0, newline).trim();
+            receiveBuffer = receiveBuffer.slice(newline + 1);
+            if (line) handleLine(line);
+          }
+        });
+        const rejectAll = (reason) => {
+          const message = sanitizeError(reason || "Computer Use pipe closed");
+          connectionPromise = undefined;
+          receiveBuffer = "";
+          for (const waiter of pending.values()) {
+            clearTimeout(waiter.timeout);
+            waiter.reject(new Error(message));
+          }
+          pending.clear();
+        };
+        connection.on("error", rejectAll);
+        connection.on("close", () => rejectAll("Computer Use pipe closed"));
+        return connection;
+      })
+      .catch((error) => {
         connectionPromise = undefined;
-        for (const waiter of pending.values()) {
-          clearTimeout(waiter.timeout);
-          waiter.reject(new Error(message));
-        }
-        pending.clear();
-      };
-      connection.on("error", rejectAll);
-      connection.on("close", () => rejectAll("Computer Use pipe closed"));
-      return connection;
-    });
+        throw error;
+      });
   }
   return connectionPromise;
 };
@@ -224,7 +229,12 @@ const invoke = async (method, rawParams) => {
       if (decision?.action !== "accept") {
         throw new Error("Computer Use was not approved to use " + displayName);
       }
-      if (decision?._meta?.persist === "session") sessionApprovedScopes.add(approvalScope);
+      if (
+        decision?._meta?.persist === "session" ||
+        decision?._meta?.persist === "always"
+      ) {
+        sessionApprovedScopes.add(approvalScope);
+      }
     }
 
     const approvedMetadata = inertClone(metadata, "Computer Use metadata");
@@ -325,11 +335,35 @@ export interface CodexComputerUseBridgeInput {
 export class CodexComputerUseBridgeError extends Schema.TaggedErrorClass<CodexComputerUseBridgeError>()(
   "CodexComputerUseBridgeError",
   {
+    operation: Schema.Literals(["listen", "read", "write"]),
+    pipePath: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return "Failed to start the T3 Computer Use bridge";
+    return `Failed to ${this.operation} the T3 Computer Use bridge pipe at '${this.pipePath}'.`;
+  }
+}
+
+export class ComputerUseShimFileSystemError extends Schema.TaggedErrorClass<ComputerUseShimFileSystemError>()(
+  "ComputerUseShimFileSystemError",
+  {
+    operation: Schema.Literals(["makeDirectory", "read", "write", "link"]),
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} the T3 Computer Use shim at '${this.path}'.`;
+  }
+}
+
+export class ComputerUseShimMismatchError extends Schema.TaggedErrorClass<ComputerUseShimMismatchError>()(
+  "ComputerUseShimMismatchError",
+  { path: Schema.String },
+) {
+  override get message(): string {
+    return `Refusing to use mismatched Computer Use shim at '${this.path}'.`;
   }
 }
 
@@ -344,68 +378,107 @@ export const findComputerUseHelper = Effect.fn("findComputerUseHelper")(function
     if (Option.isSome(info) && info.value.type === "File") return candidate;
   }
   return undefined;
-}, Effect.provide(ComputerUseFileSystemLayer));
+});
 
 const writeFileExactly = Effect.fn("writeFileExactly")(function* (
   filePath: string,
   content: string,
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
-  const existing = yield* fileSystem.readFileString(filePath).pipe(Effect.option);
+  const existing = yield* fileSystem.readFileString(filePath).pipe(
+    Effect.map(Option.some),
+    Effect.catchTags({
+      PlatformError: (cause) =>
+        cause.reason._tag === "NotFound"
+          ? Effect.succeed(Option.none<string>())
+          : new ComputerUseShimFileSystemError({
+              operation: "read",
+              path: filePath,
+              cause,
+            }),
+    }),
+  );
   if (Option.isSome(existing)) {
     if (existing.value !== content) {
-      return yield* new CodexComputerUseBridgeError({
-        cause: `Refusing to use mismatched Computer Use shim: ${filePath}`,
-      });
+      return yield* new ComputerUseShimMismatchError({ path: filePath });
     }
     return;
   }
 
   const temporaryPath = `${filePath}.${NodeCrypto.randomUUID()}.tmp`;
-  yield* fileSystem.writeFileString(temporaryPath, content, { flag: "wx" });
+  yield* fileSystem.writeFileString(temporaryPath, content, { flag: "wx" }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ComputerUseShimFileSystemError({
+          operation: "write",
+          path: temporaryPath,
+          cause,
+        }),
+    ),
+  );
   yield* fileSystem.link(temporaryPath, filePath).pipe(
-    Effect.catchIf(
-      (error) => error.reason._tag === "AlreadyExists",
-      () =>
-        fileSystem.readFileString(filePath).pipe(
+    Effect.catchTags({
+      PlatformError: (cause) => {
+        if (cause.reason._tag !== "AlreadyExists") {
+          return new ComputerUseShimFileSystemError({
+            operation: "link",
+            path: filePath,
+            cause,
+          });
+        }
+        return fileSystem.readFileString(filePath).pipe(
+          Effect.mapError(
+            (readCause) =>
+              new ComputerUseShimFileSystemError({
+                operation: "read",
+                path: filePath,
+                cause: readCause,
+              }),
+          ),
           Effect.flatMap((current) =>
             current === content
               ? Effect.void
-              : new CodexComputerUseBridgeError({
-                  cause: `Refusing to use mismatched Computer Use shim: ${filePath}`,
-                }),
+              : new ComputerUseShimMismatchError({ path: filePath }),
           ),
-        ),
-    ),
+        );
+      },
+    }),
     Effect.ensuring(fileSystem.remove(temporaryPath, { force: true }).pipe(Effect.ignore)),
   );
 });
 
-export const materializeComputerUseShim = Effect.fn("materializeComputerUseShim")(
-  function* (codexHome: string) {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const nodeModulesRoot = path.join(
-      codexHome,
-      "cache",
-      "t3-code",
-      "cua-shim",
-      COMPUTER_USE_SHIM_SHA256,
-      "node_modules",
-    );
-    const packageDirectory = path.join(nodeModulesRoot, "@oai", "sky");
-    yield* fileSystem.makeDirectory(packageDirectory, { recursive: true });
-    const entryPath = path.join(packageDirectory, "index.js");
-    yield* writeFileExactly(entryPath, COMPUTER_USE_SHIM_SOURCE);
-    yield* writeFileExactly(
-      path.join(packageDirectory, "package.json"),
-      COMPUTER_USE_SHIM_PACKAGE_JSON,
-    );
-    return { nodeModulesRoot, entryPath };
-  },
-  Effect.mapError((cause) => new CodexComputerUseBridgeError({ cause })),
-  Effect.provide(ComputerUseFileSystemLayer),
-);
+export const materializeComputerUseShim = Effect.fn("materializeComputerUseShim")(function* (
+  codexHome: string,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const nodeModulesRoot = path.join(
+    codexHome,
+    "cache",
+    "t3-code",
+    "cua-shim",
+    COMPUTER_USE_SHIM_SHA256,
+    "node_modules",
+  );
+  const packageDirectory = path.join(nodeModulesRoot, "@oai", "sky");
+  yield* fileSystem.makeDirectory(packageDirectory, { recursive: true }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ComputerUseShimFileSystemError({
+          operation: "makeDirectory",
+          path: packageDirectory,
+          cause,
+        }),
+    ),
+  );
+  const entryPath = path.join(packageDirectory, "index.js");
+  yield* writeFileExactly(entryPath, COMPUTER_USE_SHIM_SOURCE);
+  yield* writeFileExactly(
+    path.join(packageDirectory, "package.json"),
+    COMPUTER_USE_SHIM_PACKAGE_JSON,
+  );
+  return { nodeModulesRoot, entryPath };
+});
 
 function listenNamedPipe(
   server: NodeNet.Server,
@@ -414,7 +487,9 @@ function listenNamedPipe(
   return Effect.callback<void, CodexComputerUseBridgeError>((resume) => {
     const onError = (cause: Error) => {
       server.off("listening", onListening);
-      resume(Effect.fail(new CodexComputerUseBridgeError({ cause })));
+      resume(
+        Effect.fail(new CodexComputerUseBridgeError({ operation: "listen", pipePath, cause })),
+      );
     };
     const onListening = () => {
       server.off("error", onError);
@@ -430,16 +505,23 @@ function listenNamedPipe(
   });
 }
 
-function closeNamedPipe(server: NodeNet.Server, sockets: Set<NodeNet.Socket>): Effect.Effect<void> {
-  return Effect.callback<void>((resume) => {
-    for (const socket of sockets) socket.destroy();
-    if (!server.listening) {
-      resume(Effect.void);
-      return;
+const shutdownNamedPipe = Effect.fn("shutdownNamedPipe")(function* (
+  server: NodeNet.Server,
+  sockets: Set<NodeNet.Socket>,
+  connectionScope: Scope.Scope,
+) {
+  const serverClosed = yield* Deferred.make<void>();
+  yield* Effect.sync(() => {
+    try {
+      server.close(() => Deferred.doneUnsafe(serverClosed, Effect.void));
+    } catch {
+      Deferred.doneUnsafe(serverClosed, Effect.void);
     }
-    server.close(() => resume(Effect.void));
+    for (const socket of sockets) socket.destroy();
   });
-}
+  yield* Scope.close(connectionScope, Exit.void);
+  yield* Deferred.await(serverClosed);
+});
 
 export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge")(function* (
   input: CodexComputerUseBridgeInput,
@@ -450,24 +532,27 @@ export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge"
   const shim = yield* materializeComputerUseShim(input.codexHome);
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const hostPlatform = yield* HostProcessPlatform;
-  const runConnection = yield* FiberSet.makeRuntime<never, void, never>();
   const pipeId = NodeCrypto.randomUUID();
   const pipePath =
     hostPlatform === "win32"
       ? `\\\\.\\pipe\\t3code-cua-${pipeId}`
       : `${NodeOS.tmpdir().replace(/[\\/]+$/, "")}/t3code-cua-${pipeId}.sock`;
   const sockets = new Set<NodeNet.Socket>();
+  const connectionScope = yield* Effect.acquireRelease(Scope.make("sequential"), (scope) =>
+    Scope.close(scope, Exit.void),
+  );
+  const runConnection = yield* FiberSet.makeRuntime<never, void, never>().pipe(
+    Effect.provideService(Scope.Scope, connectionScope),
+  );
 
   const handleConnection = Effect.fn("CodexComputerUseBridge.handleConnection")(function* (
     socket: NodeNet.Socket,
   ) {
-    yield* Effect.acquireRelease(
-      Effect.sync(() => sockets.add(socket)),
-      () =>
-        Effect.sync(() => {
-          sockets.delete(socket);
-          if (!socket.destroyed) socket.destroy();
-        }),
+    yield* Effect.acquireRelease(Effect.void, () =>
+      Effect.sync(() => {
+        sockets.delete(socket);
+        if (!socket.destroyed) socket.destroy();
+      }),
     );
 
     const helper = yield* spawner.spawn(
@@ -481,12 +566,12 @@ export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge"
     const socketInput = NodeStream.fromReadable<Uint8Array, CodexComputerUseBridgeError>({
       evaluate: () => socket,
       closeOnDone: false,
-      onError: (cause) => new CodexComputerUseBridgeError({ cause }),
+      onError: (cause) => new CodexComputerUseBridgeError({ operation: "read", pipePath, cause }),
     });
     const socketOutput = NodeSink.fromWritable<CodexComputerUseBridgeError>({
       evaluate: () => socket,
       endOnDone: false,
-      onError: (cause) => new CodexComputerUseBridgeError({ cause }),
+      onError: (cause) => new CodexComputerUseBridgeError({ operation: "write", pipePath, cause }),
     });
 
     yield* Effect.raceFirst(
@@ -499,6 +584,7 @@ export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge"
   });
 
   const server = NodeNet.createServer((socket) => {
+    sockets.add(socket);
     runConnection(
       handleConnection(socket).pipe(
         Effect.scoped,
@@ -508,9 +594,10 @@ export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge"
       ),
     );
   });
-  yield* Effect.acquireRelease(listenNamedPipe(server, pipePath), () =>
-    closeNamedPipe(server, sockets),
+  yield* Effect.acquireRelease(Effect.succeed(server), () =>
+    shutdownNamedPipe(server, sockets, connectionScope),
   );
+  yield* listenNamedPipe(server, pipePath);
 
   return {
     nodeModulesRoot: shim.nodeModulesRoot,

--- a/apps/server/src/provider/CodexComputerUseBridge.ts
+++ b/apps/server/src/provider/CodexComputerUseBridge.ts
@@ -131,7 +131,7 @@ const handleLine = (line) => {
 
 const getConnection = async () => {
   if (!connectionPromise) {
-    connectionPromise = nodeRepl.nativePipe
+    const candidate = nodeRepl.nativePipe
       .createConnection(pipePath)
       .then((connection) => {
         connection.on("data", (chunk) => {
@@ -145,6 +145,7 @@ const getConnection = async () => {
           }
         });
         const rejectAll = (reason) => {
+          if (connectionPromise !== candidate) return;
           const message = sanitizeError(reason || "Computer Use pipe closed");
           connectionPromise = undefined;
           receiveBuffer = "";
@@ -159,9 +160,10 @@ const getConnection = async () => {
         return connection;
       })
       .catch((error) => {
-        connectionPromise = undefined;
+        if (connectionPromise === candidate) connectionPromise = undefined;
         throw error;
       });
+    connectionPromise = candidate;
   }
   return connectionPromise;
 };
@@ -544,6 +546,7 @@ export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge"
   const runConnection = yield* FiberSet.makeRuntime<never, void, never>().pipe(
     Effect.provideService(Scope.Scope, connectionScope),
   );
+  const runBridgeTask = yield* FiberSet.makeRuntime<never, void, never>();
 
   const handleConnection = Effect.fn("CodexComputerUseBridge.handleConnection")(function* (
     socket: NodeNet.Socket,
@@ -594,8 +597,18 @@ export const makeCodexComputerUseBridge = Effect.fn("makeCodexComputerUseBridge"
       ),
     );
   });
-  yield* Effect.acquireRelease(Effect.succeed(server), () =>
-    shutdownNamedPipe(server, sockets, connectionScope),
+  const shutdown = yield* Effect.cached(shutdownNamedPipe(server, sockets, connectionScope));
+  yield* Effect.acquireRelease(Effect.succeed(server), () => shutdown);
+  const onServerError = (cause: Error) => {
+    runBridgeTask(
+      Effect.logWarning("Windows Computer Use bridge server failed.", { cause }).pipe(
+        Effect.andThen(shutdown),
+      ),
+    );
+  };
+  yield* Effect.acquireRelease(
+    Effect.sync(() => server.on("error", onServerError)),
+    () => Effect.sync(() => server.off("error", onServerError)),
   );
   yield* listenNamedPipe(server, pipePath);
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -31,6 +31,7 @@ import * as Crypto from "effect/Crypto";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
@@ -1642,6 +1643,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 ) {
   const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("codex");
   const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const crypto = yield* Crypto.Crypto;
   const serverConfig = yield* Effect.service(ServerConfig);
@@ -1719,6 +1721,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           Effect.provideService(Scope.Scope, sessionScope),
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
           Effect.provideService(Crypto.Crypto, crypto),
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
           Effect.mapError(
             (cause) =>
               new ProviderAdapterProcessError({

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../CodexDeveloperInstructions.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
+  buildDirectComputerUseThreadConfig,
   buildTurnStartParams,
   describeMcpElicitation,
   hasConfiguredMcpServer,
@@ -247,6 +248,66 @@ describe("buildTurnStartParams", () => {
         },
       ],
     });
+  });
+});
+
+describe("buildDirectComputerUseThreadConfig", () => {
+  it("replaces the unavailable Desktop pipe with the T3 bridge", () => {
+    const config = {
+      mcp_servers: {
+        node_repl: {
+          command: "node_repl.exe",
+          env: {
+            NODE_REPL_NODE_MODULE_DIRS: "C:\\original\\node_modules",
+            NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S: "existing-hash",
+            SKY_CUA_NATIVE_PIPE: "1",
+            SKY_CUA_NATIVE_PIPE_DIRECTORY: "desktop-owned-pipe",
+          },
+        },
+      },
+    };
+
+    NodeAssert.deepStrictEqual(
+      buildDirectComputerUseThreadConfig(config, "win32", {
+        nodeModulesRoot: "C:\\shim\\node_modules",
+        pipePath: "\\\\.\\pipe\\t3code-cua-test",
+        trustedModuleSha256: "shim-hash",
+      }),
+      {
+        "mcp_servers.node_repl": {
+          command: "node_repl.exe",
+          env: {
+            NODE_REPL_NODE_MODULE_DIRS: "C:\\shim\\node_modules;C:\\original\\node_modules",
+            NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S: "existing-hash,shim-hash",
+            T3_CODEX_COMPUTER_USE_PIPE_PATH: "\\\\.\\pipe\\t3code-cua-test",
+          },
+        },
+      },
+    );
+  });
+
+  it("removes stale Desktop pipe settings when no T3 helper is available", () => {
+    const config = {
+      mcp_servers: {
+        node_repl: {
+          command: "node_repl.exe",
+          env: {
+            NODE_REPL_NODE_PATH: "node.exe",
+            SKY_CUA_NATIVE_PIPE: "1",
+            SKY_CUA_NATIVE_PIPE_DIRECTORY: "desktop-owned-pipe",
+          },
+        },
+      },
+    };
+
+    NodeAssert.deepStrictEqual(buildDirectComputerUseThreadConfig(config, "win32"), {
+      "mcp_servers.node_repl": {
+        command: "node_repl.exe",
+        env: { NODE_REPL_NODE_PATH: "node.exe" },
+      },
+    });
+    NodeAssert.equal(buildDirectComputerUseThreadConfig(config, "linux"), undefined);
+    NodeAssert.equal(buildDirectComputerUseThreadConfig({}, "win32"), undefined);
   });
 });
 
@@ -805,6 +866,12 @@ describe("openCodexThread", () => {
         requestedModel: "gpt-5.3-codex",
         serviceTier: undefined,
         resumeThreadId: "stale-thread",
+        config: {
+          "mcp_servers.node_repl": {
+            command: "node_repl.exe",
+            env: { T3_CODEX_COMPUTER_USE_PIPE_PATH: "\\\\.\\pipe\\t3code-cua-test" },
+          },
+        },
       });
 
       NodeAssert.equal(opened.thread.id, "fresh-thread");
@@ -812,6 +879,14 @@ describe("openCodexThread", () => {
         calls.map((call) => call.method),
         ["thread/resume", "thread/start"],
       );
+      for (const call of calls) {
+        NodeAssert.deepStrictEqual((call.payload as { config?: unknown }).config, {
+          "mcp_servers.node_repl": {
+            command: "node_repl.exe",
+            env: { T3_CODEX_COMPUTER_USE_PIPE_PATH: "\\\\.\\pipe\\t3code-cua-test" },
+          },
+        });
+      }
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -19,6 +19,7 @@ import {
 } from "@t3tools/contracts";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -40,6 +41,10 @@ import { buildCodexInitializeParams } from "./CodexProvider.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
+import {
+  type CodexComputerUseBridgeConfig,
+  makeCodexComputerUseBridge,
+} from "../CodexComputerUseBridge.ts";
 const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
 
 const PROVIDER = ProviderDriverKind.make("codex");
@@ -61,6 +66,22 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "does not exist",
   "no rollout found",
 ];
+const CodexNodeReplMcpConfig = Schema.StructWithRest(
+  Schema.Struct({
+    command: Schema.String,
+    env: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+const CodexConfigWithNodeRepl = Schema.StructWithRest(
+  Schema.Struct({
+    mcp_servers: Schema.StructWithRest(Schema.Struct({ node_repl: CodexNodeReplMcpConfig }), [
+      Schema.Record(Schema.String, Schema.Unknown),
+    ]),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+const isCodexConfigWithNodeRepl = Schema.is(CodexConfigWithNodeRepl);
 
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {
   return appServerArgs?.some((argument) => argument.includes("mcp_servers.")) === true;
@@ -208,6 +229,51 @@ export interface CodexSessionRuntimeShape {
   ) => Effect.Effect<void, CodexSessionRuntimeError>;
   readonly events: Stream.Stream<ProviderEvent, never>;
   readonly close: Effect.Effect<void>;
+}
+
+export function buildDirectComputerUseThreadConfig(
+  config: EffectCodexSchema.V2ConfigReadResponse["config"],
+  platform: NodeJS.Platform,
+  bridge?: CodexComputerUseBridgeConfig,
+): Record<string, unknown> | undefined {
+  if (platform !== "win32" || !isCodexConfigWithNodeRepl(config)) {
+    return undefined;
+  }
+
+  const nodeRepl = config.mcp_servers.node_repl;
+  const {
+    SKY_CUA_NATIVE_PIPE: _nativePipe,
+    SKY_CUA_NATIVE_PIPE_DIRECTORY: _nativePipeDirectory,
+    ...env
+  } = nodeRepl.env ?? {};
+  const {
+    startup_timeout_sec: startupTimeoutSec,
+    tool_timeout_sec: toolTimeoutSec,
+    ...nodeReplConfig
+  } = nodeRepl;
+
+  return {
+    "mcp_servers.node_repl": {
+      ...nodeReplConfig,
+      ...(typeof startupTimeoutSec === "number" ? { startup_timeout_sec: startupTimeoutSec } : {}),
+      ...(typeof toolTimeoutSec === "number" ? { tool_timeout_sec: toolTimeoutSec } : {}),
+      env: bridge
+        ? {
+            ...env,
+            NODE_REPL_NODE_MODULE_DIRS: [bridge.nodeModulesRoot, env.NODE_REPL_NODE_MODULE_DIRS]
+              .filter((value): value is string => typeof value === "string" && value.length > 0)
+              .join(";"),
+            NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S: [
+              env.NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S,
+              bridge.trustedModuleSha256,
+            ]
+              .filter((value): value is string => typeof value === "string" && value.length > 0)
+              .join(","),
+            T3_CODEX_COMPUTER_USE_PIPE_PATH: bridge.pipePath,
+          }
+        : env,
+    },
+  };
 }
 
 export type CodexSessionRuntimeError =
@@ -525,6 +591,7 @@ function buildThreadStartParams(input: {
   readonly runtimeMode: RuntimeMode;
   readonly model: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
+  readonly config: Record<string, unknown> | undefined;
 }): EffectCodexSchema.V2ThreadStartParams {
   const config = runtimeModeToThreadConfig(input.runtimeMode);
   return {
@@ -534,6 +601,7 @@ function buildThreadStartParams(input: {
     approvalsReviewer: config.approvalsReviewer,
     ...(input.model ? { model: input.model } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
+    ...(input.config ? { config: input.config } : {}),
   };
 }
 
@@ -690,6 +758,7 @@ export const openCodexThread = (input: {
   readonly requestedModel: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
+  readonly config?: Record<string, unknown>;
 }): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
   const resumeThreadId = input.resumeThreadId;
   const startParams = buildThreadStartParams({
@@ -697,6 +766,7 @@ export const openCodexThread = (input: {
     runtimeMode: input.runtimeMode,
     model: input.requestedModel,
     serviceTier: input.serviceTier,
+    config: input.config,
   });
 
   if (resumeThreadId === undefined) {
@@ -1118,6 +1188,7 @@ export const makeCodexSessionRuntime = (
 > =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const hostPlatform = yield* HostProcessPlatform;
     const runtimeScope = yield* Scope.Scope;
     const crypto = yield* Crypto.Crypto;
     const events = yield* Queue.unbounded<ProviderEvent>();
@@ -2031,6 +2102,50 @@ export const makeCodexSessionRuntime = (
       yield* client.notify("initialized", undefined);
 
       const requestedModel = normalizeCodexModelSlug(options.model);
+      // The Desktop-owned native pipe in Codex's inherited config does not
+      // exist when T3 hosts app-server. Failure here must not block Codex.
+      const config =
+        hostPlatform === "win32"
+          ? yield* client
+              .request("config/read", {
+                cwd: options.cwd,
+                includeLayers: false,
+              })
+              .pipe(
+                Effect.catch((cause) =>
+                  Effect.logWarning(
+                    "config/read failed; continuing without the Computer Use bridge.",
+                    { cause },
+                  ).pipe(Effect.as(undefined)),
+                ),
+              )
+          : undefined;
+      const nodeReplConfig =
+        config && isCodexConfigWithNodeRepl(config.config)
+          ? config.config.mcp_servers.node_repl
+          : undefined;
+      const nodeReplEnvironment = nodeReplConfig?.env ?? {};
+      const codexHome = nodeReplEnvironment.CODEX_HOME ?? resolvedHomePath;
+      const nodeModuleRoots = (nodeReplEnvironment.NODE_REPL_NODE_MODULE_DIRS ?? "")
+        .split(";")
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+      const computerUseBridgeConfig =
+        hostPlatform === "win32" && codexHome && nodeModuleRoots.length > 0
+          ? yield* makeCodexComputerUseBridge({ codexHome, nodeModuleRoots }).pipe(
+              Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+              Effect.provideService(HostProcessPlatform, hostPlatform),
+              Effect.provideService(Scope.Scope, runtimeScope),
+              Effect.catch((cause) =>
+                Effect.logWarning("Failed to start the Windows Computer Use bridge.", {
+                  cause,
+                }).pipe(Effect.as(undefined)),
+              ),
+            )
+          : undefined;
+      const directComputerUseConfig = config
+        ? buildDirectComputerUseThreadConfig(config.config, hostPlatform, computerUseBridgeConfig)
+        : undefined;
 
       const opened = yield* openCodexThread({
         client,
@@ -2040,6 +2155,7 @@ export const makeCodexSessionRuntime = (
         requestedModel,
         serviceTier: options.serviceTier,
         resumeThreadId: readResumeCursorThreadId(options.resumeCursor),
+        ...(directComputerUseConfig ? { config: directComputerUseConfig } : {}),
       });
 
       const providerThreadId = opened.thread.id;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -25,7 +25,9 @@ import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -1184,13 +1186,19 @@ export const makeCodexSessionRuntime = (
 ): Effect.Effect<
   CodexSessionRuntimeShape,
   CodexErrors.CodexAppServerError,
-  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto | Scope.Scope
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | Path.Path
+  | Scope.Scope
 > =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const hostPlatform = yield* HostProcessPlatform;
     const runtimeScope = yield* Scope.Scope;
     const crypto = yield* Crypto.Crypto;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const events = yield* Queue.unbounded<ProviderEvent>();
     const pendingApprovalsRef = yield* Ref.make(new Map<ApprovalRequestId, PendingApproval>());
     const approvalCorrelationsRef = yield* Ref.make(new Map<string, ApprovalCorrelation>());
@@ -2135,6 +2143,8 @@ export const makeCodexSessionRuntime = (
           ? yield* makeCodexComputerUseBridge({ codexHome, nodeModuleRoots }).pipe(
               Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
               Effect.provideService(HostProcessPlatform, hostPlatform),
+              Effect.provideService(FileSystem.FileSystem, fileSystem),
+              Effect.provideService(Path.Path, path),
               Effect.provideService(Scope.Scope, runtimeScope),
               Effect.catch((cause) =>
                 Effect.logWarning("Failed to start the Windows Computer Use bridge.", {


### PR DESCRIPTION
## Problem

Codex Computer Use sessions on Windows can load `@oai/sky`, but calls such as `sky.list_apps()` fail because the T3-owned app server does not provision the native helper pipe.

## Fix

- Provision a scoped native-pipe bridge for Windows Codex sessions.
- Locate and spawn the installed `codex-computer-use.exe` helper through Effect's process APIs.
- Inject a SHA-256-pinned `@oai/sky` transport shim into the Codex thread configuration.
- Keep bridge setup failure-tolerant so plain Codex sessions still start if Computer Use is unavailable.
- Cover helper discovery, shim materialization, proxy traffic, helper termination, connection closure, and pipe cleanup.

Closes #8318.

Credit to @Nelglor for the original Windows native bridge work in [Nelglor/t3code@0b29564](https://github.com/Nelglor/t3code/commit/0b29564de58cb2289d26d0e2630410bb92a67544). Nick is also credited as a co-author in the commit.

## Verification

- `vp test run apps/server/src/provider/CodexComputerUseBridge.test.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts`
- Targeted type-aware lint for the four changed files
- Server typecheck
- Formatting check
- `git diff --check`

Implemented with GPT-5.6-Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Windows Codex thread config and a trusted SHA-pinned shim affect Computer Use and approval flows; failures are logged and sessions still start, but misconfiguration could disable Computer Use or change which pipe env vars Codex sees.
> 
> **Overview**
> Adds a **Windows-only Codex Computer Use bridge** so T3-hosted app-server sessions can talk to `codex-computer-use.exe` without the Desktop-owned native pipe.
> 
> **`CodexComputerUseBridge`** discovers the helper under configured `node_modules` roots, writes a **SHA-256–pinned, content-addressed `@oai/sky` shim** into `codexHome`, and runs a **scoped named-pipe server** that proxies newline-delimited JSON to a per-connection helper process (spawned with `--parent-pid`). The embedded shim forwards `sky.*` calls over `nodeRepl.nativePipe`, handles **app-approval elicitations**, reconnects on pipe failures, and emits screenshot images when needed.
> 
> **`CodexSessionRuntime`** on Windows reads Codex config, optionally starts the bridge (warnings only on failure), and passes **`buildDirectComputerUseThreadConfig`** into thread start/resume: it strips **`SKY_CUA_NATIVE_PIPE*`** Desktop settings, and when the bridge is up injects shim module dirs, trusted hash, and **`T3_CODEX_COMPUTER_USE_PIPE_PATH`**. If the helper is missing, stale Desktop pipe env vars are still removed so sessions do not point at a nonexistent pipe. **`CodexAdapter`** now provides **FileSystem/Path** into the session runtime for shim materialization.
> 
> Tests cover shim behavior, materialization, proxy lifecycle, helper discovery, thread-config rewriting, and config propagation on open/resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c576713b8a3b44bfab47b769332947ce431915f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Windows named-pipe bridge for `CodexComputerUseBridge`
> - Embeds a self-contained, SHA-pinned shim in [CodexComputerUseBridge.ts](https://github.com/pingdotgg/t3code/pull/8325/files#diff-e47c8295614cf9160dbd9b6f5af0ccac5b61fc26e71670ece6f8847afa1599d0) that manages a JSON-over-line protocol, approvals, and timeouts over a named pipe.
> - `makeCodexSessionRuntime` starts the bridge on Windows and injects its configuration into the `node_repl` MCP environment for thread start/resume.
> - Adds tests for routing, approval flows, connection retries, and shim integrity in [CodexComputerUseBridge.test.ts](https://github.com/pingdotgg/t3code/pull/8325/files#diff-8d906b1b636fc5692ff9e4588ab1d932fbefa0f6b81d0e9d82ac6511dc1b5671).
> - Risk: Bridge startup failures on Windows log a warning and continue without Computer Use; `buildDirectComputerUseThreadConfig` removes `SKY_CUA_*` vars and modifies `NODE_REPL_NODE_MODULE_DIRS` and `NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c576713.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->