### PR TITLE
feat(keybindings): allow disabling bindings without losing them

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -459,6 +459,63 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("disables a rule in place and resolves it as disabled", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle" },
+      ]);
+
+      const resolved = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        return yield* keybindings.upsertKeybindingRule({
+          key: "mod+j",
+          command: "terminal.toggle",
+          disabled: true,
+          replace: { key: "mod+j", command: "terminal.toggle" },
+        });
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command, disabled }) => ({
+        key,
+        command,
+        disabled,
+      }));
+      assert.deepEqual(persistedView, [
+        { key: "mod+j", command: "terminal.toggle", disabled: true },
+      ]);
+
+      const toggleRules = resolved.filter((entry) => entry.command === "terminal.toggle");
+      assert.equal(toggleRules.length, 1);
+      assert.isTrue(toggleRules[0]?.disabled);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("startup sync does not re-add a default that was disabled", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle", disabled: true },
+      ]);
+
+      const resolved = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+        return (yield* keybindings.loadConfigState).keybindings;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const toggleEntries = persisted.filter((entry) => entry.command === "terminal.toggle");
+      assert.equal(toggleEntries.length, 1);
+      assert.isTrue(toggleEntries[0]?.disabled);
+
+      const toggleRules = resolved.filter((entry) => entry.command === "terminal.toggle");
+      assert.equal(toggleRules.length, 1);
+      assert.isTrue(toggleRules[0]?.disabled);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("refuses to overwrite malformed keybindings config", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -90,6 +90,7 @@ export const ResolvedKeybindingFromConfig = KeybindingRule.pipe(
             key,
             command: resolved.command,
             when,
+            ...(resolved.disabled === true ? { disabled: true } : {}),
           };
         }),
     }),
