### PR TITLE
feat(desktop): route window close through the window.close keybinding

### DIFF
--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -94,6 +94,7 @@ function makeDesktopWindowLayer(
     flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,
     zoomMain: () => Effect.void,
+    closeMain: Effect.void,
     syncAppearance: Effect.void,
   });
 }

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -92,6 +92,7 @@ function makePoolLayer(
           flushMainWindowBounds: Effect.void,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
           zoomMain: () => Effect.die("unexpected zoom"),
+          closeMain: Effect.die("unexpected window close"),
           syncAppearance: Effect.void,
         } satisfies DesktopWindow.DesktopWindow["Service"]),
       ),

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -31,6 +31,7 @@ import {
   setUpdateChannel,
 } from "./methods/updates.ts";
 import {
+  closeWindow,
   getAppBranding,
   getLocalEnvironmentBootstraps,
   getLocalEnvironmentBearerToken,
@@ -56,6 +57,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handleSync(getWindowFullscreenState);
   yield* ipc.handleSync(getLocalEnvironmentBootstraps);
   yield* ipc.handle(getLocalEnvironmentBearerToken);
+  yield* ipc.handle(closeWindow);
 
   yield* ipc.handle(getClientSettings);
   yield* ipc.handle(setClientSettings);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -7,6 +7,7 @@ export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const PROBE_REMOTE_EDITORS_CHANNEL = "desktop:probe-remote-editors";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const QUIT_SHORTCUT_CHANNEL = "desktop:quit-shortcut";
+export const CLOSE_WINDOW_CHANNEL = "desktop:close-window";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -10,7 +11,9 @@ import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
+import * as DesktopWindow from "../../window/DesktopWindow.ts";
 import {
+  closeWindow,
   getLocalEnvironmentBootstraps,
   getWindowFullscreenState,
   pickProjectFavicon,
@@ -151,6 +154,23 @@ describe("getWindowFullscreenState", () => {
       ),
     );
   });
+});
+
+describe("closeWindow", () => {
+  it.effect("delegates to the desktop window service", () =>
+    Effect.gen(function* () {
+      const closeMain = yield* Deferred.make<boolean>();
+      yield* closeWindow.handler(undefined).pipe(
+        Effect.provide(
+          Layer.mock(DesktopWindow.DesktopWindow)({
+            closeMain: Deferred.succeed(closeMain, true).pipe(Effect.asVoid),
+          }),
+        ),
+      );
+
+      assert.isTrue(yield* Deferred.await(closeMain));
+    }),
+  );
 });
 
 describe("pickProjectFavicon", () => {

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -27,6 +27,7 @@ import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
 import * as DesktopWslBackend from "../../wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "../../wsl/DesktopWslEnvironment.ts";
+import * as DesktopWindow from "../../window/DesktopWindow.ts";
 import * as ElectronApp from "../../electron/ElectronApp.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../../electron/ElectronMenu.ts";
@@ -82,6 +83,18 @@ export const getWindowFullscreenState = DesktopIpc.makeSyncIpcMethod({
     const electronWindow = yield* ElectronWindow.ElectronWindow;
     const window = yield* electronWindow.currentMainOrFirst;
     return Option.isSome(window) && window.value.isFullScreen();
+  }),
+});
+
+/** Backs the renderer's `window.close` keybinding; the native menu binds no
+ *  CmdOrCtrl+W accelerator of its own. */
+export const closeWindow = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.CLOSE_WINDOW_CHANNEL,
+  payload: Schema.Void,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.closeWindow")(function* () {
+    const desktopWindow = yield* DesktopWindow.DesktopWindow;
+    yield* desktopWindow.closeMain;
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -134,6 +134,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.removeListener(IpcChannels.QUIT_SHORTCUT_CHANNEL, wrappedListener);
     };
   },
+  closeWindow: () => ipcRenderer.invoke(IpcChannels.CLOSE_WINDOW_CHANNEL, undefined),
   getWindowFullscreenState: () =>
     ipcRenderer.sendSync(IpcChannels.GET_WINDOW_FULLSCREEN_STATE_CHANNEL) === true,
   onWindowFullscreenStateChange: (listener) => {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -58,6 +58,45 @@ describe("isPreviewRefreshShortcut", () => {
   });
 });
 
+describe("isAppForwardedShortcut", () => {
+  const input = (overrides: Partial<Electron.Input> = {}) =>
+    ({
+      type: "keyDown",
+      key: "w",
+      meta: false,
+      control: false,
+      shift: false,
+      alt: false,
+      ...overrides,
+    }) as Electron.Input;
+
+  it("forwards mod+W with the platform's spelling of mod", () => {
+    expect(PreviewManager.isAppForwardedShortcut(input({ meta: true }), "darwin")).toBe(true);
+    expect(PreviewManager.isAppForwardedShortcut(input({ control: true }), "darwin")).toBe(false);
+    expect(PreviewManager.isAppForwardedShortcut(input({ control: true }), "linux")).toBe(true);
+    expect(PreviewManager.isAppForwardedShortcut(input({ control: true }), "win32")).toBe(true);
+    expect(PreviewManager.isAppForwardedShortcut(input({ meta: true }), "linux")).toBe(false);
+  });
+
+  it("ignores key-up events and unrelated chords", () => {
+    expect(
+      PreviewManager.isAppForwardedShortcut(input({ control: true, type: "keyUp" }), "linux"),
+    ).toBe(false);
+    expect(
+      PreviewManager.isAppForwardedShortcut(input({ control: true, shift: true }), "linux"),
+    ).toBe(false);
+  });
+
+  it("keeps the other forwarded chords meta-only on every platform", () => {
+    expect(PreviewManager.isAppForwardedShortcut(input({ key: "k", meta: true }), "linux")).toBe(
+      true,
+    );
+    expect(PreviewManager.isAppForwardedShortcut(input({ key: "k", control: true }), "linux")).toBe(
+      false,
+    );
+  });
+});
+
 const {
   browserWindowConstructor,
   createFromPath,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -423,6 +423,8 @@ const APP_FORWARDED_SHORTCUTS: ReadonlyArray<{
   meta: boolean;
   shift: boolean;
   control: boolean;
+  /** Omitted forwards everywhere; otherwise the entry is macOS-only or macOS-never. */
+  onlyOn?: "darwin" | "non-darwin";
 }> = Object.freeze([
   // mod+shift+J → preview.toggle
   { key: "j", meta: true, shift: true, control: false },
@@ -430,9 +432,27 @@ const APP_FORWARDED_SHORTCUTS: ReadonlyArray<{
   { key: "k", meta: true, shift: false, control: false },
   // mod+, → settings (macOS convention)
   { key: ",", meta: true, shift: false, control: false },
-  // mod+W → close tab/panel
-  { key: "w", meta: true, shift: false, control: false },
+  // mod+W → close tab/panel, and `window.close` when nothing closer claims it.
+  // The renderer keybinding registry decides, so mod has to be spelled per
+  // platform: Cmd on macOS, Ctrl everywhere else.
+  { key: "w", meta: true, shift: false, control: false, onlyOn: "darwin" },
+  { key: "w", meta: false, shift: false, control: true, onlyOn: "non-darwin" },
 ]);
+
+/**
+ * True when a preview guest keystroke belongs to the main renderer instead.
+ * `platform` is the host platform, which decides how `mod` is spelled.
+ */
+export const isAppForwardedShortcut = (input: Electron.Input, platform: NodeJS.Platform): boolean =>
+  input.type === "keyDown" &&
+  APP_FORWARDED_SHORTCUTS.some(
+    (shortcut) =>
+      shortcut.key.toLowerCase() === input.key.toLowerCase() &&
+      shortcut.meta === input.meta &&
+      shortcut.shift === input.shift &&
+      shortcut.control === input.control &&
+      (shortcut.onlyOn === undefined || (shortcut.onlyOn === "darwin") === (platform === "darwin")),
+  );
 
 export const isPreviewRefreshShortcut = (input: Electron.Input): boolean =>
   input.type === "keyDown" &&
@@ -1358,14 +1378,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   const isAppShortcut = (input: Electron.Input): boolean =>
-    input.type === "keyDown" &&
-    APP_FORWARDED_SHORTCUTS.some(
-      (shortcut) =>
-        shortcut.key.toLowerCase() === input.key.toLowerCase() &&
-        shortcut.meta === input.meta &&
-        shortcut.shift === input.shift &&
-        shortcut.control === input.control,
-    );
+    isAppForwardedShortcut(input, hostPlatform);
 
   const computeNavStatus = (wc: Electron.WebContents): PreviewNavStatus => {
     const url = wc.getURL();

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -83,6 +83,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     zoomMain: (direction) =>
       Deferred.succeed(selectedAction, `zoom-${direction}`).pipe(Effect.asVoid),
+    closeMain: Deferred.succeed(selectedAction, "close-window").pipe(Effect.asVoid),
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindow["Service"]);
 
@@ -119,6 +120,15 @@ const configureMenu = (
       ),
     ),
   );
