### PR TITLE
fix(server): drop pending approvals when a thread reverts

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2626,6 +2626,210 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       ]);
     }),
   );
+
+  it.effect("drops later-turn pending approvals when a thread is reverted", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.make("evt-revert-approval-1"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.make("project-revert-approval"),
+        occurredAt: "2026-02-26T13:00:00.000Z",
+        commandId: CommandId.make("cmd-revert-approval-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-1"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.make("project-revert-approval"),
+          title: "Project Revert Approval",
+          workspaceRoot: "/tmp/project-revert-approval",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: "2026-02-26T13:00:00.000Z",
+          updatedAt: "2026-02-26T13:00:00.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.make("evt-revert-approval-2"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert-approval"),
+        occurredAt: "2026-02-26T13:00:01.000Z",
+        commandId: CommandId.make("cmd-revert-approval-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-2"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert-approval"),
+          projectId: ProjectId.make("project-revert-approval"),
+          title: "Thread Revert Approval",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-02-26T13:00:01.000Z",
+          updatedAt: "2026-02-26T13:00:01.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-revert-approval-3"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert-approval"),
+        occurredAt: "2026-02-26T13:00:02.000Z",
+        commandId: CommandId.make("cmd-revert-approval-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-3"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert-approval"),
+          turnId: TurnId.make("turn-keep"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert-approval/turn/1"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("assistant-keep-approval"),
+          completedAt: "2026-02-26T13:00:02.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-revert-approval-4"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert-approval"),
+        occurredAt: "2026-02-26T13:00:02.100Z",
+        commandId: CommandId.make("cmd-revert-approval-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-4"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert-approval"),
+          activity: {
+            id: EventId.make("activity-keep-approval"),
+            tone: "approval",
+            kind: "approval.requested",
+            summary: "Keep this approval",
+            payload: {
+              requestId: "approval-request-keep",
+              requestKind: "command",
+            },
+            turnId: TurnId.make("turn-keep"),
+            createdAt: "2026-02-26T13:00:02.100Z",
+          },
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-revert-approval-5"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert-approval"),
+        occurredAt: "2026-02-26T13:00:03.000Z",
+        commandId: CommandId.make("cmd-revert-approval-5"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-5"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert-approval"),
+          turnId: TurnId.make("turn-drop"),
+          checkpointTurnCount: 2,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert-approval/turn/2"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("assistant-drop-approval"),
+          completedAt: "2026-02-26T13:00:03.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-revert-approval-6"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert-approval"),
+        occurredAt: "2026-02-26T13:00:03.100Z",
+        commandId: CommandId.make("cmd-revert-approval-6"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-6"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert-approval"),
+          activity: {
+            id: EventId.make("activity-drop-approval"),
+            tone: "approval",
+            kind: "approval.requested",
+            summary: "Drop this approval",
+            payload: {
+              requestId: "approval-request-drop",
+              requestKind: "command",
+            },
+            turnId: TurnId.make("turn-drop"),
+            createdAt: "2026-02-26T13:00:03.100Z",
+          },
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.reverted",
+        eventId: EventId.make("evt-revert-approval-7"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert-approval"),
+        occurredAt: "2026-02-26T13:00:04.000Z",
+        commandId: CommandId.make("cmd-revert-approval-7"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-approval-7"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert-approval"),
+          turnCount: 1,
+        },
+      });
+
+      const approvalRows = yield* sql<{
+        readonly requestId: string;
+        readonly status: string;
+        readonly turnId: string | null;
+      }>`
+        SELECT
+          request_id AS "requestId",
+          status,
+          turn_id AS "turnId"
+        FROM projection_pending_approvals
+        WHERE thread_id = 'thread-revert-approval'
+        ORDER BY request_id ASC
+      `;
+      assert.deepEqual(approvalRows, [
+        {
+          requestId: "approval-request-keep",
+          status: "pending",
+          turnId: "turn-keep",
+        },
+      ]);
+
+      const threadRows = yield* sql<{
+        readonly pendingApprovalCount: number;
+      }>`
+        SELECT pending_approval_count AS "pendingApprovalCount"
+        FROM projection_threads
+        WHERE thread_id = 'thread-revert-approval'
+      `;
+      assert.deepEqual(threadRows, [{ pendingApprovalCount: 1 }]);
+    }),
+  );
 });
 
 it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-"))(

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -15,7 +15,10 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { toPersistenceSqlError, type ProjectionRepositoryError } from "../../persistence/Errors.ts";
 import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
