### PR TITLE
perf(server): cut chatty tool-update frames by 90%

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -488,9 +488,6 @@ function toolLifecycleIdentity(activity: OrchestrationThreadActivity): string | 
  * update within the turn — a later update belongs to a subsequent call that
  * reuses the same identity and is still in flight. Rows without a lifecycle
  * identity pass through, matching the clients, which never collapse them.
- * Live `thread.activity-appended` events use the same identity in
- * `coalesceLiveToolUpdatedEvents`, but only within a short bounded window.
- *
  * Deliberate divergence from client collapse: clients fold only *adjacent*
  * lifecycle rows, so a superseded update separated from its completion by an
  * interleaved parallel call renders as its own row today, and this drop
@@ -517,7 +514,7 @@ function dropSupersededToolUpdatedActivities(
     if (!identity) {
       continue;
     }
-    const key = `${activity.turnId ?? ""} ${identity}`;
+    const key = `${activity.turnId ?? ""}\u0000${identity}`;
     const indices = completionIndicesByKey.get(key);
     if (indices) {
       indices.push(index);
@@ -537,58 +534,9 @@ function dropSupersededToolUpdatedActivities(
     if (!identity) {
       return true;
     }
-    const indices = completionIndicesByKey.get(`${activity.turnId ?? ""} ${identity}`);
+    const indices = completionIndicesByKey.get(`${activity.turnId ?? ""}\u0000${identity}`);
     return !indices?.some((completionIndex) => completionIndex > index);
   });
-}
-
-/**
- * Retain only the latest in-flight update for each tool call in a live batch.
- * A later completion also supersedes preceding updates for the same call. All
- * survivors stay in sequence order so client-side sequence dedup remains safe.
- */
-export function coalesceLiveToolUpdatedEvents(
-  events: ReadonlyArray<OrchestrationEvent>,
-): ReadonlyArray<OrchestrationEvent> {
-  const seenUpdates = new Set<string>();
-  const seenCompletions = new Set<string>();
-  const survivors: Array<OrchestrationEvent> = [];
-
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const event = events[index]!;
-    if (event.type !== "thread.activity-appended") {
-      survivors.push(event);
-      continue;
-    }
-
-    const activity = event.payload.activity;
-    if (activity.kind !== "tool.updated" && activity.kind !== "tool.completed") {
-      survivors.push(event);
-      continue;
-    }
-
-    const identity = toolLifecycleIdentity(activity);
-    if (!identity) {
-      survivors.push(event);
-      continue;
-    }
-
-    const key = `${activity.turnId ?? ""}\u0000${identity}`;
-    if (activity.kind === "tool.completed") {
-      seenCompletions.add(key);
-      survivors.push(event);
-      continue;
-    }
-
-    if (seenUpdates.has(key) || seenCompletions.has(key)) {
-      continue;
-    }
-    seenUpdates.add(key);
-    survivors.push(event);
-  }
-
-  survivors.reverse();
-  return survivors;
 }
 
 export function projectThreadDetailSnapshot(

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -488,8 +488,8 @@ function toolLifecycleIdentity(activity: OrchestrationThreadActivity): string | 
  * update within the turn — a later update belongs to a subsequent call that
  * reuses the same identity and is still in flight. Rows without a lifecycle
  * identity pass through, matching the clients, which never collapse them.
- * Live `thread.activity-appended` events are untouched: updates still stream
- * in real time and the completion supersedes them on the client as before.
+ * Live `thread.activity-appended` events use the same identity in
+ * `coalesceLiveToolUpdatedEvents`, but only within a short bounded window.
  *
  * Deliberate divergence from client collapse: clients fold only *adjacent*
  * lifecycle rows, so a superseded update separated from its completion by an
@@ -540,6 +540,55 @@ function dropSupersededToolUpdatedActivities(
     const indices = completionIndicesByKey.get(`${activity.turnId ?? ""} ${identity}`);
     return !indices?.some((completionIndex) => completionIndex > index);
   });
+}
+
+/**
+ * Retain only the latest in-flight update for each tool call in a live batch.
+ * A later completion also supersedes preceding updates for the same call. All
+ * survivors stay in sequence order so client-side sequence dedup remains safe.
+ */
+export function coalesceLiveToolUpdatedEvents(
+  events: ReadonlyArray<OrchestrationEvent>,
+): ReadonlyArray<OrchestrationEvent> {
+  const seenUpdates = new Set<string>();
+  const seenCompletions = new Set<string>();
+  const survivors: Array<OrchestrationEvent> = [];
+
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!;
+    if (event.type !== "thread.activity-appended") {
+      survivors.push(event);
+      continue;
+    }
+
+    const activity = event.payload.activity;
+    if (activity.kind !== "tool.updated" && activity.kind !== "tool.completed") {
+      survivors.push(event);
+      continue;
+    }
+
+    const identity = toolLifecycleIdentity(activity);
+    if (!identity) {
+      survivors.push(event);
+      continue;
+    }
+
+    const key = `${activity.turnId ?? ""}\u0000${identity}`;
+    if (activity.kind === "tool.completed") {
+      seenCompletions.add(key);
+      survivors.push(event);
+      continue;
+    }
+
+    if (seenUpdates.has(key) || seenCompletions.has(key)) {
+      continue;
+    }
+    seenUpdates.add(key);
+    survivors.push(event);
+  }
+
+  survivors.reverse();
+  return survivors;
 }
 
 export function projectThreadDetailSnapshot(

--- a/apps/server/src/orchestration/ThreadLiveEventCoalescer.test.ts
+++ b/apps/server/src/orchestration/ThreadLiveEventCoalescer.test.ts
@@ -1,0 +1,174 @@
+import {
+  EventId,
+  MessageId,
+  ThreadId,
+  TurnId,
+  type OrchestrationEvent,
+  type OrchestrationThreadActivity,
+} from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  coalesceLiveToolUpdatedEvents,
+  makeThreadLiveEventCoalescer,
+} from "./ThreadLiveEventCoalescer.ts";
+
+const threadId = ThreadId.make("thread-coalescer-test");
+const turnId = TurnId.make("turn-coalescer-test");
+
+function makeToolActivity(
+  sequence: number,
+  options: {
+    readonly kind?: "tool.updated" | "tool.completed";
+    readonly toolCallId?: string;
+    readonly turnId?: TurnId;
+  } = {},
+): OrchestrationEvent {
+  const {
+    kind = "tool.updated",
+    toolCallId = "call-edit",
+    turnId: activityTurnId = turnId,
+  } = options;
+  const activity: OrchestrationThreadActivity = {
+    id: EventId.make(`activity-${sequence}`),
+    tone: "tool",
+    kind,
+    summary: "Editing app.ts",
+    payload: {
+      itemType: "file_change",
+      title: "Editing app.ts",
+      data: { ...(toolCallId ? { toolCallId } : {}) },
+    },
+    turnId: activityTurnId,
+    createdAt: "2026-01-01T00:00:01.000Z",
+  };
+  return {
+    sequence,
+    eventId: EventId.make(`event-${sequence}`),
+    aggregateKind: "thread",
+    aggregateId: threadId,
+    occurredAt: "2026-01-01T00:00:01.000Z",
+    commandId: null,
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+    type: "thread.activity-appended",
+    payload: { threadId, activity },
+  };
+}
+
+function makeMessage(sequence: number): OrchestrationEvent {
+  return {
+    sequence,
+    eventId: EventId.make(`event-${sequence}`),
+    aggregateKind: "thread",
+    aggregateId: threadId,
+    occurredAt: "2026-01-01T00:00:02.000Z",
+    commandId: null,
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+    type: "thread.message-sent",
+    payload: {
+      threadId,
+      messageId: MessageId.make(`message-${sequence}`),
+      role: "assistant",
+      text: "Still working",
+      turnId,
+      streaming: false,
+      createdAt: "2026-01-01T00:00:02.000Z",
+      updatedAt: "2026-01-01T00:00:02.000Z",
+    },
+  };
+}
+
+describe("ThreadLiveEventCoalescer", () => {
+  it("coalesces only calls with a stable toolCallId", () => {
+    const events = [
+      makeToolActivity(1, { toolCallId: "call-a" }),
+      makeToolActivity(2, { toolCallId: "call-b" }),
+      makeToolActivity(3, { toolCallId: "call-a" }),
+    ];
+
+    expect(coalesceLiveToolUpdatedEvents(events).map((event) => event.sequence)).toEqual([2, 3]);
+  });
+
+  it("preserves parallel same-label calls without a stable toolCallId", () => {
+    const events = [
+      makeToolActivity(1, { toolCallId: "" }),
+      makeToolActivity(2, { toolCallId: "" }),
+      makeToolActivity(3, { kind: "tool.completed", toolCallId: "" }),
+    ];
+
+    expect(coalesceLiveToolUpdatedEvents(events).map((event) => event.sequence)).toEqual([1, 2, 3]);
+  });
+
+  it("does not coalesce stable tool calls across turns", () => {
+    const events = [
+      makeToolActivity(1, { turnId: TurnId.make("turn-old") }),
+      makeToolActivity(2, { turnId: TurnId.make("turn-new") }),
+    ];
+
+    expect(coalesceLiveToolUpdatedEvents(events).map((event) => event.sequence)).toEqual([1, 2]);
+  });
+
+  it("flushes a stable update run before a completion boundary", () => {
+    const events = [
+      makeToolActivity(1),
+      makeToolActivity(2),
+      makeToolActivity(3, { kind: "tool.completed" }),
+      makeToolActivity(4),
+    ];
+
+    expect(coalesceLiveToolUpdatedEvents(events).map((event) => event.sequence)).toEqual([2, 3, 4]);
+  });
+
+  it("flushes pending tool updates as soon as an unrelated event arrives", async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const coalescer = yield* makeThreadLiveEventCoalescer({ coalesceWindow: "500 millis" });
+          const startedAt = yield* Clock.currentTimeMillis;
+          yield* Effect.forEach(
+            Array.from({ length: 10 }, (_, index) => index + 2),
+            (sequence) =>
+              coalescer.offerAndWait({ kind: "event", event: makeToolActivity(sequence) }),
+            { discard: true },
+          );
+          yield* coalescer.offerAndWait({ kind: "event", event: makeMessage(12) });
+
+          expect(yield* Clock.currentTimeMillis).toBe(startedAt);
+          expect(
+            Array.from(yield* coalescer.takeAll).map((item) =>
+              item.kind === "event" ? item.event.sequence : item.kind,
+            ),
+          ).toEqual([11, 12]);
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    );
+  });
+
+  it("flushes pending tool updates as soon as a synchronization marker arrives", async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const coalescer = yield* makeThreadLiveEventCoalescer({ coalesceWindow: "500 millis" });
+          const startedAt = yield* Clock.currentTimeMillis;
+          yield* coalescer.offerAndWait({ kind: "event", event: makeToolActivity(2) });
+          yield* coalescer.offerAndWait({ kind: "event", event: makeToolActivity(3) });
+          yield* coalescer.offerAndWait({ kind: "synchronized" });
+
+          expect(yield* Clock.currentTimeMillis).toBe(startedAt);
+          expect(
+            Array.from(yield* coalescer.takeAll).map((item) =>
+              item.kind === "event" ? item.event.sequence : item.kind,
+            ),
+          ).toEqual([3, "synchronized"]);
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    );
+  });
+});

