### PR TITLE
fix(server): keep the file tree working without the native index

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -2,7 +2,7 @@
 import * as NodeFSP from "node:fs/promises";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { FileFinder } from "@ff-labs/fff-node";
-import { it, afterEach, describe, expect } from "@effect/vitest";
+import { it, afterEach, beforeEach, describe, expect } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -182,11 +182,13 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
     it.effect("honors git ignore rules in the fallback listing", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir({ git: true });
-        yield* writeTextFile(cwd, ".gitignore", "ignored.txt\n");
         yield* writeTextFile(cwd, "src/components/Composer.tsx");
         yield* writeTextFile(cwd, "ignored.txt", "ignore me");
+        yield* writeTextFile(cwd, "stale.ts", "remove me");
         yield* writeTextFile(cwd, "node_modules/pkg/index.js");
-        yield* git(cwd, ["add", "src/components/Composer.tsx"]);
+        yield* git(cwd, ["add", "src/components/Composer.tsx", "ignored.txt", "stale.ts"]);
+        yield* writeTextFile(cwd, ".gitignore", "ignored.txt\n");
+        yield* Effect.promise(() => NodeFSP.unlink(`${cwd}/stale.ts`));
 
         vi.spyOn(WorkspaceSearchIndex.nativeBinding, "load").mockRejectedValueOnce(
           new Error("cannot open shared object file"),
@@ -205,6 +207,7 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
           ]),
         );
         expect(paths).not.toContain("ignored.txt");
+        expect(paths).not.toContain("stale.ts");
         expect(paths.some((entryPath) => entryPath.startsWith("node_modules"))).toBe(false);
         expect(result.truncated).toBe(false);
       }),
@@ -874,6 +877,15 @@ const gitLsFilesOutput = (
 it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
   "WorkspaceEntries fallback git parsing",
   (it) => {
+    beforeEach(() => {
+      fallbackVcsRunMock.mockImplementation((input) => {
+        if (input.operation === "WorkspaceEntries.fallbackList.gitCheckIgnore") {
+          return Effect.succeed(gitLsFilesOutput(""));
+        }
+        throw new Error(`Unexpected VcsProcess call: ${input.operation}`);
+      });
+    });
+
     afterEach(() => {
       vi.restoreAllMocks();
       fallbackVcsRunMock.mockReset();
@@ -891,6 +903,8 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
     it.effect("reconstructs parent directories from git file paths", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/components/Composer.tsx");
+        yield* writeTextFile(cwd, "README.md");
         fallbackVcsRunMock.mockReturnValueOnce(
           Effect.succeed(gitLsFilesOutput("src/components/Composer.tsx\0README.md\0")),
         );
@@ -910,6 +924,7 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
     it.effect("preserves backslashes in POSIX file names", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/foo\\bar.ts");
         fallbackVcsRunMock.mockReturnValueOnce(
           Effect.succeed(gitLsFilesOutput("src/foo\\bar.ts\0")),
         );
@@ -923,6 +938,8 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
     it.effect("drops the partial trailing entry from truncated git output", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/kept.ts");
+        yield* writeTextFile(cwd, "README.md");
         fallbackVcsRunMock.mockReturnValueOnce(
           Effect.succeed(gitLsFilesOutput("src/kept.ts\0README.md\0src/part", true)),
         );
@@ -941,6 +958,8 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
     it.effect("keeps a complete trailing entry when truncation ends on the delimiter", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "a.txt");
+        yield* writeTextFile(cwd, "b.txt");
         fallbackVcsRunMock.mockReturnValueOnce(
           Effect.succeed(gitLsFilesOutput("a.txt\0b.txt\0", true)),
         );
@@ -959,6 +978,9 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();
         const files = Array.from({ length: 25_001 }, (_, index) => `file-${index}.txt`);
+        vi.spyOn(NodeFSP, "lstat").mockResolvedValue({
+          isDirectory: () => false,
+        } as Awaited<ReturnType<typeof NodeFSP.lstat>>);
         fallbackVcsRunMock.mockReturnValueOnce(
           Effect.succeed(gitLsFilesOutput(`${files.join("\0")}\0`)),
         );
@@ -967,6 +989,18 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
 
         expect(result.entries).toHaveLength(25_000);
         expect(result.truncated).toBe(true);
+      }),
+    );
+
+    it.effect("classifies git submodules as directories", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* Effect.promise(() => NodeFSP.mkdir(`${cwd}/vendor/sdk`, { recursive: true }));
+        fallbackVcsRunMock.mockReturnValueOnce(Effect.succeed(gitLsFilesOutput("vendor/sdk\0")));
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toContainEqual({ path: "vendor/sdk", kind: "directory" });
       }),
     );
 

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -907,6 +907,19 @@ it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
       }),
     );
 
