### PR TITLE
fix(mobile): send on Ctrl/Cmd+Enter from a hardware keyboard on Android

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorModule.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorModule.kt
@@ -54,6 +54,7 @@ class T3ComposerEditorModule : Module() {
         "onComposerSelectionChange",
         "onComposerFocus",
         "onComposerBlur",
+        "onComposerSubmit",
         "onComposerPasteImages",
         "onComposerContentSizeChange",
       )

--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
@@ -13,6 +13,7 @@ import android.text.Spanned
 import android.text.TextWatcher
 import android.text.style.ReplacementSpan
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
@@ -31,6 +32,7 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
   private val onComposerSelectionChange by EventDispatcher()
   private val onComposerFocus by EventDispatcher()
   private val onComposerBlur by EventDispatcher()
+  private val onComposerSubmit by EventDispatcher()
   private val onComposerPasteImages by EventDispatcher()
   private val onComposerContentSizeChange by EventDispatcher()
   private var applyingNativeValue = false
@@ -64,6 +66,11 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
     }
     editor.pasteImagesListener = { uris ->
       onComposerPasteImages(mapOf("uris" to uris))
+    }
+    // A hardware keyboard has no on-screen Send button to reach for, so
+    // Ctrl/Meta+Enter is the way to send. Plain Enter still inserts a newline.
+    editor.submitListener = {
+      onComposerSubmit(emptyMap<String, Any>())
     }
     editor.setOnFocusChangeListener { _, hasFocus ->
       if (hasFocus) {
@@ -457,10 +464,28 @@ private fun parseTokens(value: String): List<ComposerToken> = try {
 private class SelectionAwareEditText(context: Context) : EditText(context) {
   var selectionListener: ((Int, Int) -> Unit)? = null
   var pasteImagesListener: ((List<String>) -> Unit)? = null
+  var submitListener: (() -> Unit)? = null
 
   override fun onSelectionChanged(selStart: Int, selEnd: Int) {
     super.onSelectionChanged(selStart, selEnd)
     selectionListener?.invoke(selStart, selEnd)
+  }
+
+  override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+    // Ctrl/Meta+Enter from a hardware keyboard sends; plain Enter falls
+    // through to the default multiline newline insertion.
+    val listener = submitListener
+    if (event != null && listener != null && isSubmitShortcut(keyCode, event)) {
+      listener.invoke()
+      return true
+    }
+    return super.onKeyDown(keyCode, event)
+  }
+
+  private fun isSubmitShortcut(keyCode: Int, event: KeyEvent): Boolean {
+    val isEnter = keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER
+    val hasSubmitModifier = event.isCtrlPressed || event.isMetaPressed
+    return isEnter && hasSubmitModifier
   }
 
   override fun onTextContextMenuItem(id: Int): Boolean {

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -74,6 +74,7 @@ interface NativeComposerEditorProps extends ViewProps {
   readonly onComposerPasteImages?: (event: NativePasteImagesEvent) => void;
   readonly onComposerFocus?: () => void;
   readonly onComposerBlur?: () => void;
+  readonly onComposerSubmit?: () => void;
 }
 
 const NativeView = requireNativeView<NativeComposerEditorProps>(NATIVE_MODULE_NAME);
@@ -98,6 +99,7 @@ export function ComposerEditor({
   onPasteImages,
   onFocus,
   onBlur,
+  onSubmit,
   contentInsetVertical = 0,
   ...props
 }: ComposerEditorProps) {
@@ -296,6 +298,7 @@ export function ComposerEditor({
         onComposerPasteImages={(event) => onPasteImages?.(event.nativeEvent.uris)}
         onComposerFocus={onFocus}
         onComposerBlur={onBlur}
+        onComposerSubmit={onSubmit}
       />
     </TextInputWrapper>
   );


### PR DESCRIPTION
## Problem

On the Android app, there is no way to send a message from a hardware (e.g. Bluetooth) keyboard. Plain **Enter** inserts a newline — correct for touch — but no modifier shortcut was wired, so tablet/phone users with a keyboard attached are stuck reaching for the on-screen Send button.

iOS already handles this: the Swift view registers a `Cmd+Enter` key command and emits an `onComposerSubmit` event, which `T3ComposerEditor.ios.tsx` forwards to the composer's `onSubmit`. The Android side never implemented `onComposerSubmit` — not in the native module, not in the view, and not in the `T3ComposerEditor.native.tsx` bridge.

## Fix

Wire the same `onComposerSubmit` path on Android, mirroring iOS:

- **`T3ComposerEditorModule.kt`** — declare the `onComposerSubmit` event.
- **`T3ComposerEditorView.kt`** — the native `EditText` now detects **Ctrl/Meta+Enter** in `onKeyDown` and emits `onComposerSubmit`; plain Enter falls through to the default multiline newline insertion.
- **`T3ComposerEditor.native.tsx`** — declare and forward `onComposerSubmit` to the composer's `onSubmit`, exactly as the iOS variant already does.

Ctrl+Enter is the Android convention (matching iOS's Cmd+Enter); Meta is accepted too for external keyboards that map a Command/Meta key.

## Surfaces

- **Android**: fixed here.
- **iOS**: already worked; unchanged.
- **Web**: mobile-web has the same gap (plain Enter never submits on a mobile viewport, no modifier fallback) — that lives in a completely separate code path (`composer-logic.ts`) and is out of scope for this PR to keep it to one concern.

## Testing

- `vp run typecheck` (mobile) — pass.
- `vp run lint:mobile` (ktlint 1.8.0 + detekt against `detekt.yml --build-upon-default-config`) — pass.
- Native Android build is not part of PR CI, so the Kotlin was verified against ktlint/detekt locally.

I don't have a device set up to capture a hardware-keyboard video; happy to add one if a maintainer can point me at the mobile e2e harness.

Done by Claude Opus 4.8 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Android composer keyboard handling with no auth, data, or shared business-logic changes; behavior aligns with existing iOS submit path.
> 
> **Overview**
> **Android composer** now matches iOS for keyboard send: hardware **Ctrl/Meta+Enter** triggers submit; plain **Enter** still inserts a newline in the multiline editor.
> 
> The Expo module declares **`onComposerSubmit`**, the native `EditText` handles the shortcut in **`onKeyDown`**, and **`T3ComposerEditor.native.tsx`** forwards it to the composer's **`onSubmit`** prop (same wiring as the iOS bridge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094a8d253bee5eaebf8384eb3e0288157b36905b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send submit event on Ctrl/Cmd+Enter from hardware keyboard on Android composer
> - Adds a `submitListener` callback to `SelectionAwareEditText` that fires on Ctrl+Enter or Meta+Enter, consuming the key event so plain Enter still inserts a newline.
> - Wires the callback through `T3ComposerEditorView` to dispatch an `onComposerSubmit` event, exported by `T3ComposerEditorModule`.
> - Forwards a new `onSubmit` prop from the `ComposerEditor` React component to the native view as `onComposerSubmit`.
> - Risk: `onKeyDown` override in `SelectionAwareEditText` consumes Ctrl/Meta+Enter before default handling; verify no other key handlers depend on receiving that event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 094a8d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->