### PR TITLE
fix(app): hide cached threads from unavailable environments

### DIFF
--- a/apps/mobile/src/state/threads.ts
+++ b/apps/mobile/src/state/threads.ts
@@ -22,6 +22,7 @@ export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
 );
 export const environmentThreadShells = createEnvironmentThreadShellAtoms({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
+  connectionStateAtom: environmentCatalog.stateAtom,
   snapshotAtom: environmentSnapshotAtom,
 });
 

--- a/apps/web/src/state/threads.ts
+++ b/apps/web/src/state/threads.ts
@@ -22,6 +22,7 @@ export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
 );
 export const environmentThreadShells = createEnvironmentThreadShellAtoms({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
+  connectionStateAtom: environmentCatalog.stateAtom,
   snapshotAtom: environmentSnapshotAtom,
 });
 

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -7,6 +7,10 @@ one environment.
 Pinned threads still move to **Settled** when they become inactive. They also move when their pull
 request merges if **Auto-settle merged threads** is enabled.
 
+When a remote environment is unavailable, its cached threads are hidden from the combined sidebar
+while you are online. The cache is kept and appears again after reconnecting; while your device is
+offline, cached threads remain visible for browsing.
+
 When you un-settle a thread, it returns to the top of the active list so you can find it right
 away. Its timestamps do not change. Other threads keep their positions.
 

