### PR TITLE
fix: make Claude 200k context window selection take effect

### DIFF
--- a/apps/server/src/provider/ClaudeModelCatalog.test.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest";
 import { ProviderInstanceId } from "@t3tools/contracts";
+import { createModelSelection } from "@t3tools/shared/model";
 
 import { hasValidClaudeManifestAdapters } from "./ClaudeModelManifest.ts";
 import type { ModelManifestData } from "./ModelManifest.ts";
@@ -7,6 +8,7 @@ import {
   formatClaudeVersionUpgradeMessage,
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
+  resolveClaudeCatalogContextWindowEnv,
   resolveClaudeModelCatalog,
   resolveClaudeModelsForVersion,
   resolveClaudeModelSlug,
@@ -38,7 +40,10 @@ const manifest = (): ModelManifestData => ({
                 id: "contextWindow",
                 label: "Context Window",
                 type: "select",
-                options: [{ id: "large", label: "Large", isDefault: true }],
+                options: [
+                  { id: "small", label: "Small" },
+                  { id: "large", label: "Large", isDefault: true },
+                ],
               },
             ],
           },
@@ -46,6 +51,7 @@ const manifest = (): ModelManifestData => ({
             claudeCode: {
               effortMap: { extreme: "high" },
               modelSuffixes: { contextWindow: { large: "[large]" } },
+              contextWindowTokens: { small: 200_000, large: 1_000_000 },
             },
           },
         },
@@ -111,6 +117,58 @@ describe("Claude model catalog", () => {
         model: "synthetic",
       }),
       "claude-synthetic-next[large]",
