### PR TITLE
fix(server): close live websockets when a session is revoked

### DIFF
--- a/apps/server/src/auth/SessionStore.test.ts
+++ b/apps/server/src/auth/SessionStore.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as TestClock from "effect/testing/TestClock";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -273,6 +274,77 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
         expect(revokedClientWebSocket.sessionId).toBe(client.sessionId);
         expect(revokedClientWebSocket.revokedAt.epochMilliseconds).toBeGreaterThanOrEqual(0);
       }
+    }).pipe(Effect.provide(makeSessionStoreLayer())),
+  );
+
+  it.effect("completes awaitRevoked when the session is revoked", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const issued = yield* sessions.issue({
+        subject: "await-revoked",
+        method: "bearer-access-token",
+      });
+      const fiber = yield* sessions
+        .awaitRevoked(issued.sessionId)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* sessions.revoke(issued.sessionId);
+      yield* Fiber.join(fiber);
+    }).pipe(Effect.provide(makeSessionStoreLayer())),
+  );
+
+  it.effect("completes awaitRevoked immediately when the session is already revoked", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const issued = yield* sessions.issue({
+        subject: "already-revoked",
+        method: "bearer-access-token",
+      });
+      yield* sessions.revoke(issued.sessionId);
+      yield* sessions.awaitRevoked(issued.sessionId);
+    }).pipe(Effect.provide(makeSessionStoreLayer())),
+  );
+
+  it.effect("completes awaitRevoked when other sessions are revoked", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const keep = yield* sessions.issue({
+        subject: "keep",
+        method: "bearer-access-token",
+      });
+      const drop = yield* sessions.issue({
+        subject: "drop",
+        method: "bearer-access-token",
+      });
+      const fiber = yield* sessions
+        .awaitRevoked(drop.sessionId)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* sessions.revokeAllExcept(keep.sessionId);
+      yield* Fiber.join(fiber);
+    }).pipe(Effect.provide(makeSessionStoreLayer())),
+  );
+
+  it.effect("does not complete awaitRevoked for a different session", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionStore.SessionStore;
+      const watched = yield* sessions.issue({
+        subject: "watched",
+        method: "bearer-access-token",
+      });
+      const other = yield* sessions.issue({
+        subject: "other",
+        method: "bearer-access-token",
+      });
+      const fiber = yield* sessions
+        .awaitRevoked(watched.sessionId)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* sessions.revoke(other.sessionId);
+      expect(fiber.pollUnsafe()).toBeUndefined();
+
+      yield* sessions.revoke(watched.sessionId);
+      yield* Fiber.join(fiber);
     }).pipe(Effect.provide(makeSessionStoreLayer())),
   );
 

