### PR TITLE
feat(web): setting to keep the terminal from taking focus automatically

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -48,6 +48,7 @@ const clientSettings: ClientSettings = {
   sidebarThreadSortOrder: "created_at",
   sidebarThreadPreviewCount: 6,
   legacySidebarEnabled: false,
+  terminalAutoFocus: false,
   timestampFormat: "24-hour",
   wordWrap: true,
 };

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -727,7 +727,6 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   keybindings,
   onAddTerminalContext,
 }: PersistentThreadTerminalDrawerProps) {
-  const terminalAutoFocus = useClientSettings((settings) => settings.terminalAutoFocus);
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
   const writeTerminal = useAtomCommand(terminalEnvironment.write, "terminal write");
   const closeTerminalMutation = useAtomCommand(terminalEnvironment.close, "terminal close");
@@ -1045,13 +1044,13 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         activeTerminalId={terminalUiState.activeTerminalId}
         terminalGroups={terminalUiState.terminalGroups}
         activeTerminalGroupId={terminalUiState.activeTerminalGroupId}
-        // The visible term turns thread activation and drawer reveal into a
-        // focus request; those are automatic reveals, so the terminalAutoFocus
-        // setting gates them. Action-driven bumps (localFocusRequestId and the
-        // ChatView-level requests) stay ungated.
-        focusRequestId={
-          focusRequestId + localFocusRequestId + (visible && terminalAutoFocus ? 1 : 0)
-        }
+        // Carries only explicit, action-driven focus requests. Reveal focus
+        // (thread activation, drawer open) is the viewport's own visible
+        // transition, checked against the terminalAutoFocus setting at frame
+        // time - encoding visibility or the setting into this id would turn
+        // their transitions (including async settings hydration) into spoofed
+        // requests.
+        focusRequestId={focusRequestId + localFocusRequestId}
         onSplitTerminal={splitTerminal}
         onSplitTerminalVertical={splitTerminalVertical}
         onNewTerminal={createNewTerminal}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -727,6 +727,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   keybindings,
   onAddTerminalContext,
 }: PersistentThreadTerminalDrawerProps) {
+  const terminalAutoFocus = useClientSettings((settings) => settings.terminalAutoFocus);
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
   const writeTerminal = useAtomCommand(terminalEnvironment.write, "terminal write");
   const closeTerminalMutation = useAtomCommand(terminalEnvironment.close, "terminal close");
@@ -1044,7 +1045,13 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         activeTerminalId={terminalUiState.activeTerminalId}
         terminalGroups={terminalUiState.terminalGroups}
         activeTerminalGroupId={terminalUiState.activeTerminalGroupId}
-        focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
+        // The visible term turns thread activation and drawer reveal into a
+        // focus request; those are automatic reveals, so the terminalAutoFocus
+        // setting gates them. Action-driven bumps (localFocusRequestId and the
+        // ChatView-level requests) stay ungated.
+        focusRequestId={
+          focusRequestId + localFocusRequestId + (visible && terminalAutoFocus ? 1 : 0)
+        }
         onSplitTerminal={splitTerminal}
         onSplitTerminalVertical={splitTerminalVertical}
         onNewTerminal={createNewTerminal}
@@ -1464,6 +1471,7 @@ function ChatViewContent(props: ChatViewProps) {
     useState<Record<string, number>>({});
   const shouldUseRightPanelSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
+  const terminalAutoFocus = useClientSettings((settings) => settings.terminalAutoFocus);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
   const [terminalUiLaunchContext, setTerminalUiLaunchContext] =
@@ -5059,7 +5067,12 @@ function ChatViewContent(props: ChatViewProps) {
 
     if (!previous && current) {
       terminalUiOpenByThreadRef.current[activeThreadKey] = current;
-      setTerminalFocusRequestId((value) => value + 1);
+      // Opening the drawer is an automatic reveal, so the terminalAutoFocus
+      // setting gates its focus request. Closing always returns focus to the
+      // composer below, setting or not.
+      if (terminalAutoFocus) {
+        setTerminalFocusRequestId((value) => value + 1);
+      }
       return;
     } else if (previous && !current) {
       terminalUiOpenByThreadRef.current[activeThreadKey] = current;
@@ -5072,7 +5085,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     terminalUiOpenByThreadRef.current[activeThreadKey] = current;
-  }, [activeThreadKey, focusComposer, terminalUiState.terminalOpen]);
+  }, [activeThreadKey, focusComposer, terminalAutoFocus, terminalUiState.terminalOpen]);
 
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
@@ -7226,7 +7239,11 @@ function ChatViewContent(props: ChatViewProps) {
             launchContext={
               mountedThreadKey === activeThreadKey ? (activeTerminalLaunchContext ?? null) : null
             }
-            focusRequestId={mountedThreadKey === activeThreadKey ? terminalFocusRequestId : 0}
+            // Passed unconditionally: swapping to 0 for inactive threads made
+            // the id jump on activation, which reads as a focus request. Hidden
+            // drawers cannot act on requests anyway - their viewports render
+            // with autoFocus false.
+            focusRequestId={terminalFocusRequestId}
             splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
             splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
             newShortcutLabel={newTerminalShortcutLabel ?? undefined}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -402,6 +402,11 @@ export function TerminalViewport({
       terminal: settings.fontSizeTerminal,
     }),
   );
