### PR TITLE
fix(server): pnpm-global provider updates no longer leave a broken CLI

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -297,11 +297,17 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("scopedPackageTool"),
           packageName: "@example/scoped-package-tool",
           update: {
-            command: "pnpm add -g @example/scoped-package-tool@latest",
+            command:
+              "pnpm add -g --allow-build=@example/scoped-package-tool @example/scoped-package-tool@latest",
 
             executable: "pnpm",
 
-            args: ["add", "-g", "@example/scoped-package-tool@latest"],
+            args: [
+              "add",
+              "-g",
+              "--allow-build=@example/scoped-package-tool",
+              "@example/scoped-package-tool@latest",
+            ],
 
             lockKey: "pnpm-global",
           },
@@ -536,11 +542,16 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         provider: driver("packageTool"),
         packageName: "@example/package-tool",
         update: {
-          command: "pnpm add -g @example/package-tool@latest",
+          command: "pnpm add -g --allow-build=@example/package-tool @example/package-tool@latest",
 
           executable: "pnpm",
 
-          args: ["add", "-g", "@example/package-tool@latest"],
+          args: [
+            "add",
+            "-g",
+            "--allow-build=@example/package-tool",
+            "@example/package-tool@latest",
+          ],
 
           lockKey: "pnpm-global",
         },

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -171,10 +171,6 @@ function makePnpmGlobalProviderMaintenanceCapabilities(
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "pnpm",
-    // pnpm 10+ blocks install scripts by default, so a package whose
-    // postinstall finishes the install (fetching or unpacking its platform
-    // binary) is left broken while the update reports success. Allow this one
-    // package's scripts; the flag needs pnpm 10.4+.
     updateArgs: [
       "add",
       "-g",

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -171,7 +171,16 @@ function makePnpmGlobalProviderMaintenanceCapabilities(
     provider: definition.provider,
     packageName: definition.npmPackageName,
     updateExecutable: "pnpm",
-    updateArgs: ["add", "-g", `${definition.npmPackageName}@latest`],
+    // pnpm 10+ blocks install scripts by default, so a package whose
+    // postinstall finishes the install (fetching or unpacking its platform
+    // binary) is left broken while the update reports success. Allow this one
+    // package's scripts; the flag needs pnpm 10.4+.
+    updateArgs: [
+      "add",
+      "-g",
+      `--allow-build=${definition.npmPackageName}`,
+      `${definition.npmPackageName}@latest`,
+    ],
     updateLockKey: "pnpm-global",
   });
 }


### PR DESCRIPTION
## Problem

pnpm 10 and later block install scripts by default. The one-click provider update runs `pnpm add -g <package>@latest`, so for any provider whose postinstall is what finishes the install (fetching or unpacking a platform-native binary over a stub), pnpm skips that step and still exits 0. The user gets a "successful" update and a global CLI that no longer runs.

This is the pnpm counterpart of the npm path fixed in #5646, which noted the pnpm and bun paths carried the same class of exposure and deliberately left them alone.

## Fix

`makePnpmGlobalProviderMaintenanceCapabilities` now passes `--allow-build=<packageName>`, scoped to exactly the package being updated. Two existing test expectations pick up the flag. No other update path changes.

## Compatibility

Worth a reviewer's attention, because pnpm differs from npm here: pnpm rejects unknown options outright rather than warning and continuing. I confirmed on 11.10.0 that `pnpm add -g --totally-bogus-flag-xyz cowsay` exits with `[ERROR] Unknown option`, while `--allow-build=<pkg>` is accepted.

`--allow-build` landed in pnpm 10.4 (February 2025). On 10.3 and older, this turns a silent partial install into a hard failure on the update. I think a loud failure is the better outcome, and it is still recoverable by hand, but it is a real behavior change that the npm fix did not carry. Happy to version-gate instead if you would rather not raise the floor.

## Not covered

`bun i -g` gates lifecycle scripts behind a trusted-dependencies allowlist and has the same exposure. Left out to keep this to one concern.

## Verification

`apps/server/src/provider/providerMaintenance.test.ts` passes, 18/18. Lint and format clean on both touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shell command executed for in-app provider updates on pnpm installs; older pnpm versions without `--allow-build` will fail the update instead of silently skipping scripts.
> 
> **Overview**
> **Fixes one-click pnpm global provider updates** so they no longer report success while leaving a broken CLI when the package needs a postinstall/build step (pnpm 10+ blocks those by default).
> 
> `makePnpmGlobalProviderMaintenanceCapabilities` now adds a package-scoped `--allow-build=<npmPackageName>` to the generated `pnpm add -g …@latest` command and args, mirroring the existing npm `--allow-scripts` behavior. Two provider maintenance tests were updated to expect the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d8048ccda1cc422598582a4bcb4e57b58f81c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--allow-build=<package>` flag to pnpm-global provider update commands
> Updates `makePnpmGlobalProviderMaintenanceCapabilities` in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/8363/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14) to insert the package-scoped `--allow-build=<npmPackageName>` flag into `updateArgs`, placed between `-g` and `<pkg>@latest`. This prevents pnpm global updates from leaving a broken CLI after updating packages that require a build step. Test assertions in [providerMaintenance.test.ts](https://github.com/pingdotgg/t3code/pull/8363/files#diff-40e44f8465f8c4e465f1d73d81229b1ff72980f8fa6e6711363d9ef9c1fb54ad) are updated to expect the new flag and args.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71d8048.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->