+    );
+  });
+
+  it("states the Claude Code 1M context window opt-out per selection", () => {
+    const catalog = resolveClaudeModelCatalog(manifest());
+    const instanceId = ProviderInstanceId.make("claudeAgent");
+    assert.deepStrictEqual(
+      resolveClaudeCatalogContextWindowEnv(
+        catalog,
+        createModelSelection(instanceId, "synthetic", [{ id: "contextWindow", value: "small" }]),
+      ),
+      { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" },
+    );
+    assert.deepStrictEqual(
+      resolveClaudeCatalogContextWindowEnv(catalog, { instanceId, model: "synthetic" }),
+      { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+    );
+    assert.strictEqual(resolveClaudeCatalogContextWindowEnv(catalog, undefined), undefined);
+  });
+
+  it("states the 1M context window opt-out for models with a fixed window", () => {
+    const base = manifest();
+    const claudeAgent = base.providers!.claudeAgent!;
+    const input: ModelManifestData = {
+      ...base,
+      providers: {
+        ...base.providers,
+        claudeAgent: {
+          ...claudeAgent,
+          profiles: {
+            ...claudeAgent.profiles,
+            fixed: { adapter: { claudeCode: { fixedContextWindowTokens: 1_000_000 } } },
+          },
+          models: [
+            ...claudeAgent.models,
+            {
+              slug: "claude-synthetic-fixed",
+              name: "Claude Synthetic Fixed",
+              status: "current",
+              profile: "fixed",
+            },
+          ],
+        },
+      },
+    };
+    const catalog = resolveClaudeModelCatalog(input);
+    assert.deepStrictEqual(
+      resolveClaudeCatalogContextWindowEnv(catalog, {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-synthetic-fixed",
+      }),
+      { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
     );
   });
 

--- a/apps/server/src/provider/ClaudeModelCatalog.ts
+++ b/apps/server/src/provider/ClaudeModelCatalog.ts
@@ -240,3 +240,23 @@ export function resolveClaudeCatalogContextWindowTokens(
   const contextWindow = resolveClaudeCatalogContextWindow(catalog, modelSelection);
   return contextWindow ? entry.runtime.contextWindowTokens?.[contextWindow] : undefined;
 }
+
+/**
+ * Claude Code auto-enables the 1M-token context window for every model with a
+ * native 1M window, so a bare model slug does not select 200k — the CLI only
+ * holds a session at 200k when `CLAUDE_CODE_DISABLE_1M_CONTEXT` is set, and a
+ * user or project settings file may already set it (live-test finding). State
+ * the window the catalog resolved in both directions, so the session runs the
+ * window T3 displays — for a fixed-window model as much as for a picked option.
+ * Managed policy settings still outrank this; the CLI's own usage report then
+ * corrects the meter. Models without catalog token data are left to the
+ * user's configuration.
+ */
+export function resolveClaudeCatalogContextWindowEnv(
+  catalog: ClaudeModelCatalog,
+  modelSelection: ModelSelection | undefined,
+): Record<string, string> | undefined {
+  const tokens = resolveClaudeCatalogContextWindowTokens(catalog, modelSelection);
+  if (tokens === undefined) return undefined;
+  return { CLAUDE_CODE_DISABLE_1M_CONTEXT: tokens <= 200_000 ? "1" : "0" };
+}

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -63,6 +63,7 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   private failure: unknown | undefined;
 
   public readonly setModelCalls: Array<string | undefined> = [];
+  public readonly applyFlagSettingsCalls: Array<Record<string, unknown>> = [];
   public readonly setPermissionModeCalls: Array<string> = [];
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
   public closeCalls = 0;
@@ -104,6 +105,10 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
 
   readonly setModel = async (model?: string): Promise<void> => {
     this.setModelCalls.push(model);
+  };
+
+  readonly applyFlagSettings = async (settings: Record<string, unknown>): Promise<void> => {
+    this.applyFlagSettingsCalls.push(settings);
   };
 
   readonly setPermissionMode = async (mode: PermissionMode): Promise<void> => {
@@ -555,7 +560,9 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.settings, undefined);
+      assert.deepEqual(createInput?.options.settings, {
+        env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+      });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -580,6 +587,7 @@ describe("ClaudeAdapterLive", () => {
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settings, {
         fastMode: true,
+        env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
       });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -603,7 +611,132 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.settings, undefined);
+      assert.deepEqual(createInput?.options.settings, {
+        env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+      });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("opts out of the 1M context window when the 200k window is selected", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+          [{ id: "contextWindow", value: "standard" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, SYNTHETIC_CLAUDE_CAPABLE_MODEL);
+      assert.deepEqual(createInput?.options.settings, {
+        env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" },
+      });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "updates cached usage after a mid-thread context-window switch so streaming usage is not clamped to the old window",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.takeUntil(
+          adapter.streamEvents,
+          (event) => event.type === "thread.token-usage.updated",
+        ).pipe(Stream.runCollect, Effect.forkChild);
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+            [{ id: "contextWindow", value: "standard" }],
+          ),
+          runtimeMode: "full-access",
+        });
+        yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "hello",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+            [{ id: "contextWindow", value: "expanded" }],
+          ),
+          attachments: [],
+        });
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-window-switch",
+          uuid: "stream-window-switch",
+          parent_tool_use_id: null,
+          event: {
+            type: "message_delta",
+            usage: {
+              input_tokens: 500_000,
+              output_tokens: 100,
+            },
+          },
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const usageEvent = runtimeEvents.find(
+          (event) => event.type === "thread.token-usage.updated",
+        );
+        assert.equal(usageEvent?.type, "thread.token-usage.updated");
+        if (usageEvent?.type === "thread.token-usage.updated") {
+          // Before the fix this clamped to the session's starting 200k
+          // window (usedTokens: 200000, maxTokens: 200000) because the
+          // model switch never refreshed the cache streaming usage reads.
+          assert.deepEqual(usageEvent.payload.usage, {
+            usedTokens: 500_100,
+            lastUsedTokens: 500_100,
+            inputTokens: 500_000,
+            outputTokens: 100,
+            maxTokens: 1_000_000,
+          });
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("opts back into the 1M context window when the expanded window is selected", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+          [{ id: "contextWindow", value: "expanded" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`);
+      assert.deepEqual(createInput?.options.settings, {
+        env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+      });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -691,15 +824,74 @@ describe("ClaudeAdapterLive", () => {
           `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
           SYNTHETIC_CLAUDE_COLLIDING_ALIAS,
         ]);
+        assert.deepEqual(customHarness.query.applyFlagSettingsCalls, [
+          { env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" } },
+          { env: null },
+        ]);
         assert.equal(customPrompt, "keep this prompt literal");
 
         const builtInOptions = yield* start(builtInHarness, SYNTHETIC_CLAUDE_CAPABLE_MODEL);
         assert.equal(builtInOptions.model, `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`);
         assert.equal(builtInOptions.effort, "max");
-        assert.deepEqual(builtInOptions.settings, { fastMode: true });
+        assert.deepEqual(builtInOptions.settings, {
+          fastMode: true,
+          env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" },
+        });
       });
     },
   );
