### PR TITLE
fix(web): stop highlighter freezes and worker spin by using the Oniguruma WASM engine

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -37,6 +37,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../lib/syntaxHighlighting";
 import { areAllDiffFilesCollapsed, toggleAllDiffFiles } from "../lib/diffCollapse";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { useWorkspaceMutationRefresh } from "../hooks/useWorkspaceMutationRefresh";
@@ -948,6 +949,7 @@ export default function DiffPanel({
                     lineDiffType: "none",
                     overflow: wordWrap ? "wrap" : "scroll",
                     theme: resolveDiffThemeName(resolvedTheme),
+                    preferredHighlighter: PREFERRED_HIGHLIGHTER,
                     themeType: resolvedTheme as DiffThemeType,
                     stickyHeaders: true,
                     ...(loadDiffFiles ? { loadDiffFiles } : {}),

--- a/apps/web/src/components/DiffWorkerPoolProvider.tsx
+++ b/apps/web/src/components/DiffWorkerPoolProvider.tsx
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import { useEffect, useMemo, type ReactNode } from "react";
 import { useTheme } from "../hooks/useTheme";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../lib/syntaxHighlighting";
 
 export class DiffWorkerError extends Schema.TaggedErrorClass<DiffWorkerError>()("DiffWorkerError", {
   operation: Schema.Literals(["create-worker", "get-render-options", "set-render-options"]),
@@ -73,6 +74,7 @@ export function DiffWorkerPoolProvider({ children }: { children?: ReactNode }) {
       }}
       highlighterOptions={{
         theme: diffThemeName,
+        preferredHighlighter: PREFERRED_HIGHLIGHTER,
         tokenizeMaxLineLength: 1_000,
         useTokenTransformer: true,
       }}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -59,6 +59,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../../lib/syntaxHighlighting";
 import ChatMarkdown, { ChatMarkdownAssetImage } from "../ChatMarkdown";
 import {
   BotIcon,
@@ -2060,6 +2061,7 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
               collapsed: false,
               diffStyle: "unified",
               theme: resolveDiffThemeName(ctx.resolvedTheme),
+              preferredHighlighter: PREFERRED_HIGHLIGHTER,
             }}
           />
         ))}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -31,6 +31,7 @@ import { useTheme } from "~/hooks/useTheme";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
 import { useWorkspaceMutationRefresh } from "~/hooks/useWorkspaceMutationRefresh";
 import { DIFF_SURFACE_THEME_UNSAFE_CSS, resolveDiffThemeName } from "~/lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "~/lib/syntaxHighlighting";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 import { resolvePathLinkTarget } from "~/terminal-links";