--- a/apps/server/src/orchestration/ThreadLiveEventCoalescer.test.ts
+++ b/apps/server/src/orchestration/ThreadLiveEventCoalescer.test.ts
@@ -6,10 +6,11 @@ import {
   type OrchestrationEvent,
   type OrchestrationThreadActivity,
 } from "@t3tools/contracts";
+import { it } from "@effect/vitest";
 import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as TestClock from "effect/testing/TestClock";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect } from "vite-plus/test";
 
 import {
   coalesceLiveToolUpdatedEvents,
@@ -40,7 +41,7 @@ function makeToolActivity(
     payload: {
       itemType: "file_change",
       title: "Editing app.ts",
-      data: { ...(toolCallId ? { toolCallId } : {}) },
+      data: toolCallId ? { toolCallId } : {},
     },
     turnId: activityTurnId,
     createdAt: "2026-01-01T00:00:01.000Z",
@@ -126,49 +127,45 @@ describe("ThreadLiveEventCoalescer", () => {
     expect(coalesceLiveToolUpdatedEvents(events).map((event) => event.sequence)).toEqual([2, 3, 4]);
   });
 
-  it("flushes pending tool updates as soon as an unrelated event arrives", async () => {
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const coalescer = yield* makeThreadLiveEventCoalescer({ coalesceWindow: "500 millis" });
-          const startedAt = yield* Clock.currentTimeMillis;
-          yield* Effect.forEach(
-            Array.from({ length: 10 }, (_, index) => index + 2),
-            (sequence) =>
-              coalescer.offerAndWait({ kind: "event", event: makeToolActivity(sequence) }),
-            { discard: true },
-          );
-          yield* coalescer.offerAndWait({ kind: "event", event: makeMessage(12) });
+  it.effect("flushes pending tool updates as soon as an unrelated event arrives", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const coalescer = yield* makeThreadLiveEventCoalescer({ coalesceWindow: "500 millis" });
+        const startedAt = yield* Clock.currentTimeMillis;
+        yield* Effect.forEach(
+          Array.from({ length: 10 }, (_, index) => index + 2),
+          (sequence) =>
+            coalescer.offerAndWait({ kind: "event", event: makeToolActivity(sequence) }),
+          { discard: true },
+        );
+        yield* coalescer.offerAndWait({ kind: "event", event: makeMessage(12) });
 
-          expect(yield* Clock.currentTimeMillis).toBe(startedAt);
-          expect(
-            Array.from(yield* coalescer.takeAll).map((item) =>
-              item.kind === "event" ? item.event.sequence : item.kind,
-            ),
-          ).toEqual([11, 12]);
-        }),
-      ).pipe(Effect.provide(TestClock.layer())),
-    );
-  });
+        expect(yield* Clock.currentTimeMillis).toBe(startedAt);
+        expect(
+          Array.from(yield* coalescer.takeAll).map((item) =>
+            item.kind === "event" ? item.event.sequence : item.kind,
+          ),
+        ).toEqual([11, 12]);
+      }),
+    ).pipe(Effect.provide(TestClock.layer())),
+  );
 
-  it("flushes pending tool updates as soon as a synchronization marker arrives", async () => {
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const coalescer = yield* makeThreadLiveEventCoalescer({ coalesceWindow: "500 millis" });
-          const startedAt = yield* Clock.currentTimeMillis;
-          yield* coalescer.offerAndWait({ kind: "event", event: makeToolActivity(2) });
-          yield* coalescer.offerAndWait({ kind: "event", event: makeToolActivity(3) });
-          yield* coalescer.offerAndWait({ kind: "synchronized" });
+  it.effect("flushes pending tool updates as soon as a synchronization marker arrives", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const coalescer = yield* makeThreadLiveEventCoalescer({ coalesceWindow: "500 millis" });
+        const startedAt = yield* Clock.currentTimeMillis;
+        yield* coalescer.offerAndWait({ kind: "event", event: makeToolActivity(2) });
+        yield* coalescer.offerAndWait({ kind: "event", event: makeToolActivity(3) });
+        yield* coalescer.offerAndWait({ kind: "synchronized" });
 
-          expect(yield* Clock.currentTimeMillis).toBe(startedAt);
-          expect(
-            Array.from(yield* coalescer.takeAll).map((item) =>
-              item.kind === "event" ? item.event.sequence : item.kind,
-            ),
-          ).toEqual([3, "synchronized"]);
-        }),
-      ).pipe(Effect.provide(TestClock.layer())),
-    );
-  });
+        expect(yield* Clock.currentTimeMillis).toBe(startedAt);
+        expect(
+          Array.from(yield* coalescer.takeAll).map((item) =>
+            item.kind === "event" ? item.event.sequence : item.kind,
+          ),
+        ).toEqual([3, "synchronized"]);
+      }),
+    ).pipe(Effect.provide(TestClock.layer())),
+  );
 });

