### PR TITLE
feat(web): choose where pull request links open

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -35,6 +35,7 @@ const clientSettings: ClientSettings = {
   fontSizeTerminal: 12,
   fontSmoothing: true,
   glassOpacity: 80,
+  openPullRequestLinksInApp: false,
   planModeEnabled: false,
   showSkillsInSlashMenu: false,
   providerModelPreferences: {},

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -507,6 +507,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
         ? ["Diff whitespace changes"]
         : []),
+      ...(settings.openPullRequestLinksInApp !== DEFAULT_UNIFIED_SETTINGS.openPullRequestLinksInApp
+        ? ["Open pull request links in T3 Code"]
+        : []),
       ...(settings.showSkillsInSlashMenu !== DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu
         ? ["Show skills in slash menu"]
         : []),
@@ -572,6 +575,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.glassOpacity,
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
+      settings.openPullRequestLinksInApp,
       settings.sidebarAutoSettleAfterDays,
       settings.sidebarAutoSettleOnMerge,
       settings.sidebarProjectGroupingMode,
@@ -652,6 +656,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+      openPullRequestLinksInApp: DEFAULT_UNIFIED_SETTINGS.openPullRequestLinksInApp,
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
@@ -2077,6 +2082,33 @@ export function GeneralSettingsPanel() {
                 updateSettings({ diffIgnoreWhitespace: Boolean(checked) })
               }
               aria-label="Hide whitespace changes by default"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("pull-request-links-in-app")}
