### PR TITLE
feat(grok): show Grok subagents in the Agents panel

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -19,6 +19,7 @@ const emitInterleavedAssistantToolCalls =
 const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHOLDERS === "1";
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
+const emitXAiSubagent = process.env.T3_ACP_EMIT_XAI_SUBAGENT === "1";
 const emitXAiExitPlanMode = process.env.T3_ACP_EMIT_XAI_EXIT_PLAN_MODE === "1";
 const emitXAiPlanMdWrite = process.env.T3_ACP_EMIT_XAI_PLAN_MD_WRITE === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
@@ -541,6 +542,44 @@ const program = Effect.gen(function* () {
 
       if (hangPromptForever || (hangFirstPromptForever && promptCount === 1)) {
         return yield* Effect.never;
+      }
+
+      if (emitXAiSubagent) {
+        writeJsonRpcNotification("_x.ai/session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "subagent_spawned",
+            subagent_id: "grok-subagent-1",
+            subagent_type: "explore",
+            description: "Search the codebase",
+            model: "grok-4.6",
+          },
+        });
+        writeJsonRpcNotification("_x.ai/session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "subagent_progress",
+            subagent_id: "grok-subagent-1",
+            subagent_type: "explore",
+            description: "Search the codebase",
+            status: "running",
+            last_tool_name: "grep",
+            tokens_used: 80,
+          },
+        });
+        writeJsonRpcNotification("_x.ai/session/update", {
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "subagent_finished",
+            subagent_id: "grok-subagent-1",
+            subagent_type: "explore",
+            description: "Search the codebase",
+            status: "completed",
+            output: "Found 3 call sites.",
+            tokens_used: 120,
+            duration_ms: 400,
+          },
+        });
       }
 
       if (emitXAiRateLimitThenHang) {

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -2085,4 +2085,57 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       // hang until the suite timeout instead of failing here.
     }).pipe(TestClock.withLive),
   );
+
+  it.effect("maps Grok ACP subagent notifications onto the Agents panel task stream", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-subagent-panel");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_EMIT_XAI_SUBAGENT: "1" }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const started =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "task.started" }>>();
+      const completed =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "task.completed" }>>();
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
+        if (String(event.threadId) !== String(threadId)) {
+          return Effect.void;
+        }
+        if (event.type === "task.started") {
+          return Deferred.succeed(started, event).pipe(Effect.ignore);
+        }
+        if (event.type === "task.completed") {
+          return Deferred.succeed(completed, event).pipe(Effect.ignore);
+        }
+        return Effect.void;
+      }).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "delegate the search",
+        attachments: [],
+      });
+
+      const startedEvent = yield* Deferred.await(started);
+      const completedEvent = yield* Deferred.await(completed);
+      assert.equal(startedEvent.payload.taskId, "grok-subagent-1");
+      assert.equal(startedEvent.payload.taskType, "subagent");
+      assert.equal(startedEvent.payload.role, "explore");
+      assert.equal(startedEvent.payload.title, "Search the codebase");
+      assert.equal(startedEvent.payload.timelineBypass, true);
+      assert.equal(startedEvent.raw?.method, "_x.ai/session/update");
+      assert.equal(completedEvent.payload.taskId, "grok-subagent-1");
+      assert.equal(completedEvent.payload.status, "completed");
+      assert.equal(completedEvent.payload.summary, "Found 3 call sites.");
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -566,6 +566,20 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       return ctx && turnId !== undefined ? signalTurnLiveness(ctx, turnId) : Effect.void;
     };
 
+    const refreshGrokSessionTurnLiveness = (ctx: GrokSessionContext) =>
+      Effect.gen(function* () {
+        const turnId = resolveNotificationTurnId(ctx);
+        if (turnId === undefined || ctx.livenessTurnId !== turnId) {
+          return;
+        }
+        // Subagent/workflow ticks prove the provider is still working even
+        // when the parent ACP stream is quiet. Stamp the watchdog clock
+        // before signalling; a wake without a fresh timestamp cancels a
+        // turn that has already sat near turnInactivityTimeoutMs.
+        ctx.lastTurnActivityAtNanos = yield* Clock.monotonicTimeNanos;
+        yield* signalTurnLiveness(ctx, turnId);
+      });
+
     const applyGrokSessionNotification = (
       ctx: GrokSessionContext,
       method: GrokSessionNotificationMethod,
@@ -582,7 +596,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             payload: params,
             specs: applied.events,
           });
-          yield* signalSessionTurnLiveness(ctx.threadId, resolveNotificationTurnId(ctx));
+          yield* refreshGrokSessionTurnLiveness(ctx);
           return;
         }
         const subagent = parseXAiSubagentUpdate(params);
@@ -597,7 +611,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           payload: params,
           specs: applied.events,
         });
