### PR TITLE
fix(web): roll back file editor when save fails

### DIFF
--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -429,6 +429,7 @@ function useFileSaveCoordinator({
         onRollback: ({ failedContents, result }) => {
           const overlay = getOptimisticProjectFileQueryData(environmentId, cwd, relativePath);
           if (overlay !== null && overlay.contents !== failedContents) {
+            onPendingChange(relativePath, true);
             return;
           }
           clearProjectFileQueryData(environmentId, cwd, relativePath);

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -59,7 +59,6 @@ import { fileBreadcrumbs } from "./filePath";
 import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
 import {
-  clearProjectFileQueryData,
   confirmProjectFileQueryData,
   getOptimisticProjectFileQueryData,
   setProjectFileQueryData,
@@ -426,14 +425,16 @@ function useFileSaveCoordinator({
         onConfirmed: (confirmedContents) => {
           confirmProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
         },
-        onRollback: ({ failedContents, result }) => {
+        onRollback: ({ failedContents, confirmedContents, result }) => {
           const overlay = getOptimisticProjectFileQueryData(environmentId, cwd, relativePath);
           if (overlay !== null && overlay.contents !== failedContents) {
             onPendingChange(relativePath, true);
             return;
           }
-          clearProjectFileQueryData(environmentId, cwd, relativePath);
-          const error = result === null ? null : squashAtomCommandFailure(result);
+          setProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
+          confirmProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
+          onPendingChange(relativePath, false);
+          const error = result?._tag === "Failure" ? squashAtomCommandFailure(result) : null;
           toastManager.add({
             type: "error",
             title: "Could not save file",

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -404,16 +404,18 @@ function useFileSaveCoordinator({
   environmentId,
   cwd,
   relativePath,
+  contents,
   onPendingChange,
 }: Pick<
   EditableFileSurfaceProps,
-  "environmentId" | "cwd" | "relativePath" | "onPendingChange"
+  "environmentId" | "cwd" | "relativePath" | "contents" | "onPendingChange"
 >): FileSaveCoordinator {
   const writeFile = useAtomCommand(projectEnvironment.writeFile);
   const coordinator = useMemo(
     () =>
       new FileSaveCoordinator({
         debounceMs: FILE_SAVE_DEBOUNCE_MS,
+        initialContents: contents,
         onPendingChange: (pending) => onPendingChange(relativePath, pending),
         persist: (nextContents) =>
           writeFile({
@@ -423,7 +425,17 @@ function useFileSaveCoordinator({
         onConfirmed: (confirmedContents) => {
           confirmProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
         },
+        onRollback: (confirmedContents) => {
+          setProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
+          toastManager.add({
+            type: "error",
+            title: "Could not save file",
+            description: relativePath,
+          });
+        },
       }),
+    // initialContents is the loaded file at mount. Overlay edits must not
+    // rebuild the coordinator or last-confirmed state resets on every keystroke.
     [cwd, environmentId, onPendingChange, relativePath, writeFile],
   );
 
@@ -461,6 +473,7 @@ function EditableFileSurface({
     environmentId,
     cwd,
     relativePath,
+    contents,
     onPendingChange,
   });
   const editor = useMemo(
@@ -722,6 +735,7 @@ function RenderedMarkdownSurface({
     environmentId,
     cwd,
     relativePath,
+    contents,
     onPendingChange,
   });
 

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -59,6 +59,7 @@ import { fileBreadcrumbs } from "./filePath";
 import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
 import { FileSaveCoordinator } from "./fileSaveCoordinator";
 import {
+  clearProjectFileQueryData,
   confirmProjectFileQueryData,
   getOptimisticProjectFileQueryData,
   setProjectFileQueryData,
@@ -425,12 +426,17 @@ function useFileSaveCoordinator({
         onConfirmed: (confirmedContents) => {
           confirmProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
         },
-        onRollback: (confirmedContents) => {
-          setProjectFileQueryData(environmentId, cwd, relativePath, confirmedContents);
+        onRollback: ({ failedContents, result }) => {
+          const overlay = getOptimisticProjectFileQueryData(environmentId, cwd, relativePath);
+          if (overlay !== null && overlay.contents !== failedContents) {
+            return;
+          }
+          clearProjectFileQueryData(environmentId, cwd, relativePath);
+          const error = result === null ? null : squashAtomCommandFailure(result);
           toastManager.add({
             type: "error",
             title: "Could not save file",
-            description: relativePath,
+            description: error instanceof Error ? error.message : relativePath,
           });
         },
       }),
@@ -439,6 +445,9 @@ function useFileSaveCoordinator({
     [cwd, environmentId, onPendingChange, relativePath, writeFile],
   );
 
+  useEffect(() => {
+    coordinator.syncConfirmed(contents);
+  }, [contents, coordinator]);
   useEffect(() => () => coordinator.dispose(), [coordinator]);
   return coordinator;
 }

--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -227,4 +227,35 @@ describe("FileSaveCoordinator", () => {
       }),
     );
   });
+
+  it("lets idle refreshes update the baseline after a successful save", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValueOnce(AsyncResult.success(undefined))
+      .mockResolvedValueOnce(AsyncResult.failure(Cause.fail(new Error("write failed"))));
+    const onRollback = vi.fn();
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      initialContents: "disk",
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+      onRollback,
+    });
+
+    coordinator.change("saved");
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+    coordinator.syncConfirmed("refreshed");
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+    expect(onRollback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        failedContents: "latest",
+        confirmedContents: "refreshed",
+      }),
+    );
+  });
 });

--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -81,12 +81,11 @@ describe("FileSaveCoordinator", () => {
     vi.useFakeTimers();
     const onPendingChange = vi.fn();
     const onRollback = vi.fn();
+    const failure = AsyncResult.failure(Cause.fail(new Error("write failed")));
     const coordinator = new FileSaveCoordinator({
       debounceMs: 500,
       initialContents: "disk",
-      persist: vi
-        .fn()
-        .mockResolvedValue(AsyncResult.failure(Cause.fail(new Error("write failed")))),
+      persist: vi.fn().mockResolvedValue(failure),
       onPendingChange,
       onConfirmed: vi.fn(),
       onRollback,
@@ -95,7 +94,11 @@ describe("FileSaveCoordinator", () => {
     coordinator.change("latest");
     await vi.advanceTimersByTimeAsync(500);
     await Promise.resolve();
-    expect(onRollback).toHaveBeenCalledWith("disk");
+    expect(onRollback).toHaveBeenCalledWith({
+      failedContents: "latest",
+      confirmedContents: "disk",
+      result: failure,
+    });
     expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
   });
 
@@ -126,5 +129,97 @@ describe("FileSaveCoordinator", () => {
     expect(onRollback).not.toHaveBeenCalled();
     expect(persist).toHaveBeenLastCalledWith("latest");
     expect(onConfirmed).toHaveBeenCalledWith("latest");
+  });
+
+  it("does not roll back an interrupted write", async () => {
+    vi.useFakeTimers();
+    const onRollback = vi.fn();
+    const onPendingChange = vi.fn();
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      initialContents: "disk",
+      persist: vi.fn().mockResolvedValue(AsyncResult.failure(Cause.interrupt(1))),
+      onPendingChange,
+      onConfirmed: vi.fn(),
+      onRollback,
+    });
+
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+    expect(onRollback).not.toHaveBeenCalled();
+    expect(onPendingChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("does not roll back or clear pending after dispose", async () => {
+    vi.useFakeTimers();
+    const write = deferred();
+    const onRollback = vi.fn();
+    const onPendingChange = vi.fn();
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      initialContents: "disk",
+      persist: vi.fn().mockReturnValue(write.promise),
+      onPendingChange,
+      onConfirmed: vi.fn(),
+      onRollback,
+    });
+
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.dispose();
+    write.resolve(AsyncResult.failure(Cause.fail(new Error("write failed"))));
+    await Promise.resolve();
+    expect(onRollback).not.toHaveBeenCalled();
+    expect(onPendingChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("does not persist a discarded failed edit on dispose", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValue(AsyncResult.failure(Cause.fail(new Error("write failed"))));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      initialContents: "disk",
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+      onRollback: vi.fn(),
+    });
+
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+    expect(persist).toHaveBeenCalledOnce();
+    coordinator.dispose();
+    await Promise.resolve();
+    expect(persist).toHaveBeenCalledOnce();
+  });
+
+  it("uses a later confirmed refresh as the rollback baseline", async () => {
+    vi.useFakeTimers();
+    const onRollback = vi.fn();
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      initialContents: "disk",
+      persist: vi
+        .fn()
+        .mockResolvedValue(AsyncResult.failure(Cause.fail(new Error("write failed")))),
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+      onRollback,
+    });
+
+    coordinator.syncConfirmed("refreshed");
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.resolve();
+    expect(onRollback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        failedContents: "latest",
+        confirmedContents: "refreshed",
+      }),
+    );
   });
 });

--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -27,9 +27,11 @@ describe("FileSaveCoordinator", () => {
     const onConfirmed = vi.fn();
     const coordinator = new FileSaveCoordinator({
       debounceMs: 500,
+      initialContents: "disk",
       persist,
       onPendingChange,
       onConfirmed,
+      onRollback: vi.fn(),
     });
 
     coordinator.change("first");
@@ -55,9 +57,11 @@ describe("FileSaveCoordinator", () => {
     const onPendingChange = vi.fn();
     const coordinator = new FileSaveCoordinator({
       debounceMs: 500,
+      initialContents: "disk",
       persist,
       onPendingChange,
       onConfirmed: vi.fn(),
+      onRollback: vi.fn(),
     });
 
     coordinator.change("first");
@@ -73,22 +77,54 @@ describe("FileSaveCoordinator", () => {
     expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
   });
 
-  it("leaves the file pending when the latest write fails", async () => {
+  it("rolls back to the last confirmed contents when the latest write fails", async () => {
     vi.useFakeTimers();
     const onPendingChange = vi.fn();
+    const onRollback = vi.fn();
     const coordinator = new FileSaveCoordinator({
       debounceMs: 500,
+      initialContents: "disk",
       persist: vi
         .fn()
         .mockResolvedValue(AsyncResult.failure(Cause.fail(new Error("write failed")))),
       onPendingChange,
       onConfirmed: vi.fn(),
+      onRollback,
     });
 
     coordinator.change("latest");
     await vi.advanceTimersByTimeAsync(500);
     await Promise.resolve();
-    expect(onPendingChange).toHaveBeenCalledWith(true);
-    expect(onPendingChange).not.toHaveBeenCalledWith(false);
+    expect(onRollback).toHaveBeenCalledWith("disk");
+    expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
+  });
+
+  it("does not roll back a newer edit when an older write fails", async () => {
+    vi.useFakeTimers();
+    const firstWrite = deferred();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockReturnValueOnce(firstWrite.promise)
+      .mockResolvedValueOnce(AsyncResult.success(undefined));
+    const onRollback = vi.fn();
+    const onConfirmed = vi.fn();
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      initialContents: "disk",
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed,
+      onRollback,
+    });
+
+    coordinator.change("first");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.change("latest");
+    firstWrite.resolve(AsyncResult.failure(Cause.fail(new Error("write failed"))));
+    await vi.runAllTimersAsync();
+
+    expect(onRollback).not.toHaveBeenCalled();
+    expect(persist).toHaveBeenLastCalledWith("latest");
+    expect(onConfirmed).toHaveBeenCalledWith("latest");
   });
 });

--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -99,7 +99,7 @@ describe("FileSaveCoordinator", () => {
       confirmedContents: "disk",
       result: failure,
     });
-    expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
+    expect(onPendingChange).not.toHaveBeenCalledWith(false);
   });
 
   it("does not roll back a newer edit when an older write fails", async () => {
@@ -176,7 +176,7 @@ describe("FileSaveCoordinator", () => {
       confirmedContents: "disk",
       result: failure,
     });
-    expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
+    expect(onPendingChange).not.toHaveBeenCalledWith(false);
   });
 
   it("does not persist a discarded failed edit on dispose", async () => {

--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -151,11 +151,12 @@ describe("FileSaveCoordinator", () => {
     expect(onPendingChange).not.toHaveBeenCalledWith(false);
   });
 
-  it("does not roll back or clear pending after dispose", async () => {
+  it("still rolls back a failed write that finishes after dispose", async () => {
     vi.useFakeTimers();
     const write = deferred();
     const onRollback = vi.fn();
     const onPendingChange = vi.fn();
+    const failure = AsyncResult.failure(Cause.fail(new Error("write failed")));
     const coordinator = new FileSaveCoordinator({
       debounceMs: 500,
       initialContents: "disk",
@@ -168,10 +169,14 @@ describe("FileSaveCoordinator", () => {
     coordinator.change("latest");
     await vi.advanceTimersByTimeAsync(500);
     coordinator.dispose();
-    write.resolve(AsyncResult.failure(Cause.fail(new Error("write failed"))));
+    write.resolve(failure);
     await Promise.resolve();
-    expect(onRollback).not.toHaveBeenCalled();
-    expect(onPendingChange).not.toHaveBeenCalledWith(false);
+    expect(onRollback).toHaveBeenCalledWith({
+      failedContents: "latest",
+      confirmedContents: "disk",
+      result: failure,
+    });
+    expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
   });
 
   it("does not persist a discarded failed edit on dispose", async () => {

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -102,6 +102,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
         });
         return;
       }
+      this.latestRevision = 0;
       if (!this.disposed) this.options.onPendingChange(false);
       return;
     }

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -100,7 +100,6 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
           confirmedContents: this.lastConfirmedContents,
           result,
         });
-        this.options.onPendingChange(false);
         return;
       }
       if (!this.disposed) this.options.onPendingChange(false);

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -2,20 +2,25 @@ import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
 
 export interface FileSaveCoordinatorOptions<A, E> {
   readonly debounceMs: number;
+  readonly initialContents: string;
   readonly persist: (contents: string) => Promise<AtomCommandResult<A, E>>;
   readonly onPendingChange: (pending: boolean) => void;
   readonly onConfirmed: (contents: string) => void;
+  readonly onRollback: (contents: string) => void;
 }
 
 export class FileSaveCoordinator<A = unknown, E = unknown> {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private latestContents = "";
+  private lastConfirmedContents: string;
   private latestRevision = 0;
   private lastChangeAt = 0;
   private saving = false;
   private disposed = false;
 
-  constructor(private readonly options: FileSaveCoordinatorOptions<A, E>) {}
+  constructor(private readonly options: FileSaveCoordinatorOptions<A, E>) {
+    this.lastConfirmedContents = options.initialContents;
+  }
 
   change(contents: string): void {
     this.latestContents = contents;
@@ -51,15 +56,24 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
     this.saving = true;
     const contents = this.latestContents;
     const revision = this.latestRevision;
-    const result = await this.options.persist(contents);
-    const succeeded = result._tag === "Success";
-    if (succeeded) {
-      this.options.onConfirmed(contents);
+    let succeeded = false;
+    try {
+      const result = await this.options.persist(contents);
+      succeeded = result._tag === "Success";
+      if (succeeded) {
+        this.lastConfirmedContents = contents;
+        this.options.onConfirmed(contents);
+      }
+    } catch {
+      succeeded = false;
     }
 
     this.saving = false;
     if (revision === this.latestRevision) {
-      if (succeeded) this.options.onPendingChange(false);
+      if (!succeeded) {
+        this.options.onRollback(this.lastConfirmedContents);
+      }
+      this.options.onPendingChange(false);
       return;
     }
 

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -1,4 +1,13 @@
-import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import {
+  type AtomCommandResult,
+  isAtomCommandInterrupted,
+} from "@t3tools/client-runtime/state/runtime";
+
+export interface FileSaveRollback<A = unknown, E = unknown> {
+  readonly failedContents: string;
+  readonly confirmedContents: string;
+  readonly result: AtomCommandResult<A, E> | null;
+}
 
 export interface FileSaveCoordinatorOptions<A, E> {
   readonly debounceMs: number;
@@ -6,7 +15,7 @@ export interface FileSaveCoordinatorOptions<A, E> {
   readonly persist: (contents: string) => Promise<AtomCommandResult<A, E>>;
   readonly onPendingChange: (pending: boolean) => void;
   readonly onConfirmed: (contents: string) => void;
-  readonly onRollback: (contents: string) => void;
+  readonly onRollback: (rollback: FileSaveRollback<A, E>) => void;
 }
 
 export class FileSaveCoordinator<A = unknown, E = unknown> {
@@ -28,6 +37,12 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
     this.lastChangeAt = Date.now();
     this.options.onPendingChange(true);
     this.schedule(this.options.debounceMs);
+  }
+
+  syncConfirmed(contents: string): void {
+    if (this.latestRevision === 0 && !this.saving) {
+      this.lastConfirmedContents = contents;
+    }
   }
 
   dispose(): void {
@@ -56,24 +71,41 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
     this.saving = true;
     const contents = this.latestContents;
     const revision = this.latestRevision;
+    let result: AtomCommandResult<A, E> | null = null;
     let succeeded = false;
+    let interrupted = false;
     try {
-      const result = await this.options.persist(contents);
+      result = await this.options.persist(contents);
       succeeded = result._tag === "Success";
+      interrupted = !succeeded && isAtomCommandInterrupted(result);
       if (succeeded) {
         this.lastConfirmedContents = contents;
         this.options.onConfirmed(contents);
       }
     } catch {
       succeeded = false;
+      interrupted = false;
     }
 
     this.saving = false;
     if (revision === this.latestRevision) {
-      if (!succeeded) {
-        this.options.onRollback(this.lastConfirmedContents);
+      if (interrupted) {
+        return;
       }
-      this.options.onPendingChange(false);
+      if (!succeeded) {
+        this.latestRevision = 0;
+        this.latestContents = this.lastConfirmedContents;
+        if (!this.disposed) {
+          this.options.onRollback({
+            failedContents: contents,
+            confirmedContents: this.lastConfirmedContents,
+            result,
+          });
+          this.options.onPendingChange(false);
+        }
+        return;
+      }
+      if (!this.disposed) this.options.onPendingChange(false);
       return;
     }
 

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -95,14 +95,12 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
       if (!succeeded) {
         this.latestRevision = 0;
         this.latestContents = this.lastConfirmedContents;
-        if (!this.disposed) {
-          this.options.onRollback({
-            failedContents: contents,
-            confirmedContents: this.lastConfirmedContents,
-            result,
-          });
-          this.options.onPendingChange(false);
-        }
+        this.options.onRollback({
+          failedContents: contents,
+          confirmedContents: this.lastConfirmedContents,
+          result,
+        });
+        this.options.onPendingChange(false);
         return;
       }
       if (!this.disposed) this.options.onPendingChange(false);


### PR DESCRIPTION
## What Changed

The file editor now restores the last confirmed text when a save fails.

Edits still apply to the overlay first. If the latest write fails, the overlay goes back, the unsaved mark clears, and a toast says the save failed. A newer edit that landed during that write is not rolled back. The coordinator retries it.

## Why

A failed write left the new text on screen. Reload then showed the old disk contents. Easy to think the file was saved.

## UI Changes

Failed saves now toast and restore the last confirmed file text. No other visual change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A. toast plus restored text is the change)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autosave and optimistic file cache behavior on write failure; incorrect rollback could drop user edits or show stale disk content, though guards exist for newer overlay edits and interrupted commands.
> 
> **Overview**
> Failed file writes no longer leave optimistic editor text on screen. **`FileSaveCoordinator`** now tracks **`lastConfirmedContents`** (from **`initialContents`** and successful saves), exposes **`syncConfirmed`** so idle server refreshes update the rollback baseline, and on a non-interrupted persist failure resets internal state and invokes **`onRollback`** instead of leaving the file “saved.” Interrupted writes and in-flight newer edits are unchanged: stale failures do not roll back newer typing, and overlapping saves still debounce to the latest revision.
> 
> **`FilePreviewPanel`** wires this up by passing loaded **`contents`**, syncing confirmed text when **`contents`** changes without rebuilding the coordinator on every keystroke, and implementing **`onRollback`** to restore project file query data, clear pending when appropriate, skip rollback if the overlay already diverged, and show a **“Could not save file”** error toast.
> 
> Tests cover rollback, baseline refresh, interrupted/dispose edge cases, and concurrent edit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de49ca51f059cc5e0c5701fc5431208987af8ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Roll back file editor to last confirmed contents on save failure
> - `FileSaveCoordinator` now tracks a `lastConfirmedContents` baseline, seeded from a new `initialContents` option and updated on successful saves and idle external refreshes via `syncConfirmed`.
> - On save failure, the coordinator restores `latestContents` to the baseline, resets `latestRevision` to 0, and invokes a new `onRollback` callback with `failedContents`, `confirmedContents`, and the persist `result`; pending state is intentionally left uncleared so the UI can mark the file as pending.
> - Write interruptions detected by `isAtomCommandInterrupted` are treated as a distinct case — no rollback, no pending change.
> - `useFileSaveCoordinator` wires `initialContents` and a new `useEffect` that calls `coordinator.syncConfirmed(contents)` on external content changes, and implements `onRollback` to reset query data and show an error toast.
> - Behavioral Change: pending state is no longer cleared on save failure or interruption; callers that relied on pending being cleared after a failed save will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de49ca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->