@@ -124,9 +125,12 @@ function hasSameShortcutContext(left: KeybindingRule, right: KeybindingRule): bo
 }
 
 function keybindingRuleFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule {
-  return input.when === undefined
-    ? { key: input.key, command: input.command }
-    : { key: input.key, command: input.command, when: input.when };
+  return {
+    key: input.key,
+    command: input.command,
+    ...(input.when === undefined ? {} : { when: input.when }),
+    ...(input.disabled === true ? { disabled: true } : {}),
+  };
 }
 
 function replaceTargetFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule | null {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -21,6 +21,7 @@ export interface KeybindingRow {
   readonly key: string;
   readonly when: string;
   readonly source: KeybindingSource;
+  readonly disabled: boolean;
   readonly defaultKey: string | null;
   readonly defaultWhen: string;
   readonly binding: ResolvedKeybindingRule;
@@ -95,6 +96,11 @@ function sourceForBinding(binding: ResolvedKeybindingRule): KeybindingSource {
     return "Project";
   }
 
+  // Defaults are never disabled, so a disabled rule is always a user override.
+  if (binding.disabled) {
+    return "Custom";
+  }
+
   const bindingKey = shortcutToKeybindingInput(binding.shortcut);
   const bindingWhen = whenAstToExpression(binding.whenAst);
   const isDefault = DEFAULT_RESOLVED_KEYBINDINGS.some(
@@ -145,6 +151,7 @@ export function keybindingConflictLabels(
   for (const candidate of rows) {
     if (
       candidate.id !== input.rowId &&
+      !candidate.disabled &&
       candidate.key === input.key &&
       conflictsWithWhen(candidate.when, input.when)
     ) {
@@ -169,6 +176,7 @@ export function buildKeybindingRows(
       key,
       when,
       source: sourceForBinding(binding),
+      disabled: binding.disabled === true,
       defaultKey: defaultBinding ? shortcutToKeybindingInput(defaultBinding.shortcut) : null,
       defaultWhen: whenAstToExpression(defaultBinding?.whenAst),
       binding,
@@ -177,6 +185,7 @@ export function buildKeybindingRows(
   });
 
   const rowsWithConflicts = rows.map((row) => {
+    if (row.disabled) return row;
     const conflicts = keybindingConflictLabels(rows, {
       rowId: row.id,
       key: row.key,
@@ -202,7 +211,8 @@ export function buildKeybindingRows(
       row.command.toLowerCase().includes(normalizedQuery) ||
       row.key.toLowerCase().includes(normalizedQuery) ||
       row.when.toLowerCase().includes(normalizedQuery) ||
-      row.source.toLowerCase().includes(normalizedQuery)
+      row.source.toLowerCase().includes(normalizedQuery) ||
+      (row.disabled && "disabled".includes(normalizedQuery))
     );
   });
 }

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -741,6 +741,7 @@ function KeybindingTableRow({
   onSave,
   onReset,
   onRemove,
+  onToggleDisabled,
 }: {
   row: KeybindingRow;
   allRows: ReadonlyArray<KeybindingRow>;
@@ -749,6 +750,7 @@ function KeybindingTableRow({
   onSave: (input: ServerUpsertKeybindingInput) => void;
   onReset: (row: KeybindingRow) => void;
   onRemove: (row: KeybindingRow) => void;
+  onToggleDisabled: (row: KeybindingRow) => void;
 }) {
   const [draft, setDraft] = useReducer(keybindingRowDraftReducer, row, createKeybindingRowDraft);
   const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
@@ -757,19 +759,21 @@ function KeybindingTableRow({
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
   const canReset = row.source === "Custom" && row.defaultKey !== null;
   const canRemove = row.source !== "Default";
-  const hasRowActions = canReset || canRemove;
   const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
-  const conflictLabels = keybindingConflictLabels(allRows, {
-    rowId: row.id,
-    key: keyDraft,
-    when: whenDraftExpression,
-  });
+  const conflictLabels = row.disabled
+    ? []
+    : keybindingConflictLabels(allRows, {
+        rowId: row.id,
+        key: keyDraft,
+        when: whenDraftExpression,
+      });
 
   const save = () => {
     onSave({
       command: row.command,
       key: keyDraft,
       when: whenDraftExpression.trim().length > 0 ? whenDraftExpression : undefined,
+      ...(row.disabled ? { disabled: true } : {}),
       replace: rowKeybindingTarget(row),
     });
   };
@@ -811,7 +815,10 @@ function KeybindingTableRow({
             type="button"
             onClick={() => setDraft({ isRecording: true })}
             aria-label={`Edit shortcut for ${commandLabel(row.command)}`}
-            className="group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
+            className={cn(
+              "group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              row.disabled && "opacity-45",
+            )}
           >
             <KeybindingPill value={row.key} />
             <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/0 transition-opacity group-hover:text-muted-foreground/70 group-focus-visible:text-muted-foreground/70">
@@ -835,6 +842,11 @@ function KeybindingTableRow({
             onKeyDown={captureKeybinding}
           />
         )}
+        {row.disabled && !isDirty ? (
+          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            Disabled
+          </span>
+        ) : null}
         {isDirty ? (
           <Button
             size="compact"
@@ -869,36 +881,37 @@ function KeybindingTableRow({
       </div>
       <div className="flex items-center justify-end gap-1">
         <KeybindingConflictWarning labels={conflictLabels} />
-        {hasRowActions ? (
-          <Menu>
-            <MenuTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
-                  disabled={isSaving}
-                  aria-label={`Actions for ${commandLabel(row.command)}`}
-                />
-              }
-            >
-              <EllipsisIcon className="size-3.5" />
-            </MenuTrigger>
-            <MenuPopup align="end" className="min-w-36">
-              {canReset ? (
-                <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
-                  Reset to default
-                </MenuItem>
-              ) : null}
-              {canRemove ? (
-                <MenuItem variant="destructive" disabled={isSaving} onClick={() => onRemove(row)}>
-                  Remove
-                </MenuItem>
-              ) : null}
-            </MenuPopup>
-          </Menu>
-        ) : null}
+        <Menu>
+          <MenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
+                disabled={isSaving}
+                aria-label={`Actions for ${commandLabel(row.command)}`}
+              />
+            }
+          >
+            <EllipsisIcon className="size-3.5" />
+          </MenuTrigger>
+          <MenuPopup align="end" className="min-w-36">
+            <MenuItem disabled={isSaving} onClick={() => onToggleDisabled(row)}>
+              {row.disabled ? "Enable" : "Disable"}
+            </MenuItem>
+            {canReset ? (
+              <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
+                Reset to default
+              </MenuItem>
+            ) : null}
+            {canRemove ? (
+              <MenuItem variant="destructive" disabled={isSaving} onClick={() => onRemove(row)}>
+                Remove
+              </MenuItem>
+            ) : null}
+          </MenuPopup>
+        </Menu>
         <span className="sr-only">{displayShortcut}</span>
       </div>
     </div>
@@ -1122,6 +1135,7 @@ export function KeybindingsSettingsPanel() {
         command: input.command,
         key: input.key.trim(),
         ...(input.when?.trim() ? { when: input.when.trim() } : {}),
+        ...(input.disabled === true ? { disabled: true } : {}),
         ...(input.replace ? { replace: input.replace } : {}),
       };
       void (async () => {
@@ -1168,6 +1182,19 @@ export function KeybindingsSettingsPanel() {
       })();
     },
     [primaryEnvironment, removeKeybindingMutation],
+  );
+
+  const toggleKeybindingDisabled = useCallback(
+    (row: KeybindingRow) => {
+      saveKeybinding({
+        command: row.command,
+        key: row.key,
+        when: row.when.trim().length > 0 ? row.when : undefined,
+        ...(row.disabled ? {} : { disabled: true }),
+        replace: rowKeybindingTarget(row),
+      });
+    },
+    [saveKeybinding],
   );
 
   const resetKeybinding = useCallback(
@@ -1287,6 +1314,7 @@ export function KeybindingsSettingsPanel() {
                 onSave={saveKeybinding}
                 onReset={resetKeybinding}
                 onRemove={removeKeybinding}
+                onToggleDisabled={toggleKeybindingDisabled}
               />
             ))}
             {rows.length === 0 && !isAddingBinding ? (

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -44,6 +44,7 @@ import {
   serverEnvironment,
 } from "../../state/server";
 import { usePrimaryEnvironment } from "../../state/environments";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -843,9 +844,13 @@ function KeybindingTableRow({
           />
         )}
         {row.disabled && !isDirty ? (
-          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+          <Badge
+            size="sm"
+            variant="secondary"
+            className="bg-muted uppercase tracking-[0.08em] text-muted-foreground"
+          >
             Disabled
-          </span>
+          </Badge>
         ) : null}
         {isDirty ? (
           <Button

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -518,8 +518,12 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       setIsSavingScripts(true);
       try {
         // Captured before the write so a cleared or deleted binding can be
-        // removed from the keybindings config afterwards.
-        const previousKeybinding = keybindingValueForCommand(keybindings, keybindingCommand);
+        // removed from the keybindings config afterwards. Disabled rules count
+        // here: they still claim the command, so they are what a replace or
+        // remove has to target instead of leaving them orphaned.
+        const previousKeybinding = keybindingValueForCommand(keybindings, keybindingCommand, {
+          includeDisabled: true,
+        });
         const updateResult = mapAtomCommandResult(
           await updateProject({
             environmentId: selectedCheckout.environmentId,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -74,6 +74,7 @@ interface TestBinding {
   shortcut: KeybindingShortcut;
   command: KeybindingCommand;
   whenAst?: KeybindingWhenNode;
+  disabled?: boolean;
 }
 
 function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
@@ -81,6 +82,7 @@ function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
     command: binding.command,
     shortcut: binding.shortcut,
     ...(binding.whenAst ? { whenAst: binding.whenAst } : {}),
+    ...(binding.disabled ? { disabled: true } : {}),
   }));
 }
 
@@ -705,6 +707,42 @@ describe("cross-command precedence", () => {
         context: { terminalFocus: true },
       }),
     );
+  });
+});
+
+describe("disabled bindings", () => {
+  it("returns null when the only binding for a shortcut is disabled", () => {
+    const keybindings = compile([
+      { shortcut: modShortcut("j"), command: "terminal.toggle", disabled: true },
+    ]);
+
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "j", ctrlKey: true }), keybindings, {
+        platform: "Linux",
+      }),
+    );
+  });
+
+  it("skips a disabled later rule so an earlier rule still wins", () => {
+    const keybindings = compile([
+      { shortcut: modShortcut("j"), command: "terminal.toggle" },
+      { shortcut: modShortcut("j"), command: "sidebar.toggle", disabled: true },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "j", ctrlKey: true }), keybindings, {
+        platform: "Linux",
+      }),
+      "terminal.toggle",
+    );
+  });
+
+  it("shows no shortcut label for a disabled binding", () => {
+    const keybindings = compile([
+      { shortcut: modShortcut("j"), command: "terminal.toggle", disabled: true },
+    ]);
+
+    assert.isNull(shortcutLabelForCommand(keybindings, "terminal.toggle", "Linux"));
   });
 });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -178,7 +178,7 @@ function findEffectiveShortcutForCommand(
 
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding) continue;
+    if (!binding || binding.disabled) continue;
     if (!matchesWhenClause(binding.whenAst, context)) continue;
 
     const conflictKey = shortcutConflictKey(binding.shortcut, platform);
@@ -214,7 +214,7 @@ export function resolveShortcutCommand(
 
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding) continue;
+    if (!binding || binding.disabled) continue;
     if (!matchesWhenClause(binding.whenAst, context)) continue;
     if (!matchesShortcut(event, binding.shortcut, platform)) continue;
     return binding.command;

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -137,4 +137,63 @@ describe("projectScriptKeybindings", () => {
 
     expect(value).toBe("mod+alt+j");
   });
+
+  it("returns a disabled keybinding when disabled rules are included", () => {
+    const command = commandForProjectScript("test");
+    const bindings = [
+      {
+        command,
+        disabled: true,
+        shortcut: {
+          key: "k",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: true,
+          altKey: false,
+          modKey: true,
+        },
+      },
+    ];
+
+    expect(keybindingValueForCommand(bindings, command, { includeDisabled: true })).toBe(
+      "mod+shift+k",
+    );
+    expect(keybindingValueForCommand(bindings, command, { includeDisabled: false })).toBeNull();
+    expect(keybindingValueForCommand(bindings, command)).toBeNull();
+  });
+
+  it("prefers the latest rule when disabled rules are included", () => {
+    const command = commandForProjectScript("test");
+    const value = keybindingValueForCommand(
+      [
+        {
+          command,
+          shortcut: {
+            key: "j",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: true,
+            modKey: true,
+          },
+        },
+        {
+          command,
+          disabled: true,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
+      command,
+      { includeDisabled: true },
+    );
+
+    expect(value).toBe("mod+shift+k");
+  });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -80,4 +80,61 @@ describe("projectScriptKeybindings", () => {
 
     expect(value).toBe("mod+shift+k");
   });
+
+  it("ignores disabled keybindings for a command", () => {
+    const command = commandForProjectScript("test");
+    const value = keybindingValueForCommand(
+      [
+        {
+          command,
+          disabled: true,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
+      command,
+    );
+
+    expect(value).toBeNull();
+  });
+
+  it("falls through a later disabled rule to an earlier enabled one", () => {
+    const command = commandForProjectScript("test");
+    const value = keybindingValueForCommand(
+      [
+        {
+          command,
+          shortcut: {
+            key: "j",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: true,
+            modKey: true,
+          },
+        },
+        {
+          command,
+          disabled: true,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
+      command,
+    );
+
+    expect(value).toBe("mod+alt+j");
+  });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -34,13 +34,22 @@ export function decodeProjectScriptKeybindingRule(input: {
   return decoded.value;
 }
 
+/**
+ * Reads the shortcut a command currently resolves to. Disabled rules are
+ * skipped by default so nothing presents a dead shortcut as active; pass
+ * `includeDisabled` when the caller needs the rule that owns the command in
+ * the config, such as the replace/remove target of a keybinding write.
+ */
 export function keybindingValueForCommand(
   keybindings: ResolvedKeybindingsConfig,
   command: KeybindingCommand,
+  options?: { includeDisabled?: boolean },
 ): string | null {
+  const includeDisabled = options?.includeDisabled ?? false;
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding || binding.disabled || binding.command !== command) continue;
+    if (!binding || binding.command !== command) continue;
+    if (binding.disabled && !includeDisabled) continue;
 
     const parts: string[] = [];
     if (binding.shortcut.modKey) parts.push("mod");

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -40,7 +40,7 @@ export function keybindingValueForCommand(
 ): string | null {
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding || binding.command !== command) continue;
+    if (!binding || binding.disabled || binding.command !== command) continue;
 
     const parts: string[] = [];
     if (binding.shortcut.modKey) parts.push("mod");

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -1,7 +1,9 @@
 # Keybindings
 
 Edit keybindings from **Settings** → **Keybindings**. That page lists every command, its current
-shortcut, whether it is a default or your own, and warns about conflicts.
+shortcut, whether it is a default or your own, and warns about conflicts. Each row's menu can also
+disable the binding entirely; a disabled binding keeps its place in the list but never fires until
+you enable it again or reset it to the default.
 
 The same configuration lives in `~/.t3/userdata/keybindings.json` on the machine running the
 server, if you prefer editing it directly. T3 Code writes the built-in defaults into that file on
@@ -24,6 +26,8 @@ Invalid rules are ignored. An invalid file is ignored entirely, and the server l
 - `key` (required): shortcut string, like `mod+j`, `ctrl+k`, `cmd+shift+d`
 - `command` (required): the command ID to run
 - `when` (optional): boolean expression controlling when the shortcut is active
+- `disabled` (optional): `true` turns the rule off without deleting it. Deleting a default's rule
+  brings the default back on the next startup; disabling it is how you switch a default off.
 
 ## Key Syntax
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -2,8 +2,8 @@
 
 Edit keybindings from **Settings** → **Keybindings**. That page lists every command, its current
 shortcut, whether it is a default or your own, and warns about conflicts. Each row's menu can also
-disable the binding entirely; a disabled binding keeps its place in the list but never fires until
-you enable it again or reset it to the default.
+disable the binding entirely; a disabled binding stays in the list but never fires until you enable
+it again or reset it to the default.
 
 The same configuration lives in `~/.t3/userdata/keybindings.json` on the machine running the
 server, if you prefer editing it directly. T3 Code writes the built-in defaults into that file on

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -104,6 +104,8 @@ export const KeybindingRule = Schema.Struct({
   key: KeybindingValue,
   command: KeybindingCommand,
   when: Schema.optional(KeybindingWhen),
+  /** A disabled rule keeps its slot (so the default is not re-added) but never matches. */
+  disabled: Schema.optional(Schema.Boolean),
 });
 export type KeybindingRule = typeof KeybindingRule.Type;
 
@@ -155,6 +157,7 @@ export const ResolvedKeybindingRule = Schema.Struct({
   command: KeybindingCommand,
   shortcut: KeybindingShortcut,
   whenAst: Schema.optional(KeybindingWhenNode),
+  disabled: Schema.optional(Schema.Boolean),
 }).annotate({ parseOptions: { onExcessProperty: "ignore" } });
 export type ResolvedKeybindingRule = typeof ResolvedKeybindingRule.Type;
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -104,7 +104,7 @@ export const KeybindingRule = Schema.Struct({
   key: KeybindingValue,
   command: KeybindingCommand,
   when: Schema.optional(KeybindingWhen),
-  /** A disabled rule keeps its slot (so the default is not re-added) but never matches. */
+  /** A disabled rule still claims its command (so the default is not re-added) but never matches. */
   disabled: Schema.optional(Schema.Boolean),
 });
 export type KeybindingRule = typeof KeybindingRule.Type;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -464,6 +464,7 @@ export const ServerUpsertKeybindingInput = Schema.Struct({
   key: KeybindingValue,
   command: KeybindingCommand,
   when: Schema.optional(KeybindingWhen),
+  disabled: Schema.optional(Schema.Boolean),
   replace: Schema.optional(ServerUpsertKeybindingReplaceTarget),
 });
 export type ServerUpsertKeybindingInput = typeof ServerUpsertKeybindingInput.Type;

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -266,6 +266,7 @@ export function compileResolvedKeybindingRule(rule: KeybindingRule): ResolvedKey
   const shortcut = parseKeybindingShortcut(rule.key);
   if (!shortcut) return null;
 
+  const disabled = rule.disabled === true ? { disabled: true } : {};
   if (rule.when !== undefined) {
     const whenAst = parseKeybindingWhenExpression(rule.when);
     if (!whenAst) return null;
@@ -273,12 +274,14 @@ export function compileResolvedKeybindingRule(rule: KeybindingRule): ResolvedKey
       command: rule.command,
       shortcut,
       whenAst,
+      ...disabled,
     };
   }
 
   return {
     command: rule.command,
     shortcut,
+    ...disabled,
   };
 }
 


### PR DESCRIPTION
## Problem

A keybinding can be rebound but never switched off. Removing a default command's rule from `keybindings.json` just brings the default back on the next merge and startup sync, so there is no way to say "this shortcut should do nothing". That is a one-way door: the settings page offers a way in (rebind) with no way out.

## Fix

Rules accept an optional `disabled: true`. A disabled rule keeps its slot in the config, which keeps the default suppressed, but shortcut resolution skips it. Concretely:

- `KeybindingRule`, `ResolvedKeybindingRule`, and the upsert RPC input gain the optional `disabled` flag (old clients that don't know the flag keep their current behavior).
- `resolveShortcutCommand` and shortcut-label lookup skip disabled rules.
- Settings → Keybindings: each row's menu gets **Disable** / **Enable**, disabled rows show a badge, stop counting as conflicts, and "Reset to default" re-enables. `keybindings.json` edits work the same way by hand.
- Startup default-backfill already keys on the command, so a disabled rule blocks re-adding that default. Covered by new server and web tests.

This is groundwork for making the desktop window-close shortcut controllable (follow-up PR).

## Before / after

Before: a row's menu offers only Reset/Remove (default rows have no menu at all):

<img width="2186" alt="before: row menu, only Reset/Remove" src="https://github.com/user-attachments/assets/2ff93a37-e831-46ab-b779-d9d202101d6d" />

After: every row's menu gains Disable, and a disabled row shows a dimmed pill with a badge:

<img width="2622" alt="after: Disable in every row menu, disabled row below" src="https://github.com/user-attachments/assets/f13d9ba9-4930-4570-8559-55a04e29219c" />

After: a disabled row's menu offers Enable alongside Reset/Remove:

<img width="2292" alt="after: disabled row with Enable/Reset/Remove" src="https://github.com/user-attachments/assets/7e13e334-c299-49fd-ae39-07d17b0503da" />

Built by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keybinding config and UI behavior with broad test coverage; no auth, security, or data-handling changes.
> 
> **Overview**
> Keybindings can now be **turned off without deleting** them via an optional `disabled: true` on rules in `keybindings.json`, contracts, and the upsert RPC. Disabled rules still **claim the command** so startup default backfill does not resurrect the shortcut, but **shortcut resolution, labels, and conflict detection skip them**.
> 
> **Settings → Keybindings** adds **Disable / Enable** in each row’s menu, a **Disabled** badge and muted shortcut styling, and search matches “disabled”. Saving preserves the disabled flag; project script keybinding updates use `includeDisabled` when targeting replace/remove so orphaned disabled rules are not left behind.
> 
> Server persistence and shared compile paths carry `disabled` through resolved config; new server and web tests cover disable-in-place, startup sync, and resolution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e4b04e96d880b7bfd13c660f3d3d2066ec6779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `disabled` flag to keybinding rules to disable without deleting
> - Adds optional `disabled: boolean` to `KeybindingRule`, `ResolvedKeybindingRule`, and `ServerUpsertKeybindingInput` schemas so a rule can be disabled without being removed.
> - Disabled rules are persisted and round-tripped, but skipped in `resolveShortcutCommand`, `findEffectiveShortcutForCommand`, and conflict detection so they never trigger or show conflicts.
> - The keybindings settings UI shows a 'Disabled' badge, dimmed Edit button, and an Enable/Disable toggle menu item; the search filter recognizes the term 'disabled'.
> - `keybindingValueForCommand` gains an `includeDisabled` option (default false) so callers like script-saving in `ProjectDetail` can target disabled rules as owners for replace/remove.
> - Risk: `keybindingValueForCommand` default behavior changes — it now skips disabled rules; any caller relying on reading a disabled rule's value without passing `includeDisabled: true` will see it fall through to the next enabled rule.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7e4b04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
