### PR TITLE
fix(server): keep ready checkpoints when a later placeholder arrives

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2626,6 +2626,130 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       ]);
     }),
   );
+
+  it.effect("does not let a later missing placeholder clobber a ready checkpoint", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.make("evt-checkpoint-guard-1"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.make("project-checkpoint-guard"),
+        occurredAt: "2026-02-26T14:00:00.000Z",
+        commandId: CommandId.make("cmd-checkpoint-guard-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-checkpoint-guard-1"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.make("project-checkpoint-guard"),
+          title: "Project Checkpoint Guard",
+          workspaceRoot: "/tmp/project-checkpoint-guard",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: "2026-02-26T14:00:00.000Z",
+          updatedAt: "2026-02-26T14:00:00.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.make("evt-checkpoint-guard-2"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-checkpoint-guard"),
+        occurredAt: "2026-02-26T14:00:01.000Z",
+        commandId: CommandId.make("cmd-checkpoint-guard-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-checkpoint-guard-2"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-checkpoint-guard"),
+          projectId: ProjectId.make("project-checkpoint-guard"),
+          title: "Thread Checkpoint Guard",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-02-26T14:00:01.000Z",
+          updatedAt: "2026-02-26T14:00:01.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-checkpoint-guard-3"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-checkpoint-guard"),
+        occurredAt: "2026-02-26T14:00:02.000Z",
+        commandId: CommandId.make("cmd-checkpoint-guard-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-checkpoint-guard-3"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-checkpoint-guard"),
+          turnId: TurnId.make("turn-ready"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-checkpoint-guard/turn/1"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("assistant-ready"),
+          completedAt: "2026-02-26T14:00:02.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-checkpoint-guard-4"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-checkpoint-guard"),
+        occurredAt: "2026-02-26T14:00:03.000Z",
+        commandId: CommandId.make("cmd-checkpoint-guard-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-checkpoint-guard-4"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-checkpoint-guard"),
+          turnId: TurnId.make("turn-ready"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-checkpoint-guard/turn/1"),
+          status: "missing",
+          files: [],
+          assistantMessageId: MessageId.make("assistant-ready"),
+          completedAt: "2026-02-26T14:00:03.000Z",
+        },
+      });
+
+      const turnRows = yield* sql<{
+        readonly turnId: string;
+        readonly checkpointStatus: string | null;
+        readonly checkpointRef: string | null;
+      }>`
+        SELECT
+          turn_id AS "turnId",
+          checkpoint_status AS "checkpointStatus",
+          checkpoint_ref AS "checkpointRef"
+        FROM projection_turns
+        WHERE thread_id = 'thread-checkpoint-guard'
+      `;
+      assert.deepEqual(turnRows, [
+        {
+          turnId: "turn-ready",
+          checkpointStatus: "ready",
+          checkpointRef: "refs/t3/checkpoints/thread-checkpoint-guard/turn/1",
+        },
+      ]);
+    }),
+  );
 });
 
 it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-"))(

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1445,6 +1445,18 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             threadId: event.payload.threadId,
             turnId: event.payload.turnId,
           });
+          // Do not let a placeholder (status "missing") overwrite a checkpoint
+          // that has already been captured with a real git ref. In-memory
+          // projectEvent already refuses this. SQL did not, so thread detail
+          // and diffs could show missing after a ready capture.
+          if (
+            Option.isSome(existingTurn) &&
+            existingTurn.value.checkpointStatus !== null &&
+            existingTurn.value.checkpointStatus !== "missing" &&
+            event.payload.status === "missing"
+          ) {
+            return;
+          }
           const nextState = event.payload.status === "error" ? "error" : "completed";
           yield* projectionTurnRepository.clearCheckpointTurnConflict({
             threadId: event.payload.threadId,


### PR DESCRIPTION
## What Changed

The SQL turns projector now refuses a later `missing` placeholder over a checkpoint that is already `ready` or `error`.

In-memory `projectEvent` already had this guard. SQL always wrote `checkpointStatus: event.payload.status`. Thread detail and diffs read SQL.

Same-turn placeholder then ready is still the happy path. This only stops a later placeholder from wiping a capture that already landed.

## Why

Ingestion and CheckpointReactor dispatch onto the same serial queue. If `ready` lands first, a later `missing` was a no-op in memory and a clobber in SQL.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow projection guard on duplicate turn-diff events; improves read-model consistency for checkpoints with limited blast radius.
> 
> **Overview**
> Aligns the **SQL turn projector** with in-memory event projection so a later `thread.turn-diff-completed` with **`missing`** cannot overwrite a turn that already has a real checkpoint (`ready` or `error`).
> 
> When `ready` is projected before a trailing placeholder (e.g. shared serial queue ordering), `projection_turns` used to always take the latest status, so thread detail and diffs could show **missing** even after a successful capture. The handler now **no-ops** that downgrade; placeholder-then-ready on the same turn is unchanged.
> 
> Adds an integration test that projects `ready` then `missing` for the same turn and asserts SQL still stores **`ready`** and the checkpoint ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e84c9079d682ca5e1505814ebb88c1bfdabfa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ProjectionPipeline` to keep ready checkpoints when a later `missing` placeholder arrives
> - In the `thread.turn-diff-completed` handler in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/8432/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4), adds an early return guard: if an existing turn projection already has a non-null, non-`missing` `checkpointStatus`, incoming events with status `missing` are ignored for that turn.
> - Adds a test in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/8432/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) that projects a `ready` checkpoint followed by a `missing` event for the same turn and asserts the `ready` status and original `checkpointRef` are retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5e84c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing ready checkpoints when a later update reports a missing checkpoint.
  - Prevented valid checkpoint references and associated files from being replaced by a missing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->