### PR TITLE
fix(web): support fuzzy project search

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -243,7 +243,7 @@ describe("buildThreadActionItems", () => {
     ]);
   });
 
-  it("preserves thread project-name matches when there is no stronger title match", () => {
+  it("preserves queries spanning thread and project search terms", () => {
     const group: CommandPaletteGroup = {
       value: "threads-search",
       label: "Threads",
@@ -262,7 +262,7 @@ describe("buildThreadActionItems", () => {
 
     const groups = filterCommandPaletteGroups({
       activeGroups: [group],
-      query: "project",
+      query: "spacing project",
       isInSubmenu: false,
       projectSearchItems: [],
       threadSearchItems: [],

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -338,7 +338,8 @@ export function filterCommandPaletteGroups(input: {
   return searchableGroups.flatMap((group) => {
     const items = Arr.filterMap(group.items, (item, index) => {
       const rank = rankCommandPaletteItemMatch(item, normalizedQuery);
-      if (rank === 0) {
+      const haystack = normalizeSearchText(item.searchTerms.join(" "));
+      if (rank === 0 && !haystack.includes(normalizedQuery)) {
         return Result.failVoid;
       }
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { filterFilesystemBrowseEntries } from "@t3tools/client-runtime/state/filesystem";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import { scoreSubsequenceMatch } from "@t3tools/shared/searchRanking";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
 import { type ReactNode } from "react";
@@ -257,7 +258,10 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
 
 function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
   const normalizedField = normalizeSearchText(field);
-  if (normalizedField.length === 0 || !normalizedField.includes(normalizedQuery)) {
+  if (
+    normalizedField.length === 0 ||
+    scoreSubsequenceMatch(normalizedField, normalizedQuery) === null
+  ) {
     return Number.NEGATIVE_INFINITY;
   }
   if (normalizedField === normalizedQuery) {
@@ -333,15 +337,15 @@ export function filterCommandPaletteGroups(input: {
 
   return searchableGroups.flatMap((group) => {
     const items = Arr.filterMap(group.items, (item, index) => {
-      const haystack = normalizeSearchText(item.searchTerms.join(" "));
-      if (!haystack.includes(normalizedQuery)) {
+      const rank = rankCommandPaletteItemMatch(item, normalizedQuery);
+      if (rank === 0) {
         return Result.failVoid;
       }
 
       return Result.succeed({
         item,
         index,
-        rank: rankCommandPaletteItemMatch(item, normalizedQuery),
+        rank,
       });
     })
       .toSorted((left, right) => right.rank - left.rank || left.index - right.index)


### PR DESCRIPTION
Project search required a contiguous substring, so natural abbreviations could hide projects whose names contain separators

Use the existing shared subsequence matcher while preserving exact, prefix, and substring ranking.

the search below used to return no results, now it does fuzzy matching similar to the skills search

<img width="662" height="243" alt="Screenshot 2026-08-27 at 10 45 26 AM" src="https://github.com/user-attachments/assets/c962d27f-fdb4-4995-8245-7d0ffb909ccc" />



Created with GPT-5.6 Sol via Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fuzzy subsequence matching to `CommandPalette` project search
> Replaces substring-based matching with `scoreSubsequenceMatch` from `@t3tools/shared/searchRanking` in [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/8434/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e). `rankSearchFieldMatch` now treats fields without a subsequence match as `Number.NEGATIVE_INFINITY`, and `filterCommandPaletteGroups` filters items whose computed rank is `0` instead of gating on substring inclusion. The existing equality and `startsWith` rank cases are unchanged.
> - Risk: items that previously matched only via raw substring but do not form a subsequence of the query will no longer appear in results; verify `scoreSubsequenceMatch` behavior on edge-case queries like repeated characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7be7d43. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->