### PR TITLE
fix(auth): explain DPoP clock-skew failures

### DIFF
--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -1043,7 +1043,7 @@ describe("mobile cloud link environment client", () => {
     }),
   );
 
-  it.effect("preserves relay DPoP auth failures while connecting environments", () =>
+  it.effect("explains relay DPoP clock-skew failures while connecting environments", () =>
     Effect.gen(function* () {
       vi.stubGlobal(
         "fetch",
@@ -1057,6 +1057,7 @@ describe("mobile cloud link environment client", () => {
                     code: "auth_invalid",
                     reason: "invalid_dpop",
                     traceId: "trace-connect",
+                    clockSkewSeconds: 25,
                   },
                   { status: 401 },
                 ),
@@ -1082,7 +1083,7 @@ describe("mobile cloud link environment client", () => {
       expect(error).toMatchObject({
         _tag: "CloudEnvironmentLinkError",
         message:
-          "https://relay.example.test/v1/environments/env-1/connect failed: Relay rejected the DPoP proof.",
+          "https://relay.example.test/v1/environments/env-1/connect failed: This device's clock appears to be out of sync. Enable automatic date and time, then try again.",
         traceId: "trace-connect",
       });
     }),

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -125,7 +125,9 @@ function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
         case "invalid_bearer":
           return "Relay rejected the cloud session token.";
         case "invalid_dpop":
-          return "Relay rejected the DPoP proof.";
+          return error.clockSkewSeconds === undefined
+            ? "Relay rejected the DPoP proof."
+            : "This device's clock appears to be out of sync. Enable automatic date and time, then try again.";
         case "not_authorized":
           return "Relay rejected the authenticated request.";
       }

--- a/apps/server/src/auth/EnvironmentAuth.ts
+++ b/apps/server/src/auth/EnvironmentAuth.ts
@@ -347,6 +347,7 @@ export class ServerAuthInvalidCredentialError extends Schema.TaggedErrorClass<Se
   "ServerAuthInvalidCredentialError",
   {
     diagnostic: Schema.optional(Schema.String),
+    clockSkewSeconds: Schema.optional(Schema.Int),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
@@ -365,6 +366,10 @@ export const serverAuthCredentialReason = (
   error: ServerAuthCredentialError,
 ): "missing_credential" | "invalid_credential" =>
   error._tag === "ServerAuthMissingCredentialError" ? "missing_credential" : "invalid_credential";
+export const serverAuthCredentialClockSkewSeconds = (
+  error: ServerAuthCredentialError,
+): number | undefined =>
+  error._tag === "ServerAuthInvalidCredentialError" ? error.clockSkewSeconds : undefined;
 
 export class ServerAuthInvalidScopeError extends Schema.TaggedErrorClass<ServerAuthInvalidScopeError>()(
   "ServerAuthInvalidScopeError",

--- a/apps/server/src/auth/dpop.test.ts
+++ b/apps/server/src/auth/dpop.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import * as PlatformError from "effect/PlatformError";
 
 import { SecretStorePersistError } from "./ServerSecretStore.ts";
-import { mapDpopReplayStoreError } from "./dpop.ts";
+import { mapDpopReplayStoreError, mapDpopVerificationFailure } from "./dpop.ts";
 
 const storeFailure = (tag: "AlreadyExists" | "PermissionDenied") =>
   new SecretStorePersistError({
@@ -33,5 +33,18 @@ describe("mapDpopReplayStoreError", () => {
     if (error._tag === "ServerAuthDpopReplayStateRecordError") {
       expect(error.message).toBe("Failed to record DPoP proof replay state.");
     }
+  });
+});
+
+describe("mapDpopVerificationFailure", () => {
+  it("preserves a detected clock offset for the HTTP boundary", () => {
+    const error = mapDpopVerificationFailure({
+      ok: false,
+      reason: "DPoP proof is outside the allowed time window.",
+      clockSkewSeconds: 25,
+    });
+
+    expect(error.clockSkewSeconds).toBe(25);
+    expect(error.diagnostic).toBe("DPoP proof is outside the allowed time window.");
   });
 });

--- a/apps/server/src/auth/dpop.ts
+++ b/apps/server/src/auth/dpop.ts
@@ -1,4 +1,4 @@
-import { verifyDpopProof } from "@t3tools/shared/dpop";
+import { type DpopVerificationResult, verifyDpopProof } from "@t3tools/shared/dpop";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -26,6 +26,14 @@ export const mapDpopReplayStoreError = (
         cause: error,
       });
 
+export const mapDpopVerificationFailure = (
+  result: Extract<DpopVerificationResult, { readonly ok: false }>,
+) =>
+  new ServerAuthInvalidCredentialError({
+    diagnostic: result.reason,
+    ...(result.clockSkewSeconds === undefined ? {} : { clockSkewSeconds: result.clockSkewSeconds }),
+  });
+
 export const verifyRequestDpopProof = (input: {
   readonly request: HttpServerRequest.HttpServerRequest;
   readonly expectedThumbprint?: string;
@@ -49,9 +57,7 @@ export const verifyRequestDpopProof = (input: {
       ...(input.expectedAccessToken ? { expectedAccessToken: input.expectedAccessToken } : {}),
     });
     if (!result.ok) {
-      return yield* new ServerAuthInvalidCredentialError({
-        diagnostic: result.reason,
-      });
+      return yield* mapDpopVerificationFailure(result);
     }
     const secretStore = yield* ServerSecretStore.ServerSecretStore;
     const replayKey = yield* Crypto.Crypto.pipe(

--- a/apps/server/src/auth/http.ts
+++ b/apps/server/src/auth/http.ts
@@ -95,10 +95,20 @@ export function annotateEnvironmentRequest(endpoint: string) {
   });
 }
 
-export function failEnvironmentAuthInvalid(reason: EnvironmentAuthInvalidReason) {
+export function failEnvironmentAuthInvalid(
+  reason: EnvironmentAuthInvalidReason,
+  clockSkewSeconds?: number,
+) {
   return currentEnvironmentTraceId.pipe(
     Effect.flatMap((traceId) =>
-      Effect.fail(new EnvironmentAuthInvalidError({ code: "auth_invalid", reason, traceId })),
+      Effect.fail(
+        new EnvironmentAuthInvalidError({
+          code: "auth_invalid",
+          reason,
+          traceId,
+          ...(clockSkewSeconds === undefined ? {} : { clockSkewSeconds }),
+        }),
+      ),
     ),
   );
 }
@@ -180,7 +190,10 @@ export const environmentAuthenticatedAuthLayer = Layer.effect(
         const request = yield* HttpServerRequest.HttpServerRequest;
         const session = yield* serverAuth.authenticateHttpRequest(request).pipe(
           Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-            failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+            failEnvironmentAuthInvalid(
+              EnvironmentAuth.serverAuthCredentialReason(error),
+              EnvironmentAuth.serverAuthCredentialClockSkewSeconds(error),
+            ),
           ),
           Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
             failEnvironmentInternal("internal_error", error),
@@ -244,7 +257,10 @@ export const authHttpApiLayer = HttpApiBuilder.group(
             return result.response;
           },
           Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-            failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+            failEnvironmentAuthInvalid(
+              EnvironmentAuth.serverAuthCredentialReason(error),
+              EnvironmentAuth.serverAuthCredentialClockSkewSeconds(error),
+            ),
           ),
           Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
             failEnvironmentInternal("browser_session_issuance_failed", error),
@@ -278,9 +294,14 @@ export const authHttpApiLayer = HttpApiBuilder.group(
             }
             const proofKeyThumbprint = args.headers.dpop
               ? yield* verifyRequestDpopProof({ request }).pipe(
-                  Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, () =>
+                  Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
                     appendDpopChallengeHeader.pipe(
-                      Effect.andThen(failEnvironmentAuthInvalid("invalid_credential")),
+                      Effect.andThen(
+                        failEnvironmentAuthInvalid(
+                          "invalid_credential",
+                          EnvironmentAuth.serverAuthCredentialClockSkewSeconds(error),
+                        ),
+                      ),
                     ),
                   ),
                   Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
@@ -307,7 +328,10 @@ export const authHttpApiLayer = HttpApiBuilder.group(
           },
           traceRelayRequest,
           Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-            failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+            failEnvironmentAuthInvalid(
+              EnvironmentAuth.serverAuthCredentialReason(error),
+              EnvironmentAuth.serverAuthCredentialClockSkewSeconds(error),
+            ),
           ),
           Effect.catchIf(EnvironmentAuth.isServerAuthInvalidRequestError, (error) =>
             failEnvironmentInvalidRequest(EnvironmentAuth.serverAuthInvalidRequestReason(error)),

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -117,7 +117,10 @@ const authenticateRawRouteWithScope = (
     const serverAuth = yield* EnvironmentAuth.EnvironmentAuth;
     const session = yield* serverAuth.authenticateHttpRequest(request).pipe(
       Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-        failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+        failEnvironmentAuthInvalid(
+          EnvironmentAuth.serverAuthCredentialReason(error),
+          EnvironmentAuth.serverAuthCredentialClockSkewSeconds(error),
+        ),
       ),
       Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
         failEnvironmentInternal("internal_error", error),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1116,6 +1116,7 @@ const exchangeAccessToken = (
       readonly code?: string;
       readonly reason?: string;
       readonly traceId?: string;
+      readonly clockSkewSeconds?: number;
     }>(response);
     return {
       response,
@@ -1847,6 +1848,45 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(replayBootstrap.body.code, "auth_invalid");
       assert.equal(replayBootstrap.body.reason, "invalid_credential");
       assert.equal(typeof replayBootstrap.body.traceId, "string");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("reports clock skew when a token exchange DPoP proof is from the future", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const ownerCookie = yield* getAuthenticatedSessionCookieHeader();
+      const credentialResponse = yield* HttpClient.post("/api/auth/pairing-token", {
+        headers: {
+          cookie: ownerCookie,
+        },
+        body: yield* HttpBody.json({}),
+      });
+      const credential = (yield* credentialResponse.json) as {
+        readonly credential: string;
+      };
+      const tokenUrl = yield* getHttpServerUrl("/oauth/token");
+      const now = yield* DateTime.now;
+      const dpop = makeDpopProof({
+        method: "POST",
+        url: tokenUrl,
+        iat: Math.floor(now.epochMilliseconds / 1_000) + 25,
+      });
+
+      const bootstrap = yield* exchangeAccessToken(credential.credential, {
+        headers: {
+          dpop: dpop.proof,
+        },
+      });
+
+      assert.equal(bootstrap.response.status, 401);
+      assert.equal(bootstrap.body._tag, "EnvironmentAuthInvalidError");
+      assert.equal(bootstrap.body.reason, "invalid_credential");
+      assert.ok(
+        bootstrap.body.clockSkewSeconds !== undefined &&
+          bootstrap.body.clockSkewSeconds >= 24 &&
+          bootstrap.body.clockSkewSeconds <= 25,
+      );
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2472,7 +2472,10 @@ export const websocketRpcRouteLayer = Layer.unwrap(
         const analytics = yield* AnalyticsService.AnalyticsService;
         const session = yield* serverAuth.authenticateWebSocketUpgrade(request).pipe(
           Effect.catchIf(EnvironmentAuth.isServerAuthCredentialError, (error) =>
-            failEnvironmentAuthInvalid(EnvironmentAuth.serverAuthCredentialReason(error)),
+            failEnvironmentAuthInvalid(
+              EnvironmentAuth.serverAuthCredentialReason(error),
+              EnvironmentAuth.serverAuthCredentialClockSkewSeconds(error),
+            ),
           ),
           Effect.catchIf(EnvironmentAuth.isServerAuthInternalError, (error) =>
             failEnvironmentInternal("internal_error", error),

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -136,7 +136,9 @@ function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
         case "invalid_bearer":
           return "Relay rejected the cloud session token.";
         case "invalid_dpop":
-          return "Relay rejected the DPoP proof.";
+          return error.clockSkewSeconds === undefined
+            ? "Relay rejected the DPoP proof."
+            : "This device's clock appears to be out of sync. Enable automatic date and time, then try again.";
         case "not_authorized":
           return "Relay rejected the authenticated request.";
       }

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -84,7 +84,9 @@ that sends a `DPoP` header has its proof verified by `verifyRequestDpopProof`;
 the resulting JWK thumbprint is stored on the session, which is then issued with
 method `dpop-access-token` and a one-hour TTL instead of the bearer default. An
 invalid proof gets a DPoP challenge header and a credential error rather than a
-bearer token.
+bearer token. Time-window failures retain the existing `invalid_credential`
+reason for wire compatibility and add `clockSkewSeconds`, allowing newer
+clients to explain that the client and environment clocks need synchronization.
 
 `dpop-access-token` is advertised alongside `browser-session-cookie` and
 `bearer-access-token` in the descriptor's `sessionMethods`

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -180,6 +180,13 @@ see [Keeping T3 Code in Sync](./updating.md).
 On a Linux host, you can keep the server running after logout and manage it independently of the
 connection method. See [Running T3 Code in the Background](./background-service.md).
 
+### Clock Sync Errors
+
+Secure T3 Connect sessions use short-lived proofs that depend on accurate time. If T3 Code reports
+that the device and environment host clocks are out of sync, enable automatic date and time on both
+machines, force a time sync if the operating system offers one, and then retry the connection. You
+do not need to relink the environment or regenerate its credential after the clocks synchronize.
+
 ## How Pairing Works
 
 The remote device does not need a long-lived secret up front.

--- a/infra/relay/src/auth/DpopProofs.ts
+++ b/infra/relay/src/auth/DpopProofs.ts
@@ -26,6 +26,18 @@ export class DpopProofReplayPersistenceError extends Schema.TaggedErrorClass<Dpo
   }
 }
 
+export class DpopProofClockSkewError extends Schema.TaggedErrorClass<DpopProofClockSkewError>()(
+  "DpopProofClockSkewError",
+  {
+    clockSkewSeconds: Schema.Int,
+  },
+) {
+  override get message(): string {
+    return "DPoP proof is outside the allowed time window.";
+  }
+}
+export const isDpopProofClockSkewError = Schema.is(DpopProofClockSkewError);
+
 export class DpopProofReplay extends Context.Service<
   DpopProofReplay,
   {
@@ -36,7 +48,10 @@ export class DpopProofReplay extends Context.Service<
       readonly expectedThumbprint?: string;
       readonly expectedAccessToken?: string;
       readonly now: DateTime.DateTime;
-    }) => Effect.Effect<string, HttpApiError.Unauthorized | DpopProofReplayPersistenceError>;
+    }) => Effect.Effect<
+      string,
+      HttpApiError.Unauthorized | DpopProofClockSkewError | DpopProofReplayPersistenceError
+    >;
     readonly consume: (input: {
       readonly thumbprint: string;
       readonly jti: string;
@@ -104,6 +119,11 @@ const make = Effect.gen(function* () {
         expectedThumbprintPresent: input.expectedThumbprint !== undefined,
         expectedAccessTokenPresent: input.expectedAccessToken !== undefined,
       });
+      if (result.clockSkewSeconds !== undefined) {
+        return yield* new DpopProofClockSkewError({
+          clockSkewSeconds: result.clockSkewSeconds,
+        });
+      }
       return yield* new HttpApiError.Unauthorized({});
     }
     const consumed = yield* consume({

--- a/infra/relay/src/auth/DpopProofs.verifyAndConsume.test.ts
+++ b/infra/relay/src/auth/DpopProofs.verifyAndConsume.test.ts
@@ -96,6 +96,34 @@ function consumeEachProofOnce() {
 }
 
 describe("DpopProofReplay.verifyAndConsume", () => {
+  it.effect("reports the clock offset for proofs outside the allowed time window", () => {
+    const now = DateTime.makeUnsafe("2026-05-25T12:00:00.000Z");
+    const proof = makeDpopProof({
+      method: "POST",
+      url: "https://relay.example.com/v1/environments/env/connect",
+      iat: Math.floor(now.epochMilliseconds / 1_000) + 25,
+      jti: "proof-with-clock-skew",
+    });
+
+    return Effect.gen(function* () {
+      const replay = yield* DpopProofs.DpopProofReplay;
+      const error = yield* Effect.flip(
+        replay.verifyAndConsume({
+          proof: proof.proof,
+          method: "POST",
+          url: "https://relay.example.com/v1/environments/env/connect",
+          expectedThumbprint: proof.thumbprint,
+          now,
+        }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "DpopProofClockSkewError",
+        clockSkewSeconds: 25,
+      });
+    }).pipe(Effect.provide(layer(() => Effect.die("unexpected DPoP replay persistence"))));
+  });
+
   it.effect("rejects replayed proofs after persistence consumes the jti once", () => {
     const now = DateTime.makeUnsafe("2026-05-25T12:00:00.000Z");
     const proof = makeDpopProof({

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -1030,8 +1030,13 @@ type RelayCommonPersistenceError = typeof RelayCommonPersistenceError.Type;
 const isRelayCommonPersistenceError = Schema.is(RelayCommonPersistenceError);
 
 type MapRelayCommonApiError<E> =
-  | Exclude<E, HttpApiError.Unauthorized | RelayCommonPersistenceError>
-  | (Extract<E, HttpApiError.Unauthorized> extends never ? never : RelayAuthInvalidError)
+  | Exclude<
+      E,
+      HttpApiError.Unauthorized | DpopProofs.DpopProofClockSkewError | RelayCommonPersistenceError
+    >
+  | (Extract<E, HttpApiError.Unauthorized | DpopProofs.DpopProofClockSkewError> extends never
+      ? never
+      : RelayAuthInvalidError)
   | (Extract<E, RelayCommonPersistenceError> extends never ? never : RelayInternalError);
 
 function relayInternalErrorResponse(reason: RelayInternalError["reason"]) {
@@ -1045,12 +1050,15 @@ function relayInternalErrorResponse(reason: RelayInternalError["reason"]) {
 function mapRelayCommonApiErrors(authReason: RelayAuthInvalidReason) {
   const mapError = Effect.fnUntraced(function* <E>(error: E) {
     const traceId = yield* currentTraceId;
-    if (isHttpUnauthorized(error)) {
+    if (isHttpUnauthorized(error) || DpopProofs.isDpopProofClockSkewError(error)) {
       return yield* Effect.fail(
         new RelayAuthInvalidError({
           code: "auth_invalid",
           reason: authReason,
           traceId,
+          ...(DpopProofs.isDpopProofClockSkewError(error)
+            ? { clockSkewSeconds: error.clockSkewSeconds }
+            : {}),
         }) as MapRelayCommonApiError<E>,
       );
     }

--- a/packages/client-runtime/src/authorization/remote.test.ts
+++ b/packages/client-runtime/src/authorization/remote.test.ts
@@ -423,6 +423,34 @@ describe("remote environment authorization", () => {
     }),
   );
 
+  it.effect("revives the server-reported clock offset from remote auth failures", () =>
+    Effect.gen(function* () {
+      const fetch = recordedFetch(
+        Response.json(
+          {
+            _tag: "EnvironmentAuthInvalidError",
+            code: "auth_invalid",
+            reason: "invalid_credential",
+            traceId: "trace-clock-skew",
+            clockSkewSeconds: 25,
+          },
+          { status: 401 },
+        ),
+      );
+
+      const error = yield* issueRemoteDpopWebSocketTicket({
+        httpBaseUrl: "https://remote.example.com/",
+        accessToken: "dpop-access-token",
+        dpopProof: "dpop-proof",
+      }).pipe(provideRemoteHttp(fetch.fetchFn), Effect.flip);
+
+      expect(isEnvironmentAuthInvalidError(error)).toBe(true);
+      if (isEnvironmentAuthInvalidError(error)) {
+        expect(error.clockSkewSeconds).toBe(25);
+      }
+    }),
+  );
+
   it.effect("classifies malformed successful remote auth responses as invalid responses", () =>
     Effect.gen(function* () {
       const fetch = recordedFetch(

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -1,0 +1,37 @@
+import { EnvironmentAuthInvalidError } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { mapRemoteEnvironmentError } from "./errors.ts";
+
+describe("mapRemoteEnvironmentError", () => {
+  it("turns a DPoP clock-skew rejection into actionable connection guidance", () => {
+    const mapped = mapRemoteEnvironmentError(
+      new EnvironmentAuthInvalidError({
+        code: "auth_invalid",
+        reason: "invalid_credential",
+        traceId: "trace-clock-skew",
+        clockSkewSeconds: 25,
+      }),
+    );
+
+    expect(mapped).toMatchObject({
+      _tag: "ConnectionBlockedError",
+      reason: "authentication",
+      detail:
+        "The clocks on this device and the environment host are out of sync. Enable automatic date and time on both, then try again.",
+      traceId: "trace-clock-skew",
+    });
+  });
+
+  it("keeps generic credential guidance when the server did not identify clock skew", () => {
+    const mapped = mapRemoteEnvironmentError(
+      new EnvironmentAuthInvalidError({
+        code: "auth_invalid",
+        reason: "invalid_credential",
+        traceId: "trace-invalid-credential",
+      }),
+    );
+
+    expect(mapped.detail).toBe("The environment credential is invalid.");
+  });
+});

--- a/packages/client-runtime/src/connection/errors.ts
+++ b/packages/client-runtime/src/connection/errors.ts
@@ -117,7 +117,10 @@ export function mapRemoteEnvironmentError(
     case "EnvironmentAuthInvalidError":
       return new ConnectionBlockedError({
         reason: "authentication",
-        detail: "The environment credential is invalid.",
+        detail:
+          error.clockSkewSeconds === undefined
+            ? "The environment credential is invalid."
+            : "The clocks on this device and the environment host are out of sync. Enable automatic date and time on both, then try again.",
         traceId: error.traceId,
       });
     case "EnvironmentScopeRequiredError":

--- a/packages/contracts/src/environmentHttp.test.ts
+++ b/packages/contracts/src/environmentHttp.test.ts
@@ -59,4 +59,16 @@ describe("environment HTTP errors", () => {
       expect(error.message).toContain(details[index]);
     });
   });
+
+  it("gives clock-skew failures an actionable message", () => {
+    const error = new EnvironmentAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_credential",
+      traceId,
+      clockSkewSeconds: 25,
+    });
+
+    expect(error.message).toContain("clocks");
+    expect(error.message).toContain("automatic date and time");
+  });
 });

--- a/packages/contracts/src/environmentHttp.ts
+++ b/packages/contracts/src/environmentHttp.ts
@@ -118,6 +118,8 @@ export class EnvironmentAuthInvalidError extends Schema.TaggedErrorClass<Environ
     code: Schema.Literal("auth_invalid"),
     reason: EnvironmentAuthInvalidReason,
     traceId: TrimmedNonEmptyString,
+    // DPoP `iat` minus verifier time. Positive means the proof-producing clock appears ahead.
+    clockSkewSeconds: Schema.optional(Schema.Int),
   },
   { httpApiStatus: 401 },
 ) {
@@ -126,6 +128,9 @@ export class EnvironmentAuthInvalidError extends Schema.TaggedErrorClass<Environ
   }
 
   override get message(): string {
+    if (this.clockSkewSeconds !== undefined) {
+      return "The clocks on this device and the environment host are out of sync. Enable automatic date and time on both, then try again.";
+    }
     return `The environment rejected this client's credentials (${this.reason}).`;
   }
 }

--- a/packages/contracts/src/relay.test.ts
+++ b/packages/contracts/src/relay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as OpenApi from "effect/unstable/httpapi/OpenApi";
 
-import { RelayApi } from "./relay.ts";
+import { RelayApi, RelayAuthInvalidError } from "./relay.ts";
 
 describe("RelayApi security", () => {
   it("describes DPoP access tokens using the HTTP DPoP authorization scheme", () => {
@@ -12,5 +12,19 @@ describe("RelayApi security", () => {
       scheme: "DPoP",
       description: "DPoP-bound access token. Requests must also include the DPoP proof JWT header.",
     });
+  });
+});
+
+describe("RelayAuthInvalidError", () => {
+  it("gives clock-skew failures an actionable message", () => {
+    const error = new RelayAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_dpop",
+      traceId: "trace-1",
+      clockSkewSeconds: 25,
+    });
+
+    expect(error.message).toContain("device's clock");
+    expect(error.message).toContain("automatic date and time");
   });
 });

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -336,10 +336,15 @@ export class RelayAuthInvalidError extends Schema.TaggedErrorClass<RelayAuthInva
     code: Schema.Literal("auth_invalid"),
     reason: RelayAuthInvalidReason,
     traceId: TrimmedNonEmptyString,
+    // DPoP `iat` minus verifier time. Positive means the proof-producing clock appears ahead.
+    clockSkewSeconds: Schema.optional(Schema.Int),
   },
   { httpApiStatus: 401 },
 ) {
   override get message(): string {
+    if (this.clockSkewSeconds !== undefined) {
+      return "This device's clock appears to be out of sync. Enable automatic date and time, then try again.";
+    }
     return `Relay authentication failed: ${this.reason}`;
   }
 }

--- a/packages/shared/src/dpop.test.ts
+++ b/packages/shared/src/dpop.test.ts
@@ -133,16 +133,33 @@ describe("verifyDpopProof", () => {
       }).ok,
       false,
     );
-    assert.equal(
-      verifyDpopProof({
-        proof,
-        method: "POST",
-        url: "https://example.com/oauth/token",
-        nowEpochSeconds: 1_000,
-        expectedThumbprint: thumbprint,
-      }).ok,
-      false,
-    );
+    const stale = verifyDpopProof({
+      proof,
+      method: "POST",
+      url: "https://example.com/oauth/token",
+      nowEpochSeconds: 1_000,
+      expectedThumbprint: thumbprint,
+    });
+    assert.deepEqual(stale, {
+      ok: false,
+      reason: "DPoP proof is outside the allowed time window.",
+      clockSkewSeconds: -900,
+    });
+  });
+
+  it("reports the clock offset when a proof was issued in the future", () => {
+    const result = verifyDpopProof({
+      proof,
+      method: "POST",
+      url: "https://example.com/oauth/token",
+      nowEpochSeconds: 75,
+    });
+
+    assert.deepEqual(result, {
+      ok: false,
+      reason: "DPoP proof is outside the allowed time window.",
+      clockSkewSeconds: 25,
+    });
   });
 
   it("requires the RFC 9449 access token hash when an access token is expected", () => {

--- a/packages/shared/src/dpop.ts
+++ b/packages/shared/src/dpop.ts
@@ -52,6 +52,7 @@ export type DpopVerificationResult =
   | {
       readonly ok: false;
       readonly reason: string;
+      readonly clockSkewSeconds?: number;
     };
 
 function base64UrlToBytes(value: string): Uint8Array {
@@ -143,11 +144,13 @@ export function verifyDpopProof(input: {
     }
 
     const maxAgeSeconds = input.maxAgeSeconds ?? DEFAULT_MAX_AGE_SECONDS;
-    if (
-      payload.value.iat > input.nowEpochSeconds + 5 ||
-      input.nowEpochSeconds - payload.value.iat > maxAgeSeconds
-    ) {
-      return { ok: false, reason: "DPoP proof is outside the allowed time window." };
+    const clockSkewSeconds = payload.value.iat - input.nowEpochSeconds;
+    if (clockSkewSeconds > 5 || clockSkewSeconds < -maxAgeSeconds) {
+      return {
+        ok: false,
+        reason: "DPoP proof is outside the allowed time window.",
+        clockSkewSeconds,
+      };
     }
 
     const signature = base64UrlToBytes(parts[2]);


### PR DESCRIPTION
## What Changed

Propagate detected DPoP clock skew through environment and relay authentication errors, while preserving existing wire-compatible error reasons. Clients now show actionable guidance to enable automatic date and time on the affected devices. Added focused coverage across shared DPoP verification, server and relay auth boundaries, client runtimes, web, mobile, and contracts, plus remote-access documentation.

## Why

DPoP proofs are rejected when device clocks differ from the verifier clock, but the previous generic credential errors made the cause difficult to diagnose. Exposing the measured offset lets clients distinguish clock synchronization problems from other authentication failures and recover without relinking environments or regenerating credentials.

## UI Changes

No layout or visual UI changes. Existing connection and environment-link error messages now provide clock-synchronization guidance when the server identifies DPoP clock skew.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication error shapes and messaging across server, relay, and clients, but preserves existing error reasons and only adds optional fields; incorrect skew propagation could mislead users or leak timing detail.
> 
> **Overview**
> When DPoP proof verification fails because the proof is outside the allowed time window, **`verifyDpopProof`** now returns a measured **`clockSkewSeconds`** offset (proof `iat` minus verifier time) alongside the existing failure reason.
> 
> That offset is carried through **environment server** and **relay** auth layers into **`EnvironmentAuthInvalidError`** and **`RelayAuthInvalidError`** as an optional field, while keeping the same wire **`reason`** values (`invalid_credential` / `invalid_dpop`) for compatibility. **Web, mobile, and client-runtime** connection error mapping now show clock-sync guidance when **`clockSkewSeconds`** is present, instead of generic DPoP or credential failures.
> 
> Docs add a **Clock Sync Errors** section for remote access; tests cover shared verification, server/relay boundaries, contracts, and client decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e686c7d890af9f1f57e950e1957a30bee065f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `clockSkewSeconds` to DPoP verification failures across stack
> - `verifyDpopProof` in [dpop.ts](https://github.com/pingdotgg/t3code/pull/8383/files#diff-a70e3eceffb70848b1ea9f7dd87b2d3cd5f20af4faacba0e185745d8560ec50d) now computes `clockSkewSeconds` as `iat - nowEpochSeconds` and includes it in the failure result when the proof falls outside the allowed time window.
> - The value propagates end-to-end: relay raises `DpopProofClockSkewError`, server includes `clockSkewSeconds` in `ServerAuthInvalidCredentialError` and 401 `EnvironmentAuthInvalidError` responses, and client-runtime/UI layers surface a clock-sync guidance message instead of the generic DPoP rejection text.
> - Added a "Clock Sync Errors" section to [remote-access.md](https://github.com/pingdotgg/t3code/pull/8383/files#diff-e6cd63b1b8b5df551539c3cbb1790b40f70baa2a5ed146d56f1c7044d7adcb8a) instructing users to enable automatic date and time.
> - Behavioral Change: `DpopProofReplay.verifyAndConsume` in [DpopProofs.ts](https://github.com/pingdotgg/t3code/pull/8383/files#diff-127a65caea5dd22f8715d51fb2321010c34ff439b3c68f830b19ca81ba1e5937) now fails with `DpopProofClockSkewError` instead of `Unauthorized` when a time-window violation carries `clockSkewSeconds`; callers relying on the `Unauthorized` error type for clock-skew cases should check for the new tagged error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e686c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->