### PR TITLE
fix(web): unify desktop update progress in sidebar

### DIFF
--- a/apps/web/src/components/sidebar/DesktopUpdateStatusIcon.tsx
+++ b/apps/web/src/components/sidebar/DesktopUpdateStatusIcon.tsx
@@ -3,20 +3,12 @@ import type { AnimationEventHandler } from "react";
 
 import { cn } from "../../lib/utils";
 
-const DOWNLOAD_PROGRESS_RADIUS = 14;
-const DOWNLOAD_PROGRESS_CIRCUMFERENCE = 2 * Math.PI * DOWNLOAD_PROGRESS_RADIUS;
-
 export type DesktopUpdateStatusIconState =
   | "idle"
   | "checking"
   | "available"
   | "downloading"
   | "downloaded";
-
-function normalizeDesktopUpdateDownloadPercent(percent: number | null): number {
-  if (percent === null || !Number.isFinite(percent)) return 0;
-  return Math.min(100, Math.max(0, percent));
-}
 
 export function shouldShowDesktopUpdateCheckIcon({
   isAnimationLatched,
@@ -52,43 +44,6 @@ function DesktopUpdateAvailableIcon() {
   );
 }
 
-function DesktopUpdateDownloadingIcon({ percent }: { readonly percent: number | null }) {
-  const normalizedPercent = normalizeDesktopUpdateDownloadPercent(percent);
-  const progressOffset = DOWNLOAD_PROGRESS_CIRCUMFERENCE * (1 - normalizedPercent / 100);
-
-  return (
-    <span className="relative grid size-8 place-items-center">
-      <svg
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 size-full -rotate-90"
-        viewBox="0 0 32 32"
-      >
-        <circle
-          cx="16"
-          cy="16"
-          r={DOWNLOAD_PROGRESS_RADIUS}
-          fill="none"
-          stroke="color-mix(in srgb, currentColor 22%, transparent)"
-          strokeWidth="1.5"
-        />
-        <circle
-          cx="16"
-          cy="16"
-          r={DOWNLOAD_PROGRESS_RADIUS}
-          fill="none"
-          stroke="currentColor"
-          strokeDasharray={DOWNLOAD_PROGRESS_CIRCUMFERENCE}
-          strokeDashoffset={progressOffset}
-          strokeLinecap="round"
-          strokeWidth="1.5"
-          className="transition-[stroke-dashoffset] duration-300 ease-out motion-reduce:transition-none"
-        />
-      </svg>
-      <DownloadIcon className="size-4" />
-    </span>
-  );
-}
-
 function DesktopUpdateDownloadedIcon() {
   return (
     <span className="relative grid size-4 place-items-center">
@@ -101,19 +56,17 @@ function DesktopUpdateDownloadedIcon() {
 }
 
 export function DesktopUpdateStatusIcon({
-  downloadPercent,
   isCheckAnimating,
   onCheckAnimationIteration,
   status,
 }: {
-  readonly downloadPercent?: number | null;
   readonly isCheckAnimating?: boolean;
   readonly onCheckAnimationIteration?: AnimationEventHandler<SVGSVGElement>;
   readonly status: DesktopUpdateStatusIconState;
 }) {
   if (status === "available") return <DesktopUpdateAvailableIcon />;
   if (status === "downloading") {
-    return <DesktopUpdateDownloadingIcon percent={downloadPercent ?? null} />;
+    return <DownloadIcon className="size-4" />;
   }
   if (status === "downloaded") return <DesktopUpdateDownloadedIcon />;
 

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -29,7 +29,7 @@ import {
   useSidebar,
 } from "../ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
-import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
+import { SidebarUpdateProgressPill } from "./SidebarUpdateProgressPill";
 import { SidebarUpdateArchitectureWarning, SidebarUpdatePill } from "./SidebarUpdatePill";
 
 export const SidebarChromeHeader = memo(function SidebarChromeHeader({
@@ -231,7 +231,7 @@ export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
 export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   return (
     <SidebarFooter className="p-[var(--sidebar-content-inset)]">
-      <SidebarProviderUpdatePill />
+      <SidebarUpdateProgressPill />
       <SidebarUpdateArchitectureWarning />
       <SidebarUtilityMenu />
     </SidebarFooter>

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -333,7 +333,6 @@ function SidebarUpdateControl() {
             >
               <DesktopUpdateStatusIcon
                 key={showCheckIcon ? checkAnimationKey : iconStatus}
-                downloadPercent={state?.downloadPercent ?? null}
                 isCheckAnimating={showCheckIcon && !prefersReducedMotion}
                 onCheckAnimationIteration={handleCheckAnimationIteration}
                 status={iconStatus}

--- a/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.test.ts
+++ b/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.test.ts
@@ -1,0 +1,113 @@
+import type { DesktopUpdateState } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getDesktopUpdateProgressView,
+  resolveDisplayedSidebarUpdateProgressView,
+  selectSidebarUpdateProgressView,
+  type SidebarUpdateProgressView,
+} from "./SidebarUpdateProgressPill.logic";
+
+const baseState: DesktopUpdateState = {
+  enabled: true,
+  status: "idle",
+  channel: "latest",
+  currentVersion: "1.0.0",
+  hostArch: "x64",
+  appArch: "x64",
+  runningUnderArm64Translation: false,
+  availableVersion: null,
+  downloadedVersion: null,
+  releaseNotes: [],
+  downloadPercent: null,
+  checkedAt: null,
+  message: null,
+  errorContext: null,
+  canRetry: false,
+};
+
+describe("desktop update sidebar progress", () => {
+  it("shows determinate download progress in the shared sidebar pill", () => {
+    expect(
+      getDesktopUpdateProgressView({
+        ...baseState,
+        status: "downloading",
+        availableVersion: "1.1.0",
+        downloadPercent: 42.5,
+      }),
+    ).toEqual({
+      key: "desktop:downloading:1.1.0",
+      tone: "loading",
+      title: "Downloading T3 Code",
+      description: "T3 Code 1.1.0 download is 42% complete.",
+      destination: "/settings/general",
+      progress: 42.5,
+    });
+  });
+
+  it("keeps download progress valid when the updater reports an invalid percentage", () => {
+    expect(
+      getDesktopUpdateProgressView({
+        ...baseState,
+        status: "downloading",
+        downloadPercent: 150,
+      }),
+    ).toMatchObject({ progress: 100, description: "T3 Code update download is 100% complete." });
+
+    expect(
+      getDesktopUpdateProgressView({
+        ...baseState,
+        status: "downloading",
+        downloadPercent: Number.NaN,
+      }),
+    ).not.toHaveProperty("progress");
+  });
+
+  it("does not occupy the progress pill outside an active download", () => {
+    expect(
+      getDesktopUpdateProgressView({
+        ...baseState,
+        status: "available",
+        availableVersion: "1.1.0",
+      }),
+    ).toBeNull();
+  });
+
+  it("prioritizes a determinate app download over indeterminate provider work", () => {
+    const desktopView = getDesktopUpdateProgressView({
+      ...baseState,
+      status: "downloading",
+      downloadPercent: 20,
+    });
+    const providerView: SidebarUpdateProgressView = {
+      key: "provider:loading:codex",
+      tone: "loading",
+      title: "Updating Codex",
+      description: "Codex update in progress.",
+      destination: "/settings/providers",
+    };
+
+    expect(selectSidebarUpdateProgressView({ desktopView, providerView })).toBe(desktopView);
+    expect(selectSidebarUpdateProgressView({ desktopView: null, providerView })).toBe(providerView);
+  });
+
+  it("refreshes progress in place without replacing a view during an exit transition", () => {
+    const renderedView: SidebarUpdateProgressView = {
+      key: "desktop:downloading:1.1.0",
+      tone: "loading",
+      title: "Downloading T3 Code",
+      description: "T3 Code 1.1.0 download is 10% complete.",
+      destination: "/settings/general",
+      progress: 10,
+    };
+    const currentView = { ...renderedView, progress: 45 };
+
+    expect(resolveDisplayedSidebarUpdateProgressView(renderedView, currentView)).toBe(currentView);
+    expect(
+      resolveDisplayedSidebarUpdateProgressView(renderedView, {
+        ...currentView,
+        key: "provider:loading:codex",
+      }),
+    ).toBe(renderedView);
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.test.ts
+++ b/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   getDesktopUpdateProgressView,
+  refreshRenderedSidebarUpdateProgressView,
   resolveDisplayedSidebarUpdateProgressView,
   selectSidebarUpdateProgressView,
   type SidebarUpdateProgressView,
@@ -91,7 +92,7 @@ describe("desktop update sidebar progress", () => {
     expect(selectSidebarUpdateProgressView({ desktopView: null, providerView })).toBe(providerView);
   });
 
-  it("refreshes progress in place without replacing a view during an exit transition", () => {
+  it("retains the latest progress while the pill exits", () => {
     const renderedView: SidebarUpdateProgressView = {
       key: "desktop:downloading:1.1.0",
       tone: "loading",
@@ -101,8 +102,10 @@ describe("desktop update sidebar progress", () => {
       progress: 10,
     };
     const currentView = { ...renderedView, progress: 45 };
+    const refreshedView = refreshRenderedSidebarUpdateProgressView(renderedView, currentView);
 
-    expect(resolveDisplayedSidebarUpdateProgressView(renderedView, currentView)).toBe(currentView);
+    expect(refreshedView).toBe(currentView);
+    expect(resolveDisplayedSidebarUpdateProgressView(refreshedView, null)).toBe(currentView);
     expect(
       resolveDisplayedSidebarUpdateProgressView(renderedView, {
         ...currentView,

--- a/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.ts
+++ b/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.ts
@@ -1,0 +1,60 @@
+import type { DesktopUpdateState } from "@t3tools/contracts";
+
+export type SidebarUpdateProgressTone = "loading" | "warning" | "error" | "success";
+
+export interface SidebarUpdateProgressView {
+  readonly key: string;
+  readonly tone: SidebarUpdateProgressTone;
+  readonly title: string;
+  readonly description: string;
+  readonly destination: "/settings/general" | "/settings/providers";
+  readonly progress?: number;
+  readonly dismissible?: boolean;
+  readonly dismissAfterVisibleMs?: number;
+}
+
+function normalizeProgress(progress: number | null): number | undefined {
+  if (progress === null || !Number.isFinite(progress)) return undefined;
+  return Math.min(100, Math.max(0, progress));
+}
+
+export function getDesktopUpdateProgressView(
+  state: DesktopUpdateState | null,
+): SidebarUpdateProgressView | null {
+  if (state?.status !== "downloading") return null;
+
+  const progress = normalizeProgress(state.downloadPercent);
+  const version = state.availableVersion;
+  const subject = version ? `T3 Code ${version}` : "T3 Code update";
+  const description =
+    progress === undefined
+      ? `${subject} download is in progress.`
+      : `${subject} download is ${Math.floor(progress)}% complete.`;
+
+  return {
+    key: `desktop:downloading:${version ?? "unknown"}`,
+    tone: "loading",
+    title: "Downloading T3 Code",
+    description,
+    destination: "/settings/general",
+    ...(progress === undefined ? {} : { progress }),
+  };
+}
+
+export function selectSidebarUpdateProgressView({
+  desktopView,
+  providerView,
+}: {
+  readonly desktopView: SidebarUpdateProgressView | null;
+  readonly providerView: SidebarUpdateProgressView | null;
+}): SidebarUpdateProgressView | null {
+  return desktopView ?? providerView;
+}
+
+export function resolveDisplayedSidebarUpdateProgressView(
+  renderedView: SidebarUpdateProgressView | null,
+  currentView: SidebarUpdateProgressView | null,
+): SidebarUpdateProgressView | null {
+  if (renderedView?.key === currentView?.key) return currentView;
+  return renderedView ?? currentView;
+}

--- a/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.ts
+++ b/apps/web/src/components/sidebar/SidebarUpdateProgressPill.logic.ts
@@ -51,6 +51,21 @@ export function selectSidebarUpdateProgressView({
   return desktopView ?? providerView;
 }
 
+export function refreshRenderedSidebarUpdateProgressView(
+  renderedView: SidebarUpdateProgressView | null,
+  currentView: SidebarUpdateProgressView | null,
+): SidebarUpdateProgressView | null {
+  if (
+    renderedView !== null &&
+    currentView !== null &&
+    renderedView.key === currentView.key &&
+    renderedView.progress !== currentView.progress
+  ) {
+    return currentView;
+  }
+  return renderedView;
+}
+
 export function resolveDisplayedSidebarUpdateProgressView(
   renderedView: SidebarUpdateProgressView | null,
   currentView: SidebarUpdateProgressView | null,

--- a/apps/web/src/components/sidebar/SidebarUpdateProgressPill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateProgressPill.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { Button } from "../ui/button";
 import {
   getDesktopUpdateProgressView,
+  refreshRenderedSidebarUpdateProgressView,
   resolveDisplayedSidebarUpdateProgressView,
   selectSidebarUpdateProgressView,
   type SidebarUpdateProgressView,
@@ -103,6 +104,11 @@ export function SidebarUpdateProgressPill() {
       if (view) {
         setRenderedView(view);
       }
+      return;
+    }
+    const refreshedView = refreshRenderedSidebarUpdateProgressView(renderedView, view);
+    if (refreshedView !== renderedView) {
+      setRenderedView(refreshedView);
       return;
     }
     if (!view) {

--- a/apps/web/src/components/sidebar/SidebarUpdateProgressPill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdateProgressPill.tsx
@@ -5,25 +5,29 @@ import { CircleCheckIcon, DownloadIcon, LoaderIcon, TriangleAlertIcon, XIcon } f
 import { useCallback, useEffect, useState, type CSSProperties } from "react";
 
 import { primaryServerProvidersAtom } from "../../state/server";
-import {
-  getProviderUpdateSidebarPillView,
-  type ProviderUpdateSidebarPillView,
-} from "../ProviderUpdateLaunchNotification.logic";
+import { useDesktopUpdateState } from "../../state/desktopUpdate";
+import { getProviderUpdateSidebarPillView } from "../ProviderUpdateLaunchNotification.logic";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { Button } from "../ui/button";
+import {
+  getDesktopUpdateProgressView,
+  resolveDisplayedSidebarUpdateProgressView,
+  selectSidebarUpdateProgressView,
+  type SidebarUpdateProgressView,
+} from "./SidebarUpdateProgressPill.logic";
 
-const PROVIDER_UPDATE_PILL_STYLES = {
+const UPDATE_PROGRESS_PILL_STYLES = {
   loading:
-    "bg-update-surface text-update-foreground group-has-[button.provider-update-main:hover]/provider-update:bg-update/22",
+    "bg-update-surface text-update-foreground group-has-[button.update-progress-main:hover]/update-progress:bg-update/22",
   success:
-    "bg-success/12 text-success group-has-[button.provider-update-main:hover]/provider-update:bg-success/18",
+    "bg-success/12 text-success group-has-[button.update-progress-main:hover]/update-progress:bg-success/18",
   warning:
-    "bg-warning/12 text-warning group-has-[button.provider-update-main:hover]/provider-update:bg-warning/18",
+    "bg-warning/12 text-warning group-has-[button.update-progress-main:hover]/update-progress:bg-warning/18",
   error:
-    "bg-destructive/12 text-destructive group-has-[button.provider-update-main:hover]/provider-update:bg-destructive/18",
+    "bg-destructive/12 text-destructive group-has-[button.update-progress-main:hover]/update-progress:bg-destructive/18",
 } as const;
 
-const PROVIDER_UPDATE_PILL_PROGRESS_STYLES = {
+const UPDATE_PROGRESS_PILL_COUNTDOWN_STYLES = {
   success: "bg-success/18",
   warning: "bg-warning/14",
   error: "bg-destructive/14",
@@ -39,21 +43,26 @@ function latestProviderCheckedAt(
   );
 }
 
-export function SidebarProviderUpdatePill() {
+export function SidebarUpdateProgressPill() {
   const navigate = useNavigate();
   const providers = useAtomValue(primaryServerProvidersAtom);
+  const desktopUpdateState = useDesktopUpdateState();
   const [dismissedKeys, setDismissedKeys] = useState<ReadonlySet<string>>(() => new Set());
-  const [renderedView, setRenderedView] = useState<ProviderUpdateSidebarPillView | null>(null);
-  const [pendingView, setPendingView] = useState<ProviderUpdateSidebarPillView | null>(null);
+  const [renderedView, setRenderedView] = useState<SidebarUpdateProgressView | null>(null);
+  const [pendingView, setPendingView] = useState<SidebarUpdateProgressView | null>(null);
   const [exitingKey, setExitingKey] = useState<string | null>(null);
   const [dismissAfterExitKey, setDismissAfterExitKey] = useState<string | null>(null);
   const [visibleAfterIso, setVisibleAfterIso] = useState<string | undefined>();
   const effectiveVisibleAfterIso = visibleAfterIso ?? latestProviderCheckedAt(providers);
-  const view = getProviderUpdateSidebarPillView(providers, {
+  const providerView = getProviderUpdateSidebarPillView(providers, {
     ...(effectiveVisibleAfterIso !== undefined
       ? { visibleAfterIso: effectiveVisibleAfterIso }
       : {}),
     dismissedKeys,
+  });
+  const view = selectSidebarUpdateProgressView({
+    desktopView: getDesktopUpdateProgressView(desktopUpdateState),
+    providerView: providerView ? { ...providerView, destination: "/settings/providers" } : null,
   });
 
   useEffect(() => {
@@ -62,19 +71,20 @@ export function SidebarProviderUpdatePill() {
     }
   }, [effectiveVisibleAfterIso, visibleAfterIso]);
 
-  const openProviderSettings = useCallback(() => {
-    void navigate({ to: "/settings/providers" });
-  }, [navigate]);
-  const displayedView = renderedView ?? view;
+  const displayedView = resolveDisplayedSidebarUpdateProgressView(renderedView, view);
   const dismissAfterVisibleMs = displayedView?.dismissAfterVisibleMs;
   const viewKey = displayedView?.key ?? null;
   const showDismissProgress =
     dismissAfterVisibleMs !== undefined &&
     displayedView?.tone !== "loading" &&
     exitingKey !== viewKey;
+  const openUpdateSettings = useCallback(() => {
+    if (!displayedView) return;
+    void navigate({ to: displayedView.destination });
+  }, [displayedView, navigate]);
 
   const startExit = useCallback(
-    (key: string, nextView: ProviderUpdateSidebarPillView | null, dismissKey?: string) => {
+    (key: string, nextView: SidebarUpdateProgressView | null, dismissKey?: string) => {
       if (exitingKey === key) {
         return;
       }
@@ -125,8 +135,8 @@ export function SidebarProviderUpdatePill() {
 
   return (
     <div
-      className={`group/provider-update relative flex h-7 w-full items-center overflow-hidden rounded-lg text-xs font-medium transform-gpu transition-all duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform ${
-        PROVIDER_UPDATE_PILL_STYLES[displayedView.tone]
+      className={`group/update-progress relative flex h-7 w-full items-center overflow-hidden rounded-lg text-xs font-medium transform-gpu transition-all duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform ${
+        UPDATE_PROGRESS_PILL_STYLES[displayedView.tone]
       } ${
         exitingKey === displayedView.key
           ? "pointer-events-none translate-y-1.5 opacity-0"
@@ -148,16 +158,23 @@ export function SidebarProviderUpdatePill() {
         setDismissAfterExitKey(null);
       }}
     >
+      {displayedView.progress !== undefined ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 bg-update/18 transition-[width] duration-300 ease-out motion-reduce:transition-none"
+          style={{ width: `${displayedView.progress}%` }}
+        />
+      ) : null}
       {showDismissProgress ? (
         <div
           key={displayedView.key}
           aria-hidden="true"
-          className={`pointer-events-none absolute inset-y-0 left-0 w-full origin-left animate-[provider-update-pill-countdown_var(--provider-update-pill-dismiss-ms)_linear_forwards] border-r border-current/15 shadow-[inset_0_1px_0_rgb(255_255_255_/_0.08)] ${
-            PROVIDER_UPDATE_PILL_PROGRESS_STYLES[displayedView.tone]
+          className={`pointer-events-none absolute inset-y-0 left-0 w-full origin-left animate-[update-progress-pill-countdown_var(--update-progress-pill-dismiss-ms)_linear_forwards] border-r border-current/15 shadow-[inset_0_1px_0_rgb(255_255_255_/_0.08)] ${
+            UPDATE_PROGRESS_PILL_COUNTDOWN_STYLES[displayedView.tone]
           }`}
           style={
             {
-              "--provider-update-pill-dismiss-ms": `${dismissAfterVisibleMs}ms`,
+              "--update-progress-pill-dismiss-ms": `${dismissAfterVisibleMs}ms`,
             } as CSSProperties
           }
         />
@@ -169,8 +186,8 @@ export function SidebarProviderUpdatePill() {
             <button
               type="button"
               aria-label={displayedView.description}
-              className="provider-update-main relative z-[1] flex h-full flex-1 items-center gap-2 px-2 text-left"
-              onClick={openProviderSettings}
+              className="update-progress-main relative z-[1] flex h-full flex-1 items-center gap-2 px-2 text-left"
+              onClick={openUpdateSettings}
             >
               {displayedView.tone === "loading" ? (
                 <LoaderIcon className="size-3.5 animate-spin" />
@@ -181,7 +198,10 @@ export function SidebarProviderUpdatePill() {
               ) : (
                 <DownloadIcon className="size-3.5" />
               )}
-              <span>{displayedView.title}</span>
+              <span className="min-w-0 flex-1 truncate">{displayedView.title}</span>
+              {displayedView.progress !== undefined ? (
+                <span className="tabular-nums">{Math.floor(displayedView.progress)}%</span>
+              ) : null}
             </button>
           }
         />
@@ -194,7 +214,7 @@ export function SidebarProviderUpdatePill() {
               <Button
                 size="icon-micro"
                 variant="ghost"
-                aria-label="Dismiss provider update notice"
+                aria-label="Dismiss update notice"
                 className="relative z-[1] mr-1 [--control-icon-color:currentColor] rounded-md text-inherit opacity-70 hover:bg-transparent hover:opacity-100"
                 onClick={() => startExit(displayedView.key, null, displayedView.key)}
               >
@@ -202,7 +222,7 @@ export function SidebarProviderUpdatePill() {
               </Button>
             }
           />
-          <TooltipPopup side="top">Dismiss until provider status changes</TooltipPopup>
+          <TooltipPopup side="top">Dismiss until update status changes</TooltipPopup>
         </Tooltip>
       )}
     </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2398,7 +2398,7 @@ code {
   }
 }
 
-@keyframes provider-update-pill-countdown {
+@keyframes update-progress-pill-countdown {
   from {
     transform: scaleX(1);
   }

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -20,6 +20,14 @@ connection will disappear briefly and work that is still running may be interrup
 
 The update does not remove saved threads, settings, or project files.
 
+## Desktop App Downloads
+
+When a desktop app update is available, select the download icon in the sidebar footer. While it
+downloads, the shared update status above the footer actions shows the percentage complete. The
+same status area reports provider updates, so background update progress stays in one place.
+
+After the download finishes, the footer icon changes to the restart and install action.
+
 ## Choose the Action You See
 
 | Action                     | What to do                                                                                                                                                                  |


### PR DESCRIPTION
## What Changed

- Moves desktop app download progress into the shared sidebar update pill used for provider updates.
- Shows a determinate progress fill and percentage while downloading.
- Removes the duplicate circular progress ring from the download icon.
- Prioritizes desktop download progress when desktop and provider updates overlap.
- Opens General settings when the desktop progress pill is selected.
- Preserves the existing restart-and-install icon after the download completes.

## Why

Desktop app downloads and provider updates displayed progress in different places. Using the shared sidebar pill provides one consistent location for tracking update activity and makes the percentage easier to understand.

## UI Changes

### Before
Desktop download progress appeared as a ring around the footer icon.
<img width="255" height="43" alt="Screenshot 2026-08-27 at 2 42 24 PM" src="https://github.com/user-attachments/assets/4540f417-775f-470d-9134-8bf2ddee1475" />


### After
Desktop download progress appears in the shared sidebar pill with a visible percentage.
<img width="194" height="61" alt="After" src="https://github.com/user-attachments/assets/23f1a0d4-75b2-4574-94e4-d97e4b74a521" />

## Verification

- 82 focused tests passed across five test files.
- Targeted lint and formatting checks passed.
- Web typecheck passed.
- `git diff --check` passed.
- Browser-verified progress at 42.5% and 76%, settings navigation, accessible labels, and the absence of the circular icon ring.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No new animation behavior was introduced; the existing sidebar pill transition is reused

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only consolidation of update progress display with tested selection and normalization logic; no auth, data, or server behavior changes.
> 
> **Overview**
> Desktop app download progress now appears in the **shared sidebar update pill** (renamed from provider-only to `SidebarUpdateProgressPill`) instead of a circular ring on the footer download icon.
> 
> While status is `downloading`, new logic builds a progress view with title, description, optional **determinate fill and floored percentage**, and navigation to **General settings**; desktop progress **wins over** concurrent provider update notices in the same pill. The footer icon’s downloading state is a plain download glyph; restart/install behavior after download is unchanged.
> 
> Provider update messaging still uses the same pill UI (renamed CSS/keyframes from `provider-update` to `update-progress`), with clicks routing to the appropriate settings page. User docs describe the unified sidebar status area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c85614eded51dc758b50334a3152de1a41a1879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify desktop update progress in sidebar `SidebarUpdateProgressPill`
> - Replaces `SidebarProviderUpdatePill` with `SidebarUpdateProgressPill` in the sidebar footer to display both desktop app download progress and provider updates.
> - Adds logic in [SidebarUpdateProgressPill.logic.ts](https://github.com/pingdotgg/t3code/pull/8381/files#diff-72d156c44410b3c027fe3677094c49b4f5156398825a2d8a686c8ea33b19ea2b) to select between desktop and provider progress views, normalize invalid percentages, and update progress during exit animations.
> - Removes the circular progress ring from `DesktopUpdateStatusIcon`, replacing it with a static `DownloadIcon` and dropping the `downloadPercent` prop.
> - Renames CSS keyframes and classes from `provider-update-*` to `update-progress-*`.
> - Risk: `DesktopUpdateStatusIcon` no longer accepts `downloadPercent`; callers passing this prop will not render a progress ring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c85614.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->