@@ -755,6 +756,7 @@ function EditableFileSurface({
               onLineSelectionEnd: handleLineSelectionEnd,
               overflow: wordWrap ? "wrap" : "scroll",
               theme: resolveDiffThemeName(resolvedTheme),
+              preferredHighlighter: PREFERRED_HIGHLIGHTER,
               themeType: resolvedTheme,
               unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
               onPostRender: handlePostRender,
@@ -1149,6 +1151,7 @@ export default function FilePreviewPanel({
                     disableFileHeader: true,
                     overflow: wordWrap ? "wrap" : "scroll",
                     theme: resolveDiffThemeName(resolvedTheme),
+                    preferredHighlighter: PREFERRED_HIGHLIGHTER,
                     themeType: resolvedTheme,
                     unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
                     onPostRender: onFilePostRender,

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -42,6 +42,7 @@ import {
   resolveFileDiffPreviousPath,
   type RenderablePatch,
 } from "~/lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "~/lib/syntaxHighlighting";
 import { cn } from "~/lib/utils";
 import { createPullRequestDiffFileContentsLoader } from "~/lib/diffFileContents";
 import {
@@ -743,6 +744,7 @@ export function PullRequestCodeTab({
       lineDiffType: "none" as const,
       overflow: wordWrap ? ("wrap" as const) : ("scroll" as const),
       theme: resolveDiffThemeName(resolvedTheme),
+      preferredHighlighter: PREFERRED_HIGHLIGHTER,
       themeType: resolvedTheme,
       stickyHeaders: true,
       loadDiffFiles,

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -5,6 +5,7 @@ import { terminalThemeFromApp } from "../ThreadTerminalDrawer";
 import { useTheme } from "../../hooks/useTheme";
 import { DISCONNECTED_COMPOSER_PLACEHOLDER } from "../../composerPlaceholder";
 import { resolveDiffThemeName, type DiffThemeName } from "../../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../../lib/syntaxHighlighting";
 import { GhosttyTerminalSurface } from "~/terminal/ghostty/surface";
 
 // The font previews are the real surfaces, not lookalikes: the composer's
@@ -79,7 +80,7 @@ function loadDiffPreviewHtml(theme: DiffThemeName): Promise<readonly string[]> {
   if (promise === undefined) {
     promise = preloadPatchFile({
       patch: DIFF_PREVIEW_PATCH,
-      options: { diffStyle: "unified", theme },
+      options: { diffStyle: "unified", theme, preferredHighlighter: PREFERRED_HIGHLIGHTER },
     }).then((results) => results.map((result) => result.prerenderedHTML));
     diffPreviewHtmlByTheme.set(theme, promise);
   }

--- a/apps/web/src/lib/syntaxHighlighting.ts
+++ b/apps/web/src/lib/syntaxHighlighting.ts
@@ -1,10 +1,21 @@
 import {
   getSharedHighlighter,
   type DiffsHighlighter,
+  type HighlighterTypes,
   type SupportedLanguages,
 } from "@pierre/diffs";
 
 import { resolveDiffThemeName } from "./diffRendering";
+
+/**
+ * Always highlight with the Oniguruma WASM engine. The JavaScript regex engine
+ * can backtrack catastrophically on ordinary source lines (a Go comment
+ * containing `{}` and a non-ASCII dash pinned the renderer main thread for 12+
+ * minutes; the same input tokenizes in under 10ms on WASM). The shared
+ * highlighter is a first-caller-wins singleton, so every creation site must
+ * pass this value.
+ */
+export const PREFERRED_HIGHLIGHTER: HighlighterTypes = "shiki-wasm";
 
 const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
 
@@ -15,7 +26,7 @@ export function getSyntaxHighlighterPromise(language: string): Promise<DiffsHigh
   const promise = getSharedHighlighter({
     themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
     langs: [language as SupportedLanguages],
-    preferredHighlighter: "shiki-js",
+    preferredHighlighter: PREFERRED_HIGHLIGHTER,
   }).catch((error) => {
     if (language === "text") {
       highlighterPromiseCache.delete(language);

--- a/apps/web/src/lib/syntaxHighlighting.ts
+++ b/apps/web/src/lib/syntaxHighlighting.ts
@@ -8,10 +8,8 @@ import {
 import { resolveDiffThemeName } from "./diffRendering";
 
 /**
- * Always highlight with the Oniguruma WASM engine. The JavaScript regex engine
- * can backtrack catastrophically on ordinary source lines (a Go comment
- * containing `{}` and a non-ASCII dash pinned the renderer main thread for 12+
- * minutes; the same input tokenizes in under 10ms on WASM). The shared
+ * Always highlight with the Oniguruma WASM engine — the JS regex engine can
+ * backtrack catastrophically and hang the tokenizing thread. The shared
  * highlighter is a first-caller-wins singleton, so every creation site must
  * pass this value.
  */


### PR DESCRIPTION
Opening a large file in the file preview panel could freeze the whole window until force-quit: Shiki's JavaScript regex engine backtracks catastrophically on some ordinary source lines (repro in #8356 is a 66-char Go comment), and one catastrophic match is uninterruptible — the editor's synchronous tokenizer then pins the renderer main thread indefinitely (12+ min at ~200% CPU observed). In the read-only path the same input instead leaves the diff workers spinning forever and highlighting never renders — the symptom in #3884.

Fix: select `shiki-wasm` (Oniguruma) at every site that can create a highlighter — the shared singleton (`syntaxHighlighting.ts`, now a `PREFERRED_HIGHLIGHTER` constant), the diff worker pool, and each component options object. All must agree because the singleton is first-caller-wins and `FileRenderer.initializeHighlighter()` falls back to the library's `shiki-js` default. Same grammars and themes, so no visual change; the WASM engine loads as a lazy ~600 KB chunk (CSP already allows `'wasm-unsafe-eval'`). The repro file (476 KB, 10,915-line Go) tokenizes in 377 ms on WASM vs a >120 s hang on the JS engine. Superset of #3885, which switches only the worker pool; credit to it for the approach.

Fixes #8356. Fixes #3884 (worker spin reproduced on macOS: four DedicatedWorkers at 100% CPU each, cleared by this change).

Before (`main`): file renders with no highlighting, worker pool at ~400% CPU; the editable path freezes the tab ("Page Unresponsive"):

![before: no highlighting, workers spinning](https://raw.githubusercontent.com/LetZico/t3code/assets/highlighter-wasm-screenshots/before-prefix-no-highlighting.png)

After: same file, highlighted, UI interactive:

![after: highlighted and responsive](https://raw.githubusercontent.com/LetZico/t3code/assets/highlighter-wasm-screenshots/after-wasm-highlighted.png)

## Tests

- `pnpm -C apps/web typecheck` (tsgo) — clean
- `pnpm -C apps/web test` — 281 files, 2,859 tests pass
- `pnpm lint` — no errors, none in changed files
- `pnpm -C apps/web build` — succeeds; WASM engine emitted as lazy chunk
- A/B on two dev instances at the same base commit with the #8356 repro file: pre-fix renders unhighlighted with workers spinning (or freezes the tab via the editable path); with the fix it renders highlighted and stays interactive (screenshots above)

Built with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every syntax-highlighting and diff render path; wrong or partial rollout could leave mixed engines on the singleton, but the change is narrowly scoped to `preferredHighlighter` with no auth or data-handling impact.
> 
> **Overview**
> **Fixes main-thread freezes and diff-worker CPU spin** by standardizing on the Oniguruma WASM highlighter (`shiki-wasm`) instead of Shiki’s JS regex engine, which could hang indefinitely on some source lines.
> 
> Introduces **`PREFERRED_HIGHLIGHTER`** in `syntaxHighlighting.ts` (replacing `"shiki-js"` in `getSharedHighlighter`) and threads **`preferredHighlighter: PREFERRED_HIGHLIGHTER`** through every Pierre diffs entry point: the diff worker pool, diff panel, file preview (read-only and editable), chat turn/review diffs, PR code tab, and settings font diff preview SSR.
> 
> No intended visual change (same themes/grammars); the WASM bundle loads lazily. All sites must agree because the shared highlighter is first-caller-wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6384d96a36685a9599bfa9c6dc1f5d9c1277d87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch syntax highlighter to `shiki-wasm` to stop UI freezes
> - Adds `PREFERRED_HIGHLIGHTER = "shiki-wasm"` constant to [syntaxHighlighting.ts](https://github.com/pingdotgg/t3code/pull/8360/files#diff-6d4d3c0a7aa81a9e767dae7d3b6022e3aaae7763e19adbbcc99a51714e275f9b) to switch to the Oniguruma WASM engine.
> - Passes `preferredHighlighter: PREFERRED_HIGHLIGHTER` into file, diff, and PR code viewer options across the web app.
> - Behavioral Change: All syntax highlighting across the web app switches from the previous default engine to `shiki-wasm`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6384d96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->