### PR TITLE
fix(web): use the drawer close fallback for right-panel terminals

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3115,7 +3115,7 @@ function ChatViewContent(props: ChatViewProps) {
     gitCwd,
     storeNewTerminal,
   ]);
-  const closeTerminal = useCallback(
+  const closeTerminalSession = useCallback(
     (terminalId: string) => {
       if (!activeThreadId || !activeThreadRef) return;
       const fallbackExitWrite = () =>
@@ -3137,7 +3137,6 @@ function ChatViewContent(props: ChatViewProps) {
         }
       })();
       storeCloseTerminal(activeThreadRef, terminalId);
-      setTerminalFocusRequestId((value) => value + 1);
     },
     [
       activeThreadId,
@@ -3147,6 +3146,13 @@ function ChatViewContent(props: ChatViewProps) {
       storeCloseTerminal,
       writeTerminal,
     ],
+  );
+  const closeTerminal = useCallback(
+    (terminalId: string) => {
+      closeTerminalSession(terminalId);
+      setTerminalFocusRequestId((value) => value + 1);
+    },
+    [closeTerminalSession],
   );
   const runProjectScript = useCallback(
     async (
@@ -3692,12 +3698,12 @@ function ChatViewContent(props: ChatViewProps) {
         }
         if (surface.kind === "terminal") {
           for (const terminalId of surface.terminalIds) {
-            closeTerminal(terminalId);
+            closeTerminalSession(terminalId);
           }
         }
       }
     },
-    [activeThreadRef, activePreviewState.sessions, closePreview, closeTerminal],
+    [activeThreadRef, activePreviewState.sessions, closePreview, closeTerminalSession],
   );
   const syncActivePreviewSurface = useCallback(() => {
     if (!activeThreadRef) return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3623,17 +3623,12 @@ function ChatViewContent(props: ChatViewProps) {
   const closePanelTerminal = useCallback(
     (terminalId: string) => {
       if (!activeThreadRef || activeRightPanelSurface?.kind !== "terminal") return;
-      void closeTerminalMutation({
-        environmentId: activeThreadRef.environmentId,
-        input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
-      });
-      storeCloseTerminal(activeThreadRef, terminalId);
+      closeTerminal(terminalId);
       useRightPanelStore
         .getState()
         .closeTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId);
-      setTerminalFocusRequestId((value) => value + 1);
     },
-    [activeRightPanelSurface, activeThreadRef, closeTerminalMutation, storeCloseTerminal],
+    [activeRightPanelSurface, activeThreadRef, closeTerminal],
   );
   const requestCloseTerminal = useCallback(
     (terminalId: string) => {
@@ -3697,22 +3692,12 @@ function ChatViewContent(props: ChatViewProps) {
         }
         if (surface.kind === "terminal") {
           for (const terminalId of surface.terminalIds) {
-            storeCloseTerminal(activeThreadRef, terminalId);
-            void closeTerminalMutation({
-              environmentId: activeThreadRef.environmentId,
-              input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
-            });
+            closeTerminal(terminalId);
           }
         }
       }
     },
-    [
-      activeThreadRef,
-      activePreviewState.sessions,
-      closePreview,
-      closeTerminalMutation,
-      storeCloseTerminal,
-    ],
+    [activeThreadRef, activePreviewState.sessions, closePreview, closeTerminal],
   );
   const syncActivePreviewSurface = useCallback(() => {
     if (!activeThreadRef) return;


### PR DESCRIPTION
## What Changed

Right-panel terminal close now uses the same close path as the drawer.

If `terminalClose` fails, that path writes `exit\n` so the process dies. Panel close and panel-surface cleanup used to call `terminalClose` and hide the session, with no fallback.

## Why

A failed close left the PTY running. The UI said it was gone. Reload cleared the local hide list, so the closed terminal came back.

The drawer already had the fallback. The panel did not.

## UI Changes

None. Closing a tab looks the same. The process is what changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors terminal close call sites in ChatView; behavior improves parity with existing drawer fallback rather than changing auth or data paths.
> 
> **Overview**
> Right-panel terminal teardown no longer calls `closeTerminalMutation` and `storeCloseTerminal` inline. **`closeTerminalSession`** holds the shared logic (mutation, store close, and **`exit\n` fallback** when close fails). **`closeTerminal`** wraps that and bumps **`terminalFocusRequestId`** for user-initiated closes.
> 
> **`closePanelTerminal`** and confirmed closes go through **`closeTerminal`**, so panel tabs get the same PTY cleanup as the drawer. When **closing all terminal surfaces** on the right panel, the code calls **`closeTerminalSession`** only so bulk cleanup does not repeatedly refocus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11293b843cb7e0854192283cd4026bc9bdcecaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route right-panel terminal closes through `closeTerminalSession` fallback
> Extracts terminal close logic into a shared `closeTerminalSession` hook in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8421/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). This hook issues the close mutation, falls back to writing `exit\n` on failure (excluding interruptions), and updates the local store.
> - Right-panel surface cleanup and `closePanelTerminal` now call `closeTerminalSession` instead of inlining the mutation and store update, so they gain the same failure fallback.
> - `closeTerminal` wraps `closeTerminalSession` and increments `setTerminalFocusRequestId` for focus changes; callers that need focus still use this wrapper.
> - Behavioral Change: right-panel terminal closes now issue a single focus request (via `closeTerminal`) instead of a separate increment, removing the prior duplicate. Surface cleanup closes do not request focus changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11293b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->