### PR TITLE
fix(codex): accept Codex 0.150 multi-agent events

### DIFF
--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -145,6 +145,33 @@ const ManualSchemas: Record<string, Schema.Json> = {
   },
 };
 
+// Codex 0.150 added these multi-agent values before our next full protocol
+// refresh. Keep every generated response namespace compatible with them.
+const Codex0150DefinitionSchemas: Record<string, Schema.Json> = {
+  CollabAgentTool: {
+    type: "string",
+    enum: [
+      "spawnAgent",
+      "sendInput",
+      "resumeAgent",
+      "wait",
+      "closeAgent",
+      "sendMessage",
+      "followupTask",
+      "interruptAgent",
+      "listAgents",
+    ],
+  },
+  CollabAgentToolCallStatus: {
+    type: "string",
+    enum: ["inProgress", "completed", "failed", "interrupted"],
+  },
+  SubAgentActivityKind: {
+    type: "string",
+    enum: ["started", "interacted", "interrupted", "completed"],
+  },
+};
+
 const getGeneratedPaths = Effect.fn("getGeneratedPaths")(function* () {
   const path = yield* Path.Path;
   const generatedDir = path.join(import.meta.dirname, "..", "src", "_generated");
@@ -556,10 +583,12 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
     );
 
     for (const [definitionName, definitionSchema] of Object.entries(parsed.definitions ?? {})) {
+      const compatibleDefinitionSchema =
+        Codex0150DefinitionSchemas[definitionName] ?? definitionSchema;
       aggregateSchemas[localDefinitionNames.get(definitionName)!] = stripNullDefaults(
         normalizeNullableTypes(
           rewriteExternalRefs(
-            definitionSchema,
+            compatibleDefinitionSchema,
             localDefinitionNames,
             file.namespace,
             exportNameByQualifiedName,

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -20636,7 +20636,7 @@ export const ServerNotification__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -20645,6 +20645,10 @@ export const ServerNotification__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -21724,7 +21728,7 @@ export const V2ItemCompletedNotification__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -21733,6 +21737,10 @@ export const V2ItemCompletedNotification__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -22175,7 +22183,7 @@ export const V2ItemStartedNotification__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -22184,6 +22192,10 @@ export const V2ItemStartedNotification__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -22795,7 +22807,7 @@ export const V2ReviewStartResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -22804,6 +22816,10 @@ export const V2ReviewStartResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -23231,7 +23247,7 @@ export const V2ThreadForkResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -23240,6 +23256,10 @@ export const V2ThreadForkResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -23636,7 +23656,7 @@ export const V2ThreadListResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -23645,6 +23665,10 @@ export const V2ThreadListResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -24046,7 +24070,7 @@ export const V2ThreadMetadataUpdateResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -24055,6 +24079,10 @@ export const V2ThreadMetadataUpdateResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -24451,7 +24479,7 @@ export const V2ThreadReadResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -24460,6 +24488,10 @@ export const V2ThreadReadResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -24864,7 +24896,7 @@ export const V2ThreadResumeResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -24873,6 +24905,10 @@ export const V2ThreadResumeResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -25272,7 +25308,7 @@ export const V2ThreadRollbackResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -25281,6 +25317,10 @@ export const V2ThreadRollbackResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -25691,7 +25731,7 @@ export const V2ThreadStartedNotification__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -25700,6 +25740,10 @@ export const V2ThreadStartedNotification__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -26096,7 +26140,7 @@ export const V2ThreadStartResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -26105,6 +26149,10 @@ export const V2ThreadStartResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -26504,7 +26552,7 @@ export const V2ThreadUnarchiveResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -26513,6 +26561,10 @@ export const V2ThreadUnarchiveResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -26914,7 +26966,7 @@ export const V2TurnCompletedNotification__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -26923,6 +26975,10 @@ export const V2TurnCompletedNotification__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -27322,7 +27378,7 @@ export const V2TurnStartedNotification__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -27331,6 +27387,10 @@ export const V2TurnStartedNotification__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",
@@ -27725,7 +27785,7 @@ export const V2TurnStartResponse__ThreadItem = Schema.Union(
       senderThreadId: Schema.String.annotate({
         description: "Thread ID of the agent issuing the collab request.",
       }),
-      status: Schema.Literals(["inProgress", "completed", "failed"]).annotate({
+      status: Schema.Literals(["inProgress", "completed", "failed", "interrupted"]).annotate({
         description: "Current status of the collab tool call.",
       }),
       tool: Schema.Literals([
@@ -27734,6 +27794,10 @@ export const V2TurnStartResponse__ThreadItem = Schema.Union(
         "resumeAgent",
         "wait",
         "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents",
       ]).annotate({ description: "Name of the collab tool that was invoked." }),
       type: Schema.Literal("collabAgentToolCall").annotate({
         title: "CollabAgentToolCallThreadItemType",

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -20413,8 +20413,17 @@ export type ServerNotification__ThreadItem =
       readonly reasoningEffort?: ServerNotification__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -21500,8 +21509,17 @@ export type V2ItemCompletedNotification__ThreadItem =
       readonly reasoningEffort?: V2ItemCompletedNotification__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -21955,8 +21973,17 @@ export type V2ItemStartedNotification__ThreadItem =
       readonly reasoningEffort?: V2ItemStartedNotification__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -22582,8 +22609,17 @@ export type V2ReviewStartResponse__ThreadItem =
       readonly reasoningEffort?: V2ReviewStartResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -23022,8 +23058,17 @@ export type V2ThreadForkResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadForkResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -23431,8 +23476,17 @@ export type V2ThreadListResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadListResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -23842,8 +23896,17 @@ export type V2ThreadMetadataUpdateResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadMetadataUpdateResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -24254,8 +24317,17 @@ export type V2ThreadReadResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadReadResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -24671,8 +24743,17 @@ export type V2ThreadResumeResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadResumeResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -25080,8 +25161,17 @@ export type V2ThreadRollbackResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadRollbackResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -25503,8 +25593,17 @@ export type V2ThreadStartedNotification__ThreadItem =
       readonly reasoningEffort?: V2ThreadStartedNotification__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -25915,8 +26014,17 @@ export type V2ThreadStartResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadStartResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -26324,8 +26432,17 @@ export type V2ThreadUnarchiveResponse__ThreadItem =
       readonly reasoningEffort?: V2ThreadUnarchiveResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -26738,8 +26855,17 @@ export type V2TurnCompletedNotification__ThreadItem =
       readonly reasoningEffort?: V2TurnCompletedNotification__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -27150,8 +27276,17 @@ export type V2TurnStartedNotification__ThreadItem =
       readonly reasoningEffort?: V2TurnStartedNotification__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {
@@ -27562,8 +27697,17 @@ export type V2TurnStartResponse__ThreadItem =
       readonly reasoningEffort?: V2TurnStartResponse__ReasoningEffort | null;
       readonly receiverThreadIds: ReadonlyArray<string>;
       readonly senderThreadId: string;
-      readonly status: "inProgress" | "completed" | "failed";
-      readonly tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      readonly status: "inProgress" | "completed" | "failed" | "interrupted";
+      readonly tool:
+        | "spawnAgent"
+        | "sendInput"
+        | "resumeAgent"
+        | "wait"
+        | "closeAgent"
+        | "sendMessage"
+        | "followupTask"
+        | "interruptAgent"
+        | "listAgents";
       readonly type: "collabAgentToolCall";
     }
   | {

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -2616,11 +2616,16 @@ export const ServerNotification__SpendControlLimitSnapshot = Schema.Struct({
   used: Schema.String,
 });
 
-export type ServerNotification__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type ServerNotification__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const ServerNotification__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type ServerNotification__TerminalInteractionNotification = {
@@ -4710,11 +4715,13 @@ export const V2ItemCompletedNotification__ReasoningEffort = Schema.String.annota
 export type V2ItemCompletedNotification__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2ItemCompletedNotification__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ItemCompletedNotification__TextElement = {
@@ -5115,11 +5122,13 @@ export const V2ItemStartedNotification__ReasoningEffort = Schema.String.annotate
 export type V2ItemStartedNotification__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2ItemStartedNotification__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ItemStartedNotification__TextElement = {
@@ -6284,11 +6293,16 @@ export const V2ReviewStartResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2ReviewStartResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2ReviewStartResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2ReviewStartResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ReviewStartResponse__TextElement = {
@@ -6720,11 +6734,16 @@ export const V2ThreadForkResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2ThreadForkResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2ThreadForkResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2ThreadForkResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadForkResponse__TextElement = {
@@ -7119,11 +7138,16 @@ export const V2ThreadListResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2ThreadListResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2ThreadListResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2ThreadListResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadListResponse__TextElement = {
@@ -7463,11 +7487,13 @@ export const V2ThreadMetadataUpdateResponse__ReasoningEffort = Schema.String.ann
 export type V2ThreadMetadataUpdateResponse__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2ThreadMetadataUpdateResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadMetadataUpdateResponse__TextElement = {
@@ -7760,11 +7786,16 @@ export const V2ThreadReadResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2ThreadReadResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2ThreadReadResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2ThreadReadResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadReadResponse__TextElement = {
@@ -8342,11 +8373,16 @@ export const V2ThreadResumeResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2ThreadResumeResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2ThreadResumeResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2ThreadResumeResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadResumeResponse__TextElement = {
@@ -8643,11 +8679,13 @@ export const V2ThreadRollbackResponse__ReasoningEffort = Schema.String.annotate(
 export type V2ThreadRollbackResponse__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2ThreadRollbackResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadRollbackResponse__TextElement = {
@@ -9051,11 +9089,13 @@ export const V2ThreadStartedNotification__ReasoningEffort = Schema.String.annota
 export type V2ThreadStartedNotification__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2ThreadStartedNotification__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadStartedNotification__TextElement = {
@@ -9458,11 +9498,16 @@ export const V2ThreadStartResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2ThreadStartResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2ThreadStartResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2ThreadStartResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadStartResponse__TextElement = {
@@ -9791,11 +9836,13 @@ export const V2ThreadUnarchiveResponse__ReasoningEffort = Schema.String.annotate
 export type V2ThreadUnarchiveResponse__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2ThreadUnarchiveResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2ThreadUnarchiveResponse__TextElement = {
@@ -10095,11 +10142,13 @@ export const V2TurnCompletedNotification__ReasoningEffort = Schema.String.annota
 export type V2TurnCompletedNotification__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2TurnCompletedNotification__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2TurnCompletedNotification__TextElement = {
@@ -10385,11 +10434,13 @@ export const V2TurnStartedNotification__ReasoningEffort = Schema.String.annotate
 export type V2TurnStartedNotification__SubAgentActivityKind =
   | "started"
   | "interacted"
-  | "interrupted";
+  | "interrupted"
+  | "completed";
 export const V2TurnStartedNotification__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2TurnStartedNotification__TextElement = {
@@ -10761,11 +10812,16 @@ export const V2TurnStartResponse__ReasoningEffort = Schema.String.annotate({
   description: "A non-empty reasoning effort value advertised by the model.",
 }).check(Schema.isMinLength(1));
 
-export type V2TurnStartResponse__SubAgentActivityKind = "started" | "interacted" | "interrupted";
+export type V2TurnStartResponse__SubAgentActivityKind =
+  | "started"
+  | "interacted"
+  | "interrupted"
+  | "completed";
 export const V2TurnStartResponse__SubAgentActivityKind = Schema.Literals([
   "started",
   "interacted",
   "interrupted",
+  "completed",
 ]);
 
 export type V2TurnStartResponse__TextElement = {
@@ -35971,20 +36027,33 @@ export type ServerNotification__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const ServerNotification__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
-export type ServerNotification__CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+export type ServerNotification__CollabAgentToolCallStatus =
+  | "inProgress"
+  | "completed"
+  | "failed"
+  | "interrupted";
 export const ServerNotification__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type ServerNotification__CommandExecOutputStream = "stdout" | "stderr";
@@ -38046,23 +38115,33 @@ export type V2ItemCompletedNotification__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ItemCompletedNotification__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ItemCompletedNotification__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ItemCompletedNotification__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ItemCompletedNotification__CommandExecutionSource =
@@ -38183,23 +38262,33 @@ export type V2ItemStartedNotification__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ItemStartedNotification__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ItemStartedNotification__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ItemStartedNotification__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ItemStartedNotification__CommandExecutionSource =
@@ -39200,23 +39289,33 @@ export type V2ReviewStartResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ReviewStartResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ReviewStartResponse__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ReviewStartResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ReviewStartResponse__CommandExecutionSource =
@@ -39598,20 +39697,33 @@ export type V2ThreadForkResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadForkResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
-export type V2ThreadForkResponse__CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+export type V2ThreadForkResponse__CollabAgentToolCallStatus =
+  | "inProgress"
+  | "completed"
+  | "failed"
+  | "interrupted";
 export const V2ThreadForkResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadForkResponse__CommandExecutionSource =
@@ -39955,20 +40067,33 @@ export type V2ThreadListResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadListResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
-export type V2ThreadListResponse__CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+export type V2ThreadListResponse__CollabAgentToolCallStatus =
+  | "inProgress"
+  | "completed"
+  | "failed"
+  | "interrupted";
 export const V2ThreadListResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadListResponse__CommandExecutionSource =
@@ -40131,23 +40256,33 @@ export type V2ThreadMetadataUpdateResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadMetadataUpdateResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ThreadMetadataUpdateResponse__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ThreadMetadataUpdateResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadMetadataUpdateResponse__CommandExecutionSource =
@@ -40265,20 +40400,33 @@ export type V2ThreadReadResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadReadResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
-export type V2ThreadReadResponse__CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+export type V2ThreadReadResponse__CollabAgentToolCallStatus =
+  | "inProgress"
+  | "completed"
+  | "failed"
+  | "interrupted";
 export const V2ThreadReadResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadReadResponse__CommandExecutionSource =
@@ -40964,23 +41112,33 @@ export type V2ThreadResumeResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadResumeResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ThreadResumeResponse__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ThreadResumeResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadResumeResponse__CommandExecutionSource =
@@ -41334,23 +41492,33 @@ export type V2ThreadRollbackResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadRollbackResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ThreadRollbackResponse__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ThreadRollbackResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadRollbackResponse__CommandExecutionSource =
@@ -41673,23 +41841,33 @@ export type V2ThreadStartedNotification__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadStartedNotification__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ThreadStartedNotification__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ThreadStartedNotification__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadStartedNotification__CommandExecutionSource =
@@ -42075,23 +42253,33 @@ export type V2ThreadStartResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadStartResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ThreadStartResponse__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ThreadStartResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadStartResponse__CommandExecutionSource =
@@ -42278,23 +42466,33 @@ export type V2ThreadUnarchiveResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2ThreadUnarchiveResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2ThreadUnarchiveResponse__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2ThreadUnarchiveResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2ThreadUnarchiveResponse__CommandExecutionSource =
@@ -42412,23 +42610,33 @@ export type V2TurnCompletedNotification__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2TurnCompletedNotification__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2TurnCompletedNotification__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2TurnCompletedNotification__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2TurnCompletedNotification__CommandExecutionSource =
@@ -42524,23 +42732,33 @@ export type V2TurnStartedNotification__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2TurnStartedNotification__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
 export type V2TurnStartedNotification__CollabAgentToolCallStatus =
   | "inProgress"
   | "completed"
-  | "failed";
+  | "failed"
+  | "interrupted";
 export const V2TurnStartedNotification__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2TurnStartedNotification__CommandExecutionSource =
@@ -42728,20 +42946,33 @@ export type V2TurnStartResponse__CollabAgentTool =
   | "sendInput"
   | "resumeAgent"
   | "wait"
-  | "closeAgent";
+  | "closeAgent"
+  | "sendMessage"
+  | "followupTask"
+  | "interruptAgent"
+  | "listAgents";
 export const V2TurnStartResponse__CollabAgentTool = Schema.Literals([
   "spawnAgent",
   "sendInput",
   "resumeAgent",
   "wait",
   "closeAgent",
+  "sendMessage",
+  "followupTask",
+  "interruptAgent",
+  "listAgents",
 ]);
 
-export type V2TurnStartResponse__CollabAgentToolCallStatus = "inProgress" | "completed" | "failed";
+export type V2TurnStartResponse__CollabAgentToolCallStatus =
+  | "inProgress"
+  | "completed"
+  | "failed"
+  | "interrupted";
 export const V2TurnStartResponse__CollabAgentToolCallStatus = Schema.Literals([
   "inProgress",
   "completed",
   "failed",
+  "interrupted",
 ]);
 
 export type V2TurnStartResponse__CommandExecutionSource =

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -29,4 +29,45 @@ it("accepts Codex 0.150 multi-agent values", () => {
     Schema.is(CodexSchema.V2ThreadResumeResponse__CollabAgentToolCallStatus)("interrupted"),
     true,
   );
+
+  const resumeResponse = {
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    cwd: "/tmp/project",
+    model: "gpt-5.6-sol",
+    modelProvider: "openai",
+    sandbox: { type: "dangerFullAccess" },
+    thread: {
+      cliVersion: "0.150.0",
+      createdAt: 0,
+      cwd: "/tmp/project",
+      ephemeral: false,
+      id: "root-thread",
+      modelProvider: "openai",
+      preview: "",
+      sessionId: "session-1",
+      source: "cli",
+      status: { type: "idle" },
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              agentsStates: {},
+              id: "item-1",
+              receiverThreadIds: ["child-thread"],
+              senderThreadId: "root-thread",
+              status: "interrupted",
+              tool: "followupTask",
+              type: "collabAgentToolCall",
+            },
+          ],
+        },
+      ],
+      updatedAt: 0,
+    },
+  };
+
+  assert.equal(Schema.is(CodexSchema.V2ThreadResumeResponse)(resumeResponse), true);
 });

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -1,0 +1,32 @@
+import { assert, it } from "@effect/vitest";
+import * as Schema from "effect/Schema";
+
+import * as CodexSchema from "./schema.ts";
+
+it("accepts Codex 0.150 multi-agent values", () => {
+  const schemas = [
+    CodexSchema.ServerNotification__SubAgentActivityKind,
+    CodexSchema.V2ItemStartedNotification__SubAgentActivityKind,
+    CodexSchema.V2ItemCompletedNotification__SubAgentActivityKind,
+    CodexSchema.V2ThreadReadResponse__SubAgentActivityKind,
+    CodexSchema.V2ThreadResumeResponse__SubAgentActivityKind,
+  ];
+
+  for (const schema of schemas) {
+    assert.equal(Schema.is(schema)("completed"), true);
+  }
+
+  for (const tool of ["sendMessage", "followupTask", "interruptAgent", "listAgents"]) {
+    assert.equal(Schema.is(CodexSchema.ServerNotification__CollabAgentTool)(tool), true);
+    assert.equal(Schema.is(CodexSchema.V2ThreadResumeResponse__CollabAgentTool)(tool), true);
+  }
+
+  assert.equal(
+    Schema.is(CodexSchema.ServerNotification__CollabAgentToolCallStatus)("interrupted"),
+    true,
+  );
+  assert.equal(
+    Schema.is(CodexSchema.V2ThreadResumeResponse__CollabAgentToolCallStatus)("interrupted"),
+    true,
+  );
+});


### PR DESCRIPTION
Codex 0.150 added multi-agent values that our pinned app-server schema does not accept. A persisted `subAgentActivity` with `kind: "completed"` blocks `thread/resume`, while matching live events and new collaboration tool values get dropped during decoding.

This adds the 0.150 multi-agent enum values to every generated response namespace and keeps the compatibility definitions in the generator. It avoids a full protocol refresh, which would pull unrelated changes and can break older Codex releases. This complements #8342, which makes thread opening tolerant of future history drift but deliberately leaves live event decoding unchanged.

Tests:

- `vp test run packages/effect-codex-app-server/src/schema.test.ts packages/effect-codex-app-server/src/client.test.ts packages/effect-codex-app-server/src/protocol.test.ts`
- `vp run --filter effect-codex-app-server typecheck`
- Isolated provider probe with Codex 0.150.0 and an empty temporary `CODEX_HOME`

Made with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protocol decoding across many generated schemas; incorrect overrides could accept invalid payloads or mask upstream schema drift until the next full refresh.
> 
> **Overview**
> Codex **0.150** emits multi-agent collaboration enums that the pinned protocol schema still rejects, which can break **`thread/resume`** on persisted history and drop live **`collabAgentToolCall`** / **`subAgentActivity`** events during decode.
> 
> This PR adds a **`Codex0150DefinitionSchemas`** override in **`generate.ts`** so generation substitutes wider enums for **`CollabAgentTool`**, **`CollabAgentToolCallStatus`**, and **`SubAgentActivityKind`** before the usual rewrite pipeline. Regenerated **`schema.gen.ts`** carries those values through every response namespace (extra tools **`sendMessage`**, **`followupTask`**, **`interruptAgent`**, **`listAgents`**; status **`interrupted`**; activity kind **`completed`**).
> 
> **`schema.test.ts`** asserts the generated Effect schemas accept the new literals and a sample **`V2ThreadResumeResponse`** with **`followupTask`** / **`interrupted`**, without a full protocol refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be1453d8ac1decfc367d4e086073931ab3941c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Codex 0.150 multi-agent event values to schema generation
> - Introduces `Codex0150DefinitionSchemas` in [generate.ts](https://github.com/pingdotgg/t3code/pull/8346/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) to override parsed definitions for `CollabAgentTool`, `CollabAgentToolCallStatus`, and `SubAgentActivityKind` with hard-coded enum schemas.
> - The `generateFiles` generator substitutes these definitions before normalization and reference rewriting, producing updated generated code in [schema.gen.ts](https://github.com/pingdotgg/t3code/pull/8346/files#diff-c283b8cf9097ca9d1030e7acabd5d3c70e2a5ca2bfaf229f79512ba96ed58296).
> - New enum members: `sendMessage`, `followupTask`, `interruptAgent`, `listAgents` for `CollabAgentTool`; `interrupted` for `CollabAgentToolCallStatus`; `completed` for `SubAgentActivityKind`.
> - Adds a test in [schema.test.ts](https://github.com/pingdotgg/t3code/pull/8346/files#diff-2912bd8ff7cdd905fd768f119080c3d493102a78d5d464b72be82e48868a7079) validating the new values across affected schemas and a `V2ThreadResumeResponse` instance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7be1453.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->