### PR TITLE
fix(github): search repositories by name

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -11,6 +11,7 @@ import {
   getCloneDestinationPath,
   getCloneDirectoryName,
   getDefaultCloneUrl,
+  isGitHubRepositoryShorthand,
   normalizePastedCloneUrl,
   resolveAddProjectPath,
   sortAddProjectProviderSources,
@@ -31,7 +32,12 @@ import {
   inferProjectTitleFromPath,
   isWindowsPlatform,
 } from "@t3tools/client-runtime/state/projects";
-import { CommandId, type EnvironmentId, ProjectId } from "@t3tools/contracts";
+import {
+  CommandId,
+  type EnvironmentId,
+  ProjectId,
+  type SourceControlRepositoryInfo,
+} from "@t3tools/contracts";
 import { CommonActions, StackActions, useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
@@ -55,6 +61,7 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import { uuidv4 } from "../../lib/uuid";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useAtomQueryRunner } from "../../state/use-atom-query-runner";
+import { useDebouncedValue } from "../../state/queries";
 import {
   useRemoteConnectionStatus,
   useRemoteEnvironmentRuntime,
@@ -71,6 +78,8 @@ interface EnvironmentOption {
   readonly connectionError: string | null;
   readonly connectionErrorTraceId: string | null;
 }
+
+const REPOSITORY_SEARCH_DEBOUNCE_MS = 100;
 
 const environmentOptionOrder = Order.mapInput(
   Order.Struct({
@@ -651,12 +660,84 @@ export function AddProjectRepositoryScreen(props: {
   const lookupRepositoryQuery = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
+  const searchRepositoriesQuery = useAtomQueryRunner(sourceControlEnvironment.repositorySearch, {
+    reportFailure: false,
+  });
   const navigation = useNavigation();
+  const iconColor = useThemeColor("--color-icon");
   const environment = useEnvironmentFromParam(props.environmentId);
   const source = sourceFromParam(props.source);
   const [repositoryInput, setRepositoryInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [repositories, setRepositories] =
+    useState<ReadonlyArray<SourceControlRepositoryInfo> | null>(null);
+  const normalizedRepositoryInput = repositoryInput.trim();
+  const debouncedRepositoryInput = useDebouncedValue(
+    normalizedRepositoryInput,
+    REPOSITORY_SEARCH_DEBOUNCE_MS,
+  );
+  const githubRepositorySearchEnvironmentId =
+    source === "github" ? (environment?.environmentId ?? null) : null;
+
+  useEffect(() => {
+    if (githubRepositorySearchEnvironmentId === null) {
+      return;
+    }
+    if (
+      normalizedRepositoryInput.length === 0 ||
+      normalizedRepositoryInput !== debouncedRepositoryInput
+    ) {
+      setIsSubmitting(normalizedRepositoryInput.length > 0);
+      return;
+    }
+
+    let cancelled = false;
+    setError(null);
+    setIsSubmitting(true);
+    void searchRepositoriesQuery({
+      environmentId: githubRepositorySearchEnvironmentId,
+      input: {
+        provider: "github",
+        query: debouncedRepositoryInput,
+      },
+    }).then((result) => {
+      if (cancelled) {
+        return;
+      }
+      setIsSubmitting(false);
+      if (AsyncResult.isFailure(result)) {
+        setError(errorMessage(Cause.squash(result.cause)));
+      } else {
+        setRepositories(result.value);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    debouncedRepositoryInput,
+    githubRepositorySearchEnvironmentId,
+    normalizedRepositoryInput,
+    searchRepositoriesQuery,
+  ]);
+
+  const selectRepository = useCallback(
+    (repository: SourceControlRepositoryInfo) => {
+      if (!environment) return;
+      navigation.dispatch(
+        StackActions.push("AddProjectDestination", {
+          environmentId: environment.environmentId,
+          source,
+          remoteUrl: getDefaultCloneUrl(repository),
+          repositoryTitle: repository.nameWithOwner,
+          repositoryName: getCloneDirectoryName(repository.nameWithOwner),
+        }),
+      );
+    },
+    [environment, navigation, source],
+  );
 
   const lookupRepository = useCallback(async () => {
     if (!environment || repositoryInput.trim().length === 0 || isSubmitting) return;
@@ -674,6 +755,11 @@ export function AddProjectRepositoryScreen(props: {
           repositoryName: getCloneDirectoryName(remoteUrl),
         }),
       );
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (provider === "github" && !isGitHubRepositoryShorthand(repositoryInput)) {
       setIsSubmitting(false);
       return;
     }
@@ -710,7 +796,13 @@ export function AddProjectRepositoryScreen(props: {
           <TextInput
             className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-base leading-snug"
             value={repositoryInput}
-            onChangeText={setRepositoryInput}
+            onChangeText={(value) => {
+              if (value.trim() !== normalizedRepositoryInput) {
+                setRepositories(null);
+                setError(null);
+              }
+              setRepositoryInput(value);
+            }}
             autoCapitalize="none"
             autoCorrect={false}
             placeholder={
@@ -718,15 +810,45 @@ export function AddProjectRepositoryScreen(props: {
                 ? "https://github.com/org/repo.git"
                 : addProjectRemoteSourcePathHint(source)
             }
-            returnKeyType="next"
+            returnKeyType={source === "github" ? "done" : "next"}
             onSubmitEditing={() => void lookupRepository()}
           />
-          <PrimaryActionButton
-            label={source === "url" ? "Continue" : "Lookup repository"}
-            disabled={isSubmitting || repositoryInput.trim().length === 0}
-            onPress={() => void lookupRepository()}
-            loading={isSubmitting}
-          />
+          {source === "github" ? null : (
+            <PrimaryActionButton
+              label={source === "url" ? "Continue" : "Lookup repository"}
+              disabled={isSubmitting || repositoryInput.trim().length === 0}
+              onPress={() => void lookupRepository()}
+              loading={isSubmitting}
+            />
+          )}
+          {source === "github" && isSubmitting ? (
+            <View className="items-center py-3">
+              <ActivityIndicator />
+            </View>
+          ) : null}
+          {repositories ? (
+            <>
+              <SectionTitle>Repositories</SectionTitle>
+              <ListSection>
+                {repositories.length === 0 ? (
+                  <View className="items-center px-4 py-5">
+                    <Text className="text-sm text-foreground-muted">No repositories found.</Text>
+                  </View>
+                ) : (
+                  repositories.map((repository, index) => (
+                    <ListRow
+                      key={repository.nameWithOwner}
+                      title={repository.nameWithOwner}
+                      subtitle={repository.url}
+                      icon={<SourceControlIcon kind="github" size={18} color={String(iconColor)} />}
+                      isFirst={index === 0}
+                      onPress={() => selectRepository(repository)}
+                    />
+                  ))
+                )}
+              </ListSection>
+            </>
+          ) : null}
         </>
       ) : (
         <EmptyEnvironmentState />

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -660,9 +660,6 @@ export function AddProjectRepositoryScreen(props: {
   const lookupRepositoryQuery = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
-  const searchRepositoriesQuery = useAtomQueryRunner(sourceControlEnvironment.repositorySearch, {
-    reportFailure: false,
-  });
   const navigation = useNavigation();
   const iconColor = useThemeColor("--color-icon");
   const environment = useEnvironmentFromParam(props.environmentId);
@@ -670,8 +667,6 @@ export function AddProjectRepositoryScreen(props: {
   const [repositoryInput, setRepositoryInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [repositories, setRepositories] =
-    useState<ReadonlyArray<SourceControlRepositoryInfo> | null>(null);
   const normalizedRepositoryInput = repositoryInput.trim();
   const debouncedRepositoryInput = useDebouncedValue(
     normalizedRepositoryInput,
@@ -679,49 +674,26 @@ export function AddProjectRepositoryScreen(props: {
   );
   const githubRepositorySearchEnvironmentId =
     source === "github" ? (environment?.environmentId ?? null) : null;
-
-  useEffect(() => {
-    if (githubRepositorySearchEnvironmentId === null) {
-      return;
-    }
-    if (
-      normalizedRepositoryInput.length === 0 ||
-      normalizedRepositoryInput !== debouncedRepositoryInput
-    ) {
-      setIsSubmitting(normalizedRepositoryInput.length > 0);
-      return;
-    }
-
-    let cancelled = false;
-    setError(null);
-    setIsSubmitting(true);
-    void searchRepositoriesQuery({
-      environmentId: githubRepositorySearchEnvironmentId,
-      input: {
-        provider: "github",
-        query: debouncedRepositoryInput,
-      },
-    }).then((result) => {
-      if (cancelled) {
-        return;
-      }
-      setIsSubmitting(false);
-      if (AsyncResult.isFailure(result)) {
-        setError(errorMessage(Cause.squash(result.cause)));
-      } else {
-        setRepositories(result.value);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    debouncedRepositoryInput,
-    githubRepositorySearchEnvironmentId,
-    normalizedRepositoryInput,
-    searchRepositoriesQuery,
-  ]);
+  const settledRepositoryInput =
+    normalizedRepositoryInput.length > 0 && normalizedRepositoryInput === debouncedRepositoryInput
+      ? debouncedRepositoryInput
+      : null;
+  const repositorySearch = useEnvironmentQuery(
+    githubRepositorySearchEnvironmentId !== null && settledRepositoryInput !== null
+      ? sourceControlEnvironment.repositorySearch({
+          environmentId: githubRepositorySearchEnvironmentId,
+          input: {
+            provider: "github",
+            query: settledRepositoryInput,
+          },
+        })
+      : null,
+  );
+  const repositories = repositorySearch.data;
+  const isRepositorySearchPending =
+    normalizedRepositoryInput.length > 0 &&
+    (normalizedRepositoryInput !== debouncedRepositoryInput || repositorySearch.isPending);
+  const visibleError = error ?? repositorySearch.error;
 
   const selectRepository = useCallback(
     (repository: SourceControlRepositoryInfo) => {
@@ -790,7 +762,7 @@ export function AddProjectRepositoryScreen(props: {
 
   return (
     <AddProjectShell>
-      {error ? <ErrorBanner message={error} /> : null}
+      {visibleError ? <ErrorBanner message={visibleError} /> : null}
       {environment ? (
         <>
           <TextInput
@@ -798,7 +770,6 @@ export function AddProjectRepositoryScreen(props: {
             value={repositoryInput}
             onChangeText={(value) => {
               if (value.trim() !== normalizedRepositoryInput) {
-                setRepositories(null);
                 setError(null);
               }
               setRepositoryInput(value);
@@ -821,7 +792,7 @@ export function AddProjectRepositoryScreen(props: {
               loading={isSubmitting}
             />
           )}
-          {source === "github" && isSubmitting ? (
+          {source === "github" && isRepositorySearchPending ? (
             <View className="items-center py-3">
               <ActivityIndicator />
             </View>

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -74,6 +74,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsReviewerCandidates]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsRequestReviewers]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlLookupRepository]: AuthOrchestrationReadScope,
+  [WS_METHODS.sourceControlSearchRepositories]: AuthOrchestrationReadScope,
   [WS_METHODS.sourceControlCloneRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlPublishRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.projectsListEntries]: AuthOrchestrationReadScope,

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -562,6 +562,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
           cwd: input.cwd,
           args: ["repo", "view", input.repository, "--json", "nameWithOwner,url,sshUrl"],
         }).pipe(Effect.map((result) => JSON.parse(result.stdout))),
+      searchRepositories: () => Effect.succeed([]),
       createRepository: (input) =>
         Effect.fail(
           new GitHubCli.GitHubCliCommandError({

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -16,6 +16,33 @@ const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
   stderrTruncated: false,
 });
 
+const repositorySearchOutput = (...fullNames: ReadonlyArray<string>): VcsProcess.VcsProcessOutput =>
+  processOutput(
+    JSON.stringify(
+      fullNames.map((fullName) => ({ fullName, url: `https://github.com/${fullName}` })),
+    ),
+  );
+
+const repositorySearchArgs = (input: {
+  readonly query: string;
+  readonly owner?: string;
+  readonly includeForks: boolean;
+}): ReadonlyArray<string> => [
+  "search",
+  "repos",
+  "--match",
+  "name",
+  ...(input.owner === undefined ? [] : ["--owner", input.owner]),
+  "--include-forks",
+  String(input.includeForks),
+  "--limit",
+  "20",
+  "--json",
+  "fullName,url",
+  "--",
+  input.query,
+];
+
 const mockRun = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
 
 const layer = GitHubCli.layer.pipe(
@@ -289,6 +316,138 @@ describe("GitHubCli.layer", () => {
         url: "https://github.com/octocat/codething-mvp",
         sshUrl: "git@github.com:octocat/codething-mvp.git",
       });
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: ["repo", "view", "octocat/codething-mvp", "--json", "nameWithOwner,url,sshUrl"],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("searches repositories with the authenticated owner's matches first", () =>
+    Effect.gen(function* () {
+      mockRun
+        .mockReturnValueOnce(Effect.succeed(processOutput("current-user\n")))
+        .mockReturnValueOnce(Effect.succeed(repositorySearchOutput("current-user/skills")))
+        .mockReturnValueOnce(
+          Effect.succeed(
+            repositorySearchOutput(
+              "mattpocock/skills",
+              "current-user/skills",
+              "someone-else/skills",
+            ),
+          ),
+        );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.searchRepositories({
+        cwd: "/repo",
+        query: "skills",
+      });
+
+      assert.deepStrictEqual(
+        result.map((repository) => repository.nameWithOwner),
+        ["current-user/skills", "mattpocock/skills", "someone-else/skills"],
+      );
+      assert.equal(result[0]?.sshUrl, "git@github.com:current-user/skills.git");
+      expect(mockRun).toHaveBeenCalledTimes(3);
+      expect(mockRun).toHaveBeenNthCalledWith(1, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: ["api", "user", "--hostname", "github.com", "--jq", ".login"],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+      expect(mockRun).toHaveBeenNthCalledWith(2, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: repositorySearchArgs({ query: "skills", owner: "current-user", includeForks: true }),
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+      expect(mockRun).toHaveBeenNthCalledWith(3, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: repositorySearchArgs({ query: "skills", includeForks: false }),
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("returns an exact owner and repository path before other owner matches", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(repositorySearchOutput("octocat/codething-tools", "octocat/codething-mvp")),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.searchRepositories({
+        cwd: "/repo",
+        query: " octocat/codething-mvp ",
+      });
+
+      assert.deepStrictEqual(result, [
+        {
+          nameWithOwner: "octocat/codething-mvp",
+          url: "https://github.com/octocat/codething-mvp",
+          sshUrl: "git@github.com:octocat/codething-mvp.git",
+        },
+        {
+          nameWithOwner: "octocat/codething-tools",
+          url: "https://github.com/octocat/codething-tools",
+          sshUrl: "git@github.com:octocat/codething-tools.git",
+        },
+      ]);
+      expect(mockRun).toHaveBeenCalledTimes(1);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("searches within an owner for a partial repository path", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(repositorySearchOutput("octocat/codething-mvp")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.searchRepositories({ cwd: "/repo", query: "octocat/code" });
+
+      assert.deepStrictEqual(
+        result.map((repository) => repository.nameWithOwner),
+        ["octocat/codething-mvp"],
+      );
+      expect(mockRun).toHaveBeenCalledTimes(1);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("returns no repository search results when there are no matches", () =>
+    Effect.gen(function* () {
+      mockRun
+        .mockReturnValueOnce(Effect.succeed(processOutput("current-user\n")))
+        .mockReturnValueOnce(Effect.succeed(processOutput("[]")))
+        .mockReturnValueOnce(Effect.succeed(processOutput("[]")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.searchRepositories({ cwd: "/repo", query: "does-not-exist" });
+
+      assert.deepStrictEqual(result, []);
+      expect(mockRun).toHaveBeenCalledTimes(3);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("reports a missing authenticated account without fabricating a cause", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const error = yield* gh
+        .searchRepositories({ cwd: "/repo", query: "skills" })
+        .pipe(Effect.flip);
+
+      assert.equal(error._tag, "GitHubCliAuthenticationError");
+      assert.notProperty(error, "cause");
+      expect(mockRun).toHaveBeenCalledTimes(1);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -316,21 +316,12 @@ describe("GitHubCli.layer", () => {
         url: "https://github.com/octocat/codething-mvp",
         sshUrl: "git@github.com:octocat/codething-mvp.git",
       });
-      expect(mockRun).toHaveBeenCalledTimes(1);
-      expect(mockRun).toHaveBeenCalledWith({
-        operation: "GitHubCli.execute",
-        command: "gh",
-        args: ["repo", "view", "octocat/codething-mvp", "--json", "nameWithOwner,url,sshUrl"],
-        cwd: "/repo",
-        timeoutMs: 30_000,
-      });
     }).pipe(Effect.provide(layer)),
   );
 
   it.effect("searches repositories with the authenticated owner's matches first", () =>
     Effect.gen(function* () {
       mockRun
-        .mockReturnValueOnce(Effect.succeed(processOutput("current-user\n")))
         .mockReturnValueOnce(Effect.succeed(repositorySearchOutput("current-user/skills")))
         .mockReturnValueOnce(
           Effect.succeed(
@@ -353,22 +344,15 @@ describe("GitHubCli.layer", () => {
         ["current-user/skills", "mattpocock/skills", "someone-else/skills"],
       );
       assert.equal(result[0]?.sshUrl, "git@github.com:current-user/skills.git");
-      expect(mockRun).toHaveBeenCalledTimes(3);
+      expect(mockRun).toHaveBeenCalledTimes(2);
       expect(mockRun).toHaveBeenNthCalledWith(1, {
         operation: "GitHubCli.execute",
         command: "gh",
-        args: ["api", "user", "--hostname", "github.com", "--jq", ".login"],
+        args: repositorySearchArgs({ query: "skills", owner: "@me", includeForks: true }),
         cwd: "/repo",
         timeoutMs: 30_000,
       });
       expect(mockRun).toHaveBeenNthCalledWith(2, {
-        operation: "GitHubCli.execute",
-        command: "gh",
-        args: repositorySearchArgs({ query: "skills", owner: "current-user", includeForks: true }),
-        cwd: "/repo",
-        timeoutMs: 30_000,
-      });
-      expect(mockRun).toHaveBeenNthCalledWith(3, {
         operation: "GitHubCli.execute",
         command: "gh",
         args: repositorySearchArgs({ query: "skills", includeForks: false }),
@@ -424,7 +408,6 @@ describe("GitHubCli.layer", () => {
   it.effect("returns no repository search results when there are no matches", () =>
     Effect.gen(function* () {
       mockRun
-        .mockReturnValueOnce(Effect.succeed(processOutput("current-user\n")))
         .mockReturnValueOnce(Effect.succeed(processOutput("[]")))
         .mockReturnValueOnce(Effect.succeed(processOutput("[]")));
 
@@ -432,22 +415,7 @@ describe("GitHubCli.layer", () => {
       const result = yield* gh.searchRepositories({ cwd: "/repo", query: "does-not-exist" });
 
       assert.deepStrictEqual(result, []);
-      expect(mockRun).toHaveBeenCalledTimes(3);
-    }).pipe(Effect.provide(layer)),
-  );
-
-  it.effect("reports a missing authenticated account without fabricating a cause", () =>
-    Effect.gen(function* () {
-      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
-
-      const gh = yield* GitHubCli.GitHubCli;
-      const error = yield* gh
-        .searchRepositories({ cwd: "/repo", query: "skills" })
-        .pipe(Effect.flip);
-
-      assert.equal(error._tag, "GitHubCliAuthenticationError");
-      assert.notProperty(error, "cause");
-      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledTimes(2);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -16,32 +16,24 @@ const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
   stderrTruncated: false,
 });
 
-const repositorySearchOutput = (...fullNames: ReadonlyArray<string>): VcsProcess.VcsProcessOutput =>
-  processOutput(
-    JSON.stringify(
-      fullNames.map((fullName) => ({ fullName, url: `https://github.com/${fullName}` })),
-    ),
-  );
+const repositorySearchResult = (nameWithOwner: string) => ({
+  nameWithOwner,
+  url: `https://github.com/${nameWithOwner}`,
+  sshUrl: `git@github.com:${nameWithOwner}.git`,
+});
 
-const repositorySearchArgs = (input: {
-  readonly query: string;
-  readonly owner?: string;
-  readonly includeForks: boolean;
-}): ReadonlyArray<string> => [
-  "search",
-  "repos",
-  "--match",
-  "name",
-  ...(input.owner === undefined ? [] : ["--owner", input.owner]),
-  "--include-forks",
-  String(input.includeForks),
-  "--limit",
-  "20",
-  "--json",
-  "fullName,url",
-  "--",
-  input.query,
-];
+const repositorySearchOutput = (input: {
+  readonly owner: ReadonlyArray<string>;
+  readonly global?: ReadonlyArray<string>;
+}): VcsProcess.VcsProcessOutput =>
+  processOutput(
+    JSON.stringify({
+      data: {
+        owner: { nodes: input.owner.map(repositorySearchResult) },
+        global: { nodes: (input.global ?? []).map(repositorySearchResult) },
+      },
+    }),
+  );
 
 const mockRun = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
 
@@ -321,17 +313,14 @@ describe("GitHubCli.layer", () => {
 
   it.effect("searches repositories with the authenticated owner's matches first", () =>
     Effect.gen(function* () {
-      mockRun
-        .mockReturnValueOnce(Effect.succeed(repositorySearchOutput("current-user/skills")))
-        .mockReturnValueOnce(
-          Effect.succeed(
-            repositorySearchOutput(
-              "mattpocock/skills",
-              "current-user/skills",
-              "someone-else/skills",
-            ),
-          ),
-        );
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          repositorySearchOutput({
+            owner: ["current-user/skills"],
+            global: ["mattpocock/skills", "current-user/skills", "someone-else/skills"],
+          }),
+        ),
+      );
 
       const gh = yield* GitHubCli.GitHubCli;
       const result = yield* gh.searchRepositories({
@@ -344,18 +333,16 @@ describe("GitHubCli.layer", () => {
         ["current-user/skills", "mattpocock/skills", "someone-else/skills"],
       );
       assert.equal(result[0]?.sshUrl, "git@github.com:current-user/skills.git");
-      expect(mockRun).toHaveBeenCalledTimes(2);
-      expect(mockRun).toHaveBeenNthCalledWith(1, {
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledWith({
         operation: "GitHubCli.execute",
         command: "gh",
-        args: repositorySearchArgs({ query: "skills", owner: "@me", includeForks: true }),
-        cwd: "/repo",
-        timeoutMs: 30_000,
-      });
-      expect(mockRun).toHaveBeenNthCalledWith(2, {
-        operation: "GitHubCli.execute",
-        command: "gh",
-        args: repositorySearchArgs({ query: "skills", includeForks: false }),
+        args: expect.arrayContaining([
+          "api",
+          "graphql",
+          "ownerQuery=skills in:name user:@me fork:true",
+          "globalQuery=skills in:name fork:false",
+        ]),
         cwd: "/repo",
         timeoutMs: 30_000,
       });
@@ -365,7 +352,11 @@ describe("GitHubCli.layer", () => {
   it.effect("returns an exact owner and repository path before other owner matches", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(
-        Effect.succeed(repositorySearchOutput("octocat/codething-tools", "octocat/codething-mvp")),
+        Effect.succeed(
+          repositorySearchOutput({
+            owner: ["octocat/codething-tools", "octocat/codething-mvp"],
+          }),
+        ),
       );
 
       const gh = yield* GitHubCli.GitHubCli;
@@ -392,7 +383,9 @@ describe("GitHubCli.layer", () => {
 
   it.effect("searches within an owner for a partial repository path", () =>
     Effect.gen(function* () {
-      mockRun.mockReturnValueOnce(Effect.succeed(repositorySearchOutput("octocat/codething-mvp")));
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(repositorySearchOutput({ owner: ["octocat/codething-mvp"] })),
+      );
 
       const gh = yield* GitHubCli.GitHubCli;
       const result = yield* gh.searchRepositories({ cwd: "/repo", query: "octocat/code" });
@@ -407,15 +400,13 @@ describe("GitHubCli.layer", () => {
 
   it.effect("returns no repository search results when there are no matches", () =>
     Effect.gen(function* () {
-      mockRun
-        .mockReturnValueOnce(Effect.succeed(processOutput("[]")))
-        .mockReturnValueOnce(Effect.succeed(processOutput("[]")));
+      mockRun.mockReturnValueOnce(Effect.succeed(repositorySearchOutput({ owner: [] })));
 
       const gh = yield* GitHubCli.GitHubCli;
       const result = yield* gh.searchRepositories({ cwd: "/repo", query: "does-not-exist" });
 
       assert.deepStrictEqual(result, []);
-      expect(mockRun).toHaveBeenCalledTimes(2);
+      expect(mockRun).toHaveBeenCalledTimes(1);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -1,5 +1,8 @@
+import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 import * as Result from "effect/Result";
@@ -18,6 +21,8 @@ import {
 } from "./gitHubPullRequests.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const GITHUB_DOT_COM = "github.com";
+const AUTH_ACCOUNT_CACHE_TTL = Duration.minutes(5);
 
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
@@ -40,7 +45,11 @@ export class GitHubCliUnavailableError extends Schema.TaggedErrorClass<GitHubCli
 
 export class GitHubCliAuthenticationError extends Schema.TaggedErrorClass<GitHubCliAuthenticationError>()(
   "GitHubCliAuthenticationError",
-  gitHubCliFailureFields,
+  {
+    command: Schema.Literal("gh"),
+    cwd: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
 ) {
   get detail(): string {
     return "GitHub CLI is not authenticated. Run `gh auth login` and retry.";
@@ -148,6 +157,19 @@ export class GitHubRepositoryDecodeError extends Schema.TaggedErrorClass<GitHubR
   }
 }
 
+export class GitHubRepositorySearchDecodeError extends Schema.TaggedErrorClass<GitHubRepositorySearchDecodeError>()(
+  "GitHubRepositorySearchDecodeError",
+  gitHubCliDecodeFields,
+) {
+  get detail(): string {
+    return "GitHub CLI returned invalid repository search JSON.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in searchRepositories: ${this.detail}`;
+  }
+}
+
 export const GitHubCliError = Schema.Union([
   GitHubCliUnavailableError,
   GitHubCliAuthenticationError,
@@ -158,6 +180,7 @@ export const GitHubCliError = Schema.Union([
   GitHubChangeRequestListDecodeError,
   GitHubPullRequestDecodeError,
   GitHubRepositoryDecodeError,
+  GitHubRepositorySearchDecodeError,
 ]);
 export type GitHubCliError = typeof GitHubCliError.Type;
 
@@ -241,6 +264,11 @@ export class GitHubCli extends Context.Service<
       readonly repository: string;
     }) => Effect.Effect<GitHubRepositoryCloneUrls, GitHubCliError>;
 
+    readonly searchRepositories: (input: {
+      readonly cwd: string;
+      readonly query: string;
+    }) => Effect.Effect<ReadonlyArray<GitHubRepositoryCloneUrls>, GitHubCliError>;
+
     readonly createRepository: (input: {
       readonly cwd: string;
       readonly repository: string;
@@ -276,6 +304,14 @@ const decodeRawGitHubRepositoryCloneUrls = Schema.decodeEffect(
   Schema.fromJsonString(RawGitHubRepositoryCloneUrlsSchema),
 );
 
+const RawGitHubRepositorySearchResultSchema = Schema.Struct({
+  fullName: TrimmedNonEmptyString,
+  url: Schema.URLFromString,
+});
+const decodeRawGitHubRepositorySearchResults = Schema.decodeEffect(
+  Schema.fromJsonString(Schema.Array(RawGitHubRepositorySearchResultSchema)),
+);
+
 function normalizeRepositoryCloneUrls(
   raw: Schema.Schema.Type<typeof RawGitHubRepositoryCloneUrlsSchema>,
 ): GitHubRepositoryCloneUrls {
@@ -283,6 +319,16 @@ function normalizeRepositoryCloneUrls(
     nameWithOwner: raw.nameWithOwner,
     url: raw.url,
     sshUrl: raw.sshUrl,
+  };
+}
+
+function normalizeRepositorySearchResult(
+  raw: Schema.Schema.Type<typeof RawGitHubRepositorySearchResultSchema>,
+): GitHubRepositoryCloneUrls {
+  return {
+    nameWithOwner: raw.fullName,
+    url: raw.url.toString(),
+    sshUrl: `git@${GITHUB_DOT_COM}:${raw.fullName}.git`,
   };
 }
 
@@ -338,6 +384,148 @@ export const make = Effect.gen(function* () {
         ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
       })
       .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
+
+  const authenticatedAccountCache = yield* Cache.makeWith<string, string, GitHubCliError>(
+    (cwd) =>
+      execute({
+        cwd,
+        args: ["api", "user", "--hostname", GITHUB_DOT_COM, "--jq", ".login"],
+      }).pipe(
+        Effect.flatMap((result) => {
+          const account = result.stdout.trim();
+          return account.length > 0
+            ? Effect.succeed(account)
+            : Effect.fail(
+                new GitHubCliAuthenticationError({
+                  command: "gh",
+                  cwd,
+                }),
+              );
+        }),
+      ),
+    {
+      capacity: 16,
+      timeToLive: (exit) => (Exit.isSuccess(exit) ? AUTH_ACCOUNT_CACHE_TTL : Duration.zero),
+    },
+  );
+
+  const searchGitHubRepositories = Effect.fn("GitHubCli.searchGitHubRepositories")(
+    function* (input: {
+      readonly cwd: string;
+      readonly query: string;
+      readonly owner?: string;
+      readonly includeForks: boolean;
+    }) {
+      const result = yield* execute({
+        cwd: input.cwd,
+        args: [
+          "search",
+          "repos",
+          "--match",
+          "name",
+          ...(input.owner === undefined ? [] : ["--owner", input.owner]),
+          "--include-forks",
+          String(input.includeForks),
+          "--limit",
+          "20",
+          "--json",
+          "fullName,url",
+          "--",
+          input.query,
+        ],
+      });
+      const repositories = yield* decodeRawGitHubRepositorySearchResults(result.stdout.trim()).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitHubRepositorySearchDecodeError({
+              command: "gh",
+              cwd: input.cwd,
+              cause,
+            }),
+        ),
+      );
+      return repositories.map(normalizeRepositorySearchResult);
+    },
+  );
+
+  const getRepositoryCloneUrls = Effect.fn("GitHubCli.getRepositoryCloneUrls")(function* (input: {
+    readonly cwd: string;
+    readonly repository: string;
+  }) {
+    const repository = input.repository.trim();
+    const result = yield* execute({
+      cwd: input.cwd,
+      args: ["repo", "view", repository, "--json", "nameWithOwner,url,sshUrl"],
+    });
+    const raw = result.stdout.trim();
+    const urls = yield* decodeRawGitHubRepositoryCloneUrls(raw).pipe(
+      Effect.mapError(
+        (cause) =>
+          new GitHubRepositoryDecodeError({
+            command: "gh",
+            cwd: input.cwd,
+            cause,
+          }),
+      ),
+    );
+    return normalizeRepositoryCloneUrls(urls);
+  });
+
+  const searchRepositories = Effect.fn("GitHubCli.searchRepositories")(function* (input: {
+    readonly cwd: string;
+    readonly query: string;
+  }) {
+    const query = input.query.trim();
+    if (query.length === 0) {
+      return [];
+    }
+
+    const slashIndex = query.indexOf("/");
+    if (slashIndex >= 0) {
+      const owner = query.slice(0, slashIndex).trim();
+      const repositoryName = query.slice(slashIndex + 1).trim();
+      if (owner.length === 0 || repositoryName.length === 0) {
+        return [];
+      }
+      const repositories = yield* searchGitHubRepositories({
+        cwd: input.cwd,
+        query: repositoryName,
+        owner,
+        includeForks: true,
+      });
+      const exactNameWithOwner = `${owner}/${repositoryName}`.toLowerCase();
+      return [...repositories].sort((left, right) => {
+        const leftIsExact = left.nameWithOwner.toLowerCase() === exactNameWithOwner;
+        const rightIsExact = right.nameWithOwner.toLowerCase() === exactNameWithOwner;
+        return Number(rightIsExact) - Number(leftIsExact);
+      });
+    }
+
+    const account = yield* Cache.get(authenticatedAccountCache, input.cwd);
+    const [ownerMatches, globalMatches] = yield* Effect.all(
+      [
+        searchGitHubRepositories({
+          cwd: input.cwd,
+          query,
+          owner: account,
+          includeForks: true,
+        }),
+        searchGitHubRepositories({
+          cwd: input.cwd,
+          query,
+          includeForks: false,
+        }),
+      ],
+      { concurrency: "unbounded" },
+    );
+    const repositories = new Map<string, GitHubRepositoryCloneUrls>();
+    for (const repository of [...ownerMatches, ...globalMatches]) {
+      if (!repositories.has(repository.nameWithOwner)) {
+        repositories.set(repository.nameWithOwner, repository);
+      }
+    }
+    return [...repositories.values()].slice(0, 20);
+  });
 
   return GitHubCli.of({
     execute,
@@ -412,26 +600,8 @@ export const make = Effect.gen(function* () {
           ),
         ),
       ),
-    getRepositoryCloneUrls: (input) =>
-      execute({
-        cwd: input.cwd,
-        args: ["repo", "view", input.repository, "--json", "nameWithOwner,url,sshUrl"],
-      }).pipe(
-        Effect.map((result) => result.stdout.trim()),
-        Effect.flatMap((raw) =>
-          decodeRawGitHubRepositoryCloneUrls(raw).pipe(
-            Effect.mapError(
-              (cause) =>
-                new GitHubRepositoryDecodeError({
-                  command: "gh",
-                  cwd: input.cwd,
-                  cause,
-                }),
-            ),
-          ),
-        ),
-        Effect.map(normalizeRepositoryCloneUrls),
-      ),
+    getRepositoryCloneUrls,
+    searchRepositories,
     createRepository: (input) =>
       execute({
         cwd: input.cwd,

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -18,7 +18,28 @@ import {
 } from "./gitHubPullRequests.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
-const GITHUB_DOT_COM = "github.com";
+const SEARCH_REPOSITORIES_QUERY = `
+  query SearchRepositories($ownerQuery: String!, $globalQuery: String!) {
+    owner: search(query: $ownerQuery, type: REPOSITORY, first: 20) {
+      nodes {
+        ... on Repository {
+          nameWithOwner
+          url
+          sshUrl
+        }
+      }
+    }
+    global: search(query: $globalQuery, type: REPOSITORY, first: 20) {
+      nodes {
+        ... on Repository {
+          nameWithOwner
+          url
+          sshUrl
+        }
+      }
+    }
+  }
+`.trim();
 
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
@@ -297,11 +318,19 @@ const decodeRawGitHubRepositoryCloneUrls = Schema.decodeEffect(
 );
 
 const RawGitHubRepositorySearchResultSchema = Schema.Struct({
-  fullName: TrimmedNonEmptyString,
-  url: Schema.URLFromString,
+  nameWithOwner: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+  sshUrl: TrimmedNonEmptyString,
 });
 const decodeRawGitHubRepositorySearchResults = Schema.decodeEffect(
-  Schema.fromJsonString(Schema.Array(RawGitHubRepositorySearchResultSchema)),
+  Schema.fromJsonString(
+    Schema.Struct({
+      data: Schema.Struct({
+        owner: Schema.Struct({ nodes: Schema.Array(RawGitHubRepositorySearchResultSchema) }),
+        global: Schema.Struct({ nodes: Schema.Array(RawGitHubRepositorySearchResultSchema) }),
+      }),
+    }),
+  ),
 );
 
 function normalizeRepositoryCloneUrls(
@@ -311,16 +340,6 @@ function normalizeRepositoryCloneUrls(
     nameWithOwner: raw.nameWithOwner,
     url: raw.url,
     sshUrl: raw.sshUrl,
-  };
-}
-
-function normalizeRepositorySearchResult(
-  raw: Schema.Schema.Type<typeof RawGitHubRepositorySearchResultSchema>,
-): GitHubRepositoryCloneUrls {
-  return {
-    nameWithOwner: raw.fullName,
-    url: raw.url.toString(),
-    sshUrl: `git@${GITHUB_DOT_COM}:${raw.fullName}.git`,
   };
 }
 
@@ -377,45 +396,6 @@ export const make = Effect.gen(function* () {
       })
       .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
 
-  const searchGitHubRepositories = Effect.fn("GitHubCli.searchGitHubRepositories")(
-    function* (input: {
-      readonly cwd: string;
-      readonly query: string;
-      readonly owner?: string;
-      readonly includeForks: boolean;
-    }) {
-      const result = yield* execute({
-        cwd: input.cwd,
-        args: [
-          "search",
-          "repos",
-          "--match",
-          "name",
-          ...(input.owner === undefined ? [] : ["--owner", input.owner]),
-          "--include-forks",
-          String(input.includeForks),
-          "--limit",
-          "20",
-          "--json",
-          "fullName,url",
-          "--",
-          input.query,
-        ],
-      });
-      const repositories = yield* decodeRawGitHubRepositorySearchResults(result.stdout.trim()).pipe(
-        Effect.mapError(
-          (cause) =>
-            new GitHubRepositorySearchDecodeError({
-              command: "gh",
-              cwd: input.cwd,
-              cause,
-            }),
-        ),
-      );
-      return repositories.map(normalizeRepositorySearchResult);
-    },
-  );
-
   const searchRepositories = Effect.fn("GitHubCli.searchRepositories")(function* (input: {
     readonly cwd: string;
     readonly query: string;
@@ -426,49 +406,62 @@ export const make = Effect.gen(function* () {
     }
 
     const slashIndex = query.indexOf("/");
-    if (slashIndex >= 0) {
+    let ownerQuery: string;
+    let globalQuery: string;
+    let exactNameWithOwner: string | null = null;
+    if (slashIndex < 0) {
+      ownerQuery = `${query} in:name user:@me fork:true`;
+      globalQuery = `${query} in:name fork:false`;
+    } else {
       const owner = query.slice(0, slashIndex).trim();
       const repositoryName = query.slice(slashIndex + 1).trim();
       if (owner.length === 0 || repositoryName.length === 0) {
         return [];
       }
-      const repositories = yield* searchGitHubRepositories({
-        cwd: input.cwd,
-        query: repositoryName,
-        owner,
-        includeForks: true,
-      });
-      const exactNameWithOwner = `${owner}/${repositoryName}`.toLowerCase();
-      return [...repositories].sort((left, right) => {
-        const leftIsExact = left.nameWithOwner.toLowerCase() === exactNameWithOwner;
-        const rightIsExact = right.nameWithOwner.toLowerCase() === exactNameWithOwner;
-        return Number(rightIsExact) - Number(leftIsExact);
-      });
+      ownerQuery = `${repositoryName} in:name user:${owner} fork:true`;
+      globalQuery = ownerQuery;
+      exactNameWithOwner = `${owner}/${repositoryName}`.toLowerCase();
     }
 
-    const [ownerMatches, globalMatches] = yield* Effect.all(
-      [
-        searchGitHubRepositories({
-          cwd: input.cwd,
-          query,
-          owner: "@me",
-          includeForks: true,
-        }),
-        searchGitHubRepositories({
-          cwd: input.cwd,
-          query,
-          includeForks: false,
-        }),
+    const result = yield* execute({
+      cwd: input.cwd,
+      args: [
+        "api",
+        "graphql",
+        "-f",
+        `query=${SEARCH_REPOSITORIES_QUERY}`,
+        "-f",
+        `ownerQuery=${ownerQuery}`,
+        "-f",
+        `globalQuery=${globalQuery}`,
       ],
-      { concurrency: "unbounded" },
+    });
+    const response = yield* decodeRawGitHubRepositorySearchResults(result.stdout.trim()).pipe(
+      Effect.mapError(
+        (cause) =>
+          new GitHubRepositorySearchDecodeError({
+            command: "gh",
+            cwd: input.cwd,
+            cause,
+          }),
+      ),
     );
     const repositories = new Map<string, GitHubRepositoryCloneUrls>();
-    for (const repository of [...ownerMatches, ...globalMatches]) {
+    for (const repository of [...response.data.owner.nodes, ...response.data.global.nodes]) {
       if (!repositories.has(repository.nameWithOwner)) {
         repositories.set(repository.nameWithOwner, repository);
       }
     }
-    return [...repositories.values()].slice(0, 20);
+    return [...repositories.values()]
+      .sort((left, right) => {
+        if (exactNameWithOwner === null) {
+          return 0;
+        }
+        const leftIsExact = left.nameWithOwner.toLowerCase() === exactNameWithOwner;
+        const rightIsExact = right.nameWithOwner.toLowerCase() === exactNameWithOwner;
+        return Number(rightIsExact) - Number(leftIsExact);
+      })
+      .slice(0, 20);
   });
 
   return GitHubCli.of({

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -1,8 +1,5 @@
-import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
-import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 import * as Result from "effect/Result";
@@ -22,7 +19,6 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const GITHUB_DOT_COM = "github.com";
-const AUTH_ACCOUNT_CACHE_TTL = Duration.minutes(5);
 
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
@@ -45,11 +41,7 @@ export class GitHubCliUnavailableError extends Schema.TaggedErrorClass<GitHubCli
 
 export class GitHubCliAuthenticationError extends Schema.TaggedErrorClass<GitHubCliAuthenticationError>()(
   "GitHubCliAuthenticationError",
-  {
-    command: Schema.Literal("gh"),
-    cwd: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
-  },
+  gitHubCliFailureFields,
 ) {
   get detail(): string {
     return "GitHub CLI is not authenticated. Run `gh auth login` and retry.";
@@ -385,30 +377,6 @@ export const make = Effect.gen(function* () {
       })
       .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
 
-  const authenticatedAccountCache = yield* Cache.makeWith<string, string, GitHubCliError>(
-    (cwd) =>
-      execute({
-        cwd,
-        args: ["api", "user", "--hostname", GITHUB_DOT_COM, "--jq", ".login"],
-      }).pipe(
-        Effect.flatMap((result) => {
-          const account = result.stdout.trim();
-          return account.length > 0
-            ? Effect.succeed(account)
-            : Effect.fail(
-                new GitHubCliAuthenticationError({
-                  command: "gh",
-                  cwd,
-                }),
-              );
-        }),
-      ),
-    {
-      capacity: 16,
-      timeToLive: (exit) => (Exit.isSuccess(exit) ? AUTH_ACCOUNT_CACHE_TTL : Duration.zero),
-    },
-  );
-
   const searchGitHubRepositories = Effect.fn("GitHubCli.searchGitHubRepositories")(
     function* (input: {
       readonly cwd: string;
@@ -448,29 +416,6 @@ export const make = Effect.gen(function* () {
     },
   );
 
-  const getRepositoryCloneUrls = Effect.fn("GitHubCli.getRepositoryCloneUrls")(function* (input: {
-    readonly cwd: string;
-    readonly repository: string;
-  }) {
-    const repository = input.repository.trim();
-    const result = yield* execute({
-      cwd: input.cwd,
-      args: ["repo", "view", repository, "--json", "nameWithOwner,url,sshUrl"],
-    });
-    const raw = result.stdout.trim();
-    const urls = yield* decodeRawGitHubRepositoryCloneUrls(raw).pipe(
-      Effect.mapError(
-        (cause) =>
-          new GitHubRepositoryDecodeError({
-            command: "gh",
-            cwd: input.cwd,
-            cause,
-          }),
-      ),
-    );
-    return normalizeRepositoryCloneUrls(urls);
-  });
-
   const searchRepositories = Effect.fn("GitHubCli.searchRepositories")(function* (input: {
     readonly cwd: string;
     readonly query: string;
@@ -501,13 +446,12 @@ export const make = Effect.gen(function* () {
       });
     }
 
-    const account = yield* Cache.get(authenticatedAccountCache, input.cwd);
     const [ownerMatches, globalMatches] = yield* Effect.all(
       [
         searchGitHubRepositories({
           cwd: input.cwd,
           query,
-          owner: account,
+          owner: "@me",
           includeForks: true,
         }),
         searchGitHubRepositories({
@@ -600,7 +544,26 @@ export const make = Effect.gen(function* () {
           ),
         ),
       ),
-    getRepositoryCloneUrls,
+    getRepositoryCloneUrls: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["repo", "view", input.repository, "--json", "nameWithOwner,url,sshUrl"],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          decodeRawGitHubRepositoryCloneUrls(raw).pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitHubRepositoryDecodeError({
+                  command: "gh",
+                  cwd: input.cwd,
+                  cause,
+                }),
+            ),
+          ),
+        ),
+        Effect.map(normalizeRepositoryCloneUrls),
+      ),
     searchRepositories,
     createRepository: (input) =>
       execute({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -257,6 +257,21 @@ export const make = Effect.gen(function* () {
             }),
         ),
       ),
+    searchRepositories: (input) =>
+      github.searchRepositories(input).pipe(
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "github",
+              operation: "searchRepositories",
+              command: error.command,
+              cwd: input.cwd,
+              repository: SourceControlProvider.transportSafeSourceControlErrorValue(input.query),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
     createRepository: (input) =>
       github.createRepository(input).pipe(
         Effect.mapError(

--- a/apps/server/src/sourceControl/SourceControlProvider.ts
+++ b/apps/server/src/sourceControl/SourceControlProvider.ts
@@ -111,6 +111,13 @@ export class SourceControlProvider extends Context.Service<
       readonly context?: SourceControlProviderContext;
       readonly repository: string;
     }) => Effect.Effect<SourceControlRepositoryCloneUrls, SourceControlProviderError>;
+    readonly searchRepositories?: (input: {
+      readonly cwd: string;
+      readonly query: string;
+    }) => Effect.Effect<
+      ReadonlyArray<SourceControlRepositoryCloneUrls>,
+      SourceControlProviderError
+    >;
     readonly createRepository: (input: {
       readonly cwd: string;
       readonly repository: string;

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -117,6 +117,44 @@ it.effect("looks up repositories through the requested provider without search",
   }).pipe(Effect.provide(makeLayer({ provider })));
 });
 
+it.effect("returns all repository search results in provider order", () => {
+  const calls: Array<{ cwd: string; query: string }> = [];
+  const provider = makeProvider({
+    searchRepositories: (input) =>
+      Effect.sync(() => {
+        calls.push(input);
+        return [
+          CLONE_URLS,
+          {
+            nameWithOwner: "mattpocock/t3code",
+            url: "https://github.com/mattpocock/t3code",
+            sshUrl: "git@github.com:mattpocock/t3code.git",
+          },
+        ];
+      }),
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+    const result = yield* service.searchRepositories({
+      provider: "github",
+      query: "t3code",
+      cwd: "/workspace",
+    });
+
+    assert.deepStrictEqual(result, [
+      { provider: "github", ...CLONE_URLS },
+      {
+        provider: "github",
+        nameWithOwner: "mattpocock/t3code",
+        url: "https://github.com/mattpocock/t3code",
+        sshUrl: "git@github.com:mattpocock/t3code.git",
+      },
+    ]);
+    assert.deepStrictEqual(calls, [{ cwd: "/workspace", query: "t3code" }]);
+  }).pipe(Effect.provide(makeLayer({ provider })));
+});
+
 it.effect("preserves provider failures without deriving the repository message from them", () => {
   const providerCause = new SourceControlProviderError({
     provider: "github",

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -17,6 +17,8 @@ import {
   type SourceControlRepositoryCloneUrls,
   type SourceControlRepositoryInfo,
   type SourceControlRepositoryLookupInput,
+  type SourceControlRepositorySearchInput,
+  type SourceControlRepositorySearchResult,
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../config.ts";
@@ -30,6 +32,9 @@ export class SourceControlRepositoryService extends Context.Service<
     readonly lookupRepository: (
       input: SourceControlRepositoryLookupInput,
     ) => Effect.Effect<SourceControlRepositoryInfo, SourceControlRepositoryError>;
+    readonly searchRepositories: (
+      input: SourceControlRepositorySearchInput,
+    ) => Effect.Effect<SourceControlRepositorySearchResult, SourceControlRepositoryError>;
     readonly cloneRepository: (
       input: SourceControlCloneRepositoryInput,
     ) => Effect.Effect<SourceControlCloneRepositoryResult, SourceControlRepositoryError>;
@@ -125,6 +130,22 @@ export const make = Effect.gen(function* () {
     });
     return toRepositoryInfo(providerKind, urls);
   });
+
+  const searchRepositories = Effect.fn("SourceControlRepositoryService.searchRepositories")(
+    function* (input: SourceControlRepositorySearchInput) {
+      const providerKind = yield* ensureConcreteProvider({
+        operation: "searchRepositories",
+        provider: input.provider,
+      });
+      const provider = yield* providers.get(providerKind);
+      const cwd = input.cwd ?? config.cwd;
+      const query = input.query.trim();
+      const urls = provider.searchRepositories
+        ? yield* provider.searchRepositories({ cwd, query })
+        : [yield* provider.getRepositoryCloneUrls({ cwd, repository: query })];
+      return urls.map((repository) => toRepositoryInfo(providerKind, repository));
+    },
+  );
 
   const normalizeDestinationPath = Effect.fn("SourceControlRepositoryService.normalizeDestination")(
     function* (destinationPath: string) {
@@ -276,6 +297,8 @@ export const make = Effect.gen(function* () {
   );
 
   return SourceControlRepositoryService.of({
+    searchRepositories: (input) =>
+      searchRepositories(input).pipe(mapRepositoryError("searchRepositories", input.provider)),
     lookupRepository: (input) =>
       lookupRepository(input).pipe(mapRepositoryError("lookupRepository", input.provider)),
     cloneRepository: (input) =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1886,6 +1886,14 @@ const makeWsRpcLayer = (
               "rpc.aggregate": "source-control",
             },
           ),
+        [WS_METHODS.sourceControlSearchRepositories]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.sourceControlSearchRepositories,
+            sourceControlRepositories.searchRepositories(input),
+            {
+              "rpc.aggregate": "source-control",
+            },
+          ),
         [WS_METHODS.sourceControlCloneRepository]: (input) =>
           observeRpcEffect(
             WS_METHODS.sourceControlCloneRepository,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -215,8 +215,6 @@ type AddProjectCloneFlow =
       readonly step: "repository";
       readonly environmentId: EnvironmentId;
       readonly source: AddProjectRemoteSource;
-      readonly repositories: ReadonlyArray<SourceControlRepositoryInfo> | null;
-      readonly repositoryQuery: string | null;
     }
   | {
       readonly step: "confirm";
@@ -225,7 +223,6 @@ type AddProjectCloneFlow =
       readonly repositoryInput: string;
       readonly repository: SourceControlRepositoryInfo | null;
       readonly remoteUrl: string;
-      readonly searchResults: ReadonlyArray<SourceControlRepositoryInfo> | null;
     };
 
 const REMOTE_PROJECT_SOURCES: ReadonlyArray<AddProjectRemoteSource> = [
@@ -581,9 +578,6 @@ function OpenCommandPaletteDialog(props: {
   const lookupRepository = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
-  const searchRepositories = useAtomQueryRunner(sourceControlEnvironment.repositorySearch, {
-    reportFailure: false,
-  });
   const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
     reportFailure: false,
     reportDefect: false,
@@ -657,79 +651,31 @@ function OpenCommandPaletteDialog(props: {
       : null;
   const normalizedRepositorySearchQuery =
     githubRepositorySearchEnvironmentId === null ? "" : query.trim();
-  const hasCurrentGithubRepositorySearchResults =
-    addProjectCloneFlow?.step === "repository" &&
-    addProjectCloneFlow.source === "github" &&
-    addProjectCloneFlow.repositories !== null &&
-    addProjectCloneFlow.repositoryQuery === normalizedRepositorySearchQuery;
   const debouncedRepositorySearchQuery = useDebouncedValue(
     normalizedRepositorySearchQuery,
     REPOSITORY_SEARCH_DEBOUNCE_MS,
   );
-
-  useEffect(() => {
-    if (githubRepositorySearchEnvironmentId === null) {
-      setIsRemoteProjectLookingUp(false);
-      return;
-    }
-    if (hasCurrentGithubRepositorySearchResults) {
-      setIsRemoteProjectLookingUp(false);
-      return;
-    }
-    if (
-      normalizedRepositorySearchQuery.length === 0 ||
-      normalizedRepositorySearchQuery !== debouncedRepositorySearchQuery
-    ) {
-      setIsRemoteProjectLookingUp(normalizedRepositorySearchQuery.length > 0);
-      return;
-    }
-
-    let cancelled = false;
-    setIsRemoteProjectLookingUp(true);
-    void searchRepositories({
-      environmentId: githubRepositorySearchEnvironmentId,
-      input: {
-        provider: "github",
-        query: debouncedRepositorySearchQuery,
-      },
-    }).then((searchResult) => {
-      if (cancelled) {
-        return;
-      }
-      setIsRemoteProjectLookingUp(false);
-      if (searchResult._tag === "Failure") {
-        return;
-      }
-
-      setAddProjectCloneFlow((currentFlow) => {
-        if (
-          currentFlow?.source !== "github" ||
-          currentFlow.environmentId !== githubRepositorySearchEnvironmentId ||
-          currentFlow.step !== "repository"
-        ) {
-          return currentFlow;
-        }
-        return {
-          step: "repository",
-          environmentId: currentFlow.environmentId,
-          source: "github",
-          repositories: searchResult.value,
-          repositoryQuery: debouncedRepositorySearchQuery,
-        };
-      });
-      setHighlightedItemValue(null);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    debouncedRepositorySearchQuery,
-    githubRepositorySearchEnvironmentId,
-    hasCurrentGithubRepositorySearchResults,
-    normalizedRepositorySearchQuery,
-    searchRepositories,
-  ]);
+  const settledRepositorySearchQuery =
+    normalizedRepositorySearchQuery.length > 0 &&
+    normalizedRepositorySearchQuery === debouncedRepositorySearchQuery
+      ? debouncedRepositorySearchQuery
+      : null;
+  const repositorySearch = useEnvironmentQuery(
+    githubRepositorySearchEnvironmentId !== null && settledRepositorySearchQuery !== null
+      ? sourceControlEnvironment.repositorySearch({
+          environmentId: githubRepositorySearchEnvironmentId,
+          input: {
+            provider: "github",
+            query: settledRepositorySearchQuery,
+          },
+        })
+      : null,
+  );
+  const repositorySearchResults = repositorySearch.data;
+  const isGitHubRepositorySearchPending =
+    normalizedRepositorySearchQuery.length > 0 &&
+    (normalizedRepositorySearchQuery !== debouncedRepositorySearchQuery ||
+      repositorySearch.isPending);
   const projectGroupingSettings = useMemo(
     () => selectProjectGroupingSettings(clientSettings),
     [clientSettings],
@@ -1289,40 +1235,16 @@ function OpenCommandPaletteDialog(props: {
       popView();
       return;
     }
-    if (addProjectCloneFlow.searchResults) {
-      setAddProjectCloneFlow({
-        step: "repository",
-        environmentId: addProjectCloneFlow.environmentId,
-        source: "github",
-        repositories: addProjectCloneFlow.searchResults,
-        repositoryQuery: addProjectCloneFlow.repositoryInput,
-      });
-      setQuery(addProjectCloneFlow.repositoryInput);
-    } else {
-      setAddProjectCloneFlow({
-        step: "repository",
-        environmentId: addProjectCloneFlow.environmentId,
-        source: addProjectCloneFlow.source,
-        repositories: null,
-        repositoryQuery: null,
-      });
-      setQuery(addProjectCloneFlow.repositoryInput);
-    }
+    setAddProjectCloneFlow({
+      step: "repository",
+      environmentId: addProjectCloneFlow.environmentId,
+      source: addProjectCloneFlow.source,
+    });
+    setQuery(addProjectCloneFlow.repositoryInput);
     setBrowseGeneration((generation) => generation + 1);
   }
 
   function handleQueryChange(nextQuery: string): void {
-    if (
-      githubRepositorySearchEnvironmentId !== null &&
-      nextQuery.trim() !== normalizedRepositorySearchQuery
-    ) {
-      setIsRemoteProjectLookingUp(nextQuery.trim().length > 0);
-      setAddProjectCloneFlow((currentFlow) =>
-        currentFlow?.source === "github" && currentFlow.step === "repository"
-          ? { ...currentFlow, repositories: null, repositoryQuery: null }
-          : currentFlow,
-      );
-    }
     browseNavigation.invalidate();
     setHighlightedItemValue(null);
     setQuery(nextQuery);
@@ -1370,8 +1292,6 @@ function OpenCommandPaletteDialog(props: {
         step: "repository",
         environmentId,
         source,
-        repositories: null,
-        repositoryQuery: null,
       });
       pushPaletteView({
         addonIcon: remoteProjectSourceIcon(source, ADDON_ICON_CLASS),
@@ -1981,11 +1901,7 @@ function OpenCommandPaletteDialog(props: {
   }
 
   function selectAddProjectRepository(repository: SourceControlRepositoryInfo): void {
-    if (
-      addProjectCloneFlow?.step !== "repository" ||
-      addProjectCloneFlow.source !== "github" ||
-      addProjectCloneFlow.repositories === null
-    ) {
+    if (addProjectCloneFlow?.step !== "repository" || addProjectCloneFlow.source !== "github") {
       return;
     }
     setIsRemoteProjectLookingUp(false);
@@ -2000,7 +1916,6 @@ function OpenCommandPaletteDialog(props: {
       repositoryInput: query.trim(),
       repository,
       remoteUrl: getDefaultCloneUrl(repository),
-      searchResults: addProjectCloneFlow.repositories,
     });
     setHighlightedItemValue(null);
     setQuery(destinationPath);
@@ -2041,7 +1956,6 @@ function OpenCommandPaletteDialog(props: {
           repositoryInput: rawRepository,
           repository: null,
           remoteUrl: normalizePastedCloneUrl(rawRepository),
-          searchResults: null,
         });
         setHighlightedItemValue(null);
         setQuery(destinationPath);
@@ -2086,7 +2000,6 @@ function OpenCommandPaletteDialog(props: {
         repositoryInput: rawRepository,
         repository,
         remoteUrl: getDefaultCloneUrl(repository),
-        searchResults: null,
       });
       setHighlightedItemValue(null);
       setQuery(destinationPath);
@@ -2245,12 +2158,12 @@ function OpenCommandPaletteDialog(props: {
   const repositorySearchGroups: CommandPaletteView["groups"] =
     addProjectCloneFlow?.step === "repository" &&
     addProjectCloneFlow.source === "github" &&
-    addProjectCloneFlow.repositories !== null
+    repositorySearchResults !== null
       ? [
           {
             value: "repositories",
             label: "Repositories",
-            items: addProjectCloneFlow.repositories.map((repository) => ({
+            items: repositorySearchResults.map((repository) => ({
               kind: "action" as const,
               value: `repository:${repository.nameWithOwner}`,
               searchTerms: [repository.nameWithOwner, repository.url],
@@ -2263,13 +2176,6 @@ function OpenCommandPaletteDialog(props: {
           },
         ]
       : [];
-  const isGitHubRepositorySearchPending =
-    githubRepositorySearchEnvironmentId !== null &&
-    normalizedRepositorySearchQuery.length > 0 &&
-    !hasCurrentGithubRepositorySearchResults &&
-    (normalizedRepositorySearchQuery !== debouncedRepositorySearchQuery ||
-      isRemoteProjectLookingUp);
-
   let displayedGroups: CommandPaletteView["groups"] = filteredGroups;
   if (addProjectCloneFlow?.step === "repository") {
     displayedGroups =
@@ -2736,9 +2642,9 @@ function OpenCommandPaletteDialog(props: {
                       ? "Start typing to search GitHub repositories."
                       : isGitHubRepositorySearchPending
                         ? "Searching repositories…"
-                        : addProjectCloneFlow.repositories === null
+                        : repositorySearch.error !== null
                           ? "Unable to search repositories. Try again."
-                          : addProjectCloneFlow.repositories.length === 0
+                          : repositorySearchResults?.length === 0
                             ? "No repositories found."
                             : "Start typing to search GitHub repositories."
                     : "Enter a repository path and press Enter to look it up.",

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -7,6 +7,7 @@ import {
   getCloneDestinationPath,
   getCloneDirectoryName,
   getDefaultCloneUrl,
+  isGitHubRepositoryShorthand,
   normalizePastedCloneUrl,
 } from "@t3tools/client-runtime/operations/projects";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
@@ -77,7 +78,7 @@ import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
-import { useThreadSearch } from "../state/queries";
+import { useDebouncedValue, useThreadSearch } from "../state/queries";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
@@ -169,6 +170,7 @@ import {
 import type { Project } from "../types";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
+const REPOSITORY_SEARCH_DEBOUNCE_MS = 100;
 
 function projectFavicon(project: Project) {
   return (
@@ -213,6 +215,8 @@ type AddProjectCloneFlow =
       readonly step: "repository";
       readonly environmentId: EnvironmentId;
       readonly source: AddProjectRemoteSource;
+      readonly repositories: ReadonlyArray<SourceControlRepositoryInfo> | null;
+      readonly repositoryQuery: string | null;
     }
   | {
       readonly step: "confirm";
@@ -221,6 +225,7 @@ type AddProjectCloneFlow =
       readonly repositoryInput: string;
       readonly repository: SourceControlRepositoryInfo | null;
       readonly remoteUrl: string;
+      readonly searchResults: ReadonlyArray<SourceControlRepositoryInfo> | null;
     };
 
 const REMOTE_PROJECT_SOURCES: ReadonlyArray<AddProjectRemoteSource> = [
@@ -255,7 +260,7 @@ function remoteProjectSourceLabel(source: AddProjectRemoteSource): string {
 function remoteProjectSourcePathHint(source: AddProjectRemoteSource): string {
   switch (source) {
     case "github":
-      return "owner/repo";
+      return "owner/repo or repository name";
     case "gitlab":
       return "group/project";
     case "bitbucket":
@@ -291,6 +296,7 @@ function remoteProjectSourceIcon(source: AddProjectRemoteSource, className: stri
 function remoteProjectInputPlaceholder(flow: AddProjectCloneFlow | null): string | null {
   if (!flow) return null;
   if (flow.step === "confirm") return null;
+  if (flow.source === "github") return "Search repositories";
   if (flow.source === "url") {
     return "Enter Git clone URL";
   }
@@ -575,6 +581,9 @@ function OpenCommandPaletteDialog(props: {
   const lookupRepository = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
+  const searchRepositories = useAtomQueryRunner(sourceControlEnvironment.repositorySearch, {
+    reportFailure: false,
+  });
   const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
     reportFailure: false,
     reportDefect: false,
@@ -642,6 +651,85 @@ function OpenCommandPaletteDialog(props: {
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
+  const githubRepositorySearchEnvironmentId =
+    addProjectCloneFlow?.source === "github" && addProjectCloneFlow.step === "repository"
+      ? addProjectCloneFlow.environmentId
+      : null;
+  const normalizedRepositorySearchQuery =
+    githubRepositorySearchEnvironmentId === null ? "" : query.trim();
+  const hasCurrentGithubRepositorySearchResults =
+    addProjectCloneFlow?.step === "repository" &&
+    addProjectCloneFlow.source === "github" &&
+    addProjectCloneFlow.repositories !== null &&
+    addProjectCloneFlow.repositoryQuery === normalizedRepositorySearchQuery;
+  const debouncedRepositorySearchQuery = useDebouncedValue(
+    normalizedRepositorySearchQuery,
+    REPOSITORY_SEARCH_DEBOUNCE_MS,
+  );
+
+  useEffect(() => {
+    if (githubRepositorySearchEnvironmentId === null) {
+      setIsRemoteProjectLookingUp(false);
+      return;
+    }
+    if (hasCurrentGithubRepositorySearchResults) {
+      setIsRemoteProjectLookingUp(false);
+      return;
+    }
+    if (
+      normalizedRepositorySearchQuery.length === 0 ||
+      normalizedRepositorySearchQuery !== debouncedRepositorySearchQuery
+    ) {
+      setIsRemoteProjectLookingUp(normalizedRepositorySearchQuery.length > 0);
+      return;
+    }
+
+    let cancelled = false;
+    setIsRemoteProjectLookingUp(true);
+    void searchRepositories({
+      environmentId: githubRepositorySearchEnvironmentId,
+      input: {
+        provider: "github",
+        query: debouncedRepositorySearchQuery,
+      },
+    }).then((searchResult) => {
+      if (cancelled) {
+        return;
+      }
+      setIsRemoteProjectLookingUp(false);
+      if (searchResult._tag === "Failure") {
+        return;
+      }
+
+      setAddProjectCloneFlow((currentFlow) => {
+        if (
+          currentFlow?.source !== "github" ||
+          currentFlow.environmentId !== githubRepositorySearchEnvironmentId ||
+          currentFlow.step !== "repository"
+        ) {
+          return currentFlow;
+        }
+        return {
+          step: "repository",
+          environmentId: currentFlow.environmentId,
+          source: "github",
+          repositories: searchResult.value,
+          repositoryQuery: debouncedRepositorySearchQuery,
+        };
+      });
+      setHighlightedItemValue(null);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    debouncedRepositorySearchQuery,
+    githubRepositorySearchEnvironmentId,
+    hasCurrentGithubRepositorySearchResults,
+    normalizedRepositorySearchQuery,
+    searchRepositories,
+  ]);
   const projectGroupingSettings = useMemo(
     () => selectProjectGroupingSettings(clientSettings),
     [clientSettings],
@@ -1177,6 +1265,7 @@ function OpenCommandPaletteDialog(props: {
   }
 
   function popView(): void {
+    setIsRemoteProjectLookingUp(false);
     browseNavigation.invalidate();
     setAddProjectCloneFlow(null);
     if (viewStack.length <= 1) {
@@ -1187,7 +1276,53 @@ function OpenCommandPaletteDialog(props: {
     setQuery("");
   }
 
+  function backAddProjectCloneFlow(): void {
+    if (!addProjectCloneFlow) {
+      popView();
+      return;
+    }
+
+    setIsRemoteProjectLookingUp(false);
+    browseNavigation.invalidate();
+    setHighlightedItemValue(null);
+    if (addProjectCloneFlow.step === "repository") {
+      popView();
+      return;
+    }
+    if (addProjectCloneFlow.searchResults) {
+      setAddProjectCloneFlow({
+        step: "repository",
+        environmentId: addProjectCloneFlow.environmentId,
+        source: "github",
+        repositories: addProjectCloneFlow.searchResults,
+        repositoryQuery: addProjectCloneFlow.repositoryInput,
+      });
+      setQuery(addProjectCloneFlow.repositoryInput);
+    } else {
+      setAddProjectCloneFlow({
+        step: "repository",
+        environmentId: addProjectCloneFlow.environmentId,
+        source: addProjectCloneFlow.source,
+        repositories: null,
+        repositoryQuery: null,
+      });
+      setQuery(addProjectCloneFlow.repositoryInput);
+    }
+    setBrowseGeneration((generation) => generation + 1);
+  }
+
   function handleQueryChange(nextQuery: string): void {
+    if (
+      githubRepositorySearchEnvironmentId !== null &&
+      nextQuery.trim() !== normalizedRepositorySearchQuery
+    ) {
+      setIsRemoteProjectLookingUp(nextQuery.trim().length > 0);
+      setAddProjectCloneFlow((currentFlow) =>
+        currentFlow?.source === "github" && currentFlow.step === "repository"
+          ? { ...currentFlow, repositories: null, repositoryQuery: null }
+          : currentFlow,
+      );
+    }
     browseNavigation.invalidate();
     setHighlightedItemValue(null);
     setQuery(nextQuery);
@@ -1231,7 +1366,13 @@ function OpenCommandPaletteDialog(props: {
   const startAddProjectClone = useCallback(
     (environmentId: EnvironmentId, source: AddProjectRemoteSource): void => {
       setAddProjectEnvironmentId(environmentId);
-      setAddProjectCloneFlow({ step: "repository", environmentId, source });
+      setAddProjectCloneFlow({
+        step: "repository",
+        environmentId,
+        source,
+        repositories: null,
+        repositoryQuery: null,
+      });
       pushPaletteView({
         addonIcon: remoteProjectSourceIcon(source, ADDON_ICON_CLASS),
         groups: [],
@@ -1839,6 +1980,33 @@ function OpenCommandPaletteDialog(props: {
     return getAddProjectInitialQueryForEnvironment(environmentId);
   }
 
+  function selectAddProjectRepository(repository: SourceControlRepositoryInfo): void {
+    if (
+      addProjectCloneFlow?.step !== "repository" ||
+      addProjectCloneFlow.source !== "github" ||
+      addProjectCloneFlow.repositories === null
+    ) {
+      return;
+    }
+    setIsRemoteProjectLookingUp(false);
+    const destinationPath = getCloneDestinationPath(
+      getDefaultCloneParentPath(addProjectCloneFlow.environmentId),
+      getCloneDirectoryName(repository.nameWithOwner),
+    );
+    setAddProjectCloneFlow({
+      step: "confirm",
+      environmentId: addProjectCloneFlow.environmentId,
+      source: addProjectCloneFlow.source,
+      repositoryInput: query.trim(),
+      repository,
+      remoteUrl: getDefaultCloneUrl(repository),
+      searchResults: addProjectCloneFlow.repositories,
+    });
+    setHighlightedItemValue(null);
+    setQuery(destinationPath);
+    setBrowseGeneration((generation) => generation + 1);
+  }
+
   async function submitAddProjectCloneFlow(destinationPathInput?: string): Promise<void> {
     if (!addProjectCloneFlow) {
       return;
@@ -1873,10 +2041,15 @@ function OpenCommandPaletteDialog(props: {
           repositoryInput: rawRepository,
           repository: null,
           remoteUrl: normalizePastedCloneUrl(rawRepository),
+          searchResults: null,
         });
         setHighlightedItemValue(null);
         setQuery(destinationPath);
         setBrowseGeneration((generation) => generation + 1);
+        return;
+      }
+
+      if (provider === "github" && !isGitHubRepositoryShorthand(rawRepository)) {
         return;
       }
 
@@ -1913,10 +2086,15 @@ function OpenCommandPaletteDialog(props: {
         repositoryInput: rawRepository,
         repository,
         remoteUrl: getDefaultCloneUrl(repository),
+        searchResults: null,
       });
       setHighlightedItemValue(null);
       setQuery(destinationPath);
       setBrowseGeneration((generation) => generation + 1);
+      return;
+    }
+
+    if (addProjectCloneFlow.step !== "confirm") {
       return;
     }
 
@@ -2064,9 +2242,42 @@ function OpenCommandPaletteDialog(props: {
     };
   }, [addProjectCloneFlow]);
 
+  const repositorySearchGroups: CommandPaletteView["groups"] =
+    addProjectCloneFlow?.step === "repository" &&
+    addProjectCloneFlow.source === "github" &&
+    addProjectCloneFlow.repositories !== null
+      ? [
+          {
+            value: "repositories",
+            label: "Repositories",
+            items: addProjectCloneFlow.repositories.map((repository) => ({
+              kind: "action" as const,
+              value: `repository:${repository.nameWithOwner}`,
+              searchTerms: [repository.nameWithOwner, repository.url],
+              title: repository.nameWithOwner,
+              description: repository.url,
+              icon: <GitHubIcon className={ITEM_ICON_CLASS} />,
+              keepOpen: true,
+              run: async () => selectAddProjectRepository(repository),
+            })),
+          },
+        ]
+      : [];
+  const isGitHubRepositorySearchPending =
+    githubRepositorySearchEnvironmentId !== null &&
+    normalizedRepositorySearchQuery.length > 0 &&
+    !hasCurrentGithubRepositorySearchResults &&
+    (normalizedRepositorySearchQuery !== debouncedRepositorySearchQuery ||
+      isRemoteProjectLookingUp);
+
   let displayedGroups: CommandPaletteView["groups"] = filteredGroups;
   if (addProjectCloneFlow?.step === "repository") {
-    displayedGroups = [];
+    displayedGroups =
+      addProjectCloneFlow.source !== "github" ||
+      normalizedRepositorySearchQuery.length === 0 ||
+      isGitHubRepositorySearchPending
+        ? []
+        : repositorySearchGroups;
   } else if (addProjectCloneFlow?.step === "confirm") {
     displayedGroups = relativePathNeedsActiveProject ? [] : cloneDestinationBrowseGroups;
   } else if (isBrowsing) {
@@ -2077,6 +2288,10 @@ function OpenCommandPaletteDialog(props: {
     remoteProjectInputPlaceholder(addProjectCloneFlow) ??
     getCommandPaletteInputPlaceholder(paletteMode);
   const isSubmenu = paletteMode === "submenu" || paletteMode === "submenu-browse";
+  const shouldAutoHighlightRepositoryResult =
+    addProjectCloneFlow?.step === "repository" &&
+    addProjectCloneFlow.source === "github" &&
+    displayedGroups.some((group) => group.items.length > 0);
   const hasHighlightedBrowseItem = highlightedItemValue?.startsWith("browse:") ?? false;
   const canSubmitBrowsePath =
     isBrowsing &&
@@ -2110,6 +2325,15 @@ function OpenCommandPaletteDialog(props: {
     query.trim().length > 0 &&
     canCreateProjectInEnvironment(browseEnvironment?.connection.phase) &&
     !isRemoteProjectPending;
+  const shouldOfferGitHubRepositoryLookup =
+    addProjectCloneFlow?.step === "repository" &&
+    addProjectCloneFlow.source === "github" &&
+    isGitHubRepositoryShorthand(query) &&
+    !shouldAutoHighlightRepositoryResult &&
+    !isGitHubRepositorySearchPending;
+  const shouldShowRemoteProjectAccessory =
+    addProjectCloneFlow?.step === "repository" &&
+    (addProjectCloneFlow.source !== "github" || shouldOfferGitHubRepositoryLookup);
   const fileManagerName = getLocalFileManagerName(navigator.platform);
   const canOpenProjectFromFileManager =
     isBrowsing &&
@@ -2168,7 +2392,11 @@ function OpenCommandPaletteDialog(props: {
       }
     }
 
-    if (addProjectCloneFlow?.step === "repository" && event.key === "Enter") {
+    if (
+      addProjectCloneFlow?.step === "repository" &&
+      (addProjectCloneFlow.source !== "github" || shouldOfferGitHubRepositoryLookup) &&
+      event.key === "Enter"
+    ) {
       event.preventDefault();
       void submitAddProjectCloneFlow();
       return;
@@ -2191,7 +2419,7 @@ function OpenCommandPaletteDialog(props: {
 
     if (event.key === "Backspace" && query === "" && isSubmenu) {
       event.preventDefault();
-      popView();
+      backAddProjectCloneFlow();
     }
   }
 
@@ -2332,7 +2560,8 @@ function OpenCommandPaletteDialog(props: {
   ]);
 
   const inputAccessory =
-    addProjectCloneFlow?.step === "repository" ? (
+    addProjectCloneFlow?.step === "repository" &&
+    (addProjectCloneFlow.source !== "github" || shouldOfferGitHubRepositoryLookup) ? (
       <Tooltip>
         <TooltipTrigger
           render={
@@ -2406,12 +2635,11 @@ function OpenCommandPaletteDialog(props: {
       </Tooltip>
     ) : null;
 
-  const footerActionLabel =
-    addProjectCloneFlow?.step === "repository"
-      ? (remoteProjectButtonLabel ?? "Continue")
-      : !canSubmitBrowsePath || hasHighlightedBrowseItem
-        ? "Select"
-        : undefined;
+  const footerActionLabel = shouldShowRemoteProjectAccessory
+    ? (remoteProjectButtonLabel ?? "Continue")
+    : !canSubmitBrowsePath || hasHighlightedBrowseItem
+      ? "Select"
+      : undefined;
 
   const footerTrailing = canOpenProjectFromFileManager ? (
     <CommandFooterAction
@@ -2428,22 +2656,25 @@ function OpenCommandPaletteDialog(props: {
     <CommandPaletteContent
       key={`${viewStack.length}-${browseGeneration}-${isBrowsing}-${addProjectCloneFlow?.step ?? "none"}`}
       aria-label="Command palette"
-      autoHighlight={isBrowsing || isRemoteProjectCloneFlow ? false : "always"}
+      autoHighlight={
+        isBrowsing || (isRemoteProjectCloneFlow && !shouldAutoHighlightRepositoryResult)
+          ? false
+          : "always"
+      }
       footerActionLabel={footerActionLabel}
       footerTrailing={footerTrailing}
       inputAccessory={inputAccessory}
       inputProps={{
         // The submit button is absolutely positioned over the field, so the
         // inner input must reserve enough room for the full action label.
-        className:
-          addProjectCloneFlow?.step === "repository"
-            ? "*:data-[slot=autocomplete-input]:pe-32!"
-            : isBrowsing
-              ? browseInputEndPaddingClass({
-                  willCreateProjectPath,
-                  hasHighlightedBrowseItem,
-                })
-              : undefined,
+        className: shouldShowRemoteProjectAccessory
+          ? "*:data-[slot=autocomplete-input]:pe-32!"
+          : isBrowsing
+            ? browseInputEndPaddingClass({
+                willCreateProjectPath,
+                hasHighlightedBrowseItem,
+              })
+            : undefined,
         placeholder: inputPlaceholder,
         wrapperClassName: isSubmenu
           ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"
@@ -2455,7 +2686,7 @@ function OpenCommandPaletteDialog(props: {
                   type="button"
                   className="flex cursor-pointer items-center"
                   aria-label="Back"
-                  onClick={popView}
+                  onClick={backAddProjectCloneFlow}
                 >
                   <ArrowLeftIcon />
                 </button>
@@ -2500,7 +2731,17 @@ function OpenCommandPaletteDialog(props: {
               emptyStateMessage:
                 addProjectCloneFlow.source === "url"
                   ? "Enter a Git clone URL and press Enter to continue."
-                  : "Enter a repository path and press Enter to look it up.",
+                  : addProjectCloneFlow.source === "github"
+                    ? normalizedRepositorySearchQuery.length === 0
+                      ? "Start typing to search GitHub repositories."
+                      : isGitHubRepositorySearchPending
+                        ? "Searching repositories…"
+                        : addProjectCloneFlow.repositories === null
+                          ? "Unable to search repositories. Try again."
+                          : addProjectCloneFlow.repositories.length === 0
+                            ? "No repositories found."
+                            : "Start typing to search GitHub repositories."
+                    : "Enter a repository path and press Enter to look it up.",
             }
           : addProjectCloneFlow?.step === "confirm"
             ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -19,7 +19,8 @@ T3 Code works with the platforms your team already uses:
 
 - Open the Command Palette (`Cmd/Ctrl + K`) → **Add Project**
 - Choose **GitHub repository**, **GitLab repository**, **Bitbucket repository**, **Azure DevOps repository**, or paste any **Git URL**
-- Enter the repository path (`owner/repo`, `group/project`, `workspace/repository`, or `project/repository`) or a full Git URL, pick a destination, and start coding
+- For GitHub, start typing a repository name and choose from the matches; repositories owned by your signed-in account appear first
+- For other providers, enter the repository path (`group/project`, `workspace/repository`, or `project/repository`) or paste a full Git URL, then pick a destination and start coding
 
 **Publish local projects to the cloud**
 

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -17,6 +17,7 @@ import {
   getCloneDestinationPath,
   getCloneDirectoryName,
   getDefaultCloneUrl,
+  isGitHubRepositoryShorthand,
   normalizePastedCloneUrl,
   resolveAddProjectPath,
   sortAddProjectProviderSources,
@@ -49,6 +50,8 @@ describe("add project shared logic", () => {
   });
 
   it("routes owner/repository shorthand to GitHub over HTTPS", () => {
+    expect(isGitHubRepositoryShorthand("imputnet/helium")).toBe(true);
+    expect(isGitHubRepositoryShorthand("skills")).toBe(false);
     expect(normalizePastedCloneUrl("imputnet/helium")).toBe(
       "https://github.com/imputnet/helium.git",
     );

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -88,7 +88,7 @@ export function addProjectRemoteSourceLabel(source: AddProjectRemoteSource): str
 export function addProjectRemoteSourcePathHint(source: AddProjectRemoteSource): string {
   switch (source) {
     case "github":
-      return "owner/repo";
+      return "owner/repo or repository name";
     case "gitlab":
       return "group/project";
     case "bitbucket":
@@ -109,10 +109,14 @@ export function addProjectRemoteSourceProvider(
 const GITHUB_REPOSITORY_SHORTHAND =
   /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]+(?:\.git)?$/;
 
+export function isGitHubRepositoryShorthand(input: string): boolean {
+  return GITHUB_REPOSITORY_SHORTHAND.test(input.trim());
+}
+
 /** Treat the common owner/repository shorthand as a public GitHub HTTPS URL. */
 export function normalizePastedCloneUrl(input: string): string {
   const trimmed = input.trim();
-  if (!GITHUB_REPOSITORY_SHORTHAND.test(trimmed)) return trimmed;
+  if (!isGitHubRepositoryShorthand(trimmed)) return trimmed;
   const repository = trimmed.endsWith(".git") ? trimmed : `${trimmed}.git`;
   return `https://github.com/${repository}`;
 }

--- a/packages/client-runtime/src/state/sourceControl.ts
+++ b/packages/client-runtime/src/state/sourceControl.ts
@@ -24,6 +24,10 @@ export function createSourceControlEnvironmentAtoms<R, E>(
       label: "environment-data:source-control:repository",
       tag: WS_METHODS.sourceControlLookupRepository,
     }),
+    repositorySearch: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:source-control:repository-search",
+      tag: WS_METHODS.sourceControlSearchRepositories,
+    }),
     cloneRepository: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:source-control:clone-repository",
       tag: WS_METHODS.sourceControlCloneRepository,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -100,6 +100,8 @@ import type {
   SourceControlPublishRepositoryResult,
   SourceControlRepositoryInfo,
   SourceControlRepositoryLookupInput,
+  SourceControlRepositorySearchInput,
+  SourceControlRepositorySearchResult,
 } from "./sourceControl.ts";
 
 export interface ContextMenuItem<T extends string = string> {
@@ -1311,6 +1313,9 @@ export interface EnvironmentApi {
     createUrl: (input: AssetCreateUrlInput) => Promise<AssetCreateUrlResult>;
   };
   sourceControl: {
+    searchRepositories: (
+      input: SourceControlRepositorySearchInput,
+    ) => Promise<SourceControlRepositorySearchResult>;
     lookupRepository: (
       input: SourceControlRepositoryLookupInput,
     ) => Promise<SourceControlRepositoryInfo>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -203,6 +203,8 @@ import {
   SourceControlRepositoryError,
   SourceControlRepositoryInfo,
   SourceControlRepositoryLookupInput,
+  SourceControlRepositorySearchInput,
+  SourceControlRepositorySearchResult,
 } from "./sourceControl.ts";
 import { VcsError } from "./vcs.ts";
 
@@ -317,6 +319,7 @@ export const WS_METHODS = {
 
   // Source control methods
   sourceControlLookupRepository: "sourceControl.lookupRepository",
+  sourceControlSearchRepositories: "sourceControl.searchRepositories",
   sourceControlCloneRepository: "sourceControl.cloneRepository",
   sourceControlPublishRepository: "sourceControl.publishRepository",
 
@@ -617,6 +620,15 @@ export const WsSourceControlLookupRepositoryRpc = Rpc.make(
   {
     payload: SourceControlRepositoryLookupInput,
     success: SourceControlRepositoryInfo,
+    error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
+  },
+);
+
+export const WsSourceControlSearchRepositoriesRpc = Rpc.make(
+  WS_METHODS.sourceControlSearchRepositories,
+  {
+    payload: SourceControlRepositorySearchInput,
+    success: SourceControlRepositorySearchResult,
     error: Schema.Union([SourceControlRepositoryError, EnvironmentAuthorizationError]),
   },
 );
@@ -1059,6 +1071,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsPullRequestsReviewerCandidatesRpc,
   WsPullRequestsRequestReviewersRpc,
   WsSourceControlLookupRepositoryRpc,
+  WsSourceControlSearchRepositoriesRpc,
   WsSourceControlCloneRepositoryRpc,
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -64,6 +64,16 @@ export const SourceControlRepositoryLookupInput = Schema.Struct({
 });
 export type SourceControlRepositoryLookupInput = typeof SourceControlRepositoryLookupInput.Type;
 
+export const SourceControlRepositorySearchInput = Schema.Struct({
+  provider: SourceControlProviderKind,
+  query: TrimmedNonEmptyString,
+  cwd: Schema.optional(TrimmedNonEmptyString),
+});
+export type SourceControlRepositorySearchInput = typeof SourceControlRepositorySearchInput.Type;
+
+export const SourceControlRepositorySearchResult = Schema.Array(SourceControlRepositoryInfo);
+export type SourceControlRepositorySearchResult = typeof SourceControlRepositorySearchResult.Type;
+
 export const SourceControlCloneRepositoryInput = Schema.Struct({
   provider: Schema.optional(SourceControlProviderKind),
   repository: Schema.optional(TrimmedNonEmptyString),


### PR DESCRIPTION
GitHub repository lookup treated a bare name such as `openclaw` as an exact repository path and failed.
That forced users to know the repository owner even when GitHub could find the repository by name.
This PR adds a 100 ms debounced `github.com` repository-name search backed by one GitHub GraphQL request through `gh api graphql`, while preserving exact `owner/name` and URL lookup.
The signed-in user's matches appear first, followed by other repositories; selecting one opens clone destination, and Back returns to search.

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Web and mobile UI | 2 | +275 | -35 |
| Server search and transport | 6 | +180 | -0 |
| Shared client and contracts | 5 | +38 | -2 |
| Tests and fixtures | 4 | +160 | -0 |
| Documentation | 1 | +2 | -1 |
| **Total** | **18** | **+655** | **-38** |

Repository search fetches owner and global matches in one `gh api graphql` request, avoiding GitHub's 30-request-per-minute Search API limit while preserving 100 ms live search. This PR intentionally targets `github.com`; GitHub Enterprise host/account routing stays in #5089 instead of being duplicated here.

## UI proof

### Before: direct base

Typing `openclaw` and pressing Enter attempts an exact lookup and fails.

![Direct-base Add Project dialog showing repository lookup failed for openclaw](https://github.com/user-attachments/assets/3faba025-0ed1-4656-9fc7-d9e0eded9775)

```text
query: openclaw
result: Repository lookup failed
```

### After: PR

Typing the same query starts search without Enter and returns multiple repositories, with the signed-in user's match first.

![PR Add Project dialog showing multiple openclaw repositories with jesse-merhi first](https://github.com/user-attachments/assets/d7d9f4d5-ef49-434b-9c94-8b48a9605525)

```text
query: openclaw
1. jesse-merhi/openclaw-dotfiles
2. openclaw/openclaw

query after Back: skills
1. jesse-merhi/skills
2. mattpocock/skills

shorthand query: pingdotgg/t3
highlighted result: pingdotgg/t3code
Enter: opens clone destination for pingdotgg/t3code

zero-result shorthand: octocat/code
visible fallback action: Lookup (Enter)
```

The recorded UI pass at `d7a485d1f17b` selected a result, opened clone destination, used Back to return to repository search, confirmed that Enter chooses the highlighted shorthand match, and verified the pointer-accessible fallback for a zero-result shorthand query. The current head `6cf30bd0d762` preserves that behavior, uses reactive query atoms instead of manual search effects and result state, and avoids Search API rate limits with one GraphQL request per query; focused web, mobile, and server typechecks and 39 focused tests pass.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [ ] I included a video for animation/interaction changes (not applicable; no motion change)

Created with GPT-5.6 Sol in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated GitHub GraphQL search on the add-project path increases API surface and rate-limit exposure, but it is read-scoped and does not change clone/publish write flows.
> 
> **Overview**
> Adds **GitHub repository search by name** when cloning a project, so bare names like `openclaw` no longer require an exact `owner/repo` lookup.
> 
> A new **`sourceControl.searchRepositories`** RPC (read scope) runs through `SourceControlRepositoryService` into **`GitHubCli.searchRepositories`**, which uses **`gh api graphql`** with separate owner (`user:@me`) and global queries, merges/dedupes results, and boosts exact `owner/repo` matches. Providers without search still fall back to a single lookup.
> 
> **Web** (`CommandPalette`) and **mobile** (`AddProjectRepositoryScreen`) call the search via debounced **`repositorySearch`** query atoms as the user types on the GitHub path: results are selectable and jump to clone destination; **`isGitHubRepositoryShorthand`** keeps Enter-based exact lookup for `owner/repo` when search has no highlighted hits. GitHub hints/placeholders and user docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf30bd0d762572ce5469f865805a68a1566ef1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub repository search across source control and UI
> - Adds `searchRepositories` to `GitHubCli` using a GraphQL query that scopes to the authenticated owner and globally, deduplicates results, prioritizes exact `owner/repo` matches, and limits to 20.
> - Exposes the search via a new `sourceControl.searchRepositories` WebSocket RPC and updates `SourceControlProvider` and `SourceControlRepositoryService`.
> - Updates mobile ([AddProjectScreen.tsx](https://github.com/pingdotgg/t3code/pull/8340/files#diff-8d2af7e60f72647a590cd07374db01b9c44b29ebe1f0b9f3ba264e1c38d08bb2)) and web ([CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/8340/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a)) Add Project flows to perform a 100ms debounced GitHub search, rendering selectable results instead of requiring exact input.
> - Behavioral Change: GitHub repository inputs hide the primary action button during search; direct lookup via Enter only triggers if the input is a valid `owner/repo` shorthand.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cf30bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