+
+  it.effect("leaves the 1M context window alone for models without the option", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          SYNTHETIC_CLAUDE_THINKING_MODEL,
+          [],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.settings, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("merges the 1M opt-out with other SDK settings", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+          [
+            { id: "fastMode", value: true },
+            { id: "contextWindow", value: "standard" },
+          ],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.deepEqual(createInput?.options.settings, {
+        fastMode: true,
+        env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" },
+      });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 
   it.effect("treats ultrathink as a prompt keyword instead of a session effort", () => {
     const harness = makeHarness();
@@ -4659,6 +4851,7 @@ describe("ClaudeAdapterLive", () => {
         });
 
         assert.deepEqual(harness.query.setModelCalls, []);
+        assert.deepEqual(harness.query.applyFlagSettingsCalls, []);
       }).pipe(
         Effect.provideService(Random.Random, makeDeterministicRandomService()),
         Effect.provide(harness.layer),
@@ -4701,6 +4894,10 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(harness.query.setModelCalls, [
         `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
         SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+      ]);
+      assert.deepEqual(harness.query.applyFlagSettingsCalls, [
+        { env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "0" } },
+        { env: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" } },
       ]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -13,6 +13,7 @@ import {
   type PermissionMode,
   type PermissionResult,
   type PermissionUpdate,
+  type Query as ClaudeSdkQuery,
   type SDKMessage,
   type SDKResultMessage,
   type SettingSource,
@@ -89,6 +90,7 @@ import {
   isClaudeCatalogUltracodeEffort,
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
+  resolveClaudeCatalogContextWindowEnv,
   resolveClaudeCatalogContextWindowTokens,
   resolveClaudeCatalogEffort,
   resolveClaudeModelSlug,
@@ -287,6 +289,7 @@ interface ClaudeSessionContext {
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
   currentApiModelId: string | undefined;
+  currentContextWindowEnv: Record<string, string> | undefined;
   /** Effective effort for the session's turns; subagents without an explicit
    * effort override inherit this. */
   currentEffort: string | undefined;
@@ -327,6 +330,7 @@ interface ClaudeSessionContext {
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
   readonly setModel: (model?: string) => Promise<void>;
+  readonly applyFlagSettings: ClaudeSdkQuery["applyFlagSettings"];
   readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
   readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
   readonly close: () => void;
@@ -477,6 +481,15 @@ function maxClaudeContextWindowFromModelUsage(
   }
 
   return maxContextWindow;
+}
+
+function sameContextWindowEnv(
+  left: Record<string, string> | undefined,
+  right: Record<string, string> | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const keys = Object.keys(left);
+  return keys.length === Object.keys(right).length && keys.every((key) => left[key] === right[key]);
 }
 
 function selectedClaudeContextWindow(
@@ -4306,6 +4319,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const apiModelId = modelSelection
         ? resolveClaudeCatalogApiModelId(modelCatalog, modelSelection)
         : undefined;
+      const contextWindowEnv = resolveClaudeCatalogContextWindowEnv(modelCatalog, modelSelection);
       const initialContextWindow = selectedClaudeContextWindow(modelCatalog, modelSelection);
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
       const effort =
@@ -4341,6 +4355,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(claudeSettings.autoCompactWindow
           ? { autoCompactWindow: Number(claudeSettings.autoCompactWindow) }
           : {}),
+        // The context-window selection must be stated to the CLI (see
+        // `resolveClaudeCatalogContextWindowEnv`). Set it via flag settings
+        // rather than the process env: a user or project settings file's
+        // `env` block overrides the spawned process env, while flag settings
+        // outrank both (live-test finding; managed policy settings still win).
+        ...(contextWindowEnv ? { env: contextWindowEnv } : {}),
       };
       const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
       // The attachments dir grant lets the agent Read/copy pasted images at
@@ -4460,6 +4480,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         startedAt,
         basePermissionMode: permissionMode,
         currentApiModelId: apiModelId,
+        currentContextWindowEnv: contextWindowEnv,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
         pendingApprovals,
@@ -4580,6 +4601,39 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     if (modelSelection?.model) {
       const apiModelId = resolveClaudeCatalogApiModelId(modelCatalog, modelSelection);
+      const contextWindowEnv = resolveClaudeCatalogContextWindowEnv(modelCatalog, modelSelection);
+      const contextWindowTokens = selectedClaudeContextWindow(modelCatalog, modelSelection);
+      if (!sameContextWindowEnv(context.currentContextWindowEnv, contextWindowEnv)) {
+        // The context-window opt-out lives in the flag-settings layer, not in
+        // the model id, and it outranks an explicit `[1m]` suffix (live-test
+        // finding) — so it is restated whenever the resolved value changes,
+        // ahead of the model switch. `null` clears the key, leaving a model
+        // without catalog token data in the same state as a freshly started
+        // session. Successive calls replace the whole `env` object, so this
+        // helper must stay its only writer. A failure is logged instead of
+        // failing the turn: an older CLI that does not know the control
+        // request would otherwise lose the turn over a wrong context window,
+        // and the unchanged tracked value retries on the next turn.
+        const applied = yield* Effect.tryPromise({
+          try: () => context.query.applyFlagSettings({ env: contextWindowEnv ?? null }),
+          catch: (cause) => toRequestError(input.threadId, "turn/applyFlagSettings", cause),
+        }).pipe(
+          Effect.as(true),
+          Effect.catch((cause) =>
+            Effect.logWarning("Failed to apply Claude context-window flag settings.", {
+              cause,
+            }).pipe(Effect.as(false)),
+          ),
+        );
+        if (applied) {
+          context.currentContextWindowEnv = contextWindowEnv;
+          // Streaming usage snapshots read this cache until the turn's
+          // result message reports the model's real window (completeTurn);
+          // without updating it here, usage on the new window is clamped to
+          // the old one for the rest of this turn.
+          context.lastKnownContextWindow = contextWindowTokens ?? context.lastKnownContextWindow;
+        }
+      }
       if (context.currentApiModelId !== apiModelId) {
         yield* Effect.tryPromise({
           try: () => context.query.setModel(apiModelId),

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -320,7 +320,7 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
               body: "Body",
             },
           }),
-          argsMustContain: `--model ${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded] --effort max --settings {"fastMode":true} --dangerously-skip-permissions`,
+          argsMustContain: `--model ${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded] --effort max --settings {"fastMode":true,"env":{"CLAUDE_CODE_DISABLE_1M_CONTEXT":"0"}} --dangerously-skip-permissions`,
           claudeConfig: { customModels: [SYNTHETIC_CLAUDE_COLLIDING_ALIAS] },
         },
         (textGeneration) =>
@@ -347,6 +347,38 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             expect(generated.title).toBe("Improve orchestration flow");
           }),
       ),
+  );
+
+  it.effect("opts out of the 1M context window for 200k selections", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: {
+            subject: "Add important change",
+            body: "",
+          },
+        }),
+        argsMustContain: `--model ${SYNTHETIC_CLAUDE_CAPABLE_MODEL} --effort high --settings {"env":{"CLAUDE_CODE_DISABLE_1M_CONTEXT":"1"}}`,
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateCommitMessage({
+            cwd: process.cwd(),
+            branch: "feature/claude-effect",
+            stagedSummary: "M README.md",
+            stagedPatch: "diff --git a/README.md b/README.md",
+            modelSelection: {
+              ...createModelSelection(
+                ProviderInstanceId.make("claudeAgent"),
+                SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+                [{ id: "contextWindow", value: "standard" }],
+              ),
+            },
+          });
+
+          expect(generated.subject).toBe("Add important change");
+        }),
+    ),
   );
 
   it.effect("generates thread titles through the Claude provider", () =>

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -43,6 +43,7 @@ import {
   isClaudeCatalogUltracodeEffort,
   normalizeClaudeCatalogEffort,
   resolveClaudeCatalogApiModelId,
+  resolveClaudeCatalogContextWindowEnv,
   resolveClaudeCatalogEffort,
   resolveClaudeModelSlug,
   scopeClaudeModelCatalog,
@@ -163,10 +164,12 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       thinkingDescriptor?.type === "boolean" ? thinkingDescriptor.currentValue : undefined;
     const fastMode =
       fastModeDescriptor?.type === "boolean" ? fastModeDescriptor.currentValue : undefined;
+    const contextWindowEnv = resolveClaudeCatalogContextWindowEnv(catalog, resolvedModelSelection);
     const settings = {
       ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
       ...(fastMode ? { fastMode: true } : {}),
       ...(ultracode ? { ultracode: true } : {}),
+      ...(contextWindowEnv ? { env: contextWindowEnv } : {}),
     };
     const settingsJson =
       Object.keys(settings).length > 0


### PR DESCRIPTION
## What Changed

Selecting the **200k context window** for Claude models now actually runs the session at 200k. A new catalog helper, `resolveClaudeCatalogContextWindowEnv`, states the resolved window to the CLI as `CLAUDE_CODE_DISABLE_1M_CONTEXT` — `"1"` when the manifest resolves the selection to 200k tokens, `"0"` for any other known window, nothing for models without catalog token data. The adapter injects it into the SDK's flag-settings layer at session start and restates it via `applyFlagSettings` whenever the resolved value changes mid-thread; `ClaudeTextGeneration` (commit-message / PR-content / thread-title generation, which spawns the same CLI) applies the same value.

## Why

Fixes #8405. Claude Code auto-enables the 1M window for `claude-opus-5` / `claude-fable-5` / `claude-sonnet-5` unless the process opts out, so the bare model slug does not mean 200k — the 200k selection was a silent no-op and every such session ran at 1M (verified empirically via `modelUsage[].contextWindow`; details in the issue).

Design points, each verified against SDK 0.3.170 + CLI 2.1.247:

- **Catalog-driven, not option-id-driven:** the rule keys off the manifest's `contextWindowTokens` rather than the literal `"200k"` option id, so remote manifest updates keep working and the synthetic test catalog covers it.
- **Flag settings, not process env:** sessions spawn with `settingSources: ["user", "project", "local"]`, and an `env` block in a user/project settings file overrides the spawned process env — a `queryOptions.env`-based fix is silently defeated by e.g. `"env": {"CLAUDE_CODE_DISABLE_1M_CONTEXT": "0"}` in `~/.claude/settings.json`. Flag settings (the SDK `settings` option) outrank those files. Managed policy settings still win; the CLI's own usage report then corrects T3's meter.
- **Two-way, so the window is decided by the selection:** stating only the 200k opt-out leaves the mirror-image bug (raised in review): a user/project settings file setting `"1"` would clamp a 1M selection to 200k while T3's meter claims 1M. Since T3's meter, warnings and `maxTokens` all derive from the same catalog data, any divergence makes T3 lie to the user — so the value is stated in both directions. **Note for maintainers:** this means T3 overrides a user's global `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` for every 1M-capable model, including `claude-opus-4-7/4-8` where T3 offers no selector. The per-selection control in T3's UI is the intended replacement.
- **Mid-thread switches:** the flag-settings value outranks an explicit `[1m]` model suffix, so without restating it a session started at 200k (any default Sonnet session) would silently clamp a later 1M selection. `sendTurn` restates it whenever the resolved value changes, ahead of `setModel`. A failure is logged rather than failing the turn, so an older CLI that doesn't know the control request loses only the window, not the turn.
- **Same bug in text generation:** `ClaudeTextGeneration` spawns the same CLI with the same bare slug and already builds a `--settings` object, so it gets the same conditional spread.

This also makes the context meter agree with reality (#5286): `selectedClaudeContextWindow` seeds 200k and the CLI now confirms it instead of reporting 1M.

**Testing:** new/updated unit tests in `ClaudeModelCatalog.test.ts` (200k / 1m / fixed-window / no-data cases), `ClaudeAdapter.test.ts`, and `ClaudeTextGeneration.test.ts` (all on synthetic catalog fixtures); typecheck clean. Behavior verified end-to-end through the real SDK: bare slug → 1,000,000; flag-settings `"1"` → 200,000 even against a conflicting user-settings `env` block; flag-settings `"0"` → 1,000,000 against a project-settings `"1"`; mid-session `applyFlagSettings` flip verified in both directions.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] ~~I included before/after screenshots for any UI changes~~ (no UI changes)
- [ ] ~~I included a video for animation/interaction changes~~ (no animation changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude 200k context window selection to set `CLAUDE_CODE_DISABLE_1M_CONTEXT`
> - Adds `resolveClaudeCatalogContextWindowEnv` to [ClaudeModelCatalog.ts](https://github.com/pingdotgg/t3code/pull/8409/files#diff-870489ca53b30490568a8e002e32b0e2b331e5ab59fe69b346fd83543bd3ee6e), which returns `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` for catalog windows ≤200,000 tokens, `0` for larger windows, and `undefined` when the catalog has no token data for the selection.
> - Session start and per-turn handlers in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/8409/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) apply the resolved setting via the SDK `applyFlagSettings` operation, clearing it with `null` when a new selection has no catalog token data and caching the applied value to skip redundant calls.
> - Text generation in [ClaudeTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/8409/files#diff-782736de45e734285d68cfe4a294d8a7d4ede95ff201d8ece36a89e0a020c576) merges the same setting into the Claude CLI settings JSON so commit-message and PR-content generation respect the selected window.
> - Behavioral Change: if `applyFlagSettings` fails mid-thread, the adapter logs and suppresses the error but leaves the cached setting unchanged, so the next turn retries the same setting rather than advancing to the new one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f9e869.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude session configuration and mid-turn SDK flag updates; incorrect env mapping could mis-report context limits or clash with user settings files, though failures are non-fatal on turn apply.
> 
> **Overview**
> **Claude 200k context window selections now take effect** instead of silently running at 1M. A new catalog helper maps manifest-resolved token counts to `CLAUDE_CODE_DISABLE_1M_CONTEXT` (`"1"` for ≤200k, `"0"` for larger known windows, omitted when the catalog has no token data).
> 
> **`ClaudeAdapter`** merges that `env` into initial SDK `settings` at session start and, on **`sendTurn`**, calls **`applyFlagSettings`** when the resolved window changes (before `setModel`), clears with `env: null` when appropriate, and refreshes **`lastKnownContextWindow`** so streaming usage is not clamped to the old limit after a mid-thread switch. Failures are logged without aborting the turn.
> 
> **`ClaudeTextGeneration`** adds the same `env` block to CLI `--settings` for commit/PR/title flows. Tests cover catalog resolution, adapter behavior (including custom-alias flows), and text generation args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f9e869144592694bfbb692b0bb2bf109e8670b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->