### PR TITLE
fix(web): keep pasted decorators as text

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.test.ts
+++ b/apps/web/src/components/ComposerPromptEditor.test.ts
@@ -94,9 +94,11 @@ describe("registerComposerInlineTokenPaste", () => {
 
   it.each([
     ["@foo(bar)", "@foo(bar)"],
+    ["@écrire(option)", "@écrire(option)"],
     ["@namespace.foo(bar)\nclass Example {}", "@namespace.foo(bar)\nclass Example {}"],
     ['@"foo(bar)"', "[foo(bar)](foo%28bar%29) "],
     ["[foo(bar)](foo%28bar%29)", "[foo(bar)](foo%28bar%29) "],
+    ["@README.md (notes)", "[README.md](README.md) (notes)"],
   ])("preserves pasted decorator text and explicit file references: %s", (text, expected) => {
     vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
     const editor = createEditor();

--- a/apps/web/src/components/ComposerPromptEditor.test.ts
+++ b/apps/web/src/components/ComposerPromptEditor.test.ts
@@ -1,5 +1,6 @@
 import { EnvironmentId, MessageId, ThreadId, type AssistantCitation } from "@t3tools/contracts";
 import { serializeAssistantCitation } from "@t3tools/shared/assistantCitations";
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   $createParagraphNode,
@@ -89,6 +90,43 @@ class TestClipboardEvent extends Event {
 describe("registerComposerInlineTokenPaste", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["@foo(bar)", "@foo(bar)"],
+    ["@namespace.foo(bar)\nclass Example {}", "@namespace.foo(bar)\nclass Example {}"],
+    ['@"foo(bar)"', "[foo(bar)](foo%28bar%29) "],
+    ["[foo(bar)](foo%28bar%29)", "[foo(bar)](foo%28bar%29) "],
+  ])("preserves pasted decorator text and explicit file references: %s", (text, expected) => {
+    vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
+    const editor = createEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().append(paragraph);
+        paragraph.selectEnd();
+      },
+      { discrete: true },
+    );
+    registerComposerInlineTokenPaste(editor, {
+      createMentionNode: (path) => $createTextNode(serializeComposerFileLink(path)),
+      createCitationNode: $createComposerCitationNode,
+      getExpandedAbsoluteOffsetForPoint: () => 0,
+    });
+    editor.registerCommand(
+      PASTE_COMMAND,
+      (event) => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !(event instanceof ClipboardEvent)) return false;
+        selection.insertRawText(event.clipboardData?.getData("text/plain") ?? "");
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    );
+
+    pasteText(editor, text);
+
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(expected);
   });
 
   it("handles a copied mention without also running the plain-text paste fallback", () => {

--- a/apps/web/src/components/ComposerPromptEditor.test.ts
+++ b/apps/web/src/components/ComposerPromptEditor.test.ts
@@ -75,7 +75,8 @@ describe("registerComposerInlineTokenPaste", () => {
     "yarn expo install @expo/ui",
     "npm install @jane/foo.js",
     "import '@scope/pkg/sub/path'",
-  ])("leaves scoped package command %s to the plain-text paste fallback", (command) => {
+    "@foo(bar)",
+  ])("leaves ambiguous bare mention text %s to the plain-text paste fallback", (text) => {
     vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
     const editor = createEditor();
     const plainTextFallback = vi.fn((event: ClipboardEvent) => {
@@ -99,7 +100,7 @@ describe("registerComposerInlineTokenPaste", () => {
     });
     editor.registerCommand(PASTE_COMMAND, plainTextFallback, COMMAND_PRIORITY_EDITOR);
 
-    const event = new TestClipboardEvent(command);
+    const event = new TestClipboardEvent(text);
     let handled = false;
     editor.update(
       () => {
@@ -110,7 +111,7 @@ describe("registerComposerInlineTokenPaste", () => {
 
     expect(handled).toBe(true);
     expect(plainTextFallback).toHaveBeenCalledOnce();
-    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(command);
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(text);
   });
 
   it("pastes a canonical scoped folder link as a mention", () => {

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -94,6 +94,28 @@ describe("collectComposerInlineTokens", () => {
     expect(collectComposerInlineTokens("入力 @expo/ui　を追加")).toEqual([]);
   });
 
+  it.each(["@foo(bar)", "@namespace.foo(bar)", "@_private()", "@$inject(service)"])(
+    "keeps decorator call %s as plain text",
+    (reference) => {
+      expect(collectComposerInlineTokens(`${reference}\nclass Example {}`)).toEqual([]);
+    },
+  );
+
+  it.each(['@"foo(bar)"', "[foo(bar)](foo%28bar%29)"])(
+    "keeps an explicit decorator-shaped file reference as a mention: %s",
+    (reference) => {
+      expect(collectComposerInlineTokens(`${reference} `)).toEqual([
+        {
+          type: "mention",
+          value: "foo(bar)",
+          source: reference,
+          start: 0,
+          end: reference.length,
+        },
+      ]);
+    },
+  );
+
   it("keeps bare non-scoped file paths as mentions", () => {
     expect(collectComposerInlineTokens("Inspect @README.md next")).toEqual([
       {

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -94,12 +94,18 @@ describe("collectComposerInlineTokens", () => {
     expect(collectComposerInlineTokens("入力 @expo/ui　を追加")).toEqual([]);
   });
 
-  it.each(["@foo(bar)", "@namespace.foo(bar)", "@_private()", "@$inject(service)"])(
-    "keeps decorator call %s as plain text",
-    (reference) => {
-      expect(collectComposerInlineTokens(`${reference}\nclass Example {}`)).toEqual([]);
-    },
-  );
+  it.each([
+    "@foo(bar)",
+    "@namespace.foo(bar)",
+    "@_private()",
+    "@$inject(service)",
+    "@écrire(option)",
+    "@工場.監査(値)",
+    "@e\u0301crire(option)",
+    '@factories["audit"](options)',
+  ])("keeps decorator call %s as plain text", (reference) => {
+    expect(collectComposerInlineTokens(`${reference}\nclass Example {}`)).toEqual([]);
+  });
 
   it.each(['@"foo(bar)"', "[foo(bar)](foo%28bar%29)"])(
     "keeps an explicit decorator-shaped file reference as a mention: %s",

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -37,9 +37,10 @@ const FILE_LINK_TOKEN_REGEX = new RegExp(
 );
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
-// Autocomplete emits canonical file links, so ambiguous bare @scope/package text stays a package.
+// Autocomplete emits canonical file links, so ambiguous bare references stay text.
 const SCOPED_PACKAGE_REFERENCE_REGEX =
   /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*(?:\/[^\s@"]+)*$/;
+const DECORATOR_CALL_REFERENCE_REGEX = /^[A-Za-z_$][\w.$]*\(/;
 
 function collectMentionTokens(text: string): ComposerInlineToken[] {
   const matches: ComposerInlineToken[] = [];
@@ -77,7 +78,11 @@ function collectMentionTokens(text: string): ComposerInlineToken[] {
     const prefix = match[1] ?? "";
     const quotedPath = match[2];
     const path = quotedPath !== undefined ? quotedPath.replace(/\\(.)/g, "$1") : (match[3] ?? "");
-    if (!path || (quotedPath === undefined && SCOPED_PACKAGE_REFERENCE_REGEX.test(path))) {
+    if (
+      !path ||
+      (quotedPath === undefined &&
+        (SCOPED_PACKAGE_REFERENCE_REGEX.test(path) || DECORATOR_CALL_REFERENCE_REGEX.test(path)))
+    ) {
       continue;
     }
     const start = (match.index ?? 0) + prefix.length;

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -40,7 +40,7 @@ const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 // Autocomplete emits canonical file links, so ambiguous bare references stay text.
 const SCOPED_PACKAGE_REFERENCE_REGEX =
   /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*(?:\/[^\s@"]+)*$/;
-const DECORATOR_CALL_REFERENCE_REGEX = /^[A-Za-z_$][\w.$]*\(/;
+const DECORATOR_CALL_REFERENCE_REGEX = /^[\p{ID_Start}_$][\p{ID_Continue}.$\u200c\u200d]*\(/u;
 
 function collectMentionTokens(text: string): ComposerInlineToken[] {
   const matches: ComposerInlineToken[] = [];


### PR DESCRIPTION
Pasting decorator calls such as `@foo(bar)` turned them into file chips and changed the submitted prompt to `[foo(bar)](foo%28bar%29) `.

Keep unquoted decorator calls as plain text in the shared composer parser. Explicit quoted mentions and canonical file links still become chips. The original fix and commits by Gigioxx are preserved; this update merges current main, adds serialized-output and shared-parser regression coverage, and handles Unicode names in the same immediate-call grammar.

Fixes [#8331](https://github.com/pingdotgg/t3code/issues/8331).

### Verification

- Reproduced against [4f1092c](https://github.com/pingdotgg/t3code/commit/4f1092cec2ebaa6ed0e49821238dfe6f1add362d) with the real Lexical paste handler, composer parser, and file-link serializer. Both the exact report and a namespaced multiline decorator produced file links instead of the pasted text. Quoted and canonical file-reference controls passed.
- Integrated with [4d3907f](https://github.com/pingdotgg/t3code/commit/4d3907f63d71644e1918d76cd104b036535a1173). All 82 tests in `ComposerPromptEditor.test.ts`, `composer-editor-mentions.test.ts`, and `composerInlineTokens.test.ts` pass.
- Shared and web typechecks, changed-file lint and formatting, and diff checks pass.
- Web and desktop share this paste handler. The shared tokenizer also feeds the native mobile composer. No native device run was performed, and no provider or wire contracts change.

All executed current-head CI, native fingerprint, correctness and Bugbot checks pass. Preview/native-only jobs skip. Approvability is neutral, and one review thread remains open for a scope decision about whitespace before calls. This PR preserves existing file mentions such as `@README.md (notes)` instead of interpreting the following parenthesis as decorator syntax. The thread's Unicode case is fixed; its double-quoted computed-name example was already plain text and is now covered by a test. Current integrated browser evidence is attached below.

The captures below are the original contributor's evidence, not a new browser verification of this head.

<details>
<summary>Original contributor's before/after evidence</summary>

Before:

![Decorator pasted as a file chip](https://github.com/user-attachments/assets/afc82bea-46e3-4b8a-b61b-12dd39e8403b)

After:

![Decorator remains plain text after paste](https://github.com/user-attachments/assets/4197874c-9d11-4e16-82ec-5a6abdd7a76f)

</details>

Prepared with GPT 6 Astra via Codex in T3 Code.


### Current-client before and after

On [ac90950f](https://github.com/pingdotgg/t3code/commit/ac90950f1ac315bcef5f92b53c5e0d6579daeefd), native plain-text clipboard paste in Chromium 152 turns `@foo(bar)` into a file chip. With the exact shared-parser change from [42158d66](https://github.com/pingdotgg/t3code/commit/42158d668db1879dc8afb1bcedb07ce4431d1612), the same paste remains literal text with zero chips. The clipboard source was an ordinary temporary textarea, copied with Ctrl+C and pasted with Ctrl+V; no synthetic paste event or provider turn was used.

Before:

![Before: pasting the decorator creates a file-mention chip](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/87f123d8c4b81c0b/8331-before-paste.png)

After:

![After: the same clipboard paste remains literal decorator text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6daeaf5c71e034c0/8331-after-paste.png)

Actual-client controls also preserve `@écrire(option)` as text, preserve the explicit `@"foo(bar)"` file chip, and preserve the `@README.md (notes)` file mention. `@foo (bar)` still produces a mention followed by parenthetical text: that is the outstanding grammar decision, not a claimed fix. No native desktop/mobile run was performed. The orchestrator read the complete three-file change; this remains human-held with the decision thread open.

