### PR TITLE
fix(desktop): keep windows if update install fails

### DIFF
--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -31,6 +31,7 @@ interface UpdatesHarnessOptions {
   readonly setUpdateChannelError?: DesktopAppSettings.DesktopSettingsWriteError;
   readonly setDisableDifferentialDownload?: Effect.Effect<void>;
   readonly stopBackend?: Effect.Effect<void>;
+  readonly quitAndInstall?: Effect.Effect<void, ElectronUpdater.ElectronUpdaterQuitAndInstallError>;
   readonly env?: Record<string, string | undefined>;
 }
 
@@ -43,6 +44,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
   const feedUrls: ElectronUpdater.ElectronUpdaterFeedUrl[] = [];
   const listeners = new Map<string, Set<(...args: readonly unknown[]) => void>>();
   const sentStates: DesktopUpdateState[] = [];
+  const installSteps: string[] = [];
 
   const addListener = (eventName: string, listener: (...args: readonly unknown[]) => void) => {
     const eventListeners = listeners.get(eventName) ?? new Set();
@@ -84,7 +86,10 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
       checkCount += 1;
     }).pipe(Effect.andThen(options.checkForUpdates ?? Effect.void)),
     downloadUpdate: Effect.void,
-    quitAndInstall: () => Effect.void,
+    quitAndInstall: () =>
+      Effect.sync(() => {
+        installSteps.push("quitAndInstall");
+      }).pipe(Effect.andThen(options.quitAndInstall ?? Effect.void)),
     on: (eventName, listener) =>
       Effect.acquireRelease(
         Effect.sync(() => {
@@ -109,7 +114,9 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
       Effect.sync(() => {
         sentStates.push(state as DesktopUpdateState);
       }),
-    destroyAll: Effect.void,
+    destroyAll: Effect.sync(() => {
+      installSteps.push("destroyAll");
+    }),
     syncAllAppearance: () => Effect.void,
   } satisfies ElectronWindow.ElectronWindow["Service"]);
 
@@ -219,6 +226,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         0,
       ),
     sentStates,