+    it.effect("preserves backslashes in POSIX file names", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        fallbackVcsRunMock.mockReturnValueOnce(
+          Effect.succeed(gitLsFilesOutput("src/foo\\bar.ts\0")),
+        );
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toContainEqual({ path: "src/foo\\bar.ts", kind: "file" });
+      }),
+    );
+
     it.effect("drops the partial trailing entry from truncated git output", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -8,13 +8,16 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import { vi } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
+import { VcsProcessSpawnError } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as WorkspaceEntries from "./WorkspaceEntries.ts";
 import * as WorkspacePaths from "./WorkspacePaths.ts";
+import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -121,9 +124,111 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result.truncated).toBe(false);
       }),
     );
+
+    it.effect("falls back to the filesystem when the native index is unavailable", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/components/Composer.tsx");
+        yield* writeTextFile(cwd, "README.md");
+        yield* writeTextFile(cwd, "node_modules/pkg/index.js");
+
+        vi.spyOn(FileFinder, "create").mockImplementationOnce(() => {
+          throw new Error("native binding unavailable");
+        });
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd });
+
+        expect(result.entries).toEqual(
+          expect.arrayContaining([
+            { path: "src", kind: "directory" },
+            { path: "src/components", kind: "directory" },
+            { path: "src/components/Composer.tsx", kind: "file" },
+            { path: "README.md", kind: "file" },
+          ]),
+        );
+        expect(result.entries.some((entry) => entry.path.startsWith("node_modules"))).toBe(false);
+        expect(result.truncated).toBe(false);
+      }),
+    );
+
+    it.effect("falls back when the native workspace module cannot be imported", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/components/Composer.tsx");
+        yield* writeTextFile(cwd, "README.md");
+        yield* writeTextFile(cwd, "node_modules/pkg/index.js");
+
+        vi.spyOn(WorkspaceSearchIndex.nativeBinding, "load").mockRejectedValueOnce(
+          new Error("cannot open shared object file"),
+        );
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd });
+
+        expect(result.entries).toEqual(
+          expect.arrayContaining([
+            { path: "src", kind: "directory" },
+            { path: "src/components", kind: "directory" },
+            { path: "src/components/Composer.tsx", kind: "file" },
+            { path: "README.md", kind: "file" },
+          ]),
+        );
+        expect(result.entries.some((entry) => entry.path.startsWith("node_modules"))).toBe(false);
+        expect(result.truncated).toBe(false);
+      }),
+    );
+
+    it.effect("honors git ignore rules in the fallback listing", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ git: true });
+        yield* writeTextFile(cwd, ".gitignore", "ignored.txt\n");
+        yield* writeTextFile(cwd, "src/components/Composer.tsx");
+        yield* writeTextFile(cwd, "ignored.txt", "ignore me");
+        yield* writeTextFile(cwd, "node_modules/pkg/index.js");
+        yield* git(cwd, ["add", "src/components/Composer.tsx"]);
+
+        vi.spyOn(WorkspaceSearchIndex.nativeBinding, "load").mockRejectedValueOnce(
+          new Error("cannot open shared object file"),
+        );
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd });
+        const paths = result.entries.map((entry) => entry.path);
+
+        expect(result.entries).toEqual(
+          expect.arrayContaining([
+            { path: "src", kind: "directory" },
+            { path: "src/components", kind: "directory" },
+            { path: "src/components/Composer.tsx", kind: "file" },
+            { path: ".gitignore", kind: "file" },
+          ]),
+        );
+        expect(paths).not.toContain("ignored.txt");
+        expect(paths.some((entryPath) => entryPath.startsWith("node_modules"))).toBe(false);
+        expect(result.truncated).toBe(false);
+      }),
+    );
   });
 
   describe("search", () => {
+    it.effect("keeps the search index required when the native module is unavailable", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/index.ts");
+
+        vi.spyOn(WorkspaceSearchIndex.nativeBinding, "load").mockRejectedValueOnce(
+          new Error("cannot open shared object file"),
+        );
+
+        const error = yield* searchWorkspaceEntries({ cwd, query: "", limit: 10 }).pipe(
+          Effect.flip,
+        );
+
+        expect(error._tag).toBe("WorkspaceSearchIndexCreateFailed");
+      }),
+    );
+
     it.effect("returns files and directories relative to cwd", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir();
@@ -734,3 +839,148 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
     );
   });
 });
