### PR TITLE
fix(desktop): support OAuth popups in browser previews

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -40,7 +40,7 @@ describe("preview IPC methods", () => {
   effectIt.effect("rejects invalid webContents ids before resolving the preview service", () =>
     Effect.map(
       PreviewIpc.registerWebview
-        .handler({ tabId: "tab-1", webContentsId: 0 })
+        .handler({ tabId: "tab-1", webContentsId: 0, initialUrl: null })
         .pipe(Effect.provideService(PreviewManager.PreviewManager, null as never), Effect.exit),
       (exit) => {
         expect(Exit.isFailure(exit)).toBe(true);

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -76,9 +76,13 @@ export const registerWebview = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL,
   payload: DesktopPreviewRegisterWebviewInputSchema,
   result: Schema.Void,
-  handler: Effect.fn("desktop.ipc.preview.registerWebview")(function* ({ tabId, webContentsId }) {
+  handler: Effect.fn("desktop.ipc.preview.registerWebview")(function* ({
+    tabId,
+    webContentsId,
+    initialUrl,
+  }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.registerWebview(tabId, webContentsId);
+    yield* manager.registerWebview(tabId, webContentsId, initialUrl);
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -172,8 +172,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
         colorScheme: defaults?.colorScheme,
       }),
     closeTab: (tabId) => ipcRenderer.invoke(IpcChannels.PREVIEW_CLOSE_TAB_CHANNEL, { tabId }),
-    registerWebview: (tabId, webContentsId) =>
-      ipcRenderer.invoke(IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL, { tabId, webContentsId }),
+    registerWebview: (tabId, webContentsId, initialUrl) =>
+      ipcRenderer.invoke(IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL, {
+        tabId,
+        webContentsId,
+        initialUrl,
+      }),
     navigate: (tabId, url) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_NAVIGATE_CHANNEL, { tabId, url }),
     goBack: (tabId) => ipcRenderer.invoke(IpcChannels.PREVIEW_GO_BACK_CHANNEL, { tabId }),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -60,6 +60,7 @@ describe("isPreviewRefreshShortcut", () => {
 
 const {
   browserWindowConstructor,
+  browserWindowFromWebContents,
   createFromPath,
   fromId,
   getFocusedWebContents,
@@ -70,6 +71,9 @@ const {
   writeImage,
 } = vi.hoisted(() => ({
   browserWindowConstructor: vi.fn(),
+  browserWindowFromWebContents: vi.fn<
+    (webContents: Electron.WebContents) => Electron.BrowserWindow | null
+  >(() => null),
   createFromPath: vi.fn((): { readonly isEmpty: () => boolean } => ({ isEmpty: () => false })),
   fromId: vi.fn((_id?: number) => null),
   getFocusedWebContents: vi.fn(() => null),
@@ -81,7 +85,9 @@ const {
 }));
 
 vi.mock("electron", () => ({
-  BrowserWindow: browserWindowConstructor,
+  BrowserWindow: Object.assign(browserWindowConstructor, {
+    fromWebContents: browserWindowFromWebContents,
+  }),
   clipboard: {
     writeImage,
   },
@@ -200,6 +206,7 @@ const makeSourcePng = (width = 1, height = 1): Buffer => {
 
 const makeFaviconWebContents = (options?: {
   readonly fetch?: (url: string, init?: RequestInit) => Promise<Response>;
+  readonly hostWebContents?: Electron.WebContents | null;
   readonly id?: number;
   readonly rasterize?: (code: string) => Promise<unknown>;
   readonly url?: string;
@@ -226,6 +233,11 @@ const makeFaviconWebContents = (options?: {
   });
   const off = vi.fn();
   const debuggerOff = vi.fn();
+  const session = { fetch };
+  const setWindowOpenHandler =
+    vi.fn<
+      (handler: (details: Electron.HandlerDetails) => Electron.WindowOpenHandlerResponse) => void
+    >();
   const webContents = {
     id: options?.id ?? 42,
     isDestroyed: () => destroyed,
@@ -235,6 +247,7 @@ const makeFaviconWebContents = (options?: {
     isLoading: () => loading,
     isDevToolsOpened: () => false,
     getZoomFactor: () => 1,
+    hostWebContents: options?.hostWebContents ?? null,
     setZoomFactor: vi.fn(),
     setAudioMuted: vi.fn(),
     isCurrentlyAudible: () => false,
@@ -247,9 +260,9 @@ const makeFaviconWebContents = (options?: {
     off,
     ipc: { on: vi.fn(), off: vi.fn() },
     send: webviewSend,
-    session: { fetch },
+    session,
     navigationHistory: { canGoBack: () => false, canGoForward: () => false },
-    setWindowOpenHandler: vi.fn(),
+    setWindowOpenHandler,
     executeJavaScriptInIsolatedWorld,
     debugger: {
       isAttached: () => false,
@@ -267,6 +280,8 @@ const makeFaviconWebContents = (options?: {
     loadURL,
     off,
     reload,
+    session,
+    setWindowOpenHandler,
     setDestroyed: (value: boolean) => {
       destroyed = value;
     },
@@ -285,6 +300,14 @@ const settle = function* (until: () => boolean) {
     yield* Effect.promise(() => Promise.resolve());
   }
 };
+
+const windowOpenDetails = (url: string): Electron.HandlerDetails => ({
+  url,
+  frameName: "oauth",
+  features: "width=500,height=600",
+  disposition: "new-window",
+  referrer: { url: "http://localhost:3200/", policy: "strict-origin-when-cross-origin" },
+});
 
 const makeTestPictureInPictureWindow = (loadURL: () => Promise<void> = async () => undefined) => {
   const listeners = new Map<string, () => void>();
@@ -319,6 +342,8 @@ const makeTestPictureInPictureWindow = (loadURL: () => Promise<void> = async () 
 describe("PreviewManager", () => {
   beforeEach(() => {
     browserWindowConstructor.mockReset();
+    browserWindowFromWebContents.mockReset();
+    browserWindowFromWebContents.mockReturnValue(null);
     fromId.mockClear();
     getFocusedWebContents.mockReset();
     getFocusedWebContents.mockReturnValue(null);
@@ -329,6 +354,113 @@ describe("PreviewManager", () => {
     createFromPath.mockClear();
     webviewSend.mockClear();
   });
+
+  effectIt.effect("allows an OAuth popup without navigating the opener", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const hostWebContents = {} as Electron.WebContents;
+        const parent = { isDestroyed: () => false } as Electron.BrowserWindow;
+        const preview = makeFaviconWebContents({ hostWebContents });
+        browserWindowFromWebContents.mockReturnValue(parent);
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_popup");
+        yield* manager.registerWebview("tab_popup", 42);
+
+        const handler = preview.setWindowOpenHandler.mock.calls[0]?.[0];
+        expect(handler).toBeDefined();
+        if (!handler) return;
+
+        const expected = {
+          action: "allow",
+          outlivesOpener: false,
+          overrideBrowserWindowOptions: {
+            parent,
+            autoHideMenuBar: true,
+            webPreferences: {
+              session: preview.session,
+              sandbox: true,
+              contextIsolation: true,
+              nodeIntegration: false,
+              nodeIntegrationInSubFrames: false,
+              webviewTag: false,
+            },
+          },
+        };
+        for (const url of [
+          "https://accounts.google.com/",
+          "http://localhost:3200/auth",
+          "about:blank",
+        ]) {
+          expect(handler(windowOpenDetails(url))).toEqual(expected);
+        }
+        expect(preview.loadURL).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect("denies unsafe and nested preview popups", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents();
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_popup_policy");
+        yield* manager.registerWebview("tab_popup_policy", 42);
+
+        const handler = preview.setWindowOpenHandler.mock.calls[0]?.[0];
+        expect(handler).toBeDefined();
+        if (!handler) return;
+        for (const url of [
+          "",
+          "file:///tmp/secret",
+          "data:text/html,hello",
+          "javascript:document.body.textContent='blocked'",
+          "mailto:test@example.com",
+          "about:blank?unexpected",
+          "http://[::1",
+        ]) {
+          expect(handler(windowOpenDetails(url))).toEqual({ action: "deny" });
+        }
+
+        const setMenuBarVisibility = vi.fn();
+        const setChildWindowOpenHandler =
+          vi.fn<
+            (
+              handler: (details: Electron.HandlerDetails) => Electron.WindowOpenHandlerResponse,
+            ) => void
+          >();
+        const popupWindow = {
+          isDestroyed: () => false,
+          setMenuBarVisibility,
+          webContents: {
+            id: 84,
+            isDestroyed: () => false,
+            setWindowOpenHandler: setChildWindowOpenHandler,
+          },
+        } as never;
+        const didCreateWindow = preview.listeners.get("did-create-window") as unknown as (
+          popupWindow: Electron.BrowserWindow,
+        ) => void;
+        didCreateWindow(popupWindow);
+
+        expect(setMenuBarVisibility).toHaveBeenCalledWith(false);
+        const childHandler = setChildWindowOpenHandler.mock.calls[0]?.[0];
+        expect(childHandler).toBeDefined();
+        expect(childHandler?.(windowOpenDetails("https://example.com"))).toEqual({
+          action: "deny",
+        });
+
+        yield* manager.closeTab("tab_popup_policy");
+        expect(preview.off).toHaveBeenCalledWith("did-create-window", didCreateWindow);
+        const detachedHandler = preview.setWindowOpenHandler.mock.calls.at(-1)?.[0];
+        expect(detachedHandler?.(windowOpenDetails("https://example.com"))).toEqual({
+          action: "deny",
+        });
+        expect(preview.loadURL).not.toHaveBeenCalled();
+      }),
+    ),
+  );
 
   effectIt.effect("reports an unregistered webview as temporarily unavailable", () =>
     withManager((manager) =>
@@ -499,6 +631,26 @@ describe("PreviewManager", () => {
 
         expect(loadURL).toHaveBeenCalledOnce();
         expect(loadURL).toHaveBeenCalledWith("http://localhost:3200/");
+      }),
+    ),
+  );
+
+  effectIt.effect("loads the bootstrap URL after installing the popup policy", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents({ url: "about:blank" });
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_bootstrap");
+        yield* manager.registerWebview("tab_bootstrap", 42, "https://example.com/start");
+        yield* Effect.yieldNow;
+
+        expect(preview.setWindowOpenHandler).toHaveBeenCalledOnce();
+        expect(preview.loadURL).toHaveBeenCalledOnce();
+        expect(preview.loadURL).toHaveBeenCalledWith("https://example.com/start");
+        expect(yield* manager.automationStatus("tab_bootstrap")).toMatchObject({
+          url: "https://example.com/start",
+        });
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -211,11 +211,13 @@ const makeFaviconWebContents = (options?: {
   readonly rasterize?: (code: string) => Promise<unknown>;
   readonly trackNavigationHistory?: boolean;
   readonly url?: string;
+  readonly waitForLoad?: (url: string) => Promise<void>;
 }) => {
   const sourcePng = makeSourcePng();
   const listeners = new Map<string, (...args: never[]) => void>();
   let currentUrl = options?.url ?? "http://localhost:3200/";
-  let canGoBack = false;
+  let navigationEntries = [currentUrl];
+  let activeNavigationIndex = 0;
   let destroyed = false;
   let loading = false;
   const fetch = vi.fn(
@@ -231,13 +233,25 @@ const makeFaviconWebContents = (options?: {
   );
   const reload = vi.fn();
   const navigationHistoryClear = vi.fn(() => {
-    canGoBack = false;
+    navigationEntries = [navigationEntries[activeNavigationIndex] ?? currentUrl];
+    activeNavigationIndex = 0;
+  });
+  const navigationHistoryRemoveEntryAtIndex = vi.fn((index: number) => {
+    if (index < 0 || index >= navigationEntries.length || index === activeNavigationIndex) {
+      return false;
+    }
+    navigationEntries.splice(index, 1);
+    if (index < activeNavigationIndex) activeNavigationIndex -= 1;
+    return true;
   });
   const loadURL = vi.fn(async (url: string) => {
     if (options?.trackNavigationHistory && currentUrl !== url) {
-      canGoBack = true;
+      navigationEntries.splice(activeNavigationIndex + 1);
+      navigationEntries.push(url);
+      activeNavigationIndex = navigationEntries.length - 1;
       currentUrl = url;
       listeners.get("did-navigate")?.();
+      await options.waitForLoad?.(url);
       await Promise.resolve();
       return;
     }
@@ -274,9 +288,10 @@ const makeFaviconWebContents = (options?: {
     send: webviewSend,
     session,
     navigationHistory: {
-      canGoBack: () => canGoBack,
-      canGoForward: () => false,
+      canGoBack: () => activeNavigationIndex > 0,
+      canGoForward: () => activeNavigationIndex < navigationEntries.length - 1,
       clear: navigationHistoryClear,
+      removeEntryAtIndex: navigationHistoryRemoveEntryAtIndex,
     },
     setWindowOpenHandler,
     executeJavaScriptInIsolatedWorld,
@@ -289,13 +304,14 @@ const makeFaviconWebContents = (options?: {
     },
   };
   return {
-    canGoBack: () => canGoBack,
+    canGoBack: () => activeNavigationIndex > 0,
     executeJavaScriptInIsolatedWorld,
     fetch,
     debuggerOff,
     listeners,
     loadURL,
     navigationHistoryClear,
+    navigationHistoryRemoveEntryAtIndex,
     off,
     reload,
     session,
@@ -707,10 +723,92 @@ describe("PreviewManager", () => {
 
         yield* manager.createTab("tab_bootstrap_history");
         yield* manager.registerWebview("tab_bootstrap_history", 42, "https://example.com/start");
-        yield* settle(() => preview.navigationHistoryClear.mock.calls.length > 0);
+        yield* settle(() => preview.navigationHistoryRemoveEntryAtIndex.mock.calls.length > 0);
 
-        expect(preview.navigationHistoryClear).toHaveBeenCalledOnce();
+        expect(preview.navigationHistoryRemoveEntryAtIndex).toHaveBeenCalledOnce();
+        expect(preview.navigationHistoryRemoveEntryAtIndex).toHaveBeenCalledWith(0);
+        expect(preview.navigationHistoryClear).not.toHaveBeenCalled();
         expect(preview.canGoBack()).toBe(false);
+      }),
+    ),
+  );
+
+  effectIt.effect("does not clear history from a newer navigation", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let finishBootstrapLoad: (() => void) | undefined;
+        const bootstrapLoad = new Promise<void>((resolve) => {
+          finishBootstrapLoad = resolve;
+        });
+        const preview = makeFaviconWebContents({
+          trackNavigationHistory: true,
+          url: "about:blank",
+          waitForLoad: (url) =>
+            url === "https://example.com/start" ? bootstrapLoad : Promise.resolve(),
+        });
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_bootstrap_navigation_race");
+        yield* manager.registerWebview(
+          "tab_bootstrap_navigation_race",
+          42,
+          "https://example.com/start",
+        );
+        yield* settle(() => preview.loadURL.mock.calls.length === 1);
+
+        finishBootstrapLoad?.();
+        yield* manager.navigate("tab_bootstrap_navigation_race", "https://example.com/next");
+
+        expect(preview.loadURL).toHaveBeenLastCalledWith("https://example.com/next");
+        expect(preview.navigationHistoryClear).not.toHaveBeenCalled();
+        expect(preview.navigationHistoryRemoveEntryAtIndex).toHaveBeenCalledWith(0);
+        expect(preview.canGoBack()).toBe(true);
+      }),
+    ),
+  );
+
+  effectIt.effect("does not edit bootstrap history after the guest is replaced", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let finishFirstBootstrapLoad: (() => void) | undefined;
+        const firstBootstrapLoad = new Promise<void>((resolve) => {
+          finishFirstBootstrapLoad = resolve;
+        });
+        const first = makeFaviconWebContents({
+          id: 42,
+          trackNavigationHistory: true,
+          url: "about:blank",
+          waitForLoad: () => firstBootstrapLoad,
+        });
+        const replacement = makeFaviconWebContents({
+          id: 43,
+          trackNavigationHistory: true,
+          url: "about:blank",
+        });
+        fromId.mockImplementation((id?: number) => {
+          if (id === 42) return first.webContents;
+          if (id === 43) return replacement.webContents;
+          return null;
+        });
+
+        yield* manager.createTab("tab_bootstrap_replacement");
+        yield* manager.registerWebview(
+          "tab_bootstrap_replacement",
+          42,
+          "https://example.com/start",
+        );
+        yield* settle(() => first.loadURL.mock.calls.length === 1);
+        yield* manager.registerWebview("tab_bootstrap_replacement", 43);
+        yield* settle(
+          () => replacement.navigationHistoryRemoveEntryAtIndex.mock.calls.length === 1,
+        );
+
+        finishFirstBootstrapLoad?.();
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        expect(first.navigationHistoryRemoveEntryAtIndex).not.toHaveBeenCalled();
+        expect(replacement.navigationHistoryRemoveEntryAtIndex).toHaveBeenCalledWith(0);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -655,6 +655,29 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("keeps the bootstrap URL pending through blank guest events", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents({ url: "about:blank" });
+        fromId.mockReturnValue(preview.webContents);
+        webviewSend.mockImplementationOnce(() => {
+          preview.listeners.get("did-stop-loading")?.();
+        });
+
+        yield* manager.createTab("tab_bootstrap_blank_event");
+        yield* manager.registerWebview(
+          "tab_bootstrap_blank_event",
+          42,
+          "https://example.com/start",
+        );
+        yield* settle(() => preview.loadURL.mock.calls.length > 0);
+
+        expect(preview.loadURL).toHaveBeenCalledOnce();
+        expect(preview.loadURL).toHaveBeenCalledWith("https://example.com/start");
+      }),
+    ),
+  );
+
   effectIt.effect("detaches a destroyed webview instead of navigating it", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -209,11 +209,13 @@ const makeFaviconWebContents = (options?: {
   readonly hostWebContents?: Electron.WebContents | null;
   readonly id?: number;
   readonly rasterize?: (code: string) => Promise<unknown>;
+  readonly trackNavigationHistory?: boolean;
   readonly url?: string;
 }) => {
   const sourcePng = makeSourcePng();
   const listeners = new Map<string, (...args: never[]) => void>();
   let currentUrl = options?.url ?? "http://localhost:3200/";
+  let canGoBack = false;
   let destroyed = false;
   let loading = false;
   const fetch = vi.fn(
@@ -228,7 +230,17 @@ const makeFaviconWebContents = (options?: {
       options?.rasterize ? options.rasterize(scripts[0]?.code ?? "") : TEST_FAVICON,
   );
   const reload = vi.fn();
+  const navigationHistoryClear = vi.fn(() => {
+    canGoBack = false;
+  });
   const loadURL = vi.fn(async (url: string) => {
+    if (options?.trackNavigationHistory && currentUrl !== url) {
+      canGoBack = true;
+      currentUrl = url;
+      listeners.get("did-navigate")?.();
+      await Promise.resolve();
+      return;
+    }
     currentUrl = url;
   });
   const off = vi.fn();
@@ -261,7 +273,11 @@ const makeFaviconWebContents = (options?: {
     ipc: { on: vi.fn(), off: vi.fn() },
     send: webviewSend,
     session,
-    navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+    navigationHistory: {
+      canGoBack: () => canGoBack,
+      canGoForward: () => false,
+      clear: navigationHistoryClear,
+    },
     setWindowOpenHandler,
     executeJavaScriptInIsolatedWorld,
     debugger: {
@@ -273,11 +289,13 @@ const makeFaviconWebContents = (options?: {
     },
   };
   return {
+    canGoBack: () => canGoBack,
     executeJavaScriptInIsolatedWorld,
     fetch,
     debuggerOff,
     listeners,
     loadURL,
+    navigationHistoryClear,
     off,
     reload,
     session,
@@ -674,6 +692,25 @@ describe("PreviewManager", () => {
 
         expect(preview.loadURL).toHaveBeenCalledOnce();
         expect(preview.loadURL).toHaveBeenCalledWith("https://example.com/start");
+      }),
+    ),
+  );
+
+  effectIt.effect("removes the blank placeholder from bootstrap history", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents({
+          trackNavigationHistory: true,
+          url: "about:blank",
+        });
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_bootstrap_history");
+        yield* manager.registerWebview("tab_bootstrap_history", 42, "https://example.com/start");
+        yield* settle(() => preview.navigationHistoryClear.mock.calls.length > 0);
+
+        expect(preview.navigationHistoryClear).toHaveBeenCalledOnce();
+        expect(preview.canGoBack()).toBe(false);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -203,6 +203,20 @@ const artifactSiteSlug = (rawUrl: string): string => {
   }
 };
 
+const isAllowedPreviewPopupUrl = (rawUrl: string): boolean => {
+  if (rawUrl === "about:blank") return true;
+  try {
+    // Window-open URLs arrive fully resolved. Parsing first prevents the shared
+    // free-form URL normalizer from treating a relative value as a hostname.
+    const url = new URL(rawUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    normalizePreviewUrl(rawUrl);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 interface CdpEvaluationResult {
   readonly result?: {
     readonly value?: unknown;
@@ -1673,9 +1687,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       }
       runFork(forwardShortcut(event, input));
     };
+    const didCreateWindow = (popupWindow: BrowserWindow): void => {
+      if (popupWindow.isDestroyed() || popupWindow.webContents.isDestroyed()) return;
+      popupWindow.setMenuBarVisibility(false);
+      // Authentication windows stay human-only and cannot create more windows.
+      popupWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    };
     yield* Scope.addFinalizer(
       scope,
       attempt({ operation: "detachListeners", tabId, webContentsId: wc.id }, () => {
+        if (!wc.isDestroyed()) {
+          wc.setWindowOpenHandler(() => ({ action: "deny" }));
+        }
         cancelFaviconCapture();
         wc.off("did-start-navigation", navigationStarted);
         wc.off("did-navigate", syncNavigation);
@@ -1686,6 +1709,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.off("did-stop-loading", sync);
         wc.off("did-fail-load", failed as never);
         wc.off("audio-state-changed", audioStateChanged);
+        wc.off("did-create-window", didCreateWindow);
         wc.off("before-input-event", beforeInput);
         wc.ipc.off(HUMAN_INPUT_CHANNEL, humanInput);
         wc.ipc.off(MOUSE_NAVIGATE_CHANNEL, mouseNavigate);
@@ -1704,13 +1728,27 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.on("audio-state-changed", audioStateChanged);
         wc.ipc.on(HUMAN_INPUT_CHANNEL, humanInput);
         wc.ipc.on(MOUSE_NAVIGATE_CHANNEL, mouseNavigate);
+        wc.on("did-create-window", didCreateWindow);
         wc.setWindowOpenHandler(({ url }) => {
-          runFork(
-            attemptPromise({ operation: "openPreviewWindow", tabId, webContentsId: wc.id }, () =>
-              wc.loadURL(url),
-            ).pipe(Effect.ignore),
-          );
-          return { action: "deny" };
+          if (!isAllowedPreviewPopupUrl(url)) return { action: "deny" };
+          const hostWebContents = wc.hostWebContents;
+          const parent = hostWebContents ? BrowserWindow.fromWebContents(hostWebContents) : null;
+          return {
+            action: "allow",
+            outlivesOpener: false,
+            overrideBrowserWindowOptions: {
+              ...(parent && !parent.isDestroyed() ? { parent } : {}),
+              autoHideMenuBar: true,
+              webPreferences: {
+                session: wc.session,
+                sandbox: true,
+                contextIsolation: true,
+                nodeIntegration: false,
+                nodeIntegrationInSubFrames: false,
+                webviewTag: false,
+              },
+            },
+          };
         });
         wc.on("before-input-event", beforeInput);
       });
@@ -1876,6 +1914,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     tabId: string,
     webContentsId: number,
     expectedGeneration: number | undefined,
+    initialUrl: string | null,
   ) {
     const tab = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
     if (
@@ -1964,12 +2003,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             tabs,
           ] as const;
         }
-        const pendingUrl = current.navStatus.kind === "Loading" ? current.navStatus.url : null;
+        const currentUrl = current.navStatus.kind === "Idle" ? null : current.navStatus.url;
+        const pendingUrl = currentUrl ?? initialUrl;
         const { favicon: _favicon, ...currentWithoutFavicon } = current;
         const next: PreviewTabState = {
           ...currentWithoutFavicon,
           webContentsId,
-          navStatus: pendingUrl === null ? computeNavStatus(wc) : current.navStatus,
+          navStatus:
+            pendingUrl === null
+              ? computeNavStatus(wc)
+              : {
+                  kind: "Loading",
+                  url: pendingUrl,
+                  title: current.navStatus.kind === "Idle" ? "" : current.navStatus.title,
+                },
           canGoBack: wc.navigationHistory.canGoBack(),
           canGoForward: wc.navigationHistory.canGoForward(),
           audible: attachedAudible,
@@ -2031,11 +2078,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const registerWebview = Effect.fn("PreviewManager.registerWebview")(function* (
     tabId: string,
     webContentsId: number,
+    rawInitialUrl: string | null = null,
   ) {
+    const initialUrl =
+      rawInitialUrl === null
+        ? null
+        : yield* attempt({ operation: "registerWebview.normalizeInitialUrl", tabId }, () =>
+            normalizePreviewUrl(rawInitialUrl),
+          );
     const expectedGeneration = tabLifecycleGenerations.get(tabId);
     return yield* withTabLifecycleLock(
       tabId,
-      registerWebviewUnlocked(tabId, webContentsId, expectedGeneration),
+      registerWebviewUnlocked(tabId, webContentsId, expectedGeneration, initialUrl),
     );
   });
 
@@ -4042,6 +4096,7 @@ export class PreviewManager extends Context.Service<
     readonly registerWebview: (
       tabId: string,
       webContentsId: number,
+      initialUrl?: string | null,
     ) => Effect.Effect<void, PreviewManagerError>;
     readonly navigate: (tabId: string, url: string) => Effect.Effect<void, PreviewManagerError>;
     readonly goBack: (tabId: string) => Effect.Effect<void, PreviewManagerError>;

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -793,6 +793,35 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (Option.isSome(next)) yield* emitIfCurrent(tabId, next.value);
   });
 
+  const syncTabNavigationHistory = Effect.fn("PreviewManager.syncTabNavigationHistory")(function* (
+    tabId: string,
+    wc: Electron.WebContents,
+  ) {
+    if (wc.isDestroyed()) return;
+    const canGoBack = wc.navigationHistory.canGoBack();
+    const canGoForward = wc.navigationHistory.canGoForward();
+    const updatedAt = yield* currentIso;
+    const next = yield* SynchronizedRef.modify(tabsRef, (tabs) => {
+      const current = tabs.get(tabId);
+      if (
+        !current ||
+        current.webContentsId !== wc.id ||
+        webContents.fromId(wc.id) !== wc ||
+        (current.canGoBack === canGoBack && current.canGoForward === canGoForward)
+      ) {
+        return [Option.none<PreviewTabState>(), tabs] as const;
+      }
+      const state: PreviewTabState = { ...current, canGoBack, canGoForward, updatedAt };
+      return [
+        Option.some(state),
+        replaceMap(tabs, (copy) => {
+          copy.set(tabId, state);
+        }),
+      ] as const;
+    });
+    if (Option.isSome(next)) yield* emitIfCurrent(tabId, next.value);
+  });
+
   const requireWebContents = Effect.fn("PreviewManager.requireWebContents")(function* (
     tabId: string,
   ) {
@@ -2078,7 +2107,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       runFork(
         attemptPromise({ operation: "registerWebview.loadPendingUrl", tabId, webContentsId }, () =>
           wc.loadURL(pendingUrl),
-        ).pipe(Effect.ignore),
+        ).pipe(
+          Effect.tap(() =>
+            attempt(
+              {
+                operation: "registerWebview.clearBootstrapNavigationHistory",
+                tabId,
+                webContentsId,
+              },
+              () => wc.navigationHistory.clear(),
+            ),
+          ),
+          Effect.tap(() => syncTabNavigationHistory(tabId, wc)),
+          Effect.ignore,
+        ),
       );
     }
   });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1460,13 +1460,21 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         if (!current || current.webContentsId !== wc.id || webContents.fromId(wc.id) !== wc) {
           return [Option.none<PreviewTabState>(), tabs] as const;
         }
+        // Placeholder events can land after registration publishes the queued
+        // bootstrap URL but before loadURL starts. Keep that URL pending instead
+        // of letting about:blank erase it.
+        const placeholderLoadPending =
+          current.navStatus.kind === "Loading" &&
+          computedNavStatus.kind === "Idle" &&
+          wc.getURL() === "about:blank";
         // Electron emits did-stop-loading after did-fail-load. At that point the
         // failed guest is no longer "loading", but it has not successfully
         // navigated anywhere. Keep the failure until a new load actually starts.
         const navStatus =
-          preserveLoadFailure &&
-          current.navStatus.kind === "LoadFailed" &&
-          computedNavStatus.kind === "Success"
+          placeholderLoadPending ||
+          (preserveLoadFailure &&
+            current.navStatus.kind === "LoadFailed" &&
+            computedNavStatus.kind === "Success")
             ? current.navStatus
             : computedNavStatus;
         const clearFavicon =

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -793,34 +793,42 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (Option.isSome(next)) yield* emitIfCurrent(tabId, next.value);
   });
 
-  const syncTabNavigationHistory = Effect.fn("PreviewManager.syncTabNavigationHistory")(function* (
-    tabId: string,
-    wc: Electron.WebContents,
-  ) {
-    if (wc.isDestroyed()) return;
-    const canGoBack = wc.navigationHistory.canGoBack();
-    const canGoForward = wc.navigationHistory.canGoForward();
-    const updatedAt = yield* currentIso;
-    const next = yield* SynchronizedRef.modify(tabsRef, (tabs) => {
-      const current = tabs.get(tabId);
-      if (
-        !current ||
-        current.webContentsId !== wc.id ||
-        webContents.fromId(wc.id) !== wc ||
-        (current.canGoBack === canGoBack && current.canGoForward === canGoForward)
-      ) {
-        return [Option.none<PreviewTabState>(), tabs] as const;
-      }
-      const state: PreviewTabState = { ...current, canGoBack, canGoForward, updatedAt };
-      return [
-        Option.some(state),
-        replaceMap(tabs, (copy) => {
-          copy.set(tabId, state);
+  const removeBootstrapNavigationEntry = Effect.fn("PreviewManager.removeBootstrapNavigationEntry")(
+    function* (tabId: string, wc: Electron.WebContents, entryIndex: number) {
+      if (wc.isDestroyed()) return;
+      const updatedAt = yield* currentIso;
+      const next = yield* SynchronizedRef.modifyEffect(tabsRef, (tabs) =>
+        Effect.gen(function* () {
+          const current = tabs.get(tabId);
+          if (!current || current.webContentsId !== wc.id || webContents.fromId(wc.id) !== wc) {
+            return [Option.none<PreviewTabState>(), tabs] as const;
+          }
+          const removed = yield* attempt(
+            {
+              operation: "registerWebview.removeBootstrapNavigationEntry",
+              tabId,
+              webContentsId: wc.id,
+            },
+            () => wc.navigationHistory.removeEntryAtIndex(entryIndex),
+          );
+          if (!removed) return [Option.none<PreviewTabState>(), tabs] as const;
+          const canGoBack = wc.navigationHistory.canGoBack();
+          const canGoForward = wc.navigationHistory.canGoForward();
+          if (current.canGoBack === canGoBack && current.canGoForward === canGoForward) {
+            return [Option.none<PreviewTabState>(), tabs] as const;
+          }
+          const state: PreviewTabState = { ...current, canGoBack, canGoForward, updatedAt };
+          return [
+            Option.some(state),
+            replaceMap(tabs, (copy) => {
+              copy.set(tabId, state);
+            }),
+          ] as const;
         }),
-      ] as const;
-    });
-    if (Option.isSome(next)) yield* emitIfCurrent(tabId, next.value);
-  });
+      );
+      if (Option.isSome(next)) yield* emitIfCurrent(tabId, next.value);
+    },
+  );
 
   const requireWebContents = Effect.fn("PreviewManager.requireWebContents")(function* (
     tabId: string,
@@ -1481,8 +1489,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     ) {
       if (wc.isDestroyed()) return;
       const computedNavStatus = computeNavStatus(wc);
-      const canGoBack = wc.navigationHistory.canGoBack();
-      const canGoForward = wc.navigationHistory.canGoForward();
       const updatedAt = yield* currentIso;
       const next = yield* SynchronizedRef.modify(tabsRef, (tabs) => {
         const current = tabs.get(tabId);
@@ -1512,6 +1518,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           safeHttpOrigin(current.favicon.pageUrl) !==
             safeHttpOrigin(navStatus.kind === "Idle" ? wc.getURL() : navStatus.url);
         const { favicon: _favicon, ...currentWithoutFavicon } = current;
+        const canGoBack = wc.navigationHistory.canGoBack();
+        const canGoForward = wc.navigationHistory.canGoForward();
         const state: PreviewTabState = {
           ...(clearFavicon ? currentWithoutFavicon : current),
           navStatus,
@@ -2104,21 +2112,21 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       latestNavStatus.url === pendingUrl &&
       wc.getURL() !== pendingUrl
     ) {
+      const bootstrapHistoryEntryIndex =
+        wc.getURL() === "about:blank" &&
+        !wc.navigationHistory.canGoBack() &&
+        !wc.navigationHistory.canGoForward()
+          ? 0
+          : null;
       runFork(
         attemptPromise({ operation: "registerWebview.loadPendingUrl", tabId, webContentsId }, () =>
           wc.loadURL(pendingUrl),
         ).pipe(
           Effect.tap(() =>
-            attempt(
-              {
-                operation: "registerWebview.clearBootstrapNavigationHistory",
-                tabId,
-                webContentsId,
-              },
-              () => wc.navigationHistory.clear(),
-            ),
+            bootstrapHistoryEntryIndex === null
+              ? Effect.void
+              : removeBootstrapNavigationEntry(tabId, wc, bootstrapHistoryEntryIndex),
           ),
-          Effect.tap(() => syncTabNavigationHistory(tabId, wc)),
           Effect.ignore,
         ),
       );

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -2,7 +2,14 @@
 
 import type { PreviewViewportSetting, ScopedThreadRef } from "@t3tools/contracts";
 import { useShallow } from "zustand/react/shallow";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ComponentProps,
+  type ComponentType,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { previewBridge } from "~/components/preview/previewBridge";
 import { usePreviewBridge } from "~/components/preview/usePreviewBridge";
@@ -34,6 +41,14 @@ interface ElectronWebview extends HTMLElement {
   getWebContentsId: () => number;
   executeJavaScript: (code: string, userGesture?: boolean) => Promise<unknown>;
 }
+
+type PreviewWebviewProps = Omit<ComponentProps<"webview">, "allowpopups"> & {
+  readonly allowpopups: "true";
+};
+
+// React types this Electron attribute as boolean, but React omits unknown
+// boolean attributes. Electron needs the string attribute before guest attach.
+const PreviewWebview = "webview" as unknown as ComponentType<PreviewWebviewProps>;
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -84,6 +99,7 @@ export function HostedBrowserWebview(props: {
 
   const [webviewGeneration, setWebviewGeneration] = useState(0);
   const [recoverySrc, setRecoverySrc] = useState(initialSrc);
+  const targetSrc = webviewGeneration === 0 ? initialSrc : recoverySrc;
   const latestUrlRef = useRef(initialUrl);
 
   useEffect(() => {
@@ -92,7 +108,6 @@ export function HostedBrowserWebview(props: {
 
   const setWebviewRef = useCallback((node: HTMLElement | null) => {
     webviewRef.current = node as ElectronWebview | null;
-    if (node && !node.hasAttribute("allowpopups")) node.setAttribute("allowpopups", "true");
   }, []);
 
   useEffect(() => {
@@ -113,7 +128,11 @@ export function HostedBrowserWebview(props: {
           if (disposed || webviewRef.current !== webview) return;
           const webContentsId = webview.getWebContentsId();
           if (Number.isInteger(webContentsId) && webContentsId > 0) {
-            await bridge.registerWebview(runtimeTabId, webContentsId);
+            await bridge.registerWebview(
+              runtimeTabId,
+              webContentsId,
+              targetSrc === "about:blank" ? null : targetSrc,
+            );
           }
         } catch {
           // did-attach/dom-ready will retry if the guest was not ready yet.
@@ -144,7 +163,7 @@ export function HostedBrowserWebview(props: {
       webview.removeEventListener("dom-ready", register);
       webview.removeEventListener("render-process-gone", recoverGuest);
     };
-  }, [config, initialSrc, runtimeTabId, webviewGeneration]);
+  }, [config, initialSrc, runtimeTabId, targetSrc, webviewGeneration]);
 
   const active = presentation.visible && presentation.rect !== null;
   const lastRect = presentation.rect;
@@ -256,12 +275,13 @@ export function HostedBrowserWebview(props: {
             onChange={commitViewportChange}
           />
         ) : null}
-        <webview
+        <PreviewWebview
           key={webviewGeneration}
           ref={setWebviewRef}
-          src={webviewGeneration === 0 ? initialSrc : recoverySrc}
+          src="about:blank"
           partition={config.partition}
           webpreferences={config.webPreferences}
+          allowpopups="true"
           {...(config.preloadUrl ? { preload: config.preloadUrl } : {})}
           data-preview-tab={runtimeTabId}
           data-preview-server-tab={tabId}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -996,6 +996,7 @@ export interface DesktopPreviewTabDefaults {
 export const DesktopPreviewRegisterWebviewInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   webContentsId: Schema.Int.check(Schema.isGreaterThan(0)),
+  initialUrl: Schema.NullOr(Schema.String),
 });
 
 export const DesktopPreviewNavigateInputSchema = Schema.Struct({
@@ -1155,7 +1156,11 @@ export interface DesktopBridge {
 export interface DesktopPreviewBridge {
   createTab: (tabId: string, defaults?: DesktopPreviewTabDefaults) => Promise<void>;
   closeTab: (tabId: string) => Promise<void>;
-  registerWebview: (tabId: string, webContentsId: number) => Promise<void>;
+  registerWebview: (
+    tabId: string,
+    webContentsId: number,
+    initialUrl: string | null,
+  ) => Promise<void>;
   navigate: (tabId: string, url: string) => Promise<void>;
   goBack: (tabId: string) => Promise<void>;
   goForward: (tabId: string) => Promise<void>;


### PR DESCRIPTION
Fixes #6561.

Browser previews denied every `window.open()` request and loaded the requested URL in the opener. OAuth libraries therefore reported the popup as blocked, and the opener/child handshake could never run.

This change permits real child windows for HTTP, HTTPS, and exact `about:blank` targets. Each child shares the opener session, runs sandboxed without Node or nested webviews, closes with its opener, and cannot create another popup. Unsafe and malformed URLs remain blocked through the shared preview URL validation.

The preview webview now attaches at `about:blank` and sends its intended URL through the typed registration IPC. The main process installs the popup policy before loading that URL, while preserving any newer navigation already queued for the tab.

This ports the sound parts of #6620 to current `main` and includes the URL-validation intent from #6156.

Verification:

- `vp test run apps/desktop/src/preview/Manager.test.ts apps/desktop/src/ipc/methods/preview.test.ts`
- `vp run --filter @t3tools/desktop typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/contracts typecheck`
- Targeted `vp lint` and `vp fmt --check` on all changed files

Made with GPT-5.6 Sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview navigation, popup policy, and OAuth-related window behavior in Electron; mis-handled `initialUrl` could leave previews stuck on `about:blank`, while popup session sharing affects login flows.
> 
> **Overview**
> Desktop browser previews no longer treat every `window.open()` as navigation in the opener. **PreviewManager** installs a `setWindowOpenHandler` that allows sandboxed child windows for validated `http`/`https` URLs and exact `about:blank`, shares the guest session, parents them to the host window when possible, and denies unsafe schemes plus nested popups from auth windows.
> 
> **Registration bootstrap** changes so popups are configured before the first real load: `registerWebview` gains optional `initialUrl` end-to-end (contracts IPC schema, preload, IPC handler). The hosted `<webview>` always mounts at `about:blank` with `allowpopups="true"` and passes the intended URL at registration; the main process loads it after listeners are attached, keeps loading state through blank guest events, and strips the placeholder `about:blank` history entry when appropriate without racing newer navigations or replaced guests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1d86549221a9d4f56a790484539b6b3996e70a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow OAuth popups in desktop browser previews via main-process URL loading
> - Webview registration now accepts an `initialUrl` that the main process loads after installing popup policy and listeners, replacing direct `src` navigation on the webview element.
> - Popups opened from a preview are restricted to `about:blank` and normalizable `http`/`https` URLs; approved popups open in a separate sandboxed `BrowserWindow` with no `nodeIntegration` or `webviewTag`, sharing the parent session. Nested popups are denied and child windows hide the menu bar.
> - The initial `about:blank` placeholder entry is removed from navigation history after the bootstrap URL loads; `did-stop-loading` from `about:blank` no longer overwrites a pending bootstrap navigation in `syncWebContentsState`.
> - The `PreviewWebview` alias forces `allowpopups` as a string attribute so Electron receives it before guest attach, replacing the previous imperative `setAttribute` call.
> - Behavioral Change: `desktopBridge.preview.registerWebview` and the IPC schema in [ipc.ts](https://github.com/pingdotgg/t3code/pull/8413/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a) now require a nullable `initialUrl` argument; any caller not updated will fail type validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a1d865.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## request provenance

- requested by: @MatthewFeroz

<!-- t3bot-requester: discord_user_id=125372739530784768 github=MatthewFeroz message_id=1542575142666895381 -->
