### PR TITLE
fix(grok): allow model changes in existing threads

### DIFF
--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -214,7 +214,7 @@ describe("buildInitialGrokProviderSnapshot", () => {
       expect(snapshot.status).toBe("warning");
       expect(snapshot.version).toBeNull();
       expect(snapshot.message).toContain("Checking Grok");
-      expect(snapshot.requiresNewThreadForModelChange).toBe(true);
+      expect(snapshot.requiresNewThreadForModelChange).toBeUndefined();
     }),
   );
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -40,7 +40,6 @@ const GROK_PRESENTATION = {
   displayName: "Grok",
   badgeLabel: "Early Access",
   showInteractionModeToggle: false,
-  requiresNewThreadForModelChange: true,
 } as const;
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],


### PR DESCRIPTION
Grok supports `session/set_model`, and T3's adapter already applies a changed model before the next prompt. However, the provider snapshot still marked Grok as requiring a new thread, so the client disabled model changes and the server rejected them before they reached the adapter.

This removes that stale provider lock. Existing client and server behavior now passes the changed selection through to Grok, which switches models within the active session.

Fixes #8385. Builds on the Grok reliability work merged in #8358. The same lock removal appeared in the broader closed PRs #6383 and #7070; this PR isolates only the missing behavior. #6075 remains separate and tracks invalid synthetic `grok-build` model IDs.

Checks:
- `vp test run apps/server/src/provider/Layers/GrokProvider.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/web/src/components/ChatView.logic.test.ts` (111 passed)
- targeted format and lint checks
- server and web typechecks
- real Grok 1.0.5 ACP session: completed a prompt, then accepted `session/set_model` for another advertised model

No UI components changed, so there are no before/after screenshots.

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presentation-field removal with no auth or data-path changes; behavior aligns with already-implemented Grok ACP model switching.
> 
> **Overview**
> **Grok no longer advertises that model switches require a new thread.** The provider presentation drops `requiresNewThreadForModelChange: true`, so snapshots no longer carry that lock even though Grok ACP already supports `session/set_model` in the active session.
> 
> With the flag gone, existing client and server paths can accept mid-thread model changes instead of blocking them up front. The initial snapshot test now expects `requiresNewThreadForModelChange` to be **undefined** rather than **true**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c262aa9d4ce43daa89359259bcd2fa69d7cd11d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `requiresNewThreadForModelChange` from `GROK_PRESENTATION` in `GrokProvider`
> Allows Grok model changes in existing threads by removing the `requiresNewThreadForModelChange: true` flag from the `GROK_PRESENTATION` constant in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/8392/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f). Updates the pending snapshot test to expect the property as `undefined`.
> - Risk: any consumer reading `requiresNewThreadForModelChange` from `GROK_PRESENTATION` or derived snapshots will now see `undefined` instead of `true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c262aa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->