### PR TITLE
feat(web): split provider settings into list and editor

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -37,6 +37,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import type { DriverOption } from "./providerDriverMeta";
+import { providerSettingsTabClassName } from "./providerSettingsTabs";
 import { ProviderSettingsForm } from "./ProviderSettingsForm";
 import { ProviderModelsSection } from "./ProviderModelsSection";
 import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
@@ -699,17 +700,12 @@ export function ProviderInstanceCard({
         </div>
       </div>
 
-      <div className="flex h-11 gap-6 border-b border-border/70 px-4">
+      <div className="flex h-11 border-b border-border/70 px-1">
         {driverOption !== undefined ? (
           <button
             type="button"
             aria-pressed={visibleTab === "models"}
-            className={cn(
-              "relative flex h-11 cursor-pointer items-center rounded-sm px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-              visibleTab === "models"
-                ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
-                : "text-muted-foreground hover:text-foreground",
-            )}
+            className={providerSettingsTabClassName(visibleTab === "models")}
             onClick={() => setActiveTab("models")}
           >
             Models
@@ -718,12 +714,7 @@ export function ProviderInstanceCard({
         <button
           type="button"
           aria-pressed={visibleTab === "configuration"}
-          className={cn(
-            "relative flex h-11 cursor-pointer items-center rounded-sm px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-            visibleTab === "configuration"
-              ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
-              : "text-muted-foreground hover:text-foreground",
-          )}
+          className={providerSettingsTabClassName(visibleTab === "configuration")}
           onClick={() => setActiveTab("configuration")}
         >
           Configuration

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -376,7 +376,7 @@ export function ProviderInstanceCard({
     : "disabled";
   const statusStyle = PROVIDER_STATUS_STYLES[statusKey];
   const rawSummary = getProviderSummary(liveProvider);
-  const summary = rawSummary;
+  const summary = enabled ? rawSummary : { headline: "Disabled", detail: null };
   const versionLabel = getProviderVersionLabel(liveProvider?.version);
   const versionAdvisory = getProviderVersionAdvisoryPresentation(liveProvider?.versionAdvisory);
   const updateCommand = versionAdvisory?.updateCommand ?? null;

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -475,25 +475,16 @@ export function ProviderInstanceCard({
       displayName={displayName}
       accentColor={accentColor}
       showBadge={Boolean(accentColor)}
-      statusDotClassName={statusStyle.dot}
-      indicatorBackground="var(--card)"
       className="size-5"
       iconClassName="size-4 text-foreground/80"
       badgeClassName="right-[-0.125rem] bottom-[-0.125rem] h-3 min-w-3 px-0.5 text-[7px]"
     />
   ) : FallbackIconComponent ? (
-    <span className="relative inline-flex size-5 shrink-0 items-center justify-center">
+    <span className="inline-flex size-5 shrink-0 items-center justify-center">
       <FallbackIconComponent className="size-4 text-foreground/80" aria-hidden />
-      <span
-        className={cn(
-          "pointer-events-none absolute -left-0.5 -top-0.5 size-2 rounded-full ring-2 ring-card",
-          statusStyle.dot,
-        )}
-        aria-hidden
-      />
     </span>
   ) : (
-    <span className={cn("size-2 shrink-0 rounded-full", statusStyle.dot)} />
+    <span className="size-4 shrink-0 rounded-sm border border-border" aria-hidden />
   );
 
   const titleHeadNode = (

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -303,6 +303,7 @@ interface ProviderInstanceCardProps {
   readonly mode: "list" | "editor";
   readonly selected?: boolean | undefined;
   readonly onSelect?: (() => void) | undefined;
+  readonly readOnly?: boolean | undefined;
   readonly onUpdate: (nextInstance: ProviderInstanceConfig) => void;
   /**
    * Pass `undefined` to hide the delete button entirely. Built-in default
@@ -356,6 +357,7 @@ export function ProviderInstanceCard({
   mode,
   selected = false,
   onSelect,
+  readOnly = false,
   onUpdate,
   onDelete,
   headerAction,
@@ -585,6 +587,7 @@ export function ProviderInstanceCard({
         </button>
         <Switch
           checked={enabled}
+          disabled={readOnly}
           onCheckedChange={(checked) => updateEnabled(Boolean(checked))}
           aria-label={`Enable ${displayName}`}
         />

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -727,65 +727,64 @@ export function ProviderInstanceCard({
       </div>
 
       <div className="px-4 py-5">
-        {visibleTab === "configuration" ? (
-          <div className="space-y-5">
-            <div>
-              <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
-                <span className="text-xs font-medium text-foreground">Display name</span>
-                <DraftInput
-                  id={`provider-instance-${instanceId}-display-name`}
-                  className="mt-1.5"
-                  value={instance.displayName ?? ""}
-                  onCommit={updateDisplayName}
-                  placeholder={driverOption?.label ?? "Instance label"}
-                  spellCheck={false}
-                />
-                <span className="mt-1 block text-xs text-muted-foreground">
-                  Optional label shown in the provider list.
-                </span>
-              </label>
-            </div>
-
-            <div>
-              <ProviderAccentColorPicker
-                displayName={displayName}
-                value={accentColor}
-                onCommit={updateAccentColor}
-                commitDelayMs={120}
-                description="Used to distinguish this instance in picker rails and model lists."
-              />
-            </div>
-
-            <div>
-              <ProviderEnvironmentSection
-                environment={instance.environment ?? []}
-                onChange={updateEnvironment}
-              />
-            </div>
-
-            {driverOption ? (
-              <ProviderSettingsForm
-                definition={driverOption}
-                value={instance.config}
-                idPrefix={`provider-instance-${instanceId}`}
-                variant="card"
-                onChange={updateConfig}
-              />
-            ) : null}
-
-            {driverOption === undefined ? (
-              <div>
-                <p className="text-xs text-muted-foreground">
-                  This instance uses a driver (
-                  <code className="text-foreground">{String(instance.driver)}</code>) that is not
-                  shipped with the current build. Configuration values are preserved but cannot be
-                  edited from this surface.
-                </p>
-              </div>
-            ) : null}
-          </div>
-        ) : driverOption !== undefined ? (
+        <div className="space-y-5" hidden={visibleTab !== "configuration"}>
           <div>
+            <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
+              <span className="text-xs font-medium text-foreground">Display name</span>
+              <DraftInput
+                id={`provider-instance-${instanceId}-display-name`}
+                className="mt-1.5"
+                value={instance.displayName ?? ""}
+                onCommit={updateDisplayName}
+                placeholder={driverOption?.label ?? "Instance label"}
+                spellCheck={false}
+              />
+              <span className="mt-1 block text-xs text-muted-foreground">
+                Optional label shown in the provider list.
+              </span>
+            </label>
+          </div>
+
+          <div>
+            <ProviderAccentColorPicker
+              displayName={displayName}
+              value={accentColor}
+              onCommit={updateAccentColor}
+              commitDelayMs={120}
+              description="Used to distinguish this instance in picker rails and model lists."
+            />
+          </div>
+
+          <div>
+            <ProviderEnvironmentSection
+              environment={instance.environment ?? []}
+              onChange={updateEnvironment}
+            />
+          </div>
+
+          {driverOption ? (
+            <ProviderSettingsForm
+              definition={driverOption}
+              value={instance.config}
+              idPrefix={`provider-instance-${instanceId}`}
+              variant="card"
+              onChange={updateConfig}
+            />
+          ) : null}
+
+          {driverOption === undefined ? (
+            <div>
+              <p className="text-xs text-muted-foreground">
+                This instance uses a driver (
+                <code className="text-foreground">{String(instance.driver)}</code>) that is not
+                shipped with the current build. Configuration values are preserved but cannot be
+                edited from this surface.
+              </p>
+            </div>
+          ) : null}
+        </div>
+        {driverOption !== undefined ? (
+          <div hidden={visibleTab !== "models"}>
             <ProviderModelsSection
               instanceId={instanceId}
               driverKind={driverKind}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -157,13 +157,20 @@ function ProviderEnvironmentSection(props: {
     props.environment.map(makeEnvironmentDraftRow),
   );
   const previousEnvironmentRef = useRef(props.environment);
+  const lastPublishedEnvironmentRef = useRef<
+    ReadonlyArray<ProviderInstanceEnvironmentVariable> | undefined
+  >(undefined);
 
   useEffect(() => {
     const previousEnvironment = previousEnvironmentRef.current;
+    const lastPublishedEnvironment = lastPublishedEnvironmentRef.current;
     previousEnvironmentRef.current = props.environment;
+    lastPublishedEnvironmentRef.current = undefined;
     if (
       previousEnvironment === props.environment ||
-      providerEnvironmentsEqual(previousEnvironment, props.environment)
+      providerEnvironmentsEqual(previousEnvironment, props.environment) ||
+      (lastPublishedEnvironment !== undefined &&
+        providerEnvironmentsEqual(lastPublishedEnvironment, props.environment))
     ) {
       return;
     }
@@ -188,6 +195,7 @@ function ProviderEnvironmentSection(props: {
       const { id: _id, ...rest } = row;
       published.push({ ...rest, name });
     }
+    lastPublishedEnvironmentRef.current = published;
     props.onChange(published);
   };
 

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -369,11 +369,11 @@ export function ProviderInstanceCard({
 }: ProviderInstanceCardProps) {
   const [activeTab, setActiveTab] = useState<"models" | "configuration">("configuration");
   const enabled = resolveProviderInstanceEnabled(instance);
-  // The server-reported status wins when present; otherwise fall back to
-  // "disabled"/"warning" based on the local `enabled` flag so the dot
-  // reflects the persisted intent even before the first probe completes.
-  const statusKey: ProviderStatusKey =
-    (liveProvider?.status as ProviderStatusKey | undefined) ?? (enabled ? "warning" : "disabled");
+  // A locally disabled provider stays neutral even if its last server status
+  // is stale. Enabled providers use the server status when one is available.
+  const statusKey: ProviderStatusKey = enabled
+    ? ((liveProvider?.status as ProviderStatusKey | undefined) ?? "warning")
+    : "disabled";
   const statusStyle = PROVIDER_STATUS_STYLES[statusKey];
   const rawSummary = getProviderSummary(liveProvider);
   const summary = rawSummary;
@@ -410,6 +410,7 @@ export function ProviderInstanceCard({
   const driverKind: ProviderDriverKind | null = isProviderDriverKind(instance.driver)
     ? instance.driver
     : null;
+  const visibleTab = driverOption === undefined ? "configuration" : activeTab;
 
   const customModels = readConfigStringArray(instance.config, "customModels");
   // Server-returned models may lag behind settings writes. Treat probe
@@ -551,7 +552,10 @@ export function ProviderInstanceCard({
         {selected ? <span className="absolute inset-y-0 left-0 w-0.5 bg-primary" /> : null}
         <button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-3 text-left"
+          className={cn(
+            "flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-sm text-left outline-none transition-opacity focus-visible:ring-2 focus-visible:ring-ring",
+            !enabled && !selected && "opacity-60 group-hover:opacity-100",
+          )}
           onClick={onSelect}
           aria-pressed={selected}
         >
@@ -688,28 +692,28 @@ export function ProviderInstanceCard({
         </div>
       </div>
 
-      <div className="flex h-11 items-end gap-6 border-b border-border/70 px-4" role="tablist">
+      <div className="flex h-11 items-end gap-6 border-b border-border/70 px-4">
+        {driverOption !== undefined ? (
+          <button
+            type="button"
+            aria-pressed={visibleTab === "models"}
+            className={cn(
+              "h-11 cursor-pointer rounded-sm border-b-2 px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+              visibleTab === "models"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => setActiveTab("models")}
+          >
+            Models
+          </button>
+        ) : null}
         <button
           type="button"
-          role="tab"
-          aria-selected={activeTab === "models"}
+          aria-pressed={visibleTab === "configuration"}
           className={cn(
-            "h-11 border-b-2 px-0 text-xs font-medium transition-colors",
-            activeTab === "models"
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground",
-          )}
-          onClick={() => setActiveTab("models")}
-        >
-          Models
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeTab === "configuration"}
-          className={cn(
-            "h-11 border-b-2 px-0 text-xs font-medium transition-colors",
-            activeTab === "configuration"
+            "h-11 cursor-pointer rounded-sm border-b-2 px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+            visibleTab === "configuration"
               ? "border-primary text-foreground"
               : "border-transparent text-muted-foreground hover:text-foreground",
           )}
@@ -720,8 +724,8 @@ export function ProviderInstanceCard({
       </div>
 
       <div className="px-4 py-5">
-        {activeTab === "configuration" ? (
-          <div className="space-y-5" role="tabpanel">
+        {visibleTab === "configuration" ? (
+          <div className="space-y-5">
             <div>
               <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
                 <span className="text-xs font-medium text-foreground">Display name</span>
@@ -778,7 +782,7 @@ export function ProviderInstanceCard({
             ) : null}
           </div>
         ) : driverOption !== undefined ? (
-          <div role="tabpanel">
+          <div>
             <ProviderModelsSection
               instanceId={instanceId}
               driverKind={driverKind}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   isProviderDriverKind,
   resolveProviderInstanceEnabled,
@@ -137,6 +137,13 @@ function ProviderEnvironmentSection(props: {
   const [rows, setRows] = useState<ReadonlyArray<EnvironmentDraftRow>>(() =>
     props.environment.map(makeEnvironmentDraftRow),
   );
+  const previousEnvironmentRef = useRef(props.environment);
+
+  useEffect(() => {
+    if (previousEnvironmentRef.current === props.environment) return;
+    previousEnvironmentRef.current = props.environment;
+    setRows(props.environment.map(makeEnvironmentDraftRow));
+  }, [props.environment]);
 
   const publishRows = (nextRows: ReadonlyArray<EnvironmentDraftRow>) => {
     const published: ProviderInstanceEnvironmentVariable[] = [];

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -377,6 +377,7 @@ export function ProviderInstanceCard({
   const statusStyle = PROVIDER_STATUS_STYLES[statusKey];
   const rawSummary = getProviderSummary(liveProvider);
   const summary = enabled ? rawSummary : { headline: "Disabled", detail: null };
+  const showEditorStatus = enabled && (statusKey === "warning" || statusKey === "error");
   const versionLabel = getProviderVersionLabel(liveProvider?.version);
   const versionAdvisory = getProviderVersionAdvisoryPresentation(liveProvider?.versionAdvisory);
   const updateCommand = versionAdvisory?.updateCommand ?? null;
@@ -689,19 +690,25 @@ export function ProviderInstanceCard({
             ) : null}
             {titleTailNode}
           </div>
+          {showEditorStatus ? (
+            <p className="flex min-w-0 flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
+              <span>{summary.headline}</span>
+              {summary.detail ? <span>· {summary.detail}</span> : null}
+            </p>
+          ) : null}
         </div>
       </div>
 
-      <div className="flex h-11 items-end gap-6 border-b border-border/70 px-4">
+      <div className="flex h-11 gap-6 border-b border-border/70 px-4">
         {driverOption !== undefined ? (
           <button
             type="button"
             aria-pressed={visibleTab === "models"}
             className={cn(
-              "h-11 cursor-pointer rounded-sm border-b-2 px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+              "relative flex h-11 cursor-pointer items-center rounded-sm px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
               visibleTab === "models"
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
+                ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+                : "text-muted-foreground hover:text-foreground",
             )}
             onClick={() => setActiveTab("models")}
           >
@@ -712,10 +719,10 @@ export function ProviderInstanceCard({
           type="button"
           aria-pressed={visibleTab === "configuration"}
           className={cn(
-            "h-11 cursor-pointer rounded-sm border-b-2 px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+            "relative flex h-11 cursor-pointer items-center rounded-sm px-0 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
             visibleTab === "configuration"
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground",
+              ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+              : "text-muted-foreground hover:text-foreground",
           )}
           onClick={() => setActiveTab("configuration")}
         >

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -2,7 +2,6 @@
 
 import {
   ArrowUpCircleIcon,
-  ChevronDownIcon,
   CopyIcon,
   DownloadIcon,
   LoaderIcon,
@@ -30,7 +29,6 @@ import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
-import { Collapsible, CollapsibleContent } from "../ui/collapsible";
 import { DraftInput } from "../ui/draft-input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { ScrollArea } from "../ui/scroll-area";
@@ -43,7 +41,6 @@ import { ProviderSettingsForm } from "./ProviderSettingsForm";
 import { ProviderModelsSection } from "./ProviderModelsSection";
 import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
 import { ProviderAccentColorPicker } from "./ProviderAccentColorPicker";
-import { RedactedSensitiveText } from "./RedactedSensitiveText";
 import {
   getProviderVersionAdvisoryPresentation,
   PROVIDER_STATUS_STYLES,
@@ -130,28 +127,6 @@ export function deriveProviderModelsForDisplay(input: {
       },
   );
   return [...serverModels, ...customModels];
-}
-
-function ProviderAuthEmail(props: {
-  readonly email: string | undefined;
-  readonly prefix?: string;
-  readonly separator?: boolean;
-}) {
-  const trimmed = props.email?.trim();
-  if (!trimmed) return null;
-
-  return (
-    <span className="inline-flex min-w-0 items-center gap-1.5">
-      {props.separator ? <span aria-hidden>·</span> : null}
-      {props.prefix ? <span className="text-muted-foreground/80">{props.prefix}</span> : null}
-      <RedactedSensitiveText
-        value={trimmed}
-        ariaLabel="Toggle account email visibility"
-        revealTooltip="Click to reveal email"
-        hideTooltip="Click to hide email"
-      />
-    </span>
-  );
 }
 
 function ProviderEnvironmentSection(props: {
@@ -324,8 +299,9 @@ interface ProviderInstanceCardProps {
   readonly instance: ProviderInstanceConfig;
   readonly driverOption: DriverOption | undefined;
   readonly liveProvider: ServerProvider | undefined;
-  readonly isExpanded: boolean;
-  readonly onExpandedChange: (open: boolean) => void;
+  readonly mode: "list" | "editor";
+  readonly selected?: boolean | undefined;
+  readonly onSelect?: (() => void) | undefined;
   readonly onUpdate: (nextInstance: ProviderInstanceConfig) => void;
   /**
    * Pass `undefined` to hide the delete button entirely. Built-in default
@@ -353,12 +329,9 @@ interface ProviderInstanceCardProps {
 }
 
 /**
- * A single configured provider-instance row in the Providers settings
- * section. Used for every row — both the built-in default instance for a
- * driver (rendered with `onDelete` omitted) and user-authored custom
- * instances (`onDelete` supplied). The only UI difference between the two
- * is whether the trash button is visible; every other field (display
- * name, config fields, models) behaves identically.
+ * Renders one provider instance as either a compact selectable list row or
+ * the full editor shown beside that list. Both modes use the same enabled
+ * state and provider metadata.
  *
  * Behavior notes:
  *   - `liveProvider` is matched by the caller via `instanceId`; when no
@@ -379,8 +352,9 @@ export function ProviderInstanceCard({
   instance,
   driverOption,
   liveProvider,
-  isExpanded,
-  onExpandedChange,
+  mode,
+  selected = false,
+  onSelect,
   onUpdate,
   onDelete,
   headerAction,
@@ -393,6 +367,7 @@ export function ProviderInstanceCard({
   onRunUpdate,
   isUpdating = false,
 }: ProviderInstanceCardProps) {
+  const [activeTab, setActiveTab] = useState<"models" | "configuration">("configuration");
   const enabled = resolveProviderInstanceEnabled(instance);
   // The server-reported status wins when present; otherwise fall back to
   // "disabled"/"warning" based on the local `enabled` flag so the dot
@@ -401,12 +376,6 @@ export function ProviderInstanceCard({
     (liveProvider?.status as ProviderStatusKey | undefined) ?? (enabled ? "warning" : "disabled");
   const statusStyle = PROVIDER_STATUS_STYLES[statusKey];
   const rawSummary = getProviderSummary(liveProvider);
-  const authEmail = liveProvider?.auth.email;
-  const hasAuthenticatedEmail =
-    liveProvider?.auth.status === "authenticated" && Boolean(authEmail?.trim());
-  const authenticatedDetail = hasAuthenticatedEmail
-    ? (liveProvider?.auth.label ?? liveProvider?.auth.type ?? null)
-    : null;
   const summary = rawSummary;
   const versionLabel = getProviderVersionLabel(liveProvider?.version);
   const versionAdvisory = getProviderVersionAdvisoryPresentation(liveProvider?.versionAdvisory);
@@ -576,158 +545,192 @@ export function ProviderInstanceCard({
     </>
   );
 
-  const authRowNode = (
-    <p className="flex min-w-0 flex-wrap items-center gap-x-1 text-[13px] leading-[1.45] text-muted-foreground/80">
-      {hasAuthenticatedEmail ? (
-        <>
-          <span>Authenticated as</span>
-          <ProviderAuthEmail email={authEmail} />
-          {authenticatedDetail ? <span>· {authenticatedDetail}</span> : null}
-        </>
-      ) : (
-        <>
-          <span>{summary.headline}</span>
-          <ProviderAuthEmail email={authEmail} separator prefix="Email" />
-        </>
-      )}
-      {summary.detail ? <span>- {summary.detail}</span> : null}
-    </p>
-  );
-
   const versionCodeNode = versionLabel ? (
     <code className="text-xs text-muted-foreground">{versionLabel}</code>
   ) : null;
 
-  return (
-    <div className="rounded-xl transition-colors hover:bg-muted/20">
-      <div className="px-3 py-3 sm:px-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0 flex-1 space-y-1">
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              {titleHeadNode}
+  if (mode === "list") {
+    return (
+      <div
+        className={cn(
+          "group relative flex min-h-16 items-center gap-3 border-b border-border/60 px-3 py-2.5 transition-colors last:border-b-0",
+          selected ? "bg-muted/50" : "hover:bg-muted/25",
+        )}
+      >
+        {selected ? <span className="absolute inset-y-0 left-0 w-0.5 bg-primary" /> : null}
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-3 text-left"
+          onClick={onSelect}
+          aria-pressed={selected}
+        >
+          {titleIconNode}
+          <span className="min-w-0 flex-1">
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
               {versionCodeNode}
-              {versionAdvisory ? (
-                <Popover>
-                  <PopoverTrigger
-                    render={
+            </span>
+            <span className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+              <span className={cn("size-1.5 shrink-0 rounded-full", statusStyle.dot)} />
+              <span className="truncate">{summary.headline}</span>
+            </span>
+            {String(instanceId) !== String(instance.driver) ? (
+              <code className="mt-0.5 block truncate text-[10px] text-muted-foreground/70">
+                {instanceId}
+              </code>
+            ) : null}
+          </span>
+        </button>
+        <Switch
+          checked={enabled}
+          onCheckedChange={(checked) => updateEnabled(Boolean(checked))}
+          aria-label={`Enable ${displayName}`}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0">
+      <div className="flex min-h-16 items-center justify-between gap-3 border-b border-border/70 px-4 py-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            {titleHeadNode}
+            {versionCodeNode}
+            {versionAdvisory ? (
+              <Popover>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      className={cn(
+                        "size-5 rounded-sm p-0",
+                        versionAdvisory.emphasis === "strong"
+                          ? "text-warning hover:text-warning"
+                          : "text-update-foreground hover:text-update-foreground",
+                      )}
+                      aria-label="Update available — view details"
+                    >
+                      <ArrowUpCircleIcon className="size-3.5" />
+                    </Button>
+                  }
+                />
+                <PopoverPopup
+                  side="bottom"
+                  align="start"
+                  className="w-[min(21rem,calc(100vw-1.5rem))] [--popup-width:min(21rem,calc(100vw-1.5rem))]"
+                >
+                  <div className="grid min-w-0 gap-3">
+                    <div className="grid gap-0.5">
+                      <p className="text-[13px] font-semibold leading-tight text-foreground">
+                        Update available
+                      </p>
+                      <p
+                        className={cn(
+                          "text-xs leading-snug",
+                          versionAdvisory.emphasis === "strong"
+                            ? "text-warning"
+                            : "text-muted-foreground",
+                        )}
+                      >
+                        {versionAdvisory.detail}
+                      </p>
+                    </div>
+                    {onRunUpdate ? (
                       <Button
                         type="button"
-                        size="icon-xs"
-                        variant="ghost"
-                        className={cn(
-                          "size-5 rounded-sm p-0",
-                          versionAdvisory.emphasis === "strong"
-                            ? "text-warning hover:text-warning"
-                            : "text-update-foreground hover:text-update-foreground",
-                        )}
-                        aria-label="Update available — view details"
+                        size="xs"
+                        variant="default"
+                        className="w-full"
+                        disabled={isUpdating}
+                        onClick={onRunUpdate}
                       >
-                        <ArrowUpCircleIcon className="size-3.5 [animation:bounce_2.4s_ease-in-out_infinite] motion-reduce:animate-none" />
+                        {isUpdating ? <LoaderIcon className="animate-spin" /> : <DownloadIcon />}
+                        {isUpdating ? "Updating" : "Update now"}
                       </Button>
-                    }
-                  />
-                  <PopoverPopup
-                    side="bottom"
-                    align="start"
-                    className="w-[min(21rem,calc(100vw-1.5rem))] [--popup-width:min(21rem,calc(100vw-1.5rem))]"
-                  >
-                    <div className="grid min-w-0 gap-3">
-                      <div className="grid gap-0.5">
-                        <p className="text-[13px] font-semibold leading-tight text-foreground">
-                          Update available
-                        </p>
-                        <p
-                          className={cn(
-                            "text-xs leading-snug",
-                            versionAdvisory.emphasis === "strong"
-                              ? "text-warning"
-                              : "text-muted-foreground",
-                          )}
-                        >
-                          {versionAdvisory.detail}
-                        </p>
+                    ) : null}
+                    {onRunUpdate && updateCommand ? (
+                      <div className="flex items-center gap-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                        <span aria-hidden className="h-px flex-1 bg-border" />
+                        or, update manually using
+                        <span aria-hidden className="h-px flex-1 bg-border" />
                       </div>
-                      {onRunUpdate ? (
-                        <Button
-                          type="button"
-                          size="xs"
-                          variant="default"
-                          className="w-full"
-                          disabled={isUpdating}
-                          onClick={onRunUpdate}
-                        >
-                          {isUpdating ? <LoaderIcon className="animate-spin" /> : <DownloadIcon />}
-                          {isUpdating ? "Updating" : "Update now"}
-                        </Button>
-                      ) : null}
-                      {onRunUpdate && updateCommand ? (
-                        <div className="flex items-center gap-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                          <span aria-hidden className="h-px flex-1 bg-border" />
-                          or, update manually using
-                          <span aria-hidden className="h-px flex-1 bg-border" />
-                        </div>
-                      ) : null}
-                      {updateCommand ? (
-                        <div className="flex min-w-0 items-center gap-1 rounded-md border border-border/70 bg-muted/40 py-0.5 pr-0.5 pl-2">
-                          <ScrollArea scrollFade className="h-8 min-w-0 flex-1 rounded-none">
-                            <code className="flex h-full w-max items-center whitespace-nowrap pr-3 font-mono text-[11px] text-foreground">
-                              {updateCommand}
-                            </code>
-                          </ScrollArea>
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <Button
-                                  type="button"
-                                  size="icon-xs"
-                                  variant="ghost"
-                                  className="size-6 shrink-0 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                                  onClick={() =>
-                                    copyToClipboard(updateCommand, {
-                                      providerName: displayName,
-                                    })
-                                  }
-                                  aria-label="Copy update command"
-                                >
-                                  <CopyIcon className="size-3" />
-                                </Button>
-                              }
-                            />
-                            <TooltipPopup side="top">Copy command</TooltipPopup>
-                          </Tooltip>
-                        </div>
-                      ) : null}
-                    </div>
-                  </PopoverPopup>
-                </Popover>
-              ) : null}
-              {titleTailNode}
-            </div>
-            {authRowNode}
-          </div>
-          <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
-            <Button
-              size="compact"
-              variant="ghost-muted"
-              onClick={() => onExpandedChange(!isExpanded)}
-              aria-label={`Toggle ${displayName} details`}
-            >
-              <ChevronDownIcon
-                className={cn("size-3.5 transition-transform", isExpanded && "rotate-180")}
-              />
-            </Button>
-            <Switch
-              checked={enabled}
-              onCheckedChange={(checked) => updateEnabled(Boolean(checked))}
-              aria-label={`Enable ${displayName}`}
-            />
+                    ) : null}
+                    {updateCommand ? (
+                      <div className="flex min-w-0 items-center gap-1 rounded-md border border-border/70 bg-muted/40 py-0.5 pr-0.5 pl-2">
+                        <ScrollArea scrollFade className="h-8 min-w-0 flex-1 rounded-none">
+                          <code className="flex h-full w-max items-center whitespace-nowrap pr-3 font-mono text-[11px] text-foreground">
+                            {updateCommand}
+                          </code>
+                        </ScrollArea>
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                type="button"
+                                size="icon-xs"
+                                variant="ghost"
+                                className="size-6 shrink-0 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                                onClick={() =>
+                                  copyToClipboard(updateCommand, {
+                                    providerName: displayName,
+                                  })
+                                }
+                                aria-label="Copy update command"
+                              >
+                                <CopyIcon className="size-3" />
+                              </Button>
+                            }
+                          />
+                          <TooltipPopup side="top">Copy command</TooltipPopup>
+                        </Tooltip>
+                      </div>
+                    ) : null}
+                  </div>
+                </PopoverPopup>
+              </Popover>
+            ) : null}
+            {titleTailNode}
           </div>
         </div>
       </div>
 
-      <Collapsible open={isExpanded} onOpenChange={onExpandedChange}>
-        <CollapsibleContent>
-          <div className="space-y-5 px-3 pb-4 pt-2 sm:px-4">
+      <div className="flex h-11 items-end gap-6 border-b border-border/70 px-4" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "models"}
+          className={cn(
+            "h-11 border-b-2 px-0 text-xs font-medium transition-colors",
+            activeTab === "models"
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          )}
+          onClick={() => setActiveTab("models")}
+        >
+          Models
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "configuration"}
+          className={cn(
+            "h-11 border-b-2 px-0 text-xs font-medium transition-colors",
+            activeTab === "configuration"
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          )}
+          onClick={() => setActiveTab("configuration")}
+        >
+          Configuration
+        </button>
+      </div>
+
+      <div className="px-4 py-5">
+        {activeTab === "configuration" ? (
+          <div className="space-y-5" role="tabpanel">
             <div>
               <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
                 <span className="text-xs font-medium text-foreground">Display name</span>
@@ -772,21 +775,7 @@ export function ProviderInstanceCard({
               />
             ) : null}
 
-            {driverOption !== undefined ? (
-              <ProviderModelsSection
-                instanceId={instanceId}
-                driverKind={driverKind}
-                models={modelsForDisplay}
-                customModels={customModels}
-                hiddenModels={hiddenModels}
-                favoriteModels={favoriteModels}
-                modelOrder={modelOrder}
-                onChange={updateCustomModels}
-                onHiddenModelsChange={onHiddenModelsChange}
-                onFavoriteModelsChange={onFavoriteModelsChange}
-                onModelOrderChange={onModelOrderChange}
-              />
-            ) : (
+            {driverOption === undefined ? (
               <div>
                 <p className="text-xs text-muted-foreground">
                   This instance uses a driver (
@@ -795,10 +784,26 @@ export function ProviderInstanceCard({
                   edited from this surface.
                 </p>
               </div>
-            )}
+            ) : null}
           </div>
-        </CollapsibleContent>
-      </Collapsible>
+        ) : driverOption !== undefined ? (
+          <div role="tabpanel">
+            <ProviderModelsSection
+              instanceId={instanceId}
+              driverKind={driverKind}
+              models={modelsForDisplay}
+              customModels={customModels}
+              hiddenModels={hiddenModels}
+              favoriteModels={favoriteModels}
+              modelOrder={modelOrder}
+              onChange={updateCustomModels}
+              onHiddenModelsChange={onHiddenModelsChange}
+              onFavoriteModelsChange={onFavoriteModelsChange}
+              onModelOrderChange={onModelOrderChange}
+            />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -76,6 +76,25 @@ function makeEnvironmentDraftRow(
   };
 }
 
+function providerEnvironmentsEqual(
+  left: ReadonlyArray<ProviderInstanceEnvironmentVariable>,
+  right: ReadonlyArray<ProviderInstanceEnvironmentVariable>,
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((variable, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        variable.name === other.name &&
+        variable.value === other.value &&
+        variable.sensitive === other.sensitive &&
+        variable.valueRedacted === other.valueRedacted
+      );
+    })
+  );
+}
+
 /**
  * Read a string[] at `key` from the opaque config blob, filtering out
  * non-string entries. Used for `customModels`, which is always typed as
@@ -140,8 +159,14 @@ function ProviderEnvironmentSection(props: {
   const previousEnvironmentRef = useRef(props.environment);
 
   useEffect(() => {
-    if (previousEnvironmentRef.current === props.environment) return;
+    const previousEnvironment = previousEnvironmentRef.current;
     previousEnvironmentRef.current = props.environment;
+    if (
+      previousEnvironment === props.environment ||
+      providerEnvironmentsEqual(previousEnvironment, props.environment)
+    ) {
+      return;
+    }
     setRows(props.environment.map(makeEnvironmentDraftRow));
   }, [props.environment]);
 
@@ -604,7 +629,14 @@ export function ProviderInstanceCard({
 
   return (
     <div className="min-w-0">
-      <div className="flex min-h-16 items-center justify-between gap-3 border-b border-border/70 px-4 py-3">
+      <div
+        inert={readOnly}
+        aria-disabled={readOnly || undefined}
+        className={cn(
+          "flex min-h-16 items-center justify-between gap-3 border-b border-border/70 px-4 py-3",
+          readOnly && "opacity-50 select-none",
+        )}
+      >
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             {titleHeadNode}
@@ -736,7 +768,11 @@ export function ProviderInstanceCard({
         </button>
       </div>
 
-      <div className="px-4 py-5">
+      <div
+        inert={readOnly}
+        aria-disabled={readOnly || undefined}
+        className={cn("px-4 py-5", readOnly && "opacity-50 select-none")}
+      >
         <div className="space-y-5" hidden={visibleTab !== "configuration"}>
           <div>
             <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -40,7 +40,7 @@ import type { DriverOption } from "./providerDriverMeta";
 import { providerSettingsTabClassName } from "./providerSettingsTabs";
 import { ProviderSettingsForm } from "./ProviderSettingsForm";
 import { ProviderModelsSection } from "./ProviderModelsSection";
-import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
+import { ProviderInstanceIcon, providerInstanceInitials } from "../chat/ProviderInstanceIcon";
 import { ProviderAccentColorPicker } from "./ProviderAccentColorPicker";
 import {
   getProviderVersionAdvisoryPresentation,
@@ -487,7 +487,12 @@ export function ProviderInstanceCard({
       <FallbackIconComponent className="size-4 text-foreground/80" aria-hidden />
     </span>
   ) : (
-    <span className="size-4 shrink-0 rounded-sm border border-border" aria-hidden />
+    <span
+      className="inline-flex size-5 shrink-0 items-center justify-center text-[10px] font-semibold leading-none text-foreground/80"
+      aria-hidden
+    >
+      {providerInstanceInitials(displayName)}
+    </span>
   );
 
   const titleHeadNode = (

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -178,21 +178,45 @@ describe("EnvironmentProviderSettings routing", () => {
     });
   });
 
-  it("renders the provider layout inert with a limited-permissions notice when read only", () => {
+  it("keeps provider selection available while write controls are read only", () => {
+    settingsState.value = {
+      ...DEFAULT_UNIFIED_SETTINGS,
+      providerInstances: {
+        [customId]: {
+          driver: ProviderDriverKind.make("codex"),
+          enabled: true,
+        },
+      },
+    };
     atoms.providers = [provider()];
-    const panel = renderPanel({ readOnly: true });
+    let panel = renderPanel({ readOnly: true });
 
     const inertWrapper = visitElements(panel, (element) => element.props.inert === true);
     expect(inertWrapper).not.toBeNull();
-    const providerCard = visitElements(panel, (element) => element.props.instanceId === codexId);
-    expect(providerCard).not.toBeNull();
+
+    const customRow = visitElements(
+      panel,
+      (element) => element.props.instanceId === customId && element.props.mode === "list",
+    );
+    expect(customRow?.props.readOnly).toBe(true);
+    expect(customRow?.props.onSelect).toBeTypeOf("function");
+    (customRow?.props.onSelect as (() => void) | undefined)?.();
+
+    panel = renderPanel({ readOnly: true });
+    const customEditor = visitElements(
+      panel,
+      (element) => element.props.instanceId === customId && element.props.mode === "editor",
+    );
+    expect(customEditor).not.toBeNull();
 
     const notice = visitElements(panel, (element) => element.props.title === "Limited permissions");
     expect(notice).not.toBeNull();
 
-    expect(
-      visitElements(panel, (element) => element.props["aria-label"] === "Add provider instance"),
-    ).toBeNull();
+    const providersSection = visitElements(
+      panel,
+      (element) => element.props.title === "Providers" && "headerAction" in element.props,
+    );
+    expect(providersSection?.props.headerAction).toBeNull();
     expect(
       visitElements(panel, (element) => element.props["aria-label"] === "Refresh provider status"),
     ).toBeNull();
@@ -205,6 +229,11 @@ describe("EnvironmentProviderSettings routing", () => {
     expect(
       visitElements(panel, (element) => element.props.title === "Limited permissions"),
     ).toBeNull();
+    const providersSection = visitElements(
+      panel,
+      (element) => element.props.title === "Providers" && "headerAction" in element.props,
+    );
+    expect(providersSection?.props.headerAction).not.toBeNull();
   });
 
   it("deletes and resets provider configuration without erasing shared preferences", () => {

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -225,8 +225,17 @@ describe("EnvironmentProviderSettings routing", () => {
       },
       favorites: [{ provider: customId, model: "favorite" }],
     };
-    const panel = renderPanel();
-    const customCard = visitElements(panel, (element) => element.props.instanceId === customId);
+    let panel = renderPanel();
+    const customRow = visitElements(
+      panel,
+      (element) => element.props.instanceId === customId && element.props.mode === "list",
+    );
+    (customRow?.props.onSelect as (() => void) | undefined)?.();
+    panel = renderPanel();
+    const customCard = visitElements(
+      panel,
+      (element) => element.props.instanceId === customId && element.props.mode === "editor",
+    );
     expect(customCard).not.toBeNull();
     (customCard?.props.onDelete as (() => void) | undefined)?.();
 
@@ -237,7 +246,16 @@ describe("EnvironmentProviderSettings routing", () => {
     });
 
     settingsState.updateSettings.mockClear();
-    const defaultCard = visitElements(panel, (element) => element.props.instanceId === codexId);
+    const defaultRow = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "list",
+    );
+    (defaultRow?.props.onSelect as (() => void) | undefined)?.();
+    panel = renderPanel();
+    const defaultCard = visitElements(
+      panel,
+      (element) => element.props.instanceId === codexId && element.props.mode === "editor",
+    );
     const resetAction = defaultCard?.props.headerAction;
     const resetButton = visitElements(
       resetAction,

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -230,10 +230,10 @@ export function ProviderSettingsPanel() {
               <Icon className="size-3.5 shrink-0" aria-hidden />
               <span className="max-w-40 truncate">{environment.label}</span>
               <ConnectionStatusDot
-                tooltipText={statusText}
                 dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
                 pingClassName={connectionPhasePingClassName(environment.connection.phase)}
               />
+              <span className="sr-only">{statusText}</span>
             </button>
           );
         })}

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -211,12 +211,8 @@ export function ProviderSettingsPanel() {
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
-      <ScrollArea
-        hideScrollbars
-        scrollFade
-        className="h-11 min-w-0 rounded-none border-b border-border/70"
-      >
-        <div className="flex w-max min-w-full px-3">
+      <ScrollArea hideScrollbars scrollFade className="h-11 min-w-0 rounded-none">
+        <div className="flex h-full w-max min-w-full border-b border-border/70 px-3">
           {options.map((environment) => {
             const Icon = providerEnvironmentIcon(environment);
             const selected = environment.environmentId === effectiveEnvironmentId;
@@ -229,7 +225,7 @@ export function ProviderSettingsPanel() {
                       type="button"
                       aria-pressed={selected}
                       className={cn(
-                        "relative flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                        "relative flex h-full shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
                         selected
                           ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
                           : "text-muted-foreground hover:text-foreground",

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -77,6 +77,7 @@ import { stackedThreadToast, toastManager } from "../ui/toast";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
+import { providerSettingsTabClassName } from "./providerSettingsTabs";
 import { searchableSetting } from "./settingsSearch";
 import {
   backgroundActivityOverrideSettings,
@@ -223,7 +224,7 @@ export function ProviderSettingsPanel() {
         <div
           role="group"
           aria-label="Devices"
-          className="flex h-full w-max min-w-full border-b border-border/70 px-3"
+          className="flex h-full w-max min-w-full border-b border-border/70 px-3 sm:px-4"
         >
           {options.map((environment) => {
             const Icon = providerEnvironmentIcon(environment);
@@ -237,12 +238,7 @@ export function ProviderSettingsPanel() {
                     <button
                       type="button"
                       aria-pressed={selected}
-                      className={cn(
-                        "relative flex h-full shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-                        selected
-                          ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
-                          : "text-muted-foreground hover:text-foreground",
-                      )}
+                      className={cn(providerSettingsTabClassName(selected), "gap-2 text-left")}
                       onClick={() => setSelectedEnvironmentId(environment.environmentId)}
                     >
                       <Icon className="size-3.5 shrink-0" aria-hidden />

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -71,6 +71,7 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from "../ui/number-field";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
@@ -215,26 +216,32 @@ export function ProviderSettingsPanel() {
           const selected = environment.environmentId === effectiveEnvironmentId;
           const statusText = connectionStatusText(environment.connection);
           return (
-            <button
-              key={environment.environmentId}
-              type="button"
-              aria-pressed={selected}
-              className={cn(
-                "relative flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-                selected
-                  ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setSelectedEnvironmentId(environment.environmentId)}
-            >
-              <Icon className="size-3.5 shrink-0" aria-hidden />
-              <span className="max-w-40 truncate">{environment.label}</span>
-              <ConnectionStatusDot
-                dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
-                pingClassName={connectionPhasePingClassName(environment.connection.phase)}
+            <Tooltip key={environment.environmentId}>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-pressed={selected}
+                    className={cn(
+                      "relative flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                      selected
+                        ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                    onClick={() => setSelectedEnvironmentId(environment.environmentId)}
+                  >
+                    <Icon className="size-3.5 shrink-0" aria-hidden />
+                    <span className="max-w-40 truncate">{environment.label}</span>
+                    <ConnectionStatusDot
+                      dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
+                      pingClassName={connectionPhasePingClassName(environment.connection.phase)}
+                    />
+                    <span className="sr-only">{statusText}</span>
+                  </button>
+                }
               />
-              <span className="sr-only">{statusText}</span>
-            </button>
+              <TooltipPopup side="top">{statusText}</TooltipPopup>
+            </Tooltip>
           );
         })}
       </div>
@@ -830,19 +837,26 @@ export function EnvironmentProviderSettings({
               <div className="flex min-h-10 items-center justify-between border-t border-border/70 px-3">
                 <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
                 {!readOnly ? (
-                  <Button
-                    size="icon-micro"
-                    variant="ghost-muted"
-                    disabled={isRefreshingProviders}
-                    onClick={() => void refreshProviders()}
-                    aria-label="Refresh provider status"
-                  >
-                    {isRefreshingProviders ? (
-                      <LoaderIcon className="size-3 animate-spin" />
-                    ) : (
-                      <RefreshCwIcon className="size-3" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          size="icon-micro"
+                          variant="ghost-muted"
+                          disabled={isRefreshingProviders}
+                          onClick={() => void refreshProviders()}
+                          aria-label="Refresh provider status"
+                        >
+                          {isRefreshingProviders ? (
+                            <LoaderIcon className="size-3 animate-spin" />
+                          ) : (
+                            <RefreshCwIcon className="size-3" />
+                          )}
+                        </Button>
+                      }
+                    />
+                    <TooltipPopup side="top">Refresh provider status</TooltipPopup>
+                  </Tooltip>
                 ) : null}
               </div>
             </div>

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -71,6 +71,7 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from "../ui/number-field";
+import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
@@ -210,41 +211,47 @@ export function ProviderSettingsPanel() {
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
-      <div className="flex min-w-0 overflow-x-auto border-b border-border/70 px-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        {options.map((environment) => {
-          const Icon = providerEnvironmentIcon(environment);
-          const selected = environment.environmentId === effectiveEnvironmentId;
-          const statusText = connectionStatusText(environment.connection);
-          return (
-            <Tooltip key={environment.environmentId}>
-              <TooltipTrigger
-                render={
-                  <button
-                    type="button"
-                    aria-pressed={selected}
-                    className={cn(
-                      "relative flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-                      selected
-                        ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                    onClick={() => setSelectedEnvironmentId(environment.environmentId)}
-                  >
-                    <Icon className="size-3.5 shrink-0" aria-hidden />
-                    <span className="max-w-40 truncate">{environment.label}</span>
-                    <ConnectionStatusDot
-                      dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
-                      pingClassName={connectionPhasePingClassName(environment.connection.phase)}
-                    />
-                    <span className="sr-only">{statusText}</span>
-                  </button>
-                }
-              />
-              <TooltipPopup side="top">{statusText}</TooltipPopup>
-            </Tooltip>
-          );
-        })}
-      </div>
+      <ScrollArea
+        hideScrollbars
+        scrollFade
+        className="h-11 min-w-0 rounded-none border-b border-border/70"
+      >
+        <div className="flex w-max min-w-full px-3">
+          {options.map((environment) => {
+            const Icon = providerEnvironmentIcon(environment);
+            const selected = environment.environmentId === effectiveEnvironmentId;
+            const statusText = connectionStatusText(environment.connection);
+            return (
+              <Tooltip key={environment.environmentId}>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-pressed={selected}
+                      className={cn(
+                        "relative flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                        selected
+                          ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                      onClick={() => setSelectedEnvironmentId(environment.environmentId)}
+                    >
+                      <Icon className="size-3.5 shrink-0" aria-hidden />
+                      <span className="max-w-40 truncate">{environment.label}</span>
+                      <ConnectionStatusDot
+                        dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
+                        pingClassName={connectionPhasePingClassName(environment.connection.phase)}
+                      />
+                      <span className="sr-only">{statusText}</span>
+                    </button>
+                  }
+                />
+                <TooltipPopup side="top">{statusText}</TooltipPopup>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </ScrollArea>
     ) : null;
 
   return (

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -63,6 +63,7 @@ import {
   type ProviderUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { Button } from "../ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import {
   NumberField,
   NumberFieldDecrement,
@@ -208,7 +209,7 @@ export function ProviderSettingsPanel() {
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
-      <div className="flex min-w-0 overflow-x-auto border-b border-border/70 px-3" role="tablist">
+      <div className="flex min-w-0 overflow-x-auto border-b border-border/70 px-3">
         {options.map((environment) => {
           const Icon = providerEnvironmentIcon(environment);
           const selected = environment.environmentId === effectiveEnvironmentId;
@@ -217,10 +218,9 @@ export function ProviderSettingsPanel() {
             <button
               key={environment.environmentId}
               type="button"
-              role="tab"
-              aria-selected={selected}
+              aria-pressed={selected}
               className={cn(
-                "relative flex h-11 shrink-0 items-center gap-2 px-3 text-left text-xs transition-colors",
+                "relative flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-sm px-3 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
                 selected
                   ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
                   : "text-muted-foreground hover:text-foreground",
@@ -796,7 +796,7 @@ export function EnvironmentProviderSettings({
             <Button
               size="sm"
               variant="outline"
-              className="h-8 gap-1.5 px-2.5 text-xs"
+              className="text-xs"
               onClick={() => setIsAddInstanceDialogOpen(true)}
             >
               <PlusIcon className="size-3.5" />
@@ -856,19 +856,18 @@ export function EnvironmentProviderSettings({
             </div>
           </div>
 
-          <div className="mt-2 border-t border-border/70">
-            <button
-              type="button"
-              className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground"
-              onClick={() => setAdvancedOpen((open) => !open)}
-              aria-expanded={advancedOpen}
-            >
+          <Collapsible
+            open={advancedOpen}
+            onOpenChange={setAdvancedOpen}
+            className="mt-2 border-t border-border/70"
+          >
+            <CollapsibleTrigger className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground">
               <ChevronDownIcon
                 className={cn("size-3 transition-transform", advancedOpen && "rotate-180")}
               />
               Advanced
-            </button>
-            {advancedOpen ? (
+            </CollapsibleTrigger>
+            <CollapsibleContent>
               <SettingsRow
                 title={
                   <span className="inline-flex items-center gap-1.5">
@@ -930,8 +929,8 @@ export function EnvironmentProviderSettings({
                   </div>
                 }
               />
-            ) : null}
-          </div>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       </SettingsSection>
 

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -755,6 +755,7 @@ export function EnvironmentProviderSettings({
         mode={mode}
         selected={mode === "list" && selectedRow?.instanceId === row.instanceId}
         onSelect={mode === "list" ? () => setSelectedInstanceId(row.instanceId) : undefined}
+        readOnly={readOnly}
         onUpdate={(next) => {
           const wasEnabled = resolveProviderInstanceEnabled(row.instance);
           const isDisabling = next.enabled === false && wasEnabled;
@@ -835,14 +836,7 @@ export function EnvironmentProviderSettings({
             description={`This session can view ${environmentLabel}'s providers, but its credential does not allow changing their configuration.`}
           />
         ) : null}
-        <div
-          // `inert` blocks focus and interaction in one attribute, so the
-          // read-only view stays byte-for-byte the editable layout without
-          // threading a disabled flag through every control.
-          inert={readOnly}
-          aria-disabled={readOnly || undefined}
-          className={readOnly ? "space-y-1 opacity-50 select-none" : "space-y-1"}
-        >
+        <div className={readOnly ? "space-y-1 opacity-50 select-none" : "space-y-1"}>
           <div className="overflow-hidden rounded-lg border border-border/70 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)]">
             <div className="border-b border-border/70 lg:border-r lg:border-b-0">
               <div className="flex min-h-9 items-center justify-between border-b border-border/70 px-3 text-[11px] font-medium text-muted-foreground">
@@ -877,7 +871,7 @@ export function EnvironmentProviderSettings({
               </div>
             </div>
 
-            <div className="min-w-0">
+            <div className="min-w-0" inert={readOnly} aria-disabled={readOnly || undefined}>
               {selectedRow ? (
                 renderProviderInstance(selectedRow, "editor")
               ) : (
@@ -886,81 +880,83 @@ export function EnvironmentProviderSettings({
             </div>
           </div>
 
-          <Collapsible
-            open={advancedVisible}
-            onOpenChange={setAdvancedOpen}
-            className="mt-2 border-t border-border/70"
-          >
-            <CollapsibleTrigger className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground sm:px-4">
-              <ChevronDownIcon
-                className={cn("size-3 transition-transform", advancedVisible && "rotate-180")}
-              />
-              Advanced
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <SettingsRow
-                title={
-                  <span className="inline-flex items-center gap-1.5">
-                    Health check interval
-                    <PolicyTooltip>
-                      This interval is configured here, then the shared Background activity policy
-                      decides whether provider probes may run when the timer fires. Custom intervals
-                      appear as Advanced in General settings.
-                    </PolicyTooltip>
-                  </span>
-                }
-                description="Set this to 0 seconds to use manual refresh only."
-                resetAction={
-                  providerHealthRefreshIntervalSeconds !==
-                  defaultProviderHealthRefreshIntervalSeconds ? (
-                    <SettingResetButton
-                      label="provider health check interval"
-                      onClick={() =>
-                        updateSettings(
-                          backgroundActivityOverrideSettings(
-                            settings.backgroundActivity,
-                            resolvedBackgroundActivity,
-                            { providerHealthRefreshInterval: undefined },
-                          ),
-                        )
-                      }
-                    />
-                  ) : null
-                }
-                control={
-                  <div className="flex shrink-0 items-center gap-2">
-                    <NumberField
-                      value={providerHealthRefreshIntervalSeconds}
-                      min={0}
-                      step={PROVIDER_HEALTH_INTERVAL_STEP_SECONDS}
-                      size="sm"
-                      className="w-32"
-                      onValueChange={(value) =>
-                        updateSettings(
-                          backgroundActivityOverrideSettings(
-                            settings.backgroundActivity,
-                            resolvedBackgroundActivity,
-                            {
-                              providerHealthRefreshInterval: Duration.seconds(
-                                normalizeIntervalSeconds(value),
-                              ),
-                            },
-                          ),
-                        )
-                      }
-                    >
-                      <NumberFieldGroup>
-                        <NumberFieldDecrement aria-label="Decrease provider health check interval" />
-                        <NumberFieldInput aria-label="Provider health check interval in seconds" />
-                        <NumberFieldIncrement aria-label="Increase provider health check interval" />
-                      </NumberFieldGroup>
-                    </NumberField>
-                    <span className="text-xs text-muted-foreground">seconds</span>
-                  </div>
-                }
-              />
-            </CollapsibleContent>
-          </Collapsible>
+          <div inert={readOnly} aria-disabled={readOnly || undefined}>
+            <Collapsible
+              open={advancedVisible}
+              onOpenChange={setAdvancedOpen}
+              className="mt-2 border-t border-border/70"
+            >
+              <CollapsibleTrigger className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground sm:px-4">
+                <ChevronDownIcon
+                  className={cn("size-3 transition-transform", advancedVisible && "rotate-180")}
+                />
+                Advanced
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <SettingsRow
+                  title={
+                    <span className="inline-flex items-center gap-1.5">
+                      Health check interval
+                      <PolicyTooltip>
+                        This interval is configured here, then the shared Background activity policy
+                        decides whether provider probes may run when the timer fires. Custom
+                        intervals appear as Advanced in General settings.
+                      </PolicyTooltip>
+                    </span>
+                  }
+                  description="Set this to 0 seconds to use manual refresh only."
+                  resetAction={
+                    providerHealthRefreshIntervalSeconds !==
+                    defaultProviderHealthRefreshIntervalSeconds ? (
+                      <SettingResetButton
+                        label="provider health check interval"
+                        onClick={() =>
+                          updateSettings(
+                            backgroundActivityOverrideSettings(
+                              settings.backgroundActivity,
+                              resolvedBackgroundActivity,
+                              { providerHealthRefreshInterval: undefined },
+                            ),
+                          )
+                        }
+                      />
+                    ) : null
+                  }
+                  control={
+                    <div className="flex shrink-0 items-center gap-2">
+                      <NumberField
+                        value={providerHealthRefreshIntervalSeconds}
+                        min={0}
+                        step={PROVIDER_HEALTH_INTERVAL_STEP_SECONDS}
+                        size="sm"
+                        className="w-32"
+                        onValueChange={(value) =>
+                          updateSettings(
+                            backgroundActivityOverrideSettings(
+                              settings.backgroundActivity,
+                              resolvedBackgroundActivity,
+                              {
+                                providerHealthRefreshInterval: Duration.seconds(
+                                  normalizeIntervalSeconds(value),
+                                ),
+                              },
+                            ),
+                          )
+                        }
+                      >
+                        <NumberFieldGroup>
+                          <NumberFieldDecrement aria-label="Decrease provider health check interval" />
+                          <NumberFieldInput aria-label="Provider health check interval in seconds" />
+                          <NumberFieldIncrement aria-label="Increase provider health check interval" />
+                        </NumberFieldGroup>
+                      </NumberField>
+                      <span className="text-xs text-muted-foreground">seconds</span>
+                    </div>
+                  }
+                />
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
         </div>
       </SettingsSection>
 

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -836,7 +836,7 @@ export function EnvironmentProviderSettings({
             description={`This session can view ${environmentLabel}'s providers, but its credential does not allow changing their configuration.`}
           />
         ) : null}
-        <div className={readOnly ? "space-y-1 opacity-50 select-none" : "space-y-1"}>
+        <div className="space-y-1">
           <div className="overflow-hidden rounded-lg border border-border/70 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)]">
             <div className="border-b border-border/70 lg:border-r lg:border-b-0">
               <div className="flex min-h-9 items-center justify-between border-b border-border/70 px-3 text-[11px] font-medium text-muted-foreground">
@@ -871,7 +871,7 @@ export function EnvironmentProviderSettings({
               </div>
             </div>
 
-            <div className="min-w-0" inert={readOnly} aria-disabled={readOnly || undefined}>
+            <div className="min-w-0">
               {selectedRow ? (
                 renderProviderInstance(selectedRow, "editor")
               ) : (
@@ -880,7 +880,11 @@ export function EnvironmentProviderSettings({
             </div>
           </div>
 
-          <div inert={readOnly} aria-disabled={readOnly || undefined}>
+          <div
+            inert={readOnly}
+            aria-disabled={readOnly || undefined}
+            className={readOnly ? "opacity-50 select-none" : undefined}
+          >
             <Collapsible
               open={advancedVisible}
               onOpenChange={setAdvancedOpen}

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -210,7 +210,7 @@ export function ProviderSettingsPanel() {
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
-      <div className="flex min-w-0 overflow-x-auto border-b border-border/70 px-3">
+      <div className="flex min-w-0 overflow-x-auto border-b border-border/70 px-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {options.map((environment) => {
           const Icon = providerEnvironmentIcon(environment);
           const selected = environment.environmentId === effectiveEnvironmentId;

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -24,6 +24,7 @@ import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
 import * as Result from "effect/Result";
 import {
+  ChevronDownIcon,
   CloudIcon,
   LaptopIcon,
   LoaderIcon,
@@ -32,7 +33,7 @@ import {
   RefreshCwIcon,
   TerminalIcon,
 } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
 import { isElectron } from "../../env";
@@ -70,7 +71,6 @@ import {
   NumberFieldInput,
 } from "../ui/number-field";
 import { stackedThreadToast, toastManager } from "../ui/toast";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
@@ -154,20 +154,14 @@ function providerEnvironmentIcon(environment: EnvironmentPresentation) {
   return CloudIcon;
 }
 
-function providerEnvironmentDetail(environment: EnvironmentPresentation): string {
-  if (environment.entry.target._tag === "PrimaryConnectionTarget") return "Primary device";
-  if (environment.relayManaged) return "T3 Connect";
-  if (environment.entry.target._tag === "SshConnectionTarget") return "SSH";
-  if (isDesktopLocalConnectionTarget(environment.entry.target)) return "Local device";
-  return environment.displayUrl ?? "Remote device";
-}
-
 function EnvironmentUnavailableRow({
   environment,
   access,
+  deviceTabs,
 }: {
   readonly environment: EnvironmentPresentation;
   readonly access: Exclude<ProviderEnvironmentAccess, { kind: "editable" | "read-only" }>;
+  readonly deviceTabs?: ReactNode;
 }) {
   const isLoading = access.kind === "loading";
   const title = isLoading
@@ -184,6 +178,7 @@ function EnvironmentUnavailableRow({
   // continuously repainting animation would run the whole time.
   return (
     <SettingsSection title="Providers">
+      {deviceTabs}
       <SettingsRow title={title} description={description} />
     </SettingsSection>
   );
@@ -211,64 +206,52 @@ export function ProviderSettingsPanel() {
     options.find((environment) => environment.environmentId === effectiveEnvironmentId) ?? null;
   const onlyPrimaryDevice =
     options.length === 1 && options[0]?.entry.target._tag === "PrimaryConnectionTarget";
+  const deviceTabs =
+    !onlyPrimaryDevice && options.length > 0 ? (
+      <div className="flex min-w-0 overflow-x-auto border-b border-border/70 px-3" role="tablist">
+        {options.map((environment) => {
+          const Icon = providerEnvironmentIcon(environment);
+          const selected = environment.environmentId === effectiveEnvironmentId;
+          const statusText = connectionStatusText(environment.connection);
+          return (
+            <button
+              key={environment.environmentId}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              className={cn(
+                "relative flex h-11 shrink-0 items-center gap-2 px-3 text-left text-xs transition-colors",
+                selected
+                  ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => setSelectedEnvironmentId(environment.environmentId)}
+            >
+              <Icon className="size-3.5 shrink-0" aria-hidden />
+              <span className="max-w-40 truncate">{environment.label}</span>
+              <ConnectionStatusDot
+                tooltipText={statusText}
+                dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
+                pingClassName={connectionPhasePingClassName(environment.connection.phase)}
+              />
+            </button>
+          );
+        })}
+      </div>
+    ) : null;
 
   return (
-    <SettingsPageContainer>
-      {!onlyPrimaryDevice ? (
-        <SettingsSection title="Devices">
-          {options.length === 0 ? (
-            // The catalog hydrates asynchronously, so an empty list before it is
-            // ready means "not loaded yet", not "nothing is connected".
-            <SettingsRow
-              title={isReady ? "No connected devices" : "Loading devices"}
-              description={
-                isReady
-                  ? "Connect an execution environment before configuring providers."
-                  : "Reading connected execution environments."
-              }
-            />
-          ) : (
-            <div className="grid gap-1 sm:grid-cols-2">
-              {options.map((environment) => {
-                const Icon = providerEnvironmentIcon(environment);
-                const selected = environment.environmentId === effectiveEnvironmentId;
-                const statusText = connectionStatusText(environment.connection);
-                return (
-                  <button
-                    key={environment.environmentId}
-                    type="button"
-                    aria-pressed={selected}
-                    className={cn(
-                      "flex min-w-0 items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors sm:px-4",
-                      selected
-                        ? "bg-primary/8 ring-1 ring-primary/25 dark:bg-primary/12"
-                        : "hover:bg-muted/40",
-                    )}
-                    onClick={() => setSelectedEnvironmentId(environment.environmentId)}
-                  >
-                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
-                      <Icon className="size-4" aria-hidden />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="flex items-center gap-1.5">
-                        <ConnectionStatusDot
-                          tooltipText={statusText}
-                          dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
-                          pingClassName={connectionPhasePingClassName(environment.connection.phase)}
-                        />
-                        <span className="truncate text-sm font-medium text-foreground">
-                          {environment.label}
-                        </span>
-                      </span>
-                      <span className="block truncate pl-[18px] text-xs text-muted-foreground">
-                        {providerEnvironmentDetail(environment)} · {statusText}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+    <SettingsPageContainer width="expanded" className="gap-8">
+      {options.length === 0 ? (
+        <SettingsSection title="Providers">
+          <SettingsRow
+            title={isReady ? "No connected devices" : "Loading devices"}
+            description={
+              isReady
+                ? "Connect an execution environment before configuring providers."
+                : "Reading connected execution environments."
+            }
+          />
         </SettingsSection>
       ) : null}
 
@@ -276,6 +259,7 @@ export function ProviderSettingsPanel() {
         <SelectedEnvironmentProviderSettings
           key={selectedEnvironment.environmentId}
           environment={selectedEnvironment}
+          deviceTabs={deviceTabs}
         />
       ) : null}
     </SettingsPageContainer>
@@ -284,25 +268,37 @@ export function ProviderSettingsPanel() {
 
 function SelectedEnvironmentProviderSettings({
   environment,
+  deviceTabs,
 }: {
   readonly environment: EnvironmentPresentation;
+  readonly deviceTabs?: ReactNode;
 }) {
   const isPrimary = environment.entry.target._tag === "PrimaryConnectionTarget";
   if (isPrimary) {
     // The desktop app owns its primary server outright; a browser session
     // checks the scopes its cookie session was granted.
     if (isElectron) {
-      return <AccessGatedProviderSettings environment={environment} operateAccess="granted" />;
+      return (
+        <AccessGatedProviderSettings
+          environment={environment}
+          operateAccess="granted"
+          deviceTabs={deviceTabs}
+        />
+      );
     }
-    return <PrimarySessionGatedProviderSettings environment={environment} />;
+    return (
+      <PrimarySessionGatedProviderSettings environment={environment} deviceTabs={deviceTabs} />
+    );
   }
-  return <RemoteSessionGatedProviderSettings environment={environment} />;
+  return <RemoteSessionGatedProviderSettings environment={environment} deviceTabs={deviceTabs} />;
 }
 
 function PrimarySessionGatedProviderSettings({
   environment,
+  deviceTabs,
 }: {
   readonly environment: EnvironmentPresentation;
+  readonly deviceTabs?: ReactNode;
 }) {
   const primarySessionState = usePrimarySessionState();
   const operateAccess = resolvePrimaryOperateAccess({
@@ -312,13 +308,21 @@ function PrimarySessionGatedProviderSettings({
     isPending: primarySessionState.isPending,
     hasError: primarySessionState.error !== null,
   });
-  return <AccessGatedProviderSettings environment={environment} operateAccess={operateAccess} />;
+  return (
+    <AccessGatedProviderSettings
+      environment={environment}
+      operateAccess={operateAccess}
+      deviceTabs={deviceTabs}
+    />
+  );
 }
 
 function RemoteSessionGatedProviderSettings({
   environment,
+  deviceTabs,
 }: {
   readonly environment: EnvironmentPresentation;
+  readonly deviceTabs?: ReactNode;
 }) {
   const sessionState = useEnvironmentSessionState(environment.environmentId);
   const operateAccess = resolveRemoteOperateAccess({
@@ -326,15 +330,23 @@ function RemoteSessionGatedProviderSettings({
     isPending: sessionState.isPending,
     hasError: sessionState.hasError,
   });
-  return <AccessGatedProviderSettings environment={environment} operateAccess={operateAccess} />;
+  return (
+    <AccessGatedProviderSettings
+      environment={environment}
+      operateAccess={operateAccess}
+      deviceTabs={deviceTabs}
+    />
+  );
 }
 
 function AccessGatedProviderSettings({
   environment,
   operateAccess,
+  deviceTabs,
 }: {
   readonly environment: EnvironmentPresentation;
   readonly operateAccess: ProviderOperateAccess;
+  readonly deviceTabs?: ReactNode;
 }) {
   const access = classifyProviderEnvironmentAccess({
     connectionPhase: environment.connection.phase,
@@ -342,13 +354,20 @@ function AccessGatedProviderSettings({
     operateAccess,
   });
   if (access.kind !== "editable" && access.kind !== "read-only") {
-    return <EnvironmentUnavailableRow environment={environment} access={access} />;
+    return (
+      <EnvironmentUnavailableRow
+        environment={environment}
+        access={access}
+        deviceTabs={deviceTabs}
+      />
+    );
   }
   return (
     <EnvironmentProviderSettings
       environmentId={environment.environmentId}
       environmentLabel={environment.label}
       readOnly={access.kind === "read-only"}
+      deviceTabs={deviceTabs}
     />
   );
 }
@@ -357,9 +376,11 @@ export function EnvironmentProviderSettings({
   environmentId,
   environmentLabel,
   readOnly = false,
+  deviceTabs,
 }: {
   readonly environmentId: EnvironmentId;
   readonly environmentLabel: string;
+  readonly deviceTabs?: ReactNode;
   /**
    * Render the full provider layout, greyed out and inert, when this session's
    * credential lacks `orchestration:operate` on the environment. Showing the
@@ -380,10 +401,11 @@ export function EnvironmentProviderSettings({
   });
   const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
   const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
     ReadonlySet<ProviderDriverKind>
   >(() => new Set());
-  const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
   const refreshingRef = useRef(false);
   const updatingDriversRef = useRef<Set<ProviderDriverKind>>(new Set());
 
@@ -577,6 +599,8 @@ export function EnvironmentProviderSettings({
     }
   }
 
+  const selectedRow = rows.find((row) => row.instanceId === selectedInstanceId) ?? rows[0] ?? null;
+
   const updateProviderInstance = (
     row: InstanceRow,
     next: ProviderInstanceConfig,
@@ -666,55 +690,122 @@ export function EnvironmentProviderSettings({
     });
   };
 
+  const renderProviderInstance = (row: InstanceRow, mode: "list" | "editor") => {
+    const driverOption = getDriverOption(row.driver);
+    const liveProvider = serverProviders.find(
+      (candidate) => candidate.instanceId === row.instanceId,
+    );
+    const updateCandidate = liveProvider
+      ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
+      : undefined;
+    const isDriverUpdateRunning =
+      updateCandidate !== undefined &&
+      (updatingProviderDrivers.has(updateCandidate.driver) ||
+        serverProviders.some(
+          (provider) =>
+            provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
+        ));
+    const showInlineUpdateButton =
+      updateCandidate !== undefined &&
+      hasOneClickUpdateProviderCandidate(updateCandidate, serverProviders);
+    const canRunInlineUpdate =
+      updateCandidate !== undefined &&
+      canOneClickUpdateProviderCandidate(updateCandidate, serverProviders) &&
+      !updatingProviderDrivers.has(updateCandidate.driver);
+    const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
+      hiddenModels: [],
+      modelOrder: [],
+    };
+    const favoriteModels = Arr.filterMap(settings.favorites ?? [], (favorite) =>
+      favorite.provider === row.instanceId ? Result.succeed(favorite.model) : Result.failVoid,
+    );
+    const resetLabel = driverOption?.label ?? String(row.driver);
+
+    return (
+      <ProviderInstanceCard
+        key={row.instanceId}
+        instanceId={row.instanceId}
+        instance={row.instance}
+        driverOption={driverOption}
+        liveProvider={liveProvider}
+        mode={mode}
+        selected={mode === "list" && selectedRow?.instanceId === row.instanceId}
+        onSelect={mode === "list" ? () => setSelectedInstanceId(row.instanceId) : undefined}
+        onUpdate={(next) => {
+          const wasEnabled = resolveProviderInstanceEnabled(row.instance);
+          const isDisabling = next.enabled === false && wasEnabled;
+          const shouldClearTextGen = isDisabling && textGenInstanceId === row.instanceId;
+          updateProviderInstance(
+            row,
+            next,
+            shouldClearTextGen
+              ? {
+                  textGenerationModelSelection:
+                    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+                }
+              : undefined,
+          );
+        }}
+        onDelete={
+          mode === "editor" && !row.isDefault
+            ? () => deleteProviderInstance(row.instanceId)
+            : undefined
+        }
+        headerAction={
+          mode === "editor" && row.isDefault && row.isDirty ? (
+            <SettingResetButton
+              label={`${resetLabel} provider settings`}
+              onClick={() => resetDefaultInstance(row.driver)}
+            />
+          ) : null
+        }
+        hiddenModels={modelPreferences.hiddenModels}
+        favoriteModels={favoriteModels}
+        modelOrder={modelPreferences.modelOrder}
+        onHiddenModelsChange={(hiddenModels) =>
+          updateProviderModelPreferences(row.instanceId, {
+            ...modelPreferences,
+            hiddenModels,
+          })
+        }
+        onFavoriteModelsChange={(next) => updateProviderFavoriteModels(row.instanceId, next)}
+        onModelOrderChange={(modelOrder) =>
+          updateProviderModelPreferences(row.instanceId, {
+            ...modelPreferences,
+            modelOrder,
+          })
+        }
+        onRunUpdate={
+          mode === "editor" && showInlineUpdateButton && updateCandidate
+            ? () => {
+                if (canRunInlineUpdate) void runProviderUpdate(updateCandidate);
+              }
+            : undefined
+        }
+        isUpdating={mode === "editor" && showInlineUpdateButton ? isDriverUpdateRunning : undefined}
+      />
+    );
+  };
+
   return (
     <>
       <SettingsSection
         {...searchableSetting("providers")}
         headerAction={
-          <div className="flex items-center gap-1.5">
-            <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
-            {!readOnly ? (
-              <>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="icon-micro"
-                        variant="ghost-muted"
-                        onClick={() => setIsAddInstanceDialogOpen(true)}
-                        aria-label="Add provider instance"
-                      >
-                        <PlusIcon className="size-3" />
-                      </Button>
-                    }
-                  />
-                  <TooltipPopup side="top">Add provider instance</TooltipPopup>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="icon-micro"
-                        variant="ghost-muted"
-                        disabled={isRefreshingProviders}
-                        onClick={() => void refreshProviders()}
-                        aria-label="Refresh provider status"
-                      >
-                        {isRefreshingProviders ? (
-                          <LoaderIcon className="size-3 animate-spin" />
-                        ) : (
-                          <RefreshCwIcon className="size-3" />
-                        )}
-                      </Button>
-                    }
-                  />
-                  <TooltipPopup side="top">Refresh provider status</TooltipPopup>
-                </Tooltip>
-              </>
-            ) : null}
-          </div>
+          !readOnly ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 gap-1.5 px-2.5 text-xs"
+              onClick={() => setIsAddInstanceDialogOpen(true)}
+            >
+              <PlusIcon className="size-3.5" />
+              Add provider
+            </Button>
+          ) : null
         }
       >
+        {deviceTabs}
         {readOnly ? (
           <SettingsRow
             title="Limited permissions"
@@ -729,170 +820,118 @@ export function EnvironmentProviderSettings({
           aria-disabled={readOnly || undefined}
           className={readOnly ? "space-y-1 opacity-50 select-none" : "space-y-1"}
         >
-          <SettingsRow
-            title={
-              <span className="inline-flex items-center gap-1.5">
-                Health check interval
-                <PolicyTooltip>
-                  This interval is configured here, then the shared Background activity policy
-                  decides whether provider probes may run when the timer fires. Custom intervals
-                  appear as Advanced in General settings.
-                </PolicyTooltip>
-              </span>
-            }
-            description="Refresh provider availability, versions, auth state, and model metadata in the background. Set this to 0 seconds to rely on manual refreshes."
-            resetAction={
-              providerHealthRefreshIntervalSeconds !==
-              defaultProviderHealthRefreshIntervalSeconds ? (
-                <SettingResetButton
-                  label="provider health check interval"
-                  onClick={() =>
-                    updateSettings(
-                      backgroundActivityOverrideSettings(
-                        settings.backgroundActivity,
-                        resolvedBackgroundActivity,
-                        {
-                          providerHealthRefreshInterval: undefined,
-                        },
-                      ),
-                    )
-                  }
-                />
-              ) : null
-            }
-            control={
-              <div className="flex shrink-0 items-center gap-2">
-                <NumberField
-                  value={providerHealthRefreshIntervalSeconds}
-                  min={0}
-                  step={PROVIDER_HEALTH_INTERVAL_STEP_SECONDS}
-                  size="sm"
-                  className="w-32"
-                  onValueChange={(value) =>
-                    updateSettings(
-                      backgroundActivityOverrideSettings(
-                        settings.backgroundActivity,
-                        resolvedBackgroundActivity,
-                        {
-                          providerHealthRefreshInterval: Duration.seconds(
-                            normalizeIntervalSeconds(value),
-                          ),
-                        },
-                      ),
-                    )
-                  }
-                >
-                  <NumberFieldGroup>
-                    <NumberFieldDecrement aria-label="Decrease provider health check interval" />
-                    <NumberFieldInput aria-label="Provider health check interval in seconds" />
-                    <NumberFieldIncrement aria-label="Increase provider health check interval" />
-                  </NumberFieldGroup>
-                </NumberField>
-                <span className="text-xs text-muted-foreground">seconds</span>
+          <div className="overflow-hidden rounded-lg border border-border/70 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)]">
+            <div className="border-b border-border/70 lg:border-r lg:border-b-0">
+              <div className="flex min-h-9 items-center justify-between border-b border-border/70 px-3 text-[11px] font-medium text-muted-foreground">
+                <span>Provider</span>
+                <span>On</span>
               </div>
-            }
-          />
+              {rows.map((row) => renderProviderInstance(row, "list"))}
+              <div className="flex min-h-10 items-center justify-between border-t border-border/70 px-3">
+                <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
+                {!readOnly ? (
+                  <Button
+                    size="icon-micro"
+                    variant="ghost-muted"
+                    disabled={isRefreshingProviders}
+                    onClick={() => void refreshProviders()}
+                    aria-label="Refresh provider status"
+                  >
+                    {isRefreshingProviders ? (
+                      <LoaderIcon className="size-3 animate-spin" />
+                    ) : (
+                      <RefreshCwIcon className="size-3" />
+                    )}
+                  </Button>
+                ) : null}
+              </div>
+            </div>
 
-          {rows.map((row) => {
-            const driverOption = getDriverOption(row.driver);
-            const liveProvider = serverProviders.find(
-              (candidate) => candidate.instanceId === row.instanceId,
-            );
-            const updateCandidate = liveProvider
-              ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
-              : undefined;
-            const isDriverUpdateRunning =
-              updateCandidate !== undefined &&
-              (updatingProviderDrivers.has(updateCandidate.driver) ||
-                serverProviders.some(
-                  (provider) =>
-                    provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
-                ));
-            const showInlineUpdateButton =
-              updateCandidate !== undefined &&
-              hasOneClickUpdateProviderCandidate(updateCandidate, serverProviders);
-            const canRunInlineUpdate =
-              updateCandidate !== undefined &&
-              canOneClickUpdateProviderCandidate(updateCandidate, serverProviders) &&
-              !updatingProviderDrivers.has(updateCandidate.driver);
-            const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
-              hiddenModels: [],
-              modelOrder: [],
-            };
-            const favoriteModels = Arr.filterMap(settings.favorites ?? [], (favorite) =>
-              favorite.provider === row.instanceId
-                ? Result.succeed(favorite.model)
-                : Result.failVoid,
-            );
-            const resetLabel = driverOption?.label ?? String(row.driver);
-            const headerAction =
-              row.isDefault && row.isDirty ? (
-                <SettingResetButton
-                  label={`${resetLabel} provider settings`}
-                  onClick={() => resetDefaultInstance(row.driver)}
-                />
-              ) : null;
-            return (
-              <ProviderInstanceCard
-                key={row.instanceId}
-                instanceId={row.instanceId}
-                instance={row.instance}
-                driverOption={driverOption}
-                liveProvider={liveProvider}
-                isExpanded={openInstanceDetails[row.instanceId] ?? false}
-                onExpandedChange={(open) =>
-                  setOpenInstanceDetails((existing) => ({
-                    ...existing,
-                    [row.instanceId]: open,
-                  }))
-                }
-                onUpdate={(next) => {
-                  const wasEnabled = resolveProviderInstanceEnabled(row.instance);
-                  const isDisabling = next.enabled === false && wasEnabled;
-                  const shouldClearTextGen = isDisabling && textGenInstanceId === row.instanceId;
-                  if (shouldClearTextGen) {
-                    updateProviderInstance(row, next, {
-                      textGenerationModelSelection:
-                        DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
-                    });
-                  } else {
-                    updateProviderInstance(row, next);
-                  }
-                }}
-                onDelete={row.isDefault ? undefined : () => deleteProviderInstance(row.instanceId)}
-                headerAction={headerAction}
-                hiddenModels={modelPreferences.hiddenModels}
-                favoriteModels={favoriteModels}
-                modelOrder={modelPreferences.modelOrder}
-                onHiddenModelsChange={(hiddenModels) =>
-                  updateProviderModelPreferences(row.instanceId, {
-                    ...modelPreferences,
-                    hiddenModels,
-                  })
-                }
-                onFavoriteModelsChange={(favoriteModels) =>
-                  updateProviderFavoriteModels(row.instanceId, favoriteModels)
-                }
-                onModelOrderChange={(modelOrder) =>
-                  updateProviderModelPreferences(row.instanceId, {
-                    ...modelPreferences,
-                    modelOrder,
-                  })
-                }
-                onRunUpdate={
-                  showInlineUpdateButton && updateCandidate
-                    ? () => {
-                        if (!canRunInlineUpdate) {
-                          return;
-                        }
-                        void runProviderUpdate(updateCandidate);
-                      }
-                    : undefined
-                }
-                isUpdating={showInlineUpdateButton ? isDriverUpdateRunning : undefined}
+            <div className="min-w-0">
+              {selectedRow ? (
+                renderProviderInstance(selectedRow, "editor")
+              ) : (
+                <div className="p-6 text-sm text-muted-foreground">No providers configured.</div>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-2 border-t border-border/70">
+            <button
+              type="button"
+              className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setAdvancedOpen((open) => !open)}
+              aria-expanded={advancedOpen}
+            >
+              <ChevronDownIcon
+                className={cn("size-3 transition-transform", advancedOpen && "rotate-180")}
               />
-            );
-          })}
+              Advanced
+            </button>
+            {advancedOpen ? (
+              <SettingsRow
+                title={
+                  <span className="inline-flex items-center gap-1.5">
+                    Health check interval
+                    <PolicyTooltip>
+                      This interval is configured here, then the shared Background activity policy
+                      decides whether provider probes may run when the timer fires. Custom intervals
+                      appear as Advanced in General settings.
+                    </PolicyTooltip>
+                  </span>
+                }
+                description="Set this to 0 seconds to use manual refresh only."
+                resetAction={
+                  providerHealthRefreshIntervalSeconds !==
+                  defaultProviderHealthRefreshIntervalSeconds ? (
+                    <SettingResetButton
+                      label="provider health check interval"
+                      onClick={() =>
+                        updateSettings(
+                          backgroundActivityOverrideSettings(
+                            settings.backgroundActivity,
+                            resolvedBackgroundActivity,
+                            { providerHealthRefreshInterval: undefined },
+                          ),
+                        )
+                      }
+                    />
+                  ) : null
+                }
+                control={
+                  <div className="flex shrink-0 items-center gap-2">
+                    <NumberField
+                      value={providerHealthRefreshIntervalSeconds}
+                      min={0}
+                      step={PROVIDER_HEALTH_INTERVAL_STEP_SECONDS}
+                      size="sm"
+                      className="w-32"
+                      onValueChange={(value) =>
+                        updateSettings(
+                          backgroundActivityOverrideSettings(
+                            settings.backgroundActivity,
+                            resolvedBackgroundActivity,
+                            {
+                              providerHealthRefreshInterval: Duration.seconds(
+                                normalizeIntervalSeconds(value),
+                              ),
+                            },
+                          ),
+                        )
+                      }
+                    >
+                      <NumberFieldGroup>
+                        <NumberFieldDecrement aria-label="Decrease provider health check interval" />
+                        <NumberFieldInput aria-label="Provider health check interval in seconds" />
+                        <NumberFieldIncrement aria-label="Increase provider health check interval" />
+                      </NumberFieldGroup>
+                    </NumberField>
+                    <span className="text-xs text-muted-foreground">seconds</span>
+                  </div>
+                }
+              />
+            ) : null}
+          </div>
         </div>
       </SettingsSection>
 

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -157,6 +157,14 @@ function providerEnvironmentIcon(environment: EnvironmentPresentation) {
   return CloudIcon;
 }
 
+function providerEnvironmentDetail(environment: EnvironmentPresentation): string {
+  if (environment.entry.target._tag === "PrimaryConnectionTarget") return "Primary device";
+  if (environment.relayManaged) return "T3 Connect";
+  if (environment.entry.target._tag === "SshConnectionTarget") return "SSH";
+  if (isDesktopLocalConnectionTarget(environment.entry.target)) return "Local device";
+  return environment.displayUrl ?? "Remote device";
+}
+
 function EnvironmentUnavailableRow({
   environment,
   access,
@@ -212,10 +220,15 @@ export function ProviderSettingsPanel() {
   const deviceTabs =
     !onlyPrimaryDevice && options.length > 0 ? (
       <ScrollArea hideScrollbars scrollFade className="h-11 min-w-0 rounded-none">
-        <div className="flex h-full w-max min-w-full border-b border-border/70 px-3">
+        <div
+          role="group"
+          aria-label="Devices"
+          className="flex h-full w-max min-w-full border-b border-border/70 px-3"
+        >
           {options.map((environment) => {
             const Icon = providerEnvironmentIcon(environment);
             const selected = environment.environmentId === effectiveEnvironmentId;
+            const detail = providerEnvironmentDetail(environment);
             const statusText = connectionStatusText(environment.connection);
             return (
               <Tooltip key={environment.environmentId}>
@@ -238,11 +251,15 @@ export function ProviderSettingsPanel() {
                         dotClassName={connectionPhaseDotClassName(environment.connection.phase)}
                         pingClassName={connectionPhasePingClassName(environment.connection.phase)}
                       />
-                      <span className="sr-only">{statusText}</span>
+                      <span className="sr-only">
+                        {detail}, {statusText}
+                      </span>
                     </button>
                   }
                 />
-                <TooltipPopup side="top">{statusText}</TooltipPopup>
+                <TooltipPopup side="top">
+                  {detail} · {statusText}
+                </TooltipPopup>
               </Tooltip>
             );
           })}
@@ -878,7 +895,7 @@ export function EnvironmentProviderSettings({
             onOpenChange={setAdvancedOpen}
             className="mt-2 border-t border-border/70"
           >
-            <CollapsibleTrigger className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground">
+            <CollapsibleTrigger className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground sm:px-4">
               <ChevronDownIcon
                 className={cn("size-3 transition-transform", advancedVisible && "rotate-180")}
               />

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -834,7 +834,7 @@ export function EnvironmentProviderSettings({
                 <span>On</span>
               </div>
               {rows.map((row) => renderProviderInstance(row, "list"))}
-              <div className="flex min-h-10 items-center justify-between border-t border-border/70 px-3">
+              <div className="flex min-h-10 items-center justify-between px-3">
                 <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
                 {!readOnly ? (
                   <Tooltip>

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -403,6 +403,7 @@ export function EnvironmentProviderSettings({
   const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
   const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const advancedVisible = readOnly || advancedOpen;
   const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
     ReadonlySet<ProviderDriverKind>
   >(() => new Set());
@@ -794,9 +795,8 @@ export function EnvironmentProviderSettings({
         headerAction={
           !readOnly ? (
             <Button
-              size="sm"
+              size="compact"
               variant="outline"
-              className="text-xs"
               onClick={() => setIsAddInstanceDialogOpen(true)}
             >
               <PlusIcon className="size-3.5" />
@@ -857,13 +857,13 @@ export function EnvironmentProviderSettings({
           </div>
 
           <Collapsible
-            open={advancedOpen}
+            open={advancedVisible}
             onOpenChange={setAdvancedOpen}
             className="mt-2 border-t border-border/70"
           >
             <CollapsibleTrigger className="flex h-10 w-full items-center gap-2 px-3 text-xs text-muted-foreground hover:text-foreground">
               <ChevronDownIcon
-                className={cn("size-3 transition-transform", advancedOpen && "rotate-180")}
+                className={cn("size-3 transition-transform", advancedVisible && "rotate-180")}
               />
               Advanced
             </CollapsibleTrigger>

--- a/apps/web/src/components/settings/providerSettingsTabs.ts
+++ b/apps/web/src/components/settings/providerSettingsTabs.ts
@@ -2,7 +2,7 @@ import { cn } from "../../lib/utils";
 
 export function providerSettingsTabClassName(selected: boolean): string {
   return cn(
-    "relative flex h-full shrink-0 cursor-pointer items-center rounded-sm px-3 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+    "relative flex h-full shrink-0 cursor-pointer items-center rounded-sm px-3 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
     selected
       ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
       : "text-muted-foreground hover:text-foreground",

--- a/apps/web/src/components/settings/providerSettingsTabs.ts
+++ b/apps/web/src/components/settings/providerSettingsTabs.ts
@@ -1,0 +1,10 @@
+import { cn } from "../../lib/utils";
+
+export function providerSettingsTabClassName(selected: boolean): string {
+  return cn(
+    "relative flex h-full shrink-0 cursor-pointer items-center rounded-sm px-3 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+    selected
+      ? "text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+      : "text-muted-foreground hover:text-foreground",
+  );
+}

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -6,7 +6,7 @@ import type { ServerProvider, ServerProviderVersionAdvisory } from "@t3tools/con
  */
 export const PROVIDER_STATUS_STYLES = {
   disabled: {
-    dot: "bg-amber-400",
+    dot: "bg-muted-foreground/50",
   },
   error: {
     dot: "bg-destructive",


### PR DESCRIPTION
Provider settings spread status, switches, and detailed controls down one long page. It was hard to scan providers or switch between configurations.

This changes the page to a two-column layout. The left side keeps every provider and its on/off switch visible. The right side edits one provider through separate Models and Configuration tabs. Device selection moves to compact tabs, while the health check interval stays available under Advanced.

## Before

![Provider settings before](https://files.tslop.org/2026/08/provider-settings-before-db4351c5.png)

## After

![Provider settings after](https://files.tslop.org/2026/08/after-muted-disabled-shared-tabs-fe004666.png)

## Checks

- `vp run --filter @t3tools/web typecheck`
- Focused lint for the three changed files
- 6 focused provider settings tests
- Manual browser check for provider selection, independent switches, Models, Configuration, and Advanced

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI and props contract changes for provider configuration editing, including environment-variable draft sync; behavior changes for disabled status display but no server-side auth or persistence logic.
> 
> **Overview**
> Provider settings move from a single scroll of expandable cards to a **master–detail layout**: a left **Provider** list (status, enable switch, selection) and a right **editor** for the selected instance.
> 
> **`ProviderInstanceCard`** drops expand/collapse in favor of **`mode: "list" | "editor"`** plus **`selected` / `onSelect` / `readOnly`**. The editor uses **Models** and **Configuration** tabs instead of one collapsible block. Disabled instances always show a neutral **Disabled** summary and muted status dot (not stale server status). Authenticated-email / **`ProviderAuthEmail`** UI is removed; warning/error status appears only in the editor header.
> 
> **`ProviderSettingsPanel`** wires selection state, puts **device picking** in a horizontal tab bar above Providers (replacing the device card grid), moves **health check interval** into an **Advanced** collapsible, and scopes **`inert`** to editor/advanced areas so list selection still works in read-only mode.
> 
> **`ProviderEnvironmentSection`** resyncs local env-var rows when the parent **`environment`** prop changes (with equality checks to avoid fighting in-flight edits). Shared tab styling lives in **`providerSettingsTabs`**. Tests are updated for list/editor flows and read-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ca5bee9394fe12b488f607753f7ff2e35e0c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split provider settings into master-detail list and editor views
> - Replaces the expand/collapse `ProviderInstanceCard` with two modes: `list` (compact selectable row with enable switch) and `editor` (full detail with Models/Configuration tabs). Callers must update to the new `mode`, `selected`, `onSelect`, and `readOnly` props.
> - Reworks `EnvironmentProviderSettings` into a two-column layout where the left pane lists instances and the right pane shows the selected editor. Devices are selected via a top tab bar instead of a grid, and the page layout is widened.
> - Moves health check interval controls into an Advanced collapsible section and relocates refresh/add controls to the list footer and header.
> - Fixes `ProviderEnvironmentSection` to preserve in-progress edits when `environment` prop re-renders with equivalent data, using the new `providerEnvironmentsEqual` helper.
> - Removes `ProviderAuthEmail` component and changes disabled provider status dot from amber to muted.
> - Risk: `ProviderInstanceCardProps` interface changed from `isExpanded`/`onExpandedChange` to `mode`/`selected`/`onSelect`/`readOnly`; any out-of-tree callers will break. Read-only mode keeps selection active but disables modification via `inert`/`aria-disabled`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6ca5be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->