### PR TITLE
fix(server): survive macOS setTypeOfService EINVAL

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -1,6 +1,7 @@
 // @effect-diagnostics nodeBuiltinImport:off - CLI integration exercises Node HTTP and filesystem boundaries.
 import * as NodeHttp from "node:http";
 import * as NodeFS from "node:fs";
+import * as NodeNet from "node:net";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
@@ -25,7 +26,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
-import { cli, makeCli } from "./bin.ts";
+import { cli, guardSetTypeOfService, makeCli } from "./bin.ts";
 import * as ServerConfig from "./config.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
@@ -52,6 +53,47 @@ const runCli = (args: ReadonlyArray<string>, command = cli) =>
 const runConnectCli = (args: ReadonlyArray<string>) => runCli(args, connectCli);
 const runCliWithRuntime = (args: ReadonlyArray<string>) =>
   runCli(args).pipe(Effect.provide(CliRuntimeLayer));
+
+it("keeps setTypeOfService EINVAL from aborting HTTP requests", () => {
+  const socket = new NodeNet.Socket();
+  const invalidArgument = Object.assign(new Error("setTypeOfService EINVAL"), {
+    code: "EINVAL",
+    errno: -22,
+    syscall: "setTypeOfService",
+  });
+  const guarded = guardSetTypeOfService(function setTypeOfService(): never {
+    throw invalidArgument;
+  });
+
+  try {
+    assert.strictEqual(guarded.call(socket, 0), socket);
+  } finally {
+    socket.destroy();
+  }
+});
+
+it("preserves non-EINVAL setTypeOfService failures", () => {
+  const socket = new NodeNet.Socket();
+  const permissionDenied = Object.assign(new Error("setTypeOfService EPERM"), {
+    code: "EPERM",
+    errno: -1,
+    syscall: "setTypeOfService",
+  });
+  const guarded = guardSetTypeOfService(function setTypeOfService(): never {
+    throw permissionDenied;
+  });
+  let thrown: unknown;
+
+  try {
+    guarded.call(socket, 0);
+  } catch (error) {
+    thrown = error;
+  } finally {
+    socket.destroy();
+  }
+
+  assert.strictEqual(thrown, permissionDenied);
+});
 
 const captureStdout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -1,3 +1,6 @@
+// @effect-diagnostics nodeBuiltinImport:off - the server entrypoint owns Node runtime compatibility.
+import * as NodeNet from "node:net";
+
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
@@ -6,6 +9,7 @@ import { Argument, Command } from "effect/unstable/cli";
 import * as CliError from "effect/unstable/cli/CliError";
 
 import * as NetService from "@t3tools/shared/Net";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { connectCommand } from "./cli/connect.ts";
@@ -20,6 +24,42 @@ import { servicePreflightCommand } from "./cli/servicePreflight.ts";
 import { triageCommand } from "./cli/triage.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
+
+type SetTypeOfService = (this: NodeNet.Socket, typeOfService: number) => NodeNet.Socket;
+
+type SocketPrototypeWithTypeOfService = NodeNet.Socket & {
+  setTypeOfService?: SetTypeOfService;
+};
+
+export const guardSetTypeOfService = (setTypeOfService: SetTypeOfService): SetTypeOfService =>
+  function guardedSetTypeOfService(this: NodeNet.Socket, typeOfService: number): NodeNet.Socket {
+    try {
+      return setTypeOfService.call(this, typeOfService);
+    } catch (cause) {
+      // Node 24's bundled Undici applies best-effort QoS to every request. macOS
+      // can reject that socket option during reuse; the request itself remains valid.
+      if (
+        typeof cause === "object" &&
+        cause !== null &&
+        "code" in cause &&
+        cause.code === "EINVAL"
+      ) {
+        return this;
+      }
+      throw cause;
+    }
+  };
+
+const installNodeNetworkCompatibility = Effect.gen(function* () {
+  const platform = yield* HostProcessPlatform;
+  if (platform !== "darwin") return;
+
+  const socketPrototype = NodeNet.Socket.prototype as SocketPrototypeWithTypeOfService;
+  const setTypeOfService = socketPrototype.setTypeOfService;
+  if (typeof setTypeOfService !== "function") return;
+
+  socketPrototype.setTypeOfService = guardSetTypeOfService(setTypeOfService);
+});
 
 const connectPublicConfigMissingMessage =
   "T3 Connect commands are unavailable: this build is missing T3 Connect public configuration.";