+
+const fallbackVcsRunMock = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
+
+// The real VcsProcess layer cannot produce truncated or oversized git output
+// cheaply, so fallback parsing gets its own block with a mocked runner.
+const MockedVcsTestLayer = Layer.empty.pipe(
+  Layer.provideMerge(
+    Layer.effect(WorkspaceEntries.WorkspaceEntries, WorkspaceEntries.make).pipe(
+      Layer.provide(WorkspaceSearchIndex.WorkspaceSearchIndexMap.layer),
+      Layer.provide(WorkspacePaths.layer),
+    ),
+  ),
+  Layer.provideMerge(Layer.mock(VcsProcess.VcsProcess)({ run: fallbackVcsRunMock })),
+  Layer.provide(
+    ServerConfig.ServerConfig.layerTest(process.cwd(), {
+      prefix: "t3-workspace-entries-vcs-mock-test-",
+    }),
+  ),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const gitLsFilesOutput = (
+  stdout: string,
+  stdoutTruncated = false,
+): VcsProcess.VcsProcessOutput => ({
+  exitCode: ChildProcessSpawner.ExitCode(0),
+  stdout,
+  stderr: "",
+  stdoutTruncated,
+  stderrTruncated: false,
+});
+
+it.layer(MockedVcsTestLayer, { excludeTestServices: true })(
+  "WorkspaceEntries fallback git parsing",
+  (it) => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      fallbackVcsRunMock.mockReset();
+    });
+
+    const listWithUnavailableIndex = (cwd: string) =>
+      Effect.gen(function* () {
+        vi.spyOn(WorkspaceSearchIndex.nativeBinding, "load").mockRejectedValueOnce(
+          new Error("cannot open shared object file"),
+        );
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        return yield* workspaceEntries.list({ cwd });
+      });
+
+    it.effect("reconstructs parent directories from git file paths", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        fallbackVcsRunMock.mockReturnValueOnce(
+          Effect.succeed(gitLsFilesOutput("src/components/Composer.tsx\0README.md\0")),
+        );
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toEqual([
+          { path: "README.md", kind: "file" },
+          { path: "src", kind: "directory" },
+          { path: "src/components", kind: "directory" },
+          { path: "src/components/Composer.tsx", kind: "file" },
+        ]);
+        expect(result.truncated).toBe(false);
+      }),
+    );
+
+    it.effect("drops the partial trailing entry from truncated git output", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        fallbackVcsRunMock.mockReturnValueOnce(
+          Effect.succeed(gitLsFilesOutput("src/kept.ts\0README.md\0src/part", true)),
+        );
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toEqual([
+          { path: "README.md", kind: "file" },
+          { path: "src", kind: "directory" },
+          { path: "src/kept.ts", kind: "file" },
+        ]);
+        expect(result.truncated).toBe(true);
+      }),
+    );
+
+    it.effect("keeps a complete trailing entry when truncation ends on the delimiter", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        fallbackVcsRunMock.mockReturnValueOnce(
+          Effect.succeed(gitLsFilesOutput("a.txt\0b.txt\0", true)),
+        );
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toEqual([
+          { path: "a.txt", kind: "file" },
+          { path: "b.txt", kind: "file" },
+        ]);
+        expect(result.truncated).toBe(true);
+      }),
+    );
+
+    it.effect("caps git-derived entries at the fallback limit", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        const files = Array.from({ length: 25_001 }, (_, index) => `file-${index}.txt`);
+        fallbackVcsRunMock.mockReturnValueOnce(
+          Effect.succeed(gitLsFilesOutput(`${files.join("\0")}\0`)),
+        );
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toHaveLength(25_000);
+        expect(result.truncated).toBe(true);
+      }),
+    );
+
+    it.effect("walks the directory tree when git cannot run", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "src/index.ts");
+        yield* writeTextFile(cwd, "node_modules/pkg/index.js");
+        fallbackVcsRunMock.mockReturnValueOnce(
+          Effect.fail(
+            new VcsProcessSpawnError({
+              operation: "WorkspaceEntries.fallbackList.gitLsFiles",
+              command: "git",
+              cwd,
+              cause: new Error("spawn git ENOENT"),
+            }),
+          ),
+        );
+
+        const result = yield* listWithUnavailableIndex(cwd);
+
+        expect(result.entries).toEqual([
+          { path: "src", kind: "directory" },
+          { path: "src/index.ts", kind: "file" },
+        ]);
+        expect(result.truncated).toBe(false);
+      }),
+    );
+  },
+);

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -12,6 +12,7 @@ import * as Schema from "effect/Schema";
 import type {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
+  ProjectEntry,
   ProjectListEntriesInput,
   ProjectListEntriesResult,
   ProjectSearchContentsInput,
@@ -23,8 +24,13 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { isExplicitRelativePath, isWindowsAbsolutePath } from "@t3tools/shared/path";
 import { normalizeSearchQuery } from "@t3tools/shared/searchRanking";
 
+import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as WorkspacePaths from "./WorkspacePaths.ts";
 import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
+
+const FALLBACK_LIST_MAX_ENTRIES = 25_000;
+const FALLBACK_LIST_GIT_OUTPUT_MAX_BYTES = 8_000_000;
+const FALLBACK_LIST_EXCLUDED_DIRECTORIES = new Set([".git", ".convex", "node_modules"]);
 
 export class WorkspaceEntriesWindowsPathUnsupportedError extends Schema.TaggedErrorClass<WorkspaceEntriesWindowsPathUnsupportedError>()(
   "WorkspaceEntriesWindowsPathUnsupportedError",
@@ -138,8 +144,118 @@ const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(fu
   return path.resolve(expandHomePath(input.cwd, path), input.partialPath);
 });
 
+function normalizeFallbackEntryPath(input: string): string {
+  return input
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "");
+}
+
+function isFallbackExcludedPath(input: string): boolean {
+  return normalizeFallbackEntryPath(input)
+    .split("/")
+    .some((segment) => FALLBACK_LIST_EXCLUDED_DIRECTORIES.has(segment));
+}
+
+function buildFallbackListResult(
+  files: ReadonlyArray<string>,
+  truncated: boolean,
+): ProjectListEntriesResult {
+  const entryByPath = new Map<string, ProjectEntry>();
+  for (const file of files) {
+    const normalizedPath = normalizeFallbackEntryPath(file);
+    if (!normalizedPath || isFallbackExcludedPath(normalizedPath)) continue;
+    entryByPath.set(normalizedPath, { path: normalizedPath, kind: "file" });
+
+    let separatorIndex = normalizedPath.lastIndexOf("/");
+    while (separatorIndex > 0) {
+      const parentPath = normalizedPath.slice(0, separatorIndex);
+      if (!entryByPath.has(parentPath)) {
+        entryByPath.set(parentPath, { path: parentPath, kind: "directory" });
+      }
+      separatorIndex = parentPath.lastIndexOf("/");
+    }
+  }
+
+  const sortedEntries = [...entryByPath.values()].toSorted((left, right) =>
+    left.path.localeCompare(right.path),
+  );
+  return {
+    entries: sortedEntries.slice(0, FALLBACK_LIST_MAX_ENTRIES),
+    truncated: truncated || sortedEntries.length > FALLBACK_LIST_MAX_ENTRIES,
+  };
+}
+
+const listWorkspaceEntriesFromFilesystem = Effect.fn(
+  "WorkspaceEntries.listWorkspaceEntriesFromFilesystem",
+)(function* (cwd: string, path: Path.Path, vcsProcess: VcsProcess.VcsProcess["Service"]) {
+  const gitResult = yield* vcsProcess
+    .run({
+      operation: "WorkspaceEntries.fallbackList.gitLsFiles",
+      command: "git",
+      cwd,
+      args: ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+      allowNonZeroExit: true,
+      timeoutMs: 15_000,
+      maxOutputBytes: FALLBACK_LIST_GIT_OUTPUT_MAX_BYTES,
+    })
+    .pipe(Effect.orElseSucceed(() => null));
+
+  if (gitResult !== null && gitResult.exitCode === 0) {
+    const files = gitResult.stdout.split("\0").filter(Boolean);
+    if (gitResult.stdoutTruncated && !gitResult.stdout.endsWith("\0")) {
+      files.pop();
+    }
+    const exceededEntryLimit = files.length > FALLBACK_LIST_MAX_ENTRIES;
+    return buildFallbackListResult(
+      files.slice(0, FALLBACK_LIST_MAX_ENTRIES + 1),
+      gitResult.stdoutTruncated || exceededEntryLimit,
+    );
+  }
+
+  const entries: ProjectEntry[] = [];
+  const pendingDirectories = [""];
+  let truncated = false;
+
+  while (pendingDirectories.length > 0 && !truncated) {
+    const relativeDirectory = pendingDirectories.shift() ?? "";
+    const absoluteDirectory = relativeDirectory ? path.join(cwd, relativeDirectory) : cwd;
+    const dirents = yield* Effect.promise(() =>
+      NodeFSP.readdir(absoluteDirectory, { withFileTypes: true }).catch(() => []),
+    );
+
+    for (const dirent of dirents.toSorted((left, right) => left.name.localeCompare(right.name))) {
+      const relativePath = normalizeFallbackEntryPath(
+        relativeDirectory ? `${relativeDirectory}/${dirent.name}` : dirent.name,
+      );
+      if (!relativePath || isFallbackExcludedPath(relativePath)) continue;
+
+      const isDirectory = dirent.isDirectory();
+      entries.push({
+        path: relativePath,
+        kind: isDirectory ? "directory" : "file",
+      });
+      if (entries.length > FALLBACK_LIST_MAX_ENTRIES) {
+        truncated = true;
+        break;
+      }
+      if (isDirectory) {
+        pendingDirectories.push(relativePath);
+      }
+    }
+  }
+
+  return {
+    entries: entries
+      .slice(0, FALLBACK_LIST_MAX_ENTRIES)
+      .toSorted((left, right) => left.path.localeCompare(right.path)),
+    truncated,
+  };
+});
+
 export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
