### PR TITLE
fix(server): Codex threads survive protocol drift on resume

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -6,7 +6,6 @@ import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
 import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
-import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import {
@@ -43,9 +42,12 @@ describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   });
 });
 
-function makeThreadOpenResponse(
-  threadId: string,
-): CodexRpc.ClientRequestResponsesByMethod["thread/start"] {
+/**
+ * Raw `thread/start` / `thread/resume` payload as Codex puts it on the wire.
+ * `items` accepts arbitrary history entries so tests can replay shapes newer
+ * than the generated bindings.
+ */
+function makeThreadOpenResponse(threadId: string, items: ReadonlyArray<unknown> = []): unknown {
   return {
     cwd: "/tmp/project",
     model: "gpt-5.3-codex",
@@ -57,13 +59,48 @@ function makeThreadOpenResponse(
       id: threadId,
       createdAt: "2026-04-18T00:00:00.000Z",
       source: { session: "cli" },
-      turns: [],
+      turns: items.length === 0 ? [] : [{ id: "turn-1", status: "completed", items }],
       status: {
         state: "idle",
         activeFlags: [],
       },
     },
-  } as unknown as CodexRpc.ClientRequestResponsesByMethod["thread/start"];
+  };
+}
+
+/**
+ * Mirrors the real client: params are ignored, and the raw payload is decoded
+ * with whichever response schema the caller supplied, surfacing failures the
+ * same way (`operation: "decode-payload"`).
+ */
+function makeThreadOpenClient(
+  respond: (
+    method: "thread/start" | "thread/resume",
+  ) => Effect.Effect<unknown, CodexErrors.CodexAppServerError>,
+) {
+  return {
+    request: <A, I>(
+      method: "thread/start" | "thread/resume",
+      _payload: unknown,
+      responseSchema: Schema.Codec<A, I>,
+    ) =>
+      respond(method).pipe(
+        Effect.flatMap((raw) =>
+          Schema.decodeUnknownEffect(responseSchema)(raw).pipe(
+            Effect.mapError(
+              (cause) =>
+                new CodexErrors.CodexAppServerRequestError({
+                  code: -32603,
+                  errorMessage: `Invalid payload for method '${method}' during 'decode-payload'`,
+                  method,
+                  operation: "decode-payload",
+                  cause,
+                }),
+            ),
+          ),
+        ),
+      ),
+  };
 }
 
 describe("buildTurnStartParams", () => {
@@ -752,6 +789,20 @@ describe("isRecoverableThreadResumeError", () => {
     );
   });
 
+  it("matches responses this build cannot decode", () => {
+    NodeAssert.equal(
+      isRecoverableThreadResumeError(
+        new CodexErrors.CodexAppServerRequestError({
+          code: -32603,
+          errorMessage: "Invalid payload for method 'thread/resume' during 'decode-payload'",
+          method: "thread/resume",
+          operation: "decode-payload",
+        }),
+      ),
+      true,
+    );
+  });
+
   it("ignores unrelated missing-resource errors that do not mention threads", () => {
     NodeAssert.equal(
       isRecoverableThreadResumeError(
@@ -775,27 +826,55 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
+  it.effect("resumes a thread whose history uses a newer protocol variant", () =>
+    Effect.gen(function* () {
+      // Codex CLI 0.150.0 grew a fourth subAgentActivity kind. Opening the
+      // session must not depend on history this build cannot name (#8322).
+      const resumed = makeThreadOpenResponse("resumed-thread", [
+        {
+          id: "item-18",
+          type: "subAgentActivity",
+          agentPath: "/root/child",
+          agentThreadId: "child-thread",
+          kind: "completed",
+        },
+      ]);
+      const calls: Array<string> = [];
+      const client = makeThreadOpenClient((method) => {
+        calls.push(method);
+        return Effect.succeed(resumed);
+      });
+
+      const opened = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "resumed-thread",
+      });
+
+      NodeAssert.equal(opened.thread.id, "resumed-thread");
+      NodeAssert.deepStrictEqual(calls, ["thread/resume"]);
+    }),
+  );
+
   it.effect("falls back to thread/start when resume fails recoverably", () =>
     Effect.gen(function* () {
-      const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
-      const started = makeThreadOpenResponse("fresh-thread");
-      const client = {
-        request: <M extends "thread/start" | "thread/resume">(
-          method: M,
-          payload: CodexRpc.ClientRequestParamsByMethod[M],
-        ) => {
-          calls.push({ method, payload });
-          if (method === "thread/resume") {
-            return Effect.fail(
-              new CodexErrors.CodexAppServerRequestError({
-                code: -32603,
-                errorMessage: "thread not found",
-              }),
-            );
-          }
-          return Effect.succeed(started as CodexRpc.ClientRequestResponsesByMethod[M]);
-        },
-      };
+      const calls: Array<string> = [];
+      const client = makeThreadOpenClient((method) => {
+        calls.push(method);
+        if (method === "thread/resume") {
+          return Effect.fail(
+            new CodexErrors.CodexAppServerRequestError({
+              code: -32603,
+              errorMessage: "thread not found",
+            }),
+          );
+        }
+        return Effect.succeed(makeThreadOpenResponse("fresh-thread"));
+      });
 
       const opened = yield* openCodexThread({
         client,
@@ -808,33 +887,48 @@ describe("openCodexThread", () => {
       });
 
       NodeAssert.equal(opened.thread.id, "fresh-thread");
-      NodeAssert.deepStrictEqual(
-        calls.map((call) => call.method),
-        ["thread/resume", "thread/start"],
-      );
+      NodeAssert.deepStrictEqual(calls, ["thread/resume", "thread/start"]);
+    }),
+  );
+
+  it.effect("falls back to thread/start when the resume response cannot be decoded", () =>
+    Effect.gen(function* () {
+      const calls: Array<string> = [];
+      const client = makeThreadOpenClient((method) => {
+        calls.push(method);
+        if (method === "thread/resume") {
+          return Effect.succeed({ thread: {} });
+        }
+        return Effect.succeed(makeThreadOpenResponse("fresh-thread"));
+      });
+
+      const opened = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "stale-thread",
+      });
+
+      NodeAssert.equal(opened.thread.id, "fresh-thread");
+      NodeAssert.deepStrictEqual(calls, ["thread/resume", "thread/start"]);
     }),
   );
 
   it.effect("propagates non-recoverable resume failures", () =>
     Effect.gen(function* () {
-      const client = {
-        request: <M extends "thread/start" | "thread/resume">(
-          method: M,
-          _payload: CodexRpc.ClientRequestParamsByMethod[M],
-        ) => {
-          if (method === "thread/resume") {
-            return Effect.fail(
+      const client = makeThreadOpenClient((method) =>
+        method === "thread/resume"
+          ? Effect.fail(
               new CodexErrors.CodexAppServerRequestError({
                 code: -32603,
                 errorMessage: "timed out waiting for server",
               }),
-            );
-          }
-          return Effect.succeed(
-            makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
-          );
-        },
-      };
+            )
+          : Effect.succeed(makeThreadOpenResponse("fresh-thread")),
+      );
 
       const error = yield* openCodexThread({
         client,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -830,15 +830,16 @@ describe("isRecoverableThreadResumeError", () => {
 describe("openCodexThread", () => {
   it.effect("resumes a thread whose history uses a newer protocol variant", () =>
     Effect.gen(function* () {
-      // Codex CLI 0.150.0 grew a fourth subAgentActivity kind. Opening the
-      // session must not depend on history this build cannot name (#8322).
+      // Opening a session must not depend on history this build cannot name
+      // (#8322). The kind is deliberately fictional so the test keeps
+      // exercising drift after the bindings learn today's values.
       const resumed = makeThreadOpenResponse("resumed-thread", [
         {
           id: "item-18",
           type: "subAgentActivity",
           agentPath: "/root/child",
           agentThreadId: "child-thread",
-          kind: "completed",
+          kind: "escalated",
         },
       ]);
       const calls: Array<string> = [];

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -6,6 +6,7 @@ import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
 import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
+import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import {
@@ -54,24 +55,28 @@ function makeThreadOpenResponse(threadId: string, items: ReadonlyArray<unknown> 
     modelProvider: "openai",
     approvalPolicy: "never",
     approvalsReviewer: "user",
-    sandbox: { type: "danger-full-access" },
+    sandbox: { type: "dangerFullAccess" },
     thread: {
       id: threadId,
-      createdAt: "2026-04-18T00:00:00.000Z",
-      source: { session: "cli" },
+      cliVersion: "0.150.0",
+      createdAt: 0,
+      updatedAt: 0,
+      cwd: "/tmp/project",
+      ephemeral: false,
+      modelProvider: "openai",
+      preview: "",
+      sessionId: "session-1",
+      source: "cli",
+      status: { type: "idle" },
       turns: items.length === 0 ? [] : [{ id: "turn-1", status: "completed", items }],
-      status: {
-        state: "idle",
-        activeFlags: [],
-      },
     },
   };
 }
 
 /**
- * Mirrors the real client: params are ignored, and the raw payload is decoded
- * with whichever response schema the caller supplied, surfacing failures the
- * same way (`operation: "decode-payload"`).
+ * Mirrors the real client: params keep their generated types, and the raw
+ * payload is decoded with whichever response schema the caller supplied,
+ * failing exactly as the client would.
  */
 function makeThreadOpenClient(
   respond: (
@@ -79,23 +84,20 @@ function makeThreadOpenClient(
   ) => Effect.Effect<unknown, CodexErrors.CodexAppServerError>,
 ) {
   return {
-    request: <A, I>(
-      method: "thread/start" | "thread/resume",
-      _payload: unknown,
-      responseSchema: Schema.Codec<A, I>,
+    request: <M extends "thread/start" | "thread/resume", A>(
+      method: M,
+      _payload: CodexRpc.ClientRequestParamsByMethod[M],
+      responseSchema: Schema.Codec<A, unknown>,
     ) =>
       respond(method).pipe(
         Effect.flatMap((raw) =>
           Schema.decodeUnknownEffect(responseSchema)(raw).pipe(
-            Effect.mapError(
-              (cause) =>
-                new CodexErrors.CodexAppServerRequestError({
-                  code: -32603,
-                  errorMessage: `Invalid payload for method '${method}' during 'decode-payload'`,
-                  method,
-                  operation: "decode-payload",
-                  cause,
-                }),
+            Effect.mapError((cause) =>
+              CodexErrors.CodexAppServerRequestError.invalidPayload(
+                method,
+                "decode-payload",
+                cause,
+              ),
             ),
           ),
         ),
@@ -793,7 +795,7 @@ describe("isRecoverableThreadResumeError", () => {
     NodeAssert.equal(
       isRecoverableThreadResumeError(
         new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
+          code: -32602,
           errorMessage: "Invalid payload for method 'thread/resume' during 'decode-payload'",
           method: "thread/resume",
           operation: "decode-payload",

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -667,7 +667,16 @@ function classifyCodexStderrLine(rawLine: string): { readonly message: string } 
   return { message: line };
 }
 
+const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+
 export function isRecoverableThreadResumeError(error: unknown): boolean {
+  // A response we cannot decode means Codex resumed the thread but described it
+  // in a protocol shape this build does not know. Retrying will never help, so
+  // treat it as recoverable and open a fresh Codex thread instead of leaving
+  // the T3 thread permanently unusable.
+  if (isCodexAppServerRequestError(error) && error.operation === "decode-payload") {
+    return true;
+  }
   const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
   if (!message.includes("thread")) {
     return false;
@@ -675,9 +684,21 @@ export function isRecoverableThreadResumeError(error: unknown): boolean {
   return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) => message.includes(snippet));
 }
 
-type CodexThreadOpenResponse =
-  | CodexRpc.ClientRequestResponsesByMethod["thread/start"]
-  | CodexRpc.ClientRequestResponsesByMethod["thread/resume"];
+/**
+ * The only parts of a `thread/start` or `thread/resume` response this runtime
+ * consumes. Codex replays the whole thread history in those responses, and
+ * decoding it against generated bindings makes opening a session fail whenever
+ * upstream adds a protocol variant we have not regenerated yet (see #8322).
+ * Session state is rebuilt from notifications anyway, so read the handful of
+ * fields we need and let the rest pass through undecoded.
+ */
+const CodexThreadOpenResponse = Schema.Struct({
+  thread: Schema.Struct({ id: Schema.String }),
+  cwd: Schema.optional(Schema.String),
+  model: Schema.optional(Schema.String),
+});
+
+type CodexThreadOpenResponse = typeof CodexThreadOpenResponse.Type;
 
 type CodexThreadOpenMethod = "thread/start" | "thread/resume";
 
@@ -685,7 +706,8 @@ interface CodexThreadOpenClient {
   readonly request: <M extends CodexThreadOpenMethod>(
     method: M,
     payload: CodexRpc.ClientRequestParamsByMethod[M],
-  ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexErrors.CodexAppServerError>;
+    responseSchema: typeof CodexThreadOpenResponse,
+  ) => Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError>;
 }
 
 export const openCodexThread = (input: {
@@ -706,14 +728,18 @@ export const openCodexThread = (input: {
   });
 
   if (resumeThreadId === undefined) {
-    return input.client.request("thread/start", startParams);
+    return input.client.request("thread/start", startParams, CodexThreadOpenResponse);
   }
 
   return input.client
-    .request("thread/resume", {
-      threadId: resumeThreadId,
-      ...startParams,
-    })
+    .request(
+      "thread/resume",
+      {
+        threadId: resumeThreadId,
+        ...startParams,
+      },
+      CodexThreadOpenResponse,
+    )
     .pipe(
       Effect.catchIf(isRecoverableThreadResumeError, (error) =>
         Effect.logWarning("codex app-server thread resume fell back to fresh start", {
@@ -722,7 +748,11 @@ export const openCodexThread = (input: {
           resumeThreadId,
           recoverable: true,
           cause: error,
-        }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
+        }).pipe(
+          Effect.andThen(
+            input.client.request("thread/start", startParams, CodexThreadOpenResponse),
+          ),
+        ),
       ),
     );
 };
@@ -2249,8 +2279,8 @@ export const makeCodexSessionRuntime = (
       const session = {
         ...(yield* Ref.get(sessionRef)),
         status: "ready",
-        cwd: opened.cwd,
-        model: opened.model,
+        cwd: opened.cwd ?? options.cwd,
+        model: opened.model ?? requestedModel,
         resumeCursor: { threadId: providerThreadId },
         updatedAt: yield* nowIso,
       } satisfies ProviderSession;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -694,8 +694,8 @@ export function isRecoverableThreadResumeError(error: unknown): boolean {
  */
 const CodexThreadOpenResponse = Schema.Struct({
   thread: Schema.Struct({ id: Schema.String }),
-  cwd: Schema.optional(Schema.String),
-  model: Schema.optional(Schema.String),
+  cwd: Schema.String,
+  model: Schema.String,
 });
 
 type CodexThreadOpenResponse = typeof CodexThreadOpenResponse.Type;
@@ -2279,8 +2279,8 @@ export const makeCodexSessionRuntime = (
       const session = {
         ...(yield* Ref.get(sessionRef)),
         status: "ready",
-        cwd: opened.cwd ?? options.cwd,
-        model: opened.model ?? requestedModel,
+        cwd: opened.cwd,
+        model: opened.model,
         resumeCursor: { threadId: providerThreadId },
         updatedAt: yield* nowIso,
       } satisfies ProviderSession;

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -100,9 +100,14 @@ Two rules keep that drift from breaking sessions:
   so the thread falls back to a fresh Codex session instead of becoming permanently unopenable.
   Notifications we cannot decode are dropped with a warning, never silently.
 
-Regenerating is not a substitute for either rule: because upstream also adds _required_ fields,
-pinning forward can break users still on an older CLI. Bindings track the protocol; the rules above
-absorb the gap between releases.
+When a live event carries a value the bindings reject, teach them that one value: the generator's
+definition overrides (`Codex0150DefinitionSchemas` in `scripts/generate.ts`) widen a named
+definition without moving the pin. Prefer that to a full refresh, which drags in unrelated changes
+and can break older CLIs — upstream adds _required_ fields too, so pinning forward breaks anyone
+who has not upgraded.
+
+None of that replaces the two rules. Overrides fix the variants we already know about; the rules
+are what keep the ones we do not know about yet from being fatal.
 
 ## Model manifest
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -83,6 +83,27 @@ empty inventory is authoritative. Existing threads keep their explicit model ide
 options when catalog metadata is missing; the catalog is not permission to choose a different
 model for a thread.
 
+## Generated Codex bindings
+
+`packages/effect-codex-app-server` holds Effect/Schema bindings generated from a pinned
+`openai/codex` revision (`scripts/generate.ts`). Codex ships far more often than we regenerate, so
+at any moment an installed CLI may describe itself with protocol variants those bindings do not
+name — a new enum member, a new item type, a newly required field.
+
+Two rules keep that drift from breaking sessions:
+
+- **Decode only what you consume.** `thread/start` and `thread/resume` replay an entire thread
+  history, and the session runtime needs three fields from it. Pass a narrow response schema as the
+  third argument to `client.request` rather than accepting the generated one; anything the runtime
+  does not read cannot then fail the request.
+- **Never treat drift as fatal.** A response we cannot decode counts as a recoverable resume error,
+  so the thread falls back to a fresh Codex session instead of becoming permanently unopenable.
+  Notifications we cannot decode are dropped with a warning, never silently.
+
+Regenerating is not a substitute for either rule: because upstream also adds _required_ fields,
+pinning forward can break users still on an older CLI. Bindings track the protocol; the rules above
+absorb the gap between releases.
+
 ## Model manifest
 
 The model picker's legacy section is driven by `apps/server/src/provider/model-manifest.json`, which

--- a/packages/effect-codex-app-server/src/client.test.ts
+++ b/packages/effect-codex-app-server/src/client.test.ts
@@ -9,7 +9,12 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 
+import * as Schema from "effect/Schema";
+
 import * as CodexClient from "./client.ts";
+import * as CodexErrors from "./errors.ts";
+
+const isRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
 
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/codex-app-server-mock-peer.ts"),
@@ -123,6 +128,38 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
       ]);
     }),
   );
+  it.effect("decodes a response with the caller's schema instead of the generated one", () =>
+    Effect.gen(function* () {
+      const handle = yield* makeHandle();
+      const scope = yield* Scope.make();
+      const clientLayer = CodexClient.layerChildProcess(handle);
+      const context = yield* Layer.buildWithScope(clientLayer, scope);
+
+      const result = yield* Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        const params = { threadId: "resumed-thread" };
+
+        const generated = yield* client.request("thread/resume", params).pipe(Effect.flip);
+        const narrow = yield* client.request(
+          "thread/resume",
+          params,
+          Schema.Struct({ thread: Schema.Struct({ id: Schema.String }) }),
+        );
+
+        return { generated, narrow };
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+      // The generated bindings reject history they do not recognize...
+      assert.equal(isRequestError(result.generated), true);
+      assert.equal(
+        isRequestError(result.generated) ? result.generated.operation : undefined,
+        "decode-payload",
+      );
+      // ...while a caller that reads only what it uses is unaffected.
+      assert.equal(result.narrow.thread.id, "resumed-thread");
+    }),
+  );
+
   it.effect("drains child stderr so large diagnostics cannot block protocol responses", () =>
     Effect.gen(function* () {
       const handle = yield* makeHandle({

--- a/packages/effect-codex-app-server/src/client.test.ts
+++ b/packages/effect-codex-app-server/src/client.test.ts
@@ -1,5 +1,6 @@
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Path from "effect/Path";
 import * as Effect from "effect/Effect";
 import * as Ref from "effect/Ref";
@@ -159,6 +160,59 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
       assert.equal(result.narrow.thread.id, "resumed-thread");
     }),
   );
+
+  it.effect("drops undecodable notifications, warning once per method", () => {
+    const warnings: Array<string> = [];
+    const logger = Logger.make(({ message }) => {
+      warnings.push(String(message));
+    });
+
+    return Effect.gen(function* () {
+      const deltas = yield* Ref.make<Array<unknown>>([]);
+      const handle = yield* makeHandle({ CODEX_APP_SERVER_TEST_DRIFT: "1" });
+      const scope = yield* Scope.make();
+      const clientLayer = CodexClient.layerChildProcess(handle);
+      const context = yield* Layer.buildWithScope(clientLayer, scope);
+
+      yield* Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        yield* client.handleServerNotification("item/agentMessage/delta", (payload) =>
+          Ref.update(deltas, (current) => [...current, payload]),
+        );
+        yield* client.request("initialize", {
+          clientInfo: {
+            name: "effect-codex-app-server-test",
+            title: "Effect Codex App Server Test",
+            version: "0.0.0",
+          },
+          capabilities: {
+            experimentalApi: true,
+            optOutNotificationMethods: null,
+          },
+        });
+        yield* client.notify("initialized", undefined);
+        // A round trip on the same stdio proves the peer's notifications have
+        // all been read before the assertions below.
+        yield* client.request("account/read", {});
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+      // The two undecodable deltas never reach the handler...
+      assert.deepEqual(yield* Ref.get(deltas), [
+        {
+          delta: "Mock server is ready.",
+          itemId: "item-1",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      ]);
+      // ...and drift is reported once for the method, not once per message.
+      assert.deepEqual(
+        warnings.filter((message) => message.includes("codex app-server notification dropped"))
+          .length,
+        1,
+      );
+    }).pipe(Effect.provide(Logger.layer([logger], { mergeWithExisting: false })));
+  });
 
   it.effect("drains child stderr so large diagnostics cannot block protocol responses", () =>
     Effect.gen(function* () {

--- a/packages/effect-codex-app-server/src/client.ts
+++ b/packages/effect-codex-app-server/src/client.ts
@@ -51,10 +51,10 @@ export class CodexAppServerClient extends Context.Service<
         method: M,
         payload: CodexRpc.ClientRequestParamsByMethod[M],
       ): Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError>;
-      <M extends CodexRpc.ClientRequestMethod, A, I>(
+      <M extends CodexRpc.ClientRequestMethod, A>(
         method: M,
         payload: CodexRpc.ClientRequestParamsByMethod[M],
-        responseSchema: Schema.Codec<A, I>,
+        responseSchema: Schema.Codec<A, unknown>,
       ): Effect.Effect<A, CodexError.CodexAppServerError>;
     };
     readonly notify: <M extends CodexRpc.ClientNotificationMethod>(
@@ -105,6 +105,10 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
 ): Effect.fn.Return<CodexAppServerClient["Service"], never, Scope.Scope> {
   const requestHandlers = new Map<string, ServerRequestHandler>();
   const notificationHandlers = new Map<string, Array<ServerNotificationHandler>>();
+  // Methods already reported as undecodable. Drift is a property of the method,
+  // not of each message, and high-frequency streams such as agent message
+  // deltas would otherwise warn once per token.
+  const warnedUndecodableMethods = new Set<string>();
   let unknownRequestHandler:
     | ((method: string, params: unknown) => Effect.Effect<unknown, CodexError.CodexAppServerError>)
     | undefined;
@@ -168,10 +172,16 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
         // session, but it is still protocol drift we want to hear about:
         // discarding it silently hides the loss of a real lifecycle event.
         Effect.tapError((error) =>
-          Effect.logWarning("codex app-server notification dropped", {
-            method: notification.method,
-            cause: error,
-          }),
+          warnedUndecodableMethods.has(notification.method)
+            ? Effect.void
+            : Effect.sync(() => warnedUndecodableMethods.add(notification.method)).pipe(
+                Effect.andThen(
+                  Effect.logWarning("codex app-server notification dropped", {
+                    method: notification.method,
+                    cause: error,
+                  }),
+                ),
+              ),
         ),
         Effect.flatMap((decoded) =>
           Effect.forEach(handlers, (handler) => handler(decoded), { discard: true }),
@@ -217,10 +227,10 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
     onRequest: dispatchRequest,
   });
 
-  const request = <M extends CodexRpc.ClientRequestMethod, A, I>(
+  const request = <M extends CodexRpc.ClientRequestMethod, A>(
     method: M,
     payload: CodexRpc.ClientRequestParamsByMethod[M],
-    responseSchema?: Schema.Codec<A, I>,
+    responseSchema?: Schema.Codec<A, unknown>,
   ): Effect.Effect<A, CodexError.CodexAppServerError> =>
     encodeOptionalPayload(method, getClientRequestParamSchema(method), payload).pipe(
       Effect.flatMap((encoded) => transport.request(method, encoded)),
@@ -228,7 +238,7 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
         (raw): Effect.Effect<A, CodexError.CodexAppServerError> =>
           decodeOptionalPayload(
             method,
-            responseSchema ?? (getClientRequestResponseSchema(method) as never),
+            responseSchema ?? (getClientRequestResponseSchema(method) as Schema.Codec<A, unknown>),
             raw,
           ),
       ),

--- a/packages/effect-codex-app-server/src/client.ts
+++ b/packages/effect-codex-app-server/src/client.ts
@@ -39,10 +39,24 @@ export class CodexAppServerClient extends Context.Service<
   CodexAppServerClient,
   {
     readonly raw: CodexAppServerClientRaw;
-    readonly request: <M extends CodexRpc.ClientRequestMethod>(
-      method: M,
-      payload: CodexRpc.ClientRequestParamsByMethod[M],
-    ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError>;
+    /**
+     * Sends a client request. Params are always encoded with the generated
+     * schema; the response is decoded with the generated schema unless a
+     * narrower `responseSchema` is supplied. Pass one when the caller only
+     * consumes part of a large payload, so an unrecognized protocol variant
+     * elsewhere in that payload cannot fail the request.
+     */
+    readonly request: {
+      <M extends CodexRpc.ClientRequestMethod>(
+        method: M,
+        payload: CodexRpc.ClientRequestParamsByMethod[M],
+      ): Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError>;
+      <M extends CodexRpc.ClientRequestMethod, A, I>(
+        method: M,
+        payload: CodexRpc.ClientRequestParamsByMethod[M],
+        responseSchema: Schema.Codec<A, I>,
+      ): Effect.Effect<A, CodexError.CodexAppServerError>;
+    };
     readonly notify: <M extends CodexRpc.ClientNotificationMethod>(
       method: M,
       payload: CodexRpc.ClientNotificationParamsByMethod[M],
@@ -150,6 +164,15 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
 
     if (schema) {
       return decodeNotificationPayload(notification.method, schema, notification.params).pipe(
+        // A notification we cannot decode is dropped rather than failing the
+        // session, but it is still protocol drift we want to hear about:
+        // discarding it silently hides the loss of a real lifecycle event.
+        Effect.tapError((error) =>
+          Effect.logWarning("codex app-server notification dropped", {
+            method: notification.method,
+            cause: error,
+          }),
+        ),
         Effect.flatMap((decoded) =>
           Effect.forEach(handlers, (handler) => handler(decoded), { discard: true }),
         ),
@@ -194,19 +217,20 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
     onRequest: dispatchRequest,
   });
 
-  const request = <M extends CodexRpc.ClientRequestMethod>(
+  const request = <M extends CodexRpc.ClientRequestMethod, A, I>(
     method: M,
     payload: CodexRpc.ClientRequestParamsByMethod[M],
-  ): Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError> =>
+    responseSchema?: Schema.Codec<A, I>,
+  ): Effect.Effect<A, CodexError.CodexAppServerError> =>
     encodeOptionalPayload(method, getClientRequestParamSchema(method), payload).pipe(
       Effect.flatMap((encoded) => transport.request(method, encoded)),
       Effect.flatMap(
-        (
-          raw,
-        ): Effect.Effect<
-          CodexRpc.ClientRequestResponsesByMethod[M],
-          CodexError.CodexAppServerError
-        > => decodeOptionalPayload(method, getClientRequestResponseSchema(method), raw),
+        (raw): Effect.Effect<A, CodexError.CodexAppServerError> =>
+          decodeOptionalPayload(
+            method,
+            responseSchema ?? (getClientRequestResponseSchema(method) as never),
+            raw,
+          ),
       ),
     );
 
@@ -227,7 +251,7 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       respond: transport.respond,
       respondError: transport.respondError,
     },
-    request,
+    request: request as CodexAppServerClient["Service"]["request"],
     notify,
     handleServerRequest: (method, handler) =>
       Effect.sync(() => {

--- a/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
+++ b/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
@@ -59,6 +59,22 @@ const handleMethod = (message: Record<string, unknown>) => {
       return;
     }
     case "initialized": {
+      // oxlint-disable-next-line t3code/no-global-process-runtime -- Standalone mock peer process has no Effect runtime.
+      if (process.env.CODEX_APP_SERVER_TEST_DRIFT === "1") {
+        // Two notifications the generated bindings cannot decode, standing in
+        // for a Codex release whose payloads outgrew them.
+        for (let index = 0; index < 2; index += 1) {
+          writeMessage({
+            method: "item/agentMessage/delta",
+            params: {
+              delta: index,
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          });
+        }
+      }
       writeMessage({
         method: "item/agentMessage/delta",
         params: {

--- a/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
+++ b/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
@@ -98,8 +98,10 @@ const handleMethod = (message: Record<string, unknown>) => {
       return;
     }
     // Replays a resume payload whose history carries a subAgentActivity kind
-    // newer than the generated bindings, the shape that made resuming a thread
-    // fail outright before responses could be decoded narrowly.
+    // the generated bindings do not name, the shape that made resuming a
+    // thread fail outright before responses could be decoded narrowly. The
+    // value is deliberately fictional: naming a real one would stop testing
+    // drift as soon as the bindings caught up with it.
     case "thread/resume": {
       respond(message.id as number | string, {
         cwd: process.cwd(),
@@ -130,7 +132,7 @@ const handleMethod = (message: Record<string, unknown>) => {
                   type: "subAgentActivity",
                   agentPath: "/root/child",
                   agentThreadId: "child-thread",
-                  kind: "completed",
+                  kind: "escalated",
                 },
               ],
             },

--- a/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
+++ b/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
@@ -81,6 +81,48 @@ const handleMethod = (message: Record<string, unknown>) => {
       });
       return;
     }
+    // Replays a resume payload whose history carries a subAgentActivity kind
+    // newer than the generated bindings, the shape that made resuming a thread
+    // fail outright before responses could be decoded narrowly.
+    case "thread/resume": {
+      respond(message.id as number | string, {
+        cwd: process.cwd(),
+        model: "gpt-5.3-codex",
+        modelProvider: "openai",
+        approvalPolicy: "never",
+        approvalsReviewer: "user",
+        sandbox: { type: "dangerFullAccess" },
+        thread: {
+          id: "resumed-thread",
+          cliVersion: "0.150.0",
+          createdAt: 0,
+          updatedAt: 0,
+          cwd: process.cwd(),
+          ephemeral: false,
+          modelProvider: "openai",
+          preview: "",
+          sessionId: "session-1",
+          source: "cli",
+          status: { type: "idle" },
+          turns: [
+            {
+              id: "turn-1",
+              status: "completed",
+              items: [
+                {
+                  id: "item-18",
+                  type: "subAgentActivity",
+                  agentPath: "/root/child",
+                  agentThreadId: "child-thread",
+                  kind: "completed",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      return;
+    }
     case "skills/list": {
       pendingSkillsListRequestId = message.id as number | string;
       pendingUserInputRequestId = sendRequest("item/tool/requestUserInput", {


### PR DESCRIPTION
## Problem

Codex CLI 0.150.0 added a fourth `SubAgentActivityKind` — `"completed"` — alongside `started`, `interacted`, and `interrupted`. Our generated app-server bindings are pinned to an openai/codex revision from 2026-07-19 that knows only three, so decoding a `thread/resume` response whose history contained that kind failed:

```
SchemaError: Expected "started" | "interacted" | "interrupted"
  at ["thread"]["turns"][0]["items"][18]["kind"]
```

`isRecoverableThreadResumeError` only matches "thread not found"-style messages, so a schema error was fatal. Every reopen of an affected thread failed the same way and the conversation could never be continued — the reporter's words: "Blocks work completely."

The same drift hit `item/started` / `item/completed` notifications, where decode failures were swallowed silently, so subagent lifecycle events were dropped with no trace.

## Fix

`thread/start` and `thread/resume` now decode only the three fields the session runtime actually consumes (`thread.id`, `cwd`, `model`). Codex replays an entire thread history in those responses; session state is rebuilt from notifications anyway, so history this build cannot name no longer fails the request.

`client.request` takes an optional response schema for that purpose — params are still encoded with the generated schema, only the response decode is narrowed.

Two smaller changes complete the recovery path:

- A response that still cannot be decoded now counts as a recoverable resume error, so the thread falls back to a fresh Codex session instead of becoming permanently unopenable.
- Notifications that cannot be decoded are logged as a warning instead of vanishing.

## Why not just regenerate the bindings

Regenerating to 0.150.0 moves the breakage rather than removing it: upstream also made `Thread.projectId` **required** in that release, so bindings pinned forward would reject responses from every CLI at 0.149 or older. Bindings should still be refreshed on their own cadence — this change is what absorbs the gap between refreshes. `docs/internals/providers.md` records the constraint.

## Verification

`packages/effect-codex-app-server/src/client.test.ts` drives the real client against the mock peer replaying a resume payload with `kind: "completed"`, and asserts the generated schema rejects it with `operation: "decode-payload"` while the narrow schema resumes cleanly. `CodexSessionRuntime.test.ts` covers the same shape through `openCodexThread`, plus the decode-error fallback. Both new tests fail against the previous decode path.

```
apps/server        CodexSessionRuntime/CodexAdapter/CodexCollabWire  80 passed
effect-codex-app-server                                              21 passed
typecheck + lint   clean on touched packages
```

No UI surface changes.

Fixes #8322

---
Model: Claude Opus 5. Harness: T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `openCodexThread` survive protocol drift on resume by decoding minimal fields
> - `openCodexThread` now decodes only `thread.id`, `cwd`, and `model` from `thread/start` and `thread/resume` responses using a narrow `CodexThreadOpenResponse` schema, instead of requiring the full generated payload to validate.
> - `isRecoverableThreadResumeError` now treats `CodexAppServerRequestError` with operation `decode-payload` as recoverable, so decode failures during resume trigger a warning and fall back to `thread/start`.
> - `CodexAppServerClient.Service.request` accepts an optional caller-supplied response schema; undecodable notifications are dropped with a single warning per method instead of being silently ignored.
> - Added guidance in [providers.md](https://github.com/pingdotgg/t3code/pull/8342/files#diff-3d909027abc31a863f0c0e5ecef5aa50ac285620ad827db723eb0a4ac46d3f85) on handling generated Codex bindings drift via narrow schemas and recoverable decode failures.
> - Risk: the narrowed `CodexThreadOpenResponse` schema in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/8342/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) only extracts three fields; if the runtime later needs additional response fields, the schema must be widened or decode will silently drop them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d352756.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->