-        yield* signalSessionTurnLiveness(ctx.threadId, resolveNotificationTurnId(ctx));
+        yield* refreshGrokSessionTurnLiveness(ctx);
       });
 
     const resumeSessionTurnLiveness = Effect.fn("GrokAdapter.resumeSessionTurnLiveness")(function* (

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -9,6 +9,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   RuntimeRequestId,
+  RuntimeTaskId,
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -67,6 +68,18 @@ import {
   normalizeGrokReasoningEffort,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
+import {
+  applyGrokSubagentUpdate,
+  applyGrokWorkflowUpdate,
+  emptyGrokSubagentTrackState,
+  GROK_SESSION_NOTIFICATION_METHODS,
+  parseXAiSubagentUpdate,
+  parseXAiWorkflowUpdated,
+  XAiSessionNotification,
+  type GrokSessionNotificationMethod,
+  type GrokSubagentTrackState,
+  type GrokTaskEventSpec,
+} from "../acp/GrokAcpSubagents.ts";
 import {
   extractGrokPlanMarkdownFromToolCallData,
   extractXAiAskUserQuestions,
@@ -162,6 +175,14 @@ interface GrokSessionContext {
   promptResponsesReady: number;
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
+  /**
+   * Grok `agent()` / workflow ACP extras mapped onto task.* so the Agents
+   * panel can list them the same way Claude Task and Codex collab children
+   * already do.
+   */
+  workflowTrack: GrokSubagentTrackState;
+  /** First-seen spawn turn per task, reused after the parent turn settles. */
+  readonly taskSpawnTurnIds: Map<string, TurnId>;
   stopped: boolean;
 }
 
@@ -399,6 +420,45 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
 
+    const emitGrokTaskSpecs = (input: {
+      readonly ctx: GrokSessionContext;
+      readonly method: string;
+      readonly payload: unknown;
+      readonly specs: ReadonlyArray<GrokTaskEventSpec>;
+    }) =>
+      Effect.forEach(
+        input.specs,
+        (spec) =>
+          Effect.gen(function* () {
+            const taskIdValue = spec.payload.taskId;
+            if (typeof taskIdValue !== "string" || taskIdValue.length === 0) {
+              return;
+            }
+            const taskId = RuntimeTaskId.make(taskIdValue);
+            let turnId = input.ctx.taskSpawnTurnIds.get(taskIdValue);
+            if (turnId === undefined) {
+              turnId = resolveNotificationTurnId(input.ctx);
+              if (turnId !== undefined) {
+                input.ctx.taskSpawnTurnIds.set(taskIdValue, turnId);
+              }
+            }
+            yield* offerRuntimeEvent({
+              type: spec.type,
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.ctx.threadId,
+              ...(turnId !== undefined ? { turnId } : {}),
+              payload: { ...spec.payload, taskId },
+              raw: {
+                source: "acp.grok.extension",
+                method: input.method,
+                payload: input.payload,
+              },
+            } as ProviderRuntimeEvent);
+          }),
+        { discard: true },
+      );
+
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
         const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
@@ -505,6 +565,40 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       const ctx = sessions.get(threadId);
       return ctx && turnId !== undefined ? signalTurnLiveness(ctx, turnId) : Effect.void;
     };
+
+    const applyGrokSessionNotification = (
+      ctx: GrokSessionContext,
+      method: GrokSessionNotificationMethod,
+      params: unknown,
+    ) =>
+      Effect.gen(function* () {
+        const workflow = parseXAiWorkflowUpdated(params);
+        if (workflow) {
+          const applied = applyGrokWorkflowUpdate(ctx.workflowTrack, workflow);
+          ctx.workflowTrack = applied.state;
+          yield* emitGrokTaskSpecs({
+            ctx,
+            method,
+            payload: params,
+            specs: applied.events,
+          });
+          yield* signalSessionTurnLiveness(ctx.threadId, resolveNotificationTurnId(ctx));
+          return;
+        }
+        const subagent = parseXAiSubagentUpdate(params);
+        if (!subagent) {
+          return;
+        }
+        const applied = applyGrokSubagentUpdate(ctx.workflowTrack, subagent);
+        ctx.workflowTrack = applied.state;
+        yield* emitGrokTaskSpecs({
+          ctx,
+          method,
+          payload: params,
+          specs: applied.events,
+        });
+        yield* signalSessionTurnLiveness(ctx.threadId, resolveNotificationTurnId(ctx));
+      });
 
     const resumeSessionTurnLiveness = Effect.fn("GrokAdapter.resumeSessionTurnLiveness")(function* (
       threadId: ThreadId,
@@ -1018,6 +1112,12 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 }),
             ),
           );
+          const pendingSessionNotifications: Array<{
+            readonly method: GrokSessionNotificationMethod;
+            readonly params: unknown;
+          }> = [];
+          let sessionNotificationsReady = false;
+          const sessionNotificationLock = yield* Semaphore.make(1);
           const started = yield* Effect.gen(function* () {
             yield* Effect.forEach(
               ["x.ai/ask_user_question", "_x.ai/ask_user_question"] as const,
@@ -1116,6 +1216,34 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         });
                       }
                       return makeXAiExitPlanModeCapturedResponse();
+                    }),
+                  ),
+                ),
+              { discard: true },
+            );
+            // Grok Build streams agent() / workflow runs over a private ACP
+            // channel. Claude maps Task/workflow_progress onto task.*; Codex
+            // maps collabAgent/* the same way. Keep that seam: parse here,
+            // emit canonical events, never a third Agents UI.
+            yield* Effect.forEach(
+              GROK_SESSION_NOTIFICATION_METHODS,
+              (method) =>
+                acp.handleExtNotification(method, XAiSessionNotification, (params) =>
+                  mapAcpCallbackFailure(
+                    Effect.gen(function* () {
+                      yield* logNative(input.threadId, method, params);
+                      if (!sessionNotificationsReady) {
+                        pendingSessionNotifications.push({ method, params });
+                        return;
+                      }
+                      const liveCtx = sessions.get(input.threadId);
+                      if (!liveCtx) {
+                        pendingSessionNotifications.push({ method, params });
+                        return;
+                      }
+                      yield* sessionNotificationLock.withPermit(
+                        applyGrokSessionNotification(liveCtx, method, params),
+                      );
                     }),
                   ),
                 ),
@@ -1290,6 +1418,8 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               requestedStartReasoningEffort !== undefined
                 ? normalizeGrokReasoningEffort(requestedStartReasoningEffort)
                 : currentStartReasoningEffort,
+            workflowTrack: emptyGrokSubagentTrackState(),
+            taskSpawnTurnIds: new Map(),
             stopped: false,
           };
 
@@ -1433,6 +1563,15 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           sessions.set(input.threadId, ctx);
           yield* runTurnLivenessWatchdog(ctx).pipe(Effect.forkIn(ctx.scope), Effect.asVoid);
           sessionScopeTransferred = true;
