### PR TITLE
fix(swift-ios): keep caret after command completion

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -483,17 +483,20 @@ struct FeatureComposerView: View {
         case let .path(entry):
             replacement = FeatureComposerFileLinkSerializer.markdownLink(for: entry.path) + " "
         }
-        textSelectionRequest = FeatureComposerTextSelectionRequest(
-            location: FeatureComposerTextSelectionPolicy.cursorLocation(
-                afterReplacing: trigger.range,
-                in: text,
-                with: replacement
-            )
+        let nextCursorLocation = FeatureComposerTextSelectionPolicy.cursorLocation(
+            afterReplacing: trigger.range,
+            in: text,
+            with: replacement
         )
         text = FeatureComposerTriggerParser.replacing(
             trigger.range,
             in: text,
             with: replacement
+        )
+        // Publish the text first so the representable cannot consume and clamp
+        // this request against the pre-replacement draft.
+        textSelectionRequest = FeatureComposerTextSelectionRequest(
+            location: nextCursorLocation
         )
         pathEntries = []
         pathSearchError = nil


### PR DESCRIPTION
## What Changed

Selecting a skill or slash command in the SwiftUI composer could leave the caret at the old trigger endpoint. Continuing to type then inserted text inside the completed command.

The composer now computes the target offset from the original draft, publishes the replaced text, and only then sends the one-shot selection request.

## Why

SwiftUI can update the UIKit representable between the two state writes. Publishing the selection request first allowed it to be applied and clamped against the shorter pre-replacement text, then marked as consumed.

## UI Changes

No visual styling changed.

Before, completing `$file` as `$file-pr ` could leave the caret after `$file`. After, the caret lands after the completed token and its trailing space.

Verified on a physical iPhone 14 Pro with `T3 Swift Dev`.

## Verification

- `T3CodeTests/FeatureComposerPowerTests`: 25 passed
- Physical iPhone 14 Pro: skill and command completion keeps subsequent typing after the inserted token

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual styling changed
- [x] The interaction change was verified on a physical device

Built with `gpt-5.6-sol` at xhigh reasoning effort in the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 39a4d5ea7bcd7e432f45ab4eec800eaec727539c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix caret placement after command completion in `FeatureComposerView`
> Reorders the trigger insertion handler in [FeatureComposerView.swift](https://github.com/pingdotgg/t3code/pull/8428/files#diff-879cf39f390728cbcdd543b9ea67d63d0509d21cf1c958b1c0a8b8f78948fee8) to publish `textSelectionRequest` after updating the text. This prevents the cursor from being clamped against the pre-replacement draft content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39a4d5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->