### PR TITLE
fix(desktop): oauth popups open from the browser preview

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -78,12 +78,12 @@ describe("previewWindowOpenAction", () => {
   });
 
   it("keeps target=_blank links in the preview tab", () => {
-    expect(
-      PreviewManager.previewWindowOpenAction(details({ disposition: "foreground-tab" })),
-    ).toBe("navigate");
-    expect(
-      PreviewManager.previewWindowOpenAction(details({ disposition: "background-tab" })),
-    ).toBe("navigate");
+    expect(PreviewManager.previewWindowOpenAction(details({ disposition: "foreground-tab" }))).toBe(
+      "navigate",
+    );
+    expect(PreviewManager.previewWindowOpenAction(details({ disposition: "background-tab" }))).toBe(
+      "navigate",
+    );
   });
 
   it("does not hand a window to schemes that cannot be hardened", () => {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -58,6 +58,50 @@ describe("isPreviewRefreshShortcut", () => {
   });
 });
 
+describe("previewWindowOpenAction", () => {
+  const details = (overrides: {
+    readonly url?: string;
+    readonly disposition?: Electron.HandlerDetails["disposition"];
+  }) => ({
+    url: "https://accounts.google.com/o/oauth2/auth",
+    disposition: "new-window" as Electron.HandlerDetails["disposition"],
+    ...overrides,
+  });
+
+  it("opens a real window for scripted popups so the opener survives", () => {
+    // OAuth SDKs read a null `window.open()` as a blocked popup, and they need
+    // the opener alive to receive the credential back.
+    expect(PreviewManager.previewWindowOpenAction(details({}))).toBe("popup");
+    expect(
+      PreviewManager.previewWindowOpenAction(details({ url: "http://localhost:5173/auth" })),
+    ).toBe("popup");
+  });
+
+  it("keeps target=_blank links in the preview tab", () => {
+    expect(
+      PreviewManager.previewWindowOpenAction(details({ disposition: "foreground-tab" })),
+    ).toBe("navigate");
+    expect(
+      PreviewManager.previewWindowOpenAction(details({ disposition: "background-tab" })),
+    ).toBe("navigate");
+  });
+
+  it("does not hand a window to schemes that cannot be hardened", () => {
+    // A popup skips the `will-attach-webview` hardening, so it only gets a window
+    // when its preferences can be overridden. Chromium copies the guest's
+    // preferences for `about:blank` and forbids overriding them.
+    for (const url of [
+      "about:blank",
+      "javascript:alert(1)",
+      "file:///etc/passwd",
+      "vscode://vscode-remote/ssh-remote+box/tmp",
+      "not a url",
+    ]) {
+      expect(PreviewManager.previewWindowOpenAction(details({ url }))).toBe("navigate");
+    }
+  });
+});
+
 const {
   browserWindowConstructor,
   createFromPath,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -434,6 +434,62 @@ const APP_FORWARDED_SHORTCUTS: ReadonlyArray<{
   { key: "w", meta: true, shift: false, control: false },
 ]);
 
