### PR TITLE
feat(web): find threads from pull request links

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,10 +4,12 @@ import type { Thread } from "../types";
 import {
   browseInputEndPaddingClass,
   buildBrowseGroups,
+  buildPullRequestLookupGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterPinnedBrowseEntries,
   filterCommandPaletteGroups,
+  matchesBranchPullRequestThread,
   reduceCommandPaletteUiState,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
@@ -332,6 +334,64 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("buildPullRequestLookupGroups", () => {
+  const query = "https://github.com/t3tools/t3code/pull/42";
+  const threadItem = {
+    kind: "action" as const,
+    value: "thread:thread-1",
+    searchTerms: ["Fix the sidebar"],
+    title: "Fix the sidebar",
+    icon: null,
+    run: async () => undefined,
+  };
+  const pullRequestItem = {
+    kind: "action" as const,
+    value: "pull-request:github.com:t3tools/t3code:42",
+    searchTerms: ["Open in Pull Requests"],
+    title: "Open in Pull Requests",
+    icon: null,
+    run: async () => undefined,
+  };
+
+  it("puts matching threads before the pull request fallback", () => {
+    const groups = buildPullRequestLookupGroups({
+      query,
+      threadItems: [threadItem],
+      pullRequestItem,
+    });
+
+    expect(groups.map((group) => group.label)).toEqual(["Matching Threads", "Pull Request"]);
+    expect(groups[0]?.items[0]?.value).toBe(threadItem.value);
+    expect(groups[1]?.items[0]?.value).toBe(pullRequestItem.value);
+  });
+
+  it("makes the pasted URL searchable without changing the displayed item metadata", () => {
+    const [threadGroup] = buildPullRequestLookupGroups({ query, threadItems: [threadItem] });
+
+    expect(threadGroup?.items[0]?.searchTerms).toEqual([query, "Fix the sidebar"]);
+    expect(threadGroup?.items[0]?.title).toBe(threadItem.title);
+  });
+});
+
+describe("matchesBranchPullRequestThread", () => {
+  it("finds a thread whose branch is the pull request head branch", () => {
+    expect(
+      matchesBranchPullRequestThread({
+        thread: {
+          environmentId: EnvironmentId.make("environment-1"),
+          projectId: PROJECT_ID,
+          branch: "t3code/fix-file-tree-resize",
+        },
+        pullRequestEnvironmentId: EnvironmentId.make("environment-1"),
+        pullRequest: {
+          projectId: PROJECT_ID,
+          headBranch: "t3code/fix-file-tree-resize",
+        },
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,6 +1,7 @@
 import {
   type FilesystemBrowseEntry,
   type KeybindingCommand,
+  type PullRequestDetail,
   THREAD_JUMP_KEYBINDING_COMMANDS,
 } from "@t3tools/contracts";
 import { filterFilesystemBrowseEntries } from "@t3tools/client-runtime/state/filesystem";
@@ -442,6 +443,52 @@ export function buildRootGroups(input: {
     });
   }
   return groups;
+}
+
+/**
+ * Builds the exact pull request lookup surface. The query is added to each item's search terms so
+ * the normal command filtering keeps the lookup visible while the user pastes a full URL.
+ */
+export function buildPullRequestLookupGroups(input: {
+  query: string;
+  threadItems: ReadonlyArray<CommandPaletteActionItem>;
+  pullRequestItem?: CommandPaletteActionItem;
+}): CommandPaletteGroup[] {
+  const groups: CommandPaletteGroup[] = [];
+  const withQuery = (item: CommandPaletteActionItem): CommandPaletteActionItem => ({
+    ...item,
+    searchTerms: [input.query, ...item.searchTerms],
+  });
+
+  if (input.threadItems.length > 0) {
+    groups.push({
+      value: "pull-request-threads",
+      label: "Matching Threads",
+      items: input.threadItems.map(withQuery),
+    });
+  }
+  if (input.pullRequestItem) {
+    groups.push({
+      value: "pull-request",
+      label: "Pull Request",
+      items: [withQuery(input.pullRequestItem)],
+    });
+  }
+
+  return groups;
+}
+
+/** Matches the PR detected from a thread's checked-out branch, scoped to its project and server. */
+export function matchesBranchPullRequestThread(input: {
+  thread: Pick<SidebarThreadSummary, "environmentId" | "projectId" | "branch">;
+  pullRequestEnvironmentId: SidebarThreadSummary["environmentId"];
+  pullRequest: Pick<PullRequestDetail, "projectId" | "headBranch">;
+}): boolean {
+  return (
+    input.thread.environmentId === input.pullRequestEnvironmentId &&
+    input.thread.projectId === input.pullRequest.projectId &&
+    input.thread.branch === input.pullRequest.headBranch
+  );
 }
 
 export function getCommandPaletteInputPlaceholder(mode: CommandPaletteMode): string {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -40,6 +40,7 @@ import {
   FileSearchIcon,
   FolderIcon,
   FolderPlusIcon,
+  GitPullRequestIcon,
   LinkIcon,
   MessageSquareIcon,
   PaletteIcon,
@@ -76,7 +77,8 @@ import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import { useProjects, useServerConfigs, useThreadShells } from "../state/entities";
+import { linkedPullRequestDetailAtom } from "../state/pullRequests";
 import { useThreadSearch } from "../state/queries";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
@@ -93,6 +95,11 @@ import {
 import { onOpenCommandPalette } from "../commandPaletteBus";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
+import {
+  findProjectForChangeRequest,
+  matchesLinkedPullRequestUrl,
+  parseChangeRequestUrl,
+} from "../lib/openPullRequestLink";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { getLatestThreadForProject, sortThreads } from "../lib/threadSort";
 import {
@@ -115,6 +122,7 @@ import {
   browseInputEndPaddingClass,
   buildBrowseGroups,
   buildProjectActionItems,
+  buildPullRequestLookupGroups,
   buildRootGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
@@ -126,6 +134,7 @@ import {
   filterPinnedBrowseEntries,
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
+  matchesBranchPullRequestThread,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
   reduceCommandPaletteUiState,
@@ -590,6 +599,7 @@ function OpenCommandPaletteDialog(props: {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
+  const serverConfigs = useServerConfigs();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const { theme, themeHalves, resolvedTheme } = useTheme();
   const providers = useAtomValue(primaryServerProvidersAtom);
@@ -614,7 +624,13 @@ function OpenCommandPaletteDialog(props: {
         .map((environment) => environment.environmentId),
     [environments],
   );
-  const threadSearchQuery = currentView === null && !isActionsOnly ? deferredQuery : "";
+  const pastedPullRequest = useMemo(
+    () => parseChangeRequestUrl(deferredQuery.trim()),
+    [deferredQuery],
+  );
+  const isPullRequestLookup = pastedPullRequest !== null;
+  const threadSearchQuery =
+    currentView === null && !isActionsOnly && !isPullRequestLookup ? deferredQuery : "";
   const threadSearch = useThreadSearch(environmentIds, threadSearchQuery);
   const threadContentMatchByKey = useMemo(
     () =>
@@ -875,6 +891,36 @@ function OpenCommandPaletteDialog(props: {
   const projectTitleById = useMemo(
     () => new Map<ProjectId, string>(projects.map((project) => [project.id, project.title])),
     [projects],
+  );
+  const pullRequestProject = useMemo(() => {
+    if (pastedPullRequest === null) {
+      return undefined;
+    }
+
+    const pullRequestProjects = projects
+      .filter(
+        (project) =>
+          serverConfigs.get(project.environmentId)?.environment.capabilities.pullRequests === true,
+      )
+      .toSorted(
+        (left, right) =>
+          Number(right.environmentId === primaryEnvironmentId) -
+          Number(left.environmentId === primaryEnvironmentId),
+      );
+    return findProjectForChangeRequest(pullRequestProjects, pastedPullRequest);
+  }, [pastedPullRequest, primaryEnvironmentId, projects, serverConfigs]);
+  const pullRequestDetailQuery = useEnvironmentQuery(
+    pastedPullRequest !== null && pullRequestProject !== undefined
+      ? linkedPullRequestDetailAtom({
+          environmentId: pullRequestProject.environmentId,
+          input: {
+            projectId: pullRequestProject.id,
+            repository:
+              pullRequestProject.repositoryIdentity?.displayName ?? pastedPullRequest.repository,
+            number: pastedPullRequest.number,
+          },
+        })
+      : null,
   );
 
   const activeThreadId = activeThread?.id;
@@ -1148,6 +1194,84 @@ function OpenCommandPaletteDialog(props: {
       threadSearchQuery,
       threads,
     ],
+  );
+  const pullRequestThreadItems = useMemo(() => {
+    if (pastedPullRequest === null) {
+      return [];
+    }
+
+    const pullRequestDetail = pullRequestDetailQuery.data;
+    const matchingThreadIds = new Set(
+      threads.flatMap((thread) =>
+        (thread.linkedPullRequest !== undefined &&
+          thread.linkedPullRequest !== null &&
+          matchesLinkedPullRequestUrl(thread.linkedPullRequest, deferredQuery)) ||
+        (pullRequestProject !== undefined &&
+          pullRequestDetail !== null &&
+          matchesBranchPullRequestThread({
+            thread,
+            pullRequestEnvironmentId: pullRequestProject.environmentId,
+            pullRequest: pullRequestDetail,
+          }))
+          ? [String(thread.id)]
+          : [],
+      ),
+    );
+    return allThreadItems.filter((item) =>
+      matchingThreadIds.has(item.value.slice("thread:".length)),
+    );
+  }, [
+    allThreadItems,
+    deferredQuery,
+    pastedPullRequest,
+    pullRequestDetailQuery.data,
+    pullRequestProject,
+    threads,
+  ]);
+  const pullRequestItem = useMemo<CommandPaletteActionItem | undefined>(() => {
+    if (pastedPullRequest === null || pullRequestProject === undefined) {
+      return undefined;
+    }
+
+    return {
+      kind: "action",
+      value: `pull-request:${pastedPullRequest.host}:${pastedPullRequest.repository}:${pastedPullRequest.number}`,
+      searchTerms: [
+        "open pull request",
+        "pull request",
+        "pr",
+        pastedPullRequest.repository,
+        `#${pastedPullRequest.number}`,
+      ],
+      title: "Open in Pull Requests",
+      description: `${pastedPullRequest.repository} #${pastedPullRequest.number}`,
+      icon: <GitPullRequestIcon className={ITEM_ICON_CLASS} />,
+      run: async () => {
+        await navigate({
+          to: "/pull-requests",
+          search: {
+            involvement: "all",
+            state: "all",
+            host: pastedPullRequest.host,
+            repository: pastedPullRequest.repository,
+            number: pastedPullRequest.number,
+            selectedProjectId: pullRequestProject.id,
+            selectedEnvironmentId: pullRequestProject.environmentId,
+          },
+        });
+      },
+    };
+  }, [navigate, pastedPullRequest, pullRequestProject]);
+  const pullRequestLookupGroups = useMemo(
+    () =>
+      pastedPullRequest === null
+        ? null
+        : buildPullRequestLookupGroups({
+            query: deferredQuery,
+            threadItems: pullRequestThreadItems,
+            ...(pullRequestItem ? { pullRequestItem } : {}),
+          }),
+    [deferredQuery, pastedPullRequest, pullRequestItem, pullRequestThreadItems],
   );
   const recentThreadItems = allThreadItems.slice(0, RECENT_THREAD_LIMIT);
 
@@ -1662,9 +1786,13 @@ function OpenCommandPaletteDialog(props: {
           buildAddProjectRemoteSourceReadiness(sourceControlDiscovery.data),
         )
       : (currentView?.groups ?? rootGroups);
+  const visibleActiveGroups =
+    pullRequestLookupGroups !== null && currentView === null && !isActionsOnly
+      ? pullRequestLookupGroups
+      : activeGroups;
 
   const filteredGroups = filterCommandPaletteGroups({
-    activeGroups,
+    activeGroups: visibleActiveGroups,
     query: deferredQuery,
     isInSubmenu: currentView !== null,
     projectSearchItems: projectSearchItems,
@@ -2506,13 +2634,16 @@ function OpenCommandPaletteDialog(props: {
             ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
             : relativePathNeedsActiveProject
               ? { emptyStateMessage: "Relative paths require an active project." }
-              : willCreateProjectPath
-                ? {
-                    emptyStateMessage: "Press Enter to create this folder and add it as a project.",
-                  }
-                : threadSearch.isPending
-                  ? { emptyStateMessage: "Searching thread messages…" }
-                  : {})}
+              : pullRequestLookupGroups !== null
+                ? { emptyStateMessage: "No linked thread or project found for this pull request." }
+                : willCreateProjectPath
+                  ? {
+                      emptyStateMessage:
+                        "Press Enter to create this folder and add it as a project.",
+                    }
+                  : threadSearch.isPending
+                    ? { emptyStateMessage: "Searching thread messages…" }
+                    : {})}
       />
     </CommandPaletteContent>
   );


### PR DESCRIPTION
## What Changed

- Detect pasted GitHub, GitLab, Bitbucket, and Azure DevOps pull request URLs in Cmd+K.
- Show matching threads before the pull request fallback.
- Match explicit thread links and branch-derived pull requests in the same project and environment.
- Keep the Pull Requests view as a direct fallback.

## Why

Pasting a pull request URL only showed the Pull Requests view. Threads with the same attached or branch-derived pull request were not found. The palette now resolves the exact pull request and uses its head branch to find the matching thread.

## UI Changes

Before and after screenshots are still needed. This is a draft for review.

## Verification

- 39 focused tests passed
- Web typecheck passed
- Targeted lint passed
- Formatting and diff checks passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the UI changes
- [ ] I included a video for interaction changes

Implemented by GPT-5.6 Sol on behalf of exotic.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pull request URL lookup mode to `CommandPalette`
> - Pasting a recognized pull request URL into the command palette triggers a PR lookup mode that replaces normal thread text search.
> - Results show matching threads first (by direct pull-request link or by branch match within the same environment and project), then a single action item that opens the `/pull-requests` view pre-populated with PR and project context.
> - Adds `buildPullRequestLookupGroups` and `matchesBranchPullRequestThread` helpers in [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/8406/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) with corresponding tests.
> - An explicit empty-state message is shown when no linked thread or project is found.
> - Behavioral Change: thread text search is disabled while PR lookup mode is active in the root view; reviewers should verify filtering still works for non-PR queries.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 09d0492. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->