### PR TITLE
fix(server): bound thread activity hydration by bytes

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2421,6 +2421,68 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
     }),
   );
 
+  it.effect("bounds activity hydration by serialized payload bytes", () =>
+    Effect.gen(function* () {
+      yield* seedFanOutThread();
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_thread_activities`;
+      yield* sql`
+        WITH RECURSIVE activity_rows(sequence) AS (
+          SELECT 1
+          UNION ALL
+          SELECT sequence + 1 FROM activity_rows WHERE sequence < 18
+        )
+        INSERT INTO projection_thread_activities (
+          activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at
+        )
+        SELECT
+          printf('large-activity-%04d', sequence),
+          'thread-w',
+          'turn-5',
+          'tool',
+          'tool.completed',
+          'viewed image',
+          json_object(
+            'sequence', sequence,
+            'data', json_object(
+              'item', json_object(
+                'result', printf('%.*c', 1048576, 'x')
+              )
+            )
+          ),
+          sequence,
+          '2026-03-01T00:04:00.000Z'
+        FROM activity_rows
+      `;
+
+      const fullDetail = yield* snapshotQuery.getThreadDetailById(threadW);
+      assert.equal(fullDetail._tag, "Some");
+      if (fullDetail._tag === "Some") {
+        assert.equal(fullDetail.value.activities.length, 15);
+        assert.equal(fullDetail.value.activities[0]?.id, asEventId("large-activity-0004"));
+        assert.equal(fullDetail.value.activities.at(-1)?.id, asEventId("large-activity-0018"));
+      }
+
+      const windowedDetail = yield* snapshotQuery.getThreadDetailSnapshot(threadW, {
+        turnLimit: 2,
+      });
+      assert.equal(windowedDetail._tag, "Some");
+      if (windowedDetail._tag === "Some") {
+        assert.equal(windowedDetail.value.thread.activities.length, 15);
+        assert.equal(
+          windowedDetail.value.thread.activities[0]?.id,
+          asEventId("large-activity-0004"),
+        );
+        assert.equal(
+          windowedDetail.value.thread.activities.at(-1)?.id,
+          asEventId("large-activity-0018"),
+        );
+      }
+    }),
+  );
+
   it.effect("a thread with no turns returns its content unwindowed on the first page", () =>
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -71,9 +71,10 @@ const decodeReadModel = Schema.decodeUnknownEffect(OrchestrationReadModel);
 const decodeShellSnapshot = Schema.decodeUnknownEffect(OrchestrationShellSnapshot);
 const decodeThread = Schema.decodeUnknownEffect(OrchestrationThread);
 // Keep detail reads consistent with the in-memory projector's retained
-// activity window. Applying the limit in SQL avoids decoding an unbounded
-// payload_json set before the projector can enforce that invariant.
+// activity window. Apply both limits in SQL so large tool results do not cross
+// into JavaScript only to be discarded by the client payload projection.
 const THREAD_DETAIL_ACTIVITY_LIMIT = 500;
+const THREAD_DETAIL_ACTIVITY_BYTE_LIMIT = 16 * 1024 * 1024;
 const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
   Struct.assign({
     defaultModelSelection: Schema.NullOr(Schema.fromJsonString(ModelSelection)),
@@ -1019,27 +1020,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
     Result: ProjectionThreadActivityDbRowSchema,
     execute: ({ threadId }) =>
       sql`
-        SELECT
-          activity_id AS "activityId",
-          thread_id AS "threadId",
-          turn_id AS "turnId",
-          tone,
-          kind,
-          summary,
-          payload_json AS "payload",
-          sequence,
-          created_at AS "createdAt"
-        FROM (
+        WITH recent_activity_metadata AS (
           SELECT
             activity_id,
-            thread_id,
-            turn_id,
-            tone,
-            kind,
-            summary,
-            payload_json,
             sequence,
-            created_at
+            created_at,
+            LENGTH(CAST(payload_json AS BLOB)) AS payload_bytes
           FROM projection_thread_activities
           WHERE thread_id = ${threadId}
           ORDER BY
@@ -1047,11 +1033,38 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             created_at DESC,
             activity_id DESC
           LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
-        ) AS recent_activities
+        ),
+        budgeted_activity_ids AS (
+          SELECT
+            activity_id,
+            ROW_NUMBER() OVER (
+              ORDER BY sequence DESC, created_at DESC, activity_id DESC
+            ) AS activity_order,
+            SUM(payload_bytes) OVER (
+              ORDER BY sequence DESC, created_at DESC, activity_id DESC
+              ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS cumulative_payload_bytes
+          FROM recent_activity_metadata
+        )
+        SELECT
+          activity.activity_id AS "activityId",
+          activity.thread_id AS "threadId",
+          activity.turn_id AS "turnId",
+          activity.tone,
+          activity.kind,
+          activity.summary,
+          activity.payload_json AS "payload",
+          activity.sequence,
+          activity.created_at AS "createdAt"
+        FROM budgeted_activity_ids AS budgeted
+        INNER JOIN projection_thread_activities AS activity
+          ON activity.activity_id = budgeted.activity_id
+        WHERE budgeted.activity_order = 1
+          OR budgeted.cumulative_payload_bytes <= ${THREAD_DETAIL_ACTIVITY_BYTE_LIMIT}
         ORDER BY
-          sequence ASC,
-          created_at ASC,
-          activity_id ASC
+          activity.sequence ASC,
+          activity.created_at ASC,
+          activity.activity_id ASC
       `,
   });
 
@@ -1357,27 +1370,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
     Result: ProjectionThreadActivityDbRowSchema,
     execute: ({ threadId, minAnchorAt, minTurnKey, beforeAnchorAt, beforeTurnKey }) =>
       sql`
-        SELECT
-          activity_id AS "activityId",
-          thread_id AS "threadId",
-          turn_id AS "turnId",
-          tone,
-          kind,
-          summary,
-          payload_json AS "payload",
-          sequence,
-          created_at AS "createdAt"
-        FROM (
+        WITH recent_activity_metadata AS (
           SELECT
             activity_id,
-            thread_id,
-            turn_id,
-            tone,
-            kind,
-            summary,
-            payload_json,
             sequence,
-            created_at
+            created_at,
+            LENGTH(CAST(payload_json AS BLOB)) AS payload_bytes
           FROM projection_thread_activities
           WHERE thread_id = ${threadId}
             AND (
@@ -1411,11 +1409,38 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             created_at DESC,
             activity_id DESC
           LIMIT ${THREAD_DETAIL_ACTIVITY_LIMIT}
-        ) AS recent_activities
+        ),
+        budgeted_activity_ids AS (
+          SELECT
+            activity_id,
+            ROW_NUMBER() OVER (
+              ORDER BY sequence DESC, created_at DESC, activity_id DESC
+            ) AS activity_order,
+            SUM(payload_bytes) OVER (
+              ORDER BY sequence DESC, created_at DESC, activity_id DESC
+              ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS cumulative_payload_bytes
+          FROM recent_activity_metadata
+        )
+        SELECT
+          activity.activity_id AS "activityId",
+          activity.thread_id AS "threadId",
+          activity.turn_id AS "turnId",
+          activity.tone,
+          activity.kind,
+          activity.summary,
+          activity.payload_json AS "payload",
+          activity.sequence,
+          activity.created_at AS "createdAt"
+        FROM budgeted_activity_ids AS budgeted
+        INNER JOIN projection_thread_activities AS activity
+          ON activity.activity_id = budgeted.activity_id
+        WHERE budgeted.activity_order = 1
+          OR budgeted.cumulative_payload_bytes <= ${THREAD_DETAIL_ACTIVITY_BYTE_LIMIT}
         ORDER BY
-          sequence ASC,
-          created_at ASC,
-          activity_id ASC
+          activity.sequence ASC,
+          activity.created_at ASC,
+          activity.activity_id ASC
       `,
   });
 


### PR DESCRIPTION
## What Changed

- cap hydrated thread activity payloads at 16 MiB while retaining the existing 500-row limit
- calculate the byte budget from the newest activity metadata before fetching `payload_json` into JavaScript
- always retain the newest activity, even when that single payload exceeds the budget
- apply the same rule to full and windowed thread detail reads
- add focused coverage for byte-heavy activity histories; the existing unresolved approval and user-input coverage remains intact

## Why

The 500-row cap added in #6153 bounds row count, but each `payload_json` can still contain megabytes of tool output. The server currently fetches and JSON-decodes those full payloads before #4622's client projection removes fields the clients do not read.

On an affected image-heavy thread, the newest 500 activities contained 140.58 MiB of JSON. The patched query selected the newest 96 activities within 15.72 MiB. In an isolated read-only database benchmark, RSS after querying and JSON-decoding fell from 332.0 MiB to 58.9 MiB. The patched SQL completed in 29 ms on that dataset.

This limits transient server heap pressure without deleting stored history, changing the wire contract, or adding a migration. Pending approvals and user-input requests are still loaded through the existing pinned-activity query.

Related: #4595, #5351, #6153, #4622

## Validation

- `pnpm exec vp fmt --check apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts`
- `pnpm exec vp test run apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts` (22 passed)
- `cd apps/server && pnpm typecheck`
- `git diff --check`
- isolated read-only benchmark against a production-sized SQLite snapshot

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Model: GPT-5.6-Sol. Harness: Codex desktop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread detail hydration semantics (fewer activities may appear on image-heavy threads) but leaves stored history and the API contract intact; pinned approval/user-input paths are unchanged.
> 
> **Overview**
> Thread detail reads now cap hydrated activity **`payload_json`** at **16 MiB** in addition to the existing **500-row** window, so megabyte tool outputs are not fully loaded and JSON-decoded in Node only to be trimmed later.
> 
> **`ProjectionSnapshotQuery`** rewrites full-thread and windowed activity SQL to score recent rows from metadata (`LENGTH(payload_json)`), walk newest-first with a running byte total, always keep the newest activity, then fetch full payloads only for rows inside the budget. The same rule applies to **`getThreadDetailById`** and windowed **`getThreadDetailSnapshot`** activity queries.
> 
> A new test seeds **18** ~1 MiB activities and asserts both detail paths return **15** activities (`large-activity-0004` through `large-activity-0018`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd55f177f3551a19d8ed3766cd693ae972ffe86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound thread activity hydration by 16 MiB in `ProjectionSnapshotQuery` queries
> - Rewrites `listThreadActivityRowsByThread` and `listThreadActivityRowsByThreadWindow` with a CTE that computes cumulative serialized payload bytes and filters out older activities once the 16 MiB budget is exceeded.
> - The single most recent activity is always included even if it alone exceeds the budget.
> - Adds `THREAD_DETAIL_ACTIVITY_BYTE_LIMIT` (16 MiB) constant and a test seeding 18 large (~1 MiB) activities to verify only 15 are returned.
> - Behavioral Change: both `listThreadActivityRowsByThread` and `listThreadActivityRowsByThreadWindow` now return fewer activities when payloads are large; consumers expecting a fixed count may see reduced results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cd55f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->