### PR TITLE
fix(server): do not burn pairing grants on a scope mismatch

### DIFF
--- a/apps/server/src/auth/EnvironmentAuth.test.ts
+++ b/apps/server/src/auth/EnvironmentAuth.test.ts
@@ -123,6 +123,13 @@ it.layer(NodeServices.layer)("EnvironmentAuth.layer", (it) => {
         .pipe(Effect.flip);
 
       expect(error._tag).toBe("ServerAuthScopeNotGrantedError");
+
+      const token = yield* serverAuth.exchangeBootstrapCredentialForAccessToken(
+        pairingCredential.credential,
+        ["orchestration:read"],
+        requestMetadata,
+      );
+      expect(token.scope).toBe("orchestration:read");
     }).pipe(Effect.provide(makeEnvironmentAuthLayer())),
   );
 

--- a/apps/server/src/auth/EnvironmentAuth.ts
+++ b/apps/server/src/auth/EnvironmentAuth.ts
@@ -690,37 +690,40 @@ export const make = Effect.gen(function* () {
 
   const exchangeBootstrapCredentialForAccessToken: EnvironmentAuth["Service"]["exchangeBootstrapCredentialForAccessToken"] =
     (credential, requestedScopes, requestMetadata, input) =>
-      bootstrapCredentials.consume(credential, input).pipe(
-        Effect.mapError(toBootstrapExchangeError),
-        Effect.flatMap((grant) =>
-          Effect.gen(function* () {
-            const grantedScopes = requestedScopes ?? grant.scopes;
-            if (!grantedScopes.every((scope) => grant.scopes.includes(scope))) {
-              return yield* new ServerAuthScopeNotGrantedError({});
-            }
-            return yield* sessions
-              .issue({
-                method: input?.proofKeyThumbprint ? "dpop-access-token" : "bearer-access-token",
-                subject: grant.subject,
-                scopes: grantedScopes,
-                ...(input?.proofKeyThumbprint
-                  ? {
-                      proofKeyThumbprint: input.proofKeyThumbprint,
-                      ttl: Duration.hours(1),
-                    }
-                  : {}),
-                client: {
-                  ...requestMetadata,
-                  ...(grant.label ? { label: grant.label } : {}),
-                },
-              })
-              .pipe(
-                Effect.mapError(
-                  (cause) => new ServerAuthAuthenticatedAccessTokenIssueError({ cause }),
-                ),
-              );
-          }),
-        ),
+      Effect.gen(function* () {
+        if (requestedScopes !== undefined) {
+          const inspected = yield* bootstrapCredentials
+            .inspect(credential, input)
+            .pipe(Effect.mapError(toBootstrapExchangeError));
+          if (!requestedScopes.every((scope) => inspected.scopes.includes(scope))) {
+            return yield* new ServerAuthScopeNotGrantedError({});
+          }
+        }
+
+        const grant = yield* bootstrapCredentials
+          .consume(credential, input)
+          .pipe(Effect.mapError(toBootstrapExchangeError));
+        const grantedScopes = requestedScopes ?? grant.scopes;
+        return yield* sessions
+          .issue({
+            method: input?.proofKeyThumbprint ? "dpop-access-token" : "bearer-access-token",
+            subject: grant.subject,
+            scopes: grantedScopes,
+            ...(input?.proofKeyThumbprint
+              ? {
+                  proofKeyThumbprint: input.proofKeyThumbprint,
+                  ttl: Duration.hours(1),
+                }
+              : {}),
+            client: {
+              ...requestMetadata,
+              ...(grant.label ? { label: grant.label } : {}),
+            },
+          })
+          .pipe(
+            Effect.mapError((cause) => new ServerAuthAuthenticatedAccessTokenIssueError({ cause })),
+          );
+      }).pipe(
         Effect.flatMap((session) =>
           DateTime.now.pipe(
             Effect.map(

--- a/apps/server/src/auth/PairingGrantStore.test.ts
+++ b/apps/server/src/auth/PairingGrantStore.test.ts
@@ -89,6 +89,19 @@ it.layer(NodeServices.layer)("PairingGrantStore.layer", (it) => {
     }).pipe(Effect.provide(makePairingGrantStoreLayer())),
   );
 
+  it.effect("inspects a pairing grant without consuming it", () =>
+    Effect.gen(function* () {
+      const bootstrapCredentials = yield* PairingGrantStore.PairingGrantStore;
+      const issued = yield* bootstrapCredentials.issueOneTimeToken({ label: "Inspect me" });
+      const inspected = yield* bootstrapCredentials.inspect(issued.credential);
+      const consumed = yield* bootstrapCredentials.consume(issued.credential);
+
+      expect(inspected.scopes).toEqual(consumed.scopes);
+      expect(inspected.label).toBe("Inspect me");
+      expect(consumed.label).toBe("Inspect me");
+    }).pipe(Effect.provide(makePairingGrantStoreLayer())),
+  );
+
   it.effect("atomically consumes a one-time token when multiple requests race", () =>
     Effect.gen(function* () {
       const bootstrapCredentials = yield* PairingGrantStore.PairingGrantStore;

--- a/apps/server/src/auth/PairingGrantStore.ts
+++ b/apps/server/src/auth/PairingGrantStore.ts
@@ -214,6 +214,12 @@ export class PairingGrantStore extends Context.Service<
     >;
     readonly streamChanges: Stream.Stream<BootstrapCredentialChange>;
     readonly revoke: (id: string) => Effect.Effect<boolean, BootstrapCredentialInternalError>;
+    readonly inspect: (
+      credential: string,
+      input?: {
+        readonly proofKeyThumbprint?: string;
+      },
+    ) => Effect.Effect<BootstrapGrant, BootstrapCredentialError>;
     readonly consume: (
       credential: string,
       input?: {
@@ -567,6 +573,66 @@ export const make = Effect.gen(function* () {
     },
   );
 
+  const inspect: PairingGrantStore["Service"]["inspect"] = Effect.fn("PairingGrantStore.inspect")(
+    function* (credential, input) {
+      const now = yield* DateTime.now;
+      const seeded = (yield* Ref.get(seededGrantsRef)).get(credential);
+      if (seeded) {
+        if (DateTime.isGreaterThanOrEqualTo(now, seeded.expiresAt)) {
+          return yield* new ExpiredBootstrapCredentialError({});
+        }
+        if (seeded.proofKeyThumbprint && seeded.proofKeyThumbprint !== input?.proofKeyThumbprint) {
+          return yield* new BootstrapCredentialProofKeyMismatchError({});
+        }
+        return {
+          method: seeded.method,
+          scopes: seeded.scopes,
+          subject: seeded.subject,
+          ...(seeded.label ? { label: seeded.label } : {}),
+          ...(seeded.proofKeyThumbprint ? { proofKeyThumbprint: seeded.proofKeyThumbprint } : {}),
+          expiresAt: seeded.expiresAt,
+        } satisfies BootstrapGrant;
+      }
+
+      const matching = yield* pairingLinks
+        .getByCredential({ credential })
+        .pipe(Effect.mapError((cause) => new BootstrapCredentialLookupError({ cause })));
+      if (Option.isNone(matching)) {
+        return yield* new UnknownBootstrapCredentialError({});
+      }
+
+      if (matching.value.revokedAt !== null) {
+        return yield* new UnavailableBootstrapCredentialError({});
+      }
+
+      if (matching.value.consumedAt !== null) {
+        return yield* new UnknownBootstrapCredentialError({});
+      }
+
+      if (DateTime.isGreaterThanOrEqualTo(now, matching.value.expiresAt)) {
+        return yield* new ExpiredBootstrapCredentialError({});
+      }
+
+      if (
+        matching.value.proofKeyThumbprint !== null &&
+        matching.value.proofKeyThumbprint !== input?.proofKeyThumbprint
+      ) {
+        return yield* new BootstrapCredentialProofKeyMismatchError({});
+      }
+
+      return {
+        method: matching.value.method,
+        scopes: matching.value.scopes,
+        subject: matching.value.subject,
+        ...(matching.value.label ? { label: matching.value.label } : {}),
+        ...(matching.value.proofKeyThumbprint
+          ? { proofKeyThumbprint: matching.value.proofKeyThumbprint }
+          : {}),
+        expiresAt: matching.value.expiresAt,
+      } satisfies BootstrapGrant;
+    },
+  );
+
   return PairingGrantStore.of({
     issueOneTimeToken,
     listActive,
@@ -574,6 +640,7 @@ export const make = Effect.gen(function* () {
       return Stream.fromPubSub(changesPubSub);
     },
     revoke,
+    inspect,
     consume,
   });
 });

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -75,7 +75,8 @@ proof key. See `SessionStore.ts` and `EnvironmentAuth.ts`.
 
 Requested scopes must be a subset of the one-time bootstrap credential grant.
 An ordinary paired client therefore cannot exchange its grant for
-`access:read`, `access:write`, or `relay:write`.
+`access:read`, `access:write`, or `relay:write`. A request that asks for
+scopes the grant does not include is rejected and the grant is left unused.
 
 ### DPoP-Bound Access Token
 


### PR DESCRIPTION
## What Changed

Token exchange now checks requested scopes before it consumes the one-time pairing grant.

A client that asks for scopes the grant does not include still gets `ServerAuthScopeNotGrantedError`. The grant stays unused, so a later exchange with allowed scopes still works.

## Why

Web and mobile always ask for standard client scopes. A constrained pairing plus that request burned the QR: one "invalid credential", mint another link. The unit test encoded the burn.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth-style bootstrap token exchange in auth, but authorization rules are unchanged—only the order of scope validation vs. one-time consumption.
> 
> **Overview**
> Bootstrap **access-token exchange** no longer **consumes** a one-time pairing grant when the client asks for scopes the grant does not allow.
> 
> `exchangeBootstrapCredentialForAccessToken` now calls a new **`PairingGrantStore.inspect`** (read-only lookup with the same expiry, proof-key, and availability checks as `consume`) **before** `consume` whenever `requestedScopes` is set. Over-scoped requests still return **`ServerAuthScopeNotGrantedError`**, but the QR/link stays valid for a later exchange with permitted scopes.
> 
> Tests now assert a failed over-scope exchange followed by a successful narrower exchange; **`environment-auth.md`** documents that rejected scope requests leave the grant unused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023d4e2032fa5352775ac85fce851a45329321f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scope mismatch burning pairing grants in `exchangeBootstrapCredentialForAccessToken`
> - Adds `PairingGrantStore.inspect` to read a grant's scopes without consuming it, with proper error handling for unknown, consumed, revoked, expired, or proof-key-mismatched credentials
> - `exchangeBootstrapCredentialForAccessToken` now calls `inspect` first; if requested scopes exceed the grant, it returns `ServerAuthScopeNotGrantedError` and leaves the grant usable for a subsequent valid exchange
> - Only after scope validation passes does the function call `PairingGrantStore.consume` and issue a session
> - Behavioral Change: a pairing grant is no longer consumed on scope mismatch; a grant that previously would have been burned remains valid for a later exchange with correct or subset scopes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 023d4e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->