+/**
+ * Protocols a preview page may open in a real popup window.
+ *
+ * `about:blank` stays out: Chromium skips browser-side navigation for it, so the
+ * child copies the guest's `contextIsolation: false` preferences and Electron
+ * gives no way to override them. Those popups keep loading in the preview tab.
+ *
+ * Deliberately not `ElectronShell.parseSafeExternalUrl`: that also admits
+ * `vscode://vscode-remote/...` deep links, which belong in `shell.openExternal`
+ * and not in a window spawned by a third-party page in the preview.
+ */
+const POPUP_PROTOCOLS = new Set(["http:", "https:"]);
+
+const isPopupUrl = (rawUrl: string): boolean => {
+  try {
+    return POPUP_PROTOCOLS.has(new URL(rawUrl).protocol);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Preferences for a popup a preview page opens.
+ *
+ * A popup is not a webview attach, so the `will-attach-webview` hardening in
+ * `DesktopWindow` never sees it, and an unoverridden child would inherit the
+ * guest's relaxed posture: the picker preload needs `contextIsolation: false`
+ * to share `globalThis` with the previewed page, and no OAuth provider should
+ * get that. The window keeps the opener and the guest session either way.
+ */
+const POPUP_WINDOW_OPTIONS: Electron.BrowserWindowConstructorOptions = {
+  webPreferences: {
+    contextIsolation: true,
+    sandbox: true,
+    nodeIntegration: false,
+    nodeIntegrationInSubFrames: false,
+  },
+};
+
+/**
+ * Decides what a preview page's `window.open` should do.
+ *
+ * `"popup"` opens a real window, which scripted popups need: denying them makes
+ * `window.open()` return `null` (OAuth SDKs report that as a blocked popup), and
+ * navigating the preview tab instead destroys the opener the popup has to
+ * `postMessage` its result back to.
+ *
+ * `target="_blank"` links arrive as a tab disposition and keep loading in the
+ * preview tab, which is what people expect from a link inside a preview.
+ */
+export const previewWindowOpenAction = (details: {
+  readonly url: string;
+  readonly disposition: Electron.HandlerDetails["disposition"];
+}): "popup" | "navigate" =>
+  details.disposition === "new-window" && isPopupUrl(details.url) ? "popup" : "navigate";
+
 export const isPreviewRefreshShortcut = (input: Electron.Input): boolean =>
   input.type === "keyDown" &&
   input.key.toLowerCase() === "r" &&
@@ -1704,10 +1760,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.on("audio-state-changed", audioStateChanged);
         wc.ipc.on(HUMAN_INPUT_CHANNEL, humanInput);
         wc.ipc.on(MOUSE_NAVIGATE_CHANNEL, mouseNavigate);
-        wc.setWindowOpenHandler(({ url }) => {
+        wc.setWindowOpenHandler((details) => {
+          if (previewWindowOpenAction(details) === "popup") {
+            return { action: "allow", overrideBrowserWindowOptions: POPUP_WINDOW_OPTIONS };
+          }
           runFork(
             attemptPromise({ operation: "openPreviewWindow", tabId, webContentsId: wc.id }, () =>
-              wc.loadURL(url),
+              wc.loadURL(details.url),
             ).pipe(Effect.ignore),
           );
           return { action: "deny" };

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -464,14 +464,13 @@ const isPopupUrl = (rawUrl: string): boolean => {
  * to share `globalThis` with the previewed page, and no OAuth provider should
  * get that. The window keeps the opener and the guest session either way.
  */
-const POPUP_WINDOW_OPTIONS: Electron.BrowserWindowConstructorOptions = {
+const POPUP_WINDOW_OPTIONS = {
   webPreferences: {
     contextIsolation: true,
-    sandbox: true,
     nodeIntegration: false,
-    nodeIntegrationInSubFrames: false,
+    sandbox: true,
   },
-};
+} satisfies Electron.BrowserWindowConstructorOptions;
 
 /**
  * Decides what a preview page's `window.open` should do.
@@ -1717,6 +1716,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         ],
       });
     });
+    // A popup opens with Electron's default handler, so the page inside it could
+    // otherwise spawn native windows without limit. Nothing in an OAuth flow
+    // opens a second popup, so the chain stops at the first one.
+    const windowCreated = (window: Electron.BrowserWindow): void => {
+      window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    };
     const beforeInput = (event: Electron.Event, input: Electron.Input): void => {
       if (isPreviewRefreshShortcut(input)) {
         event.preventDefault();
@@ -1742,6 +1747,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.off("did-stop-loading", sync);
         wc.off("did-fail-load", failed as never);
         wc.off("audio-state-changed", audioStateChanged);
+        wc.off("did-create-window", windowCreated);
         wc.off("before-input-event", beforeInput);
         wc.ipc.off(HUMAN_INPUT_CHANNEL, humanInput);
         wc.ipc.off(MOUSE_NAVIGATE_CHANNEL, mouseNavigate);
@@ -1771,6 +1777,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
           return { action: "deny" };
         });
+        wc.on("did-create-window", windowCreated);
         wc.on("before-input-event", beforeInput);
       });
       yield* Ref.update(attachedRef, (attached) =>

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -260,8 +260,10 @@ export function HostedBrowserWebview(props: {
           ref={setWebviewRef}
           // Must be an attribute on the element itself: Electron reads it when the
           // guest attaches, so setting it from the ref callback lands too late and
-          // the guest attaches with popups disabled.
-          allowpopups="true"
+          // the guest attaches with popups disabled. React types `allowpopups` as a
+          // boolean, but react-dom drops boolean values for unrecognized attributes,
+          // so the literal string has to be spread past the type.
+          {...({ allowpopups: "true" } as unknown as { readonly allowpopups?: boolean })}
           src={webviewGeneration === 0 ? initialSrc : recoverySrc}
           partition={config.partition}
           webpreferences={config.webPreferences}

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -92,7 +92,6 @@ export function HostedBrowserWebview(props: {
 
   const setWebviewRef = useCallback((node: HTMLElement | null) => {
     webviewRef.current = node as ElectronWebview | null;
-    if (node && !node.hasAttribute("allowpopups")) node.setAttribute("allowpopups", "true");
   }, []);
 
   useEffect(() => {
@@ -259,6 +258,10 @@ export function HostedBrowserWebview(props: {
         <webview
           key={webviewGeneration}
           ref={setWebviewRef}
+          // Must be an attribute on the element itself: Electron reads it when the
+          // guest attaches, so setting it from the ref callback lands too late and
+          // the guest attaches with popups disabled.
+          allowpopups="true"
           src={webviewGeneration === 0 ? initialSrc : recoverySrc}
           partition={config.partition}
           webpreferences={config.webPreferences}


### PR DESCRIPTION
## What Changed

Two changes, both needed for an OAuth popup to work in the integrated browser preview.

`apps/web/src/browser/HostedBrowserWebview.tsx` sets `allowpopups` as an attribute on the `<webview>` element instead of from the ref callback. Electron reads that flag when the guest attaches, and the ref callback runs after the element is already in the DOM, so every preview guest attached with popups disabled.

`apps/desktop/src/preview/Manager.ts` reads the `disposition` the window-open handler already received. A `new-window` disposition with an http or https URL now opens a real window; everything else, `target="_blank"` links included, keeps loading in the preview tab as before. The popup is created with `contextIsolation`, `sandbox`, and `nodeIntegration: false` set explicitly, since a popup is not a webview attach and never passes the `will-attach-webview` hardening in `DesktopWindow`. It also gets a deny-only window-open handler of its own, so a page inside it cannot spawn native windows without limit. `about:blank` popups keep loading in the preview tab: Chromium copies the guest preferences for them and gives no way to override.

## Why

A local app opened in the preview cannot finish an OAuth popup flow. Firebase `signInWithPopup(auth, new GoogleAuthProvider())` reports `auth/popup-blocked` and no window appears, while the same app works in a normal Chrome or Firefox window.

Two separate causes stack up. `window.open` was denied and the URL was force-loaded into the same webContents, so `window.open()` returned `null` (the SDK reads that as a blocked popup) and the in-tab load destroyed the opener the popup needs to `postMessage` its credential back to. Underneath that, the guest attached with `allowpopups` false, so Electron blocked the call before the handler ran at all.

Instrumenting `will-attach-webview` in a running desktop build showed it directly:

```
[popup-debug attach-webview] {"partition":"persist:t3code-preview-…","allowpopups":false}   before
[popup-debug attach-webview] {"partition":"persist:t3code-preview-…","allowpopups":true}    after
```

## Surfaces

Desktop only in behavior. The `<webview>` element lives in `apps/web` because the desktop app wraps the web client, but the tag only exists inside Electron and remote web previews never reach `setWindowOpenHandler`. No contract, provider, or docs change.

## UI Changes

No layout, styling, or motion changed. The observable difference is whether a popup window exists, captured below in a dev build against a local page that calls `window.open(url, name, "width=520,height=640")`, the same shape `signInWithPopup` uses.

### Before

`window.open()` returns null and no window opens.

![Before: popup blocked](https://raw.githubusercontent.com/walid-baharwal/t3code/pr-8435-assets/before-popup-blocked.png)

### After

`window.open()` returns a window handle.

![After: popup opens](https://raw.githubusercontent.com/walid-baharwal/t3code/pr-8435-assets/after-popup-opens.png)

The popup window itself, sized from the requested window features:

![After: the popup window](https://raw.githubusercontent.com/walid-baharwal/t3code/pr-8435-assets/after-popup-window.png)

## Verification

Run in a dev desktop build (`dev:desktop`) with the preview open on a local page:

- Scripted popup: `window.open(...)` returns a handle. Handler logged `disposition: "new-window"` and decided `popup`.
- The popup reports `window.opener` present and `typeof require === "undefined"`, so the opener survives and the hardening applied.
- A nested `window.open` from inside the popup returns `null`.
- A `target="_blank"` link logs `disposition: "foreground-tab"`, decides `navigate`, and loads in the preview tab.
- `previewWindowOpenAction` has focused unit tests next to `isPreviewRefreshShortcut`, the existing pure helper in the same file.

Checks run locally:

- `vp test run apps/desktop/src/preview/Manager.test.ts` — 66 passed
- `tsgo --noEmit` in `apps/web` and `apps/desktop` — clean
- `vp lint` and `vp fmt --check` on the changed files — clean

The attach-timing half is not unit-testable in a meaningful way. A rendered-DOM assertion passes either way, because the ref callback does set the attribute, just too late for Electron to read it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after evidence included

Fixes #6561

Written with Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview navigation and spawns hardened native windows from third-party pages; security-sensitive but scoped to http/https scripted popups with explicit hardening and nested popup denial.
> 
> **Overview**
> Fixes OAuth and other scripted `window.open` flows in the integrated browser preview by enabling popups at attach time and opening real windows when appropriate instead of navigating the preview tab.
> 
> **`HostedBrowserWebview`** sets `allowpopups="true"` on the `<webview>` element at render time (not in a ref callback), so Electron sees it before the guest attaches.
> 
> **`PreviewManager`** adds `previewWindowOpenAction`: scripted popups (`new-window` + `http:`/`https:`) are allowed as separate `BrowserWindow`s with `contextIsolation`, `sandbox`, and no Node integration; `target="_blank"` and non-hardenable URLs (`about:blank`, `file:`, `javascript:`, etc.) still load in the preview tab. Child OAuth windows get a deny-all `setWindowOpenHandler` via `did-create-window`.
> 
> Unit tests cover the new helper’s popup vs navigate decisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f60be17708fb8f2e49c0f3ac16b4ad62e1c6d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OAuth popups in desktop browser preview with hardened `window.open` handling
> - Adds `previewWindowOpenAction` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/8435/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53) to classify `window.open` requests: http/https scripted popups return `'popup'` and open as real `BrowserWindow`s; `target=_blank` tabs and disallowed/invalid schemes (about, javascript, file, vscode) return `'navigate'` and load in the existing preview tab.
> - New popup windows use hardened `webPreferences` (`contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`) and deny further `window.open` calls from within them.
> - Fixes [HostedBrowserWebview.tsx](https://github.com/pingdotgg/t3code/pull/8435/files#diff-7875066eaf4ba663c79d1d45d3fb661a9193d5e6aaaad32d6e37c9da2a733645) so the `<webview>` element reliably gets the `allowpopups` attribute at attach time.
> - Behavioral Change: `setWindowOpenHandler` now receives full `details` and uses `details.url` instead of bare `url`; non-http(s) URLs that previously may have opened as popups now navigate the current tab instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f60be1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->