-import { ProjectionPendingApprovalRepository } from "../../persistence/Services/ProjectionPendingApprovals.ts";
+import {
+  type ProjectionPendingApproval,
+  ProjectionPendingApprovalRepository,
+} from "../../persistence/Services/ProjectionPendingApprovals.ts";
 import { ProjectionProjectRepository } from "../../persistence/Services/ProjectionProjects.ts";
 import { ProjectionStateRepository } from "../../persistence/Services/ProjectionState.ts";
 import { ProjectionThreadActivityRepository } from "../../persistence/Services/ProjectionThreadActivities.ts";
@@ -347,6 +350,26 @@ function retainProjectionProposedPlansAfterRevert(
   );
   return proposedPlans.filter(
     (proposedPlan) => proposedPlan.turnId === null || retainedTurnIds.has(proposedPlan.turnId),
+  );
+}
+
+function retainProjectionPendingApprovalsAfterRevert(
+  approvals: ReadonlyArray<ProjectionPendingApproval>,
+  turns: ReadonlyArray<ProjectionTurn>,
+  turnCount: number,
+): ReadonlyArray<ProjectionPendingApproval> {
+  const retainedTurnIds = new Set<string>(
+    turns
+      .filter(
+        (turn) =>
+          turn.turnId !== null &&
+          turn.checkpointTurnCount !== null &&
+          turn.checkpointTurnCount <= turnCount,
+      )
+      .flatMap((turn) => (turn.turnId === null ? [] : [turn.turnId])),
+  );
+  return approvals.filter(
+    (approval) => approval.turnId === null || retainedTurnIds.has(approval.turnId),
   );
 }
 
@@ -1637,6 +1660,40 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               : event.payload.createdAt,
             resolvedAt: event.payload.createdAt,
           });
+          return;
+        }
+
+        case "thread.reverted": {
+          const existingRows = yield* projectionPendingApprovalRepository.listByThreadId({
+            threadId: event.payload.threadId,
+          });
+          if (existingRows.length === 0) {
+            return;
+          }
+
+          const existingTurns = yield* projectionTurnRepository.listByThreadId({
+            threadId: event.payload.threadId,
+          });
+          const keptRows = retainProjectionPendingApprovalsAfterRevert(
+            existingRows,
+            existingTurns,
+            event.payload.turnCount,
+          );
+          if (keptRows.length === existingRows.length) {
+            return;
+          }
+
+          const keptRequestIds = new Set(keptRows.map((row) => row.requestId));
+          yield* Effect.forEach(
+            existingRows,
+            (row) =>
+              keptRequestIds.has(row.requestId)
+                ? Effect.void
+                : projectionPendingApprovalRepository.deleteByRequestId({
+                    requestId: row.requestId,
+                  }),
+            { concurrency: 1 },
+          ).pipe(Effect.asVoid);
           return;
         }
 


### PR DESCRIPTION
## What Changed

`thread.reverted` now drops pending approvals for discarded turns.

Messages, activities, and proposed plans already did this. The pending-approvals projector ignored revert, so later-turn rows stayed `pending`. The shell count still included them.

Approvals with no turn stay, same as activities. The shell pending count then follows.

## Why

The user could answer a request the provider no longer had.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval projection on revert, which affects what users can respond to; logic mirrors existing revert handlers but incorrect turn filtering could drop or keep wrong requests.
> 
> **Overview**
> **Thread revert** now prunes `projection_pending_approvals` for turns that are rolled back, matching messages, activities, and proposed plans.
> 
> On `thread.reverted`, the pending-approvals projector keeps rows tied to retained checkpoint turns (or approvals with no `turnId`) and **deletes** the rest via `deleteByRequestId`. A shared `retainProjectionPendingApprovalsAfterRevert` helper applies the same checkpoint `turnCount` rule as the other retain helpers.
> 
> This stops stale pending approval UI and fixes **`pending_approval_count`** on `projection_threads` after revert (via the existing shell refresh on revert). An integration test asserts only the first-turn approval remains and the count is `1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98cd24d67de738481581f6dcab767025ef8bd1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop pending approvals for reverted turns in `ProjectionPipeline`
> - Adds a `thread.reverted` case to `makeOrchestrationProjectionPipeline.applyProjectsProjection` that deletes pending approvals tied to turns beyond the event's `turnCount`
> - New helper `retainProjectionPendingApprovalsAfterRevert` keeps approvals whose `turnId` is null or whose turn's `checkpointTurnCount` is <= the revert `turnCount`
> - Adds a test in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/8425/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) verifying that later-turn approvals are removed and `pending_approval_count` updates to 1
> - Behavioral Change: processing a `thread.reverted` event now mutates `projection_pending_approvals` by deleting approvals not in the retained subset, identified by `requestId`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e98cd24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->