### PR TITLE
fix(server): honor the provider update opt-out when settings cannot be read

### DIFF
--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -1,6 +1,10 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ProviderDriverKind, type ServerProviderModel } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  ServerSettingsError,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
@@ -119,6 +123,25 @@ const serviceLayers = (input: {
     Layer.provideMerge(httpClientLayer(input.response)),
   );
 
+/**
+ * Settings that cannot be read at all. `getSettings` carries a typed
+ * `ServerSettingsError`, and the live implementation reaches disk and the
+ * secret store, so an unreadable secret or a corrupt settings file lands here.
+ */
+const unreadableSettingsLayer = Layer.effect(
+  ServerSettings.ServerSettingsService,
+  Effect.map(ServerSettings.ServerSettingsService, (base) => ({
+    ...base,
+    getSettings: Effect.fail(
+      new ServerSettingsError({
+        settingsPath: "/nonexistent/settings.json",
+        operation: "read-secret",
+        cause: new Error("settings unreadable"),
+      }),
+    ),
+  })),
+).pipe(Layer.provide(ServerSettings.layerTest({})));
+
 describe("ModelManifest service", () => {
   it.live("prefers a fetched manifest over the bundle and caches it to disk", () =>
     Effect.gen(function* () {
@@ -179,6 +202,35 @@ describe("ModelManifest service", () => {
           response: () => Response.json(REMOTE_MANIFEST),
           settings: { enableProviderUpdateChecks: false },
         }),
+      ),
+    ),
+  );
+
+  it.live("does not fetch when the opt-out setting cannot be read", () =>
+    Effect.gen(function* () {
+      let fetchCount = 0;
+      const service = yield* make.pipe(
+        Effect.provide(
+          httpClientLayer(() => {
+            fetchCount += 1;
+            return Response.json(REMOTE_MANIFEST);
+          }),
+        ),
+      );
+      assert.deepStrictEqual(yield* service.refresh, BUNDLED_MODEL_MANIFEST);
+      // `enableProviderUpdateChecks` is a don't-phone-home switch, so failing
+      // to read it has to resolve to not contacting the host.
+      assert.strictEqual(fetchCount, 0);
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), {
+          prefix: "model-manifest-settings-unreadable-test",
+        }).pipe(
+          Layer.provideMerge(NodeServices.layer),
+          Layer.provideMerge(unreadableSettingsLayer),
+          Layer.provideMerge(httpClientLayer(() => Response.json(REMOTE_MANIFEST))),
+        ),
       ),
     ),
   );

--- a/apps/server/src/provider/ModelManifest.ts
+++ b/apps/server/src/provider/ModelManifest.ts
@@ -185,10 +185,14 @@ export const make = Effect.gen(function* () {
     // fetches only: a manifest already cached on disk from an earlier fetch
     // stays in effect, since the setting is about phoning home, not about
     // discarding data the server already holds.
+    //
+    // Unreadable settings skip the fetch too. This is a don't-phone-home
+    // switch, so "we could not tell whether the user opted out" has to resolve
+    // to not making the request.
     const settings = yield* settingsService.getSettings.pipe(
       Effect.catchCause(() => Effect.succeed(null)),
     );
-    if (settings !== null && !settings.enableProviderUpdateChecks) return manifest;
+    if (settings === null || !settings.enableProviderUpdateChecks) return manifest;
 
     lastAttemptMs = now;
     const fetched = yield* httpClient.get(MODEL_MANIFEST_URL).pipe(


### PR DESCRIPTION
## Problem

`enableProviderUpdateChecks` is the switch that stops the server phoning home. In `ModelManifest.refresh` the guard reads:

```ts
const settings = yield* settingsService.getSettings.pipe(
  Effect.catchCause(() => Effect.succeed(null)),
);
if (settings !== null && !settings.enableProviderUpdateChecks) return manifest;
```

The `catchCause` is there so unreadable settings don't fail a refresh, and `settings !== null &&` reads naturally as a null-guard. But the condition is what gates the *early return*, so a `null` doesn't just skip the guard — it skips the opt-out. The `GET` to `raw.githubusercontent.com` then goes out for a user who explicitly turned the setting off.

This is reachable, not theoretical: `getSettings` is typed `Effect.Effect<ServerSettings, ServerSettingsError>`, and the live implementation reads through a disk-backed `Cache` and runs `materializeProviderEnvironmentSecrets`, which has its own error channel. A locked keychain or a corrupt `settings.json` is enough to land on the `null` branch.

## Fix

One line — an unreadable setting now resolves to not making the request:

```ts
if (settings === null || !settings.enableProviderUpdateChecks) return manifest;
```

Nothing else changes. The preference order (remote → disk cache → bundle), the TTL and retry window, the timeout, and the background fiber are all untouched, and a failed refresh still never fails a provider check.

## Test

Adds `does not fetch when the opt-out setting cannot be read`, mirroring the existing `does not fetch when provider update checks are disabled` case but with a `getSettings` that fails with a `ServerSettingsError` (`operation: "read-secret"`). It asserts the bundled manifest is returned and that the stubbed HTTP client was called zero times.

Verified both ways: the new test fails on `main` (the refresh fetches and returns the remote manifest) and passes with the guard inverted. The other seven cases in the file are unaffected.

No UI change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard inversion in manifest refresh with a focused regression test; reduces unintended network calls when settings are unreadable.
> 
> **Overview**
> **Model manifest refresh** no longer phones home when `getSettings` fails. Previously, `catchCause` turned read errors into `null`, and the guard only skipped the fetch when settings existed *and* opted out—so unreadable settings (corrupt file, keychain errors) still triggered a `GET` to GitHub.
> 
> The early-return condition is now **`settings === null || !settings.enableProviderUpdateChecks`**, treating “can’t read the don’t-phone-home switch” the same as opting out. TTL, disk cache, bundled fallback, and non-failing refresh behavior are unchanged.
> 
> A live test **`does not fetch when the opt-out setting cannot be read`** stubs `getSettings` with `ServerSettingsError` and asserts zero HTTP calls and the bundled manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ccfd338e2da9a5887df1fc47b74ef00823954d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip remote provider manifest fetch when settings are unreadable
> - Changes the fetch gate in `ModelManifest` `make` factory to return early when settings are `null` (unreadable) or `enableProviderUpdateChecks` is `false`, instead of only skipping when the opt-out is explicitly `false`
> - Adds an `unreadableSettingsLayer` test utility and a live test asserting `refresh()` returns the bundled manifest with zero network requests when settings cannot be read
> - Behavioral Change: `refresh()` no longer attempts a remote fetch when `ServerSettingsService.getSettings` fails; it returns the current bundled or cached manifest instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09ccfd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->