@@ -71,7 +111,8 @@ if (
     runtimeMain: import.meta.main,
   })
 ) {
-  Command.run(cli, { version: packageJson.version }).pipe(
+  installNodeNetworkCompatibility.pipe(
+    Effect.andThen(Command.run(cli, { version: packageJson.version })),
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),
     NodeRuntime.runMain,


### PR DESCRIPTION
Node 24’s bundled Undici calls `socket.setTypeOfService()` on every HTTP/1 write to apply best-effort QoS. On macOS the kernel rejects that option on reused sockets with `EINVAL`, and because the call happens inside a socket event handler the throw is uncaught and kills the whole server process with exit 1.

On one nightly install (`0.0.36-nightly`, Node v24.15.0) this fired 52 times between Aug 17 and Aug 24. The desktop backend child restarts on crash, but the final burst on Aug 24 left the server down until the app was relaunched by hand.

```
node:net:683
      throw new ErrnoException(err, 'setTypeOfService');
      ^

Error: setTypeOfService EINVAL
    at Socket.setTypeOfService (node:net:683:13)
    at writeH1 (node:internal/deps/undici/undici:7836:16)
    at Object.write (node:internal/deps/undici/undici:7632:18)
    at _resume (node:internal/deps/undici/undici:9460:54)
  errno: -22, code: 'EINVAL', syscall: 'setTypeOfService'
```

The fix wraps `Socket.prototype.setTypeOfService` on darwin at the server entrypoint: an `EINVAL` from the QoS hint is swallowed (the request itself is still valid), and every other failure still propagates. Guard installation is darwin-only and no-ops if the method is absent.

Verified with `vp test run apps/server/src/bin.test.ts` (19 passed, including two new cases covering the swallow and the propagate paths), `tsgo --noEmit` on `apps/server` (exit 0), plus targeted lint and `vp fmt --check`.

Model: Claude Opus 5 (1M context). Harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runtime prototype patching on the Node net stack affects all outbound HTTP on macOS; EINVAL is narrowed but the change sits on a critical networking path.
> 
> **Overview**
> Prevents the server process from crashing on **macOS** when Node 24’s Undici calls `socket.setTypeOfService()` during HTTP/1 writes and the kernel returns **EINVAL** on reused sockets.
> 
> At CLI startup (darwin only), the entrypoint patches `Socket.prototype.setTypeOfService` via a new **`guardSetTypeOfService`** helper that ignores EINVAL and still rethrows other errors (e.g. EPERM). Guard installation runs through **`installNodeNetworkCompatibility`** before `Command.run`.
> 
> Adds two unit tests in **`bin.test.ts`** for the swallow and propagate paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a89b52ff92314431448439317f98548258e8821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `Socket.setTypeOfService` against EINVAL on macOS
> - Adds `guardSetTypeOfService` in [bin.ts](https://github.com/pingdotgg/t3code/pull/8389/files#diff-49e5d719869710e6cd7800547c130d0f20fcf22e14bb44b6ea8db436bb9a5a5f), a higher-order wrapper that catches `EINVAL` errors from `setTypeOfService` and returns the socket instead of throwing; non-EINVAL errors are rethrown
> - Adds `installNodeNetworkCompatibility`, an Effect that mutates `NodeNet.Socket.prototype.setTypeOfService` with the guard only on `darwin` platforms, then runs it before `Command.run` in the module entrypoint
> - Adds tests in [bin.test.ts](https://github.com/pingdotgg/t3code/pull/8389/files#diff-94f2a1c34e7815e43d7fbf62ddcccb7ece13c7ec57e628dcfadbedb93c853a4d) covering both the EINVAL-swallowing and non-EINVAL-rethrow paths
> - Behavioral Change: on macOS, `Socket.prototype.setTypeOfService` is monkey-patched at startup; EINVAL errors that previously propagated are now silently ignored
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a89b52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->