+          description="Open pull request links from a thread in the review panel. Turn this off to send every click to your browser; command-click (control-click on Windows and Linux) always opens the browser."
+          resetAction={
+            settings.openPullRequestLinksInApp !==
+            DEFAULT_UNIFIED_SETTINGS.openPullRequestLinksInApp ? (
+              <SettingResetButton
+                label="pull request links"
+                onClick={() =>
+                  updateSettings({
+                    openPullRequestLinksInApp: DEFAULT_UNIFIED_SETTINGS.openPullRequestLinksInApp,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.openPullRequestLinksInApp}
+              onCheckedChange={(checked) =>
+                updateSettings({ openPullRequestLinksInApp: Boolean(checked) })
+              }
+              aria-label="Open pull request links in T3 Code"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -132,6 +132,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "pull-request-links-in-app",
+    title: "Open pull request links in T3 Code",
+    to: "/settings/general",
+  },
+  {
     id: "skills-in-slash-menu",
     title: "Show skills in slash menu",
     to: "/settings/general",

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -88,12 +88,17 @@ describe("openPullRequestLink", () => {
 
 describe("shouldOpenPullRequestExternally", () => {
   it("uses the browser for command-click and control-click", () => {
-    expect(shouldOpenPullRequestExternally({ metaKey: true, ctrlKey: false })).toBe(true);
-    expect(shouldOpenPullRequestExternally({ metaKey: false, ctrlKey: true })).toBe(true);
+    expect(shouldOpenPullRequestExternally({ metaKey: true, ctrlKey: false }, true)).toBe(true);
+    expect(shouldOpenPullRequestExternally({ metaKey: false, ctrlKey: true }, true)).toBe(true);
   });
 
   it("keeps an unmodified click in the pull request view", () => {
-    expect(shouldOpenPullRequestExternally({ metaKey: false, ctrlKey: false })).toBe(false);
+    expect(shouldOpenPullRequestExternally({ metaKey: false, ctrlKey: false }, true)).toBe(false);
+  });
+
+  it("sends every click to the browser once the in-app preference is off", () => {
+    expect(shouldOpenPullRequestExternally({ metaKey: false, ctrlKey: false }, false)).toBe(true);
+    expect(shouldOpenPullRequestExternally({ metaKey: true, ctrlKey: false }, false)).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -11,6 +11,7 @@ import { type MouseEvent, useCallback } from "react";
 import { pullRequestHostOf, type SourceControlProviderKind } from "@t3tools/contracts";
 
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
+import { useClientSettings } from "../hooks/useSettings";
 import { readLocalApi } from "../localApi";
 import { useRightPanelStore } from "../rightPanelStore";
 import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
@@ -210,11 +211,16 @@ export function findProjectForChangeRequest(
  * the pull requests page: a reader following a link the agent wrote is reading the thread, and
  * should still be reading it afterwards. Any change request opens there, not only the thread's
  * own, since the panel is told which one to show.
+ *
+ * Settings → General turns this off for readers who want every pull request link in their
+ * browser, in which case nothing here claims a link at all.
  */
+/** Command-click (control-click off macOS) always means the browser; `openInApp` decides the rest. */
 export function shouldOpenPullRequestExternally(
   event: Pick<MouseEvent<HTMLElement>, "metaKey" | "ctrlKey">,
+  openInApp: boolean,
 ): boolean {
-  return event.metaKey || event.ctrlKey;
+  return !openInApp || event.metaKey || event.ctrlKey;
 }
 
 export function useOpenChangeRequestLink(
@@ -228,12 +234,13 @@ export function useOpenChangeRequestLink(
   targetThreadRef?: ScopedThreadRef,
 ) => boolean {
   const navigate = useNavigate();
+  const openInApp = useClientSettings((settings) => settings.openPullRequestLinksInApp);
   const allProjects = useProjects();
   const serverConfigs = useServerConfigs();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   return useCallback(
     (event, targetUrl, targetThreadRef) => {
-      if (shouldOpenPullRequestExternally(event)) return false;
+      if (shouldOpenPullRequestExternally(event, openInApp)) return false;
       const resolvedThreadRef = targetThreadRef ?? threadRef;
       const parsed = parseChangeRequestUrl(targetUrl);
       if (parsed === null) return false;
@@ -285,16 +292,17 @@ export function useOpenChangeRequestLink(
       });
       return true;
     },
-    [allProjects, navigate, primaryEnvironmentId, serverConfigs, threadRef],
+    [allProjects, navigate, openInApp, primaryEnvironmentId, serverConfigs, threadRef],
   );
 }
 
 export function useOpenPrLink(threadRef?: ScopedThreadRef) {
   const openChangeRequest = useOpenChangeRequestLink(threadRef);
+  const openInApp = useClientSettings((settings) => settings.openPullRequestLinksInApp);
   return useCallback(
     (event: MouseEvent<HTMLElement>, prUrl: string, targetThreadRef?: ScopedThreadRef) => {
       event.stopPropagation();
-      const openInBrowser = shouldOpenPullRequestExternally(event);
+      const openInBrowser = shouldOpenPullRequestExternally(event, openInApp);
       const isAnchor =
         event.currentTarget instanceof HTMLAnchorElement && event.currentTarget.href.length > 0;
       // A real link already knows how to cmd/ctrl+click. Leave its default
@@ -326,6 +334,6 @@ export function useOpenPrLink(threadRef?: ScopedThreadRef) {
       });
       return false;
     },
-    [openChangeRequest],
+    [openChangeRequest, openInApp],
   );
 }

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -43,6 +43,7 @@ T3 Code works with the platforms your team already uses:
   leaving the conversation
 - Open the review directly in your browser with one click
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
+- Prefer your browser for everything? Turn off **Settings → General → Open pull request links in T3 Code**, and every pull request link opens there instead
 - Check out a teammate's branch to review code locally
 
 **Fix what you wrote, in place**

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -221,6 +221,10 @@ export const ClientSettingsSchema = Schema.Struct({
       modelOrder: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
     }),
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  // Where an unmodified click on a pull request link lands: the right-panel
+  // review beside the conversation, or the browser. Off makes every click
+  // behave the way command-click already does.
+  openPullRequestLinksInApp: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Legacy plan mode. The composer's Build/Plan toggle was removed from the
   // default UI; this beta flag restores it (plus the /plan and /default slash
   // commands) for users who still rely on the old workflow.
@@ -938,6 +942,7 @@ export const ClientSettingsPatch = Schema.Struct({
       }),
     ),
   ),
+  openPullRequestLinksInApp: Schema.optionalKey(Schema.Boolean),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
Clicking a pull request link in a thread always opens the review in the right panel, and the only way to get it into a browser is to remember command-click. People who live in their browser for reviews have no way to make that the default.

Adds **Settings → General → Open pull request links in T3 Code**, a client setting that is on by default (today's behavior, unchanged). Turn it off and every pull request link — in chat, and the pull request number in the sidebar — goes straight to the browser, exactly as command-click already does. The decision lives in `shouldOpenPullRequestExternally`, so both the chat link handler and the sidebar handler follow the same rule, and the **Pull requests** page still opens reviews in panel tabs either way.

Mobile taps already open pull request links in the system browser, so nothing changes there.

Model: claude-opus-5. Harness: Claude Code in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `openPullRequestLinksInApp` setting to control where PR links open
> - Adds a boolean `openPullRequestLinksInApp` field (default `true`) to `ClientSettingsSchema` and `ClientSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/8335/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c)
> - Updates `shouldOpenPullRequestExternally` in [openPullRequestLink.ts](https://github.com/pingdotgg/t3code/pull/8335/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) to accept an `openInApp` parameter; when `false`, all clicks open externally (meta/ctrl still always open externally)
> - Adds a toggle in Settings → General in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/8335/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) with reset-to-default support and settings search integration
> - Updates `useOpenChangeRequestLink` and `useOpenPrLink` hooks to read the setting via `useClientSettings` and route unmodified clicks accordingly
> - Behavioral Change: existing users whose stored settings predate this field will decode to the default (`true`), preserving current in-app behavior; users who opt out via the new toggle will have all unmodified PR link clicks open in the system browser
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c4a4ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->