### PR TITLE
fix(server): honor explicit $skill invocations across providers

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -1,5 +1,6 @@
 import type {
   EnvironmentId,
+  ExplicitSkillInvocation,
   MessageId,
   ModelSelection,
   OrchestrationThreadShell,
@@ -7,6 +8,7 @@ import type {
   RuntimeMode,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
+import { updateExplicitSkillInvocationsForTextEdit } from "@t3tools/shared/explicitSkillInvocations";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { ReactNode } from "react";
 import {
@@ -88,6 +90,7 @@ export const COMPOSER_EXPANDED_CHROME = 156;
 
 export interface ThreadComposerProps {
   readonly draftMessage: string;
+  readonly draftSkillInvocations: ReadonlyArray<ExplicitSkillInvocation>;
   readonly draftAttachments: ReadonlyArray<DraftComposerAttachment>;
   readonly placeholder: string;
   readonly contentMaxWidth?: number;
@@ -107,7 +110,10 @@ export interface ThreadComposerProps {
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
   readonly editorRef?: RefObject<ComposerEditorHandle | null>;
-  readonly onChangeDraftMessage: (value: string) => void;
+  readonly onChangeDraftMessage: (
+    value: string,
+    skillInvocations: ReadonlyArray<ExplicitSkillInvocation>,
+  ) => void;
   readonly onPickDraftMedia: () => Promise<void>;
   readonly onPickDraftFiles: () => Promise<void>;
   readonly onNativePasteImages: (uris: ReadonlyArray<string>) => Promise<void>;
@@ -303,7 +309,19 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const settingsRoutePresentedRef = useRef(false);
   const wasExpandedBeforePreviewRef = useRef(false);
   const inFlightThreadIdsRef = useRef(new Set<string>());
+  const skillInvocationsRef = useRef<ExplicitSkillInvocation[]>([...props.draftSkillInvocations]);
+  const previousDraftMessageRef = useRef(props.draftMessage);
   const { onExpandedChange } = props;
+
+  useEffect(() => {
+    previousDraftMessageRef.current = props.draftMessage;
+    skillInvocationsRef.current = [...props.draftSkillInvocations];
+  }, [
+    props.draftMessage,
+    props.draftSkillInvocations,
+    props.environmentId,
+    props.selectedThread.id,
+  ]);
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
@@ -332,6 +350,27 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   }, [props.serverConfig, props.selectedThread.modelSelection.instanceId]);
   const composerOwnerKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
 
+  const { onChangeDraftMessage } = props;
+  // Keeps the draft's `$skill` ranges aligned with the text they point at, and
+  // records the range when the command menu inserts a skill.
+  const handleDraftMessageChange = useCallback(
+    (nextMessage: string, addedInvocation?: ExplicitSkillInvocation) => {
+      const previousMessage = previousDraftMessageRef.current;
+      skillInvocationsRef.current = updateExplicitSkillInvocationsForTextEdit({
+        previousText: previousMessage,
+        nextText: nextMessage,
+        invocations: skillInvocationsRef.current,
+      });
+      if (addedInvocation) {
+        skillInvocationsRef.current.push(addedInvocation);
+        skillInvocationsRef.current.sort((left, right) => left.start - right.start);
+      }
+      previousDraftMessageRef.current = nextMessage;
+      onChangeDraftMessage(nextMessage, skillInvocationsRef.current);
+    },
+    [onChangeDraftMessage],
+  );
+
   const composerMenu = useComposerCommandMenu({
     draftMessage: props.draftMessage,
     ownerKey: composerOwnerKey,
@@ -339,14 +378,14 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     projectCwd: props.projectCwd,
     selectedProviderStatus,
     hasThread: true,
-    onChangeDraftMessage: props.onChangeDraftMessage,
+    onChangeDraftMessage: handleDraftMessageChange,
     onUpdateInteractionMode: props.onUpdateInteractionMode,
   });
   const voiceInput = useVoiceInputController({
     ownerKey: composerOwnerKey,
     draftMessage: props.draftMessage,
     selection: composerMenu.selection,
-    onChangeDraftMessage: props.onChangeDraftMessage,
+    onChangeDraftMessage: handleDraftMessageChange,
     onChangeSelection: composerMenu.onSelectionChange,
   });
   const voicePresentation = resolveVoiceComposerPresentation(
@@ -406,6 +445,8 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       if (messageId === null) {
         return;
       }
+      skillInvocationsRef.current = [];
+      previousDraftMessageRef.current = "";
       // Sending a prompt starts agent work: arm the lock-screen card while the
       // app is foregrounded and the activity token can be registered. Armed
       // after the send so its preference read and native Activity start don't
@@ -614,7 +655,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 readOnly={voiceInput.freezesEditor}
                 skills={selectedProviderStatus?.skills ?? []}
                 selection={composerMenu.selection}
-                onChangeText={props.onChangeDraftMessage}
+                onChangeText={handleDraftMessageChange}
                 onSelectionChange={composerMenu.onSelectionChange}
                 onPasteImages={(uris) => void props.onNativePasteImages(uris)}
                 placeholder={props.placeholder}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -10,6 +10,7 @@ import { HeaderHeightContext } from "@react-navigation/elements";
 import type {
   ApprovalRequestId,
   EnvironmentId,
+  ExplicitSkillInvocation,
   MessageId,
   ModelSelection,
   OrchestrationThreadShell,
@@ -20,6 +21,7 @@ import type {
   ThreadId,
   UserInputQuestion,
 } from "@t3tools/contracts";
+import { updateExplicitSkillInvocationsForTextEdit } from "@t3tools/shared/explicitSkillInvocations";
 import * as Haptics from "expo-haptics";
 import {
   memo,
@@ -105,6 +107,7 @@ export interface ThreadDetailScreenProps {
   readonly activePendingUserInputAnswers: Record<string, string | ReadonlyArray<string>> | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
   readonly draftMessage: string;
+  readonly draftSkillInvocations: ReadonlyArray<ExplicitSkillInvocation>;
   readonly draftAttachments: ReadonlyArray<DraftComposerAttachment>;
   readonly connectionStateLabel: EnvironmentConnectionPhase;
   /** Message sync status for the selected thread (drives the composer status pill). */
@@ -120,7 +123,10 @@ export interface ThreadDetailScreenProps {
   readonly usesAutomaticContentInsets?: boolean;
   readonly onHeaderMaterialVisibilityChange?: (visible: boolean) => void;
   readonly onOpenConnectionEditor: () => void;
-  readonly onChangeDraftMessage: (value: string) => void;
+  readonly onChangeDraftMessage: (
+    value: string,
+    skillInvocations: ReadonlyArray<ExplicitSkillInvocation>,
+  ) => void;
   readonly onPickDraftMedia: () => Promise<void>;
   readonly onPickDraftFiles: () => Promise<void>;
   readonly onNativePasteImages: (uris: ReadonlyArray<string>) => Promise<void>;
@@ -626,14 +632,21 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
       const nextDraft = appendCodexArtifactTemplateUsePrompt(currentDraft, template);
       if (nextDraft !== currentDraft) {
         draftMessageRef.current = nextDraft;
-        props.onChangeDraftMessage(nextDraft);
+        props.onChangeDraftMessage(
+          nextDraft,
+          updateExplicitSkillInvocationsForTextEdit({
+            previousText: currentDraft,
+            nextText: nextDraft,
+            invocations: props.draftSkillInvocations,
+          }),
+        );
       }
       requestAnimationFrame(() => {
         composerEditorRef.current?.focus();
         composerEditorRef.current?.setSelection({ start: nextDraft.length, end: nextDraft.length });
       });
     },
-    [props.onChangeDraftMessage],
+    [props.draftSkillInvocations, props.onChangeDraftMessage],
   );
 
   const handleScrollToEnd = useCallback(() => {
@@ -798,6 +811,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 <ThreadComposer
                   editorRef={composerEditorRef}
                   draftMessage={props.draftMessage}
+                  draftSkillInvocations={props.draftSkillInvocations}
                   draftAttachments={props.draftAttachments}
                   placeholder="Ask the repo agent, or run a command…"
                   contentMaxWidth={contentMaxWidth}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -781,6 +781,7 @@ function ThreadRouteContent(
           activePendingUserInputAnswers={requests.activePendingUserInputAnswers}
           respondingUserInputId={requests.respondingUserInputId}
           draftMessage={composer.draftMessage}
+          draftSkillInvocations={composer.draftSkillInvocations}
           draftAttachments={composer.draftAttachments}
           connectionStateLabel={routeConnectionState}
           threadSyncStatus={selectedThreadDetailState.status}

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentId, ProviderInteractionMode, ServerProvider } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ExplicitSkillInvocation,
+  ProviderInteractionMode,
+  ServerProvider,
+} from "@t3tools/contracts";
 import {
   detectComposerTrigger,
   replaceTextRange,
@@ -39,7 +44,12 @@ export function useComposerCommandMenu({
   readonly selectedProviderStatus: ServerProvider | null;
   readonly hasThread: boolean;
   readonly enabled?: boolean;
-  readonly onChangeDraftMessage: (value: string) => void;
+  // Inserting a skill reports the range it occupies so callers that track
+  // explicit invocations can record it with the same edit.
+  readonly onChangeDraftMessage: (
+    value: string,
+    addedSkillInvocation?: ExplicitSkillInvocation,
+  ) => void;
   readonly onUpdateInteractionMode?: (mode: ProviderInteractionMode) => void;
 }) {
   const [selection, setSelection] = useState(() => composerSelectionAtEnd(draftMessage));
@@ -276,7 +286,16 @@ export function useComposerCommandMenu({
         replacement,
       );
       setSelection({ start: result.cursor, end: result.cursor });
-      onChangeDraftMessage(result.text);
+      onChangeDraftMessage(
+        result.text,
+        item.type === "skill"
+          ? {
+              name: item.skill.name,
+              start: trigger.rangeStart,
+              end: trigger.rangeStart + item.skill.name.length + 1,
+            }
+          : undefined,
+      );
     },
     [draftMessage, onChangeDraftMessage, onUpdateInteractionMode, trigger],
   );

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -7,6 +7,7 @@ import type { EnvironmentShellStatus } from "@t3tools/client-runtime/state/shell
 import {
   CommandId,
   EnvironmentId,
+  ExplicitSkillInvocation,
   IsoDateTime,
   MessageId,
   ModelSelection,
@@ -25,7 +26,7 @@ import { DraftComposerAttachmentSchema } from "../lib/composer-image-schema";
 import type { DraftComposerAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
 
-const THREAD_OUTBOX_SCHEMA_VERSION = 3;
+const THREAD_OUTBOX_SCHEMA_VERSION = 4;
 const THREAD_OUTBOX_MAX_RETRY_DELAY_MS = 16_000;
 
 const QueuedThreadCreationSchema = Schema.Struct({
@@ -41,12 +42,13 @@ const QueuedThreadCreationSchema = Schema.Struct({
 });
 
 export const QueuedThreadMessageSchema = Schema.Struct({
-  schemaVersion: Schema.Literals([1, 2, THREAD_OUTBOX_SCHEMA_VERSION]),
+  schemaVersion: Schema.Literals([1, 2, 3, THREAD_OUTBOX_SCHEMA_VERSION]),
   environmentId: EnvironmentId,
   threadId: ThreadId,
   messageId: MessageId,
   commandId: CommandId,
   text: Schema.String,
+  skillInvocations: Schema.optional(Schema.Array(ExplicitSkillInvocation)),
   attachments: Schema.Array(DraftComposerAttachmentSchema),
   modelSelection: Schema.optional(ModelSelection),
   runtimeMode: Schema.optional(RuntimeMode),
@@ -76,6 +78,7 @@ export interface QueuedThreadMessage {
   readonly messageId: MessageId;
   readonly commandId: CommandId;
   readonly text: string;
+  readonly skillInvocations?: ReadonlyArray<typeof ExplicitSkillInvocation.Type>;
   readonly attachments: ReadonlyArray<DraftComposerAttachment>;
   readonly modelSelection?: ModelSelectionType;
   readonly runtimeMode?: RuntimeModeType;

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -116,6 +116,7 @@ describe("thread outbox", () => {
       },
       runtimeMode: "approval-required",
       interactionMode: "plan",
+      skillInvocations: [{ name: "review", start: 0, end: 7 }],
     } satisfies QueuedThreadMessage;
 
     expect(decodeQueuedThreadMessage(encodeQueuedThreadMessage(selectedMessage))).toEqual(

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -866,6 +866,38 @@ describe("mobile composer drafts", () => {
     });
   });
 
+  it("persists explicit skill ranges and clears them with sent content", () => {
+    const draftKey = "environment-1:thread-1";
+    const draft = decodePersistedComposerDrafts({
+      schemaVersion: 1,
+      drafts: {
+        [draftKey]: {
+          text: "$review this",
+          skillInvocations: [{ name: "review", start: 0, end: 7 }],
+          attachments: [],
+        },
+      },
+    })[draftKey];
+
+    expect(draft?.skillInvocations).toEqual([{ name: "review", start: 0, end: 7 }]);
+    expect(clearComposerDraftContentState({ [draftKey]: draft! }, draftKey)).toEqual({});
+  });
+
+  it("restores skill ranges when a failed send merges into matching text", () => {
+    const draftKey = "environment-1:thread-1";
+    const merged = mergeComposerDraftContentState(
+      { [draftKey]: { text: "$review this", attachments: [] } },
+      draftKey,
+      {
+        text: "$review this",
+        skillInvocations: [{ name: "review", start: 0, end: 7 }],
+        attachments: [],
+      },
+    );
+
+    expect(merged[draftKey]?.skillInvocations).toEqual([{ name: "review", start: 0, end: 7 }]);
+  });
+
   it("clears sent content without clearing the selected model or workspace", () => {
     const draftKey = "environment-1:thread-1";
     const draft: ComposerDraft = {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -1,10 +1,12 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   ModelSelection as ModelSelectionSchema,
+  ExplicitSkillInvocation as ExplicitSkillInvocationSchema,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   ProviderInteractionMode as ProviderInteractionModeSchema,
   RuntimeMode as RuntimeModeSchema,
   type EnvironmentId,
+  type ExplicitSkillInvocation,
   type ModelSelection,
   type ProviderInteractionMode,
   type RuntimeMode,
@@ -42,6 +44,7 @@ export class ComposerDraftPersistenceError extends Schema.TaggedErrorClass<Compo
 
 export interface ComposerDraft {
   readonly text: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments: ReadonlyArray<DraftComposerAttachment>;
   readonly importedShareIds?: ReadonlyArray<string>;
   readonly modelSelection?: ModelSelection;
@@ -52,6 +55,7 @@ export interface ComposerDraft {
 
 export interface ComposerDraftContent {
   readonly text: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments: ReadonlyArray<DraftComposerAttachment>;
   readonly sourceShareId?: string;
 }
@@ -77,6 +81,7 @@ const ComposerDraftWorkspaceSelectionSchema = Schema.Struct({
 
 const ComposerDraftSchema = Schema.Struct({
   text: Schema.String,
+  skillInvocations: Schema.optional(Schema.Array(ExplicitSkillInvocationSchema)),
   attachments: Schema.Array(DraftComposerAttachmentSchema),
   importedShareIds: Schema.optional(Schema.Array(Schema.String)),
   modelSelection: Schema.optional(ModelSelectionSchema),
@@ -521,11 +526,18 @@ export function setStickyComposerModelSelection(modelSelection: ModelSelection):
   schedulePersistComposerState();
 }
 
-export function setComposerDraftText(draftKey: string, value: string): void {
+export function setComposerDraftText(
+  draftKey: string,
+  value: string,
+  skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>,
+): void {
   updateComposerDrafts((current) => {
+    const existing = normalizeDraft(current[draftKey]);
+    const { skillInvocations: _skillInvocations, ...draftWithoutSkills } = existing;
     const draft = {
-      ...normalizeDraft(current[draftKey]),
+      ...(skillInvocations === undefined ? existing : draftWithoutSkills),
       text: value,
+      ...(skillInvocations && skillInvocations.length > 0 ? { skillInvocations } : {}),
     };
     if (isEmptyDraft(draft)) {
       const next = { ...current };
@@ -675,6 +687,7 @@ export function clearComposerDraftContentState(
   const {
     importedShareIds: _importedShareIds,
     modelSelection,
+    skillInvocations: _skillInvocations,
     workspaceSelection,
     ...retained
   } = existing;
@@ -738,6 +751,7 @@ export function copyComposerDraftContentState(
     [targetDraftKey]: {
       ...target,
       text: source.text,
+      ...(source.skillInvocations ? { skillInvocations: source.skillInvocations } : {}),
       attachments: source.attachments,
       ...(source.importedShareIds ? { importedShareIds: source.importedShareIds } : {}),
     },
@@ -772,6 +786,13 @@ function mergeComposerDraftText(existing: string, incoming: string): string {
   return `${existing}\n\n${incoming}`;
 }
 
+function mergedTextOffset(existing: string, incoming: string): number | null {
+  if (incoming.length === 0) return null;
+  if (existing.length === 0 || existing === incoming) return 0;
+  if (existing.endsWith(`\n\n${incoming}`)) return existing.length - incoming.length;
+  return existing.length + 2;
+}
+
 export function mergeComposerDraftContentState(
   current: Record<string, ComposerDraft>,
   draftKey: string,
@@ -794,13 +815,35 @@ export function mergeComposerDraftContentState(
     PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   );
   const text = mergeComposerDraftText(existing.text, content.text);
+  const incomingTextOffset = mergedTextOffset(existing.text, content.text);
+  const skillInvocations = [...(existing.skillInvocations ?? [])];
+  if (incomingTextOffset !== null) {
+    for (const invocation of content.skillInvocations ?? []) {
+      const shifted = {
+        ...invocation,
+        start: invocation.start + incomingTextOffset,
+        end: invocation.end + incomingTextOffset,
+      };
+      if (
+        !skillInvocations.some(
+          (existingInvocation) =>
+            existingInvocation.name === shifted.name &&
+            existingInvocation.start === shifted.start &&
+            existingInvocation.end === shifted.end,
+        )
+      ) {
+        skillInvocations.push(shifted);
+      }
+    }
+  }
   const importedShareIds = content.sourceShareId
     ? [...(existing.importedShareIds ?? []), content.sourceShareId]
     : existing.importedShareIds;
   if (
     text === existing.text &&
     attachments.length === existing.attachments.length &&
-    importedShareIds === existing.importedShareIds
+    importedShareIds === existing.importedShareIds &&
+    skillInvocations.length === (existing.skillInvocations?.length ?? 0)
   ) {
     return current;
   }
@@ -809,6 +852,7 @@ export function mergeComposerDraftContentState(
     [draftKey]: {
       ...existing,
       text,
+      ...(skillInvocations.length > 0 ? { skillInvocations } : {}),
       attachments,
       ...(importedShareIds ? { importedShareIds } : {}),
     },

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -5,6 +5,7 @@ import * as Cause from "effect/Cause";
 
 import {
   CommandId,
+  type ExplicitSkillInvocation,
   MessageId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   type EnvironmentId,
@@ -22,6 +23,7 @@ import {
 } from "@t3tools/client-runtime/state/threads";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
+import { remapExplicitSkillInvocations } from "@t3tools/shared/explicitSkillInvocations";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
 import {
@@ -91,6 +93,7 @@ export function useThreadDraftForThread(input: {
 
   return {
     draftMessage: draft.text,
+    draftSkillInvocations: draft.skillInvocations ?? [],
     draftAttachments: draft.attachments,
   };
 }
@@ -136,6 +139,7 @@ export function useThreadComposerState() {
 
   const selectedDraft = selectedThreadKey ? composerDrafts[selectedThreadKey] : null;
   const draftMessage = selectedDraft?.text ?? "";
+  const draftSkillInvocations = selectedDraft?.skillInvocations ?? [];
   const draftAttachments = selectedDraft?.attachments ?? [];
   const selectedThreadQueueCount = selectedThreadQueuedMessages.length;
   const selectedThread = selectedThreadDetail ?? selectedThreadShell;
@@ -177,6 +181,11 @@ export function useThreadComposerState() {
     const draft = getComposerDraftSnapshot(threadKey);
     const thread = selectedThreadDetail ?? selectedThreadShell;
     const text = draft.text.trim();
+    const sentSkillInvocations = remapExplicitSkillInvocations({
+      sourceText: draft.text,
+      outgoingText: text,
+      invocations: draft.skillInvocations ?? [],
+    });
     const attachments = draft.attachments;
     if (text.length === 0 && attachments.length === 0) {
       return null;
@@ -270,6 +279,7 @@ export function useThreadComposerState() {
       messageId,
       commandId: CommandId.make(metadata.commandId),
       text,
+      ...(sentSkillInvocations.length > 0 ? { skillInvocations: sentSkillInvocations } : {}),
       attachments,
       modelSelection: draft.modelSelection ?? thread.modelSelection,
       runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
@@ -289,7 +299,11 @@ export function useThreadComposerState() {
         // append: the merge path slots existing attachments first and truncates
         // at the send limit, which would silently drop this message's images if
         // the user attached new ones while the write was in flight.
-        void mergeComposerDraftContent(threadKey, { text, attachments: [] });
+        void mergeComposerDraftContent(threadKey, {
+          text,
+          skillInvocations: sentSkillInvocations,
+          attachments: [],
+        });
         appendComposerDraftAttachments(threadKey, attachments, { allowOverflow: true });
         setPendingConnectionError(
           error instanceof Error ? error.message : "Failed to save the queued message.",
@@ -305,13 +319,13 @@ export function useThreadComposerState() {
   ]);
 
   const onChangeDraftMessage = useCallback(
-    (value: string) => {
+    (value: string, skillInvocations: ReadonlyArray<ExplicitSkillInvocation>) => {
       if (!selectedThreadShell) {
         return;
       }
 
       const threadKey = scopedThreadKey(selectedThreadShell.environmentId, selectedThreadShell.id);
-      setComposerDraftText(threadKey, value);
+      setComposerDraftText(threadKey, value, skillInvocations);
     },
     [selectedThreadShell],
   );
@@ -470,6 +484,7 @@ export function useThreadComposerState() {
     selectedThreadQueueCount,
     activeWorkStartedAt,
     draftMessage,
+    draftSkillInvocations,
     draftAttachments,
     modelSelection,
     runtimeMode,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -709,6 +709,9 @@ export function useThreadOutboxDrain(): void {
             role: "user",
             text: queuedMessage.text,
             attachments: prepared.attachments,
+            ...(queuedMessage.skillInvocations !== undefined
+              ? { skillInvocations: queuedMessage.skillInvocations }
+              : {}),
           },
           modelSelection: settings.modelSelection,
           runtimeMode: settings.runtimeMode,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -540,8 +540,9 @@ describe("ProviderCommandReactor", () => {
         message: {
           messageId: asMessageId("user-message-1"),
           role: "user",
-          text: "hello reactor",
+          text: "  hello $reactor  ",
           attachments: [],
+          skillInvocations: [{ name: "reactor", start: 8, end: 16 }],
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
@@ -566,6 +567,10 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      input: "hello $reactor",
+      skillInvocations: [{ name: "reactor", start: 6, end: 14 }],
+    });
   });
 
   effectIt.effect("projects starting before a slow provider session finishes", () =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -9,10 +9,12 @@ import {
   type OrchestrationSession,
   ThreadId,
   type ProviderSession,
+  type ProviderSendTurnInput,
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { remapExplicitSkillInvocations } from "@t3tools/shared/explicitSkillInvocations";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -776,6 +778,7 @@ const make = Effect.gen(function* () {
     readonly threadId: ThreadId;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
+    readonly skillInvocations?: ProviderSendTurnInput["skillInvocations"];
     readonly modelSelection?: ModelSelection;
     readonly interactionMode?: "default" | "plan";
     readonly createdAt: string;
@@ -795,6 +798,13 @@ const make = Effect.gen(function* () {
     }
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
     const normalizedAttachments = input.attachments ?? [];
+    const skillInvocations = normalizedInput
+      ? remapExplicitSkillInvocations({
+          sourceText: input.messageText,
+          outgoingText: normalizedInput,
+          invocations: input.skillInvocations ?? [],
+        })
+      : [];
     const activeSession = yield* providerService
       .listSessions()
       .pipe(
@@ -827,6 +837,7 @@ const make = Effect.gen(function* () {
       threadId: input.threadId,
       ...(normalizedInput ? { input: normalizedInput } : {}),
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
+      ...(skillInvocations !== undefined ? { skillInvocations } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
     };
@@ -1214,6 +1225,9 @@ const make = Effect.gen(function* () {
       threadId: event.payload.threadId,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+      ...(event.payload.skillInvocations !== undefined
+        ? { skillInvocations: event.payload.skillInvocations }
+        : {}),
       ...(event.payload.modelSelection !== undefined
         ? { modelSelection: event.payload.modelSelection }
         : {}),

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -307,8 +307,9 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
           message: {
             messageId: asMessageId("message-user-1"),
             role: "user",
-            text: "hello",
+            text: "hello $review",
             attachments: [],
+            skillInvocations: [{ name: "review", start: 6, end: 13 }],
           },
           modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
             { id: "reasoningEffort", value: "high" },
@@ -334,12 +335,14 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
       expect(turnStartEvent.payload).toMatchObject({
         threadId: ThreadId.make("thread-1"),
         messageId: asMessageId("message-user-1"),
+        skillInvocations: [{ name: "review", start: 6, end: 13 }],
         modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
           { id: "reasoningEffort", value: "high" },
           { id: "fastMode", value: true },
         ]),
         runtimeMode: "approval-required",
       });
+      expect(events[0]?.payload).not.toHaveProperty("skillInvocations");
     }),
   );
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -988,6 +988,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           messageId: command.message.messageId,
+          ...(command.message.skillInvocations !== undefined
+            ? { skillInvocations: command.message.skillInvocations }
+            : {}),
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -1,10 +1,42 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { assert, it } from "@effect/vitest";
+import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { discoverClaudeSkills } from "./ClaudeSkills.ts";
+import { discoverClaudeSkills, prepareClaudeSkillContents } from "./ClaudeSkills.ts";
+
+describe("prepareClaudeSkillContents", () => {
+  it("expands full and positional arguments", () => {
+    assert.deepEqual(
+      prepareClaudeSkillContents(
+        ["---", "name: migrate", "---", "", "Move $0 from $1. Full: $ARGUMENTS"].join("\n"),
+        'Button "old folder"',
+      ),
+      {
+        kind: "prepared",
+        contents: 'Move Button from old folder. Full: Button "old folder"',
+      },
+    );
+  });
+
+  it("appends arguments when the body has no placeholder", () => {
+    assert.deepEqual(prepareClaudeSkillContents("# Review", "this change"), {
+      kind: "prepared",
+      contents: "# Review\n\nARGUMENTS: this change",
+    });
+  });
+
+  it("rejects runtime fields the fallback cannot preserve", () => {
+    assert.deepEqual(
+      prepareClaudeSkillContents(
+        ["---", "name: review", "context: fork", "allowed-tools: Read", "---", "Review"].join("\n"),
+        "this change",
+      ),
+      { kind: "unsupported", fields: ["allowed-tools", "context"] },
+    );
+  });
+});
 
 const writeSkill = Effect.fn(function* (
   skillsDir: string,
@@ -63,6 +95,29 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
           description: "Deploy the app.",
         },
       ]);
+    }),
+  );
+
+  it.effect("hides skills disabled for user invocation", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "model-only",
+        [
+          "---",
+          "name: model-only",
+          "description: Not available in the composer.",
+          "user-invocable: false",
+          "---",
+        ].join("\n"),
+      );
+
+      assert.deepEqual(yield* discoverClaudeSkills({ homePath: configDir }), []);
     }),
   );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -17,7 +17,9 @@ import type { ClaudeSettings, ServerProviderSkill } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import { parse as parseYamlDocument } from "yaml";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
 
 import { expandHomePath } from "../../pathExpansion.ts";
 
@@ -25,10 +27,38 @@ type ClaudeSkillScope = "user" | "project";
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
+const ClaudeSkillFrontmatter = fromYaml(
+  Schema.Struct({
+    name: Schema.optional(Schema.String),
+    description: Schema.optional(Schema.String),
+    "user-invocable": Schema.optional(Schema.Boolean),
+  }),
+);
+const decodeClaudeSkillFrontmatter = Schema.decodeUnknownOption(ClaudeSkillFrontmatter);
+const decodeClaudeSkillFrontmatterRecord = Schema.decodeUnknownOption(
+  fromYaml(Schema.Record(Schema.String, Schema.Unknown)),
+);
+
+const UNSUPPORTED_FALLBACK_FIELDS = [
+  "allowed-tools",
+  "disallowed-tools",
+  "model",
+  "context",
+  "agent",
+  "background",
+  "hooks",
+  "arguments",
+] as const;
+
 type SkillFrontmatter =
   | { readonly kind: "missing" }
   | { readonly kind: "malformed" }
-  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
+  | {
+      readonly kind: "parsed";
+      readonly name?: string;
+      readonly description?: string;
+      readonly userInvocable: boolean;
+    };
 
 function parseSkillFrontmatter(contents: string): SkillFrontmatter {
   const match = FRONTMATTER_PATTERN.exec(contents);
@@ -36,23 +66,94 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
     return { kind: "missing" };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = parseYamlDocument(match[1] ?? "");
-  } catch {
-    return { kind: "malformed" };
-  }
-  if (typeof parsed !== "object" || parsed === null) {
+  const parsed = Option.getOrUndefined(decodeClaudeSkillFrontmatter(match[1] ?? ""));
+  if (!parsed) {
     return { kind: "malformed" };
   }
 
-  const record = parsed as Record<string, unknown>;
-  const name = typeof record.name === "string" ? record.name.trim() : "";
-  const description = typeof record.description === "string" ? record.description.trim() : "";
+  const name = parsed.name?.trim() ?? "";
+  const description = parsed.description?.trim() ?? "";
   return {
     kind: "parsed",
+    userInvocable: parsed["user-invocable"] !== false,
     ...(name ? { name } : {}),
     ...(description ? { description } : {}),
+  };
+}
+
+function splitClaudeSkillArguments(value: string): ReadonlyArray<string> {
+  const arguments_: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+    } else if (character === "\\" && quote !== "'") {
+      escaped = true;
+    } else if (quote) {
+      if (character === quote) quote = null;
+      else current += character;
+    } else if (character === "'" || character === '"') {
+      quote = character;
+    } else if (/\s/.test(character)) {
+      if (current.length > 0) {
+        arguments_.push(current);
+        current = "";
+      }
+    } else {
+      current += character;
+    }
+  }
+  if (escaped) current += "\\";
+  if (current.length > 0) arguments_.push(current);
+  return arguments_;
+}
+
+export type PreparedClaudeSkillContents =
+  | { readonly kind: "prepared"; readonly contents: string }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "unsupported"; readonly fields: ReadonlyArray<string> };
+
+/**
+ * Prepares a Claude skill for providers that cannot ask Claude Code to invoke
+ * it natively. Argument placeholders are expanded; runtime-only frontmatter
+ * is rejected so the fallback never silently weakens a skill's contract.
+ */
+export function prepareClaudeSkillContents(
+  contents: string,
+  argumentsText: string,
+): PreparedClaudeSkillContents {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  const body = match ? contents.slice(match[0].length).trimStart() : contents;
+  if (match) {
+    const frontmatter = Option.getOrUndefined(decodeClaudeSkillFrontmatterRecord(match[1] ?? ""));
+    if (!frontmatter) return { kind: "malformed" };
+    const fields = UNSUPPORTED_FALLBACK_FIELDS.filter((field) => frontmatter[field] !== undefined);
+    if (fields.length > 0) return { kind: "unsupported", fields };
+  }
+
+  const positionalArguments = splitClaudeSkillArguments(argumentsText);
+  let substituted = false;
+  const prepared = body.replace(
+    /(\\*)\$(?:ARGUMENTS(?:\[(\d+)\])?|(\d+))/g,
+    (token, backslashes: string, indexed: string | undefined, shorthand: string | undefined) => {
+      const placeholder = token.slice(backslashes.length);
+      if (backslashes.length === 1) return placeholder;
+      substituted = true;
+      const index = indexed ?? shorthand;
+      const replacement =
+        index === undefined ? argumentsText : (positionalArguments[Number(index)] ?? placeholder);
+      return `${backslashes}${replacement}`;
+    },
+  );
+  return {
+    kind: "prepared",
+    contents:
+      !substituted && argumentsText.length > 0
+        ? `${prepared.trimEnd()}\n\nARGUMENTS: ${argumentsText}`
+        : prepared,
   };
 }
 
@@ -131,6 +232,9 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       // either — skip it rather than surfacing a broken entry under its
       // directory name.
       if (frontmatter.kind === "malformed") {
+        continue;
+      }
+      if (frontmatter.kind === "parsed" && !frontmatter.userInvocable) {
         continue;
       }
 

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -105,6 +105,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
+      const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -132,7 +133,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       });
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/CursorSkills.test.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.test.ts
@@ -1,0 +1,90 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverCursorSkills } from "./CursorSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  relativeDirectory: string,
+  contents: string,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDirectory = path.join(skillsDir, relativeDirectory);
+  yield* fileSystem.makeDirectory(skillDirectory, { recursive: true });
+  yield* fileSystem.writeFileString(path.join(skillDirectory, "SKILL.md"), contents);
+});
+
+const skill = (name: string, description = `Use ${name}.`) =>
+  ["---", `name: ${name}`, `description: ${description}`, "---", "", `# ${name}`].join("\n");
+
+it.layer(NodeServices.layer)("discoverCursorSkills", (it) => {
+  it.effect("discovers every documented direct user and project root", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const home = path.join(tempDir, "home");
+      const workspace = path.join(tempDir, "workspace");
+      const rootNames = [".agents", ".cursor", ".claude", ".codex"] as const;
+
+      for (const rootName of rootNames) {
+        yield* writeSkill(
+          path.join(home, rootName, "skills"),
+          `user-${rootName.slice(1)}`,
+          skill(`user-${rootName.slice(1)}`),
+        );
+        yield* writeSkill(
+          path.join(workspace, rootName, "skills"),
+          `project-${rootName.slice(1)}`,
+          skill(`project-${rootName.slice(1)}`),
+        );
+      }
+
+      const skills = yield* discoverCursorSkills(workspace, { HOME: home });
+
+      assert.deepEqual(
+        skills.map((entry) => [entry.name, entry.scope]),
+        [
+          ["project-agents", "project"],
+          ["project-claude", "project"],
+          ["project-codex", "project"],
+          ["project-cursor", "project"],
+          ["user-agents", "user"],
+          ["user-claude", "user"],
+          ["user-codex", "user"],
+          ["user-cursor", "user"],
+        ],
+      );
+    }),
+  );
+
+  it.effect("discovers nested skills and rejects invalid entries", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const workspace = path.join(tempDir, "workspace");
+      const skillsDirectory = path.join(workspace, ".cursor", "skills");
+
+      yield* writeSkill(skillsDirectory, "shipping/deploy", skill("deploy"));
+      yield* writeSkill(skillsDirectory, "wrong-folder", skill("another-name"));
+      yield* writeSkill(
+        skillsDirectory,
+        "no-description",
+        ["---", "name: no-description", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverCursorSkills(workspace, { HOME: path.join(tempDir, "home") });
+
+      assert.deepEqual(
+        skills.map((entry) => entry.name),
+        ["deploy"],
+      );
+      assert.equal(skills[0]?.path, path.join(skillsDirectory, "shipping", "deploy", "SKILL.md"));
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,0 +1,121 @@
+/**
+ * CursorSkills — filesystem discovery for the Cursor `$` picker.
+ *
+ * Cursor Agent discovers skills from its own, Agent Skills, Claude, and Codex
+ * directories. T3 reads the same on-disk skills because Cursor ACP does not
+ * expose a skill catalogue.
+ *
+ * @module provider/Drivers/CursorSkills
+ */
+import * as NodeOS from "node:os";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
+
+type CursorSkillScope = "user" | "project";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const SKILL_NAME_PATTERN = /^[a-z0-9-]+$/;
+
+const CursorSkillFrontmatter = fromYaml(
+  Schema.Struct({
+    name: Schema.String,
+    description: Schema.String,
+  }),
+);
+const decodeCursorSkillFrontmatter = Schema.decodeUnknownOption(CursorSkillFrontmatter);
+
+type SkillFrontmatter =
+  | { readonly kind: "malformed" }
+  | { readonly kind: "parsed"; readonly name: string; readonly description: string };
+
+function parseSkillFrontmatter(contents: string): SkillFrontmatter {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) {
+    return { kind: "malformed" };
+  }
+
+  const parsed = Option.getOrUndefined(decodeCursorSkillFrontmatter(match[1] ?? ""));
+  if (!parsed) {
+    return { kind: "malformed" };
+  }
+
+  const name = parsed.name.trim();
+  const description = parsed.description.trim();
+  if (!SKILL_NAME_PATTERN.test(name) || !description) {
+    return { kind: "malformed" };
+  }
+
+  return { kind: "parsed", name, description };
+}
+
+function isSkillFile(entry: string): boolean {
+  return entry === "SKILL.md" || entry.replaceAll("\\", "/").endsWith("/SKILL.md");
+}
+
+/**
+ * List skills from Cursor's documented user and project roots. The scan is
+ * best-effort so unreadable or malformed entries never affect provider state.
+ */
+export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* (
+  cwd?: string,
+  environment?: NodeJS.ProcessEnv,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const homePath = environment?.HOME?.trim() || NodeOS.homedir();
+  const roots: ReadonlyArray<{ directory: string; scope: CursorSkillScope }> = [
+    { directory: path.join(homePath, ".agents", "skills"), scope: "user" },
+    { directory: path.join(homePath, ".cursor", "skills"), scope: "user" },
+    { directory: path.join(homePath, ".claude", "skills"), scope: "user" },
+    { directory: path.join(homePath, ".codex", "skills"), scope: "user" },
+    ...(cwd
+      ? [
+          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".cursor", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".codex", "skills"), scope: "project" as const },
+        ]
+      : []),
+  ];
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory, { recursive: true })
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].filter(isSkillFile).sort()) {
+      const skillPath = path.join(root.directory, entry);
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+      if (frontmatter.name !== path.basename(path.dirname(skillPath))) {
+        continue;
+      }
+
+      skillsByName.set(frontmatter.name, {
+        name: frontmatter.name,
+        description: frontmatter.description,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -782,6 +782,60 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("explicitly injects a selected skill document into Claude prompts", () => {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-skills-"));
+    const configDir = NodePath.join(baseDir, "claude-home");
+    const skillsDir = NodePath.join(configDir, "skills", "wayfinder");
+    NodeFS.mkdirSync(skillsDir, { recursive: true });
+    NodeFS.writeFileSync(
+      NodePath.join(skillsDir, "SKILL.md"),
+      [
+        "---",
+        "name: wayfinder",
+        "description: Plan and document the work.",
+        "disable-model-invocation: true",
+        "---",
+        "",
+        "# Wayfinder",
+        "Map the work before implementation.",
+      ].join("\n"),
+    );
+    const harness = makeHarness({
+      baseDir,
+      cwd: NodePath.join(baseDir, "workspace"),
+      claudeConfig: { homePath: configDir },
+    });
+
+    return Effect.gen(function* () {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(baseDir, { recursive: true, force: true })),
+      );
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "Use $wayfinder to plan this change.",
+        skillInvocations: [{ name: "wayfinder", start: 4, end: 14 }],
+        attachments: [],
+      });
+
+      const promptText = yield* Effect.promise(() =>
+        readFirstPromptText(harness.getLastCreateQueryInput()),
+      );
+      assert.include(promptText ?? "", "Map the work before implementation.");
+      assert.include(promptText ?? "", "[T3 explicitly invoked skill: wayfinder]");
+      assert.notInclude(promptText ?? "", "$wayfinder");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("embeds image attachments in Claude user messages", () => {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-attachments-"));
     const harness = makeHarness({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -35,6 +35,7 @@ import {
   type ProviderRuntimeTurnStatus,
   type ProviderSendTurnInput,
   type ProviderSession,
+  type ServerProviderSkill,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   type RuntimeContentStreamKind,
@@ -79,6 +80,7 @@ import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import { discoverClaudeSkills, prepareClaudeSkillContents } from "../Drivers/ClaudeSkills.ts";
 import {
   getClaudeModelCapabilities,
   isClaudeUltracodeEffort,
@@ -96,6 +98,11 @@ import {
   type ProviderAdapterError,
 } from "../Errors.ts";
 import { type ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
+import {
+  replaceExplicitSkillInvocations,
+  renderProviderSkillPrompt,
+  loadInvokedSkills,
+} from "../skillInvocations.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const decodeUnknownJsonStringExit = Schema.decodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
@@ -273,6 +280,7 @@ function rememberPendingTaskModel(
 
 interface ClaudeSessionContext {
   session: ProviderSession;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly promptQueue: Queue.Queue<PromptQueueItem>;
   readonly query: ClaudeQueryRuntime;
   streamFiber: Fiber.Fiber<void, Error> | undefined;
@@ -1716,6 +1724,76 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
   const sessions = new Map<ThreadId, ClaudeSessionContext>();
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+
+  const discoverSkills = (cwd?: string) =>
+    discoverClaudeSkills(claudeSettings, cwd, claudeEnvironment).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+    );
+
+  const prepareSkillPrompt = (input: ProviderSendTurnInput, context: ClaudeSessionContext) =>
+    Effect.gen(function* () {
+      const prompt = input.input?.trim();
+      const invocations = input.skillInvocations ?? [];
+      if (!prompt || invocations.length === 0) {
+        return undefined;
+      }
+
+      const resolved = yield* loadInvokedSkills({
+        provider: PROVIDER,
+        providerLabel: "Claude",
+        prompt,
+        invocations,
+        skills: context.skills,
+        readFile: (skillPath) =>
+          fileSystem.readFileString(skillPath).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "turn/start",
+                  detail: `Failed to read Claude skill '${skillPath}'.`,
+                  cause,
+                }),
+            ),
+          ),
+      });
+      const argumentsText = replaceExplicitSkillInvocations(
+        prompt,
+        resolved.invocations,
+        () => "",
+      ).trim();
+      const documents = resolved.documents.map((document) => ({
+        ...document,
+        prepared: prepareClaudeSkillContents(document.contents, argumentsText),
+      }));
+      const malformed = documents.find((document) => document.prepared.kind === "malformed");
+      if (malformed) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "sendTurn",
+          issue: `Claude skill '$${malformed.name}' has malformed frontmatter.`,
+        });
+      }
+      const unsupported = documents.find((document) => document.prepared.kind === "unsupported");
+      if (unsupported?.prepared.kind === "unsupported") {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "sendTurn",
+          issue: `Claude skill '$${unsupported.name}' requires native runtime fields unsupported by T3's explicit fallback: ${unsupported.prepared.fields.join(", ")}.`,
+        });
+      }
+      return renderProviderSkillPrompt(
+        prompt,
+        documents.map((document) => ({
+          name: document.name,
+          path: document.path,
+          contents:
+            document.prepared.kind === "prepared" ? document.prepared.contents : document.contents,
+        })),
+        resolved.invocations,
+      );
+    });
 
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
   const randomUUIDv4 = crypto.randomUUIDv4.pipe(
@@ -3735,7 +3813,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     // Same reason as the approvals above: a request nobody can answer any more
     // must not stay open, or the thread can never be settled.
-    for (const pending of [...context.pendingUserInputs.values()]) {
+    for (const pending of context.pendingUserInputs.values()) {
       yield* pending.cancel;
     }
 
@@ -3826,6 +3904,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       const startedAt = yield* nowIso;
+      const skills = yield* discoverSkills(input.cwd);
       const resumeState = readClaudeResumeState(input.resumeCursor);
       const threadId = input.threadId;
       const existingResumeSessionId = resumeState?.resume;
@@ -4391,6 +4470,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const context: ClaudeSessionContext = {
         session,
+        skills,
         promptQueue,
         query: queryRuntime,
         streamFiber: undefined,
@@ -4499,6 +4579,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
         ? input.modelSelection
         : undefined;
+    const skillPrompt = yield* prepareSkillPrompt(input, context);
 
     // A sendTurn while a real turn is running is a steer: the message is
     // queued into the live SDK agent loop and the work continues as the same
@@ -4585,11 +4666,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
     }
 
-    const message = yield* buildUserMessageEffect(input, {
-      fileSystem,
-      attachmentsDir: serverConfig.attachmentsDir,
-      boundInstanceId,
-    });
+    const message = yield* buildUserMessageEffect(
+      skillPrompt === undefined ? input : { ...input, input: skillPrompt },
+      {
+        fileSystem,
+        attachmentsDir: serverConfig.attachmentsDir,
+        boundInstanceId,
+      },
+    );
 
     yield* Queue.offer(context.promptQueue, {
       type: "message",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -57,6 +57,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
+  CodexSessionRuntimeUnknownSkillError,
   describeMcpElicitation,
   makeCodexSessionRuntime,
   type CodexSessionRuntimeError,
@@ -70,6 +71,7 @@ const isCodexAppServerTransportError = Schema.is(CodexErrors.CodexAppServerTrans
 const isCodexSessionRuntimeThreadIdMissingError = Schema.is(
   CodexSessionRuntimeThreadIdMissingError,
 );
+const isCodexSessionRuntimeUnknownSkillError = Schema.is(CodexSessionRuntimeUnknownSkillError);
 const isCodexResumeCursorSchema = Schema.is(CodexResumeCursorSchema);
 
 const PROVIDER = ProviderDriverKind.make("codex");
@@ -113,6 +115,15 @@ function mapCodexRuntimeError(
     return new ProviderAdapterSessionNotFoundError({
       provider: PROVIDER,
       threadId,
+      cause: error,
+    });
+  }
+
+  if (isCodexSessionRuntimeUnknownSkillError(error)) {
+    return new ProviderAdapterValidationError({
+      provider: PROVIDER,
+      operation: "sendTurn",
+      issue: `Unknown Codex skill${error.names.length === 1 ? "" : "s"}: ${error.names.map((name) => `$${name}`).join(", ")}.`,
       cause: error,
     });
   }
@@ -1843,6 +1854,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     return yield* session.runtime
       .sendTurn({
         ...(input.input !== undefined ? { input: input.input } : {}),
+        ...(input.skillInvocations !== undefined
+          ? { skillInvocations: input.skillInvocations }
+          : {}),
         ...(input.modelSelection?.instanceId === boundInstanceId
           ? { model: input.modelSelection.model }
           : {}),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -251,7 +251,7 @@ function appendCustomCodexModels(
   return customEntries.length === 0 ? models : [...models, ...customEntries];
 }
 
-function parseCodexSkillsListResponse(
+export function parseCodexSkillsListResponse(
   response: CodexSchema.V2SkillsListResponse,
   cwd: string,
 ): ReadonlyArray<ServerProviderSkill> {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -17,6 +17,7 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  CodexSessionRuntimeUnknownSkillError,
   describeMcpElicitation,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
@@ -25,6 +26,8 @@ import {
   toMcpElicitationResponse,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+const isCodexAppServerProtocolParseError = Schema.is(CodexErrors.CodexAppServerProtocolParseError);
+const isCodexSessionRuntimeUnknownSkillError = Schema.is(CodexSessionRuntimeUnknownSkillError);
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {
@@ -81,6 +84,10 @@ describe("buildTurnStartParams", () => {
         ],
       }).pipe(Effect.flip),
     );
+    if (!isCodexAppServerProtocolParseError(error)) {
+      NodeAssert.fail("expected CodexAppServerProtocolParseError");
+      return;
+    }
     const { cause, ...directDiagnostics } = error;
 
     NodeAssert.equal(error.operation, "decode-request-payload");
@@ -221,6 +228,85 @@ describe("buildTurnStartParams", () => {
           },
         ],
       });
+    }),
+  );
+
+  it.effect("attaches explicit $skill tokens as Codex skill user input", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "$grill-with-docs explain why this skill is not in the list",
+        skillInvocations: [{ name: "grill-with-docs", start: 0, end: 16 }],
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params.input, [
+        {
+          type: "text",
+          text: "[T3 explicitly invoked skill: grill-with-docs] explain why this skill is not in the list",
+        },
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("fails instead of sending an unknown $skill token", () =>
+    Effect.gen(function* () {
+      const error = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "$missing-skill do this",
+        skillInvocations: [{ name: "missing-skill", start: 0, end: 14 }],
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      }).pipe(Effect.flip);
+
+      if (!isCodexSessionRuntimeUnknownSkillError(error)) {
+        NodeAssert.fail("expected CodexSessionRuntimeUnknownSkillError");
+        return;
+      }
+      NodeAssert.deepStrictEqual(error.names, ["missing-skill"]);
+      NodeAssert.equal(error.message, "Unknown Codex skill $missing-skill.");
+    }),
+  );
+
+  it.effect("leaves a message without $skill tokens unchanged", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Review this change",
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params.input, [
+        {
+          type: "text",
+          text: "Review this change",
+        },
+      ]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -9,6 +9,7 @@ import {
   type ProviderApprovalOption,
   type ProviderEvent,
   type ProviderInteractionMode,
+  type ExplicitSkillInvocation,
   type ProviderRequestKind,
   type ProviderSession,
   type ProviderTurnStartResult,
@@ -17,8 +18,8 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -36,7 +37,9 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
-import { buildCodexInitializeParams } from "./CodexProvider.ts";
+import { buildCodexInitializeParams, parseCodexSkillsListResponse } from "./CodexProvider.ts";
+import { bindCodexSkillInvocations } from "./codexSkillInvocations.ts";
+import { replaceExplicitSkillInvocations } from "../skillInvocations.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
@@ -170,6 +173,7 @@ export interface CodexSessionRuntimeOptions {
 
 export interface CodexSessionRuntimeSendTurnInput {
   readonly input?: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments?: ReadonlyArray<{
     readonly type: "image";
     readonly url: string;
@@ -221,7 +225,8 @@ export type CodexSessionRuntimeError =
   | CodexSessionRuntimePendingApprovalNotFoundError
   | CodexSessionRuntimePendingUserInputNotFoundError
   | CodexSessionRuntimeInvalidUserInputAnswersError
-  | CodexSessionRuntimeThreadIdMissingError;
+  | CodexSessionRuntimeThreadIdMissingError
+  | CodexSessionRuntimeUnknownSkillError;
 
 export class CodexSessionRuntimePendingApprovalNotFoundError extends Schema.TaggedErrorClass<CodexSessionRuntimePendingApprovalNotFoundError>()(
   "CodexSessionRuntimePendingApprovalNotFoundError",
@@ -264,6 +269,21 @@ export class CodexSessionRuntimeThreadIdMissingError extends Schema.TaggedErrorC
 ) {
   override get message(): string {
     return `Codex session is missing a provider thread id for ${this.threadId}`;
+  }
+}
+
+export class CodexSessionRuntimeUnknownSkillError extends Schema.TaggedErrorClass<CodexSessionRuntimeUnknownSkillError>()(
+  "CodexSessionRuntimeUnknownSkillError",
+  {
+    names: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    const listed = this.names.map((name) => `$${name}`).join(", ");
+    if (this.names.length === 1) {
+      return `Unknown Codex skill ${listed}.`;
+    }
+    return `Unknown Codex skills ${listed}.`;
   }
 }
 
@@ -593,9 +613,15 @@ export function buildTurnStartParams(input: {
   readonly threadId: string;
   readonly runtimeMode: RuntimeMode;
   readonly prompt?: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments?: ReadonlyArray<{
     readonly type: "image";
     readonly url: string;
+  }>;
+  readonly availableSkills?: ReadonlyArray<{
+    readonly name: string;
+    readonly path: string;
+    readonly enabled: boolean;
   }>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;
@@ -605,14 +631,33 @@ export function buildTurnStartParams(input: {
   readonly browserToolsAvailable?: boolean;
 }): Effect.Effect<
   CodexTurnStartParamsWithCollaborationMode,
-  CodexErrors.CodexAppServerProtocolParseError
+  CodexErrors.CodexAppServerProtocolParseError | CodexSessionRuntimeUnknownSkillError
 > {
+  const boundSkills = bindCodexSkillInvocations(
+    input.prompt ?? "",
+    input.skillInvocations ?? [],
+    input.availableSkills ?? [],
+  );
+  if (!boundSkills.ok) {
+    return Effect.fail(new CodexSessionRuntimeUnknownSkillError({ names: boundSkills.names }));
+  }
+
   const turnInput: Array<EffectCodexSchema.V2TurnStartParams__UserInput> = [];
-  if (input.prompt) {
+  const prompt = input.prompt
+    ? replaceExplicitSkillInvocations(
+        input.prompt,
+        input.skillInvocations ?? [],
+        (name) => `[T3 explicitly invoked skill: ${name}]`,
+      )
+    : undefined;
+  if (prompt) {
     turnInput.push({
       type: "text",
-      text: input.prompt,
+      text: prompt,
     });
+  }
+  for (const skill of boundSkills.inputs) {
+    turnInput.push(skill);
   }
   for (const attachment of input.attachments ?? []) {
     turnInput.push(attachment);
@@ -2308,11 +2353,21 @@ export const makeCodexSessionRuntime = (
           const normalizedModel = normalizeCodexModelSlug(
             input.model ?? (yield* Ref.get(sessionRef)).model,
           );
+          const skillInvocations = input.skillInvocations ?? [];
+          let availableSkills: ReturnType<typeof parseCodexSkillsListResponse> = [];
+          if (skillInvocations.length > 0) {
+            const session = yield* Ref.get(sessionRef);
+            const cwd = session.cwd ?? options.cwd;
+            const skillsResponse = yield* client.request("skills/list", { cwds: [cwd] });
+            availableSkills = parseCodexSkillsListResponse(skillsResponse, cwd);
+          }
           const params = yield* buildTurnStartParams({
             threadId: providerThreadId,
             runtimeMode: options.runtimeMode,
             ...(input.input ? { prompt: input.input } : {}),
+            ...(skillInvocations.length > 0 ? { skillInvocations } : {}),
             ...(input.attachments ? { attachments: input.attachments } : {}),
+            ...(skillInvocations.length > 0 ? { availableSkills } : {}),
             ...(normalizedModel ? { model: normalizedModel } : {}),
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
             ...(input.effort ? { effort: input.effort } : {}),

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -168,6 +168,77 @@ const cursorAdapterTestLayer = it.layer(
 );
 
 cursorAdapterTestLayer("CursorAdapterLive", (it) => {
+  it.effect("injects selected Cursor skill documents", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-skill-invocation");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-acp-skill-")),
+      );
+      const workspace = NodePath.join(tempDir, "workspace");
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const skillPath = NodePath.join(workspace, ".cursor", "skills", "deploy", "SKILL.md");
+      const reviewSkillPath = NodePath.join(workspace, ".cursor", "skills", "review", "SKILL.md");
+      yield* Effect.promise(async () => {
+        await NodeFSP.mkdir(NodePath.dirname(skillPath), { recursive: true });
+        await NodeFSP.mkdir(NodePath.dirname(reviewSkillPath), { recursive: true });
+        await NodeFSP.writeFile(
+          skillPath,
+          ["---", "name: deploy", "description: Deploy the service.", "---", "", "# Deploy"].join(
+            "\n",
+          ),
+          "utf8",
+        );
+        await NodeFSP.writeFile(
+          reviewSkillPath,
+          ["---", "name: review", "description: Review the service.", "---", "", "# Review"].join(
+            "\n",
+          ),
+          "utf8",
+        );
+        await NodeFSP.writeFile(requestLogPath, "", "utf8");
+      });
+      const wrapperPath = yield* Effect.promise(() =>
+        makeProbeWrapper(requestLogPath, NodePath.join(tempDir, "argv.txt")),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: workspace,
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "First use $deploy, then $review to ship the release.",
+        skillInvocations: [
+          { name: "deploy", start: 10, end: 17 },
+          { name: "review", start: 24, end: 31 },
+        ],
+        attachments: [],
+      });
+
+      const requests = yield* waitForJsonLogMatch(
+        requestLogPath,
+        (entry) => entry.method === "session/prompt",
+      );
+      const promptRequest = requests.find((entry) => entry.method === "session/prompt");
+      const prompt = (promptRequest?.params as { prompt?: Array<{ text?: string }> } | undefined)
+        ?.prompt?.[0]?.text;
+      assert.include(prompt ?? "", "# Deploy");
+      assert.include(prompt ?? "", "# Review");
+      assert.include(prompt ?? "", "[T3 explicitly invoked skill: deploy]");
+      assert.include(prompt ?? "", "[T3 explicitly invoked skill: review]");
+      assert.notInclude(prompt ?? "", "$deploy");
+      assert.notInclude(prompt ?? "", "$review");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -7,6 +7,7 @@
 import {
   ApprovalRequestId,
   type CursorSettings,
+  type ServerProviderSkill,
   type ProviderOptionSelection,
   EventId,
   type ProviderApprovalDecision,
@@ -43,6 +44,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import { discoverCursorSkills } from "../Drivers/CursorSkills.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
@@ -75,6 +77,7 @@ import {
   extractTodosAsPlan,
 } from "../acp/CursorAcpExtension.ts";
 import { type CursorAdapterShape } from "../Services/CursorAdapter.ts";
+import { renderProviderSkillPrompt, loadInvokedSkills } from "../skillInvocations.ts";
 import { resolveCursorAcpBaseModelId } from "./CursorProvider.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
@@ -133,6 +136,8 @@ interface CursorSessionContext {
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
   activeTurnId: TurnId | undefined;
+  /** Skills discovered for the session cwd, refreshed lazily before a `$` turn. */
+  skills: ReadonlyArray<ServerProviderSkill>;
   /** Number of sendTurn prompts currently in flight or being prepared.
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
@@ -336,6 +341,12 @@ export function makeCursorAdapter(
     const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
 
+    const discoverSkills = (cwd?: string) =>
+      discoverCursorSkills(cwd, options?.environment).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
       Effect.mapError(
@@ -530,6 +541,7 @@ export function makeCursorAdapter(
           const effectiveCursorSettings = options?.resolveSettings
             ? yield* options.resolveSettings
             : cursorSettings;
+          const skills = yield* discoverSkills(cwd);
 
           const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
           const acp = yield* makeCursorAcpRuntime({
@@ -778,6 +790,7 @@ export function makeCursorAdapter(
             turns: [],
             lastPlanFingerprint: undefined,
             activeTurnId: undefined,
+            skills,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -916,6 +929,34 @@ export function makeCursorAdapter(
     const sendTurn: CursorAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
+        const promptText = input.input?.trim();
+        let preparedPromptText = promptText;
+        if (promptText && input.skillInvocations && input.skillInvocations.length > 0) {
+          const resolved = yield* loadInvokedSkills({
+            provider: PROVIDER,
+            providerLabel: "Cursor",
+            prompt: promptText,
+            invocations: input.skillInvocations,
+            skills: ctx.skills,
+            readFile: (skillPath) =>
+              fileSystem.readFileString(skillPath).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new ProviderAdapterRequestError({
+                      provider: PROVIDER,
+                      method: "session/prompt",
+                      detail: `Failed to read Cursor skill '${skillPath}'.`,
+                      cause,
+                    }),
+                ),
+              ),
+          });
+          preparedPromptText = renderProviderSkillPrompt(
+            promptText,
+            resolved.documents,
+            resolved.invocations,
+          );
+        }
         // A sendTurn while a prompt is in flight is a steer: the agent folds
         // the new prompt into the ongoing work, so the active turn id is
         // reused instead of opening a new turn.
@@ -967,8 +1008,11 @@ export function makeCursorAdapter(
           }
 
           const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          if (input.input?.trim()) {
-            promptParts.push({ type: "text", text: input.input.trim() });
+          if (preparedPromptText) {
+            promptParts.push({
+              type: "text",
+              text: preparedPromptText,
+            });
           }
           if (input.attachments && input.attachments.length > 0) {
             for (const attachment of input.attachments) {

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -87,7 +87,9 @@ exec ${mockAgentCommand} "$@"
   return wrapperPath;
 });
 
-const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")(function* () {
+const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")(function* (
+  version = "2026.04.09-f2b0fcd",
+) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const mockAgentPath = yield* resolveMockAgentPath();
@@ -99,7 +101,7 @@ const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")
   const mockAgentCommand = ["node", mockAgentPath].map((arg) => JSON.stringify(arg)).join(" ");
   const script = `#!/bin/sh
 if [ "$1" = "about" ]; then
-  printf 'CLI Version         2026.04.09-f2b0fcd\\n'
+  printf 'CLI Version         ${version}\\n'
   printf 'User Email          cursor@example.com\\n'
   exit 0
 fi
@@ -323,6 +325,37 @@ describe("getCursorFallbackModels", () => {
 });
 
 describe("buildCursorProviderSnapshot", () => {
+  it("publishes discovered skills for the shared composer picker", () => {
+    expect(
+      buildCursorProviderSnapshot({
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        cursorSettings: baseCursorSettings,
+        parsed: {
+          version: "2026.04.09-f2b0fcd",
+          status: "ready",
+          auth: { status: "authenticated" },
+        },
+        skills: [
+          {
+            name: "deploy",
+            description: "Deploy the service.",
+            path: "/workspace/.cursor/skills/deploy/SKILL.md",
+            enabled: true,
+            scope: "project",
+          },
+        ],
+      }).skills,
+    ).toEqual([
+      {
+        name: "deploy",
+        description: "Deploy the service.",
+        path: "/workspace/.cursor/skills/deploy/SKILL.md",
+        enabled: true,
+        scope: "project",
+      },
+    ]);
+  });
+
   it("downgrades ready status to warning when ACP model discovery times out", () => {
     expect(
       buildCursorProviderSnapshot({
@@ -471,6 +504,43 @@ describe("checkCursorProviderStatus", () => {
       "claude-opus-4-6",
     ]);
     await expect(runNode(waitForFileContent(requestLogPath))).resolves.toContain("initialize");
+  });
+
+  it("keeps discovered skills when the parameterized model picker is unavailable", async () => {
+    const fixture = await runNode(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fileSystem.makeTempDirectory({
+          directory: NodeOS.tmpdir(),
+          prefix: "cursor-provider-skills-",
+        });
+        const workspace = path.join(tempDir, "workspace");
+        const skillPath = path.join(workspace, ".cursor", "skills", "deploy", "SKILL.md");
+        yield* fileSystem.makeDirectory(path.dirname(skillPath), { recursive: true });
+        yield* fileSystem.writeFileString(
+          skillPath,
+          ["---", "name: deploy", "description: Deploy the service.", "---"].join("\n"),
+        );
+        return { workspace, home: path.join(tempDir, "home") };
+      }),
+    );
+    const wrapperPath = await runNode(makeMockAgentWithAboutWrapper("2026.04.07-f2b0fcd"));
+
+    const provider = await runNode(
+      checkCursorProviderStatus(
+        {
+          enabled: true,
+          binaryPath: wrapperPath,
+          apiEndpoint: "",
+          customModels: [],
+        },
+        { HOME: fixture.home },
+        fixture.workspace,
+      ),
+    );
+
+    expect(provider.skills.map((skill) => skill.name)).toEqual(["deploy"]);
   });
 });
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -7,6 +7,7 @@ import type {
   ServerProviderAuth,
   ServerProviderModel,
   ServerProviderState,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
@@ -30,6 +31,7 @@ import {
 } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
+import { discoverCursorSkills } from "../Drivers/CursorSkills.ts";
 import {
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
@@ -627,6 +629,7 @@ export function buildCursorProviderSnapshot(input: {
   readonly cursorSettings: CursorSettings;
   readonly parsed: CursorAboutResult;
   readonly discoveredModels?: ReadonlyArray<ServerProviderModel>;
+  readonly skills?: ReadonlyArray<ServerProviderSkill>;
   readonly discoveryWarning?: string;
 }): ServerProviderDraft {
   const message = joinProviderMessages(input.parsed.message, input.discoveryWarning);
@@ -639,6 +642,7 @@ export function buildCursorProviderSnapshot(input: {
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
     ),
+    skills: input.skills ?? [],
     probe: {
       installed: true,
       version: input.parsed.version,
@@ -987,6 +991,7 @@ const runCursorAboutCommand = (cursorSettings: CursorSettings, environment?: Nod
 export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(function* (
   cursorSettings: CursorSettings,
   environment?: NodeJS.ProcessEnv,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -1056,6 +1061,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
   }
 
   const parsed = parseCursorAboutOutput(aboutProbe.success.value);
+  const skills = yield* discoverCursorSkills(cwd, environment);
   const cursorCliConfigChannel = yield* readCursorCliConfigChannel();
   const parameterizedModelPickerUnsupportedMessage =
     getCursorParameterizedModelPickerUnsupportedMessage({
@@ -1068,6 +1074,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version: parsed.version,
@@ -1109,6 +1116,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       Option.filter(discoveredModels, (models) => models.length > 0),
       () => [] as const,
     ),
+    skills,
     ...(discoveryWarning ? { discoveryWarning } : {}),
   });
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -38,15 +38,22 @@ const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
 const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
 const mockAgentCommand = process.execPath;
+const encodeInspectJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
 
-async function makeMockGrokWrapper(extraEnv?: Record<string, string>) {
+async function makeMockGrokWrapper(extraEnv?: Record<string, string>, inspectJson?: string) {
   const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-mock-"));
   const wrapperPath = NodePath.join(dir, "fake-grok.sh");
   const envExports = Object.entries(extraEnv ?? {})
     .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
     .join("\n");
+  const inspectBranch = `export T3_GROK_INSPECT_JSON=${JSON.stringify(inspectJson ?? '{"skills":[]}')}
+if [ "$1" = "inspect" ] && [ "$2" = "--json" ]; then
+  printf '%s\\n' "$T3_GROK_INSPECT_JSON"
+  exit 0
+fi`;
   const script = `#!/bin/sh
 ${envExports}
+${inspectBranch}
 exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
 `;
   await NodeFSP.writeFile(wrapperPath, script, "utf8");
@@ -273,6 +280,61 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       if (delta?.type === "content.delta") {
         assert.equal(delta.payload.delta, "hello from mock");
       }
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("injects explicitly selected skills into Grok ACP prompts", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-skill-invocation");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-skill-")),
+      );
+      const workspace = NodePath.join(tempDir, "workspace");
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const skillPath = NodePath.join(workspace, ".agents", "skills", "review", "SKILL.md");
+      const inspectJson = yield* encodeInspectJson({
+        skills: [
+          {
+            name: "review",
+            description: "Review the change.",
+            source: { type: "project", path: skillPath },
+            userInvocable: true,
+          },
+        ],
+      });
+      yield* Effect.promise(async () => {
+        await NodeFSP.mkdir(NodePath.dirname(skillPath), { recursive: true });
+        await NodeFSP.writeFile(
+          skillPath,
+          "---\nname: review\ndescription: Review the change.\n---\n\n# Review checklist",
+          "utf8",
+        );
+        await NodeFSP.writeFile(requestLogPath, "", "utf8");
+      });
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }, inspectJson),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: workspace,
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Use $review to inspect this change.",
+        skillInvocations: [{ name: "review", start: 4, end: 11 }],
+        attachments: [],
+      });
+
+      const requests = yield* waitForFileContent(requestLogPath, 40, "# Review checklist");
+      assert.include(requests, "# Review checklist");
+      assert.notInclude(requests, "$review");
 
       yield* adapter.stopSession(threadId);
     }),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -5,6 +5,7 @@ import {
   type ProviderApprovalDecision,
   type ProviderRuntimeEvent,
   type ProviderSession,
+  type ServerProviderSkill,
   type ProviderUserInputAnswers,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -59,6 +60,7 @@ import {
 } from "../acp/AcpCoreRuntimeEvents.ts";
 import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import { discoverGrokSkills } from "../Drivers/GrokSkills.ts";
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
@@ -80,6 +82,7 @@ import {
 } from "../acp/XAiAcpExtension.ts";
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { renderProviderSkillPrompt, loadInvokedSkills } from "../skillInvocations.ts";
 
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
@@ -131,6 +134,7 @@ interface GrokSessionContext {
   readonly threadId: ThreadId;
   readonly acpSessionId: string;
   session: ProviderSession;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly scope: Scope.Closeable;
   readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
   notificationFiber: Fiber.Fiber<void, never> | undefined;
@@ -370,6 +374,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
         : DEFAULT_GROK_ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS;
     const activeToolInactivityTimeoutNanos =
       BigInt(activeToolInactivityTimeoutMs) * NANOS_PER_MILLI;
+    const discoverSkills = (cwd?: string) =>
+      discoverGrokSkills(grokSettings, options?.environment ?? hostEnvironment, cwd).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+      );
 
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
@@ -955,6 +963,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           }
 
           const cwd = path.resolve(input.cwd.trim());
+          const skills = yield* discoverSkills(cwd);
           const grokModelSelection =
             input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
           const existing = sessions.get(input.threadId);
@@ -1266,6 +1275,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             threadId: input.threadId,
             acpSessionId: started.sessionId,
             session,
+            skills,
             scope: sessionScope,
             acp,
             notificationFiber: undefined,
@@ -1504,6 +1514,33 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               );
 
               const text = input.input?.trim();
+              let promptText = text;
+              if (text && input.skillInvocations && input.skillInvocations.length > 0) {
+                const resolved = yield* loadInvokedSkills({
+                  provider: PROVIDER,
+                  providerLabel: "Grok",
+                  prompt: text,
+                  invocations: input.skillInvocations,
+                  skills: ctx.skills,
+                  readFile: (skillPath) =>
+                    fileSystem.readFileString(skillPath).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ProviderAdapterRequestError({
+                            provider: PROVIDER,
+                            method: "session/prompt",
+                            detail: `Failed to read Grok skill '${skillPath}'.`,
+                            cause,
+                          }),
+                      ),
+                    ),
+                });
+                promptText = renderProviderSkillPrompt(
+                  text,
+                  resolved.documents,
+                  resolved.invocations,
+                );
+              }
               // Grok ingests images only. Generic files reach the agent
               // through the path line ProviderService puts in the prompt.
               const imagePromptParts = yield* Effect.forEach(
@@ -1540,7 +1577,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   }),
               );
               const promptParts: Array<EffectAcpSchema.ContentBlock> = [
-                ...(text ? [{ type: "text" as const, text }] : []),
+                ...(promptText ? [{ type: "text" as const, text: promptText }] : []),
                 ...imagePromptParts,
               ];
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -74,6 +74,8 @@ const runtimeMock = {
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
     messageFailures: 0,
     promptCalls: [] as Array<unknown>,
+    skillCalls: [] as Array<{ directory?: string }>,
+    skills: [] as Array<{ name: string; location: string; content: string }>,
     promptAsyncError: null as Error | null,
     promptAsyncImplementation: null as (() => Promise<void>) | null,
     autoPromptEcho: true,
@@ -121,6 +123,8 @@ const runtimeMock = {
     this.state.messageCalls.length = 0;
     this.state.messageFailures = 0;
     this.state.promptCalls.length = 0;
+    this.state.skillCalls.length = 0;
+    this.state.skills = [];
     this.state.promptAsyncError = null;
     this.state.promptAsyncImplementation = null;
     this.state.autoPromptEcho = true;
@@ -329,6 +333,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             targetIndex >= 0
               ? runtimeMock.state.messages.slice(0, targetIndex + 1)
               : runtimeMock.state.messages;
+        },
+      },
+      app: {
+        skills: async (input?: { directory?: string }) => {
+          runtimeMock.state.skillCalls.push(input?.directory ? { directory: input.directory } : {});
+          return { data: runtimeMock.state.skills };
         },
       },
       event: {
@@ -926,6 +936,45 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         schemaVersion: 1,
         sessionId: "ses_persisted",
       });
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("injects explicitly selected skills into OpenCode prompts", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-skill");
+      runtimeMock.state.skills = [
+        {
+          name: "review",
+          location: "/workspace/.agents/skills/review/SKILL.md",
+          content: "---\nname: review\n---\n\n# Review checklist",
+        },
+      ];
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        cwd: "/workspace",
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Use $review to inspect this change.",
+        skillInvocations: [{ name: "review", start: 4, end: 11 }],
+        modelSelection: createModelSelection(ProviderInstanceId.make("opencode"), "openai/gpt-5"),
+      });
+
+      const prompt = runtimeMock.state.promptCalls.at(-1) as {
+        parts?: Array<{ type?: string; text?: string }>;
+      };
+      const promptText = prompt.parts?.find((part) => part.type === "text")?.text ?? "";
+      NodeAssert.equal(runtimeMock.state.skillCalls.length, 1);
+      NodeAssert.equal(runtimeMock.state.skillCalls[0]?.directory, "/workspace");
+      NodeAssert.equal(promptText.includes("# Review checklist"), true);
+      NodeAssert.equal(promptText.includes("[T3 explicitly invoked skill: review]"), true);
+      NodeAssert.equal(promptText.includes("$review"), false);
 
       yield* adapter.stopSession(threadId);
     }),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1,5 +1,6 @@
 import {
   EventId,
+  type ProviderSendTurnInput,
   type OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -55,6 +56,7 @@ import {
   toOpenCodeQuestionAnswers,
   type OpenCodeServerConnection,
 } from "../opencodeRuntime.ts";
+import { renderProviderSkillPrompt, loadInvokedSkills } from "../skillInvocations.ts";
 import * as Option from "effect/Option";
 
 const PROVIDER = ProviderDriverKind.make("opencode");
@@ -318,8 +320,15 @@ function isOpenCodeDefaultTitle(title: string): boolean {
   return OPENCODE_DEFAULT_TITLE_PATTERN.test(title);
 }
 
+interface OpenCodeSkillSnapshot {
+  readonly name: string;
+  readonly location: string;
+  readonly content: string;
+}
+
 interface OpenCodeSessionContext {
   session: ProviderSession;
+  readonly skills: ReadonlyArray<OpenCodeSkillSnapshot>;
   readonly client: OpencodeClient;
   readonly server: OpenCodeServerConnection;
   readonly directory: string;
@@ -820,6 +829,31 @@ export function makeOpenCodeAdapter(
       }
       return current;
     });
+    const prepareSkillPrompt = (
+      context: OpenCodeSessionContext,
+      text: string | undefined,
+      invocations: ProviderSendTurnInput["skillInvocations"],
+    ) =>
+      Effect.gen(function* () {
+        if (!text || !invocations || invocations.length === 0) {
+          return text;
+        }
+
+        const skillsByPath = new Map(context.skills.map((skill) => [skill.location, skill]));
+        const resolved = yield* loadInvokedSkills({
+          provider: PROVIDER,
+          providerLabel: "OpenCode",
+          prompt: text,
+          invocations,
+          skills: context.skills.map((skill) => ({
+            name: skill.name,
+            path: skill.location,
+            enabled: true,
+          })),
+          readFile: (skillPath) => Effect.succeed(skillsByPath.get(skillPath)?.content ?? ""),
+        });
+        return renderProviderSkillPrompt(text, resolved.documents, resolved.invocations);
+      });
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
       Effect.mapError(
         (cause) =>
@@ -2435,6 +2469,10 @@ export function makeOpenCodeAdapter(
         });
 
         const createdAt = yield* nowIso;
+        const skillResponse = yield* runOpenCodeSdk("app.skills", () =>
+          started.client.app.skills({ directory }),
+        ).pipe(Effect.mapError(toRequestError));
+        const skills = (skillResponse.data ?? []) satisfies ReadonlyArray<OpenCodeSkillSnapshot>;
         const session: ProviderSession = {
           provider: PROVIDER,
           providerInstanceId: boundInstanceId,
@@ -2456,6 +2494,7 @@ export function makeOpenCodeAdapter(
 
         const context: OpenCodeSessionContext = {
           session,
+          skills,
           client: started.client,
           server: started.server,
           directory,
@@ -2586,6 +2625,7 @@ export function makeOpenCodeAdapter(
           issue: "OpenCode turns require text input or at least one attachment.",
         });
       }
+      const promptText = yield* prepareSkillPrompt(context, text, input.skillInvocations);
 
       return yield* context.promptSemaphore.withPermit(
         Effect.gen(function* () {
@@ -2692,7 +2732,10 @@ export function makeOpenCodeAdapter(
                 model: parsedModel,
                 ...(context.activeAgent ? { agent: context.activeAgent } : {}),
                 ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-                parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+                parts: [
+                  ...(promptText ? [{ type: "text" as const, text: promptText }] : []),
+                  ...fileParts,
+                ],
               },
               { signal },
             ),

--- a/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { bindCodexSkillInvocations } from "./codexSkillInvocations.ts";
+
+const grillWithDocs = {
+  name: "grill-with-docs",
+  path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+  enabled: true,
+};
+
+describe("bindCodexSkillInvocations", () => {
+  it("attaches a selected skill as structured Codex input", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "Use $grill-with-docs please",
+        [{ name: "grill-with-docs", start: 4, end: 20 }],
+        [grillWithDocs],
+      ),
+    ).toEqual({
+      ok: true,
+      inputs: [{ type: "skill", name: "grill-with-docs", path: grillWithDocs.path }],
+    });
+  });
+
+  it("allows explicitly selected Codex skills disabled for model invocation", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "$grill-with-docs go",
+        [{ name: "grill-with-docs", start: 0, end: 16 }],
+        [{ ...grillWithDocs, enabled: false }],
+      ),
+    ).toEqual({
+      ok: true,
+      inputs: [{ type: "skill", name: "grill-with-docs", path: grillWithDocs.path }],
+    });
+  });
+
+  it("does not infer invocations from ordinary dollar text", () => {
+    expect(bindCodexSkillInvocations("check $HOME/.config", [], [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
+  });
+
+  it("rejects unknown and stale invocation metadata", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "$missing-skill do this",
+        [{ name: "missing-skill", start: 0, end: 14 }],
+        [grillWithDocs],
+      ),
+    ).toEqual({ ok: false, names: ["missing-skill"] });
+    expect(
+      bindCodexSkillInvocations(
+        "$grill-with-docs go",
+        [{ name: "grill-with-docs", start: 1, end: 17 }],
+        [grillWithDocs],
+      ),
+    ).toEqual({ ok: false, names: ["grill-with-docs"] });
+  });
+
+  it("deduplicates selected skills by path", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "$grill-with-docs then $grill-with-docs",
+        [
+          { name: "grill-with-docs", start: 0, end: 16 },
+          { name: "grill-with-docs", start: 22, end: 38 },
+        ],
+        [grillWithDocs],
+      ),
+    ).toEqual({
+      ok: true,
+      inputs: [{ type: "skill", name: "grill-with-docs", path: grillWithDocs.path }],
+    });
+  });
+});

--- a/apps/server/src/provider/Layers/codexSkillInvocations.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.ts
@@ -1,0 +1,40 @@
+import type { ExplicitSkillInvocation, ServerProviderSkill } from "@t3tools/contracts";
+import { resolveProviderSkillInvocations } from "../skillInvocations.ts";
+
+export type CodexSkillUserInput = {
+  readonly type: "skill";
+  readonly name: string;
+  readonly path: string;
+};
+
+export type BindCodexSkillInvocationsResult =
+  | { readonly ok: true; readonly inputs: ReadonlyArray<CodexSkillUserInput> }
+  | { readonly ok: false; readonly names: readonly string[] };
+
+export function bindCodexSkillInvocations(
+  prompt: string,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "path" | "enabled">>,
+): BindCodexSkillInvocationsResult {
+  if (invocations.length === 0) {
+    return { ok: true, inputs: [] };
+  }
+
+  // Codex reports skills disabled for model invocation as disabled. Users can
+  // still invoke those skills explicitly.
+  const resolution = resolveProviderSkillInvocations(prompt, invocations, skills, {
+    allowDisabled: true,
+  });
+  const failedNames = [...new Set([...resolution.invalidNames, ...resolution.unknownNames])];
+  if (failedNames.length > 0) {
+    return { ok: false, names: failedNames };
+  }
+  return {
+    ok: true,
+    inputs: resolution.references.map((skill) => ({
+      type: "skill",
+      name: skill.name,
+      path: skill.path,
+    })),
+  };
+}

--- a/apps/server/src/provider/skillInvocations.test.ts
+++ b/apps/server/src/provider/skillInvocations.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderProviderSkillPrompt, resolveProviderSkillInvocations } from "./skillInvocations.ts";
+
+const reviewSkill = {
+  name: "review",
+  path: "/workspace/.agents/skills/review/SKILL.md",
+  enabled: true,
+};
+
+describe("resolveProviderSkillInvocations", () => {
+  it("resolves only explicit composer selections", () => {
+    const prompt = "Use $review, then inspect $HOME/.config.";
+    const invocation = { name: "review", start: 4, end: 11 };
+
+    expect(resolveProviderSkillInvocations(prompt, [invocation], [reviewSkill])).toEqual({
+      references: [reviewSkill],
+      invocations: [invocation],
+      unknownNames: [],
+      invalidNames: [],
+    });
+  });
+
+  it("reports unknown, disabled, and invalid explicit invocations", () => {
+    expect(
+      resolveProviderSkillInvocations(
+        "$missing $review",
+        [
+          { name: "missing", start: 0, end: 8 },
+          { name: "review", start: 10, end: 17 },
+        ],
+        [{ ...reviewSkill, enabled: false }],
+      ),
+    ).toEqual({
+      references: [],
+      invocations: [],
+      unknownNames: ["missing"],
+      invalidNames: ["review"],
+    });
+  });
+});
+
+describe("renderProviderSkillPrompt", () => {
+  it("replaces selected ranges and includes the skill location and document", () => {
+    const rendered = renderProviderSkillPrompt(
+      "Use $review to inspect $HOME.",
+      [
+        {
+          ...reviewSkill,
+          contents: "---\nname: review\n---\n\n# Review checklist",
+        },
+      ],
+      [{ name: "review", start: 4, end: 11 }],
+    );
+
+    expect(rendered).toContain(
+      "file: /workspace/.agents/skills/review/SKILL.md\n---\nname: review\n---\n\n# Review checklist",
+    );
+    expect(rendered).toContain("Use [T3 explicitly invoked skill: review] to inspect $HOME.");
+  });
+});

--- a/apps/server/src/provider/skillInvocations.ts
+++ b/apps/server/src/provider/skillInvocations.ts
@@ -1,0 +1,182 @@
+import type {
+  ExplicitSkillInvocation,
+  ProviderDriverKind,
+  ServerProviderSkill,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import { ProviderAdapterValidationError } from "./Errors.ts";
+
+export type ProviderSkillReference = Pick<ServerProviderSkill, "name" | "path" | "enabled">;
+
+export interface ProviderSkillDocument {
+  readonly name: string;
+  readonly path: string;
+  readonly contents: string;
+}
+
+export interface ProviderSkillInvocationResolution {
+  readonly references: ReadonlyArray<ProviderSkillReference>;
+  readonly invocations: ReadonlyArray<ExplicitSkillInvocation>;
+  readonly unknownNames: ReadonlyArray<string>;
+  readonly invalidNames: ReadonlyArray<string>;
+}
+
+export function replaceExplicitSkillInvocations(
+  prompt: string,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+  replace: (name: string) => string,
+): string {
+  let result = prompt;
+  for (const invocation of invocations.toReversed()) {
+    result = `${result.slice(0, invocation.start)}${replace(invocation.name)}${result.slice(invocation.end)}`;
+  }
+  return result;
+}
+
+export function loadProviderSkillDocuments<E>(
+  references: ReadonlyArray<ProviderSkillReference>,
+  readFile: (path: string) => Effect.Effect<string, E>,
+): Effect.Effect<ReadonlyArray<ProviderSkillDocument>, E> {
+  return Effect.forEach(references, (reference) =>
+    readFile(reference.path).pipe(
+      Effect.map(
+        (contents): ProviderSkillDocument => ({
+          name: reference.name,
+          path: reference.path,
+          contents,
+        }),
+      ),
+    ),
+  );
+}
+
+export function findProviderSkill(
+  name: string,
+  skills: ReadonlyArray<ProviderSkillReference>,
+  options?: { readonly allowDisabled?: boolean },
+): ProviderSkillReference | undefined {
+  const candidates = options?.allowDisabled ? skills : skills.filter((skill) => skill.enabled);
+  const exact = candidates.find((skill) => skill.name === name);
+  if (exact) {
+    return exact;
+  }
+
+  const lowerName = name.toLowerCase();
+  return candidates.find((skill) => skill.name.toLowerCase() === lowerName);
+}
+
+export function resolveProviderSkillInvocations(
+  prompt: string,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+  skills: ReadonlyArray<ProviderSkillReference>,
+  options?: { readonly allowDisabled?: boolean },
+): ProviderSkillInvocationResolution {
+  const references: ProviderSkillReference[] = [];
+  const validInvocations: ExplicitSkillInvocation[] = [];
+  const unknownNames: string[] = [];
+  const invalidNames: string[] = [];
+  const seenPaths = new Set<string>();
+  let previousEnd = 0;
+
+  for (const invocation of invocations) {
+    const expectedToken = `$${invocation.name}`;
+    const validRange =
+      invocation.start >= previousEnd &&
+      invocation.end > invocation.start &&
+      prompt.slice(invocation.start, invocation.end) === expectedToken;
+    if (!validRange) {
+      if (!invalidNames.includes(invocation.name)) {
+        invalidNames.push(invocation.name);
+      }
+      continue;
+    }
+    previousEnd = invocation.end;
+
+    const skill = findProviderSkill(invocation.name, skills, options);
+    if (!skill) {
+      if (!unknownNames.includes(invocation.name)) {
+        unknownNames.push(invocation.name);
+      }
+      continue;
+    }
+    validInvocations.push(invocation);
+    if (!seenPaths.has(skill.path)) {
+      seenPaths.add(skill.path);
+      references.push(skill);
+    }
+  }
+
+  return { references, invocations: validInvocations, unknownNames, invalidNames };
+}
+
+export function loadInvokedSkills<E>(input: {
+  readonly provider: ProviderDriverKind;
+  readonly providerLabel: string;
+  readonly prompt: string;
+  readonly invocations: ReadonlyArray<ExplicitSkillInvocation>;
+  readonly skills: ReadonlyArray<ProviderSkillReference>;
+  readonly readFile: (path: string) => Effect.Effect<string, E>;
+}): Effect.Effect<
+  {
+    readonly documents: ReadonlyArray<ProviderSkillDocument>;
+    readonly invocations: ReadonlyArray<ExplicitSkillInvocation>;
+  },
+  E | ProviderAdapterValidationError
+> {
+  const resolution = resolveProviderSkillInvocations(input.prompt, input.invocations, input.skills);
+  if (resolution.invalidNames.length > 0) {
+    return Effect.fail(
+      new ProviderAdapterValidationError({
+        provider: input.provider,
+        operation: "sendTurn",
+        issue: `Invalid explicit ${input.providerLabel} skill invocation metadata for: ${resolution.invalidNames.map((name) => `$${name}`).join(", ")}.`,
+      }),
+    );
+  }
+  if (resolution.unknownNames.length > 0) {
+    return Effect.fail(
+      new ProviderAdapterValidationError({
+        provider: input.provider,
+        operation: "sendTurn",
+        issue: `Unknown ${input.providerLabel} skill${resolution.unknownNames.length === 1 ? "" : "s"}: ${resolution.unknownNames.map((name) => `$${name}`).join(", ")}.`,
+      }),
+    );
+  }
+  return loadProviderSkillDocuments(resolution.references, input.readFile).pipe(
+    Effect.map((documents) => ({ documents, invocations: resolution.invocations })),
+  );
+}
+
+/**
+ * Makes a provider-neutral skill document part of the turn without leaving a
+ * `$skill` token for the provider to reinterpret as a model-invoked tool.
+ */
+export function renderProviderSkillPrompt(
+  prompt: string,
+  documents: ReadonlyArray<ProviderSkillDocument>,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+): string {
+  if (documents.length === 0) {
+    return prompt;
+  }
+
+  const documentsByName = new Map<string, ProviderSkillDocument>();
+  for (const document of documents) {
+    documentsByName.set(document.name, document);
+    documentsByName.set(document.name.toLowerCase(), document);
+  }
+
+  const promptWithoutTokens = replaceExplicitSkillInvocations(prompt, invocations, (name) => {
+    const document = documentsByName.get(name) ?? documentsByName.get(name.toLowerCase());
+    return document ? `[T3 explicitly invoked skill: ${document.name}]` : `$${name}`;
+  });
+  const skillContext = documents
+    .map(
+      (document) =>
+        `<t3-explicit-skill>\nname: ${document.name}\nfile: ${document.path}\n${document.contents.trim()}\n</t3-explicit-skill>`,
+    )
+    .join("\n\n");
+
+  return `The user explicitly invoked the skills below. Follow their instructions. Resolve relative file references from the parent directory of each skill file.\n\n${skillContext}\n\n${promptWithoutTokens}`;
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -143,6 +143,7 @@ import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import { remapExplicitSkillInvocations } from "@t3tools/shared/explicitSkillInvocations";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import {
@@ -248,7 +249,7 @@ import {
   type DraftId,
 } from "../composerDraftStore";
 import {
-  appendTerminalContextsToPrompt,
+  appendTerminalContextsToPromptWithRanges,
   formatTerminalContextLabel,
   type TerminalContextDraft,
   type TerminalContextSelection,
@@ -581,6 +582,7 @@ function formatOutgoingPrompt(params: {
   const promptEffort = resolvePromptInjectedEffort(caps, params.effort);
   return applyClaudePromptEffortPrefix(params.text, promptEffort);
 }
+
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
 
@@ -5611,6 +5613,7 @@ function ChatViewContent(props: ChatViewProps) {
       selectedProviderModels: ctxSelectedProviderModels,
       selectedPromptEffort: ctxSelectedPromptEffort,
       selectedModelSelection: ctxSelectedModelSelection,
+      skillInvocations: composerSkillInvocations,
     } = sendCtx;
     const annotationImageAlreadyAttached =
       directAnnotation?.image !== undefined &&
@@ -5644,7 +5647,7 @@ function ChatViewContent(props: ChatViewProps) {
             },
           ]
         : sendContextPreviewAnnotations;
-    const promptForSend = promptRef.current;
+    const promptForSend = sendCtx.prompt;
     const {
       trimmedPrompt: trimmed,
       sendableTerminalContexts: sendableComposerTerminalContexts,
@@ -5853,8 +5856,13 @@ function ChatViewContent(props: ChatViewProps) {
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
     const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const terminalContextPrompt = appendTerminalContextsToPromptWithRanges(
+      promptForSend,
+      composerTerminalContextsSnapshot,
+      composerSkillInvocations,
+    );
     const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      terminalContextPrompt.prompt,
       composerElementContextsSnapshot,
     );
     const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
@@ -5871,6 +5879,11 @@ function ChatViewContent(props: ChatViewProps) {
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
       text: messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
+    });
+    const outgoingSkillInvocations = remapExplicitSkillInvocations({
+      sourceText: messageTextForSend,
+      outgoingText: outgoingMessageText,
+      invocations: terminalContextPrompt.ranges,
     });
     if (composerRef.current?.validateProviderInput(outgoingMessageText) === false) {
       return;
@@ -6176,6 +6189,9 @@ function ChatViewContent(props: ChatViewProps) {
             role: "user",
             text: outgoingMessageText,
             attachments: turnAttachmentsResult.value,
+            ...(outgoingSkillInvocations.length > 0
+              ? { skillInvocations: outgoingSkillInvocations }
+              : {}),
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: title,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -5,7 +5,7 @@ import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
-import { type ServerProviderSkill } from "@t3tools/contracts";
+import { type ExplicitSkillInvocation, type ServerProviderSkill } from "@t3tools/contracts";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import {
   $applyNodeReplacement,
@@ -230,17 +230,19 @@ type ComposerSkillMetadata = {
   description: string | null;
 };
 
-function skillMetadataByName(
+function enabledSkillMetadataByName(
   skills: ReadonlyArray<ServerProviderSkill>,
 ): ReadonlyMap<string, ComposerSkillMetadata> {
   return new Map(
-    skills.map((skill) => [
-      skill.name,
-      {
-        label: formatProviderSkillDisplayName(skill),
-        description: resolveSkillDescription(skill),
-      },
-    ]),
+    skills
+      .filter((skill) => skill.enabled)
+      .map((skill) => [
+        skill.name,
+        {
+          label: formatProviderSkillDisplayName(skill),
+          description: resolveSkillDescription(skill),
+        },
+      ]),
   );
 }
 
@@ -865,6 +867,23 @@ function collectTerminalContextIds(node: LexicalNode): string[] {
   return [];
 }
 
+function collectExplicitSkillInvocations(
+  node: LexicalNode,
+  skillMetadata: ReadonlyMap<string, ComposerSkillMetadata>,
+): ExplicitSkillInvocation[] {
+  if (node instanceof ComposerSkillNode) {
+    if (!skillMetadata.has(node.__skillName)) return [];
+    const start = getExpandedAbsoluteOffsetForPoint(node, 0);
+    return [{ name: node.__skillName, start, end: start + node.getTextContentSize() }];
+  }
+  if ($isElementNode(node)) {
+    return node
+      .getChildren()
+      .flatMap((child) => collectExplicitSkillInvocations(child, skillMetadata));
+  }
+  return [];
+}
+
 export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
@@ -874,6 +893,7 @@ export interface ComposerPromptEditorHandle {
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   };
 }
 
@@ -1266,7 +1286,7 @@ function ComposerSurroundSelectionPlugin(props: {
 }) {
   const [editor] = useLexicalComposerContext();
   const terminalContextsRef = useRef(props.terminalContexts);
-  const skillMetadataRef = useRef(skillMetadataByName(props.skills));
+  const skillMetadataRef = useRef(enabledSkillMetadataByName(props.skills));
   const pendingSurroundSelectionRef = useRef<{
     value: string;
     expandedStart: number;
@@ -1283,7 +1303,7 @@ function ComposerSurroundSelectionPlugin(props: {
   }, [props.terminalContexts]);
 
   useEffect(() => {
-    skillMetadataRef.current = skillMetadataByName(props.skills);
+    skillMetadataRef.current = enabledSkillMetadataByName(props.skills);
   }, [props.skills]);
 
   const applySurroundInsertion = useEffectEvent((inputData: string): boolean => {
@@ -1547,12 +1567,13 @@ function ComposerPromptEditorInner({
   const terminalContextsSignatureRef = useRef(terminalContextsSignature);
   const skillsSignature = skillSignature(skills);
   const skillsSignatureRef = useRef(skillsSignature);
-  const skillMetadataRef = useRef(skillMetadataByName(skills));
+  const skillMetadataRef = useRef(enabledSkillMetadataByName(skills));
   const snapshotRef = useRef({
     value,
     cursor: initialCursor,
     expandedCursor: expandCollapsedComposerCursor(value, initialCursor),
     terminalContextIds: terminalContexts.map((context) => context.id),
+    skillInvocations: [] as ExplicitSkillInvocation[],
   });
   const isApplyingControlledUpdateRef = useRef(false);
   const terminalContextActions = useMemo(
@@ -1565,7 +1586,7 @@ function ComposerPromptEditorInner({
   }, [onChange]);
 
   useLayoutEffect(() => {
-    skillMetadataRef.current = skillMetadataByName(skills);
+    skillMetadataRef.current = enabledSkillMetadataByName(skills);
   }, [skills]);
 
   useEffect(() => {
@@ -1591,6 +1612,7 @@ function ComposerPromptEditorInner({
       cursor: normalizedCursor,
       expandedCursor: expandCollapsedComposerCursor(value, normalizedCursor),
       terminalContextIds: terminalContexts.map((context) => context.id),
+      skillInvocations: [],
     };
     terminalContextsSignatureRef.current = terminalContextsSignature;
     skillsSignatureRef.current = skillsSignature;
@@ -1631,6 +1653,7 @@ function ComposerPromptEditorInner({
         cursor: boundedCursor,
         expandedCursor: expandCollapsedComposerCursor(snapshotRef.current.value, boundedCursor),
         terminalContextIds: snapshotRef.current.terminalContextIds,
+        skillInvocations: snapshotRef.current.skillInvocations,
       };
       onChangeRef.current(
         snapshotRef.current.value,
@@ -1648,6 +1671,7 @@ function ComposerPromptEditorInner({
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   } => {
     let snapshot = snapshotRef.current;
     editor.getEditorState().read(() => {
@@ -1666,11 +1690,16 @@ function ComposerPromptEditorInner({
         $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
       );
       const terminalContextIds = collectTerminalContextIds($getRoot());
+      const skillInvocations = collectExplicitSkillInvocations(
+        $getRoot(),
+        skillMetadataRef.current,
+      );
       snapshot = {
         value: nextValue,
         cursor: nextCursor,
         expandedCursor: nextExpandedCursor,
         terminalContextIds,
+        skillInvocations,
       };
     });
     snapshotRef.current = snapshot;
@@ -1714,13 +1743,26 @@ function ComposerPromptEditorInner({
         $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
       );
       const terminalContextIds = collectTerminalContextIds($getRoot());
+      const skillInvocations = collectExplicitSkillInvocations(
+        $getRoot(),
+        skillMetadataRef.current,
+      );
       const previousSnapshot = snapshotRef.current;
       if (
         previousSnapshot.value === nextValue &&
         previousSnapshot.cursor === nextCursor &&
         previousSnapshot.expandedCursor === nextExpandedCursor &&
         previousSnapshot.terminalContextIds.length === terminalContextIds.length &&
-        previousSnapshot.terminalContextIds.every((id, index) => id === terminalContextIds[index])
+        previousSnapshot.terminalContextIds.every(
+          (id, index) => id === terminalContextIds[index],
+        ) &&
+        previousSnapshot.skillInvocations.length === skillInvocations.length &&
+        previousSnapshot.skillInvocations.every(
+          (invocation, index) =>
+            invocation.name === skillInvocations[index]?.name &&
+            invocation.start === skillInvocations[index]?.start &&
+            invocation.end === skillInvocations[index]?.end,
+        )
       ) {
         return;
       }
@@ -1732,6 +1774,7 @@ function ComposerPromptEditorInner({
         cursor: nextCursor,
         expandedCursor: nextExpandedCursor,
         terminalContextIds,
+        skillInvocations,
       };
       const cursorAdjacentToMention =
         isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "left") ||
@@ -1803,7 +1846,7 @@ export function ComposerPromptEditor({
 }: ComposerPromptEditorProps) {
   const initialValueRef = useRef(value);
   const initialTerminalContextsRef = useRef(terminalContexts);
-  const initialSkillMetadataRef = useRef(skillMetadataByName(skills));
+  const initialSkillMetadataRef = useRef(enabledSkillMetadataByName(skills));
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "t3tools-composer-editor",

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2,6 +2,7 @@ import type {
   ApprovalRequestId,
   ChatFileAttachment,
   EnvironmentId,
+  ExplicitSkillInvocation,
   ModelSelection,
   PreviewAnnotationPayload,
   ProviderApprovalDecision,
@@ -578,6 +579,7 @@ export interface ChatComposerHandle {
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   };
   /** Reset composer cursor/trigger/highlight after external prompt mutations (e.g. onSend). */
   resetCursorState: (options?: {
@@ -603,6 +605,7 @@ export interface ChatComposerHandle {
     selectedProvider: ProviderDriverKind;
     selectedModel: string;
     selectedProviderModels: ReadonlyArray<ServerProvider["models"][number]>;
+    skillInvocations: ExplicitSkillInvocation[];
   };
   /** Validate the fully composed text immediately before a provider turn starts. */
   validateProviderInput: (providerInput: string) => boolean;
@@ -1964,6 +1967,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   } => {
     const editorSnapshot = composerEditorRef.current?.readSnapshot();
     if (editorSnapshot) {
@@ -1974,6 +1978,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       cursor: composerCursor,
       expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
       terminalContextIds: composerTerminalContexts.map((context) => context.id),
+      skillInvocations: [],
     };
   }, [composerCursor, composerTerminalContexts, promptRef]);
 
@@ -3340,22 +3345,28 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           composerEditorRef.current?.focusAt(nextCollapsedCursor);
         });
       },
-      getSendContext: () => ({
-        prompt: promptRef.current,
-        images: composerImagesRef.current,
-        files: composerFilesRef.current,
-        terminalContexts: composerTerminalContextsRef.current,
-        elementContexts: composerElementContextsRef.current,
-        previewAnnotations: composerPreviewAnnotations,
-        reviewComments: composerReviewComments,
-        selectedPromptEffort,
-        selectedModelOptionsForDispatch,
-        selectedModelSelection,
-        providerAvailable: !noProviderAvailable,
-        selectedProvider,
-        selectedModel,
-        selectedProviderModels,
-      }),
+      getSendContext: () => {
+        const snapshot = isComposerApprovalState
+          ? undefined
+          : composerEditorRef.current?.readSnapshot();
+        return {
+          prompt: snapshot?.value ?? promptRef.current,
+          images: composerImagesRef.current,
+          files: composerFilesRef.current,
+          terminalContexts: composerTerminalContextsRef.current,
+          elementContexts: composerElementContextsRef.current,
+          previewAnnotations: composerPreviewAnnotations,
+          reviewComments: composerReviewComments,
+          selectedPromptEffort,
+          selectedModelOptionsForDispatch,
+          selectedModelSelection,
+          providerAvailable: !noProviderAvailable,
+          selectedProvider,
+          selectedModel,
+          selectedProviderModels,
+          skillInvocations: snapshot?.skillInvocations ?? [],
+        };
+      },
       validateProviderInput: (providerInput: string) => {
         const validationMessage = getComposerSubmissionValidationMessage({
           prompt: promptRef.current,

--- a/apps/web/src/lib/terminalContext.test.ts
+++ b/apps/web/src/lib/terminalContext.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   appendTerminalContextsToPrompt,
+  appendTerminalContextsToPromptWithRanges,
   buildTerminalContextPreviewTitle,
   buildTerminalContextBlock,
   countInlineTerminalContextPlaceholders,
@@ -207,5 +208,21 @@ describe("terminalContext", () => {
         [makeContext()],
       ),
     ).toBe("Investigate @terminal-1:12-13 carefully");
+  });
+
+  it("remaps prompt ranges after trimming and materializing terminal labels", () => {
+    const prompt = `  ${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} then $review  `;
+    const start = prompt.indexOf("$review");
+    const result = appendTerminalContextsToPromptWithRanges(
+      prompt,
+      [makeContext()],
+      [{ name: "review", start, end: start + "$review".length }],
+    );
+    const mappedStart = result.prompt.indexOf("$review");
+
+    expect(result.ranges).toEqual([
+      { name: "review", start: mappedStart, end: mappedStart + "$review".length },
+    ]);
+    expect(result.prompt.slice(result.ranges[0]!.start, result.ranges[0]!.end)).toBe("$review");
   });
 });

--- a/apps/web/src/lib/terminalContext.ts
+++ b/apps/web/src/lib/terminalContext.ts
@@ -189,10 +189,43 @@ export function materializeInlineTerminalContextPrompt(
     lineEnd: number;
   }>,
 ): string {
+  return materializeInlineTerminalContextPromptWithRanges(prompt, contexts, []).prompt;
+}
+
+interface PromptRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+function materializeInlineTerminalContextPromptWithRanges<T extends PromptRange>(
+  prompt: string,
+  contexts: ReadonlyArray<{
+    terminalLabel: string;
+    lineStart: number;
+    lineEnd: number;
+  }>,
+  ranges: ReadonlyArray<T>,
+): { prompt: string; ranges: T[] } {
+  const validRanges = ranges.filter(
+    (range) =>
+      Number.isInteger(range.start) &&
+      Number.isInteger(range.end) &&
+      range.start >= 0 &&
+      range.end >= range.start &&
+      range.end <= prompt.length,
+  );
+  const boundaries = new Set(validRanges.flatMap((range) => [range.start, range.end]));
+  const outputOffsets = new Map<number, number>();
   let nextContextIndex = 0;
   let result = "";
 
-  for (const char of prompt) {
+  for (let index = 0; index <= prompt.length; index += 1) {
+    if (boundaries.has(index)) {
+      outputOffsets.set(index, result.length);
+    }
+    if (index === prompt.length) break;
+
+    const char = prompt[index]!;
     if (char !== INLINE_TERMINAL_CONTEXT_PLACEHOLDER) {
       result += char;
       continue;
@@ -205,19 +238,44 @@ export function materializeInlineTerminalContextPrompt(
     result += formatInlineTerminalContextLabel(context);
   }
 
-  return result;
+  return {
+    prompt: result,
+    ranges: validRanges.map((range) => ({
+      ...range,
+      start: outputOffsets.get(range.start)!,
+      end: outputOffsets.get(range.end)!,
+    })),
+  };
+}
+
+export function appendTerminalContextsToPromptWithRanges<T extends PromptRange>(
+  prompt: string,
+  contexts: ReadonlyArray<TerminalContextSelection>,
+  ranges: ReadonlyArray<T>,
+): { prompt: string; ranges: T[] } {
+  const materialized = materializeInlineTerminalContextPromptWithRanges(prompt, contexts, ranges);
+  const leadingTrim = materialized.prompt.length - materialized.prompt.trimStart().length;
+  const trimmedPrompt = materialized.prompt.trim();
+  const trimmedRanges = materialized.ranges.flatMap((range) => {
+    const start = range.start - leadingTrim;
+    const end = range.end - leadingTrim;
+    return start < 0 || end > trimmedPrompt.length ? [] : [{ ...range, start, end }];
+  });
+  const contextBlock = buildTerminalContextBlock(contexts);
+  if (contextBlock.length === 0) {
+    return { prompt: trimmedPrompt, ranges: trimmedRanges };
+  }
+  return {
+    prompt: trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock,
+    ranges: trimmedRanges,
+  };
 }
 
 export function appendTerminalContextsToPrompt(
   prompt: string,
   contexts: ReadonlyArray<TerminalContextSelection>,
 ): string {
-  const trimmedPrompt = materializeInlineTerminalContextPrompt(prompt, contexts).trim();
-  const contextBlock = buildTerminalContextBlock(contexts);
-  if (contextBlock.length === 0) {
-    return trimmedPrompt;
-  }
-  return trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock;
+  return appendTerminalContextsToPromptWithRanges(prompt, contexts, []).prompt;
 }
 
 export function extractTrailingTerminalContexts(prompt: string): ExtractedTerminalContexts {

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -71,11 +71,22 @@ use the skills and commands from the selected environment and provider.
 
 By default, the `/` menu includes skills. To keep this menu command-only, turn off **Show skills in
 slash menu** in **Settings → General**. Skill results use the `/skill:Skill Name` label and add the
-same `$name` skill token to your message. The original skill name remains searchable. If the provider
-also reports that skill as a native slash command, T3 Code hides the duplicate native entry and keeps
-the `/skill:Skill Name` label.
+same `$name` skill chip to your message. When you send the message, T3 passes the selected skill
+explicitly to the provider. Typing ordinary dollar-prefixed text does not invoke a skill. If the
+provider also reports that skill as a native slash command, T3 Code hides the duplicate native entry
+and keeps the `/skill:Skill Name` label.
 
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New
 worktree** is selected, each background thread creates its own worktree.
+
+## Cursor skills
+
+When a thread uses Cursor, type `$` in the composer to search the skills T3 Code found. Choose a
+skill to add it to your message. T3 Code passes the selected skill's instructions to Cursor
+explicitly, including when several skills are selected in one message.
+
+T3 Code finds skills stored in your project or user skill folders. Cursor-managed built-in,
+marketplace, and plugin skills are not shown because Cursor does not make that list available to
+T3 Code.

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -911,6 +911,18 @@ it.effect("decodes thread.turn-start-requested source proposed plan metadata whe
   }),
 );
 
+it.effect("decodes explicit skill invocation metadata when present", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadTurnStartRequestedPayload({
+      threadId: "thread-2",
+      messageId: "msg-2",
+      skillInvocations: [{ name: "review", start: 4, end: 11 }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.deepStrictEqual(parsed.skillInvocations, [{ name: "review", start: 4, end: 11 }]);
+  }),
+);
+
 it.effect("decodes thread.turn-start-requested title seed when present", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadTurnStartRequestedPayload({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -246,6 +246,22 @@ export type ChatAttachment = typeof ChatAttachment.Type;
 const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
+/** A skill chip the user explicitly selected in the composer. Offsets refer to the sent text. */
+export const ExplicitSkillInvocation = Schema.Struct({
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  start: NonNegativeInt,
+  end: NonNegativeInt,
+}).check(
+  Schema.makeFilter(
+    (input: { readonly start: number; readonly end: number }) =>
+      input.end > input.start || "Skill invocation end must be greater than start.",
+  ),
+);
+export type ExplicitSkillInvocation = typeof ExplicitSkillInvocation.Type;
+export const ExplicitSkillInvocations = Schema.Array(ExplicitSkillInvocation).check(
+  Schema.isMaxLength(256),
+);
+
 export const ProjectScriptIcon = Schema.Literals([
   "play",
   "test",
@@ -900,6 +916,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(ChatAttachment),
+    skillInvocations: Schema.optional(ExplicitSkillInvocations),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -921,6 +938,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(Schema.Union([UploadChatAttachment, ChatAttachment])),
+    skillInvocations: Schema.optional(ExplicitSkillInvocations),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -1317,6 +1335,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
 export const ThreadTurnStartRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
+  skillInvocations: Schema.optional(ExplicitSkillInvocations),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -121,6 +121,16 @@ describe("ProviderSessionStartInput", () => {
 });
 
 describe("ProviderSendTurnInput", () => {
+  it("accepts explicit skill invocation ranges", () => {
+    const parsed = decodeProviderSendTurnInput({
+      threadId: "thread-1",
+      input: "Use $review",
+      skillInvocations: [{ name: "review", start: 4, end: 11 }],
+    });
+
+    expect(parsed.skillInvocations).toEqual([{ name: "review", start: 4, end: 11 }]);
+  });
+
   it("accepts codex modelSelection", () => {
     const parsed = decodeProviderSendTurnInput({
       threadId: "thread-1",

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -10,6 +10,7 @@ import {
 } from "./baseSchemas.ts";
 import {
   ChatAttachment,
+  ExplicitSkillInvocations,
   ModelSelection,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
@@ -73,6 +74,7 @@ export const ProviderSendTurnInput = Schema.Struct({
   attachments: Schema.optional(
     Schema.Array(ChatAttachment).check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_ATTACHMENTS)),
   ),
+  skillInvocations: Schema.optional(ExplicitSkillInvocations),
   modelSelection: Schema.optional(ModelSelection),
   interactionMode: Schema.optional(ProviderInteractionMode),
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -175,6 +175,10 @@
       "types": "./src/composerInlineTokens.ts",
       "import": "./src/composerInlineTokens.ts"
     },
+    "./explicitSkillInvocations": {
+      "types": "./src/explicitSkillInvocations.ts",
+      "import": "./src/explicitSkillInvocations.ts"
+    },
     "./terminalLabels": {
       "types": "./src/terminalLabels.ts",
       "import": "./src/terminalLabels.ts"

--- a/packages/shared/src/explicitSkillInvocations.test.ts
+++ b/packages/shared/src/explicitSkillInvocations.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  remapExplicitSkillInvocations,
+  updateExplicitSkillInvocationsForTextEdit,
+} from "./explicitSkillInvocations.ts";
+
+describe("explicit skill invocation ranges", () => {
+  it("remaps ranges through trimming and an outgoing prefix", () => {
+    expect(
+      remapExplicitSkillInvocations({
+        sourceText: "  $review this  ",
+        outgoingText: "Think carefully.\n\n$review this",
+        invocations: [{ name: "review", start: 2, end: 9 }],
+      }),
+    ).toEqual([{ name: "review", start: 18, end: 25 }]);
+  });
+
+  it("drops stale ranges instead of invoking matching names elsewhere", () => {
+    expect(
+      remapExplicitSkillInvocations({
+        sourceText: "$review this",
+        outgoingText: "$review this",
+        invocations: [{ name: "review", start: 1, end: 8 }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("moves untouched ranges and drops edited tokens", () => {
+    const moved = updateExplicitSkillInvocationsForTextEdit({
+      previousText: "$review then $test",
+      nextText: "please $review then $test",
+      invocations: [
+        { name: "review", start: 0, end: 7 },
+        { name: "test", start: 13, end: 18 },
+      ],
+    });
+    expect(moved).toEqual([
+      { name: "review", start: 7, end: 14 },
+      { name: "test", start: 20, end: 25 },
+    ]);
+    expect(
+      updateExplicitSkillInvocationsForTextEdit({
+        previousText: "please $review then $test",
+        nextText: "please $review then $best",
+        invocations: moved,
+      }),
+    ).toEqual([{ name: "review", start: 7, end: 14 }]);
+  });
+});

--- a/packages/shared/src/explicitSkillInvocations.ts
+++ b/packages/shared/src/explicitSkillInvocations.ts
@@ -1,0 +1,71 @@
+export interface ExplicitSkillInvocationRange {
+  readonly name: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+export function remapExplicitSkillInvocations<T extends ExplicitSkillInvocationRange>(input: {
+  readonly sourceText: string;
+  readonly outgoingText: string;
+  readonly invocations: ReadonlyArray<T>;
+}): T[] {
+  if (input.invocations.length === 0) return [];
+
+  const trimmedSource = input.sourceText.trim();
+  const leadingTrim = input.sourceText.length - input.sourceText.trimStart().length;
+  const prefixLength = input.outgoingText.length - trimmedSource.length;
+  if (!input.outgoingText.endsWith(trimmedSource) || prefixLength < 0) return [];
+
+  return input.invocations.flatMap((invocation) => {
+    if (input.sourceText.slice(invocation.start, invocation.end) !== `$${invocation.name}`) {
+      return [];
+    }
+    const start = invocation.start - leadingTrim + prefixLength;
+    const end = invocation.end - leadingTrim + prefixLength;
+    return start < prefixLength || end > input.outgoingText.length
+      ? []
+      : [{ ...invocation, start, end }];
+  });
+}
+
+export function updateExplicitSkillInvocationsForTextEdit<
+  T extends ExplicitSkillInvocationRange,
+>(input: {
+  readonly previousText: string;
+  readonly nextText: string;
+  readonly invocations: ReadonlyArray<T>;
+}): T[] {
+  let prefixLength = 0;
+  while (
+    prefixLength < input.previousText.length &&
+    prefixLength < input.nextText.length &&
+    input.previousText[prefixLength] === input.nextText[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < input.previousText.length - prefixLength &&
+    suffixLength < input.nextText.length - prefixLength &&
+    input.previousText[input.previousText.length - 1 - suffixLength] ===
+      input.nextText[input.nextText.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1;
+  }
+
+  const previousChangeEnd = input.previousText.length - suffixLength;
+  const delta = input.nextText.length - input.previousText.length;
+  return input.invocations.flatMap((invocation) => {
+    const candidate =
+      invocation.end <= prefixLength
+        ? invocation
+        : invocation.start >= previousChangeEnd
+          ? { ...invocation, start: invocation.start + delta, end: invocation.end + delta }
+          : null;
+    return candidate &&
+      input.nextText.slice(candidate.start, candidate.end) === `$${candidate.name}`
+      ? [candidate]
+      : [];
+  });
+}


### PR DESCRIPTION
## Problem

The composer flattened a selected skill chip into plain `$name` text. Provider adapters then guessed intent with a regex, so ordinary dollar-prefixed text could be treated as a skill and provider behavior differed.

## Fix

- Preserve selected skill metadata as `{ name, start, end }` from web/mobile composers through durable drafts, queued sends, turn-start events, and provider requests. Timeline text stays canonical.
- Send native structured skill inputs to Codex. Claude Code, Cursor, Grok, and OpenCode receive explicitly selected skill documents with their source file for relative references.
- Validate stale, overlapping, disabled, and unknown invocations at the provider boundary. Plain dollar-prefixed text is never inferred as a skill.
- Discover provider skills once per session instead of scanning during send.
- Preserve Claude argument substitution and reject runtime-only skill fields that the fallback cannot safely emulate.
- Discover Cursor skills in the session workspace and use upstream Grok skill discovery, while honoring provider user-invocation visibility.

## Verification

- 470 focused tests across contracts, orchestration, draft/outbox persistence, skill discovery, provider adapters, and upstream Grok reliability paths.
- Contracts, server, shared, web, and mobile typechecks pass. Server reports only existing Effect suggestions.
- Focused lint, formatting, and `git diff --check` pass.

Closes #6095
Closes #8758 
Implements #7795.

Implemented with GPT-5.6 Codex in the T3 Code harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor explicit `$skill` invocations across all providers and clients
> - Adds `ExplicitSkillInvocation` schema to contracts and extends `thread.turn.start` commands, payloads, and `ProviderSendTurnInput` with optional `skillInvocations` ranges.
> - Each provider adapter (Claude, Cursor, Grok, OpenCode, Codex) now discovers available skills at session start and, when `skillInvocations` are present on a turn, replaces raw `$skill` tokens in the prompt with rendered skill document contents and explicit invocation markers. Unknown or invalid skill references fail early with `ProviderAdapterValidationError`.
> - Web and mobile composers track explicit skill ranges in editor snapshots and draft state, persist them across offline queues, and remap offsets through text trimming and terminal-context appending before send.
> - Introduces shared utilities `remapExplicitSkillInvocations` and `updateExplicitSkillInvocationsForTextEdit` to keep ranges valid across text edits.
> - Behavioral Change: `ClaudeSkills.parseSkillFrontmatter` now uses schema validation and skills with `user-invocable: false` are excluded from discovery; `CursorSkills.discoverCursorSkills` scans multiple user and project roots; malformed skill frontmatter in Claude causes `ProviderAdapterValidationError` on sendTurn; queued thread message schema bumps to version 4.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35bc117.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->