--- a/packages/client-runtime/src/state/entities.test.ts
+++ b/packages/client-runtime/src/state/entities.test.ts
@@ -225,6 +225,10 @@ describe("environment entity projections", () => {
     const environmentRefs = harness.registry.get(
       harness.threadShells.environmentThreadRefsAtom(ENVIRONMENT_ID),
     );
+    const projectThreadsAtom = harness.threadShells.threadShellsForProjectRefsAtom([
+      { environmentId: ENVIRONMENT_ID, projectId: PROJECT_ID },
+    ]);
+    const projectThreads = harness.registry.get(projectThreadsAtom);
 
     harness.registry.set(
       harness.connectionStateAtom(ENVIRONMENT_ID),
@@ -238,6 +242,7 @@ describe("environment entity projections", () => {
       }),
     );
     expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual(environmentRefs);
+    expect(harness.registry.get(projectThreadsAtom)).toBe(projectThreads);
 
     const unavailable = {
       desired: true,
@@ -255,6 +260,7 @@ describe("environment entity projections", () => {
     );
 
     expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual([]);
+    expect(harness.registry.get(projectThreadsAtom)).toEqual([]);
     expect(
       harness.registry.get(harness.threadShells.environmentThreadRefsAtom(ENVIRONMENT_ID)),
     ).toBe(environmentRefs);
@@ -271,6 +277,7 @@ describe("environment entity projections", () => {
     );
 
     expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual([]);
+    expect(harness.registry.get(projectThreadsAtom)).toEqual([]);
 
     harness.registry.set(
       harness.connectionStateAtom(ENVIRONMENT_ID),
@@ -284,6 +291,7 @@ describe("environment entity projections", () => {
     );
 
     expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual(environmentRefs);
+    expect(harness.registry.get(projectThreadsAtom)).toEqual(projectThreads);
   });
 
   it("composes detail collections with authoritative shell workspace metadata", () => {

--- a/packages/client-runtime/src/state/entities.test.ts
+++ b/packages/client-runtime/src/state/entities.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
-import { PrimaryConnectionTarget } from "../connection/model.ts";
+import {
+  AVAILABLE_CONNECTION_STATE,
+  ConnectionTransientError,
+  PrimaryConnectionTarget,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
 import {
   InvalidScopedProjectKeyError,
   InvalidScopedProjectRefCollectionKeyError,
@@ -150,6 +155,18 @@ function shellState(snapshot: OrchestrationShellSnapshot): EnvironmentShellState
 }
 
 function makeHarness() {
+  const connectionStateAtoms = Atom.family((_environmentId: EnvironmentId) =>
+    Atom.make(
+      AsyncResult.success<SupervisorConnectionState>({
+        ...AVAILABLE_CONNECTION_STATE,
+        desired: true,
+        network: "online",
+        phase: "connected",
+        attempt: 1,
+        generation: 1,
+      }),
+    ),
+  );
   const shellStateAtoms = Atom.family((_environmentId: EnvironmentId) =>
     Atom.make(AsyncResult.success(shellState(SNAPSHOT))),
   );
@@ -180,6 +197,7 @@ function makeHarness() {
   });
   const threadShells = createEnvironmentThreadShellAtoms({
     catalogValueAtom,
+    connectionStateAtom: connectionStateAtoms,
     snapshotAtom,
   });
   const threadDetails = createEnvironmentThreadDetailAtoms((environmentId, threadId) =>
@@ -188,6 +206,7 @@ function makeHarness() {
 
   return {
     registry: AtomRegistry.make(),
+    connectionStateAtom: connectionStateAtoms,
     shellStateAtom: shellStateAtoms(ENVIRONMENT_ID),
     threadStateAtom: (threadId: ThreadId) => threadStateAtoms(`${ENVIRONMENT_ID}\u0000${threadId}`),
     projects,
@@ -197,6 +216,76 @@ function makeHarness() {
 }
 
 describe("environment entity projections", () => {
+  it("hides unavailable environment caches from the global thread list while online", () => {
+    const harness = makeHarness();
+    const failure = new ConnectionTransientError({
+      reason: "remote-unavailable",
+      detail: "Remote environment is unavailable.",
+    });
+    const environmentRefs = harness.registry.get(
+      harness.threadShells.environmentThreadRefsAtom(ENVIRONMENT_ID),
+    );
+
+    harness.registry.set(
+      harness.connectionStateAtom(ENVIRONMENT_ID),
+      AsyncResult.success({
+        ...AVAILABLE_CONNECTION_STATE,
+        desired: true,
+        network: "online",
+        phase: "connecting",
+        stage: "preparing",
+        attempt: 1,
+      }),
+    );
+    expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual(environmentRefs);
+
+    const unavailable = {
+      desired: true,
+      network: "online",
+      phase: "backoff",
+      stage: null,
+      attempt: 1,
+      generation: 0,
+      lastFailure: failure,
+      retryAt: 1,
+    } as const;
+    harness.registry.set(
+      harness.connectionStateAtom(ENVIRONMENT_ID),
+      AsyncResult.success(unavailable),
+    );
+
+    expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual([]);
+    expect(
+      harness.registry.get(harness.threadShells.environmentThreadRefsAtom(ENVIRONMENT_ID)),
+    ).toBe(environmentRefs);
+
+    harness.registry.set(
+      harness.connectionStateAtom(ENVIRONMENT_ID),
+      AsyncResult.success({
+        ...unavailable,
+        phase: "connecting",
+        stage: "preparing",
+        attempt: 2,
+        retryAt: null,
+      }),
+    );
+
+    expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual([]);
+
+    harness.registry.set(
+      harness.connectionStateAtom(ENVIRONMENT_ID),
+      AsyncResult.success({
+        ...unavailable,
+        network: "offline",
+        phase: "offline",
+        attempt: 2,
+        retryAt: null,
+      }),
+    );
+
+    expect(harness.registry.get(harness.threadShells.threadRefsAtom)).toEqual(environmentRefs);
+  });
+
   it("composes detail collections with authoritative shell workspace metadata", () => {
     const messages: OrchestrationThread["messages"] = [];
     const detail = {

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -72,6 +72,20 @@ export function createEnvironmentThreadShellAtoms<E>(input: {
     }).pipe(Atom.withLabel(`environment-thread-refs:${environmentId}`));
   });
 
+  const environmentThreadsVisibleAtom = Atom.family((environmentId: EnvironmentId) =>
+    Atom.make((get) => {
+      const connection = Option.getOrElse(
+        AsyncResult.value(get(input.connectionStateAtom(environmentId))),
+        () => AVAILABLE_CONNECTION_STATE,
+      );
+      const isInitialConnection =
+        connection.phase === "connecting" && connection.lastFailure === null;
+      return (
+        connection.network !== "online" || connection.phase === "connected" || isInitialConnection
+      );
+    }).pipe(Atom.withLabel(`environment-threads-visible:${environmentId}`)),
+  );
+
   const environmentThreadRefsByProjectAtom = Atom.family((environmentId: EnvironmentId) => {
     let previous: ReadonlyMap<
       ProjectId,
@@ -127,6 +141,9 @@ export function createEnvironmentThreadShellAtoms<E>(input: {
       const next: EnvironmentThreadShell[] = [];
       const seen = new Set<string>();
       for (const projectRef of projectRefs) {
+        if (!get(environmentThreadsVisibleAtom(projectRef.environmentId))) {
+          continue;
+        }
         const refs =
           get(environmentThreadRefsByProjectAtom(projectRef.environmentId)).get(
             projectRef.projectId,
@@ -155,17 +172,7 @@ export function createEnvironmentThreadShellAtoms<E>(input: {
   const threadRefsAtom = Atom.make((get) => {
     const refs: ScopedThreadRef[] = [];
     for (const environmentId of get(input.catalogValueAtom).entries.keys()) {
-      const connection = Option.getOrElse(
-        AsyncResult.value(get(input.connectionStateAtom(environmentId))),
-        () => AVAILABLE_CONNECTION_STATE,
-      );
-      const isInitialConnection =
-        connection.phase === "connecting" && connection.lastFailure === null;
-      if (
-        connection.network === "online" &&
-        connection.phase !== "connected" &&
-        !isInitialConnection
-      ) {
+      if (!get(environmentThreadsVisibleAtom(environmentId))) {
         continue;
       }
       refs.push(...get(environmentThreadRefsAtom(environmentId)));

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -7,8 +7,10 @@ import type {
   ScopedThreadRef,
   ThreadId,
 } from "@t3tools/contracts";
-import { Atom } from "effect/unstable/reactivity";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
+import { AVAILABLE_CONNECTION_STATE, type SupervisorConnectionState } from "../connection/model.ts";
 import type { EnvironmentThreadShell } from "./models.ts";
 import { scopeThreadShell } from "./models.ts";
 import type { EnvironmentCatalogState } from "./connections.ts";
@@ -29,8 +31,11 @@ const EMPTY_THREAD_REFS_BY_PROJECT: ReadonlyMap<
   ReadonlyArray<ScopedThreadRef>
 > = new Map();
 
-export function createEnvironmentThreadShellAtoms(input: {
+export function createEnvironmentThreadShellAtoms<E>(input: {
   readonly catalogValueAtom: Atom.Atom<EnvironmentCatalogState>;
+  readonly connectionStateAtom: (
+    environmentId: EnvironmentId,
+  ) => Atom.Atom<AsyncResult.AsyncResult<SupervisorConnectionState, E>>;
   readonly snapshotAtom: (
     environmentId: EnvironmentId,
   ) => Atom.Atom<OrchestrationShellSnapshot | null>;
@@ -150,6 +155,19 @@ export function createEnvironmentThreadShellAtoms(input: {
   const threadRefsAtom = Atom.make((get) => {
     const refs: ScopedThreadRef[] = [];
     for (const environmentId of get(input.catalogValueAtom).entries.keys()) {
+      const connection = Option.getOrElse(
+        AsyncResult.value(get(input.connectionStateAtom(environmentId))),
+        () => AVAILABLE_CONNECTION_STATE,
+      );
+      const isInitialConnection =
+        connection.phase === "connecting" && connection.lastFailure === null;
+      if (
+        connection.network === "online" &&
+        connection.phase !== "connected" &&
+        !isInitialConnection
+      ) {
+        continue;
+      }
       refs.push(...get(environmentThreadRefsAtom(environmentId)));
     }
     if (threadRefsEqual(previousThreadRefs, refs)) {


### PR DESCRIPTION
When a remote environment went offline, the combined sidebar kept rendering its cached thread shells. Those rows looked actionable, but mutations could not reach the disconnected environment, leaving stale running or settled state stuck in the list.

The shared client runtime now excludes failed or disconnected environment caches from the combined sidebar while the client is online. Environment-scoped caches remain untouched, a first connection attempt can still show cached rows, retry attempts do not make them flicker back, and offline browsing still shows cached threads. Web and mobile both use the same selector.

Tests:

- `vp test run packages/client-runtime/src/state/entities.test.ts`
- `vp run --filter @t3tools/client-runtime typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/mobile typecheck`
- Changed-file lint and formatting checks

No screenshots: this changes disconnected-cache eligibility only; the existing sidebar rendering is unchanged.

Made with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which threads appear in the global sidebar based on connection phase, which could surprise users or affect UI that assumed cached rows always show while online; environment-scoped data is preserved.
> 
> **Overview**
> When a remote environment cannot be reached while the client is **online**, **cached thread shells are no longer included in the combined sidebar** (`threadRefsAtom` and project-scoped combined lists). The cache is not cleared—environment-scoped thread refs stay the same, and cached rows come back after reconnect or when the device is **offline** for browsing.
> 
> `createEnvironmentThreadShellAtoms` now takes **`connectionStateAtom`** and gates visibility: online + connected shows threads; online + first connect attempt (no prior failure) still shows cache; online + backoff or reconnect after failure hides them from combined selectors. Web and mobile pass `environmentCatalog.stateAtom`. User docs in `thread-sidebar.md` describe this behavior. Tests cover online/offline and reconnect phases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a878870dd97bd36aa7838cc546e6bff1699bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide cached threads from unavailable environments in `threadRefsAtom` and `threadShellsForProjectRefsAtom`
> Passes a per-environment `connectionStateAtom` into `createEnvironmentThreadShellAtoms` so thread visibility derives from connection state. Threads are hidden when the device is online but the environment is unavailable (e.g., backoff after failure); they remain visible when offline, connected, or initially connecting without prior failures. The cache is retained and threads reappear after reconnecting. Mobile and web both wire `environmentCatalog.stateAtom` as the connection state source. Tests cover connecting, unavailable-backoff, connecting-after-failure, and offline transitions.
> - Risk: callers of `createEnvironmentThreadShellAtoms` must now supply the new `connectionStateAtom` argument; the function signature changed in [threadShell.ts](https://github.com/pingdotgg/t3code/pull/8414/files#diff-e49ef617e91bb0815a2056981dd21ded980875b9367bfad26d6f2cc019e2ef06).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56a8788.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->