--- a/apps/server/src/orchestration/ThreadLiveEventCoalescer.ts
+++ b/apps/server/src/orchestration/ThreadLiveEventCoalescer.ts
@@ -1,0 +1,207 @@
+import type { OrchestrationEvent, OrchestrationThreadStreamItem } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Predicate from "effect/Predicate";
+import * as Queue from "effect/Queue";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+
+import { projectActivityEvent } from "./ActivityPayloadProjection.ts";
+
+const COALESCE_WINDOW = Duration.millis(50);
+const MAX_PENDING_UPDATES = 512;
+
+export type ThreadLiveInput =
+  | { readonly kind: "event"; readonly event: OrchestrationEvent }
+  | { readonly kind: "synchronized" };
+
+function isToolUpdated(event: OrchestrationEvent): boolean {
+  return (
+    event.type === "thread.activity-appended" && event.payload.activity.kind === "tool.updated"
+  );
+}
+
+function asTrimmedString(value: unknown): string | null {
+  if (!Predicate.isString(value)) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function stableToolCallIdentity(event: OrchestrationEvent): string | null {
+  if (event.type !== "thread.activity-appended") {
+    return null;
+  }
+  const payload = event.payload.activity.payload;
+  if (!Predicate.isObject(payload)) {
+    return null;
+  }
+  const data = Predicate.isObject(payload.data) ? payload.data : null;
+  return asTrimmedString(payload.toolCallId) ?? asTrimmedString(data?.toolCallId);
+}
+
+/**
+ * Retain only the latest in-flight update for each stable tool-call id in a
+ * live run. Anonymous calls pass through because labels are not unique when
+ * tools execute in parallel. Survivors remain in sequence order.
+ */
+export function coalesceLiveToolUpdatedEvents(
+  events: ReadonlyArray<OrchestrationEvent>,
+): ReadonlyArray<OrchestrationEvent> {
+  const survivors: Array<OrchestrationEvent> = [];
+  let pendingUpdates: Array<OrchestrationEvent> = [];
+
+  const flushUpdates = () => {
+    const seen = new Set<string>();
+    const latestUpdates: Array<OrchestrationEvent> = [];
+    for (let index = pendingUpdates.length - 1; index >= 0; index -= 1) {
+      const event = pendingUpdates[index]!;
+      const identity = stableToolCallIdentity(event);
+      const activity =
+        event.type === "thread.activity-appended" ? event.payload.activity : undefined;
+      const key = identity ? `${activity?.turnId ?? ""}\u0000${identity}` : null;
+      if (key && seen.has(key)) {
+        continue;
+      }
+      if (key) {
+        seen.add(key);
+      }
+      latestUpdates.push(event);
+    }
+    latestUpdates.reverse();
+    survivors.push(...latestUpdates);
+    pendingUpdates = [];
+  };
+
+  for (const event of events) {
+    if (isToolUpdated(event)) {
+      pendingUpdates.push(event);
+      continue;
+    }
+    flushUpdates();
+    survivors.push(event);
+  }
+  flushUpdates();
+  return survivors;
+}
+
+export const makeThreadLiveEventCoalescer = Effect.fn("makeThreadLiveEventCoalescer")(
+  function* (options?: { readonly coalesceWindow?: Duration.Input }) {
+    const output = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
+    const input = yield* Queue.unbounded<{
+      readonly value: ThreadLiveInput;
+      readonly processed?: Deferred.Deferred<void>;
+    }>();
+    const mutex = yield* Semaphore.make(1);
+    const coalesceWindow = options?.coalesceWindow ?? COALESCE_WINDOW;
+    let pendingUpdates: Array<OrchestrationEvent> = [];
+    let windowGeneration = 0;
+    let windowFiber: Fiber.Fiber<void, never> | null = null;
+
+    const cancelWindow = Effect.fn("ThreadLiveEventCoalescer.cancelWindow")(function* () {
+      const fiber = windowFiber;
+      if (!fiber) {
+        return;
+      }
+      windowFiber = null;
+      yield* Fiber.interrupt(fiber);
+    });
+
+    const flushPending = Effect.fn("ThreadLiveEventCoalescer.flushPending")(function* (
+      boundary?: OrchestrationEvent,
+    ) {
+      const events = boundary ? [...pendingUpdates, boundary] : pendingUpdates;
+      pendingUpdates = [];
+      if (events.length === 0) {
+        return;
+      }
+      yield* Queue.offerAll(
+        output,
+        coalesceLiveToolUpdatedEvents(events).map((event) => ({
+          kind: "event" as const,
+          event: projectActivityEvent(event),
+        })),
+      );
+    });
+
+    const flushWindow = (generation: number) =>
+      Effect.sleep(coalesceWindow).pipe(
+        Effect.andThen(
+          mutex.withPermits(1)(
+            Effect.suspend(() => (generation === windowGeneration ? flushPending() : Effect.void)),
+          ),
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (generation === windowGeneration) {
+              windowFiber = null;
+            }
+          }),
+        ),
+      );
+
+    const process = Effect.fn("ThreadLiveEventCoalescer.process")(function* (
+      input: ThreadLiveInput,
+    ) {
+      yield* mutex.withPermits(1)(
+        Effect.gen(function* () {
+          if (input.kind === "event" && isToolUpdated(input.event)) {
+            pendingUpdates.push(input.event);
+            if (pendingUpdates.length === 1) {
+              const generation = ++windowGeneration;
+              windowFiber = yield* Effect.forkScoped(flushWindow(generation));
+            }
+            if (pendingUpdates.length >= MAX_PENDING_UPDATES) {
+              yield* cancelWindow();
+              windowGeneration += 1;
+              yield* flushPending();
+            }
+            return;
+          }
+
+          yield* cancelWindow();
+          windowGeneration += 1;
+          // A non-update event closes the run immediately. The coalescer keeps
+          // that boundary after the final update from the run.
+          if (input.kind === "event") {
+            yield* flushPending(input.event);
+          } else {
+            yield* flushPending();
+            yield* Queue.offer(output, { kind: "synchronized" });
+          }
+        }),
+      );
+    });
+
+    yield* Stream.fromQueue(input).pipe(
+      Stream.runForEach(({ value, processed }) =>
+        process(value).pipe(
+          Effect.andThen(processed ? Deferred.succeed(processed, undefined) : Effect.void),
+        ),
+      ),
+      Effect.forkScoped,
+    );
+
+    const offer = (value: ThreadLiveInput) => Queue.offer(input, { value }).pipe(Effect.asVoid);
+
+    // Synchronization callers wait for their marker to pass through the same
+    // ordered input queue before draining output produced ahead of it.
+    const offerAndWait = Effect.fn("ThreadLiveEventCoalescer.offerAndWait")(function* (
+      value: ThreadLiveInput,
+    ) {
+      const processed = yield* Deferred.make<void>();
+      yield* Queue.offer(input, { value, processed });
+      yield* Deferred.await(processed);
+    });
+
+    return {
+      offer,
+      offerAndWait,
+      stream: Stream.fromQueue(output),
+      takeAll: Queue.takeAll(output),
+    } as const;
+  },
+);

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6999,7 +6999,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
-  it.effect("preserves an interleaved message while coalescing a tool lifecycle", () =>
+  it.effect("flushes a tool update before an interleaved message", () =>
     Effect.gen(function* () {
       const thread = makeDefaultOrchestrationReadModel().threads[0]!;
       const liveEvents = yield* PubSub.unbounded<OrchestrationEvent>();
@@ -7051,7 +7051,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         withWsRpcClient(wsUrl, (client) =>
           client[ORCHESTRATION_WS_METHODS.subscribeThread]({
             threadId: defaultThreadId,
-          }).pipe(Stream.take(3), Stream.runCollect),
+          }).pipe(Stream.take(4), Stream.runCollect),
         ),
       ).pipe(Effect.timeout("2 seconds"));
 
@@ -7061,13 +7061,14 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           .slice(1)
           .map((item) => (item.kind === "event" ? [item.event.sequence, item.event.type] : null)),
         [
+          [2, "thread.activity-appended"],
           [3, "thread.message-sent"],
           [4, "thread.activity-appended"],
         ],
       );
       assert.equal(
-        items[2]?.kind === "event" && items[2].event.type === "thread.activity-appended"
-          ? items[2].event.payload.activity.kind
+        items[3]?.kind === "event" && items[3].event.type === "thread.activity-appended"
+          ? items[3].event.payload.activity.kind
           : null,
         "tool.completed",
       );

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -203,16 +203,22 @@ const defaultModelSelection = {
 const makeLiveToolActivityEvent = (
   sequence: number,
   kind: "tool.updated" | "tool.completed" = "tool.updated",
+  options: {
+    readonly toolCallId?: string;
+    readonly title?: string;
+    readonly path?: string;
+  } = {},
 ): Extract<OrchestrationEvent, { type: "thread.activity-appended" }> => {
+  const { toolCallId = "call-edit", title = "Editing app.ts", path = "src/app.ts" } = options;
   const activity: OrchestrationThreadActivity = {
     id: EventId.make(`activity-${sequence}`),
     tone: "tool",
     kind,
-    summary: "Editing app.ts",
+    summary: title,
     payload: {
       itemType: "file_change",
-      title: "Editing app.ts",
-      data: { toolCallId: "call-edit" },
+      title,
+      data: { toolCallId, path },
     },
     turnId: TurnId.make("turn-edit"),
     createdAt: "2026-01-01T00:00:01.000Z",
@@ -6923,10 +6929,16 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             getThreadDetailSnapshot: () =>
               Effect.gen(function* () {
                 yield* Effect.sleep("25 millis");
-                yield* PubSub.publishAll(
-                  liveEvents,
-                  Array.from({ length: 513 }, (_, index) => makeLiveToolActivityEvent(index + 2)),
-                );
+                yield* PubSub.publishAll(liveEvents, [
+                  ...Array.from({ length: 512 }, (_, index) =>
+                    makeLiveToolActivityEvent(index + 2),
+                  ),
+                  makeLiveToolActivityEvent(514, "tool.updated", {
+                    toolCallId: "call-read",
+                    title: "Reading server.test.ts",
+                    path: "apps/server/src/server.test.ts",
+                  }),
+                ]);
                 return Option.some({ snapshotSequence: 1, thread });
               }),
           },
@@ -6939,13 +6951,51 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           client[ORCHESTRATION_WS_METHODS.subscribeThread]({
             threadId: defaultThreadId,
             requestCompletionMarker: true,
-          }).pipe(Stream.take(3), Stream.runCollect),
+          }).pipe(Stream.take(4), Stream.runCollect),
         ),
       ).pipe(Effect.timeout("2 seconds"));
 
       assert.equal(items[0]?.kind, "snapshot");
