### PR TITLE
fix(web): hide deleted providers with prototype keys

### DIFF
--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -119,6 +119,77 @@ describe("applyProviderInstanceSettings", () => {
 
     expect(entry?.enabled).toBe(false);
   });
+
+  it.each(["constructor", "toString"])(
+    "treats a removed custom instance named %s as disabled",
+    (instanceId) => {
+      const entries = deriveProviderInstanceEntries([
+        provider({
+          provider: ProviderDriverKind.make("claudeAgent"),
+          instanceId,
+        }),
+      ]);
+      const [entry] = applyProviderInstanceSettings(entries, {
+        providerInstances: {},
+        providers: {} as never,
+      });
+
+      expect(entry?.enabled).toBe(false);
+    },
+  );
+
+  it("uses settings for a configured custom instance named constructor", () => {
+    const instanceId = ProviderInstanceId.make("constructor");
+    const entries = deriveProviderInstanceEntries([
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId,
+      }),
+    ]);
+    const [entry] = applyProviderInstanceSettings(entries, {
+      providerInstances: {
+        [instanceId]: {
+          driver: ProviderDriverKind.make("claudeAgent"),
+          enabled: false,
+        },
+      },
+      providers: {} as never,
+    });
+
+    expect(entry?.enabled).toBe(false);
+  });
+
+  it("treats a removed default instance for a fork driver as disabled", () => {
+    const driver = ProviderDriverKind.make("constructor");
+    const entries = deriveProviderInstanceEntries([
+      provider({
+        provider: driver,
+        instanceId: "constructor",
+      }),
+    ]);
+    const [entry] = applyProviderInstanceSettings(entries, {
+      providerInstances: {},
+      providers: {} as never,
+    });
+
+    expect(entry?.isDefault).toBe(true);
+    expect(entry?.enabled).toBe(false);
+  });
+
+  it("uses legacy settings for a built-in default instance", () => {
+    const entries = deriveProviderInstanceEntries([
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: "codex",
+      }),
+    ]);
+    const [entry] = applyProviderInstanceSettings(entries, {
+      providerInstances: {},
+      providers: { codex: { enabled: false } } as never,
+    });
+
+    expect(entry?.enabled).toBe(false);
+  });
 });
 
 describe("deriveProviderInstanceEntries", () => {

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -233,9 +233,10 @@ export function deriveProviderEntriesByEnvironment(
  * settings write, so picker visibility must follow settings rather than waiting
  * for probe reconciliation.
  *
- * Non-default instances only exist through `providerInstances`; if one is
- * absent there, its streamed snapshot is stale (for example immediately after
- * deletion) and is treated as disabled.
+ * Only built-in default instances have a legacy `providers` entry. Every
+ * other instance exists through `providerInstances`; if it is absent there,
+ * its streamed snapshot is stale (for example immediately after deletion)
+ * and is treated as disabled.
  */
 export function applyProviderInstanceSettings(
   entries: ReadonlyArray<ProviderInstanceEntry>,
@@ -246,11 +247,16 @@ export function applyProviderInstanceSettings(
   >;
 
   return entries.map((entry) => {
-    const explicitInstance = settings.providerInstances?.[entry.instanceId];
+    const explicitInstance = Object.hasOwn(settings.providerInstances, entry.instanceId)
+      ? settings.providerInstances[entry.instanceId]
+      : undefined;
+    const legacyProvider = Object.hasOwn(legacyProviders, entry.driverKind)
+      ? legacyProviders[entry.driverKind]
+      : undefined;
     const enabled = explicitInstance
       ? resolveProviderInstanceEnabled(explicitInstance)
-      : entry.isDefault
-        ? (legacyProviders[entry.driverKind]?.enabled ?? entry.enabled)
+      : entry.isDefault && legacyProvider
+        ? (legacyProvider.enabled ?? entry.enabled)
         : false;
     return enabled === entry.enabled ? entry : { ...entry, enabled };
   });


### PR DESCRIPTION
## What Changed

- Check provider instance settings maps for own properties before applying them.
- Treat removed custom and fork-provider snapshots as disabled while keeping valid prototype-named instances configurable.
- Add regression coverage for inherited keys and the built-in legacy fallback.

## Why

Plain object lookups can resolve inherited values such as `Object.prototype.constructor`. A deleted provider with that instance ID was therefore treated as configured and could remain visible until the next provider snapshot.

Own-property checks match the settings invariant without restricting valid provider slugs.

## UI Changes

No visual design changes. This only removes stale deleted provider entries during settings reconciliation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable: no visual changes)
- [x] I included a video for animation/interaction changes (not applicable)

Built with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to client-side settings overlay for provider picker visibility; no auth or server persistence changes.
> 
> **Overview**
> Fixes stale provider entries staying visible in the picker when a deleted instance ID collides with inherited object keys (e.g. `constructor`, `toString`).
> 
> **`applyProviderInstanceSettings`** now uses **`Object.hasOwn`** for both `providerInstances` and legacy `providers` before reading settings. Removed custom instances (including fork defaults with no legacy row) are forced **disabled** when absent from settings; legacy **`providers.*.enabled`** applies only to built-in defaults that actually have an own legacy entry. Explicitly configured instances with prototype-like names still honor their settings.
> 
> Regression tests cover inherited-key deletion, valid prototype-named instances, fork-driver defaults, and built-in legacy fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdeb3b5705fa0e032bb09381c93dc2e68981b3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix deleted providers with prototype keys in `applyProviderInstanceSettings`
> - `applyProviderInstanceSettings` in [providerInstances.ts](https://github.com/pingdotgg/t3code/pull/8337/files#diff-366ee4ff966b3b9fefcc872cdc0d10484ac52c174b5ed0e8ed59e84e97f58d5b) now uses `Object.hasOwn` before reading `providerInstances` and `legacyProviders`, so prototype members like `constructor` or `toString` are no longer treated as configured instances or legacy provider entries.
> - Default instances without an explicit config or a real legacy entry now default to disabled instead of preserving the streamed enabled state.
> - Risk: default instances absent from both `providerInstances` and `legacyProviders` will now be disabled rather than kept enabled; reviewers should check `providerInstances.ts` defaulting logic for any callers relying on the old pass-through behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdeb3b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected provider instance enablement when custom instances use reserved names such as `constructor` or `toString`.
  * Removed custom and forked default instances are now correctly treated as disabled while preserving default status.
  * Legacy provider settings that disable built-in instances are now honored consistently.
  * Default instances without legacy configuration no longer retain an unintended enabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->