+
+function flattenMenuItems(
+  template: readonly Electron.MenuItemConstructorOptions[],
+): readonly Electron.MenuItemConstructorOptions[] {
+  return template.flatMap((item) => [
+    item,
+    ...(Array.isArray(item.submenu) ? flattenMenuItems(item.submenu) : []),
+  ]);
+}
 
 describe("DesktopApplicationMenu", () => {
   it.effect("installs the native menu and routes Settings through DesktopWindow", () =>
@@ -178,6 +188,44 @@ describe("DesktopApplicationMenu", () => {
 
       zoomIn.click({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
       assert.equal(yield* Deferred.await(selectedAction), "zoom-in");
+    }),
+  );
+
+  // The `close` role carries an implicit CmdOrCtrl+W accelerator, which would
+  // consume the key before the renderer's `window.close` keybinding sees it.
+  it.effect("routes Close Window through DesktopWindow and leaves CmdOrCtrl+W unbound", () =>
+    Effect.gen(function* () {
+      const selectedAction = yield* Deferred.make<string>();
+      const applicationMenuTemplate =
+        yield* Deferred.make<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* configureMenu(selectedAction, applicationMenuTemplate);
+
+      const template = yield* Deferred.await(applicationMenuTemplate);
+      const allItems = flattenMenuItems(template);
+      assert.isUndefined(allItems.find((item) => item.role?.toLowerCase() === "close"));
+      assert.isUndefined(
+        allItems.find((item) => item.accelerator?.toLowerCase().endsWith("+w") === true),
+      );
+
+      const windowMenu = template.find((item) => item.label === "Window");
+      assert.isDefined(windowMenu);
+      if (!Array.isArray(windowMenu.submenu)) {
+        throw new Error("Expected Window menu submenu to be an array.");
+      }
+      assert.deepEqual(
+        windowMenu.submenu.map((item) => item.role ?? item.label),
+        ["minimize", "zoom", "Close Window"],
+      );
+
+      const closeWindow = windowMenu.submenu.find((item) => item.label === "Close Window");
+      assert.isDefined(closeWindow);
+      if (typeof closeWindow.click !== "function") {
+        throw new Error("Expected Close Window menu item to have a click handler.");
+      }
+
+      closeWindow.click({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
+      assert.equal(yield* Deferred.await(selectedAction), "close-window");
     }),
   );
 });

--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -56,6 +56,11 @@ const zoomMainWindow = Effect.fn("desktop.menu.zoomMainWindow")(function* (
   yield* desktopWindow.zoomMain(direction);
 });
 
+const closeMainWindow = Effect.gen(function* () {
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  yield* desktopWindow.closeMain;
+}).pipe(Effect.withSpan("desktop.menu.closeMainWindow"));
+
 const checkForUpdatesFromMenu = Effect.gen(function* () {
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const electronDialog = yield* ElectronDialog.ElectronDialog;
@@ -137,6 +142,18 @@ export const make = Effect.gen(function* () {
     const zoomClick = (direction: DesktopWindow.MainWindowZoomDirection) => () => {
       runMenuEffect(`zoom-${direction}`, zoomMainWindow(direction));
     };
+    /*
+      Not the `close` role: it registers CmdOrCtrl+W as a native accelerator,
+      which would take the shortcut away from the `window.close` keybinding
+      before the renderer ever sees the key. No item in this menu may bind
+      CmdOrCtrl+W.
+    */
+    const closeWindowItem: Electron.MenuItemConstructorOptions = {
+      label: "Close Window",
+      click: () => {
+        runMenuEffect("close-window", closeMainWindow);
+      },
+    };
     const template: Electron.MenuItemConstructorOptions[] = [];
 
     if (environment.platform === "darwin") {
@@ -180,7 +197,7 @@ export const make = Effect.gen(function* () {
                 },
                 { type: "separator" as const },
               ]),
-          { role: environment.platform === "darwin" ? "close" : "quit" },
+          environment.platform === "darwin" ? closeWindowItem : { role: "quit" },
         ],
       },
       { role: "editMenu" },
@@ -210,7 +227,19 @@ export const make = Effect.gen(function* () {
           { role: "togglefullscreen" },
         ],
       },
-      { role: "windowMenu" },
+      {
+        // Electron's `windowMenu` role, with its close role swapped for the
+        // accelerator-less item. macOS keeps Close Window in the File menu,
+        // exactly as the role does.
+        label: "Window",
+        submenu: [
+          { role: "minimize" },
+          { role: "zoom" },
+          ...(environment.platform === "darwin"
+            ? [{ type: "separator" as const }, { role: "front" as const }]
+            : [closeWindowItem]),
+        ],
+      },
       {
         role: "help",
         submenu: [

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -106,6 +106,10 @@ export class DesktopWindow extends Context.Service<
     // guest page instead of the app UI. The menu routes here to always target
     // the main window.
     readonly zoomMain: (direction: MainWindowZoomDirection) => Effect.Effect<void>;
+    // Closes the focused app window. The native menu registers no CmdOrCtrl+W
+    // accelerator, so both the "Close Window" menu item and the renderer's
+    // `window.close` keybinding route here.
+    readonly closeMain: Effect.Effect<void>;
     readonly syncAppearance: Effect.Effect<void>;
   }
 >()("@t3tools/desktop/window/DesktopWindow") {}
@@ -547,10 +551,6 @@ export const make = Effect.gen(function* () {
       }
     });
 
-    // Electron's windowMenu close role owns CmdOrCtrl+W. Holding the
-    // close-terminal shortcut can outlive the terminal that handled its first
-    // press, so reject repeats before they reach the native window accelerator.
-    // Deliberate presses still flow through the renderer or native menu.
     // Chrome-style hold-to-quit: intercept the quit accelerator before the
     // native menu sees it and only quit after the shortcut is held. The
     // renderer shows the "Hold to Quit" hint via QUIT_SHORTCUT_CHANNEL.
@@ -577,6 +577,11 @@ export const make = Effect.gen(function* () {
     });
     window.webContents.on("before-input-event", (event, input) => {
       quitHoldHandler(event, input);
+      // The renderer owns mod+W through the keybinding registry (terminal.close
+      // or window.close), and the native menu registers no CmdOrCtrl+W
+      // accelerator. Holding the key can still outlive the terminal that
+      // handled the first press, so drop auto-repeats before the renderer sees
+      // them; deliberate presses are untouched.
       if (input.type !== "keyDown" || !input.isAutoRepeat) return;
       const modifier = environment.platform === "darwin" ? input.meta : input.control;
       if (modifier && !input.alt && !input.shift && input.key.toLowerCase() === "w") {
@@ -908,6 +913,13 @@ export const make = Effect.gen(function* () {
       // own zoom, so put each guest back where the preview left it.
       yield* previewManager.reapplyZoom();
     }),
+    closeMain: Effect.gen(function* () {
+      const window = yield* focusedMainWindow;
+      if (Option.isNone(window) || window.value.isDestroyed()) {
+        return;
+      }
+      window.value.close();
+    }).pipe(Effect.withSpan("desktop.window.closeMain")),
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
       yield* electronWindow.syncAllAppearance((window) =>

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -385,6 +385,40 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("backfills mod+w defaults when the user rule that owns the shortcut is disabled", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+w", command: "script.foo.run", disabled: true },
+      ]);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      // The disabled rule claims no shortcut, so both mod+w defaults come back.
+      assert.deepEqual(
+        persisted
+          .filter((entry) => entry.command === "window.close" || entry.command === "terminal.close")
+          .map(({ key, command, when }) => ({ key, command, when })),
+        Keybindings.DEFAULT_KEYBINDINGS.filter(
+          (entry) => entry.command === "window.close" || entry.command === "terminal.close",
+        ).map(({ key, command, when }) => ({ key, command, when })),
+      );
+
+      const disabledEntries = persisted.filter((entry) => entry.command === "script.foo.run");
+      assert.equal(disabledEntries.length, 1);
+      assert.isTrue(disabledEntries[0]?.disabled);
+
+      const byCommand = new Set(persisted.map((entry) => entry.command));
+      for (const defaultRule of Keybindings.DEFAULT_KEYBINDINGS) {
+        assert.isTrue(byCommand.has(defaultRule.command), `expected ${defaultRule.command}`);
+      }
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("upserts custom keybindings to configured path", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -459,6 +459,63 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("disables a rule in place and resolves it as disabled", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle" },
+      ]);
+
+      const resolved = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        return yield* keybindings.upsertKeybindingRule({
+          key: "mod+j",
+          command: "terminal.toggle",
+          disabled: true,
+          replace: { key: "mod+j", command: "terminal.toggle" },
+        });
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command, disabled }) => ({
+        key,
+        command,
+        disabled,
+      }));
+      assert.deepEqual(persistedView, [
+        { key: "mod+j", command: "terminal.toggle", disabled: true },
+      ]);
+
+      const toggleRules = resolved.filter((entry) => entry.command === "terminal.toggle");
+      assert.equal(toggleRules.length, 1);
+      assert.isTrue(toggleRules[0]?.disabled);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("startup sync does not re-add a default that was disabled", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle", disabled: true },
+      ]);
+
+      const resolved = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+        return (yield* keybindings.loadConfigState).keybindings;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const toggleEntries = persisted.filter((entry) => entry.command === "terminal.toggle");
+      assert.equal(toggleEntries.length, 1);
+      assert.isTrue(toggleEntries[0]?.disabled);
+
+      const toggleRules = resolved.filter((entry) => entry.command === "terminal.toggle");
+      assert.equal(toggleRules.length, 1);
+      assert.isTrue(toggleRules[0]?.disabled);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("refuses to overwrite malformed keybindings config", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -211,6 +211,17 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }),
   );
 
+  it.effect("ships mod+w defaults that split the terminal and the window", () =>
+    Effect.sync(() => {
+      const closeRules = Keybindings.DEFAULT_KEYBINDINGS.filter((rule) => rule.key === "mod+w");
+
+      assert.deepEqual(closeRules, [
+        { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
+        { key: "mod+w", command: "window.close", when: "!terminalFocus" },
+      ]);
+    }),
+  );
+
   it.effect("uses defaults in runtime when config is malformed without overriding file", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -353,6 +353,38 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     );
   });
 
+  it.effect("skips a conditional default when an unconditional user rule owns the shortcut", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+w", command: "script.foo.run" },
+      ]);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      // The unconditional user rule owns mod+w outright, so both mod+w defaults stay out.
+      assert.isFalse(
+        persisted.some((entry) => entry.key === "mod+w" && entry.command !== "script.foo.run"),
+      );
+      assert.deepEqual(
+        persisted
+          .filter((entry) => entry.command === "script.foo.run")
+          .map(({ key, command, when }) => ({ key, command, when })),
+        [{ key: "mod+w", command: "script.foo.run", when: undefined }],
+      );
+
+      const byCommand = new Set(persisted.map((entry) => entry.command));
+      for (const defaultRule of Keybindings.DEFAULT_KEYBINDINGS) {
+        if (defaultRule.key === "mod+w") continue;
+        assert.isTrue(byCommand.has(defaultRule.command), `expected ${defaultRule.command}`);
+      }
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("upserts custom keybindings to configured path", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -90,6 +90,7 @@ export const ResolvedKeybindingFromConfig = KeybindingRule.pipe(
             key,
             command: resolved.command,
             when,
+            ...(resolved.disabled === true ? { disabled: true } : {}),
           };
         }),
     }),