-      assert.equal(items[1]?.kind === "event" ? items[1].event.sequence : null, 514);
-      assert.deepEqual(items[2], { kind: "synchronized" });
+      assert.deepEqual(
+        items.slice(1, 3).map((item) => {
+          assert.equal(item?.kind, "event");
+          if (item?.kind !== "event" || item.event.type !== "thread.activity-appended") {
+            return null;
+          }
+          return {
+            sequence: item.event.sequence,
+            summary: item.event.payload.activity.summary,
+            payload: item.event.payload.activity.payload,
+          };
+        }),
+        [
+          {
+            sequence: 513,
+            summary: "Editing app.ts",
+            payload: {
+              itemType: "file_change",
+              title: "Editing app.ts",
+              data: {
+                files: [{ path: "src/app.ts" }],
+                toolCallId: "call-edit",
+              },
+            },
+          },
+          {
+            sequence: 514,
+            summary: "Reading server.test.ts",
+            payload: {
+              itemType: "file_change",
+              title: "Reading server.test.ts",
+              data: {
+                files: [{ path: "apps/server/src/server.test.ts" }],
+                toolCallId: "call-read",
+              },
+            },
+          },
+        ],
+      );
+      assert.deepEqual(items[3], { kind: "synchronized" });
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -199,6 +199,38 @@ const defaultModelSelection = {
   instanceId: ProviderInstanceId.make("codex"),
   model: "gpt-5-codex",
 } as const;
