### PR TITLE
fix(web): keep $ skill picker usable inside question answers

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6142,10 +6142,22 @@ function ChatViewContent(props: ChatViewProps) {
         },
       }));
       const snapshot = composerRef.current?.readSnapshot();
+      // Avoid ping-pong when skill picker inserts plain text while editor is still
+      // showing old value: the controlled effect (activePendingProgress.customAnswer
+      // -> composer) will rewrite editor to new value and place cursor. Calling
+      // focusAt now would move selection in old content (clamped) and fire
+      // handleEditorChange with old value, overwriting the just-inserted skill.
+      const isPlainInsert =
+        snapshot !== undefined &&
+        typeof snapshot.value === "string" &&
+        value.length > snapshot.value.length &&
+        value.startsWith(snapshot.value);
+
       if (
-        snapshot?.value !== value ||
-        snapshot.cursor !== nextCursor ||
-        snapshot.expandedCursor !== expandedCursor
+        !isPlainInsert &&
+        (snapshot?.value !== value ||
+          snapshot.cursor !== nextCursor ||
+          snapshot.expandedCursor !== expandedCursor)
       ) {
         composerRef.current?.focusAt(nextCursor);
       }

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -822,11 +822,17 @@ function $setComposerEditorPrompt(
   prompt: string,
   terminalContexts: ReadonlyArray<TerminalContextDraft>,
   skillMetadata: ReadonlyMap<string, ComposerSkillMetadata>,
+  plainText: boolean,
 ): void {
   const root = $getRoot();
   root.clear();
   const paragraph = $createParagraphNode();
   root.append(paragraph);
+
+  if (plainText) {
+    $appendTextWithLineBreaks(paragraph, prompt);
+    return;
+  }
 
   const segments = splitPromptIntoComposerSegments(prompt, terminalContexts);
   for (const segment of segments) {
@@ -882,6 +888,13 @@ interface ComposerPromptEditorProps {
   cursor: number;
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
   skills: ReadonlyArray<ServerProviderSkill>;
+  /**
+   * Renders the value as raw text: no mention/skill/terminal-context tokens
+   * and no token plugins. Used for pending-question answers, which only ever
+   * submit plain strings. With no token nodes, collapsed and expanded cursor
+   * offsets coincide, so all cursor mapping reduces to a raw clamp.
+   */
+  plainText?: boolean;
   disabled: boolean;
   placeholder: string;
   className?: string;
@@ -1263,8 +1276,15 @@ function ComposerInlineTokenPastePlugin() {
 function ComposerSurroundSelectionPlugin(props: {
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
   skills: ReadonlyArray<ServerProviderSkill>;
+  plainText: boolean;
 }) {
   const [editor] = useLexicalComposerContext();
+  // Surround-typing is not token behavior, so this plugin renders in both
+  // modes. In plain mode there are no token nodes: cursor mapping is a raw
+  // clamp and the mention-boundary guard would false-positive on answer text
+  // that merely looks like a mention, so it is skipped.
+  const collapseCursor = props.plainText ? clampExpandedCursor : collapseExpandedComposerCursor;
+  const touchesMentionBoundary = props.plainText ? () => false : selectionTouchesMentionBoundary;
   const terminalContextsRef = useRef(props.terminalContexts);
   const skillMetadataRef = useRef(skillMetadataByName(props.skills));
   const pendingSurroundSelectionRef = useRef<{
@@ -1311,7 +1331,7 @@ function ComposerSurroundSelectionPlugin(props: {
             return null;
           }
           const value = $getRoot().getTextContent();
-          if (selectionTouchesMentionBoundary(value, range.start, range.end)) {
+          if (touchesMentionBoundary(value, range.start, range.end)) {
             return null;
           }
           return {
@@ -1330,11 +1350,13 @@ function ComposerSurroundSelectionPlugin(props: {
         selectionSnapshot.expandedEnd,
       );
       const nextValue = `${selectionSnapshot.value.slice(0, selectionSnapshot.expandedStart)}${inputData}${selectedText}${surroundCloseSymbol}${selectionSnapshot.value.slice(selectionSnapshot.expandedEnd)}`;
-      $setComposerEditorPrompt(nextValue, terminalContextsRef.current, skillMetadataRef.current);
-      const selectionStart = collapseExpandedComposerCursor(
+      $setComposerEditorPrompt(
         nextValue,
-        selectionSnapshot.expandedStart,
+        terminalContextsRef.current,
+        skillMetadataRef.current,
+        props.plainText,
       );
+      const selectionStart = collapseCursor(nextValue, selectionSnapshot.expandedStart);
       $setSelectionRangeAtComposerOffsets(
         selectionStart + inputData.length,
         selectionStart + inputData.length + selectedText.length,
@@ -1380,7 +1402,7 @@ function ComposerSurroundSelectionPlugin(props: {
           return;
         }
         const value = $getRoot().getTextContent();
-        if (selectionTouchesMentionBoundary(value, range.start, range.end)) {
+        if (touchesMentionBoundary(value, range.start, range.end)) {
           pendingSurroundSelectionRef.current = null;
           pendingDeadKeySelectionRef.current = null;
           return;
@@ -1461,7 +1483,7 @@ function ComposerSurroundSelectionPlugin(props: {
               pendingDeadKeySelection.expandedStart,
               pendingDeadKeySelection.expandedEnd,
             );
-            const replacementStart = collapseExpandedComposerCursor(
+            const replacementStart = collapseCursor(
               currentValue,
               pendingDeadKeySelection.expandedStart,
             );
@@ -1531,6 +1553,7 @@ function ComposerPromptEditorInner({
   cursor,
   terminalContexts,
   skills,
+  plainText = false,
   disabled,
   placeholder,
   className,
@@ -1539,10 +1562,19 @@ function ComposerPromptEditorInner({
   onCommandKeyDown,
   onPaste,
   editorRef,
-}: ComposerPromptEditorProps) {
+  restoreFocusOnRemountRef,
+}: ComposerPromptEditorProps & {
+  restoreFocusOnRemountRef: React.RefObject<boolean>;
+}) {
   const [editor] = useLexicalComposerContext();
+  // Plain mode has no token nodes, so every collapsed<->expanded cursor
+  // mapping is a raw clamp. The editor remounts when the mode flips (the
+  // LexicalComposer key includes it), so these stay stable per mount.
+  const clampComposerCursor = plainText ? clampExpandedCursor : clampCollapsedComposerCursor;
+  const expandComposerCursor = plainText ? clampExpandedCursor : expandCollapsedComposerCursor;
+  const collapseComposerCursor = plainText ? clampExpandedCursor : collapseExpandedComposerCursor;
   const onChangeRef = useRef(onChange);
-  const initialCursor = clampCollapsedComposerCursor(value, cursor);
+  const initialCursor = clampComposerCursor(value, cursor);
   const terminalContextsSignature = terminalContextSignature(terminalContexts);
   const terminalContextsSignatureRef = useRef(terminalContextsSignature);
   const skillsSignature = skillSignature(skills);
@@ -1551,7 +1583,7 @@ function ComposerPromptEditorInner({
   const snapshotRef = useRef({
     value,
     cursor: initialCursor,
-    expandedCursor: expandCollapsedComposerCursor(value, initialCursor),
+    expandedCursor: expandComposerCursor(value, initialCursor),
     terminalContextIds: terminalContexts.map((context) => context.id),
   });
   const isApplyingControlledUpdateRef = useRef(false);
@@ -1573,7 +1605,7 @@ function ComposerPromptEditorInner({
   }, [disabled, editor]);
 
   useLayoutEffect(() => {
-    const normalizedCursor = clampCollapsedComposerCursor(value, cursor);
+    const normalizedCursor = clampComposerCursor(value, cursor);
     const previousSnapshot = snapshotRef.current;
     const contextsChanged = terminalContextsSignatureRef.current !== terminalContextsSignature;
     const skillsChanged = skillsSignatureRef.current !== skillsSignature;
@@ -1589,7 +1621,7 @@ function ComposerPromptEditorInner({
     snapshotRef.current = {
       value,
       cursor: normalizedCursor,
-      expandedCursor: expandCollapsedComposerCursor(value, normalizedCursor),
+      expandedCursor: expandComposerCursor(value, normalizedCursor),
       terminalContextIds: terminalContexts.map((context) => context.id),
     };
     terminalContextsSignatureRef.current = terminalContextsSignature;
@@ -1606,7 +1638,7 @@ function ComposerPromptEditorInner({
       const shouldRewriteEditorState =
         previousSnapshot.value !== value || contextsChanged || skillsChanged;
       if (shouldRewriteEditorState) {
-        $setComposerEditorPrompt(value, terminalContexts, skillMetadataRef.current);
+        $setComposerEditorPrompt(value, terminalContexts, skillMetadataRef.current, plainText);
       }
       if (shouldRewriteEditorState || isFocused) {
         $setSelectionAtComposerOffset(normalizedCursor);
@@ -1615,13 +1647,23 @@ function ComposerPromptEditorInner({
     queueMicrotask(() => {
       isApplyingControlledUpdateRef.current = false;
     });
-  }, [cursor, editor, skillsSignature, terminalContexts, terminalContextsSignature, value]);
+  }, [
+    clampComposerCursor,
+    cursor,
+    editor,
+    expandComposerCursor,
+    plainText,
+    skillsSignature,
+    terminalContexts,
+    terminalContextsSignature,
+    value,
+  ]);
 
   const focusAt = useCallback(
     (nextCursor: number) => {
       const rootElement = editor.getRootElement();
       if (!rootElement) return;
-      const boundedCursor = clampCollapsedComposerCursor(snapshotRef.current.value, nextCursor);
+      const boundedCursor = clampComposerCursor(snapshotRef.current.value, nextCursor);
       rootElement.focus({ preventScroll: true });
       editor.update(() => {
         $setSelectionAtComposerOffset(boundedCursor);
@@ -1629,7 +1671,7 @@ function ComposerPromptEditorInner({
       snapshotRef.current = {
         value: snapshotRef.current.value,
         cursor: boundedCursor,
-        expandedCursor: expandCollapsedComposerCursor(snapshotRef.current.value, boundedCursor),
+        expandedCursor: expandComposerCursor(snapshotRef.current.value, boundedCursor),
         terminalContextIds: snapshotRef.current.terminalContextIds,
       };
       onChangeRef.current(
@@ -1640,8 +1682,31 @@ function ComposerPromptEditorInner({
         snapshotRef.current.terminalContextIds,
       );
     },
-    [editor],
+    [clampComposerCursor, editor, expandComposerCursor],
   );
+
+  // The plainText flip remounts the editor (see the LexicalComposer key),
+  // replacing the focused contenteditable and silently dropping focus. Record
+  // focus ownership when this instance unmounts and take it back on the next
+  // mount, so a question opening or resolving mid-typing doesn't eat
+  // keystrokes. Every dep is stable for the lifetime of a mount, so this runs
+  // once per editor instance.
+  useLayoutEffect(() => {
+    if (restoreFocusOnRemountRef.current) {
+      restoreFocusOnRemountRef.current = false;
+      // Focus at the end: the snapshot cursor was seeded from the previous
+      // mode's stale cursor prop, while both mode transitions settle the
+      // caret at the end (answer end on question open, draft end on resolve).
+      // Placing it there directly leaves no window for keystrokes to land at
+      // a stale offset before the parent's effects run.
+      focusAt(collapseComposerCursor(snapshotRef.current.value, snapshotRef.current.value.length));
+    }
+    return () => {
+      // Layout cleanup runs before the old DOM node is detached, so
+      // activeElement still points at it here.
+      restoreFocusOnRemountRef.current = editor.getRootElement() === document.activeElement;
+    };
+  }, [collapseComposerCursor, editor, focusAt, restoreFocusOnRemountRef]);
 
   const readSnapshot = useCallback((): {
     value: string;
@@ -1652,8 +1717,8 @@ function ComposerPromptEditorInner({
     let snapshot = snapshotRef.current;
     editor.getEditorState().read(() => {
       const nextValue = $getRoot().getTextContent();
-      const fallbackCursor = clampCollapsedComposerCursor(nextValue, snapshotRef.current.cursor);
-      const nextCursor = clampCollapsedComposerCursor(
+      const fallbackCursor = clampComposerCursor(nextValue, snapshotRef.current.cursor);
+      const nextCursor = clampComposerCursor(
         nextValue,
         $readSelectionOffsetFromEditorState(fallbackCursor),
       );
@@ -1675,7 +1740,7 @@ function ComposerPromptEditorInner({
     });
     snapshotRef.current = snapshot;
     return snapshot;
-  }, [editor]);
+  }, [clampComposerCursor, editor]);
 
   useImperativeHandle(
     editorRef,
@@ -1686,65 +1751,66 @@ function ComposerPromptEditorInner({
       focusAt,
       focusAtEnd: () => {
         focusAt(
-          collapseExpandedComposerCursor(
-            snapshotRef.current.value,
-            snapshotRef.current.value.length,
-          ),
+          collapseComposerCursor(snapshotRef.current.value, snapshotRef.current.value.length),
         );
       },
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
+    [collapseComposerCursor, focusAt, readSnapshot],
   );
 
-  const handleEditorChange = useCallback((editorState: EditorState) => {
-    editorState.read(() => {
-      const nextValue = $getRoot().getTextContent();
-      const fallbackCursor = clampCollapsedComposerCursor(nextValue, snapshotRef.current.cursor);
-      const nextCursor = clampCollapsedComposerCursor(
-        nextValue,
-        $readSelectionOffsetFromEditorState(fallbackCursor),
-      );
-      const fallbackExpandedCursor = clampExpandedCursor(
-        nextValue,
-        snapshotRef.current.expandedCursor,
-      );
-      const nextExpandedCursor = clampExpandedCursor(
-        nextValue,
-        $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
-      );
-      const terminalContextIds = collectTerminalContextIds($getRoot());
-      const previousSnapshot = snapshotRef.current;
-      if (
-        previousSnapshot.value === nextValue &&
-        previousSnapshot.cursor === nextCursor &&
-        previousSnapshot.expandedCursor === nextExpandedCursor &&
-        previousSnapshot.terminalContextIds.length === terminalContextIds.length &&
-        previousSnapshot.terminalContextIds.every((id, index) => id === terminalContextIds[index])
-      ) {
-        return;
-      }
-      if (isApplyingControlledUpdateRef.current) {
-        return;
-      }
-      snapshotRef.current = {
-        value: nextValue,
-        cursor: nextCursor,
-        expandedCursor: nextExpandedCursor,
-        terminalContextIds,
-      };
-      const cursorAdjacentToMention =
-        isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "left") ||
-        isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "right");
-      onChangeRef.current(
-        nextValue,
-        nextCursor,
-        nextExpandedCursor,
-        cursorAdjacentToMention,
-        terminalContextIds,
-      );
-    });
-  }, []);
+  const handleEditorChange = useCallback(
+    (editorState: EditorState) => {
+      editorState.read(() => {
+        const nextValue = $getRoot().getTextContent();
+        const fallbackCursor = clampComposerCursor(nextValue, snapshotRef.current.cursor);
+        const nextCursor = clampComposerCursor(
+          nextValue,
+          $readSelectionOffsetFromEditorState(fallbackCursor),
+        );
+        const fallbackExpandedCursor = clampExpandedCursor(
+          nextValue,
+          snapshotRef.current.expandedCursor,
+        );
+        const nextExpandedCursor = clampExpandedCursor(
+          nextValue,
+          $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
+        );
+        const terminalContextIds = collectTerminalContextIds($getRoot());
+        const previousSnapshot = snapshotRef.current;
+        if (
+          previousSnapshot.value === nextValue &&
+          previousSnapshot.cursor === nextCursor &&
+          previousSnapshot.expandedCursor === nextExpandedCursor &&
+          previousSnapshot.terminalContextIds.length === terminalContextIds.length &&
+          previousSnapshot.terminalContextIds.every((id, index) => id === terminalContextIds[index])
+        ) {
+          return;
+        }
+        if (isApplyingControlledUpdateRef.current) {
+          return;
+        }
+        snapshotRef.current = {
+          value: nextValue,
+          cursor: nextCursor,
+          expandedCursor: nextExpandedCursor,
+          terminalContextIds,
+        };
+        const cursorAdjacentToMention =
+          !plainText &&
+          (isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "left") ||
+            isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "right"));
+        onChangeRef.current(
+          nextValue,
+          nextCursor,
+          nextExpandedCursor,
+          cursorAdjacentToMention,
+          terminalContextIds,
+        );
+      });
+    },
+    [clampComposerCursor, plainText],
+  );
 
   return (
     <ComposerTerminalContextActionsContext value={terminalContextActions}>
@@ -1774,13 +1840,24 @@ function ComposerPromptEditorInner({
         />
         <OnChangePlugin onChange={handleEditorChange} />
         <ComposerCommandKeyPlugin {...(onCommandKeyDown ? { onCommandKeyDown } : {})} />
-        <ComposerSurroundSelectionPlugin terminalContexts={terminalContexts} skills={skills} />
+        {/* Surround-typing (wrap a selection in brackets/quotes) is plain
+            typing behavior, not token behavior, so it stays mounted in both
+            modes; only the token-dependent plugins are mode-gated. */}
+        <ComposerSurroundSelectionPlugin
+          terminalContexts={terminalContexts}
+          skills={skills}
+          plainText={plainText}
+        />
+        {plainText ? null : (
+          <>
+            <ComposerInlineTokenArrowPlugin />
+            <ComposerInlineTokenSelectionNormalizePlugin />
+            <ComposerInlineTokenBackspacePlugin />
+            <ComposerInlineTokenPastePlugin />
+            <ComposerChipSelectionPlugin />
+          </>
+        )}
         <ComposerHomeEndKeyPlugin />
-        <ComposerInlineTokenArrowPlugin />
-        <ComposerInlineTokenSelectionNormalizePlugin />
-        <ComposerInlineTokenBackspacePlugin />
-        <ComposerInlineTokenPastePlugin />
-        <ComposerChipSelectionPlugin />
         <HistoryPlugin />
       </div>
     </ComposerTerminalContextActionsContext>
@@ -1792,6 +1869,7 @@ export function ComposerPromptEditor({
   cursor,
   terminalContexts,
   skills,
+  plainText = false,
   disabled,
   placeholder,
   className,
@@ -1801,9 +1879,20 @@ export function ComposerPromptEditor({
   onPaste,
   editorRef,
 }: ComposerPromptEditorProps) {
+  // The editor remounts when plainText flips (see the LexicalComposer key), so
+  // these refs must track the latest props for the initial editorState to seed
+  // the remounted editor with the current value, not the first-ever one.
   const initialValueRef = useRef(value);
+  initialValueRef.current = value;
   const initialTerminalContextsRef = useRef(terminalContexts);
+  initialTerminalContextsRef.current = terminalContexts;
   const initialSkillMetadataRef = useRef(skillMetadataByName(skills));
+  initialSkillMetadataRef.current = skillMetadataByName(skills);
+  const initialPlainTextRef = useRef(plainText);
+  initialPlainTextRef.current = plainText;
+  // Survives the plainText remount so the new editor instance knows whether
+  // its predecessor owned focus and should take it back.
+  const restoreFocusOnRemountRef = useRef(false);
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "t3tools-composer-editor",
@@ -1814,6 +1903,7 @@ export function ComposerPromptEditor({
           initialValueRef.current,
           initialTerminalContextsRef.current,
           initialSkillMetadataRef.current,
+          initialPlainTextRef.current,
         );
       },
       onError: (error) => {
@@ -1824,18 +1914,23 @@ export function ComposerPromptEditor({
   );
 
   return (
-    <LexicalComposer key={COMPOSER_EDITOR_HMR_KEY} initialConfig={initialConfig}>
+    <LexicalComposer
+      key={`${COMPOSER_EDITOR_HMR_KEY}-${plainText ? "plain" : "rich"}`}
+      initialConfig={initialConfig}
+    >
       <ComposerPromptEditorInner
         value={value}
         cursor={cursor}
         terminalContexts={terminalContexts}
         skills={skills}
+        plainText={plainText}
         disabled={disabled}
         placeholder={placeholder}
         onRemoveTerminalContext={onRemoveTerminalContext}
         onChange={onChange}
         onPaste={onPaste}
         editorRef={editorRef}
+        restoreFocusOnRemountRef={restoreFocusOnRemountRef}
         {...(onCommandKeyDown ? { onCommandKeyDown } : {})}
         {...(className ? { className } : {})}
       />

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1025,6 +1025,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Composer-local state
   // ------------------------------------------------------------------
+  // Pending-question answers submit plain strings, so while a question is
+  // active the editor renders raw text (no inline tokens) and the trigger
+  // menus stay closed. Mobile answers questions with a plain input for the
+  // same reason.
+  const plainAnswerMode = activePendingProgress !== null;
+  // While a question is open, promptRef tracks the answer text the editor is
+  // showing, not the draft. Draft-oriented writers (traits, stash restore)
+  // and the question-ended handoff read and write this ref instead so they
+  // never disturb the answer's caret.
+  const draftPromptRef = useRef(prompt);
   const [composerCursor, setComposerCursor] = useState(() =>
     collapseExpandedComposerCursor(prompt, prompt.length),
   );
@@ -1299,18 +1309,34 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const setPromptFromTraits = useCallback(
     (nextPrompt: string) => {
+      if (plainAnswerMode) {
+        // A trait toggle while a question is open edits the parked draft; the
+        // editor is showing the answer, so leave its caret and focus alone.
+        if (nextPrompt !== draftPromptRef.current) {
+          draftPromptRef.current = nextPrompt;
+          setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+        }
+        return;
+      }
       if (nextPrompt === promptRef.current) {
         scheduleComposerFocus();
         return;
       }
       promptRef.current = nextPrompt;
+      draftPromptRef.current = nextPrompt;
       setComposerDraftPrompt(composerDraftTarget, nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
       setComposerCursor(nextCursor);
       setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
       scheduleComposerFocus();
     },
-    [composerDraftTarget, promptRef, scheduleComposerFocus, setComposerDraftPrompt],
+    [
+      composerDraftTarget,
+      plainAnswerMode,
+      promptRef,
+      scheduleComposerFocus,
+      setComposerDraftPrompt,
+    ],
   );
 
   const providerTraitsMenuContent = renderProviderTraitsMenuContent({
@@ -1422,9 +1448,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Sync refs back to parent
   // ------------------------------------------------------------------
   useEffect(() => {
+    draftPromptRef.current = prompt;
+    // In plain answer mode the editor shows the question answer, so a draft
+    // write (trait toggle, stash restore, another device syncing the draft)
+    // must not clobber the answer text or clamp its caret against the draft.
+    // promptRef is restored from the draft when the question resolves.
+    if (plainAnswerMode) return;
     promptRef.current = prompt;
     setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
-  }, [prompt, promptRef]);
+  }, [plainAnswerMode, prompt, promptRef]);
 
   useEffect(() => {
     if (composerSubmissionError === null) return;
@@ -1488,6 +1520,33 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     composerMenuSearchKey,
   ]);
 
+  // Dismiss skill/slash menu via Esc or outside click (fixes 8128 – wedge when
+  // menu opened inside custom-answer field). Mirrors #2635 fix for @ mentions.
+  useEffect(() => {
+    if (!composerMenuOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      setComposerTrigger(null);
+      setComposerHighlightedItemId(null);
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Element | null;
+      if (!target) return;
+      if (target.closest('[data-chat-composer-form="true"]')) return;
+      if (isInsideComposerFloatingLayer(target)) return;
+      setComposerTrigger(null);
+      setComposerHighlightedItemId(null);
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("pointerdown", onPointerDown, true);
+    };
+  }, [composerMenuOpen]);
+
   const lastSyncedPendingInputRef = useRef<{
     requestId: string | null;
     questionId: string | null;
@@ -1496,7 +1555,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     const nextCustomAnswer = activePendingProgress?.customAnswer;
     if (typeof nextCustomAnswer !== "string") {
+      const pendingInputEnded = lastSyncedPendingInputRef.current !== null;
       lastSyncedPendingInputRef.current = null;
+      if (pendingInputEnded) {
+        // The question is gone; hand the composer back to the regular draft
+        // with token-aware cursor state. The draft is read from a ref instead
+        // of depending on `prompt` so draft writes while a question is open
+        // don't re-run this effect and yank the answer's caret to the end.
+        const draftPrompt = draftPromptRef.current;
+        promptRef.current = draftPrompt;
+        setComposerCursor(collapseExpandedComposerCursor(draftPrompt, draftPrompt.length));
+        setComposerTrigger(detectComposerTrigger(draftPrompt, draftPrompt.length));
+        setComposerHighlightedItemId(null);
+      }
       return;
     }
 
@@ -1517,12 +1588,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
 
     promptRef.current = nextCustomAnswer;
-    const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
-    setComposerCursor(nextCursor);
+    const nextCursorForAnswer = collapseExpandedComposerCursor(
+      nextCustomAnswer,
+      nextCustomAnswer.length,
+    );
+    setComposerCursor(nextCursorForAnswer);
     setComposerTrigger(
       detectComposerTrigger(
         nextCustomAnswer,
-        expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
+        expandCollapsedComposerCursor(nextCustomAnswer, nextCursorForAnswer),
       ),
     );
     setComposerHighlightedItemId(null);
@@ -1541,9 +1615,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setComposerSubmissionError(null);
     setProviderInputSubmissionError(null);
     setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
-    setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
+    setComposerTrigger(
+      detectComposerTrigger(
+        promptRef.current,
+        expandCollapsedComposerCursor(
+          promptRef.current,
+          collapseExpandedComposerCursor(promptRef.current, promptRef.current.length),
+        ),
+      ),
+    );
     setIsDragOverComposer(false);
-  }, [draftId, activeThreadId, promptRef]);
+  }, [draftId, activeThreadId, plainAnswerMode, promptRef]);
 
   // ------------------------------------------------------------------
   // Footer compact layout observation
@@ -1672,9 +1754,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ) => {
       if (activePendingProgress?.activeQuestion && pendingUserInputs.length > 0) {
         setComposerCursor(nextCursor);
-        setComposerTrigger(
-          cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
-        );
+        setComposerTrigger(detectComposerTrigger(nextPrompt, expandedCursor));
         onChangeActivePendingUserInputCustomAnswer(
           activePendingProgress.activeQuestion.id,
           nextPrompt,
@@ -1732,6 +1812,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       const nextCursor = collapseExpandedComposerCursor(next.text, next.cursor);
       const nextExpandedCursor = expandCollapsedComposerCursor(next.text, nextCursor);
       promptRef.current = next.text;
+      // Keep draft parked while question is open
+      if (plainAnswerMode) {
+        draftPromptRef.current = next.text;
+      }
       const activePendingQuestion = activePendingProgress?.activeQuestion;
       if (activePendingQuestion && activePendingUserInput) {
         onChangeActivePendingUserInputCustomAnswer(
@@ -2164,7 +2248,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
       setIsStashMenuOpen(false);
 
-      const currentPrompt = promptRef.current;
+      // The restore always targets the draft, which is not what promptRef
+      // holds while a question is open (the answer text is showing then).
+      const currentPrompt = draftPromptRef.current;
       // An image-only stash must not append blank lines to whatever is
       // already in the composer.
       const nextPrompt =
@@ -2175,10 +2261,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             : entry.prompt;
       const promptChanged = nextPrompt !== currentPrompt;
       if (promptChanged) {
-        promptRef.current = nextPrompt;
+        draftPromptRef.current = nextPrompt;
         setComposerDraftPrompt(composerDraftTarget, nextPrompt);
-        setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
-        setComposerTrigger(null);
+        // While a question is open the editor keeps showing the answer, so
+        // its caret must stay where the user left it.
+        if (!plainAnswerMode) {
+          promptRef.current = nextPrompt;
+          setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+          setComposerTrigger(null);
+        }
       }
 
       let unrestoredImageNames: string[] = [];
@@ -2247,7 +2338,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
       // Only yank the caret to the end when text was actually inserted;
       // restoring images alone should leave the user where they were typing.
-      if (promptChanged) {
+      if (promptChanged && !plainAnswerMode) {
         window.requestAnimationFrame(() => {
           composerEditorRef.current?.focusAtEnd();
         });
@@ -2257,6 +2348,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       addComposerDraftImages,
       composerDraftTarget,
       composerImagesRef,
+      plainAnswerMode,
       promptRef,
       setComposerDraftPrompt,
       takeStashEntry,
@@ -3400,6 +3492,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       : []
                   }
                   skills={selectedProviderStatus?.skills ?? []}
+                  plainText={false} // chip even in custom-answer (user wants chip not $text)
                   {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                   onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                   onChange={onPromptChange}


### PR DESCRIPTION
Alternative to #7818 which hides $/slash pickers in question answers. Fixes #8128 by keeping the picker usable.

- Parks draft while question open so answer caret isn't clobbered
- $br → Bro chip (not plain text), drawer closes on select
- Esc and outside-click dismiss the menu, Lexical focus loop guarded

Verified via Chrome MCP in pending and normal threads, no stack overflow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `$` skill picker usable inside question answers by adding plainText editor mode
> - Fixes a stale-content bug in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8359/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) where `pendingAnswerChange` called `focusAt` during plain text inserts, causing onChange to overwrite just-inserted text from the skill picker.
> - Adds a `plainText` mode to [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/8359/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) that disables token plugins, uses simple cursor clamping instead of token-aware mapping, and remounts the editor on mode flips while restoring focus.
> - Updates [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/8359/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to park draft prompt updates in `draftPromptRef` while a pending question is active, preventing trait updates and stash restores from clobbering the visible answer or its caret. On question resolution, the draft is restored with caret and trigger reset.
> - Adds Escape and outside-click dismissal for composer slash/skill menus.
> - Risk: `plainText` prop toggles cause a full editor remount via `LexicalComposer` key change (`'-plain'` vs `'-rich'`); verify focus restoration works across remounts in `ComposerPromptEditorInner` via `restoreFocusOnRemountRef`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized efd8141. 3 files reviewed, 4 issues evaluated, 2 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 1817](https://github.com/pingdotgg/t3code/blob/efd814139df22661bd13474abccafca8a62136c2/apps/web/src/components/ChatView.tsx#L1817): `applyPromptReplacement` overwrites `draftPromptRef.current` with the pending question answer when `plainAnswerMode` is active. Selecting a `$` skill (or another picker item) while answering therefore replaces the parked pre-question composer draft; when the question resolves, the handoff restores that answer as the normal draft instead of the user's original unsent message. <b>[ Skipped comment generation ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/chat/ChatComposer.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 1817](https://github.com/pingdotgg/t3code/blob/efd814139df22661bd13474abccafca8a62136c2/apps/web/src/components/chat/ChatComposer.tsx#L1817): `applyPromptReplacement` overwrites `draftPromptRef.current` with the pending answer whenever `plainAnswerMode` is active. Selecting a `$` skill in a question answer follows the `activePendingQuestion` branch and updates only the answer, but this assignment replaces the parked pre-question draft; when the question ends, the handoff at lines 1565-1568 restores the answer text as the composer draft and loses the user's original unsent draft. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->