@@ -124,9 +125,12 @@ function hasSameShortcutContext(left: KeybindingRule, right: KeybindingRule): bo
 }
 
 function keybindingRuleFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule {
-  return input.when === undefined
-    ? { key: input.key, command: input.command }
-    : { key: input.key, command: input.command, when: input.when };
+  return {
+    key: input.key,
+    command: input.command,
+    ...(input.when === undefined ? {} : { when: input.when }),
+    ...(input.disabled === true ? { disabled: true } : {}),
+  };
 }
 
 function replaceTargetFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule | null {

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -514,8 +514,11 @@ const make = Effect.gen(function* () {
         if (existingCommands.has(defaultRule.command)) {
           continue;
         }
-        const conflictingEntry = customConfig.find((entry) =>
-          hasConflictingShortcutContext(entry, defaultRule),
+        // A disabled rule claims no shortcut, so it must not block a default from
+        // backfilling. Matches how the settings UI reports conflicts. Defaults are
+        // never disabled, so only the user entry needs the guard.
+        const conflictingEntry = customConfig.find(
+          (entry) => entry.disabled !== true && hasConflictingShortcutContext(entry, defaultRule),
         );
         if (conflictingEntry) {
           shortcutConflictWarnings.push({

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -109,19 +109,24 @@ function isSameKeybindingRule(left: KeybindingRule, right: KeybindingRule): bool
   );
 }
 
-function keybindingShortcutContext(rule: KeybindingRule): string | null {
+function encodedKeybindingShortcut(rule: KeybindingRule): string | null {
   const parsed = parseKeybindingShortcut(rule.key);
   if (!parsed) return null;
-  const encoded = encodeShortcut(parsed);
-  if (!encoded) return null;
-  return `${encoded}\u0000${rule.when ?? ""}`;
+  return encodeShortcut(parsed);
 }
 
-function hasSameShortcutContext(left: KeybindingRule, right: KeybindingRule): boolean {
-  const leftContext = keybindingShortcutContext(left);
-  const rightContext = keybindingShortcutContext(right);
-  if (!leftContext || !rightContext) return false;
-  return leftContext === rightContext;
+/**
+ * Mirrors the conflict rule the settings UI applies: two rules fight over the
+ * same shortcut when either side is unconditional, or their `when` clauses match.
+ */
+function hasConflictingShortcutContext(left: KeybindingRule, right: KeybindingRule): boolean {
+  const leftShortcut = encodedKeybindingShortcut(left);
+  const rightShortcut = encodedKeybindingShortcut(right);
+  if (!leftShortcut || !rightShortcut) return false;
+  if (leftShortcut !== rightShortcut) return false;
+  const leftWhen = left.when ?? "";
+  const rightWhen = right.when ?? "";
+  return leftWhen.length === 0 || rightWhen.length === 0 || leftWhen === rightWhen;
 }
 
 function keybindingRuleFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule {
@@ -510,7 +515,7 @@ const make = Effect.gen(function* () {
           continue;
         }
         const conflictingEntry = customConfig.find((entry) =>
-          hasSameShortcutContext(entry, defaultRule),
+          hasConflictingShortcutContext(entry, defaultRule),
         );
         if (conflictingEntry) {
           shortcutConflictWarnings.push({

--- a/apps/web/src/AppRoot.test.tsx
+++ b/apps/web/src/AppRoot.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
 import { QuitHoldOverlay } from "./components/QuitHoldOverlay";
+import { WindowCloseShortcut } from "./components/WindowCloseShortcut";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
 import type { AppRouter } from "./router";
 import { AppRoot } from "./AppRoot";
@@ -17,10 +18,11 @@ describe("AppRoot", () => {
     const children = Children.toArray(
       (root as ReactElement<{ readonly children: ReactNode }>).props.children,
     );
-    expect(children).toHaveLength(4);
+    expect(children).toHaveLength(5);
     expect(isValidElement(children[0]) && children[0].type).toBe(RouterProvider);
     expect(isValidElement(children[1]) && children[1].type).toBe(PreviewAutomationHosts);
     expect(isValidElement(children[2]) && children[2].type).toBe(ElectronBrowserHost);
     expect(isValidElement(children[3]) && children[3].type).toBe(QuitHoldOverlay);
+    expect(isValidElement(children[4]) && children[4].type).toBe(WindowCloseShortcut);
   });
 });

--- a/apps/web/src/AppRoot.tsx
+++ b/apps/web/src/AppRoot.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
 import { QuitHoldOverlay } from "./components/QuitHoldOverlay";
+import { WindowCloseShortcut } from "./components/WindowCloseShortcut";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
 import type { AppRouter } from "./router";
 
@@ -18,6 +19,7 @@ export function AppRoot({ router }: { readonly router: AppRouter }) {
       <PreviewAutomationHosts />
       <ElectronBrowserHost />
       <QuitHoldOverlay />
+      <WindowCloseShortcut />
     </AppAtomRegistryProvider>
   );
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5082,7 +5082,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
       // While a close confirmation is open, terminal focus has moved to the
       // dialog, so a deliberate second close shortcut would otherwise fall
-      // through to the native window/tab close accelerator.
+      // through to `window.close` on desktop or the browser's tab close.
       if (isTerminalCloseConfirmPending() && preventTerminalCloseShortcut(event, keybindings)) {
         event.stopPropagation();
         return;

--- a/apps/web/src/components/WindowCloseShortcut.tsx
+++ b/apps/web/src/components/WindowCloseShortcut.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { isElectron } from "../env";
 import { resolveShortcutCommand } from "../keybindings";
+import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalCloseConfirmPending } from "../lib/terminalCloseConfirm";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { primaryServerKeybindingsAtom } from "../state/server";
@@ -20,12 +21,25 @@ export function WindowCloseShortcut() {
 
     const handler = (event: globalThis.KeyboardEvent) => {
       if (event.repeat || event.defaultPrevented) return;
+      // A shortcut recorder is spelling this keystroke, not running it.
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest("[data-keybinding-capture]")
+      ) {
+        return;
+      }
       // A terminal close confirmation holds focus outside the terminal, so the
       // `!terminalFocus` clause would otherwise match and close the window out
       // from under the dialog.
       if (isTerminalCloseConfirmPending()) return;
+      // Root-mounted, so route/thread-scoped flags such as `terminalOpen` are
+      // out of reach; a `window.close` rule that reads them evaluates them as
+      // false, matching how other global handlers pass partial context.
       const command = resolveShortcutCommand(event, keybindings, {
-        context: { terminalFocus: getTerminalFocusOwner() !== null },
+        context: {
+          terminalFocus: getTerminalFocusOwner() !== null,
+          previewFocus: isPreviewFocused(),
+        },
       });
       if (command !== "window.close") return;
       event.preventDefault();

--- a/apps/web/src/components/WindowCloseShortcut.tsx
+++ b/apps/web/src/components/WindowCloseShortcut.tsx
@@ -42,9 +42,13 @@ export function WindowCloseShortcut() {
         },
       });
       if (command !== "window.close") return;
+      // An older desktop shell has no `closeWindow` and still binds the native
+      // accelerator, so swallowing the keystroke here would break its own close.
+      const closeWindow = window.desktopBridge?.closeWindow;
+      if (!closeWindow) return;
       event.preventDefault();
       event.stopPropagation();
-      void window.desktopBridge?.closeWindow?.();
+      void closeWindow();
     };
 
     window.addEventListener("keydown", handler, true);

--- a/apps/web/src/components/WindowCloseShortcut.tsx
+++ b/apps/web/src/components/WindowCloseShortcut.tsx
@@ -1,0 +1,41 @@
+import { useAtomValue } from "@effect/atom-react";
+import { useEffect } from "react";
+
+import { isElectron } from "../env";
+import { resolveShortcutCommand } from "../keybindings";
+import { isTerminalCloseConfirmPending } from "../lib/terminalCloseConfirm";
+import { getTerminalFocusOwner } from "../lib/terminalFocus";
+import { primaryServerKeybindingsAtom } from "../state/server";
+
+/**
+ * Runs the `window.close` keybinding. Desktop only: the native menu binds no
+ * CmdOrCtrl+W accelerator, so the renderer owns the shortcut there. A browser
+ * tab keeps its own Ctrl+W, which a page cannot intercept anyway.
+ */
+export function WindowCloseShortcut() {
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+
+  useEffect(() => {
+    if (!isElectron) return;
+
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (event.repeat || event.defaultPrevented) return;
+      // A terminal close confirmation holds focus outside the terminal, so the
+      // `!terminalFocus` clause would otherwise match and close the window out
+      // from under the dialog.
+      if (isTerminalCloseConfirmPending()) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: { terminalFocus: getTerminalFocusOwner() !== null },
+      });
+      if (command !== "window.close") return;
+      event.preventDefault();
+      event.stopPropagation();
+      void window.desktopBridge?.closeWindow?.();
+    };
+
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [keybindings]);
+
+  return null;
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -21,6 +21,7 @@ export interface KeybindingRow {
   readonly key: string;
   readonly when: string;
   readonly source: KeybindingSource;
+  readonly disabled: boolean;
   readonly defaultKey: string | null;
   readonly defaultWhen: string;
   readonly binding: ResolvedKeybindingRule;
@@ -95,6 +96,11 @@ function sourceForBinding(binding: ResolvedKeybindingRule): KeybindingSource {
     return "Project";
   }
 
+  // Defaults are never disabled, so a disabled rule is always a user override.
+  if (binding.disabled) {
+    return "Custom";
+  }
+
   const bindingKey = shortcutToKeybindingInput(binding.shortcut);
   const bindingWhen = whenAstToExpression(binding.whenAst);
   const isDefault = DEFAULT_RESOLVED_KEYBINDINGS.some(
@@ -145,6 +151,7 @@ export function keybindingConflictLabels(
   for (const candidate of rows) {
     if (
       candidate.id !== input.rowId &&
+      !candidate.disabled &&
       candidate.key === input.key &&
       conflictsWithWhen(candidate.when, input.when)
     ) {
@@ -169,6 +176,7 @@ export function buildKeybindingRows(
       key,
       when,
       source: sourceForBinding(binding),
+      disabled: binding.disabled === true,
       defaultKey: defaultBinding ? shortcutToKeybindingInput(defaultBinding.shortcut) : null,
       defaultWhen: whenAstToExpression(defaultBinding?.whenAst),
       binding,
@@ -177,6 +185,7 @@ export function buildKeybindingRows(
   });
 
   const rowsWithConflicts = rows.map((row) => {
+    if (row.disabled) return row;
     const conflicts = keybindingConflictLabels(rows, {
       rowId: row.id,
       key: row.key,
@@ -202,7 +211,8 @@ export function buildKeybindingRows(
       row.command.toLowerCase().includes(normalizedQuery) ||
       row.key.toLowerCase().includes(normalizedQuery) ||
       row.when.toLowerCase().includes(normalizedQuery) ||
-      row.source.toLowerCase().includes(normalizedQuery)
+      row.source.toLowerCase().includes(normalizedQuery) ||
+      (row.disabled && "disabled".includes(normalizedQuery))
     );
   });
 }

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -741,6 +741,7 @@ function KeybindingTableRow({
   onSave,
   onReset,
   onRemove,
+  onToggleDisabled,
 }: {
   row: KeybindingRow;
   allRows: ReadonlyArray<KeybindingRow>;
@@ -749,6 +750,7 @@ function KeybindingTableRow({
   onSave: (input: ServerUpsertKeybindingInput) => void;
   onReset: (row: KeybindingRow) => void;
   onRemove: (row: KeybindingRow) => void;
+  onToggleDisabled: (row: KeybindingRow) => void;
 }) {
   const [draft, setDraft] = useReducer(keybindingRowDraftReducer, row, createKeybindingRowDraft);
   const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
@@ -757,19 +759,21 @@ function KeybindingTableRow({
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
   const canReset = row.source === "Custom" && row.defaultKey !== null;
   const canRemove = row.source !== "Default";
-  const hasRowActions = canReset || canRemove;
   const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
-  const conflictLabels = keybindingConflictLabels(allRows, {
-    rowId: row.id,
-    key: keyDraft,
-    when: whenDraftExpression,
-  });
+  const conflictLabels = row.disabled
+    ? []
+    : keybindingConflictLabels(allRows, {
+        rowId: row.id,
+        key: keyDraft,
+        when: whenDraftExpression,
+      });
 
   const save = () => {
     onSave({
       command: row.command,
       key: keyDraft,
       when: whenDraftExpression.trim().length > 0 ? whenDraftExpression : undefined,
+      ...(row.disabled ? { disabled: true } : {}),
       replace: rowKeybindingTarget(row),
     });
   };
@@ -811,7 +815,10 @@ function KeybindingTableRow({
             type="button"
             onClick={() => setDraft({ isRecording: true })}
             aria-label={`Edit shortcut for ${commandLabel(row.command)}`}
-            className="group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
+            className={cn(
+              "group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              row.disabled && "opacity-45",
+            )}
           >
             <KeybindingPill value={row.key} />
             <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/0 transition-opacity group-hover:text-muted-foreground/70 group-focus-visible:text-muted-foreground/70">
@@ -835,6 +842,11 @@ function KeybindingTableRow({
             onKeyDown={captureKeybinding}
           />
         )}
+        {row.disabled && !isDirty ? (
+          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            Disabled
+          </span>
+        ) : null}
         {isDirty ? (
           <Button
             size="compact"
@@ -869,36 +881,37 @@ function KeybindingTableRow({
       </div>
       <div className="flex items-center justify-end gap-1">
         <KeybindingConflictWarning labels={conflictLabels} />
-        {hasRowActions ? (
-          <Menu>
-            <MenuTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
-                  disabled={isSaving}
-                  aria-label={`Actions for ${commandLabel(row.command)}`}
-                />
-              }
-            >
-              <EllipsisIcon className="size-3.5" />
-            </MenuTrigger>
-            <MenuPopup align="end" className="min-w-36">
-              {canReset ? (
-                <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
-                  Reset to default
-                </MenuItem>
-              ) : null}
-              {canRemove ? (
-                <MenuItem variant="destructive" disabled={isSaving} onClick={() => onRemove(row)}>
-                  Remove
-                </MenuItem>
-              ) : null}
-            </MenuPopup>
-          </Menu>
-        ) : null}
+        <Menu>
+          <MenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
+                disabled={isSaving}
+                aria-label={`Actions for ${commandLabel(row.command)}`}
+              />
+            }
+          >
+            <EllipsisIcon className="size-3.5" />
+          </MenuTrigger>
+          <MenuPopup align="end" className="min-w-36">
+            <MenuItem disabled={isSaving} onClick={() => onToggleDisabled(row)}>
+              {row.disabled ? "Enable" : "Disable"}
+            </MenuItem>
+            {canReset ? (
+              <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
+                Reset to default
+              </MenuItem>
+            ) : null}
+            {canRemove ? (
+              <MenuItem variant="destructive" disabled={isSaving} onClick={() => onRemove(row)}>
+                Remove
+              </MenuItem>
+            ) : null}
+          </MenuPopup>
+        </Menu>
         <span className="sr-only">{displayShortcut}</span>
       </div>
     </div>
@@ -1122,6 +1135,7 @@ export function KeybindingsSettingsPanel() {
         command: input.command,
         key: input.key.trim(),
         ...(input.when?.trim() ? { when: input.when.trim() } : {}),
+        ...(input.disabled === true ? { disabled: true } : {}),
         ...(input.replace ? { replace: input.replace } : {}),
       };
       void (async () => {
@@ -1168,6 +1182,19 @@ export function KeybindingsSettingsPanel() {
       })();
     },
     [primaryEnvironment, removeKeybindingMutation],
+  );
+
+  const toggleKeybindingDisabled = useCallback(
+    (row: KeybindingRow) => {
+      saveKeybinding({
+        command: row.command,
+        key: row.key,
+        when: row.when.trim().length > 0 ? row.when : undefined,
+        ...(row.disabled ? {} : { disabled: true }),
+        replace: rowKeybindingTarget(row),
+      });
+    },
+    [saveKeybinding],
   );
 
   const resetKeybinding = useCallback(
@@ -1287,6 +1314,7 @@ export function KeybindingsSettingsPanel() {
                 onSave={saveKeybinding}
                 onReset={resetKeybinding}
                 onRemove={removeKeybinding}
+                onToggleDisabled={toggleKeybindingDisabled}
               />
             ))}
             {rows.length === 0 && !isAddingBinding ? (

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -44,6 +44,7 @@ import {
   serverEnvironment,
 } from "../../state/server";
 import { usePrimaryEnvironment } from "../../state/environments";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -843,9 +844,13 @@ function KeybindingTableRow({
           />
         )}
         {row.disabled && !isDirty ? (
-          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+          <Badge
+            size="sm"
+            variant="secondary"
+            className="bg-muted uppercase tracking-[0.08em] text-muted-foreground"
+          >
             Disabled
-          </span>
+          </Badge>
         ) : null}
         {isDirty ? (
           <Button

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -518,8 +518,12 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
       setIsSavingScripts(true);
       try {
         // Captured before the write so a cleared or deleted binding can be
-        // removed from the keybindings config afterwards.
-        const previousKeybinding = keybindingValueForCommand(keybindings, keybindingCommand);
+        // removed from the keybindings config afterwards. Disabled rules count
+        // here: they still claim the command, so they are what a replace or
+        // remove has to target instead of leaving them orphaned.
+        const previousKeybinding = keybindingValueForCommand(keybindings, keybindingCommand, {
+          includeDisabled: true,
+        });
         const updateResult = mapAtomCommandResult(
           await updateProject({
             environmentId: selectedCheckout.environmentId,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -111,6 +111,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenIdentifier("terminalFocus"),
   },
   {
+    shortcut: modShortcut("w"),
+    command: "window.close",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("d"),
     command: "diff.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -327,6 +332,28 @@ describe("split/new/close terminal shortcuts", () => {
       isTerminalNewShortcut(event({ key: "m", ctrlKey: true }), keybindings, {
         platform: "Linux",
       }),
+    );
+  });
+});
+
+describe("window close shortcut", () => {
+  it("closes the terminal while the terminal has focus", () => {
+    assert.equal(
+      resolveShortcutCommand(event({ key: "w", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: true },
+      }),
+      "terminal.close",
+    );
+  });
+
+  it("closes the window outside the terminal", () => {
+    assert.equal(
+      resolveShortcutCommand(event({ key: "w", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false },
+      }),
+      "window.close",
     );
   });
 });

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -74,6 +74,7 @@ interface TestBinding {
   shortcut: KeybindingShortcut;
   command: KeybindingCommand;
   whenAst?: KeybindingWhenNode;
+  disabled?: boolean;
 }
 
 function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
@@ -81,6 +82,7 @@ function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
     command: binding.command,
     shortcut: binding.shortcut,
     ...(binding.whenAst ? { whenAst: binding.whenAst } : {}),
+    ...(binding.disabled ? { disabled: true } : {}),
   }));
 }
 
@@ -705,6 +707,42 @@ describe("cross-command precedence", () => {
         context: { terminalFocus: true },
       }),
     );
+  });
+});
+
+describe("disabled bindings", () => {
+  it("returns null when the only binding for a shortcut is disabled", () => {
+    const keybindings = compile([
+      { shortcut: modShortcut("j"), command: "terminal.toggle", disabled: true },
+    ]);
+
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "j", ctrlKey: true }), keybindings, {
+        platform: "Linux",
+      }),
+    );
+  });
+
+  it("skips a disabled later rule so an earlier rule still wins", () => {
+    const keybindings = compile([
+      { shortcut: modShortcut("j"), command: "terminal.toggle" },
+      { shortcut: modShortcut("j"), command: "sidebar.toggle", disabled: true },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "j", ctrlKey: true }), keybindings, {
+        platform: "Linux",
+      }),
+      "terminal.toggle",
+    );
+  });
+
+  it("shows no shortcut label for a disabled binding", () => {
+    const keybindings = compile([
+      { shortcut: modShortcut("j"), command: "terminal.toggle", disabled: true },
+    ]);
+
+    assert.isNull(shortcutLabelForCommand(keybindings, "terminal.toggle", "Linux"));
   });
 });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -178,7 +178,7 @@ function findEffectiveShortcutForCommand(
 
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding) continue;
+    if (!binding || binding.disabled) continue;
     if (!matchesWhenClause(binding.whenAst, context)) continue;
 
     const conflictKey = shortcutConflictKey(binding.shortcut, platform);
@@ -214,7 +214,7 @@ export function resolveShortcutCommand(
 
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding) continue;
+    if (!binding || binding.disabled) continue;
     if (!matchesWhenClause(binding.whenAst, context)) continue;
     if (!matchesShortcut(event, binding.shortcut, platform)) continue;
     return binding.command;

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -137,4 +137,63 @@ describe("projectScriptKeybindings", () => {
 
     expect(value).toBe("mod+alt+j");
   });
+
+  it("returns a disabled keybinding when disabled rules are included", () => {
+    const command = commandForProjectScript("test");
+    const bindings = [
+      {
+        command,
+        disabled: true,
+        shortcut: {
+          key: "k",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: true,
+          altKey: false,
+          modKey: true,
+        },
+      },
+    ];
+
+    expect(keybindingValueForCommand(bindings, command, { includeDisabled: true })).toBe(
+      "mod+shift+k",
+    );
+    expect(keybindingValueForCommand(bindings, command, { includeDisabled: false })).toBeNull();
+    expect(keybindingValueForCommand(bindings, command)).toBeNull();
+  });
+
+  it("prefers the latest rule when disabled rules are included", () => {
+    const command = commandForProjectScript("test");
+    const value = keybindingValueForCommand(
+      [
+        {
+          command,
+          shortcut: {
+            key: "j",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: true,
+            modKey: true,
+          },
+        },
+        {
+          command,
+          disabled: true,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
+      command,
+      { includeDisabled: true },
+    );
+
+    expect(value).toBe("mod+shift+k");
+  });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.test.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.test.ts
@@ -80,4 +80,61 @@ describe("projectScriptKeybindings", () => {
 
     expect(value).toBe("mod+shift+k");
   });
+
+  it("ignores disabled keybindings for a command", () => {
+    const command = commandForProjectScript("test");
+    const value = keybindingValueForCommand(
+      [
+        {
+          command,
+          disabled: true,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
+      command,
+    );
+
+    expect(value).toBeNull();
+  });
+
+  it("falls through a later disabled rule to an earlier enabled one", () => {
+    const command = commandForProjectScript("test");
+    const value = keybindingValueForCommand(
+      [
+        {
+          command,
+          shortcut: {
+            key: "j",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: true,
+            modKey: true,
+          },
+        },
+        {
+          command,
+          disabled: true,
+          shortcut: {
+            key: "k",
+            metaKey: false,
+            ctrlKey: false,
+            shiftKey: true,
+            altKey: false,
+            modKey: true,
+          },
+        },
+      ],
+      command,
+    );
+
+    expect(value).toBe("mod+alt+j");
+  });
 });

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -34,13 +34,22 @@ export function decodeProjectScriptKeybindingRule(input: {
   return decoded.value;
 }
 
+/**
+ * Reads the shortcut a command currently resolves to. Disabled rules are
+ * skipped by default so nothing presents a dead shortcut as active; pass
+ * `includeDisabled` when the caller needs the rule that owns the command in
+ * the config, such as the replace/remove target of a keybinding write.
+ */
 export function keybindingValueForCommand(
   keybindings: ResolvedKeybindingsConfig,
   command: KeybindingCommand,
+  options?: { includeDisabled?: boolean },
 ): string | null {
+  const includeDisabled = options?.includeDisabled ?? false;
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding || binding.disabled || binding.command !== command) continue;
+    if (!binding || binding.command !== command) continue;
+    if (binding.disabled && !includeDisabled) continue;
 
     const parts: string[] = [];
     if (binding.shortcut.modKey) parts.push("mod");

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -40,7 +40,7 @@ export function keybindingValueForCommand(
 ): string | null {
   for (let index = keybindings.length - 1; index >= 0; index -= 1) {
     const binding = keybindings[index];
-    if (!binding || binding.command !== command) continue;
+    if (!binding || binding.disabled || binding.command !== command) continue;
 
     const parts: string[] = [];
     if (binding.shortcut.modKey) parts.push("mod");

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -1,7 +1,9 @@
 # Keybindings
 
 Edit keybindings from **Settings** → **Keybindings**. That page lists every command, its current
-shortcut, whether it is a default or your own, and warns about conflicts.
+shortcut, whether it is a default or your own, and warns about conflicts. Each row's menu can also
+disable the binding entirely; a disabled binding keeps its place in the list but never fires until
+you enable it again or reset it to the default.
 
 The same configuration lives in `~/.t3/userdata/keybindings.json` on the machine running the
 server, if you prefer editing it directly. T3 Code writes the built-in defaults into that file on
@@ -24,6 +26,8 @@ Invalid rules are ignored. An invalid file is ignored entirely, and the server l
 - `key` (required): shortcut string, like `mod+j`, `ctrl+k`, `cmd+shift+d`
 - `command` (required): the command ID to run
 - `when` (optional): boolean expression controlling when the shortcut is active
+- `disabled` (optional): `true` turns the rule off without deleting it. Deleting a default's rule
+  brings the default back on the next startup; disabling it is how you switch a default off.
 
 ## Key Syntax
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -2,8 +2,8 @@
 
 Edit keybindings from **Settings** → **Keybindings**. That page lists every command, its current
 shortcut, whether it is a default or your own, and warns about conflicts. Each row's menu can also
-disable the binding entirely; a disabled binding keeps its place in the list but never fires until
-you enable it again or reset it to the default.
+disable the binding entirely; a disabled binding stays in the list but never fires until you enable
+it again or reset it to the default.
 
 The same configuration lives in `~/.t3/userdata/keybindings.json` on the machine running the
 server, if you prefer editing it directly. T3 Code writes the built-in defaults into that file on

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -59,6 +59,12 @@ so add one in **Settings** → **Keybindings** if you want to use it.
 `thread.settle` settles the active thread or restores it when it is already settled. Its default
 shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 
+`window.close` closes the current window in the desktop app. Its default shortcut is `mod+w` with
+`"when": "!terminalFocus"`, so the same key closes the focused terminal instead while you are in
+one. Disable the rule in **Settings** → **Keybindings** if you would rather `mod+w` do nothing
+outside the terminal. In a browser tab, `ctrl+w` belongs to the browser and T3 Code never sees it,
+so the command only applies to the desktop app.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1137,6 +1137,12 @@ export interface DesktopBridge {
    * desktop builds never emit it.
    */
   onQuitShortcut?: (listener: (state: "down" | "up") => void) => () => void;
+  /**
+   * Closes the focused app window, backing the `window.close` keybinding.
+   * Optional: older desktop shells hosting a newer web client lack it, and the
+   * renderer then leaves the shortcut alone.
+   */
+  closeWindow?: () => Promise<void>;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -72,6 +72,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "chat.new",
   "chat.newLocal",
   "editor.openFavorite",
+  "window.close",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,
 ] as const;

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -104,6 +104,8 @@ export const KeybindingRule = Schema.Struct({
   key: KeybindingValue,
   command: KeybindingCommand,
   when: Schema.optional(KeybindingWhen),
+  /** A disabled rule keeps its slot (so the default is not re-added) but never matches. */
+  disabled: Schema.optional(Schema.Boolean),
 });
 export type KeybindingRule = typeof KeybindingRule.Type;
 
@@ -155,6 +157,7 @@ export const ResolvedKeybindingRule = Schema.Struct({
   command: KeybindingCommand,
   shortcut: KeybindingShortcut,
   whenAst: Schema.optional(KeybindingWhenNode),
+  disabled: Schema.optional(Schema.Boolean),
 }).annotate({ parseOptions: { onExcessProperty: "ignore" } });
 export type ResolvedKeybindingRule = typeof ResolvedKeybindingRule.Type;
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -104,7 +104,7 @@ export const KeybindingRule = Schema.Struct({
   key: KeybindingValue,
   command: KeybindingCommand,
   when: Schema.optional(KeybindingWhen),
-  /** A disabled rule keeps its slot (so the default is not re-added) but never matches. */
+  /** A disabled rule still claims its command (so the default is not re-added) but never matches. */
   disabled: Schema.optional(Schema.Boolean),
 });
 export type KeybindingRule = typeof KeybindingRule.Type;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -464,6 +464,7 @@ export const ServerUpsertKeybindingInput = Schema.Struct({
   key: KeybindingValue,
   command: KeybindingCommand,
   when: Schema.optional(KeybindingWhen),
+  disabled: Schema.optional(Schema.Boolean),
   replace: Schema.optional(ServerUpsertKeybindingReplaceTarget),
 });
 export type ServerUpsertKeybindingInput = typeof ServerUpsertKeybindingInput.Type;

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -266,6 +266,7 @@ export function compileResolvedKeybindingRule(rule: KeybindingRule): ResolvedKey
   const shortcut = parseKeybindingShortcut(rule.key);
   if (!shortcut) return null;
 
+  const disabled = rule.disabled === true ? { disabled: true } : {};
   if (rule.when !== undefined) {
     const whenAst = parseKeybindingWhenExpression(rule.when);
     if (!whenAst) return null;
@@ -273,12 +274,14 @@ export function compileResolvedKeybindingRule(rule: KeybindingRule): ResolvedKey
       command: rule.command,
       shortcut,
       whenAst,
+      ...disabled,
     };
   }
 
   return {
     command: rule.command,
     shortcut,
+    ...disabled,
   };
 }
 

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -26,6 +26,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+d", command: "terminal.splitVertical", when: "terminalFocus" },
   { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
   { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
+  { key: "mod+w", command: "window.close", when: "!terminalFocus" },
   { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
   { key: "mod+shift+j", command: "preview.toggle" },
   { key: "mod+r", command: "preview.refresh", when: "previewFocus" },


### PR DESCRIPTION
## Problem

Ctrl/Cmd+W is a hardcoded Electron menu accelerator (the `close`/`windowMenu` roles), invisible to the keybinding system. On Linux and Windows it closes the only window and takes the whole app and every running session with it - a muscle-memory tab-close away from losing your work, with no way to rebind or turn it off. The only registered mod+w keybinding (`terminal.close`) never owned this path.

## Fix

The native menu registers no CmdOrCtrl+W accelerator anymore. Instead a new `window.close` command joins the registry with the same default (`mod+w`, `when: \"!terminalFocus\"`), so out of the box nothing changes: terminal focused closes the terminal, otherwise the window closes. But the shortcut is now an ordinary row in Settings → Keybindings - rebind it, or disable it (#8376) so Ctrl+W does nothing.

- `apps/desktop`: File menu (macOS) and Window menu use an accelerator-less "Close Window" item routed through a new `DesktopWindow.closeMain`; the stale `before-input-event` comments updated. Menu template test asserts nothing binds +W.
- New `desktop:close-window` IPC method, exposed as optional `closeWindow` on the bridge so an older desktop shell hosting a newer web client degrades to ignoring the shortcut.
- `apps/web`: root-mounted `WindowCloseShortcut` resolves the key with real terminal focus context and calls the bridge; browsers are untouched (a tab's Ctrl+W belongs to the browser).
- Docs and tests across shared/server/web/desktop.

## UI

The new command appears as an ordinary row in Settings → Keybindings (it did not exist before):

<img width="2304" alt="after: Window: Close row" src="https://github.com/user-attachments/assets/1849aeb8-e8d8-412b-9a8e-1729058f0ad6" />

The native File/Window menu keeps its Close Window item but no longer shows or registers a CmdOrCtrl+W accelerator; the menu-template test asserts nothing in the menu binds +W.

**Stacked on #8376** and includes its commit until that merges; only the second commit (`feat(desktop): route window close...`) is new here.

Built by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core desktop close behavior and global mod+W handling; mismatched old desktop shells without `closeWindow` will not close on the shortcut until upgraded.
> 
> **Overview**
> **Desktop no longer registers a native Cmd/Ctrl+W accelerator.** Close Window is a custom menu action and a new `desktop:close-window` IPC path (`DesktopWindow.closeMain`, optional `desktopBridge.closeWindow`). The renderer mounts `WindowCloseShortcut` so **mod+W** resolves through keybindings: `terminal.close` when the terminal has focus, **`window.close`** otherwise.
> 
> Defaults add **`window.close`** with `when: "!terminalFocus"`. Preview guest forwarding spells mod+W per platform (Cmd on macOS, Ctrl elsewhere). Key repeat on mod+W is still swallowed at the main window.
> 
> **Keybindings gain a `disabled` flag** end-to-end (schema, server default-sync conflict rules, settings UI enable/disable). Disabled rules do not match or block default backfill the same way active custom rules do.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491ee6c6e5a4c0b5291c406d66bf2e50ccc65efc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route desktop window close through `window.close` keybinding instead of native menu accelerator
> - Adds a new `window.close` keybinding command mapped to `mod+w` with `!terminalFocus` context, splitting `mod+w` between terminal close and window close. The renderer resolves the shortcut via [WindowCloseShortcut.tsx](https://github.com/pingdotgg/t3code/pull/8377/files#diff-673cb0cd8045d0879b5ff256e06045b0c2059dda543744597499b6703a1e3871) and calls `desktopBridge.closeWindow()` through a new IPC channel.
> - Removes the implicit `CmdOrCtrl+W` accelerator from the native menu in [DesktopApplicationMenu.ts](https://github.com/pingdotgg/t3code/pull/8377/files#diff-1d27d62f2db6ae3d67221b54135a0260783acf7594fd4ad9f60035f0819a96eb). The Close Window menu item now triggers `DesktopWindow.closeMain` directly. Auto-repeated `mod+W` keystrokes are suppressed in `before-input-event` to prevent duplicate closes.
> - Adds support for disabling keybindings end-to-end: schema field `disabled` on `KeybindingRule` and `ResolvedKeybindingRule`, server persistence and round-trip, conflict detection that treats disabled rules as non-owning, and a UI toggle in settings with visual badges and conflict suppression.
> - Risk: the native menu no longer registers `CmdOrCtrl+W` as an accelerator — if the renderer keybinding handler fails to load or `desktopBridge.closeWindow` is absent (older shells), `mod+w` will not close the window. Conflict logic in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/8377/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e) `hasConflictingShortcutContext` now treats unconditional user rules as owning a shortcut across all contexts, which may change which defaults backfill on startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 491ee6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