+  const vcsProcess = yield* VcsProcess.VcsProcess;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const workspaceSearchIndexes = yield* WorkspaceSearchIndex.WorkspaceSearchIndexMap;
 
@@ -275,6 +391,20 @@ export const make = Effect.gen(function* () {
   const list: WorkspaceEntries["Service"]["list"] = Effect.fn("WorkspaceEntries.list")(
     function* (input) {
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
+      // The fallback only covers an index that could not be created at all
+      // (for example the native binding failed to load on this host). Scan
+      // timeouts and search failures on a live index still surface so they
+      // are not silently masked by a slower listing.
+      const recoverWithFilesystemList = (
+        cause: WorkspaceSearchIndex.WorkspaceSearchIndexCreateFailed,
+      ) =>
+        Effect.gen(function* () {
+          yield* Effect.logWarning("Falling back to filesystem workspace listing", {
+            cwd: normalizedCwd,
+            cause,
+          });
+          return yield* listWorkspaceEntriesFromFilesystem(normalizedCwd, path, vcsProcess);
+        });
       return yield* Effect.gen(function* () {
         const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
         return yield* searchIndex.list();
@@ -284,6 +414,7 @@ export const make = Effect.gen(function* () {
             WorkspaceSearchIndex.workspaceSearchIndexKey(normalizedCwd, "paths"),
           ),
         ),
+        Effect.catchTag("WorkspaceSearchIndexCreateFailed", recoverWithFilesystemList),
       );
     },
   );
@@ -293,4 +424,5 @@ export const make = Effect.gen(function* () {
 
 export const layer = Layer.effect(WorkspaceEntries, make).pipe(
   Layer.provide(WorkspaceSearchIndex.WorkspaceSearchIndexMap.layer),
+  Layer.provide(VcsProcess.layer),
 );

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -145,10 +145,7 @@ const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(fu
 });
 
 function normalizeFallbackEntryPath(input: string): string {
-  return input
-    .replaceAll("\\", "/")
-    .replace(/^\.\/+/, "")
-    .replace(/\/+$/, "");
+  return input.replace(/^\.\/+/, "").replace(/\/+$/, "");
 }
 
 function isFallbackExcludedPath(input: string): boolean {
@@ -414,7 +411,7 @@ export const make = Effect.gen(function* () {
             WorkspaceSearchIndex.workspaceSearchIndexKey(normalizedCwd, "paths"),
           ),
         ),
-        Effect.catchTag("WorkspaceSearchIndexCreateFailed", recoverWithFilesystemList),
+        Effect.catchTags({ WorkspaceSearchIndexCreateFailed: recoverWithFilesystemList }),
       );
     },
   );

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -155,14 +155,14 @@ function isFallbackExcludedPath(input: string): boolean {
 }
 
 function buildFallbackListResult(
-  files: ReadonlyArray<string>,
+  sourceEntries: ReadonlyArray<ProjectEntry>,
   truncated: boolean,
 ): ProjectListEntriesResult {
   const entryByPath = new Map<string, ProjectEntry>();
-  for (const file of files) {
-    const normalizedPath = normalizeFallbackEntryPath(file);
+  for (const sourceEntry of sourceEntries) {
+    const normalizedPath = normalizeFallbackEntryPath(sourceEntry.path);
     if (!normalizedPath || isFallbackExcludedPath(normalizedPath)) continue;
-    entryByPath.set(normalizedPath, { path: normalizedPath, kind: "file" });
+    entryByPath.set(normalizedPath, { path: normalizedPath, kind: sourceEntry.kind });
 
     let separatorIndex = normalizedPath.lastIndexOf("/");
     while (separatorIndex > 0) {
@@ -204,8 +204,41 @@ const listWorkspaceEntriesFromFilesystem = Effect.fn(
       files.pop();
     }
     const exceededEntryLimit = files.length > FALLBACK_LIST_MAX_ENTRIES;
+    const boundedFiles = files.slice(0, FALLBACK_LIST_MAX_ENTRIES + 1);
+    const ignoredResult = yield* vcsProcess
+      .run({
+        operation: "WorkspaceEntries.fallbackList.gitCheckIgnore",
+        command: "git",
+        cwd,
+        args: ["check-ignore", "--no-index", "-z", "--stdin"],
+        stdin: `${boundedFiles.join("\0")}\0`,
+        allowNonZeroExit: true,
+        timeoutMs: 15_000,
+        maxOutputBytes: FALLBACK_LIST_GIT_OUTPUT_MAX_BYTES,
+      })
+      .pipe(Effect.orElseSucceed(() => null));
+    const ignoredPaths = new Set(
+      ignoredResult?.stdout.split("\0").map(normalizeFallbackEntryPath).filter(Boolean) ?? [],
+    );
+    const entries = yield* Effect.forEach(
+      boundedFiles.filter((file) => !ignoredPaths.has(normalizeFallbackEntryPath(file))),
+      (file) =>
+        Effect.promise(async () => {
+          const normalizedPath = normalizeFallbackEntryPath(file);
+          try {
+            const stat = await NodeFSP.lstat(path.join(cwd, normalizedPath));
+            return {
+              path: normalizedPath,
+              kind: stat.isDirectory() ? ("directory" as const) : ("file" as const),
+            };
+          } catch {
+            return null;
+          }
+        }),
+      { concurrency: 32 },
+    );
     return buildFallbackListResult(
-      files.slice(0, FALLBACK_LIST_MAX_ENTRIES + 1),
+      entries.filter((entry): entry is ProjectEntry => entry !== null),
       gitResult.stdoutTruncated || exceededEntryLimit,
     );
   }

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -65,6 +65,24 @@ it.effect("filters image searches before applying the result limit", () =>
   ),
 );
 
+it.effect("maps a rejected native binding import to a create failure", () =>
+  Effect.gen(function* () {
+    const cause = new Error("cannot open shared object file");
+    vi.spyOn(WorkspaceSearchIndex.nativeBinding, "load").mockRejectedValueOnce(cause);
+
+    const error = yield* Effect.flip(
+      Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")),
+    );
+
+    expect(error).toMatchObject({
+      _tag: "WorkspaceSearchIndexCreateFailed",
+      cwd: "/workspace/project",
+      reason: "The native workspace index is unavailable on this host.",
+      cause,
+    });
+  }),
+);
+
 it.effect("preserves unexpected FileFinder creation failures", () =>
   Effect.gen(function* () {
     const cause = new Error("native initialization failed");

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -1,13 +1,15 @@
-import {
-  type DirItem,
-  type DirSearchResult,
-  type FileItem,
+// Keep this type-only: older glibc hosts cannot load fff-node's native binding.
+// The runtime import lives behind nativeBinding so server startup remains available.
+import type {
+  DirItem,
+  DirSearchResult,
+  FileItem,
   FileFinder,
-  type GrepCursor,
-  type MixedItem,
-  type MixedSearchResult,
-  type Result,
-  type SearchResult,
+  GrepCursor,
+  MixedItem,
+  MixedSearchResult,
+  Result,
+  SearchResult,
 } from "@ff-labs/fff-node";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -297,10 +299,28 @@ function withDirectoryAncestors(entries: ReadonlyArray<ProjectEntry>): ProjectEn
   return [...entryByPath.values()];
 }
 
+/**
+ * The native binding loads at first index use instead of module load, so hosts
+ * that cannot load it still boot the server and fail per workspace index
+ * instead. The indirection exists so tests can exercise the load-failure path.
+ */
+export const nativeBinding = {
+  load: () => import("@ff-labs/fff-node"),
+};
+
 const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (
   cwd: string,
   variant: WorkspaceSearchIndexVariant,
 ) {
+  const { FileFinder } = yield* Effect.tryPromise({
+    try: () => nativeBinding.load(),
+    catch: (cause) =>
+      new WorkspaceSearchIndexCreateFailed({
+        cwd,
+        reason: "The native workspace index is unavailable on this host.",
+        cause,
+      }),
+  });
   const result = yield* Effect.try({
     try: () =>
       FileFinder.create({


### PR DESCRIPTION
## What Changed

The server now lazy-loads `@ff-labs/fff-node` when a workspace index is first requested instead of importing the native binding during startup.

If the native index cannot be created, `projects.listEntries` falls back to a bounded file listing:

- `git ls-files --cached --others --exclude-standard` for Git repositories
- a bounded directory walk when Git is unavailable
- the existing 25,000-entry cap and truncation reporting

Workspace and content search remain index-only. Scan timeouts and failures from an already-created index are not masked by the fallback.

## Why

On hosts where the packaged native binding cannot load, such as systems with an older glibc, the eager import prevented the server from providing workspace functionality. The file tree can still provide useful degraded behavior without the native fuzzy/content index.

## Validation

- `vp test run apps/server/src/workspace/WorkspaceEntries.test.ts apps/server/src/workspace/WorkspaceSearchIndex.test.ts apps/server/src/workspace/WorkspaceFileSystem.test.ts` — 58 passed
- `tsgo --noEmit` in `apps/server`
- `vp lint` on the four touched workspace files
- Tests cover rejected native imports, Git ignore behavior, parent reconstruction, output truncation, entry limits, and the non-Git directory fallback

Implemented with Claude Fable 5 through Kiro CLI; verified and published with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new degraded listing path that shells out to Git and walks the filesystem, with different ignore/performance semantics than the native index; `WorkspaceEntries` now requires `VcsProcess` in its layer for fallback to work.
> 
> **Overview**
> **Lazy-loads** the `@ff-labs/fff-node` native binding on first index use (via `nativeBinding.load`) so hosts that cannot load it still start the server; a failed dynamic import becomes `WorkspaceSearchIndexCreateFailed` instead of crashing at module load.
> 
> When **`WorkspaceEntries.list`** hits that create failure only, it logs a warning and **falls back** to a bounded listing: `git ls-files` with `check-ignore` when Git works (8MB output cap, 15s timeout), otherwise a BFS directory walk. Results exclude `.git`, `.convex`, and `node_modules`, synthesize parent directories, sort paths, and honor the **25,000-entry** cap with `truncated`. **Search and content search** still require the native index; scan/timeouts on an existing index are **not** masked by this fallback. `WorkspaceEntries.layer` now provides **`VcsProcess`** for the Git path.
> 
> Tests cover native import/`FileFinder` failures, gitignore behavior, truncated git output, entry limits, submodule dirs, and the non-Git walk (including a mocked `VcsProcess` block).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a335642c2dc55123198685120737d68c71a44cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add filesystem fallback to `WorkspaceEntries` when native index is unavailable
> - When `WorkspaceSearchIndex` creation fails with `WorkspaceSearchIndexCreateFailed`, `WorkspaceEntries.list` now returns a filesystem-derived listing instead of propagating the error. See [WorkspaceEntries.ts](https://github.com/pingdotgg/t3code/pull/8402/files#diff-26feb5e4175dd3c4b97bf023c259c336abef121574cd5665d06d3e4dbf1b15b8).
> - The fallback first tries `git ls-files -z` (with `git check-ignore` filtering) and, if git is unavailable or fails, walks the filesystem breadth-first. Results are capped at 25,000 entries and marked truncated when the limit is exceeded.
> - Fallback excludes `.git`, `.convex`, and `node_modules` directories and reconstructs parent directories so the output resembles a normal file tree.
> - Native binding import for `WorkspaceSearchIndex` is deferred from module-load time to first use via a `nativeBinding.load()` indirection, so hosts that cannot load the binding fail deterministically with `WorkspaceSearchIndexCreateFailed` rather than crashing at import. See [WorkspaceSearchIndex.ts](https://github.com/pingdotgg/t3code/pull/8402/files#diff-c11793234fa6d81f052147cd8ae0b62e4e60366837e340f42279225a76704093).
> - Risk: `WorkspaceEntries.list` previously surfaced `WorkspaceSearchIndexCreateFailed` to callers; it now logs a warning and returns a fallback list. Other index errors still propagate. Reviewers should check every caller of `WorkspaceEntries.list` for assumptions about error propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a335642.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->