+          yield* sessionNotificationLock.withPermit(
+            Effect.gen(function* () {
+              const batch = pendingSessionNotifications.splice(0);
+              sessionNotificationsReady = true;
+              yield* Effect.forEach(batch, (pending) =>
+                applyGrokSessionNotification(ctx, pending.method, pending.params),
+              );
+            }),
+          );
 
           yield* offerRuntimeEvent({
             type: "session.started",

--- a/apps/server/src/provider/acp/GrokAcpSubagents.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSubagents.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  applyGrokSubagentUpdate,
+  applyGrokWorkflowUpdate,
+  emptyGrokSubagentTrackState,
+  grokWorkflowMemberTaskId,
+  parseXAiSubagentUpdate,
+  parseXAiWorkflowUpdated,
+} from "./GrokAcpSubagents.ts";
+
+describe("parseXAiSubagentUpdate", () => {
+  it("reads snake_case subagent_spawned envelopes", () => {
+    const parsed = parseXAiSubagentUpdate({
+      sessionId: "parent-session",
+      update: {
+        sessionUpdate: "subagent_spawned",
+        subagent_id: "child-1",
+        subagent_type: "explore",
+        description: "Search the codebase",
+        child_session_id: "child-session-1",
+        model: "grok-4.6",
+      },
+    });
+    expect(parsed).toEqual({
+      kind: "spawned",
+      subagentId: "child-1",
+      childSessionId: "child-session-1",
+      role: "explore",
+      description: "Search the codebase",
+      model: "grok-4.6",
+      status: undefined,
+      error: undefined,
+      tokensUsed: undefined,
+      durationMs: undefined,
+      turnCount: undefined,
+      toolCallCount: undefined,
+      lastToolName: undefined,
+      output: undefined,
+    });
+  });
+
+  it("accepts PascalCase tags and camelCase fields", () => {
+    const parsed = parseXAiSubagentUpdate({
+      sessionUpdate: "SubagentFinished",
+      subagentId: "child-2",
+      agentType: "plan",
+      status: "failed",
+      error: "depth limit",
+      tokensUsed: 12,
+      durationMs: 40,
+      toolCallCount: 3,
+    });
+    expect(parsed?.kind).toBe("finished");
+    expect(parsed?.subagentId).toBe("child-2");
+    expect(parsed?.role).toBe("plan");
+    expect(parsed?.error).toBe("depth limit");
+    expect(parsed?.tokensUsed).toBe(12);
+    expect(parsed?.toolCallCount).toBe(3);
+  });
+
+  it("ignores unrelated session extras", () => {
+    expect(
+      parseXAiSubagentUpdate({
+        update: { sessionUpdate: "auto_compact_started", tokens_used: 100 },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("applyGrokSubagentUpdate", () => {
+  it("maps spawn/progress/finish onto the shared child-task path", () => {
+    const spawned = applyGrokSubagentUpdate(emptyGrokSubagentTrackState(), {
+      kind: "spawned",
+      subagentId: "child-1",
+      childSessionId: "child-session",
+      role: "explore",
+      description: "Search the codebase",
+      model: "grok-4.6",
+      status: undefined,
+      error: undefined,
+      tokensUsed: undefined,
+      durationMs: undefined,
+      turnCount: undefined,
+      toolCallCount: undefined,
+      lastToolName: undefined,
+      output: undefined,
+    });
+    expect(spawned.events).toEqual([
+      {
+        type: "task.started",
+        payload: {
+          taskId: "child-1",
+          description: "Search the codebase",
+          title: "Search the codebase",
+          taskType: "subagent",
+          role: "explore",
+          model: "grok-4.6",
+          agentPath: "child-session",
+          timelineBypass: true,
+        },
+      },
+    ]);
+    expect(spawned.events[0]?.payload.parentAgentId).toBeUndefined();
+
+    const progressed = applyGrokSubagentUpdate(spawned.state, {
+      kind: "progress",
+      subagentId: "child-1",
+      childSessionId: "child-session",
+      role: "explore",
+      description: "Search the codebase",
+      model: "grok-4.6",
+      status: "running",
+      error: undefined,
+      tokensUsed: 80,
+      durationMs: 200,
+      turnCount: 1,
+      toolCallCount: 2,
+      lastToolName: "grep",
+      output: undefined,
+    });
+    expect(progressed.events).toHaveLength(1);
+    expect(progressed.events[0]).toMatchObject({
+      type: "task.progress",
+      payload: {
+        taskId: "child-1",
+        status: "running",
+        lastToolName: "grep",
+        typedUsage: { totalTokens: 80, durationMs: 200, toolUses: 2 },
+      },
+    });
+
+    const finished = applyGrokSubagentUpdate(progressed.state, {
+      kind: "finished",
+      subagentId: "child-1",
+      childSessionId: "child-session",
+      role: "explore",
+      description: "Search the codebase",
+      model: "grok-4.6",
+      status: "completed",
+      error: undefined,
+      tokensUsed: 120,
+      durationMs: 400,
+      turnCount: 2,
+      toolCallCount: 4,
+      lastToolName: undefined,
+      output: "Found 3 call sites.",
+    });
+    expect(finished.events).toEqual([
+      {
+        type: "task.completed",
+        payload: {
+          taskId: "child-1",
+          description: "Search the codebase",
+          title: "Search the codebase",
+          taskType: "subagent",
+          role: "explore",
+          model: "grok-4.6",
+          agentPath: "child-session",
+          timelineBypass: true,
+          status: "completed",
+          summary: "Found 3 call sites.",
+          typedUsage: { totalTokens: 120, durationMs: 400, toolUses: 4 },
+        },
+      },
+    ]);
+  });
+
+  it("does not treat the parent ACP session as a workflow coordinator", () => {
+    const parsed = parseXAiSubagentUpdate({
+      sessionId: "parent-session",
+      parent_session_id: "parent-session",
+      update: {
+        sessionUpdate: "subagent_spawned",
+        subagent_id: "child-1",
+        subagent_type: "explore",
+      },
+    });
+    expect(parsed).toBeDefined();
+    const applied = applyGrokSubagentUpdate(emptyGrokSubagentTrackState(), parsed!);
+    expect(applied.events[0]?.payload.parentAgentId).toBeUndefined();
+    expect(applied.events[0]?.payload.taskType).toBe("subagent");
+  });
+
+  it("completes a first-seen terminal subagent", () => {
+    const applied = applyGrokSubagentUpdate(emptyGrokSubagentTrackState(), {
+      kind: "finished",
+      subagentId: "late-1",
+      childSessionId: undefined,
+      role: "general-purpose",
+      description: undefined,
+      model: undefined,
+      status: "failed",
+      error: "cancelled by parent",
+      tokensUsed: 9,
+      durationMs: 30,
+      turnCount: undefined,
+      toolCallCount: undefined,
+      lastToolName: undefined,
+      output: undefined,
+    });
+    expect(applied.events.map((event) => event.type)).toEqual(["task.started", "task.completed"]);
+    expect(applied.events[1]?.payload).toMatchObject({
+      taskId: "late-1",
+      status: "failed",
+      summary: "cancelled by parent",
+    });
+  });
+
+  it("keeps the last token count when a later tick only reports tools", () => {
+    const spawned = applyGrokSubagentUpdate(emptyGrokSubagentTrackState(), {
+      kind: "spawned",
+      subagentId: "child-1",
+      childSessionId: undefined,
+      role: "explore",
+      description: undefined,
+      model: undefined,
+      status: undefined,
+      error: undefined,
+      tokensUsed: 50,
+      durationMs: undefined,
+      turnCount: undefined,
+      toolCallCount: undefined,
+      lastToolName: undefined,
+      output: undefined,
+    });
+    const progressed = applyGrokSubagentUpdate(spawned.state, {
+      kind: "progress",
+      subagentId: "child-1",
+      childSessionId: undefined,
+      role: "explore",
+      description: undefined,
+      model: undefined,
+      status: "running",
+      error: undefined,
+      tokensUsed: 50,
+      durationMs: undefined,
+      turnCount: undefined,
+      toolCallCount: undefined,
+      lastToolName: undefined,
+      output: undefined,
+    });
+    const toolOnly = applyGrokSubagentUpdate(progressed.state, {
+      kind: "progress",
+      subagentId: "child-1",
+      childSessionId: undefined,
+      role: "explore",
+      description: undefined,
+      model: undefined,
+      status: "running",
+      error: undefined,
+      tokensUsed: undefined,
+      durationMs: 900,
+      turnCount: undefined,
+      toolCallCount: 7,
+      lastToolName: "bash",
+      output: undefined,
+    });
+    expect(toolOnly.events[0]?.payload.typedUsage).toEqual({
+      totalTokens: 50,
+      durationMs: 900,
+      toolUses: 7,
+    });
+  });
+});
+
+describe("parseXAiWorkflowUpdated", () => {
+  it("reads a workflow_updated envelope", () => {
+    const parsed = parseXAiWorkflowUpdated({
+      update: {
+        sessionUpdate: "workflow_updated",
+        run_id: "run-1",
+        name: "review",
+        objective: "Review the PR",
+        status: "active",
+        current_phase: "review",
+        phases: [{ title: "review", state: "running" }],
+        agents: [
+          {
+            agent_id: "agent-a",
+            label: "Reviewer",
+            phase: "review",
+            model: "grok-4.6",
+            state: "running",
+            tokens_used: 20,
+            duration_ms: 100,
+          },
+        ],
+      },
+    });
+    expect(parsed?.runId).toBe("run-1");
+    expect(parsed?.agents).toHaveLength(1);
+    expect(parsed?.agents[0]?.agentId).toBe("agent-a");
+  });
+});
+
+describe("applyGrokWorkflowUpdate", () => {
+  it("stamps members with parentAgentId, timelineBypass, and a stable slot", () => {
+    const applied = applyGrokWorkflowUpdate(emptyGrokSubagentTrackState(), {
+      runId: "run-1",
+      revision: 1,
+      name: "review",
+      objective: "Review the PR",
+      status: "active",
+      phases: [{ title: "review", state: "running" }],
+      currentPhase: "review",
+      agentBudget: 4,
+      agentsUsed: 1,
+      elapsedMs: 100,
+      activeAgents: 1,
+      currentAgentLabel: "Reviewer",
+      agents: [
+        {
+          agentId: "agent-a",
+          label: "Reviewer",
+          phase: "review",
+          model: "grok-4.6",
+          state: "running",
+          tokensUsed: 20,
+          durationMs: 100,
+        },
+      ],
+      pauseMessage: undefined,
+      resultSummary: undefined,
+    });
+
+    expect(applied.events[0]).toMatchObject({
+      type: "task.started",
+      payload: {
+        taskId: "run-1",
+        taskType: "local_workflow",
+        workflowName: "review",
+      },
+    });
+    const memberStart = applied.events.find(
+      (event) =>
+        event.type === "task.started" &&
+        event.payload.taskId === grokWorkflowMemberTaskId("run-1", "agent-a"),
+    );
+    expect(memberStart?.payload).toMatchObject({
+      parentAgentId: "run-1",
+      timelineBypass: true,
+      taskType: "subagent",
+      title: "Reviewer",
+      model: "grok-4.6",
+    });
+  });
+
+  it("skips unchanged member ticks", () => {
+    const first = applyGrokWorkflowUpdate(emptyGrokSubagentTrackState(), {
+      runId: "run-1",
+      revision: 1,
+      name: "review",
+      objective: "Review the PR",
+      status: "active",
+      phases: [],
+      currentPhase: undefined,
+      agentBudget: undefined,
+      agentsUsed: undefined,
+      elapsedMs: undefined,
+      activeAgents: undefined,
+      currentAgentLabel: undefined,
+      agents: [
+        {
+          agentId: "agent-a",
+          label: "Reviewer",
+          phase: undefined,
+          model: undefined,
+          state: "running",
+          tokensUsed: 10,
+          durationMs: 50,
+        },
+      ],
+      pauseMessage: undefined,
+      resultSummary: undefined,
+    });
+    const second = applyGrokWorkflowUpdate(first.state, {
+      runId: "run-1",
+      revision: 2,
+      name: "review",
+      objective: "Review the PR",
+      status: "active",
+      phases: [],
+      currentPhase: undefined,
+      agentBudget: undefined,
+      agentsUsed: undefined,
+      elapsedMs: undefined,
+      activeAgents: undefined,
+      currentAgentLabel: undefined,
+      agents: [
+        {
+          agentId: "agent-a",
+          label: "Reviewer",
+          phase: undefined,
+          model: undefined,
+          state: "running",
+          tokensUsed: 10,
+          durationMs: 50,
+        },
+      ],
+      pauseMessage: undefined,
+      resultSummary: undefined,
+    });
+    expect(
+      second.events.filter(
+        (event) => event.payload.taskId === grokWorkflowMemberTaskId("run-1", "agent-a"),
+      ),
+    ).toHaveLength(0);
+  });
+});

--- a/apps/server/src/provider/acp/GrokAcpSubagents.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSubagents.test.ts
@@ -207,7 +207,7 @@ describe("applyGrokSubagentUpdate", () => {
     });
   });
 
-  it("keeps the last token count when a later tick only reports tools", () => {
+  it("keeps spawn-time token count when a later tick only reports tools", () => {
     const spawned = applyGrokSubagentUpdate(emptyGrokSubagentTrackState(), {
       kind: "spawned",
       subagentId: "child-1",
@@ -224,23 +224,7 @@ describe("applyGrokSubagentUpdate", () => {
       lastToolName: undefined,
       output: undefined,
     });
-    const progressed = applyGrokSubagentUpdate(spawned.state, {
-      kind: "progress",
-      subagentId: "child-1",
-      childSessionId: undefined,
-      role: "explore",
-      description: undefined,
-      model: undefined,
-      status: "running",
-      error: undefined,
-      tokensUsed: 50,
-      durationMs: undefined,
-      turnCount: undefined,
-      toolCallCount: undefined,
-      lastToolName: undefined,
-      output: undefined,
-    });
-    const toolOnly = applyGrokSubagentUpdate(progressed.state, {
+    const toolOnly = applyGrokSubagentUpdate(spawned.state, {
       kind: "progress",
       subagentId: "child-1",
       childSessionId: undefined,
@@ -406,5 +390,59 @@ describe("applyGrokWorkflowUpdate", () => {
         (event) => event.payload.taskId === grokWorkflowMemberTaskId("run-1", "agent-a"),
       ),
     ).toHaveLength(0);
+  });
+
+  it("emits member progress when wire state changes but mapped status does not", () => {
+    const member = {
+      agentId: "agent-a",
+      label: "Reviewer",
+      phase: undefined as string | undefined,
+      model: undefined as string | undefined,
+      tokensUsed: 10,
+      durationMs: 50,
+    };
+    const first = applyGrokWorkflowUpdate(emptyGrokSubagentTrackState(), {
+      runId: "run-1",
+      revision: 1,
+      name: "review",
+      objective: "Review the PR",
+      status: "active",
+      phases: [],
+      currentPhase: undefined,
+      agentBudget: undefined,
+      agentsUsed: undefined,
+      elapsedMs: undefined,
+      activeAgents: undefined,
+      currentAgentLabel: undefined,
+      agents: [{ ...member, state: "start" }],
+      pauseMessage: undefined,
+      resultSummary: undefined,
+    });
+    const second = applyGrokWorkflowUpdate(first.state, {
+      runId: "run-1",
+      revision: 2,
+      name: "review",
+      objective: "Review the PR",
+      status: "active",
+      phases: [],
+      currentPhase: undefined,
+      agentBudget: undefined,
+      agentsUsed: undefined,
+      elapsedMs: undefined,
+      activeAgents: undefined,
+      currentAgentLabel: undefined,
+      agents: [{ ...member, state: "running" }],
+      pauseMessage: undefined,
+      resultSummary: undefined,
+    });
+    const memberProgress = second.events.find(
+      (event) =>
+        event.type === "task.progress" &&
+        event.payload.taskId === grokWorkflowMemberTaskId("run-1", "agent-a"),
+    );
+    expect(memberProgress?.payload).toMatchObject({
+      status: "running",
+      summary: "running",
+    });
   });
 });

--- a/apps/server/src/provider/acp/GrokAcpSubagents.ts
+++ b/apps/server/src/provider/acp/GrokAcpSubagents.ts
@@ -1,0 +1,596 @@
+import type { RuntimeTaskStatus } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+/**
+ * Pure mapping of Grok Build x.ai session notifications onto T3's shared
+ * task.* surface. Claude stamps workflow members with parentAgentId +
+ * timelineBypass and a stable slot id; Codex does the same for collab
+ * children. Grok must not invent a third shape.
+ *
+ * Standalone `agent()` spawns are direct subagents: they must not set
+ * parentAgentId to the parent ACP session, or the Agents fold treats them
+ * as workflow members of a coordinator that does not exist.
+ */
+
+export const GROK_SESSION_NOTIFICATION_METHODS = [
+  "x.ai/session_notification",
+  "_x.ai/session_notification",
+  "x.ai/session/update",
+  "_x.ai/session/update",
+] as const;
+
+export type GrokSessionNotificationMethod = (typeof GROK_SESSION_NOTIFICATION_METHODS)[number];
+
+export const XAiSessionNotification = Schema.Unknown;
+export type XAiSessionNotification = typeof XAiSessionNotification.Type;
+
+export interface GrokWorkflowPhase {
+  readonly title: string;
+  readonly state: string;
+}
+
+export interface GrokWorkflowAgent {
+  readonly agentId: string;
+  readonly label: string;
+  readonly phase: string | undefined;
+  readonly model: string | undefined;
+  readonly state: string;
+  readonly tokensUsed: number;
+  readonly durationMs: number;
+}
+
+export interface GrokWorkflowUpdated {
+  readonly runId: string;
+  readonly revision: number;
+  readonly name: string;
+  readonly objective: string;
+  readonly status: string;
+  readonly phases: ReadonlyArray<GrokWorkflowPhase>;
+  readonly currentPhase: string | undefined;
+  readonly agentBudget: number | undefined;
+  readonly agentsUsed: number | undefined;
+  readonly elapsedMs: number | undefined;
+  readonly activeAgents: number | undefined;
+  readonly currentAgentLabel: string | undefined;
+  readonly agents: ReadonlyArray<GrokWorkflowAgent>;
+  readonly pauseMessage: string | undefined;
+  readonly resultSummary: string | undefined;
+}
+
+export interface GrokSubagentUpdate {
+  readonly kind: "spawned" | "progress" | "finished";
+  readonly subagentId: string;
+  readonly childSessionId: string | undefined;
+  readonly role: string | undefined;
+  readonly description: string | undefined;
+  readonly model: string | undefined;
+  readonly status: string | undefined;
+  readonly error: string | undefined;
+  readonly tokensUsed: number | undefined;
+  readonly durationMs: number | undefined;
+  readonly turnCount: number | undefined;
+  readonly toolCallCount: number | undefined;
+  readonly lastToolName: string | undefined;
+  readonly output: string | undefined;
+}
+
+export interface GrokTypedUsageSnapshot {
+  readonly totalTokens: number;
+  readonly durationMs?: number;
+  readonly toolUses?: number;
+}
+
+export interface GrokSubagentTrackState {
+  readonly seenRunIds: ReadonlySet<string>;
+  readonly completedRunIds: ReadonlySet<string>;
+  readonly seenMemberIds: ReadonlySet<string>;
+  readonly completedMemberIds: ReadonlySet<string>;
+  readonly memberFingerprints: ReadonlyMap<string, string>;
+  readonly seenSubagentIds: ReadonlySet<string>;
+  readonly completedSubagentIds: ReadonlySet<string>;
+  /** Last published usage per task id so a tool-only tick cannot zero tokens. */
+  readonly usageByTaskId: ReadonlyMap<string, GrokTypedUsageSnapshot>;
+}
+
+export function emptyGrokSubagentTrackState(): GrokSubagentTrackState {
+  return {
+    seenRunIds: new Set(),
+    completedRunIds: new Set(),
+    seenMemberIds: new Set(),
+    completedMemberIds: new Set(),
+    memberFingerprints: new Map(),
+    seenSubagentIds: new Set(),
+    completedSubagentIds: new Set(),
+    usageByTaskId: new Map(),
+  };
+}
+
+export interface GrokTaskEventSpec {
+  readonly type: "task.started" | "task.progress" | "task.completed";
+  readonly payload: Record<string, unknown>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function nonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.trunc(value);
+}
+
+function sessionUpdateTag(update: Record<string, unknown>): string | undefined {
+  return readString(update.sessionUpdate) ?? readString(update.session_update);
+}
+
+function unwrapSessionUpdate(payload: unknown): Record<string, unknown> | undefined {
+  const envelope = asRecord(payload);
+  if (!envelope) {
+    return undefined;
+  }
+  const nestedParams = asRecord(envelope.params);
+  return asRecord(envelope.update) ?? asRecord(nestedParams?.update) ?? envelope;
+}
+
+export function parseXAiWorkflowUpdated(payload: unknown): GrokWorkflowUpdated | undefined {
+  const update = unwrapSessionUpdate(payload);
+  if (!update) {
+    return undefined;
+  }
+  const tag = sessionUpdateTag(update);
+  if (tag !== undefined && tag !== "workflow_updated" && tag !== "WorkflowUpdated") {
+    return undefined;
+  }
+  const runId = readString(update.run_id) ?? readString(update.runId);
+  const name = readString(update.name);
+  if (runId === undefined || name === undefined) {
+    return undefined;
+  }
+  if (
+    tag === undefined &&
+    (readString(update.status) === undefined || !Array.isArray(update.phases))
+  ) {
+    return undefined;
+  }
+  const phases = Array.isArray(update.phases)
+    ? update.phases.flatMap((entry): ReadonlyArray<GrokWorkflowPhase> => {
+        const record = asRecord(entry);
+        const title = readString(record?.title);
+        const state = readString(record?.state);
+        return title && state ? [{ title, state }] : [];
+      })
+    : [];
+  const agents = Array.isArray(update.agents)
+    ? update.agents.flatMap((entry): ReadonlyArray<GrokWorkflowAgent> => {
+        const record = asRecord(entry);
+        const agentId = readString(record?.agent_id) ?? readString(record?.agentId);
+        const state = readString(record?.state);
+        if (agentId === undefined || state === undefined) {
+          return [];
+        }
+        return [
+          {
+            agentId,
+            label: readString(record?.label) ?? agentId,
+            phase: readString(record?.phase),
+            model: readString(record?.model),
+            state,
+            tokensUsed: nonNegativeInt(record?.tokens_used ?? record?.tokensUsed) ?? 0,
+            durationMs: nonNegativeInt(record?.duration_ms ?? record?.durationMs) ?? 0,
+          },
+        ];
+      })
+    : [];
+  return {
+    runId,
+    revision: nonNegativeInt(update.revision) ?? 0,
+    name,
+    objective: readString(update.objective) ?? "",
+    status: readString(update.status) ?? "active",
+    phases,
+    currentPhase: readString(update.current_phase) ?? readString(update.currentPhase),
+    agentBudget: nonNegativeInt(update.agent_budget ?? update.agentBudget),
+    agentsUsed: nonNegativeInt(update.agents_used ?? update.agentsUsed),
+    elapsedMs: nonNegativeInt(update.elapsed_ms ?? update.elapsedMs),
+    activeAgents: nonNegativeInt(update.active_agents ?? update.activeAgents),
+    currentAgentLabel:
+      readString(update.current_agent_label) ?? readString(update.currentAgentLabel),
+    agents,
+    pauseMessage: readString(update.pause_message) ?? readString(update.pauseMessage),
+    resultSummary: readString(update.result_summary) ?? readString(update.resultSummary),
+  };
+}
+
+export function parseXAiSubagentUpdate(payload: unknown): GrokSubagentUpdate | undefined {
+  const update = unwrapSessionUpdate(payload);
+  if (!update) {
+    return undefined;
+  }
+  const tag = sessionUpdateTag(update);
+  const kind =
+    tag === "subagent_spawned" || tag === "SubagentSpawned"
+      ? "spawned"
+      : tag === "subagent_progress" || tag === "SubagentProgress"
+        ? "progress"
+        : tag === "subagent_finished" || tag === "SubagentFinished"
+          ? "finished"
+          : undefined;
+  if (kind === undefined) {
+    return undefined;
+  }
+  const subagentId = readString(update.subagent_id) ?? readString(update.subagentId);
+  if (subagentId === undefined) {
+    return undefined;
+  }
+  return {
+    kind,
+    subagentId,
+    childSessionId: readString(update.child_session_id) ?? readString(update.childSessionId),
+    role:
+      readString(update.subagent_type) ??
+      readString(update.subagentType) ??
+      readString(update.agent_type) ??
+      readString(update.agentType) ??
+      readString(update.role),
+    description:
+      readString(update.description) ?? readString(update.label) ?? readString(update.title),
+    model: readString(update.model),
+    status: readString(update.status),
+    error: readString(update.error),
+    tokensUsed: nonNegativeInt(update.tokens_used ?? update.tokensUsed),
+    durationMs: nonNegativeInt(update.duration_ms ?? update.durationMs),
+    turnCount: nonNegativeInt(update.turn_count ?? update.turnCount ?? update.turns),
+    toolCallCount: nonNegativeInt(
+      update.tool_call_count ?? update.toolCallCount ?? update.tool_calls ?? update.toolCalls,
+    ),
+    lastToolName:
+      readString(update.last_tool_name) ??
+      readString(update.lastToolName) ??
+      readString(update.tool_name) ??
+      readString(update.toolName),
+    output: readString(update.output) ?? readString(update.summary),
+  };
+}
+
+export function grokWorkflowRunStatus(status: string): RuntimeTaskStatus {
+  switch (status) {
+    case "active":
+      return "running";
+    case "complete":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "cancelled":
+    case "interrupted":
+    case "cleared":
+      return "cancelled";
+    default:
+      return "idle";
+  }
+}
+
+export function grokWorkflowAgentStatus(state: string): RuntimeTaskStatus {
+  switch (state) {
+    case "queued":
+    case "pending":
+      return "pending";
+    case "running":
+    case "start":
+      return "running";
+    case "done":
+    case "completed":
+      return "completed";
+    case "failed":
+    case "error":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "running";
+  }
+}
+
+export function grokWorkflowRunIsTerminal(status: string): boolean {
+  return (
+    status === "complete" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "interrupted" ||
+    status === "cleared"
+  );
+}
+
+export function grokWorkflowAgentIsTerminal(state: string): boolean {
+  return (
+    state === "done" ||
+    state === "completed" ||
+    state === "failed" ||
+    state === "error" ||
+    state === "cancelled"
+  );
+}
+
+export function grokWorkflowMemberTaskId(runId: string, agentId: string): string {
+  return `${runId}:wf:${agentId}`;
+}
+
+function memberFingerprint(agent: GrokWorkflowAgent, status: RuntimeTaskStatus): string {
+  return [
+    status,
+    agent.label,
+    agent.model ?? "",
+    agent.phase ?? "",
+    agent.tokensUsed,
+    agent.durationMs,
+  ].join("\u001f");
+}
+
+function runCompletedStatus(status: string): "completed" | "failed" | "stopped" {
+  if (status === "failed") return "failed";
+  if (status === "complete") return "completed";
+  return "stopped";
+}
+
+function agentCompletedStatus(state: string): "completed" | "failed" | "stopped" {
+  if (state === "failed" || state === "error") return "failed";
+  if (state === "cancelled") return "stopped";
+  return "completed";
+}
+
+function mergeTypedUsageFromCounts(
+  input: {
+    readonly tokensUsed?: number | undefined;
+    readonly durationMs?: number | undefined;
+    readonly toolCallCount?: number | undefined;
+  },
+  previous: GrokTypedUsageSnapshot | undefined,
+): GrokTypedUsageSnapshot | undefined {
+  if (
+    input.tokensUsed === undefined &&
+    input.durationMs === undefined &&
+    input.toolCallCount === undefined
+  ) {
+    return previous;
+  }
+  // RuntimeTaskUsage requires totalTokens. A later tool/duration-only tick
+  // must reuse the last known count; `?? 0` would replace the task-usage row.
+  const durationMs = input.durationMs ?? previous?.durationMs;
+  const toolUses = input.toolCallCount ?? previous?.toolUses;
+  return {
+    totalTokens: input.tokensUsed ?? previous?.totalTokens ?? 0,
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(toolUses !== undefined ? { toolUses } : {}),
+  };
+}
+
+function subagentTitle(update: GrokSubagentUpdate): string {
+  return update.description ?? update.role ?? update.subagentId;
+}
+
+export function applyGrokWorkflowUpdate(
+  state: GrokSubagentTrackState,
+  update: GrokWorkflowUpdated,
+): { readonly state: GrokSubagentTrackState; readonly events: ReadonlyArray<GrokTaskEventSpec> } {
+  const seenRunIds = new Set(state.seenRunIds);
+  const completedRunIds = new Set(state.completedRunIds);
+  const seenMemberIds = new Set(state.seenMemberIds);
+  const completedMemberIds = new Set(state.completedMemberIds);
+  const memberFingerprints = new Map(state.memberFingerprints);
+  const usageByTaskId = new Map(state.usageByTaskId);
+  const events: Array<GrokTaskEventSpec> = [];
+
+  const phases = update.phases.map((phase, index) => ({ index, title: phase.title }));
+  const currentPhaseIndex = update.currentPhase
+    ? update.phases.findIndex((phase) => phase.title === update.currentPhase)
+    : -1;
+  const runStatus = grokWorkflowRunStatus(update.status);
+  const runSeen = seenRunIds.has(update.runId);
+  if (!runSeen) {
+    seenRunIds.add(update.runId);
+    events.push({
+      type: "task.started",
+      payload: {
+        taskId: update.runId,
+        description: update.objective || update.name,
+        taskType: "local_workflow",
+        workflowName: update.name,
+        title: update.name,
+        ...(phases.length > 0 ? { phases } : {}),
+        ...(currentPhaseIndex >= 0 ? { phaseIndex: currentPhaseIndex } : {}),
+        ...(update.currentPhase ? { phaseTitle: update.currentPhase } : {}),
+        runHandles: { runId: update.runId },
+      },
+    });
+  } else if (!completedRunIds.has(update.runId)) {
+    events.push({
+      type: "task.progress",
+      payload: {
+        taskId: update.runId,
+        description: update.objective || update.name,
+        summary: update.currentAgentLabel ?? update.currentPhase ?? update.status,
+        status: runStatus,
+        taskType: "local_workflow",
+        workflowName: update.name,
+        title: update.name,
+        ...(phases.length > 0 ? { phases } : {}),
+        ...(currentPhaseIndex >= 0 ? { phaseIndex: currentPhaseIndex } : {}),
+        ...(update.currentPhase ? { phaseTitle: update.currentPhase } : {}),
+        runHandles: { runId: update.runId },
+      },
+    });
+  }
+
+  if (grokWorkflowRunIsTerminal(update.status) && !completedRunIds.has(update.runId)) {
+    completedRunIds.add(update.runId);
+    events.push({
+      type: "task.completed",
+      payload: {
+        taskId: update.runId,
+        status: runCompletedStatus(update.status),
+        summary: update.resultSummary ?? update.pauseMessage ?? update.status,
+        taskType: "local_workflow",
+        workflowName: update.name,
+        title: update.name,
+        ...(phases.length > 0 ? { phases } : {}),
+        runHandles: { runId: update.runId },
+      },
+    });
+  }
+
+  for (const [agentIndex, agent] of update.agents.entries()) {
+    const memberId = grokWorkflowMemberTaskId(update.runId, agent.agentId);
+    const status = grokWorkflowAgentStatus(agent.state);
+    const fingerprint = memberFingerprint(agent, status);
+    if (memberFingerprints.get(memberId) === fingerprint) {
+      continue;
+    }
+    memberFingerprints.set(memberId, fingerprint);
+    const memberSeen = seenMemberIds.has(memberId);
+    const linkage = {
+      taskId: memberId,
+      description: agent.label,
+      taskType: "subagent",
+      parentAgentId: update.runId,
+      title: agent.label,
+      workflowName: update.name,
+      ...(agent.model ? { model: agent.model } : {}),
+      ...(agent.phase ? { phaseTitle: agent.phase } : {}),
+      agentIndex,
+      timelineBypass: true,
+    };
+    if (!memberSeen) {
+      seenMemberIds.add(memberId);
+      events.push({ type: "task.started", payload: linkage });
+    }
+    const typedUsage = mergeTypedUsageFromCounts(
+      {
+        tokensUsed: agent.tokensUsed > 0 ? agent.tokensUsed : undefined,
+        durationMs: agent.durationMs > 0 ? agent.durationMs : undefined,
+      },
+      usageByTaskId.get(memberId),
+    );
+    if (typedUsage) {
+      usageByTaskId.set(memberId, typedUsage);
+    }
+    events.push({
+      type: "task.progress",
+      payload: {
+        ...linkage,
+        summary: agent.state,
+        status,
+        ...(typedUsage ? { typedUsage } : {}),
+      },
+    });
+    if (grokWorkflowAgentIsTerminal(agent.state) && !completedMemberIds.has(memberId)) {
+      completedMemberIds.add(memberId);
+      events.push({
+        type: "task.completed",
+        payload: {
+          ...linkage,
+          status: agentCompletedStatus(agent.state),
+          summary: agent.label,
+          ...(typedUsage ? { typedUsage } : {}),
+        },
+      });
+    }
+  }
+
+  return {
+    state: {
+      ...state,
+      seenRunIds,
+      completedRunIds,
+      seenMemberIds,
+      completedMemberIds,
+      memberFingerprints,
+      usageByTaskId,
+    },
+    events,
+  };
+}
+
+export function applyGrokSubagentUpdate(
+  state: GrokSubagentTrackState,
+  update: GrokSubagentUpdate,
+): { readonly state: GrokSubagentTrackState; readonly events: ReadonlyArray<GrokTaskEventSpec> } {
+  const seenSubagentIds = new Set(state.seenSubagentIds);
+  const completedSubagentIds = new Set(state.completedSubagentIds);
+  const usageByTaskId = new Map(state.usageByTaskId);
+  const events: Array<GrokTaskEventSpec> = [];
+  const title = subagentTitle(update);
+  const linkage = {
+    taskId: update.subagentId,
+    description: title,
+    title,
+    taskType: "subagent",
+    role: update.role ?? "general-purpose",
+    ...(update.model ? { model: update.model } : {}),
+    ...(update.childSessionId ? { agentPath: update.childSessionId } : {}),
+    timelineBypass: true,
+  };
+
+  if (update.kind === "spawned" && !seenSubagentIds.has(update.subagentId)) {
+    seenSubagentIds.add(update.subagentId);
+    events.push({ type: "task.started", payload: linkage });
+  } else if (update.kind === "progress") {
+    if (!seenSubagentIds.has(update.subagentId)) {
+      seenSubagentIds.add(update.subagentId);
+      events.push({ type: "task.started", payload: linkage });
+    }
+    if (!completedSubagentIds.has(update.subagentId)) {
+      const typedUsage = mergeTypedUsageFromCounts(update, usageByTaskId.get(update.subagentId));
+      if (typedUsage) {
+        usageByTaskId.set(update.subagentId, typedUsage);
+      }
+      events.push({
+        type: "task.progress",
+        payload: {
+          ...linkage,
+          status: "running",
+          summary: update.lastToolName ?? update.status ?? update.role ?? "running",
+          ...(update.lastToolName ? { lastToolName: update.lastToolName } : {}),
+          ...(typedUsage ? { typedUsage } : {}),
+        },
+      });
+    }
+  } else if (update.kind === "finished" && !completedSubagentIds.has(update.subagentId)) {
+    if (!seenSubagentIds.has(update.subagentId)) {
+      seenSubagentIds.add(update.subagentId);
+      events.push({ type: "task.started", payload: linkage });
+    }
+    completedSubagentIds.add(update.subagentId);
+    const finished = update.status ?? "completed";
+    const typedUsage = mergeTypedUsageFromCounts(update, usageByTaskId.get(update.subagentId));
+    if (typedUsage) {
+      usageByTaskId.set(update.subagentId, typedUsage);
+    }
+    events.push({
+      type: "task.completed",
+      payload: {
+        ...linkage,
+        status:
+          finished === "failed" ? "failed" : finished === "cancelled" ? "stopped" : "completed",
+        summary: update.error ?? update.output ?? finished,
+        ...(typedUsage ? { typedUsage } : {}),
+      },
+    });
+  }
+
+  return {
+    state: {
+      ...state,
+      seenSubagentIds,
+      completedSubagentIds,
+      usageByTaskId,
+    },
+    events,
+  };
+}

--- a/apps/server/src/provider/acp/GrokAcpSubagents.ts
+++ b/apps/server/src/provider/acp/GrokAcpSubagents.ts
@@ -325,6 +325,7 @@ export function grokWorkflowMemberTaskId(runId: string, agentId: string): string
 function memberFingerprint(agent: GrokWorkflowAgent, status: RuntimeTaskStatus): string {
   return [
     status,
+    agent.state,
     agent.label,
     agent.model ?? "",
     agent.phase ?? "",
@@ -526,6 +527,10 @@ export function applyGrokSubagentUpdate(
   const usageByTaskId = new Map(state.usageByTaskId);
   const events: Array<GrokTaskEventSpec> = [];
   const title = subagentTitle(update);
+  const typedUsage = mergeTypedUsageFromCounts(update, usageByTaskId.get(update.subagentId));
+  if (typedUsage) {
+    usageByTaskId.set(update.subagentId, typedUsage);
+  }
   const linkage = {
     taskId: update.subagentId,
     description: title,
@@ -546,10 +551,6 @@ export function applyGrokSubagentUpdate(
       events.push({ type: "task.started", payload: linkage });
     }
     if (!completedSubagentIds.has(update.subagentId)) {
-      const typedUsage = mergeTypedUsageFromCounts(update, usageByTaskId.get(update.subagentId));
-      if (typedUsage) {
-        usageByTaskId.set(update.subagentId, typedUsage);
-      }
       events.push({
         type: "task.progress",
         payload: {
@@ -568,10 +569,6 @@ export function applyGrokSubagentUpdate(
     }
     completedSubagentIds.add(update.subagentId);
     const finished = update.status ?? "completed";
-    const typedUsage = mergeTypedUsageFromCounts(update, usageByTaskId.get(update.subagentId));
-    if (typedUsage) {
-      usageByTaskId.set(update.subagentId, typedUsage);
-    }
     events.push({
       type: "task.completed",
       payload: {

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -39,6 +39,11 @@ directory to route session and turn operations for a thread, so callers name a t
 Adding a driver means writing the driver plus adapter and adding it to `BUILT_IN_DRIVERS`. No
 orchestration, contract, or client change is required for the common case.
 
+Grok Build streams `agent()` children and workflow runs over private ACP methods
+(`x.ai/session_notification` / `_x.ai/session/update`). [`GrokAdapter.ts`][grok-adapter] maps those
+onto the same `task.started` / `task.progress` / `task.completed` events Claude Task and Codex
+collab children already emit, so the Agents panel lists Grok subagents without a third UI.
+
 ## Model manifest
 
 The model picker's legacy section is driven by `apps/server/src/provider/model-manifest.json`, which
@@ -92,6 +97,7 @@ when a request opens (approval) or user input is requested, via
 [claude]: ../../apps/server/src/provider/Drivers/ClaudeDriver.ts
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts
+[grok-adapter]: ../../apps/server/src/provider/Layers/GrokAdapter.ts
 [opencode]: ../../apps/server/src/provider/Drivers/OpenCodeDriver.ts
 [adapter]: ../../apps/server/src/provider/Services/ProviderAdapter.ts
 [instances]: ../../apps/server/src/provider/Services/ProviderInstanceRegistry.ts


### PR DESCRIPTION
## Problem

Claude Task and Codex collab children already emit `task.*` events that the right-hand Agents panel folds into a live roster. Grok Build streams the same child work over ACP (`subagent_spawned` / `subagent_progress` / `subagent_finished`, plus `workflow_updated`), but T3 dropped those notifications. Grok threads showed an empty Agents panel.

## Fix

Map Grok's x.ai session notifications onto the existing `task.started` / `task.progress` / `task.completed` path. Complexity stays at the adapter.

- Standalone `agent()` children become `taskType: "subagent"` rows with `timelineBypass`, so they list in the Agents panel like Claude Task.
- Workflow members use Claude/Codex linkage: `parentAgentId` + `timelineBypass` + a stable `:wf:` slot. The parent ACP session id is **not** used as `parentAgentId` (that would mis-classify a direct spawn as a workflow member).
- First-seen terminal updates still emit `task.started` then `task.completed`. Unchanged member ticks are fingerprinted and skipped. Child tokens stay on `typedUsage`.
- No new UI, contracts, or usage/rewind work. Web, desktop, and mobile already render this stream through `client-runtime`.

## Tests

`vp test run apps/server/src/provider/acp/GrokAcpSubagents.test.ts apps/server/src/provider/Layers/GrokAdapter.test.ts` — 48 passed.

Made with Grok 4.6.

Closes #9892

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Non-trivial Grok adapter changes (notification buffering, semaphore ordering, and turn-liveness interaction) could drop or mis-time events at session startup, though scope stays within existing task.* ingestion with no contract or auth changes.
> 
> **Overview**
> Grok Build child work (`subagent_*` and `workflow_updated`) was invisible in the Agents panel because those private ACP notifications were never translated into the shared **`task.*`** runtime events Claude Task and Codex collab already use.
> 
> This PR adds **`GrokAcpSubagents`** to parse flexible x.ai envelopes and emit **`task.started` / `task.progress` / `task.completed`** with the same linkage rules as other drivers: standalone **`agent()`** rows as **`subagent`** with **`timelineBypass`** (no fake **`parentAgentId`**), workflow members under a **`local_workflow`** parent with stable **`runId:wf:agentId`** slots. **`GrokAdapter`** registers four notification methods, **queues early notifications** until the session context exists, then flushes them under a lock and **refreshes turn liveness** when subagent ticks arrive so long quiet parent streams do not stall the watchdog.
> 
> The ACP mock agent can emit a sample subagent lifecycle when **`T3_ACP_EMIT_XAI_SUBAGENT=1`**; unit and adapter tests cover parsing, dedupe, and end-to-end streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468a4bf72a284c9a72ca25a2896c8c02cb452042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Grok subagents in the Agents panel by mapping session notifications to `task.*` events
> - GrokAdapter now listens to `_x.ai/session/update` notifications and parses them as workflow or subagent updates via [GrokAcpSubagents.ts](https://github.com/pingdotgg/t3code/pull/8412/files#diff-fda0f02be964d80f2a1c46ad9fed13f99dd748d937a7bb1534b8350f70f73c1d), emitting canonical `task.started`/`task.progress`/`task.completed` events with stable `RuntimeTaskId`s
> - Added buffering for early session notifications so they replay after session start, and notifications now refresh turn liveness to avoid inadvertent watchdog timeouts
> - Added a mock flag `T3_ACP_EMIT_XAI_SUBAGENT` in [acp-mock-agent.ts](https://github.com/pingdotgg/t3code/pull/8412/files#diff-8a006152e281284d31dee6c6726df790c3c486b6899a0746f334a8d0663fabc7) to simulate subagent lifecycle notifications for testing
> - Documented the mapping in [providers.md](https://github.com/pingdotgg/t3code/pull/8412/files#diff-3d909027abc31a863f0c0e5ecef5aa50ac285620ad827db723eb0a4ac46d3f85)
> - Risk: early notifications are queued via `pending` + readiness flag in `GrokSessionContext`; if the session-start handshake does not flip the readiness flag, buffered workflow/subagent events may be dropped silently
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 468a4bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->