### PR TITLE
fix(server): use Codex native updater

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -65,6 +65,14 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@openai/codex",
   homebrewFormula: "codex",
   nativeUpdate: null,
+  versionedNativeUpdate: {
+    // `codex update` first shipped in stable Codex 0.128.0. Older CLIs
+    // still need the package-manager command selected by maintenance.
+    minimumVersion: "0.128.0",
+    executable: "codex",
+    args: ["update"],
+    lockKey: "codex-native",
+  },
 });
 
 /**

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -59,6 +59,18 @@ const scopedPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
     isCommandPath: isNativeTestCommandPath("/.scoped-package-tool/bin/scoped-package-tool"),
   },
 });
+const versionedPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
+  provider: driver("versionedPackageTool"),
+  npmPackageName: "@example/versioned-package-tool",
+  homebrewFormula: "versioned-package-tool",
+  nativeUpdate: null,
+  versionedNativeUpdate: {
+    minimumVersion: "2.0.0",
+    executable: "versioned-package-tool",
+    args: ["update"],
+    lockKey: "versioned-package-tool-native",
+  },
+});
 const staticToolUpdate = makeStaticProviderMaintenanceResolver(
   makeProviderMaintenanceCapabilities({
     provider: driver("staticTool"),
@@ -180,6 +192,78 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         "npm install -g --allow-scripts=@example/native-package-tool @example/native-package-tool@latest",
       canUpdate: true,
       message: "Install the update now or review provider settings.",
+    });
+  });
+
+  it("uses the resolved native updater once the installed version supports it", () => {
+    const capabilities = versionedPackageToolUpdate.resolve({
+      binaryPath: "versioned-package-tool",
+      resolvedCommandPath: "/opt/versioned/bin/versioned-package-tool",
+    });
+
+    expect(capabilities.versionedUpdate?.update).toMatchObject({
+      command: "versioned-package-tool update",
+      executable: "/opt/versioned/bin/versioned-package-tool",
+      args: ["update"],
+      lockKey: "versioned-package-tool-native",
+    });
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("versionedPackageTool"),
+        currentVersion: "2.0.0",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: capabilities,
+      }),
+    ).toMatchObject({
+      updateCommand: "versioned-package-tool update",
+      canUpdate: true,
+    });
+  });
+
+  it("keeps the package-manager fallback for versions without the native updater", () => {
+    const capabilities = versionedPackageToolUpdate.resolve({
+      binaryPath: "versioned-package-tool",
+      resolvedCommandPath: "/usr/local/lib/node_modules/@example/versioned-package-tool/bin.js",
+    });
+
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("versionedPackageTool"),
+        currentVersion: "1.9.9",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: capabilities,
+      }),
+    ).toMatchObject({
+      updateCommand:
+        "npm install -g --allow-scripts=@example/versioned-package-tool @example/versioned-package-tool@latest",
+      canUpdate: true,
+    });
+  });
+
+  it("only enables standalone updates when the installed version supports the native updater", () => {
+    const capabilities = versionedPackageToolUpdate.resolve({
+      binaryPath: "/opt/versioned/bin/versioned-package-tool",
+      resolvedCommandPath: "/opt/versioned/bin/versioned-package-tool",
+    });
+
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("versionedPackageTool"),
+        currentVersion: "1.9.9",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: capabilities,
+      }),
+    ).toMatchObject({ updateCommand: null, canUpdate: false });
+    expect(
+      createProviderVersionAdvisory({
+        driver: driver("versionedPackageTool"),
+        currentVersion: "2.0.0",
+        latestVersion: "2.1.0",
+        maintenanceCapabilities: capabilities,
+      }),
+    ).toMatchObject({
+      updateCommand: "/opt/versioned/bin/versioned-package-tool update",
+      canUpdate: true,
     });
   });
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -40,7 +40,10 @@ const readCommandLookupEnv = CommandLookupEnvConfig.pipe(Effect.orElseSucceed(()
 export interface ProviderMaintenanceCapabilities {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
+  /** Update path for versions that predate a provider-owned updater. */
   readonly update: ProviderMaintenanceCommandAction | null;