+  const terminalAutoFocus = useClientSettings((settings) => settings.terminalAutoFocus);
+  // Every automatic focus path gates on this; a click still focuses the
+  // terminal directly, so turning the setting off keeps focus wherever the
+  // user left it (usually the composer, so thread shortcuts keep working).
+  const shouldAutoFocus = autoFocus && terminalAutoFocus;
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
   const terminalSession = useAttachedTerminalSession({
     environmentId,
@@ -526,7 +531,7 @@ export function TerminalViewport({
       // never started, so only "exited" triggers the message — as with xterm.)
       synchronizedStatusRef.current = "closed";
       synchronizeTerminalStatus(terminal, latestSession.status);
-      if (autoFocus) window.requestAnimationFrame(() => terminal.focus());
+      if (shouldAutoFocus) window.requestAnimationFrame(() => terminal.focus());
 
       const clearSelectionAction = () => {
         selectionActionRequestIdRef.current += 1;
@@ -903,7 +908,7 @@ export function TerminalViewport({
       cancelled = true;
       teardown?.();
     };
-    // autoFocus is intentionally omitted;
+    // shouldAutoFocus is intentionally omitted;
     // it is only read at mount time and must not trigger terminal teardown/recreation.
   }, [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath]);
 
@@ -940,16 +945,16 @@ export function TerminalViewport({
       writeSystemMessage(terminal, current.error);
     }
 
-    if (previous.version === 0 && autoFocus) {
+    if (previous.version === 0 && shouldAutoFocus) {
       window.requestAnimationFrame(() => {
         terminal.focus();
       });
     }
     previousSessionRef.current = current;
-  }, [autoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
+  }, [shouldAutoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
 
   useEffect(() => {
-    if (!autoFocus) return;
+    if (!shouldAutoFocus) return;
     const terminal = terminalRef.current;
     if (!terminal) return;
     const frame = window.requestAnimationFrame(() => {
@@ -958,7 +963,7 @@ export function TerminalViewport({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [autoFocus, focusRequestId]);
+  }, [shouldAutoFocus, focusRequestId]);
 
   useEffect(() => {
     const terminal = terminalRef.current;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -324,6 +324,7 @@ interface TerminalViewportProps {
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   focusRequestId: number;
   autoFocus: boolean;
+  mountFocusPending: boolean;
   resizeEpoch: number;
   drawerHeight: number;
   keybindings: ResolvedKeybindingsConfig;
@@ -348,6 +349,7 @@ export function TerminalViewport({
   onAddTerminalContext,
   focusRequestId,
   autoFocus,
+  mountFocusPending,
   resizeEpoch,
   drawerHeight,
   keybindings,
@@ -403,10 +405,27 @@ export function TerminalViewport({
     }),
   );
   const terminalAutoFocus = useClientSettings((settings) => settings.terminalAutoFocus);
-  // Every automatic focus path gates on this; a click still focuses the
-  // terminal directly, so turning the setting off keeps focus wherever the
-  // user left it (usually the composer, so thread shortcuts keep working).
+  // Automatic focus (surface ready, first output) honors the terminalAutoFocus
+  // setting; explicit focus requests honor only autoFocus, so terminal actions
+  // keep working with the setting off. A click still focuses the terminal
+  // directly either way.
   const shouldAutoFocus = autoFocus && terminalAutoFocus;
+  // Captured once at mount and consumed by the first focus it grants: a
+  // viewport mounted by the same render as an explicit focus request (the
+  // single-terminal view remounts on create/close/activate) must focus once
+  // ready even when terminalAutoFocus is off, otherwise focus falls to
+  // document.body when the previously focused viewport unmounts.
+  const mountFocusPendingRef = useRef(mountFocusPending);
+  const latestFocusRequestIdRef = useRef(focusRequestId);
+  // Effect event so queued focus callbacks read the live values at frame
+  // time: settings hydrate asynchronously after mount, and a toggle between
+  // scheduling and firing must win over the captured render.
+  const focusTerminalIfPermitted = useEffectEvent((terminal: GhosttyTerminalSurface) => {
+    if (shouldAutoFocus || (autoFocus && mountFocusPendingRef.current)) {
+      terminal.focus();
+      mountFocusPendingRef.current = false;
+    }
+  });
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
   const terminalSession = useAttachedTerminalSession({
     environmentId,
@@ -531,7 +550,8 @@ export function TerminalViewport({
       // never started, so only "exited" triggers the message — as with xterm.)
       synchronizedStatusRef.current = "closed";
       synchronizeTerminalStatus(terminal, latestSession.status);
-      if (shouldAutoFocus) window.requestAnimationFrame(() => terminal.focus());
+      const focusFrame = window.requestAnimationFrame(() => focusTerminalIfPermitted(terminal));
+      setupCleanups.push(() => window.cancelAnimationFrame(focusFrame));
 
       const clearSelectionAction = () => {
         selectionActionRequestIdRef.current += 1;
@@ -908,8 +928,9 @@ export function TerminalViewport({
       cancelled = true;
       teardown?.();
     };
-    // shouldAutoFocus is intentionally omitted;
-    // it is only read at mount time and must not trigger terminal teardown/recreation.
+    // Focus permission is intentionally not a dependency: it is checked at
+    // frame time inside focusTerminalIfPermitted, and changing it must not
+    // trigger terminal teardown/recreation.
   }, [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath]);
 
   useEffect(() => {
@@ -945,16 +966,29 @@ export function TerminalViewport({
       writeSystemMessage(terminal, current.error);
     }
 
-    if (previous.version === 0 && shouldAutoFocus) {
+    if (previous.version === 0) {
+      // No cancel on cleanup here: this effect re-runs on every buffer
+      // update, and cancelling would drop a legitimate first-output focus
+      // when a second write lands within the same frame. The frame-time
+      // permission check makes a stale grant impossible instead.
       window.requestAnimationFrame(() => {
-        terminal.focus();
+        focusTerminalIfPermitted(terminal);
       });
     }
     previousSessionRef.current = current;
-  }, [shouldAutoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
+  }, [terminalBuffer, terminalError, terminalStatus, terminalVersion]);
 
   useEffect(() => {
-    if (!shouldAutoFocus) return;
+    const previous = latestFocusRequestIdRef.current;
+    latestFocusRequestIdRef.current = focusRequestId;
+    // Explicit focus requests (terminal create/split/close/tab activation)
+    // are honored regardless of the terminalAutoFocus setting: suppressing
+    // them would drop keyboard focus on document.body when the previously
+    // focused viewport unmounts. Only an actual request may focus, so runs
+    // without a changed id (mount, autoFocus flips on reveal) bail out;
+    // those transitions belong to the gated automatic paths.
+    if (focusRequestId === previous) return;
+    if (!autoFocus) return;
     const terminal = terminalRef.current;
     if (!terminal) return;
     const frame = window.requestAnimationFrame(() => {
@@ -963,7 +997,7 @@ export function TerminalViewport({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [shouldAutoFocus, focusRequestId]);
+  }, [autoFocus, focusRequestId]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -1080,6 +1114,16 @@ export default function ThreadTerminalDrawer({
   terminalLaunchLocationsById,
 }: ThreadTerminalDrawerProps) {
   const isPanel = mode === "panel";
+  // True exactly on renders carrying a new focus request. A viewport mounted
+  // by such a render (the single-terminal view remounts on create/close/
+  // activate) captures it so the request survives the remount: the new
+  // viewport's focusRequestId effect cannot act on the change because its
+  // terminal surface is not ready yet.
+  const previousFocusRequestIdRef = useRef(focusRequestId);
+  const mountFocusPending = focusRequestId !== previousFocusRequestIdRef.current;
+  useEffect(() => {
+    previousFocusRequestIdRef.current = focusRequestId;
+  }, [focusRequestId]);
   const [advancedTypography] = useLocalStorage(
     TYPOGRAPHY_ADVANCED_STORAGE_KEY,
     false,
@@ -1546,7 +1590,8 @@ export default function ThreadTerminalDrawer({
                           onSessionExited={() => onCloseTerminal(terminalId)}
                           onAddTerminalContext={onAddTerminalContext}
                           focusRequestId={focusRequestId}
-                          autoFocus={terminalId === resolvedActiveTerminalId}
+                          autoFocus={visible && terminalId === resolvedActiveTerminalId}
+                          mountFocusPending={mountFocusPending}
                           resizeEpoch={resizeEpoch}
                           drawerHeight={drawerHeight}
                           keybindings={keybindings}
@@ -1575,7 +1620,8 @@ export default function ThreadTerminalDrawer({
                   onSessionExited={() => onCloseTerminal(resolvedActiveTerminalId)}
                   onAddTerminalContext={onAddTerminalContext}
                   focusRequestId={focusRequestId}
-                  autoFocus
+                  autoFocus={visible}
+                  mountFocusPending={mountFocusPending}
                   resizeEpoch={resizeEpoch}
                   drawerHeight={drawerHeight}
                   keybindings={keybindings}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -553,7 +553,12 @@ export function TerminalViewport({
       // never started, so only "exited" triggers the message — as with xterm.)
       synchronizedStatusRef.current = "closed";
       synchronizeTerminalStatus(terminal, latestSession.status);
-      const focusFrame = window.requestAnimationFrame(() => focusTerminalIfPermitted(terminal));
+      const focusFrame = window.requestAnimationFrame(() => {
+        focusTerminalIfPermitted(terminal);
+        // The mount-time grant covers only this first ready frame; keeping it
+        // alive would let a later automatic reveal spend it with the setting off.
+        mountFocusPendingRef.current = false;
+      });
       setupCleanups.push(() => window.cancelAnimationFrame(focusFrame));
 
       const clearSelectionAction = () => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -324,6 +324,7 @@ interface TerminalViewportProps {
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   focusRequestId: number;
   autoFocus: boolean;
+  visible: boolean;
   mountFocusPending: boolean;
   resizeEpoch: number;
   drawerHeight: number;
@@ -349,6 +350,7 @@ export function TerminalViewport({
   onAddTerminalContext,
   focusRequestId,
   autoFocus,
+  visible,
   mountFocusPending,
   resizeEpoch,
   drawerHeight,
@@ -417,6 +419,7 @@ export function TerminalViewport({
   // document.body when the previously focused viewport unmounts.
   const mountFocusPendingRef = useRef(mountFocusPending);
   const latestFocusRequestIdRef = useRef(focusRequestId);
+  const previousVisibleRef = useRef(visible);
   // Effect event so queued focus callbacks read the live values at frame
   // time: settings hydrate asynchronously after mount, and a toggle between
   // scheduling and firing must win over the captured render.
@@ -998,6 +1001,24 @@ export function TerminalViewport({
       window.cancelAnimationFrame(frame);
     };
   }, [autoFocus, focusRequestId]);
+
+  useEffect(() => {
+    const wasVisible = previousVisibleRef.current;
+    previousVisibleRef.current = visible;
+    // Reveal focus (thread activation, drawer open) is the automatic channel:
+    // it acts only on a hidden-to-visible transition, and the frame-time
+    // permission check honors the terminalAutoFocus setting. Mount-time focus
+    // belongs to the surface setup path (the terminal is not ready here yet).
+    if (wasVisible || !visible) return;
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const frame = window.requestAnimationFrame(() => {
+      focusTerminalIfPermitted(terminal);
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [visible]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -1591,6 +1612,7 @@ export default function ThreadTerminalDrawer({
                           onAddTerminalContext={onAddTerminalContext}
                           focusRequestId={focusRequestId}
                           autoFocus={visible && terminalId === resolvedActiveTerminalId}
+                          visible={visible}
                           mountFocusPending={mountFocusPending}
                           resizeEpoch={resizeEpoch}
                           drawerHeight={drawerHeight}
@@ -1621,6 +1643,7 @@ export default function ThreadTerminalDrawer({
                   onAddTerminalContext={onAddTerminalContext}
                   focusRequestId={focusRequestId}
                   autoFocus={visible}
+                  visible={visible}
                   mountFocusPending={mountFocusPending}
                   resizeEpoch={resizeEpoch}
                   drawerHeight={drawerHeight}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2327,7 +2327,7 @@ export function GeneralSettingsPanel() {
 
         <SettingsRow
           {...searchableSetting("terminal-auto-focus")}
-          description="Move focus into the terminal when it opens and when you switch to a thread whose terminal is open. When off, the terminal only takes focus when you click it."
+          description="Move focus into the terminal when it opens and when you switch to a thread whose terminal is open. When off, the terminal only takes focus when you interact with it directly, like clicking it or creating a terminal."
           resetAction={
             settings.terminalAutoFocus !== DEFAULT_UNIFIED_SETTINGS.terminalAutoFocus ? (
               <SettingResetButton

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -529,6 +529,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
+      ...(settings.terminalAutoFocus !== DEFAULT_UNIFIED_SETTINGS.terminalAutoFocus
+        ? ["Terminal auto-focus"]
+        : []),
       ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
         ? ["Archive confirmation"]
         : []),
@@ -557,6 +560,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.terminalAutoFocus,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -668,6 +672,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+      terminalAutoFocus: DEFAULT_UNIFIED_SETTINGS.terminalAutoFocus,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit,
@@ -2316,6 +2321,30 @@ export function GeneralSettingsPanel() {
               placeholder="~/"
               spellCheck={false}
               aria-label="Add project base directory"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("terminal-auto-focus")}
+          description="Move focus into the terminal when it opens and when you switch to a thread whose terminal is open. When off, the terminal only takes focus when you click it."
+          resetAction={
+            settings.terminalAutoFocus !== DEFAULT_UNIFIED_SETTINGS.terminalAutoFocus ? (
+              <SettingResetButton
+                label="terminal auto-focus"
+                onClick={() =>
+                  updateSettings({
+                    terminalAutoFocus: DEFAULT_UNIFIED_SETTINGS.terminalAutoFocus,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.terminalAutoFocus}
+              onCheckedChange={(checked) => updateSettings({ terminalAutoFocus: Boolean(checked) })}
+              aria-label="Terminal auto-focus"
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -158,6 +158,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "terminal-auto-focus",
+    title: "Terminal auto-focus",
+    to: "/settings/general",
+  },
+  {
     id: "archive-confirmation",
     title: "Archive confirmation",
     to: "/settings/general",

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -251,6 +251,11 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
   ),
+  // Whether the embedded terminal takes keyboard focus on its own: when it
+  // opens, and when switching to a thread whose terminal is open. Off keeps
+  // focus in the chat composer (thread navigation shortcuts keep working);
+  // clicking the terminal still focuses it.
+  terminalAutoFocus: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
@@ -950,6 +955,7 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
+  terminalAutoFocus: Schema.optionalKey(Schema.Boolean),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   wordWrap: Schema.optionalKey(Schema.Boolean),
 });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -254,7 +254,8 @@ export const ClientSettingsSchema = Schema.Struct({
   // Whether the embedded terminal takes keyboard focus on its own: when it
   // opens, and when switching to a thread whose terminal is open. Off keeps
   // focus in the chat composer (thread navigation shortcuts keep working);
-  // clicking the terminal still focuses it.
+  // direct interaction - clicking the terminal, or creating/activating one
+  // from its own UI - still focuses it.
   terminalAutoFocus: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),


### PR DESCRIPTION
## What Changed

A new client setting: Settings → General → "Terminal auto-focus" (`terminalAutoFocus`, default on, so behavior is unchanged for existing users). When off, the embedded terminal never takes keyboard focus on its own: not when you switch to a thread whose terminal is open, and not when the drawer opens. Direct interaction still focuses it: clicking into the terminal, and terminal actions such as creating, splitting, closing, or activating one.

The gating splits automatic focus from explicit focus requests (refined per the review feedback below). Automatic paths honor the setting: the surface-ready and first-output focus in `TerminalViewport`, its reveal effect on the hidden-to-visible transition (thread activation, drawer open), and the drawer-open request bump in `ChatView`. The focus-request id carries only explicit actions - encoding visibility or the setting into it would turn their transitions, including async settings hydration, into spoofed requests. Action-driven focus requests (terminal create/split/close/tab activation) always focus, so terminal actions cannot drop keyboard focus on `document.body`. Two supporting changes make the split sound: the focus-request id is now passed to persistent drawers unconditionally (the previous swap-to-0 made thread activation itself look like a request), and a viewport mounted by the same render as a request (the single-terminal view remounts on create/close/activate) carries it across the remount via a mount-captured flag. Focus permission is checked at frame time through an effect event, so a setting that hydrates or toggles after scheduling wins over the captured render. Both terminal surfaces (bottom drawer and right-panel terminal) render through `TerminalViewport`, so both respect the setting. The row is searchable, has a reset button, and participates in restore-defaults.

## Why

Switching threads with `thread.next` / `thread.previous` (⌘⇧] / ⌘⇧[) or `thread.jump.N` drops focus into the terminal whenever the target thread has one open. Once the Ghostty surface has focus it owns keystrokes: `keybindings.ts` already documents that the jump commands cannot run there regardless of `when` clauses, and the jump hints are deliberately hidden while `terminalFocus` for the same reason. So keyboard-driven thread navigation dead-ends on the first thread with an open terminal, and every jump costs an extra ⌘J or a click to get focus back.

This is a setting rather than a behavior change because auto-focus is the right default for people who open a terminal to type into it. Keyboard-heavy users who mostly watch agent terminals can opt out and keep focus in the composer.

## UI Changes

One standard `SettingsRow` + `Switch` in Settings → General, placed with the other interaction-behavior rows and reusing the archive/delete-confirmation row pattern verbatim. Happy to attach before/after screenshots if wanted.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (single stock SettingsRow/Switch; can add on request)
- [ ] I included a video for animation/interaction changes (no motion involved)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Terminal focus is intricate keyboard UX; regressions could break thread navigation or terminal shortcuts, though the default preserves prior auto-focus behavior.
> 
> **Overview**
> Adds a **Terminal auto-focus** client setting (`terminalAutoFocus`, default **on**) so existing behavior stays the same until users turn it off in Settings → General.
> 
> When off, the embedded terminal no longer steals keyboard focus on **automatic** reveals—opening the drawer, switching to a thread with an open terminal, surface-ready mount, or first output. **Explicit** terminal actions (create, split, close, tab activate) still focus the terminal so focus does not fall to `document.body` when a viewport remounts.
> 
> The focus model is split so `focusRequestId` carries only action-driven requests (visibility and settings are no longer mixed into that counter). `TerminalViewport` gates automatic paths via frame-time permission checks and a one-shot `mountFocusPending` flag for remounts tied to explicit requests; `ChatView` only bumps the focus request when the drawer opens if auto-focus is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f49ff3bb13fbadf0ed7f307c0b6231cc81df62d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `terminalAutoFocus` setting to control terminal drawer auto-focus
> - Adds a new boolean `terminalAutoFocus` field (default `true`) to `ClientSettingsSchema` and the patch schema in [settings.ts](https://github.com/pingdotgg/t3code/pull/8372/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c)
> - Adds a toggle in the General settings panel with reset-to-default support and a searchable entry in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/8372/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) and [settingsSearch.ts](https://github.com/pingdotgg/t3code/pull/8372/files#diff-194ff52e4b6663ea95b9f4b9bb5202fa7a3d26d917a79e9239910fa073fd9ff8)
> - Reworks focus logic in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8372/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/8372/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) so reveal and readiness events respect the setting, while explicit focus requests (create/split/activate) still focus when `autoFocus` is true
> - `focusRequestId` no longer zeroes for inactive threads and no longer changes on visibility transitions, preventing spurious focus on activation
> - Behavioral Change: `focusRequestId` is now always the current `terminalFocusRequestId` instead of zeroed for inactive threads; hidden drawers ignore requests. Reviewers should verify inactive-thread terminal activation still behaves correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f49ff3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


