### PR TITLE
fix(server): tell the user when a repository lookup finds nothing

### DIFF
--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -292,6 +292,42 @@ describe("GitHubCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("maps a repository resolution failure to GitHubRepositoryNotFoundError", () =>
+    Effect.gen(function* () {
+      const exitError = VcsProcessExitError.fromProcessExit(
+        {
+          operation: "GitHubCli.execute",
+          command: "gh",
+          cwd: "/repo",
+          argumentCount: 5,
+        },
+        {
+          exitCode: 1,
+          stderr:
+            "GraphQL: Could not resolve to a Repository with the name 'octocat/nope'. (repository)",
+          stderrTruncated: false,
+        },
+        "repository-not-found",
+      );
+      assert.strictEqual(exitError.detail, "Repository not found.");
+      mockRun.mockReturnValueOnce(Effect.fail(exitError));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const error = yield* Effect.flip(
+        gh.getRepositoryCloneUrls({
+          cwd: "/repo",
+          repository: "octocat/nope",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitHubRepositoryNotFoundError");
+      assert.strictEqual(
+        error.detail,
+        "Repository not found. Check the owner/repo path and try again.",
+      );
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("creates repositories and parses clone URLs from create output", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -77,6 +77,19 @@ export class GitHubPullRequestNotFoundError extends Schema.TaggedErrorClass<GitH
   }
 }
 
+export class GitHubRepositoryNotFoundError extends Schema.TaggedErrorClass<GitHubRepositoryNotFoundError>()(
+  "GitHubRepositoryNotFoundError",
+  gitHubCliFailureFields,
+) {
+  get detail(): string {
+    return "Repository not found. Check the owner/repo path and try again.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in execute: ${this.detail}`;
+  }
+}
+
 export class GitHubCliCommandError extends Schema.TaggedErrorClass<GitHubCliCommandError>()(
   "GitHubCliCommandError",
   gitHubCliFailureFields,
@@ -153,6 +166,7 @@ export const GitHubCliError = Schema.Union([
   GitHubCliAuthenticationError,
   GitHubCliRateLimitError,
   GitHubPullRequestNotFoundError,
+  GitHubRepositoryNotFoundError,
   GitHubCliCommandError,
   GitHubPullRequestListDecodeError,
   GitHubChangeRequestListDecodeError,
@@ -189,6 +203,9 @@ export function fromVcsError(
     }
     if (error.failureKind === "not-found") {
       return new GitHubPullRequestNotFoundError({ ...context, cause: error });
+    }
+    if (error.failureKind === "repository-not-found") {
+      return new GitHubRepositoryNotFoundError({ ...context, cause: error });
     }
   }
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -253,6 +253,9 @@ export const make = Effect.gen(function* () {
                 input.repository,
               ),
               detail: error.detail,
+              // GitHubCliError details are compile-time constants, so they are
+              // safe to show the user in place of the generic fallback.
+              userDetail: error.detail,
               cause: error,
             }),
         ),

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -142,6 +142,7 @@ export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliComm
           case "rate-limited":
             return new GitLabCliRateLimitError({ ...context, cause });
           case "not-found":
+          case "repository-not-found":
           case "command-failed":
           case undefined:
             return new GitLabCliCommandError({ ...context, cause });

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -150,6 +150,41 @@ it.effect("preserves provider failures without deriving the repository message f
   }).pipe(Effect.provide(makeLayer({ provider })));
 });
 
+it.effect("surfaces the provider's curated user detail when one is set", () => {
+  const providerCause = new SourceControlProviderError({
+    provider: "github",
+    operation: "getRepositoryCloneUrls",
+    cwd: "/workspace",
+    repository: "octocat/nope",
+    detail: "gh stderr that stays server-side",
+    userDetail: "Repository not found. Check the owner/repo path and try again.",
+  });
+  const provider = makeProvider({
+    getRepositoryCloneUrls: () => Effect.fail(providerCause),
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+    const error = yield* Effect.flip(
+      service.lookupRepository({
+        provider: "github",
+        repository: "octocat/nope",
+        cwd: "/workspace",
+      }),
+    );
+
+    assert.strictEqual(
+      error.detail,
+      "Repository not found. Check the owner/repo path and try again.",
+    );
+    assert.strictEqual(
+      error.message,
+      "Source control repository operation lookupRepository failed for github: Repository not found. Check the owner/repo path and try again.",
+    );
+    assert.strictEqual(error.cause, providerCause);
+  }).pipe(Effect.provide(makeLayer({ provider })));
+});
+
 it.effect("clones a looked-up repository into the requested destination", () =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -7,6 +7,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import {
+  SourceControlProviderError,
   SourceControlRepositoryError,
   type SourceControlCloneRepositoryInput,
   type SourceControlCloneRepositoryResult,
@@ -23,6 +24,7 @@ import { ServerConfig } from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
+const isSourceControlProviderError = Schema.is(SourceControlProviderError);
 
 export class SourceControlRepositoryService extends Context.Service<
   SourceControlRepositoryService,
@@ -46,7 +48,12 @@ function mapRepositoryError(operation: string, provider: SourceControlProviderKi
       : new SourceControlRepositoryError({
           operation,
           provider,
-          detail: "The source control operation could not be completed.",
+          // Provider `detail` may quote provider output, so only the curated
+          // `userDetail` opt-in reaches the client; everything else stays
+          // behind the generic sentence.
+          detail:
+            (isSourceControlProviderError(cause) ? cause.userDetail : undefined) ??
+            "The source control operation could not be completed.",
           cause,
         }),
   );

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -315,3 +315,26 @@ describe("VcsProcess.run", () => {
     }).pipe(provideLive),
   );
 });
+
+describe("classifyNonZeroExit", () => {
+  it("classifies a gh repository resolution failure as repository-not-found", () => {
+    expect(
+      VcsProcess.classifyNonZeroExit(
+        "gh",
+        "GraphQL: Could not resolve to a Repository with the name 'octocat/nope'. (repository)",
+      ),
+    ).toBe("repository-not-found");
+  });
+
+  it("keeps gh pull request resolution failures as not-found", () => {
+    expect(
+      VcsProcess.classifyNonZeroExit("gh", "GraphQL: Could not resolve to a PullRequest."),
+    ).toBe("not-found");
+  });
+
+  it("does not classify repository resolution failures for other commands", () => {
+    expect(VcsProcess.classifyNonZeroExit("git", "could not resolve to a repository")).toBe(
+      "command-failed",
+    );
+  });
+});

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -53,7 +53,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 
-const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFailureKind => {
+export const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFailureKind => {
   const normalized = stderr.toLowerCase();
 
   if (
@@ -77,6 +77,10 @@ const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFai
     normalized.includes("http 429")
   ) {
     return "rate-limited";
+  }
+
+  if (command === "gh" && normalized.includes("could not resolve to a repository")) {
+    return "repository-not-found";
   }
 
   if (

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -160,6 +160,13 @@ export class SourceControlProviderError extends Schema.TaggedErrorClass<SourceCo
     repository: Schema.optional(Schema.String),
     reference: Schema.optional(Schema.String),
     detail: Schema.String,
+    /**
+     * Set only to a compile-time constant that is safe to show the user.
+     * `detail` may quote provider output and stays out of client-facing
+     * errors; `userDetail` is the adapter's explicit opt-in to surface a
+     * curated explanation instead of the generic fallback.
+     */
+    userDetail: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -76,6 +76,7 @@ export interface VcsProcessTimeoutFailure {
 export const VcsProcessExitFailureKind = Schema.Literals([
   "authentication",
   "not-found",
+  "repository-not-found",
   "rate-limited",
   "command-failed",
 ]);
@@ -137,13 +138,15 @@ export class VcsProcessExitError extends Schema.TaggedErrorClass<VcsProcessExitE
         ? "Authentication failed."
         : failureKind === "rate-limited"
           ? "API rate limit exceeded."
-          : failureKind === "not-found"
-            ? context.command === "glab"
-              ? "Merge request not found."
-              : context.command === "gh" || context.command === "az"
-                ? "Pull request not found."
-                : "VCS resource not found."
-            : "Process exited with a non-zero status.";
+          : failureKind === "repository-not-found"
+            ? "Repository not found."
+            : failureKind === "not-found"
+              ? context.command === "glab"
+                ? "Merge request not found."
+                : context.command === "gh" || context.command === "az"
+                  ? "Pull request not found."
+                  : "VCS resource not found."
+              : "Process exited with a non-zero status.";
 
     return new VcsProcessExitError({
       ...context,


### PR DESCRIPTION
Typing a repository path that does not resolve in the add-project GitHub flow showed "Source control repository operation lookupRepository failed for github: The source control operation could not be completed." The real cause, gh answering "Could not resolve to a Repository", was classified as a generic command failure, and the repository service replaces every provider detail with that generic sentence.

Three small pieces fix it end to end. VcsProcess now classifies gh's repository resolution stderr as a dedicated repository-not-found kind. GitHubCli maps that kind to a new GitHubRepositoryNotFoundError whose detail says "Repository not found. Check the owner/repo path and try again." The GitHub provider opts its compile-time constant details into a new userDetail field on SourceControlProviderError, and the repository service surfaces userDetail to the client while free-text provider detail still never reaches the wire. The toast now reads "Repository lookup failed: ... Repository not found. Check the owner/repo path and try again."

Verification: focused tests on VcsProcess (11), GitHubCli (13), SourceControlRepositoryService (10), GitLabCli (9), plus typecheck and lint for apps/server and packages/contracts.

Written by Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-mapping and user-facing messaging only; no auth, persistence, or clone/push behavior changes beyond clearer failures on lookup.
> 
> **Overview**
> When a GitHub repository path does not resolve during add-project lookup, users now see a **specific “repository not found” message** instead of the generic “source control operation could not be completed” toast.
> 
> **VCS classification:** `gh` stderr that mentions resolving a **Repository** is classified as `repository-not-found` (distinct from pull-request `not-found`). That kind maps through contracts to a short server-side detail (“Repository not found.”).
> 
> **GitHub CLI layer:** A new `GitHubRepositoryNotFoundError` carries the user-facing line: check the owner/repo path and try again.
> 
> **Safe client messaging:** `SourceControlProviderError` gains optional `userDetail` for compile-time-safe text. The GitHub provider sets `userDetail` on `getRepositoryCloneUrls` failures. `SourceControlRepositoryService` prefers `userDetail` for the repository error `detail` sent to the client; raw provider `detail` (which may echo CLI output) still does not leak when `userDetail` is omitted.
> 
> GitLab continues to fold `repository-not-found` into its generic command error—no dedicated MR/repo split there in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f179f4cb3ad6b85a280d910af398149ad4628f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface a user-safe message when repository lookup finds nothing
> - Adds a new `"repository-not-found"` literal to `VcsProcessExitFailureKind` in [vcs.ts](https://github.com/pingdotgg/t3code/pull/8371/files#diff-4c8c2b37831e8d24699e4f86f07c837774b30d7a7a97bd52322ca8b08d92b80e) and classifies `gh` exits whose stderr contains "could not resolve to a repository" as this kind in [VcsProcess.ts](https://github.com/pingdotgg/t3code/pull/8371/files#diff-42ce5a28bf0b16d9cc4fdfbca0e82279f369588e696972ab8b199fe9df69336d).
> - Maps that kind to a new `GitHubRepositoryNotFoundError` in [GitHubCli.ts](https://github.com/pingdotgg/t3code/pull/8371/files#diff-99082d06cbf76369b28a49a3e7747a4bc94426a2f0d5f8fb7edd1102a2c72df7), which carries a curated detail string.
> - Adds an optional `userDetail` field to `SourceControlProviderError` in [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/8371/files#diff-87aa564a9bfc2a49955a6cb89163c947800a5dea9614ee4458d9bdd23c9753eb), and threads it through `GitHubSourceControlProvider` and [SourceControlRepositoryService.ts](https://github.com/pingdotgg/t3code/pull/8371/files#diff-ee6247891e4a01ae6615258135b417c8454fe770eae597f3591b677b32c7aa0b) so service errors surface the provider's detail instead of a generic message.
> - Risk: `GitHubCliError` union gains a new `_tag` variant `GitHubRepositoryNotFoundError`; any out-of-tree consumers narrowing on that union need to handle the new tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33f179f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->