+  /** Preferred update path once the installed provider reaches its minimum version. */
+  readonly versionedUpdate?: ProviderMaintenanceVersionedCommandAction;
 }
 
 export interface ProviderMaintenanceCommandAction {
@@ -48,6 +51,11 @@ export interface ProviderMaintenanceCommandAction {
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly lockKey: string;
+}
+
+export interface ProviderMaintenanceVersionedCommandAction {
+  readonly minimumVersion: string;
+  readonly update: ProviderMaintenanceCommandAction;
 }
 
 export interface ProviderMaintenanceCapabilityResolutionOptions {
@@ -73,6 +81,12 @@ export interface PackageManagedProviderMaintenanceDefinition {
     readonly lockKey: string;
     readonly isCommandPath: (commandPath: string) => boolean;
   } | null;
+  readonly versionedNativeUpdate?: {
+    readonly minimumVersion: string;
+    readonly executable: string;
+    readonly args: ReadonlyArray<string>;
+    readonly lockKey: string;
+  };
 }
 
 export interface ProviderVersionCacheEntry {
@@ -278,12 +292,35 @@ export function resolvePackageManagedProviderMaintenance(
   options?: ProviderMaintenanceCapabilityResolutionOptions,
 ): ProviderMaintenanceCapabilities {
   const binaryPath = nonEmptyString(options?.binaryPath);
-  if (!binaryPath) {
-    return makeNpmGlobalProviderMaintenanceCapabilities(definition);
-  }
-
   const resolvedCommandPath =
-    options?.resolvedCommandPath ?? (hasPathSeparator(binaryPath) ? binaryPath : null);
+    options?.resolvedCommandPath ??
+    (binaryPath && hasPathSeparator(binaryPath) ? binaryPath : null);
+  const withVersionedUpdate = (
+    capabilities: ProviderMaintenanceCapabilities,
+  ): ProviderMaintenanceCapabilities => {
+    const versionedNativeUpdate = definition.versionedNativeUpdate;
+    if (!versionedNativeUpdate) {
+      return capabilities;
+    }
+
+    const commandExecutable = binaryPath ?? versionedNativeUpdate.executable;
+    return {
+      ...capabilities,
+      versionedUpdate: {
+        minimumVersion: versionedNativeUpdate.minimumVersion,
+        update: {
+          command: [commandExecutable, ...versionedNativeUpdate.args].join(" "),
+          executable: resolvedCommandPath ?? commandExecutable,
+          args: versionedNativeUpdate.args,
+          lockKey: versionedNativeUpdate.lockKey,
+        },
+      },
+    };
+  };
+
+  if (!binaryPath) {
+    return withVersionedUpdate(makeNpmGlobalProviderMaintenanceCapabilities(definition));
+  }
 
   if (resolvedCommandPath) {
     const commandPaths = [
@@ -296,36 +333,53 @@ export function resolvePackageManagedProviderMaintenance(
       nativeUpdate &&
       commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
     ) {
-      return (
+      return withVersionedUpdate(
         makeNativeProviderMaintenanceCapabilities(definition) ??
-        makeNpmGlobalProviderMaintenanceCapabilities(definition)
+          makeNpmGlobalProviderMaintenanceCapabilities(definition),
       );
     }
     if (commandPaths.some(isVitePlusGlobalCommandPath)) {
-      return makeVitePlusGlobalProviderMaintenanceCapabilities(definition);
+      return withVersionedUpdate(makeVitePlusGlobalProviderMaintenanceCapabilities(definition));
     }
     if (commandPaths.some(isBunGlobalCommandPath)) {
-      return makeBunGlobalProviderMaintenanceCapabilities(definition);
+      return withVersionedUpdate(makeBunGlobalProviderMaintenanceCapabilities(definition));
     }
     if (commandPaths.some(isPnpmGlobalCommandPath)) {
-      return makePnpmGlobalProviderMaintenanceCapabilities(definition);
+      return withVersionedUpdate(makePnpmGlobalProviderMaintenanceCapabilities(definition));
     }
     if (commandPaths.some(isNpmGlobalCommandPath)) {
-      return makeNpmGlobalProviderMaintenanceCapabilities(definition);
+      return withVersionedUpdate(makeNpmGlobalProviderMaintenanceCapabilities(definition));
     }
     if (commandPaths.some(isHomebrewCommandPath)) {
-      return makeHomebrewProviderMaintenanceCapabilities(definition);
+      return withVersionedUpdate(makeHomebrewProviderMaintenanceCapabilities(definition));
     }
   }
 
   if (!hasPathSeparator(binaryPath)) {
-    return makeNpmGlobalProviderMaintenanceCapabilities(definition);
+    return withVersionedUpdate(makeNpmGlobalProviderMaintenanceCapabilities(definition));
   }
 
-  return makeManualOnlyProviderMaintenanceCapabilities({
-    provider: definition.provider,
-    packageName: definition.npmPackageName,
-  });
+  return withVersionedUpdate(
+    makeManualOnlyProviderMaintenanceCapabilities({
+      provider: definition.provider,
+      packageName: definition.npmPackageName,
+    }),
+  );
+}
+
+export function resolveProviderMaintenanceUpdate(
+  capabilities: ProviderMaintenanceCapabilities,
+  currentVersion: string | null,
+): ProviderMaintenanceCommandAction | null {
+  const versionedUpdate = capabilities.versionedUpdate;
+  if (
+    versionedUpdate &&
+    currentVersion &&
+    compareSemverVersions(currentVersion, versionedUpdate.minimumVersion) >= 0
+  ) {
+    return versionedUpdate.update;
+  }
+  return capabilities.update;
 }
 
 export function makePackageManagedProviderMaintenanceResolver(
@@ -413,6 +467,7 @@ export function createProviderVersionAdvisory(input: {
 }): ServerProviderVersionAdvisory {
   const capabilities =
     input.maintenanceCapabilities ?? makeManualProviderMaintenanceCapabilities(input.driver);
+  const update = resolveProviderMaintenanceUpdate(capabilities, input.currentVersion);
   const latestVersion = input.latestVersion ?? null;
   const advisory = deriveVersionAdvisory({
     currentVersion: input.currentVersion,
@@ -423,8 +478,8 @@ export function createProviderVersionAdvisory(input: {
     status: advisory.status,
     currentVersion: input.currentVersion,
     latestVersion,
-    updateCommand: capabilities.update?.command ?? null,
-    canUpdate: capabilities.update !== null,
+    updateCommand: update?.command ?? null,
+    canUpdate: update !== null,
     checkedAt: input.checkedAt ?? null,
     message: advisory.message,
   };

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -299,6 +299,58 @@ describe("providerMaintenanceRunner", () => {
     );
   });
 
+  it.effect("uses the version-gated native update command for supported provider versions", () => {
+    const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry({
+        ...baseProvider,
+        version: "0.128.0",
+      });
+      const fallback = makeProviderMaintenanceCapabilities({
+        provider: CODEX_DRIVER,
+        packageName: "@openai/codex",
+        updateExecutable: "npm",
+        updateArgs: ["install", "-g", "@openai/codex@latest"],
+        updateLockKey: "npm-global",
+      });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        getProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed({
+            ...fallback,
+            versionedUpdate: {
+              minimumVersion: "0.128.0",
+              update: {
+                command: "codex update",
+                executable: "/opt/codex/bin/codex",
+                args: ["update"],
+                lockKey: "codex-native",
+              },
+            },
+          }),
+      });
+
+      yield* updater.updateProvider(CODEX_DRIVER);
+      assert.deepStrictEqual(calls, [
+        {
+          command: "/opt/codex/bin/codex",
+          args: ["update"],
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.128.0"),
+          mockSpawnerLayer((command, args) => {
+            calls.push({ command, args });
+            return { stdout: "updated" };
+          }),
+        ),
+      ),
+    );
+  });
+
   it.effect(
     "runs update commands through Effect ChildProcess when no test runner is injected",
     () => {

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -23,7 +23,10 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { ProviderRegistry } from "./Services/ProviderRegistry.ts";
 import { makeProviderMaintenanceCommandCoordinator } from "./providerMaintenanceCommandCoordinator.ts";
-import { enrichProviderSnapshotWithVersionAdvisory } from "./providerMaintenance.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  resolveProviderMaintenanceUpdate,
+} from "./providerMaintenance.ts";
 import type { ProviderMaintenanceCapabilities } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 const isServerProviderUpdateError = Schema.is(ServerProviderUpdateError);
@@ -297,7 +300,10 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
       instanceId,
       provider,
     );
-    const update = capabilities.update;
+    const currentProvider = (yield* providerRegistry.getProviders).find(
+      (candidate) => candidate.instanceId === instanceId && candidate.driver === provider,
+    );
+    const update = resolveProviderMaintenanceUpdate(capabilities, currentProvider?.version ?? null);
     if (!update) {
       return yield* new ServerProviderUpdateError({
         provider,


### PR DESCRIPTION
Codex now owns installation-method detection through its native `update` command, but T3 Code still selected npm, Bun, pnpm, Vite+, or Homebrew itself. That prevented one-click updates for standalone installations and could target a different installation than the configured Codex binary.

This adds a version-aware maintenance action that uses `codex update` for Codex 0.128.0 and newer, invoking the exact resolved provider executable. Older Codex versions keep the existing package-manager fallback because they predate the native command. The advisory and execution paths share the same selector so the command shown to users is the command T3 Code runs.

Verification:
- `vp test run apps/server/src/provider/providerMaintenance.test.ts apps/server/src/provider/providerMaintenanceRunner.test.ts`
- scoped `vp lint --report-unused-disable-directives` on the five changed files
- `vp run --filter t3 typecheck`
- `vp staged`
- `git diff --check`

Implemented with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how provider update commands are chosen and executed for Codex and package-managed providers; wrong version gating could run the wrong updater or block valid updates.
> 
> **Overview**
> Provider maintenance now supports a **version-gated native update** alongside the existing npm/Bun/pnpm/Homebrew fallbacks. Drivers can declare `versionedNativeUpdate` with a minimum semver; once the installed provider meets that floor, T3 Code prefers the provider-owned command (resolved executable + args) instead of inferring a package manager from the binary path.
> 
> **Codex** is wired to run **`codex update`** for **0.128.0+**, using the configured/resolved Codex binary. Older Codex versions keep the previous package-manager update path because the native command did not exist yet.
> 
> The **version advisory** (`updateCommand` / `canUpdate`) and **one-click update runner** both go through **`resolveProviderMaintenanceUpdate`**, so the UI shows the same command the server executes. For standalone installs where the fallback is manual-only, one-click updates stay disabled until the installed version is high enough to use the native updater.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e228530d05c377297c229f36af3aad2e946df5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use Codex native updater for versions >= 0.128.0
> - Adds `versionedNativeUpdate` to `PackageManagedProviderMaintenanceDefinition`, allowing providers to declare a native updater that activates at or above a minimum version
> - Codex driver configures `codex update` as its native updater, gated at version 0.128.0; older versions fall back to the existing package-manager update path
> - New `resolveProviderMaintenanceUpdate` selects the effective update command based on the installed version, and `ProviderMaintenanceRunner.updateProvider` now uses it instead of `capabilities.update` directly
> - `createProviderVersionAdvisory` reports the native update command only when the installed version meets the minimum
> - Risk: providers that define only a `versionedNativeUpdate` and have an installed version below the minimum will report no available update via `resolveProviderMaintenanceUpdate` in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/8354/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14); verify no existing provider relies solely on versioned updates without a fallback `update` field
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e228530. 3 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/providerMaintenance.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 312](https://github.com/pingdotgg/t3code/blob/e228530d05c377297c229f36af3aad2e946df5b4/apps/server/src/provider/providerMaintenance.ts#L312): The new native `command` concatenates an arbitrary configured executable path without shell quoting. A supported direct binary path such as `C:\Program Files\Codex\codex.exe` therefore produces the copyable manual instruction `C:\Program Files\Codex\codex.exe update`, which a shell parses as command `C:\Program` and fails, even though the one-click runner can execute the path correctly. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->