### PR TITLE
fix(server): recover collided thread migration

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -56,6 +56,7 @@ import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
 import Migration0041 from "./Migrations/041_AuthSessionClientConnection.ts";
 import Migration0042 from "./Migrations/042_ProjectionThreadLinkedPullRequest.ts";
 import Migration0043 from "./Migrations/043_ProjectionThreadsUnsettledAt.ts";
+import Migration0050 from "./Migrations/050_ProjectionThreadsUnsettledAtRecovery.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -111,6 +112,8 @@ export const migrationEntries = [
   [41, "AuthSessionClientConnection", Migration0041],
   [42, "ProjectionThreadLinkedPullRequest", Migration0042],
   [43, "ProjectionThreadsUnsettledAt", Migration0043],
+  // Keep 44-49 unused because affected databases may already contain those migration IDs.
+  [50, "ProjectionThreadsUnsettledAtRecovery", Migration0050],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/050_ProjectionThreadsUnsettledAtRecovery.test.ts
+++ b/apps/server/src/persistence/Migrations/050_ProjectionThreadsUnsettledAtRecovery.test.ts
@@ -1,0 +1,38 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("050_ProjectionThreadsUnsettledAtRecovery", (it) => {
+  it.effect("recovers when migration IDs 43 through 49 belong to a divergent history", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 42 });
+      yield* sql`
+        INSERT INTO effect_sql_migrations (migration_id, name)
+        VALUES
+          (43, 'ProjectionThreadOperatorScope'),
+          (44, 'OperatorProjects'),
+          (45, 'OperatorProjectExecutionRequestText'),
+          (46, 'OperatorProjectContextRequests'),
+          (47, 'OperatorPlugins'),
+          (48, 'OperatorPluginHardening'),
+          (49, 'OperatorOrchestrationV0')
+      `;
+
+      const executed = yield* runMigrations();
+      const columns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(projection_threads)
+      `;
+
+      assert.deepStrictEqual(executed, [[50, "ProjectionThreadsUnsettledAtRecovery"]]);
+      assert.ok(columns.some((column) => column.name === "unsettled_at"));
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/050_ProjectionThreadsUnsettledAtRecovery.ts
+++ b/apps/server/src/persistence/Migrations/050_ProjectionThreadsUnsettledAtRecovery.ts
@@ -1,0 +1,3 @@
+import ProjectionThreadsUnsettledAt from "./043_ProjectionThreadsUnsettledAt.ts";
+
+export default ProjectionThreadsUnsettledAt;


### PR DESCRIPTION
## What Changed

- Reserved migration IDs 44 through 49 because affected databases may already contain those IDs from a divergent migration history.
- Added migration 50 to rerun the existing idempotent `projection_threads.unsettled_at` schema repair.
- Added a regression test covering the observed conflicting migration records.

## Why

Affected databases record different migrations at IDs 43 through 49. The migrator therefore treats the official migration 43 as complete even though `projection_threads.unsettled_at` is missing. Thread queries then fail and the desktop backend crash-loops while its window remains hidden.

## Validation

- `pnpm exec vp test run apps/server/src/persistence/Migrations/050_ProjectionThreadsUnsettledAtRecovery.test.ts`
- `pnpm exec vp run --filter t3 typecheck`
- Targeted formatting and lint checks for the three changed files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Generated with Codex using GPT-5.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration 50 to recover collided `ProjectionThreadsUnsettledAt` migration
> Some databases have migration records for IDs 44-49, which blocks migration 43 (`ProjectionThreadsUnsettledAt`) from running. Migration 50 re-exports migration 43 so the `projection_threads.unsettled_at` column gets added even when 44-49 are already marked applied.
>
> - IDs 44-49 are intentionally left unused in the migration list to avoid conflicts with affected databases
> - Risk: databases that already ran migration 43 will re-run the same schema change via migration 50; the migration must be idempotent or tolerate the existing `unsettled_at` column in `projection_threads`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4f089dd. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->