+
+const makeLiveToolActivityEvent = (
+  sequence: number,
+  kind: "tool.updated" | "tool.completed" = "tool.updated",
+): Extract<OrchestrationEvent, { type: "thread.activity-appended" }> => {
+  const activity: OrchestrationThreadActivity = {
+    id: EventId.make(`activity-${sequence}`),
+    tone: "tool",
+    kind,
+    summary: "Editing app.ts",
+    payload: {
+      itemType: "file_change",
+      title: "Editing app.ts",
+      data: { toolCallId: "call-edit" },
+    },
+    turnId: TurnId.make("turn-edit"),
+    createdAt: "2026-01-01T00:00:01.000Z",
+  };
+  return {
+    sequence,
+    eventId: EventId.make(`event-tool-${sequence}`),
+    aggregateKind: "thread",
+    aggregateId: defaultThreadId,
+    occurredAt: "2026-01-01T00:00:01.000Z",
+    commandId: null,
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+    type: "thread.activity-appended",
+    payload: { threadId: defaultThreadId, activity },
+  };
+};
 const testEnvironmentDescriptor = {
   environmentId: EnvironmentId.make("environment-test"),
   label: "Test environment",
@@ -6841,34 +6873,6 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     Effect.gen(function* () {
       const thread = makeDefaultOrchestrationReadModel().threads[0]!;
       const liveEvents = yield* PubSub.unbounded<OrchestrationEvent>();
-      const makeToolUpdate = (sequence: number): OrchestrationEvent => {
-        const activity: OrchestrationThreadActivity = {
-          id: EventId.make(`activity-${sequence}`),
-          tone: "tool",
-          kind: "tool.updated",
-          summary: "Editing app.ts",
-          payload: {
-            itemType: "file_change",
-            title: "Editing app.ts",
-            data: { toolCallId: "call-edit" },
-          },
-          turnId: TurnId.make("turn-edit"),
-          createdAt: "2026-01-01T00:00:01.000Z",
-        };
-        return {
-          sequence,
-          eventId: EventId.make(`event-tool-${sequence}`),
-          aggregateKind: "thread",
-          aggregateId: defaultThreadId,
-          occurredAt: "2026-01-01T00:00:01.000Z",
-          commandId: null,
-          causationEventId: null,
-          correlationId: null,
-          metadata: {},
-          type: "thread.activity-appended",
-          payload: { threadId: defaultThreadId, activity },
-        };
-      };
 
       yield* buildAppUnderTest({
         layers: {
@@ -6880,9 +6884,9 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               Effect.gen(function* () {
                 yield* Effect.sleep("25 millis");
                 yield* PubSub.publishAll(liveEvents, [
-                  makeToolUpdate(2),
-                  makeToolUpdate(3),
-                  makeToolUpdate(4),
+                  makeLiveToolActivityEvent(2),
+                  makeLiveToolActivityEvent(3),
+                  makeLiveToolActivityEvent(4),
                 ]);
                 return Option.some({ snapshotSequence: 1, thread });
               }),
@@ -6902,6 +6906,121 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(items[0]?.kind, "snapshot");
       assert.equal(items[1]?.kind, "event");
       assert.equal(items[1]?.kind === "event" ? items[1].event.sequence : null, 4);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
+  it.effect("flushes more than one tool chunk before the synchronization marker", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      const liveEvents = yield* PubSub.unbounded<OrchestrationEvent>();
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            streamDomainEvents: Stream.fromPubSub(liveEvents),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.gen(function* () {
+                yield* Effect.sleep("25 millis");
+                yield* PubSub.publishAll(
+                  liveEvents,
+                  Array.from({ length: 513 }, (_, index) => makeLiveToolActivityEvent(index + 2)),
+                );
+                return Option.some({ snapshotSequence: 1, thread });
+              }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+            requestCompletionMarker: true,
+          }).pipe(Stream.take(3), Stream.runCollect),
+        ),
+      ).pipe(Effect.timeout("2 seconds"));
+
+      assert.equal(items[0]?.kind, "snapshot");
+      assert.equal(items[1]?.kind === "event" ? items[1].event.sequence : null, 514);
+      assert.deepEqual(items[2], { kind: "synchronized" });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
+  it.effect("preserves an interleaved message while coalescing a tool lifecycle", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      const liveEvents = yield* PubSub.unbounded<OrchestrationEvent>();
+      const messageEvent = {
+        sequence: 3,
+        eventId: EventId.make("event-interleaved-message"),
+        aggregateKind: "thread",
+        aggregateId: defaultThreadId,
+        occurredAt: "2026-01-01T00:00:02.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId: defaultThreadId,
+          messageId: MessageId.make("message-interleaved"),
+          role: "assistant",
+          text: "Still working",
+          turnId: TurnId.make("turn-edit"),
+          streaming: false,
+          createdAt: "2026-01-01T00:00:02.000Z",
+          updatedAt: "2026-01-01T00:00:02.000Z",
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            streamDomainEvents: Stream.fromPubSub(liveEvents),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.gen(function* () {
+                yield* Effect.sleep("25 millis");
+                yield* PubSub.publishAll(liveEvents, [
+                  makeLiveToolActivityEvent(2),
+                  messageEvent,
+                  makeLiveToolActivityEvent(4, "tool.completed"),
+                ]);
+                return Option.some({ snapshotSequence: 1, thread });
+              }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+          }).pipe(Stream.take(3), Stream.runCollect),
+        ),
+      ).pipe(Effect.timeout("2 seconds"));
+
+      assert.equal(items[0]?.kind, "snapshot");
+      assert.deepEqual(
+        items
+          .slice(1)
+          .map((item) => (item.kind === "event" ? [item.event.sequence, item.event.type] : null)),
+        [
+          [3, "thread.message-sent"],
+          [4, "thread.activity-appended"],
+        ],
+      );
+      assert.equal(
+        items[2]?.kind === "event" && items[2].event.type === "thread.activity-appended"
+          ? items[2].event.payload.activity.kind
+          : null,
+        "tool.completed",
+      );
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -19,6 +19,7 @@ import {
   ExternalLauncherCommandNotFoundError,
   OrchestrationThreadDetailSnapshot,
   type OrchestrationThreadStreamItem,
+  type OrchestrationThreadActivity,
   type OrchestrationThreadShell,
   TerminalNotRunningError,
   type OrchestrationCommand,
@@ -30,6 +31,7 @@ import {
   ProviderInstanceId,
   ResolvedKeybindingRule,
   ThreadId,
+  TurnId,
   WS_METHODS,
   WsRpcGroup,
   EditorId,
@@ -6832,6 +6834,74 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(items[0]?.kind, "snapshot");
       assert.equal(items[1]?.kind, "event");
       assert.equal(items[1]?.kind === "event" ? items[1].event.sequence : null, 2);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
+  it.effect("coalesces buffered live tool updates to the latest state", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      const liveEvents = yield* PubSub.unbounded<OrchestrationEvent>();
+      const makeToolUpdate = (sequence: number): OrchestrationEvent => {
+        const activity: OrchestrationThreadActivity = {
+          id: EventId.make(`activity-${sequence}`),
+          tone: "tool",
+          kind: "tool.updated",
+          summary: "Editing app.ts",
+          payload: {
+            itemType: "file_change",
+            title: "Editing app.ts",
+            data: { toolCallId: "call-edit" },
+          },
+          turnId: TurnId.make("turn-edit"),
+          createdAt: "2026-01-01T00:00:01.000Z",
+        };
+        return {
+          sequence,
+          eventId: EventId.make(`event-tool-${sequence}`),
+          aggregateKind: "thread",
+          aggregateId: defaultThreadId,
+          occurredAt: "2026-01-01T00:00:01.000Z",
+          commandId: null,
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+          type: "thread.activity-appended",
+          payload: { threadId: defaultThreadId, activity },
+        };
+      };
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            streamDomainEvents: Stream.fromPubSub(liveEvents),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.gen(function* () {
+                yield* Effect.sleep("25 millis");
+                yield* PubSub.publishAll(liveEvents, [
+                  makeToolUpdate(2),
+                  makeToolUpdate(3),
+                  makeToolUpdate(4),
+                ]);
+                return Option.some({ snapshotSequence: 1, thread });
+              }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+          }).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      ).pipe(Effect.timeout("2 seconds"));
+
+      assert.equal(items[0]?.kind, "snapshot");
+      assert.equal(items[1]?.kind, "event");
+      assert.equal(items[1]?.kind === "event" ? items[1].event.sequence : null, 4);
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -77,10 +77,10 @@ import * as EnvironmentTheme from "./environmentTheme.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import {
-  coalesceLiveToolUpdatedEvents,
   projectActivityEvent,
   projectThreadDetailSnapshot,
 } from "./orchestration/ActivityPayloadProjection.ts";
+import { makeThreadLiveEventCoalescer } from "./orchestration/ThreadLiveEventCoalescer.ts";
 import {
   cleanupFailedUploadedAttachments,
   normalizeDispatchCommand,
@@ -889,55 +889,6 @@ const makeWsRpcLayer = (
           Stream.flatMap((items) => Stream.fromIterable(items)),
         );
 
-      const THREAD_TOOL_UPDATE_COALESCE_WINDOW = Duration.millis(50);
-      const THREAD_TOOL_UPDATE_COALESCE_MAX_CHUNK = 512;
-      type ThreadLiveInput =
-        | { readonly kind: "event"; readonly event: OrchestrationEvent }
-        | { readonly kind: "synchronized" };
-
-      // Queue markers with raw events so a marker cannot overtake an update
-      // waiting in the coalescing window. Only event segments between markers
-      // are coalesced, preserving synchronization and sequence order.
-      const coalesceThreadLiveInputs = (
-        inputs: ReadonlyArray<ThreadLiveInput>,
-      ): ReadonlyArray<OrchestrationThreadStreamItem> => {
-        const output: Array<OrchestrationThreadStreamItem> = [];
-        let pendingEvents: Array<OrchestrationEvent> = [];
-
-        const flushEvents = () => {
-          output.push(
-            ...coalesceLiveToolUpdatedEvents(pendingEvents).map((event) => ({
-              kind: "event" as const,
-              event: projectActivityEvent(event),
-            })),
-          );
-          pendingEvents = [];
-        };
-
-        for (const input of inputs) {
-          if (input.kind === "event") {
-            pendingEvents.push(input.event);
-            continue;
-          }
-          flushEvents();
-          output.push({ kind: "synchronized" });
-        }
-        flushEvents();
-        return output;
-      };
-
-      const coalesceThreadLiveStream = <E, R>(
-        stream: Stream.Stream<ThreadLiveInput, E, R>,
-      ): Stream.Stream<OrchestrationThreadStreamItem, E, R> =>
-        stream.pipe(
-          Stream.groupedWithin(
-            THREAD_TOOL_UPDATE_COALESCE_MAX_CHUNK,
-            THREAD_TOOL_UPDATE_COALESCE_WINDOW,
-          ),
-          Stream.map(coalesceThreadLiveInputs),
-          Stream.flatMap((items) => Stream.fromIterable(items)),
-        );
-
       const dispatchBootstrapTurnStart = (
         command: Extract<OrchestrationCommand, { type: "thread.turn.start" }>,
       ): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> =>
@@ -1557,11 +1508,9 @@ const makeWsRpcLayer = (
 
               // Attach live delivery before reading either replay or snapshot state.
               // Otherwise an event published while the snapshot is loading is lost.
-              const liveBuffer = yield* Queue.unbounded<ThreadLiveInput>();
-              yield* Effect.forkScoped(
-                liveStream.pipe(Stream.runForEach((item) => Queue.offer(liveBuffer, item))),
-              );
-              const bufferedLiveStream = coalesceThreadLiveStream(Stream.fromQueue(liveBuffer));
+              const liveBuffer = yield* makeThreadLiveEventCoalescer();
+              yield* Effect.forkScoped(liveStream.pipe(Stream.runForEach(liveBuffer.offer)));
+              const bufferedLiveStream = liveBuffer.stream;
 
               // When the client already loaded the snapshot over HTTP it passes
               // that snapshot's sequence, and we resume the live subscription by
@@ -1610,10 +1559,9 @@ const makeWsRpcLayer = (
                     input.requestCompletionMarker === true
                       ? Stream.concat(
                           Stream.fromEffect(
-                            Queue.offer(liveBuffer, { kind: "synchronized" as const }).pipe(
-                              Effect.andThen(Queue.takeAll(liveBuffer)),
-                              Effect.map(coalesceThreadLiveInputs),
-                            ),
+                            liveBuffer
+                              .offerAndWait({ kind: "synchronized" as const })
+                              .pipe(Effect.andThen(liveBuffer.takeAll)),
                           ).pipe(Stream.flatMap((items) => Stream.fromIterable(items))),
                           bufferedLiveStream,
                         )
@@ -1655,10 +1603,9 @@ const makeWsRpcLayer = (
                 input.requestCompletionMarker === true
                   ? Stream.concat(
                       Stream.fromEffect(
-                        Queue.offer(liveBuffer, { kind: "synchronized" as const }).pipe(
-                          Effect.andThen(Queue.takeAll(liveBuffer)),
-                          Effect.map(coalesceThreadLiveInputs),
-                        ),
+                        liveBuffer
+                          .offerAndWait({ kind: "synchronized" as const })
+                          .pipe(Effect.andThen(liveBuffer.takeAll)),
                       ).pipe(Stream.flatMap((items) => Stream.fromIterable(items))),
                       bufferedLiveStream,
                     )

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -77,6 +77,7 @@ import * as EnvironmentTheme from "./environmentTheme.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import {
+  coalesceLiveToolUpdatedEvents,
   projectActivityEvent,
   projectThreadDetailSnapshot,
 } from "./orchestration/ActivityPayloadProjection.ts";
@@ -888,6 +889,55 @@ const makeWsRpcLayer = (
           Stream.flatMap((items) => Stream.fromIterable(items)),
         );
 
+      const THREAD_TOOL_UPDATE_COALESCE_WINDOW = Duration.millis(50);
+      const THREAD_TOOL_UPDATE_COALESCE_MAX_CHUNK = 512;
+      type ThreadLiveInput =
+        | { readonly kind: "event"; readonly event: OrchestrationEvent }
+        | { readonly kind: "synchronized" };
+
+      // Queue markers with raw events so a marker cannot overtake an update
+      // waiting in the coalescing window. Only event segments between markers
+      // are coalesced, preserving synchronization and sequence order.
+      const coalesceThreadLiveInputs = (
+        inputs: ReadonlyArray<ThreadLiveInput>,
+      ): ReadonlyArray<OrchestrationThreadStreamItem> => {
+        const output: Array<OrchestrationThreadStreamItem> = [];
+        let pendingEvents: Array<OrchestrationEvent> = [];
+
+        const flushEvents = () => {
+          output.push(
+            ...coalesceLiveToolUpdatedEvents(pendingEvents).map((event) => ({
+              kind: "event" as const,
+              event: projectActivityEvent(event),
+            })),
+          );
+          pendingEvents = [];
+        };
+
+        for (const input of inputs) {
+          if (input.kind === "event") {
+            pendingEvents.push(input.event);
+            continue;
+          }
+          flushEvents();
+          output.push({ kind: "synchronized" });
+        }
+        flushEvents();
+        return output;
+      };
+
+      const coalesceThreadLiveStream = <E, R>(
+        stream: Stream.Stream<ThreadLiveInput, E, R>,
+      ): Stream.Stream<OrchestrationThreadStreamItem, E, R> =>
+        stream.pipe(
+          Stream.groupedWithin(
+            THREAD_TOOL_UPDATE_COALESCE_MAX_CHUNK,
+            THREAD_TOOL_UPDATE_COALESCE_WINDOW,
+          ),
+          Stream.map(coalesceThreadLiveInputs),
+          Stream.flatMap((items) => Stream.fromIterable(items)),
+        );
+
       const dispatchBootstrapTurnStart = (
         command: Extract<OrchestrationCommand, { type: "thread.turn.start" }>,
       ): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> =>
@@ -1501,17 +1551,17 @@ const makeWsRpcLayer = (
                 Stream.filter(isThisThreadDetailEvent),
                 Stream.map((event) => ({
                   kind: "event" as const,
-                  event: projectActivityEvent(event),
+                  event,
                 })),
               );
 
               // Attach live delivery before reading either replay or snapshot state.
               // Otherwise an event published while the snapshot is loading is lost.
-              const liveBuffer = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
+              const liveBuffer = yield* Queue.unbounded<ThreadLiveInput>();
               yield* Effect.forkScoped(
                 liveStream.pipe(Stream.runForEach((item) => Queue.offer(liveBuffer, item))),
               );
-              const bufferedLiveStream = Stream.fromQueue(liveBuffer);
+              const bufferedLiveStream = coalesceThreadLiveStream(Stream.fromQueue(liveBuffer));
 
               // When the client already loaded the snapshot over HTTP it passes
               // that snapshot's sequence, and we resume the live subscription by
@@ -1560,8 +1610,11 @@ const makeWsRpcLayer = (
                     input.requestCompletionMarker === true
                       ? Stream.concat(
                           Stream.fromEffect(
-                            Queue.offer(liveBuffer, { kind: "synchronized" as const }),
-                          ).pipe(Stream.drain),
+                            Queue.offer(liveBuffer, { kind: "synchronized" as const }).pipe(
+                              Effect.andThen(Queue.takeAll(liveBuffer)),
+                              Effect.map(coalesceThreadLiveInputs),
+                            ),
+                          ).pipe(Stream.flatMap((items) => Stream.fromIterable(items))),
                           bufferedLiveStream,
                         )
                       : bufferedLiveStream;
@@ -1602,8 +1655,11 @@ const makeWsRpcLayer = (
                 input.requestCompletionMarker === true
                   ? Stream.concat(
                       Stream.fromEffect(
-                        Queue.offer(liveBuffer, { kind: "synchronized" as const }),
-                      ).pipe(Stream.drain),
+                        Queue.offer(liveBuffer, { kind: "synchronized" as const }).pipe(
+                          Effect.andThen(Queue.takeAll(liveBuffer)),
+                          Effect.map(coalesceThreadLiveInputs),
+                        ),
+                      ).pipe(Stream.flatMap((items) => Stream.fromIterable(items))),
                       bufferedLiveStream,
                     )
                   : bufferedLiveStream;

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -14,6 +14,7 @@ import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/t
 import { deriveLatestContextWindowSnapshot } from "../../web/src/lib/contextWindow.ts";
 import { deriveWorkLogEntries } from "../../web/src/session-logic.ts";
 import {
+  coalesceLiveToolUpdatedEvents,
   projectActivityEvent,
   projectActivityPayload,
   projectThreadDetailSnapshot,
@@ -330,6 +331,32 @@ describe("superseded tool.updated snapshot dedup", () => {
     }).thread.activities.map((activity) => activity.id);
   }
 
+  function makeActivityEvent(
+    sequence: number,
+    activity: OrchestrationThreadActivity,
+  ): Extract<OrchestrationEvent, { type: "thread.activity-appended" }> {
+    const threadId = ThreadId.make("thread-live-coalescing");
+    return {
+      sequence,
+      eventId: EventId.make(`event-${sequence}`),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      occurredAt: "2026-07-27T00:00:01.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.activity-appended",
+      payload: { threadId, activity },
+    };
+  }
+
+  function coalescedIds(activities: ReadonlyArray<OrchestrationThreadActivity>) {
+    return coalesceLiveToolUpdatedEvents(
+      activities.map((activity, index) => makeActivityEvent(index + 1, activity)),
+    ).map((event) => event.eventId);
+  }
+
   it("drops updates a later completion supersedes in the same turn", () => {
     const update1 = makeToolLifecycleActivity("upd-1", "tool.updated");
     const update2 = makeToolLifecycleActivity("upd-2", "tool.updated");
@@ -419,6 +446,48 @@ describe("superseded tool.updated snapshot dedup", () => {
     };
 
     expect(projectedIds([anonymous, completed])).toEqual([anonymous.id, completed.id]);
+  });
+
+  it("coalesces a live batch to the latest update per tool call", () => {
+    const firstA = makeToolLifecycleActivity("upd-a-1", "tool.updated", {
+      toolCallId: "call-a",
+    });
+    const updateB = makeToolLifecycleActivity("upd-b", "tool.updated", {
+      toolCallId: "call-b",
+    });
+    const latestA = makeToolLifecycleActivity("upd-a-2", "tool.updated", {
+      toolCallId: "call-a",
+    });
+
+    expect(coalescedIds([firstA, updateB, latestA])).toEqual([
+      EventId.make("event-2"),
+      EventId.make("event-3"),
+    ]);
+  });
+
+  it("lets a live completion supersede earlier updates without hiding a later call", () => {
+    const update = makeToolLifecycleActivity("upd-first", "tool.updated");
+    const completed = makeToolLifecycleActivity("done-first", "tool.completed");
+    const nextCall = makeToolLifecycleActivity("upd-next", "tool.updated");
+
+    expect(coalescedIds([update, completed, nextCall])).toEqual([
+      EventId.make("event-2"),
+      EventId.make("event-3"),
+    ]);
+  });
+
+  it("does not coalesce live updates across turns", () => {
+    const oldTurn = makeToolLifecycleActivity("upd-old", "tool.updated", {
+      turn: "turn-old",
+    });
+    const newTurn = makeToolLifecycleActivity("upd-new", "tool.updated", {
+      turn: "turn-new",
+    });
+
+    expect(coalescedIds([oldTurn, newTurn])).toEqual([
+      EventId.make("event-1"),
+      EventId.make("event-2"),
+    ]);
   });
 
   it("leaves the collapsed work log identical to the full history", () => {

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -1,5 +1,7 @@
 import {
+  CheckpointRef,
   EventId,
+  MessageId,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
@@ -13,6 +15,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/threadActivity.ts";
 import { deriveLatestContextWindowSnapshot } from "../../web/src/lib/contextWindow.ts";
 import { deriveWorkLogEntries } from "../../web/src/session-logic.ts";
+import { applyThreadDetailEvent } from "../../../packages/client-runtime/src/state/threadReducer.ts";
 import {
   coalesceLiveToolUpdatedEvents,
   projectActivityEvent,
@@ -488,6 +491,118 @@ describe("superseded tool.updated snapshot dedup", () => {
       EventId.make("event-1"),
       EventId.make("event-2"),
     ]);
+  });
+
+  it("keeps client state equivalent after coalescing a mixed event sequence", () => {
+    const threadId = ThreadId.make("thread-live-coalescing");
+    const turnId = TurnId.make("turn-a");
+    const update1 = makeActivityEvent(
+      1,
+      makeToolLifecycleActivity("upd-1", "tool.updated", { toolCallId: "call-a" }),
+    );
+    const sessionSet = {
+      sequence: 2,
+      eventId: EventId.make("event-session"),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      occurredAt: "2026-07-27T00:00:02.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.session-set",
+      payload: {
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "full-access",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: "2026-07-27T00:00:02.000Z",
+        },
+      },
+    } satisfies Extract<OrchestrationEvent, { type: "thread.session-set" }>;
+    const update2 = makeActivityEvent(
+      3,
+      makeToolLifecycleActivity("upd-2", "tool.updated", { toolCallId: "call-a" }),
+    );
+    const messageSent = {
+      sequence: 4,
+      eventId: EventId.make("event-message"),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      occurredAt: "2026-07-27T00:00:04.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.message-sent",
+      payload: {
+        threadId,
+        messageId: MessageId.make("message-1"),
+        role: "assistant",
+        text: "Still working",
+        turnId,
+        streaming: false,
+        createdAt: "2026-07-27T00:00:04.000Z",
+        updatedAt: "2026-07-27T00:00:04.000Z",
+      },
+    } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
+    const completed = makeActivityEvent(
+      5,
+      makeToolLifecycleActivity("done-1", "tool.completed", { toolCallId: "call-a" }),
+    );
+    const diffCompleted = {
+      sequence: 6,
+      eventId: EventId.make("event-diff"),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      occurredAt: "2026-07-27T00:00:06.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.turn-diff-completed",
+      payload: {
+        threadId,
+        turnId,
+        checkpointTurnCount: 1,
+        checkpointRef: CheckpointRef.make("checkpoint-1"),
+        status: "ready",
+        files: [{ path: "src/app.ts", kind: "modified", additions: 2, deletions: 1 }],
+        assistantMessageId: MessageId.make("message-1"),
+        completedAt: "2026-07-27T00:00:06.000Z",
+      },
+    } satisfies Extract<OrchestrationEvent, { type: "thread.turn-diff-completed" }>;
+    const events = [update1, sessionSet, update2, messageSent, completed, diffCompleted];
+    const coalesced = coalesceLiveToolUpdatedEvents(events);
+
+    const applyEvents = (input: ReadonlyArray<OrchestrationEvent>) => {
+      let thread = makeThread([]);
+      for (const event of input.map(projectActivityEvent)) {
+        const result = applyThreadDetailEvent(thread, event);
+        expect(result.kind).toBe("updated");
+        if (result.kind === "updated") {
+          thread = result.thread;
+        }
+      }
+      return thread;
+    };
+
+    const originalState = applyEvents(events);
+    const coalescedState = applyEvents(coalesced);
+
+    expect(coalesced.map((event) => event.sequence)).toEqual([2, 4, 5, 6]);
+    expect(coalescedState.messages).toEqual(originalState.messages);
+    expect(coalescedState.session).toEqual(originalState.session);
+    expect(coalescedState.checkpoints).toEqual(originalState.checkpoints);
+    expect(coalescedState.latestTurn).toEqual(originalState.latestTurn);
+    expect(deriveWorkLogEntries(coalescedState.activities)).toEqual(
+      deriveWorkLogEntries(originalState.activities),
+    );
   });
 
   it("leaves the collapsed work log identical to the full history", () => {

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -1,7 +1,5 @@
 import {
-  CheckpointRef,
   EventId,
-  MessageId,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
@@ -15,9 +13,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/threadActivity.ts";
 import { deriveLatestContextWindowSnapshot } from "../../web/src/lib/contextWindow.ts";
 import { deriveWorkLogEntries } from "../../web/src/session-logic.ts";
-import { applyThreadDetailEvent } from "../../../packages/client-runtime/src/state/threadReducer.ts";
 import {
-  coalesceLiveToolUpdatedEvents,
   projectActivityEvent,
   projectActivityPayload,
   projectThreadDetailSnapshot,
@@ -334,32 +330,6 @@ describe("superseded tool.updated snapshot dedup", () => {
     }).thread.activities.map((activity) => activity.id);
   }
 
-  function makeActivityEvent(
-    sequence: number,
-    activity: OrchestrationThreadActivity,
-  ): Extract<OrchestrationEvent, { type: "thread.activity-appended" }> {
-    const threadId = ThreadId.make("thread-live-coalescing");
-    return {
-      sequence,
-      eventId: EventId.make(`event-${sequence}`),
-      aggregateKind: "thread",
-      aggregateId: threadId,
-      occurredAt: "2026-07-27T00:00:01.000Z",
-      commandId: null,
-      causationEventId: null,
-      correlationId: null,
-      metadata: {},
-      type: "thread.activity-appended",
-      payload: { threadId, activity },
-    };
-  }
-
-  function coalescedIds(activities: ReadonlyArray<OrchestrationThreadActivity>) {
-    return coalesceLiveToolUpdatedEvents(
-      activities.map((activity, index) => makeActivityEvent(index + 1, activity)),
-    ).map((event) => event.eventId);
-  }
-
   it("drops updates a later completion supersedes in the same turn", () => {
     const update1 = makeToolLifecycleActivity("upd-1", "tool.updated");
     const update2 = makeToolLifecycleActivity("upd-2", "tool.updated");
@@ -449,160 +419,6 @@ describe("superseded tool.updated snapshot dedup", () => {
     };
 
     expect(projectedIds([anonymous, completed])).toEqual([anonymous.id, completed.id]);
-  });
-
-  it("coalesces a live batch to the latest update per tool call", () => {
-    const firstA = makeToolLifecycleActivity("upd-a-1", "tool.updated", {
-      toolCallId: "call-a",
-    });
-    const updateB = makeToolLifecycleActivity("upd-b", "tool.updated", {
-      toolCallId: "call-b",
-    });
-    const latestA = makeToolLifecycleActivity("upd-a-2", "tool.updated", {
-      toolCallId: "call-a",
-    });
-
-    expect(coalescedIds([firstA, updateB, latestA])).toEqual([
-      EventId.make("event-2"),
-      EventId.make("event-3"),
-    ]);
-  });
-
-  it("lets a live completion supersede earlier updates without hiding a later call", () => {
-    const update = makeToolLifecycleActivity("upd-first", "tool.updated");
-    const completed = makeToolLifecycleActivity("done-first", "tool.completed");
-    const nextCall = makeToolLifecycleActivity("upd-next", "tool.updated");
-
-    expect(coalescedIds([update, completed, nextCall])).toEqual([
-      EventId.make("event-2"),
-      EventId.make("event-3"),
-    ]);
-  });
-
-  it("does not coalesce live updates across turns", () => {
-    const oldTurn = makeToolLifecycleActivity("upd-old", "tool.updated", {
-      turn: "turn-old",
-    });
-    const newTurn = makeToolLifecycleActivity("upd-new", "tool.updated", {
-      turn: "turn-new",
-    });
-
-    expect(coalescedIds([oldTurn, newTurn])).toEqual([
-      EventId.make("event-1"),
-      EventId.make("event-2"),
-    ]);
-  });
-
-  it("keeps client state equivalent after coalescing a mixed event sequence", () => {
-    const threadId = ThreadId.make("thread-live-coalescing");
-    const turnId = TurnId.make("turn-a");
-    const update1 = makeActivityEvent(
-      1,
-      makeToolLifecycleActivity("upd-1", "tool.updated", { toolCallId: "call-a" }),
-    );
-    const sessionSet = {
-      sequence: 2,
-      eventId: EventId.make("event-session"),
-      aggregateKind: "thread",
-      aggregateId: threadId,
-      occurredAt: "2026-07-27T00:00:02.000Z",
-      commandId: null,
-      causationEventId: null,
-      correlationId: null,
-      metadata: {},
-      type: "thread.session-set",
-      payload: {
-        threadId,
-        session: {
-          threadId,
-          status: "running",
-          providerName: "codex",
-          providerInstanceId: ProviderInstanceId.make("codex"),
-          runtimeMode: "full-access",
-          activeTurnId: turnId,
-          lastError: null,
-          updatedAt: "2026-07-27T00:00:02.000Z",
-        },
-      },
-    } satisfies Extract<OrchestrationEvent, { type: "thread.session-set" }>;
-    const update2 = makeActivityEvent(
-      3,
-      makeToolLifecycleActivity("upd-2", "tool.updated", { toolCallId: "call-a" }),
-    );
-    const messageSent = {
-      sequence: 4,
-      eventId: EventId.make("event-message"),
-      aggregateKind: "thread",
-      aggregateId: threadId,
-      occurredAt: "2026-07-27T00:00:04.000Z",
-      commandId: null,
-      causationEventId: null,
-      correlationId: null,
-      metadata: {},
-      type: "thread.message-sent",
-      payload: {
-        threadId,
-        messageId: MessageId.make("message-1"),
-        role: "assistant",
-        text: "Still working",
-        turnId,
-        streaming: false,
-        createdAt: "2026-07-27T00:00:04.000Z",
-        updatedAt: "2026-07-27T00:00:04.000Z",
-      },
-    } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
-    const completed = makeActivityEvent(
-      5,
-      makeToolLifecycleActivity("done-1", "tool.completed", { toolCallId: "call-a" }),
-    );
-    const diffCompleted = {
-      sequence: 6,
-      eventId: EventId.make("event-diff"),
-      aggregateKind: "thread",
-      aggregateId: threadId,
-      occurredAt: "2026-07-27T00:00:06.000Z",
-      commandId: null,
-      causationEventId: null,
-      correlationId: null,
-      metadata: {},
-      type: "thread.turn-diff-completed",
-      payload: {
-        threadId,
-        turnId,
-        checkpointTurnCount: 1,
-        checkpointRef: CheckpointRef.make("checkpoint-1"),
-        status: "ready",
-        files: [{ path: "src/app.ts", kind: "modified", additions: 2, deletions: 1 }],
-        assistantMessageId: MessageId.make("message-1"),
-        completedAt: "2026-07-27T00:00:06.000Z",
-      },
-    } satisfies Extract<OrchestrationEvent, { type: "thread.turn-diff-completed" }>;
-    const events = [update1, sessionSet, update2, messageSent, completed, diffCompleted];
-    const coalesced = coalesceLiveToolUpdatedEvents(events);
-
-    const applyEvents = (input: ReadonlyArray<OrchestrationEvent>) => {
-      let thread = makeThread([]);
-      for (const event of input.map(projectActivityEvent)) {
-        const result = applyThreadDetailEvent(thread, event);
-        expect(result.kind).toBe("updated");
-        if (result.kind === "updated") {
-          thread = result.thread;
-        }
-      }
-      return thread;
-    };
-
-    const originalState = applyEvents(events);
-    const coalescedState = applyEvents(coalesced);
-
-    expect(coalesced.map((event) => event.sequence)).toEqual([2, 4, 5, 6]);
-    expect(coalescedState.messages).toEqual(originalState.messages);
-    expect(coalescedState.session).toEqual(originalState.session);
-    expect(coalescedState.checkpoints).toEqual(originalState.checkpoints);
-    expect(coalescedState.latestTurn).toEqual(originalState.latestTurn);
-    expect(deriveWorkLogEntries(coalescedState.activities)).toEqual(
-      deriveWorkLogEntries(originalState.activities),
-    );
   });
 
   it("leaves the collapsed work log identical to the full history", () => {


### PR DESCRIPTION
## What changed

The thread WebSocket stream now coalesces live `tool.updated` events in a bounded 50 ms window. It keeps the newest update per tool call, lets completion supersede preceding updates, and preserves sequence and synchronization-marker ordering.

## Why

Chatty tools can emit many updates for one call. The server previously sent every update as a separate frame even though clients ultimately render the newest state and completion. This creates avoidable remote traffic and frame processing.

## Measured impact

Compared with `main-latest.json` from main commit `230c5d4a`, using twenty deterministic updates followed by completion:

| Live tool-update burst | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| WebSocket wire | 7,155 B | 599 B | -6,556 B (-91.6%) |
| WebSocket decoded | 7,071 B | 591 B | -6,480 B (-91.6%) |
| Messages | 21 | 2 | -19 (-90.5%) |

The broader measured-turn scenario reduced live messages from 11 to 8 for both Codex and Claude. Snapshot traffic remains within 0.1% of main. Every enforced ceiling passes.

## Validation

- `vp test run apps/server/test/ActivityPayloadProjection.test.ts`, 21 tests passed
- Three focused WebSocket integration tests in `apps/server/src/server.test.ts`
- `vp exec tsgo -p apps/server/tsconfig.json --noEmit`
- Focused lint and formatting
- Deterministic transfer and tool-burst benchmark guards

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Generated with GPT-5.6 Sol through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time thread stream semantics (up to 50ms batching and fewer frames), which could affect clients or tooling that assumed immediate per-update delivery; ordering around the synchronization marker is now queue-dependent.
> 
> **Overview**
> Live `subscribeThread` WebSocket delivery now batches chatty **`tool.updated`** activity through a new **`ThreadLiveEventCoalescer`** instead of forwarding every frame immediately.
> 
> Within a contiguous run of updates, the server keeps only the **latest event per stable `toolCallId` (scoped by turn)**; calls without an id are left alone so parallel tools do not collapse. Pending updates flush on a **~50ms window**, when a **non-update event** (e.g. message or completion) arrives, when **512** pending updates pile up, or when the client’s **`synchronized`** marker is offered—`offerAndWait` ensures the marker follows any coalesced output. **`projectActivityEvent`** runs on flush, not in `ws.ts`.
> 
> **`ActivityPayloadProjection`** only tightens comments and uses an explicit `\u0000` delimiter in snapshot supersede keys. Unit and WebSocket integration tests cover coalescing, sync ordering, and interleaved messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0118f3fa288515c202f292799046e22bc3b10d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce `tool.updated` events in `subscribeThread` to cut frames by 90%
> - Adds `ThreadLiveEventCoalescer` to buffer contiguous `tool.updated` events and emit only the latest update per stable `toolCallId` (scoped by `turnId`).
> - Integrates the coalescer into [ws.ts](https://github.com/pingdotgg/t3code/pull/8368/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) `subscribeThread` handler, buffering updates up to 50ms or a hard cap of 512 pending items.
> - Flushes buffered updates immediately when non-update events or `synchronized` markers arrive.
> - Risk: Updates without a stable `toolCallId` (anonymous calls) bypass coalescing and pass through directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0118f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->