### PR TITLE
fix(server): start thread live subscribe immediately

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6398,7 +6398,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           projectionSnapshotQuery: {
             getThreadDetailSnapshot: () =>
               Effect.gen(function* () {
-                yield* Effect.sleep("25 millis");
+                // Publish during the snapshot load, with no sleep. Effect 4
+                // schedules forkScoped work on a later tick unless
+                // startImmediately is set, so a delay here would hide a lost
+                // event.
                 yield* PubSub.publish(liveEvents, messageEvent);
                 return Option.some({ snapshotSequence: 1, thread });
               }),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1465,6 +1465,7 @@ const makeWsRpcLayer = (
               const liveBuffer = yield* Queue.unbounded<OrchestrationThreadStreamItem>();
               yield* Effect.forkScoped(
                 liveStream.pipe(Stream.runForEach((item) => Queue.offer(liveBuffer, item))),
+                { startImmediately: true },
               );
               const bufferedLiveStream = Stream.fromQueue(liveBuffer);
 


### PR DESCRIPTION
## What Changed

`subscribeThread` now starts its live event buffer fork with `startImmediately: true`, the same as `subscribeShell`.

The test that covers events published while the thread snapshot loads no longer waits 25ms before publishing. That wait let the late fork still catch the event, so a lost event would not fail the test. It now publishes during the snapshot load.

## Why

The comment on `subscribeThread` already says live delivery must attach before the snapshot loads, or an event can be lost. Effect 4 runs `forkScoped` on a later tick unless you pass `startImmediately`. Shell already passed it. Thread did not.

A message or activity that lands in that gap never reaches the client. Reconnect cannot put it back if catch-up already used a snapshot taken before that event.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted WebSocket subscription fix aligned with existing shell behavior; test change only tightens coverage.
> 
> **Overview**
> **Thread WebSocket subscriptions** now fork the live event buffer with `startImmediately: true`, matching `subscribeShell`. Under Effect 4, `forkScoped` runs on a later tick by default, so events published while the thread snapshot or catch-up replay was still loading could miss the live stream and never reach the client.
> 
> The integration test for “message sent during snapshot load” **publishes the event immediately** during snapshot fetch instead of sleeping 25ms first, so a regression in that ordering would fail instead of being masked by delayed scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70be50aaf444202f1d26a711d2418bfd56aea20c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Start WebSocket live stream subscription fiber immediately in `makeWsRpcLayer`
> Passes `{ startImmediately: true }` to the `Effect.forkScoped` call in [ws.ts](https://github.com/pingdotgg/t3code/pull/8420/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) so the live delivery fiber starts on the current tick, before snapshot or replay reads begin. This closes a window where events published during snapshot loading could be lost. The test stub in [server.test.ts](https://github.com/pingdotgg/t3code/pull/8420/files#diff-311d34bc81e1c9cdae991c24771a5c0b8f02084dc94251982be7466403965b9f) removes a 25 ms sleep and now publishes a live event during snapshot load to exercise this timing.
> - Behavioral Change: the live subscription fiber starts synchronously rather than on the next tick; the test stub no longer delays event publication, so tests that relied on the 25 ms window may need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70be50a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->