### PR TITLE
fix(server): snapshot service-update databases with VACUUM INTO

### DIFF
--- a/apps/server/src/serviceLauncher.test.ts
+++ b/apps/server/src/serviceLauncher.test.ts
@@ -3,8 +3,18 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as NodeFS from "node:fs";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
-import { Launcher, readServiceState, writeServiceState } from "./serviceLauncher.ts";
+import {
+  Launcher,
+  readServiceState,
+  vacuumDatabaseInto,
+  writeServiceState,
+} from "./serviceLauncher.ts";
 import {
   compareExactServiceVersions,
   decodeServiceState,
@@ -30,6 +40,38 @@ it("orders exact semantic versions without treating build metadata as precedence
   assert.equal(compareExactServiceVersions("2.0.0-alpha-beta", "2.0.0-alpha-alpha"), 1);
   assert.equal(compareExactServiceVersions("2.0.0", "2.0.0-rc.1"), 1);
   assert.equal(compareExactServiceVersions("2.0.0+one", "2.0.0+two"), 0);
+});
+
+it("snapshots sqlite with VACUUM INTO and no wal sidecar", async () => {
+  const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-vacuum-backup-"));
+  try {
+    const source = NodePath.join(dir, "state.sqlite");
+    const destination = NodePath.join(dir, "backup");
+    const seed = new DatabaseSync(source);
+    try {
+      seed.exec(
+        "CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL); INSERT INTO kv VALUES ('phase', 'before');",
+      );
+    } finally {
+      seed.close();
+    }
+
+    vacuumDatabaseInto(source, destination);
+
+    const restored = new DatabaseSync(destination, { readOnly: true });
+    try {
+      const row = restored.prepare("SELECT v AS v FROM kv WHERE k = 'phase'").get() as {
+        v: string;
+      };
+      assert.equal(row.v, "before");
+    } finally {
+      restored.close();
+    }
+    assert.isFalse(NodeFS.existsSync(`${destination}-wal`));
+    assert.isFalse(NodeFS.existsSync(`${destination}-shm`));
+  } finally {
+    await NodeFSP.rm(dir, { recursive: true, force: true });
+  }
 });
 
 it("rejects contradictory service state", () => {
@@ -236,16 +278,28 @@ if (context.update?.status === "pending") {
       const root = yield* fs.makeTempDirectoryScoped({ prefix: "t3-service-launcher-db-" });
       const statePath = path.join(root, "runtime", "service-state.json");
       const databasePath = path.join(root, "userdata", "state.sqlite");
-      const original = "database before migration";
       yield* fs.makeDirectory(path.dirname(databasePath), { recursive: true });
-      yield* fs.writeFileString(databasePath, original);
+      const seed = new DatabaseSync(databasePath);
+      try {
+        seed.exec(
+          "CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL); INSERT INTO kv VALUES ('phase', 'before');",
+        );
+      } finally {
+        seed.close();
+      }
       // @effect-diagnostics-next-line preferSchemaOverJson:off - embeds a path in fake child source.
       const encodedDatabasePath = JSON.stringify(databasePath);
       const childSource = `
 import { writeFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 const context = JSON.parse(process.env.T3_SERVICE_LAUNCHER_CONTEXT);
 if (context.update?.status === "pending") {
-  writeFileSync(context.update.dbPath, "database after migration");
+  const db = new DatabaseSync(context.update.dbPath);
+  try {
+    db.exec("UPDATE kv SET v = 'after'");
+  } finally {
+    db.close();
+  }
   writeFileSync(context.update.dbPath + "-wal", "trial wal");
   writeFileSync(context.update.dbPath + "-shm", "trial shm");
   process.exit(1);
@@ -281,7 +335,15 @@ if (context.update?.status === "pending") {
       const state = yield* Effect.promise(() => readServiceState(statePath));
       assert.equal(state.activeVersion, "1.0.0");
       assert.equal(state.update?.status, "rolled-back");
-      assert.equal(yield* fs.readFileString(databasePath), original);
+      const restored = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        const row = restored.prepare("SELECT v AS v FROM kv WHERE k = 'phase'").get() as {
+          v: string;
+        };
+        assert.equal(row.v, "before");
+      } finally {
+        restored.close();
+      }
       assert.isFalse(yield* fs.exists(`${databasePath}-wal`));
       assert.isFalse(yield* fs.exists(`${databasePath}-shm`));
       const updateId = state.update?.id;

--- a/apps/server/src/serviceLauncher.test.ts
+++ b/apps/server/src/serviceLauncher.test.ts
@@ -42,20 +42,23 @@ it("orders exact semantic versions without treating build metadata as precedence
   assert.equal(compareExactServiceVersions("2.0.0+one", "2.0.0+two"), 0);
 });
 
+function seedSqlite(databasePath: string): void {
+  const seed = new DatabaseSync(databasePath);
+  try {
+    seed.exec(
+      "CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL); INSERT INTO kv VALUES ('phase', 'before');",
+    );
+  } finally {
+    seed.close();
+  }
+}
+
 it("snapshots sqlite with VACUUM INTO and no wal sidecar", async () => {
   const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-vacuum-backup-"));
   try {
     const source = NodePath.join(dir, "state.sqlite");
     const destination = NodePath.join(dir, "backup");
-    const seed = new DatabaseSync(source);
-    try {
-      seed.exec(
-        "CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL); INSERT INTO kv VALUES ('phase', 'before');",
-      );
-    } finally {
-      seed.close();
-    }
-
+    seedSqlite(source);
     vacuumDatabaseInto(source, destination);
 
     const restored = new DatabaseSync(destination, { readOnly: true });
@@ -73,6 +76,23 @@ it("snapshots sqlite with VACUUM INTO and no wal sidecar", async () => {
     await NodeFSP.rm(dir, { recursive: true, force: true });
   }
 });
+
+it.skipIf(NodePath.sep === "\\")(
+  "keeps a literal backslash in a POSIX vacuum destination",
+  async () => {
+    const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3-vacuum-posix-"));
+    try {
+      const source = NodePath.join(dir, "state.sqlite");
+      const destination = NodePath.join(dir, "back\\up");
+      seedSqlite(source);
+      vacuumDatabaseInto(source, destination);
+      assert.isTrue(NodeFS.existsSync(destination));
+      assert.isFalse(NodeFS.existsSync(NodePath.join(dir, "back", "up")));
+    } finally {
+      await NodeFSP.rm(dir, { recursive: true, force: true });
+    }
+  },
+);
 
 it("rejects contradictory service state", () => {
   assert.isUndefined(
@@ -172,7 +192,7 @@ it.layer(NodeServices.layer)("service state persistence", (it) => {
       const statePath = path.join(root, "runtime", "service-state.json");
       const databasePath = path.join(root, "userdata", "state.sqlite");
       yield* fs.makeDirectory(path.dirname(databasePath), { recursive: true });
-      yield* fs.writeFileString(databasePath, "before trial");
+      seedSqlite(databasePath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off - embeds a path in fake child source.
       const encodedDatabasePath = JSON.stringify(databasePath);
       const childSource = `
@@ -225,7 +245,7 @@ if (context.update?.status === "pending") {
       const statePath = path.join(root, "runtime", "service-state.json");
       const databasePath = path.join(root, "userdata", "state.sqlite");
       yield* fs.makeDirectory(path.dirname(databasePath), { recursive: true });
-      yield* fs.writeFileString(databasePath, "before trial");
+      seedSqlite(databasePath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off - embeds a path in fake child source.
       const encodedDatabasePath = JSON.stringify(databasePath);
       const childSource = `
@@ -279,14 +299,7 @@ if (context.update?.status === "pending") {
       const statePath = path.join(root, "runtime", "service-state.json");
       const databasePath = path.join(root, "userdata", "state.sqlite");
       yield* fs.makeDirectory(path.dirname(databasePath), { recursive: true });
-      const seed = new DatabaseSync(databasePath);
-      try {
-        seed.exec(
-          "CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL); INSERT INTO kv VALUES ('phase', 'before');",
-        );
-      } finally {
-        seed.close();
-      }
+      seedSqlite(databasePath);
       // @effect-diagnostics-next-line preferSchemaOverJson:off - embeds a path in fake child source.
       const encodedDatabasePath = JSON.stringify(databasePath);
       const childSource = `

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -97,7 +97,9 @@ function quoteSqliteLiteral(value: string): string {
 export function vacuumDatabaseInto(sourcePath: string, destinationPath: string): void {
   const db = new DatabaseSync(sourcePath, { readOnly: true });
   try {
-    db.exec(`VACUUM INTO ${quoteSqliteLiteral(destinationPath.replaceAll("\\", "/"))}`);
+    const vacuumPath =
+      NodePath.sep === "\\" ? destinationPath.replaceAll("\\", "/") : destinationPath;
+    db.exec(`VACUUM INTO ${quoteSqliteLiteral(vacuumPath)}`);
   } finally {
     db.close();
   }

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -8,6 +8,7 @@ import * as NodeCrypto from "node:crypto";
 import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
 import type {
   PendingServiceUpdate,
@@ -89,10 +90,27 @@ async function syncDirectory(directory: string): Promise<void> {
   }
 }
 
+function quoteSqliteLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function vacuumDatabaseInto(sourcePath: string, destinationPath: string): void {
+  const db = new DatabaseSync(sourcePath, { readOnly: true });
+  try {
+    db.exec(`VACUUM INTO ${quoteSqliteLiteral(destinationPath.replaceAll("\\", "/"))}`);
+  } finally {
+    db.close();
+  }
+}
+
 /**
  * Snapshots the database once per update before the first trial. A completed
  * backup is never overwritten because a restarted launcher may be looking at
  * database writes from an earlier attempt by the same trial.
+ *
+ * VACUUM INTO writes one consistent file. A live copy of sqlite plus WAL plus
+ * shm can be a torn snapshot. WAL does not survive VACUUM INTO, so restore
+ * copies this file and drops leftover sidecars.
  */
 async function backupDatabaseOnce(baseDir: string, pending: PendingServiceUpdate): Promise<void> {
   const backupDir = databaseBackupDir(baseDir, pending.id);
@@ -102,13 +120,10 @@ async function backupDatabaseOnce(baseDir: string, pending: PendingServiceUpdate
   await NodeFSP.rm(stagingDir, { recursive: true, force: true });
   await NodeFSP.mkdir(stagingDir, { recursive: true, mode: 0o700 });
   try {
-    for (const suffix of DB_FILE_SUFFIXES) {
-      const source = `${pending.dbPath}${suffix}`;
-      if (suffix !== "" && !(await pathExists(source))) continue;
-      const destination = databaseBackupFile(stagingDir, suffix);
-      await NodeFSP.copyFile(source, destination);
-      await syncFile(destination);
-    }
+    const destination = databaseBackupFile(stagingDir, "");
+    vacuumDatabaseInto(pending.dbPath, destination);
+    await NodeFSP.chmod(destination, 0o600);
+    await syncFile(destination);
     await NodeFSP.rename(stagingDir, backupDir);
     await syncDirectory(NodePath.dirname(backupDir));
   } catch (cause) {
@@ -376,7 +391,8 @@ export class Launcher {
   }
 
   async #startTrial(pending: PendingServiceUpdate): Promise<void> {
-    // The previous child is dead here, so all three SQLite files are quiescent.
+    // The previous child is dead here. VACUUM INTO still snapshots one
+    // consistent file if a sidecar is left behind.
     try {
       await backupDatabaseOnce(this.#baseDir, pending);
     } catch {


### PR DESCRIPTION
## What Changed

Service-update database backup now uses `VACUUM INTO` instead of copying `state.sqlite` plus WAL plus shm.

That writes one consistent file. Restore still copies that file and drops leftover WAL and shm sidecars. A completed backup is still never overwritten.

## Why

A live-style copy of sqlite plus WAL plus shm can be a torn snapshot. Agents.md already says `VACUUM INTO` is the safe way. The launcher comment said the previous child is dead, so a quiet copy can work. Residual risk remains on Windows mapped shm and sequential copies.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-update backup semantics for user SQLite state during service updates; incorrect snapshots or restore could lose data, though VACUUM INTO is intended to reduce torn-backup risk versus multi-file copy.
> 
> **Overview**
> Service-update **database backups** no longer copy the live `state.sqlite` file plus `-wal`/`-shm` sidecars. **`backupDatabaseOnce`** now writes a single consistent snapshot via a new **`vacuumDatabaseInto`** helper that opens the source read-only and runs **`VACUUM INTO`**, with Windows path normalization and quoted destination paths.
> 
> Staging still uses a temp dir, **`chmod 0o600`**, fsync, and atomic rename; restore behavior is unchanged in shape—it still copies the backed-up main file and strips leftover sidecars when rollback runs.
> 
> **Tests** seed real SQLite databases instead of plain text, add direct coverage for **`vacuumDatabaseInto`** (data integrity, no WAL/SHM on the snapshot, POSIX literal backslash in destinations), and assert rollback restores pre-migration row data and clears trial WAL/SHM files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b50d250ffc8df7e06fce664d3c9acb7651da98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Snapshot service-update databases with `VACUUM INTO` in `backupDatabaseOnce`
> - Replaces file-copy backup with `vacuumDatabaseInto`, which opens the source DB read-only and runs `VACUUM INTO` to produce a single consistent snapshot file
> - Adds `quoteSqliteLiteral` to safely embed the destination path in the SQL statement; on Windows, backslashes are converted to forward slashes before quoting
> - Backup directory now contains a single vacuumed DB file (mode 0600) instead of separate copies of the main DB and any `-wal`/`-shm` sidecars
> - Tests in [serviceLauncher.test.ts](https://github.com/pingdotgg/t3code/pull/8431/files#diff-f704a64df9c59e77d727d6a4117c8dead6ee0f73805c3fac91243d7dceb42984) now use real SQLite databases via a `seedSqlite` helper, including new tests for `VACUUM INTO` snapshotting and POSIX backslash handling
> - Risk: `backupDatabaseOnce` no longer copies `-wal`/`-shm` files; any code expecting sidecar files in the backup directory will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37b50d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->