+    installSteps,
     emit: (eventName: string, payload?: unknown) => {
       for (const listener of listeners.get(eventName) ?? []) {
         listener(payload);
@@ -721,6 +729,56 @@ describe("DesktopUpdates", () => {
 
         const changedState = yield* updates.setChannel("nightly");
         assert.equal(changedState.channel, "nightly");
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("destroys windows only after quitAndInstall starts", () => {
+    const harness = makeHarness();
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+        assert.isTrue(result.accepted);
+        assert.deepEqual(harness.installSteps, ["quitAndInstall", "destroyAll"]);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("keeps windows when quitAndInstall fails", () => {
+    const harness = makeHarness({
+      quitAndInstall: Effect.fail(
+        new ElectronUpdater.ElectronUpdaterQuitAndInstallError({
+          channel: null,
+          isSilent: true,
+          isForceRunAfter: true,
+          cause: new Error("installer refused"),
+        }),
+      ),
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const desktopState = yield* DesktopState.DesktopState;
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const result = yield* updates.install;
+        assert.isTrue(result.accepted);
+        assert.isFalse(result.completed);
+        assert.isFalse(yield* Ref.get(desktopState.quitting));
+        assert.deepEqual(harness.installSteps, ["quitAndInstall"]);
+
+        const failedState = yield* updates.getState;
+        assert.equal(failedState.status, "downloaded");
+        assert.equal(failedState.errorContext, "install");
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -123,7 +123,9 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
   const stubBackendInstance: DesktopBackendPool.DesktopBackendInstance = {
     id: DesktopBackendPool.PRIMARY_INSTANCE_ID,
     label: Effect.succeed("Windows"),
-    start: Effect.void,
+    start: Effect.sync(() => {
+      installSteps.push("startBackend");
+    }),
     stop: () => options.stopBackend ?? Effect.void,
     currentConfig: Effect.succeed(Option.none()),
     snapshot: Effect.succeed({
@@ -774,7 +776,7 @@ describe("DesktopUpdates", () => {
         assert.isTrue(result.accepted);
         assert.isFalse(result.completed);
         assert.isFalse(yield* Ref.get(desktopState.quitting));
-        assert.deepEqual(harness.installSteps, ["quitAndInstall"]);
+        assert.deepEqual(harness.installSteps, ["quitAndInstall", "startBackend"]);
 
         const failedState = yield* updates.getState;
         assert.equal(failedState.status, "downloaded");

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -483,6 +483,11 @@ export const make = Effect.gen(function* () {
 
     yield* Ref.set(desktopState.quitting, true);
 
+    const instances = yield* pool.list;
+    const restartStoppedBackends = Effect.forEach(instances, (instance) => instance.start, {
+      concurrency: "unbounded",
+    }).pipe(Effect.asVoid);
+
     return yield* Effect.gen(function* () {
       // Stop every backend in the pool, not just the primary. With
       // parallel WSL + Windows backends, leaving the WSL instance up
@@ -491,7 +496,6 @@ export const make = Effect.gen(function* () {
       // WSL child gets hard-killed by the OS instead of receiving
       // SIGTERM + grace. Stops run concurrently with the same 5s
       // budget the primary had on its own.
-      const instances = yield* pool.list;
       yield* Effect.forEach(
         instances,
         (instance) => instance.stop({ timeout: Duration.seconds(5) }),
@@ -510,6 +514,7 @@ export const make = Effect.gen(function* () {
         ElectronUpdaterQuitAndInstallError: Effect.fn("desktop.updates.handleInstallFailure")(
           function* (error) {
             yield* resetInstallAction;
+            yield* restartStoppedBackends;
             yield* updateState((current) =>
               reduceDesktopUpdateStateOnInstallFailure(current, error.message),
             );
@@ -530,6 +535,7 @@ export const make = Effect.gen(function* () {
             return yield* Effect.failCause(cause);
           }
           yield* resetInstallAction;
+          yield* restartStoppedBackends;
           const error = new DesktopUpdateUnexpectedActionError({ action: "install", cause });
           yield* updateState((current) =>
             reduceDesktopUpdateStateOnInstallFailure(current, error.message),

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -497,11 +497,13 @@ export const make = Effect.gen(function* () {
         (instance) => instance.stop({ timeout: Duration.seconds(5) }),
         { concurrency: "unbounded" },
       );
-      yield* electronWindow.destroyAll;
       yield* electronUpdater.quitAndInstall({
         isSilent: true,
         isForceRunAfter: true,
       });
+      // Close windows only after quitAndInstall has started. If install
+      // fails, the user still has a window.
+      yield* electronWindow.destroyAll;
       return { accepted: true, completed: false };
     }).pipe(
       Effect.catchTags({


### PR DESCRIPTION
## What Changed

Desktop update install no longer destroys every window before `quitAndInstall`.

Backends still stop first, so WSL children get SIGTERM. `quitAndInstall` runs next. Windows close only after that starts. If install fails, the error path still clears quitting and records the failure, and the user still has a window.

## Why

A failed `quitAndInstall` left no window and no path to open one. Tests covered backend-stop failure before destroy. They did not cover this path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown ordering and failure recovery for a user-facing update path; incorrect ordering could still strand backends or leave windows open in edge cases.
> 
> **Overview**
> Desktop update **install** no longer calls `destroyAll` before `quitAndInstall`. Backends still stop first (unchanged), then the updater starts install; windows close only after that step begins so a failed install leaves the UI usable.
> 
> When `quitAndInstall` or an unexpected install error occurs after backends were stopped, the flow now **restarts** pool instances (along with existing reset of quitting/install state and install error reporting). Tests record install ordering via `installSteps` and assert success order `quitAndInstall` → `destroyAll`, and failure order `quitAndInstall` → `startBackend` with quitting cleared and no window teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b33ef82b2aee24f203637d63bbb062d63121949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep desktop windows if `quitAndInstall` fails during update install
> - Reorders the install flow in `make` so `electronWindow.destroyAll` runs only after `quitAndInstall` starts, not before
> - On `ElectronUpdaterQuitAndInstallError` or unexpected error, stopped backends are restarted via a captured `restartStoppedBackends` effect instead of leaving the app in a stopped state
> - Adds tests in [DesktopUpdates.test.ts](apps/desktop/src/updates/DesktopUpdates.test.ts) asserting install step ordering and that windows are kept on failure
> - Risk: backend instances are now captured before stopping and restarted concurrently on failure; if a backend cannot restart, the app may be left without a running backend despite windows remaining open
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b33ef8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->