--- a/apps/server/src/auth/SessionStore.ts
+++ b/apps/server/src/auth/SessionStore.ts
@@ -11,14 +11,16 @@ import {
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
-import * as Option from "effect/Option";
 
 import * as ServerConfig from "../config.ts";
 import * as AuthSessions from "../persistence/AuthSessions.ts";
@@ -395,6 +397,12 @@ export class SessionStore extends Context.Service<
     readonly revokeAllExcept: (
       sessionId: AuthSessionId,
     ) => Effect.Effect<number, SessionCredentialInternalError>;
+    /**
+     * Completes when this session is revoked, or immediately if it already is.
+     * WebSocket handlers race the live socket against this so a kick closes the
+     * connection instead of leaving it open until TCP drops.
+     */
+    readonly awaitRevoked: (sessionId: AuthSessionId) => Effect.Effect<void>;
     readonly markConnected: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
     readonly markDisconnected: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
     readonly recordClientConnection: (
@@ -474,6 +482,9 @@ export const make = Effect.gen(function* () {
   const authSessions = yield* AuthSessions.AuthSessionRepository;
   const signingSecret = yield* secretStore.getOrCreateRandom(SIGNING_SECRET_NAME, 32);
   const connectedSessionsRef = yield* Ref.make(new Map<string, number>());
+  const revocationWaitersRef = yield* Ref.make(
+    new Map<string, ReadonlyArray<Deferred.Deferred<void>>>(),
+  );
   const changesPubSub = yield* PubSub.unbounded<SessionCredentialChange>();
   const cookieName = resolveSessionCookieName({
     mode: serverConfig.mode,
@@ -494,6 +505,69 @@ export const make = Effect.gen(function* () {
       type: "clientRemoved",
       sessionId,
     }).pipe(Effect.asVoid);
+
+  const completeRevocationWaiters = (sessionId: AuthSessionId) =>
+    Ref.modify(revocationWaitersRef, (current) => {
+      const waiters = current.get(sessionId) ?? [];
+      if (waiters.length === 0) {
+        return [waiters, current] as const;
+      }
+      const next = new Map(current);
+      next.delete(sessionId);
+      return [waiters, next] as const;
+    }).pipe(
+      Effect.flatMap((waiters) =>
+        Effect.forEach(
+          waiters,
+          (waiter) => Deferred.succeed(waiter, undefined).pipe(Effect.asVoid),
+          { discard: true },
+        ),
+      ),
+    );
+
+  const removeRevocationWaiter = (sessionId: AuthSessionId, waiter: Deferred.Deferred<void>) =>
+    Ref.update(revocationWaitersRef, (current) => {
+      const waiters = current.get(sessionId);
+      if (waiters === undefined) {
+        return current;
+      }
+      const remaining = waiters.filter((entry) => entry !== waiter);
+      if (remaining.length === waiters.length) {
+        return current;
+      }
+      const next = new Map(current);
+      if (remaining.length === 0) {
+        next.delete(sessionId);
+      } else {
+        next.set(sessionId, remaining);
+      }
+      return next;
+    });
+
+  const awaitRevoked: SessionStore["Service"]["awaitRevoked"] = Effect.fn(
+    "SessionStore.awaitRevoked",
+  )(function* (sessionId) {
+    const waiter = yield* Deferred.make<void>();
+    yield* Ref.update(revocationWaitersRef, (current) => {
+      const next = new Map(current);
+      next.set(sessionId, [...(current.get(sessionId) ?? []), waiter]);
+      return next;
+    });
+    return yield* Effect.gen(function* () {
+      const lookup = yield* authSessions.getById({ sessionId }).pipe(Effect.result);
+      if (Result.isSuccess(lookup)) {
+        const row = lookup.success;
+        if (Option.isNone(row) || row.value.revokedAt !== null) {
+          yield* Deferred.succeed(waiter, undefined);
+        }
+      } else {
+        yield* Effect.logWarning(
+          "Failed to check whether a live session was already revoked.",
+        ).pipe(Effect.annotateLogs({ sessionId, cause: lookup.failure }));
+      }
+      return yield* Deferred.await(waiter);
+    }).pipe(Effect.ensuring(removeRevocationWaiter(sessionId, waiter)));
+  });
 
   const loadActiveSession = (sessionId: AuthSessionId) =>
     Effect.gen(function* () {
@@ -888,6 +962,7 @@ export const make = Effect.gen(function* () {
           next.delete(sessionId);
           return next;
         });
+        yield* completeRevocationWaiters(sessionId);
         yield* emitRemoved(sessionId);
       }
       return revoked;
@@ -918,7 +993,10 @@ export const make = Effect.gen(function* () {
       });
       yield* Effect.forEach(
         revokedSessionIds,
-        (revokedSessionId) => emitRemoved(revokedSessionId),
+        (revokedSessionId) =>
+          completeRevocationWaiters(revokedSessionId).pipe(
+            Effect.andThen(emitRemoved(revokedSessionId)),
+          ),
         {
           concurrency: "unbounded",
           discard: true,
@@ -940,6 +1018,7 @@ export const make = Effect.gen(function* () {
     },
     revoke,
     revokeAllExcept,
+    awaitRevoked,
     markConnected,
     markDisconnected,
     recordClientConnection,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4000,6 +4000,65 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("closes a live websocket when that client session is revoked", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest({
+        config: {
+          host: "0.0.0.0",
+        },
+      });
+
+      const ownerCookie = yield* getAuthenticatedSessionCookieHeader();
+      const pairingResponse = yield* HttpClient.post("/api/auth/pairing-token", {
+        headers: {
+          cookie: ownerCookie,
+        },
+        body: yield* HttpBody.json({}),
+      });
+      const pairingBody = (yield* pairingResponse.json) as {
+        readonly credential: string;
+      };
+      const pairedSessionCookie = yield* getAuthenticatedSessionCookieHeader(
+        pairingBody.credential,
+      );
+
+      const clientsResponse = yield* HttpClient.get("/api/auth/clients", {
+        headers: {
+          cookie: ownerCookie,
+        },
+      });
+      const clients = (yield* clientsResponse.json) as ReadonlyArray<{
+        readonly sessionId: string;
+        readonly current: boolean;
+      }>;
+      const pairedSessionId = clients.find((entry) => !entry.current)?.sessionId;
+      assert.isDefined(pairedSessionId);
+
+      const wsUrl = appendSessionCookieToWsUrl(
+        yield* getWsServerUrl("/ws", { authenticated: false }),
+        pairedSessionCookie?.split(";")[0] ?? "",
+      );
+      const streamFiber = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.runDrain),
+        ),
+      ).pipe(Effect.exit, Effect.forkChild({ startImmediately: true }));
+
+      yield* Effect.yieldNow;
+
+      const revokeResponse = yield* HttpClient.post("/api/auth/clients/revoke", {
+        headers: {
+          cookie: ownerCookie,
+          "content-type": "application/json",
+        },
+        body: HttpBody.text(jsonRequestBody({ sessionId: pairedSessionId }), "application/json"),
+      });
+      assert.equal(revokeResponse.status, 200);
+
+      yield* Fiber.join(streamFiber);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("allows reusing the desktop bootstrap credential", () =>
     Effect.gen(function* () {
       // The desktop-bootstrap grant is delivered over trusted IPC at

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2521,7 +2521,13 @@ export const websocketRpcRouteLayer = Layer.unwrap(
         );
         return yield* Effect.acquireUseRelease(
           sessions.markConnected(session.sessionId),
-          () => rpcWebSocketHttpEffect,
+          () =>
+            rpcWebSocketHttpEffect.pipe(
+              // A kick stamps revoked_at but used to leave this socket open.
+              // Racing the live connection against awaitRevoked interrupts it
+              // so the client is dropped now, not whenever TCP happens to die.
+              Effect.raceFirst(sessions.awaitRevoked(session.sessionId)),
+            ),
           () => sessions.markDisconnected(session.sessionId),
         );
       }).pipe(

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -102,6 +102,10 @@ appends only that ticket to the socket URL as `wsTicket`. This keeps long-lived
 tokens and browser cookies out of WebSocket URLs while letting the handshake
 authenticate.
 
+Revoking a session closes any live WebSocket that authenticated as that session.
+A later upgrade is already rejected because the ticket's parent session is revoked.
+The live socket used to stay open until TCP dropped.
+
 The ticket carries its session's scopes; each RPC method then enforces
 `orchestration:read`, `orchestration:operate`, `terminal:operate`,
 `review:write`, `relay:write`, or `access:read` as appropriate, through

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -235,4 +235,4 @@ controls remain in **Settings** → **Connections** on web and desktop or **Sett
 - Prefer binding `--host` to a trusted private address, such as a Tailnet IP, instead of exposing the server broadly.
 - Anyone with a valid pairing credential can create a session until that credential expires or is revoked.
 - Hosted pairing links keep the credential in the URL hash so it is not sent to the hosted app server, but it can still be exposed through browser history, screenshots, logs, or copy/paste.
-- Use `t3 auth` to revoke credentials or sessions you no longer trust.
+- Use `t3 auth` to revoke credentials or sessions you no longer trust. Revoking a session also closes that client's live connection.


### PR DESCRIPTION
## What Changed

Revoking a client session now also closes that client's live websocket.

`SessionStore.awaitRevoked` waits until the session is revoked, or returns right away if it already is. The websocket handler races the live socket against that wait. A kick interrupts the connection. New upgrades were already rejected after revoke. The open socket was not.

`revoke` and `revokeAllExcept` both wake those waiters. Tests cover the wait, an already-revoked session, revoke-others, and a live socket closing after `/api/auth/clients/revoke`.

## Why

Settings and `t3 auth` let you kick a device you no longer trust. After revoke, new HTTP calls and new `/ws` upgrades failed. The socket that was already open kept running. A phone or desktop that stayed connected still had dispatch, terminals, and file writes until TCP dropped.

This is not a grace period for a bad network. A bad network drops the socket. The path that survived was a healthy connection that never reconnected.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session revocation and WebSocket lifecycle in auth-critical paths; behavior is narrower and well-tested but affects live client access when sessions are kicked.
> 
> **Overview**
> **Revoking a client session now tears down that session’s open WebSocket**, not only blocking new HTTP and upgrade attempts.
> 
> `SessionStore` gains **`awaitRevoked`**, which finishes when the given session is revoked (or immediately if it already is), backed by per-session `Deferred` waiters that **`revoke`** and **`revokeAllExcept`** wake. The WebSocket handler **races** the live RPC effect against `awaitRevoked` via `Effect.raceFirst`, so a kick ends the connection promptly instead of leaving it up until TCP drops.
> 
> Unit tests cover waiter behavior (including `revokeAllExcept` and session isolation); an integration test asserts the socket ends after **`/api/auth/clients/revoke`**. Docs note that session revoke closes live connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2446459ba0025a8fd2adc0211e1cc658b526c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close live websockets when a session is revoked
> - Adds `SessionStore.awaitRevoked(sessionId)`, which completes when the session is revoked or immediately if already revoked, using a `Ref` of `Deferred` waiters drained by `revoke` and `revokeAllExcept`
> - Wraps the WebSocket RPC handler in `Effect.raceFirst` against `awaitRevoked` in [ws.ts](https://github.com/pingdotgg/t3code/pull/8418/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125), so active sockets terminate on revocation instead of waiting for TCP to drop
> - Updates [environment-auth.md](https://github.com/pingdotgg/t3code/pull/8418/files#diff-7f19e5e5409c468ba8360c07615568dd83e41240a7db91a70a0f2db1fcc0a2a3) and [remote-access.md](https://github.com/pingdotgg/t3code/pull/8418/files#diff-e6cd63b1b8b5df551539c3cbb1790b40f70baa2a5ed146d56f1c7044d7adcb8a) to document that revocation now closes live connections
> - Behavioral Change: revoked sessions with an open WebSocket are now closed proactively; consumers of `SessionStore` gain a new `awaitRevoked` method on the service interface
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e244645.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->