### PR TITLE
feat(web): toggle a thread's pin from the keyboard

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -196,6 +196,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
       assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+s");
+      assert.equal(defaultsByCommand.get("thread.pin"), "mod+shift+p");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1272,7 +1272,7 @@ function ChatViewContent(props: ChatViewProps) {
   const threadSyncPhase = routeKind === "server" ? (props.threadSyncPhase ?? null) : null;
   const threadDetailLoading = threadSyncPhase === "loading";
   const handleNewThread = useNewThreadHandler();
-  const { settleThread } = useThreadActions();
+  const { settleThread, pinThread, unpinThread } = useThreadActions();
   const routeThreadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
@@ -4428,6 +4428,8 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const supportsSettlement = serverConfig?.environment.capabilities.threadSettlement === true;
   const supportsSnooze = serverConfig?.environment.capabilities.threadSnooze === true;
+  const supportsPinning = serverConfig?.environment.capabilities.threadPinning === true;
+  const activeThreadPinned = supportsPinning && activeThreadShell?.pinnedAt != null;
   const nowMinute = useNowMinute();
   const snoozeNow = new Date().toISOString();
   const activeThreadSnoozed =
@@ -5140,6 +5142,25 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
+      if (command === "thread.pin") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!isServerThread || !activeThreadRef || !supportsPinning) return;
+        const pinned = activeThreadPinned;
+        void (pinned ? unpinThread(activeThreadRef) : pinThread(activeThreadRef)).then((result) => {
+          if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: pinned ? "Failed to unpin thread" : "Failed to pin thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        });
+        return;
+      }
+
       if (command === "terminal.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -5244,6 +5265,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeRightPanelSurface,
     addTerminalSurface,
     activeThreadRef,
+    activeThreadPinned,
     activeThreadSettled,
     terminalUiState.terminalOpen,
     terminalUiState.activeTerminalId,
@@ -5259,8 +5281,11 @@ function ChatViewContent(props: ChatViewProps) {
     handleUnsettleActiveThread,
     isServerThread,
     onToggleDiff,
+    pinThread,
     settleThread,
+    supportsPinning,
     supportsSettlement,
+    unpinThread,
     toggleRightPanel,
     toggleRightPanelMaximized,
     toggleTerminalVisibility,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -55,6 +55,10 @@ so add one in **Settings** → **Keybindings** if you want to use it.
 `thread.settle` settles the active thread or restores it when it is already settled. Its default
 shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 
+`thread.pin` pins the active thread to the top of the sidebar, or unpins it when it is already
+pinned. A fresh pin lands at the top of the pinned list. Its default shortcut is `mod+shift+p`, and
+it does not run while the terminal has focus.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -55,9 +55,9 @@ so add one in **Settings** → **Keybindings** if you want to use it.
 `thread.settle` settles the active thread or restores it when it is already settled. Its default
 shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 
-`thread.pin` pins the active thread to the top of the sidebar, or unpins it when it is already
-pinned. A fresh pin lands at the top of the pinned list. Its default shortcut is `mod+shift+p`, and
-it does not run while the terminal has focus.
+`thread.pin` pins the active thread to the pinned section of the sidebar, or unpins it when it is
+already pinned. Its default shortcut is `mod+shift+p`, and it does not run while the terminal has
+focus. See [Organizing threads](./thread-sidebar.md) for how pinned threads are ordered.
 
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -1,8 +1,8 @@
 # Organizing threads
 
 Pin a thread from its context menu to keep it in the pinned section above your active work.
-Pinned threads are shown independently of their project, including when you connect to more than
-one environment.
+`mod+shift+p` pins or unpins the thread you have open. Pinned threads are shown independently of
+their project, including when you connect to more than one environment.
 
 Pinned threads still move to **Settled** when they become inactive. They also move when their pull
 request merges if **Auto-settle merged threads** is enabled.

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -38,6 +38,7 @@ export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
   "thread.settle",
+  "thread.pin",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -47,6 +47,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   { key: "mod+shift+s", command: "thread.settle", when: "!terminalFocus" },
+  { key: "mod+shift+p", command: "thread.pin", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
<img width="1100" height="780" alt="image" src="https://github.com/user-attachments/assets/f67e1afa-c2ac-499a-a30c-5431c4816b3a" />



https://github.com/user-attachments/assets/aac4855d-eb50-4504-9653-723d87c345cb




=====  DESCRIPTION BELOW GENERATED BY AI   =====


Pinning a thread was only reachable by pointer: the sidebar row's context menu or the chat header's action menu. Every other thread-lifecycle action of that weight (settle, thread traversal, jump) already has a binding, so pinning was the odd one out for keyboard-driven users.

Added a `thread.pin` command that toggles the pin on the thread you have open. It defaults to `mod+shift+p`, pairing with `thread.settle`'s `mod+shift+s`, and carries `when: "!terminalFocus"` so it stays out of the way while you are in a terminal.




The handler sits next to `thread.settle` in `ChatView` and dispatches through the shared `pinThread` / `unpinThread` from `useThreadActions`, so it places a fresh pin exactly like the menu actions do (top of the arranged run where the server supports pin reordering, keyless otherwise), and failures raise the same stacked toast. The `threadPinning` capability gate keeps the command from reaching a server that predates pinning.

## Surfaces

- **Clients:** web, and desktop by wrapping it. Mobile has no keybinding layer.
- **Contracts:** `thread.pin` joins `THREAD_KEYBINDING_COMMANDS`, so it flows into `STATIC_KEYBINDING_COMMANDS` and appears in Settings → Keybindings, auto-labeled "Thread: Pin". `ResolvedKeybindingsConfig` is a `ForwardCompatibleArray`, so clients that predate the command drop the rule instead of failing the whole config.
- **Reverse state:** the one command toggles both directions.
- **Version skew:** gated on the `threadPinning` capability, same contract as settle and snooze.
- **Defaults seeding:** the server's startup sync adds the new rule unless a user rule already claims that command or that chord.
- **Docs:** `docs/user/keybindings.md` and `docs/user/thread-sidebar.md`.

## Notes

`mod+shift+p` is free in the default set. Firefox binds `Cmd/Ctrl+Shift+P` to a private window, so Firefox users will want to rebind — the same tradeoff `mod+shift+s` already makes with Firefox's screenshot chord.

Under the legacy sidebar there is no pinned section, so the shortcut pins with no visible effect there. That is pre-existing rather than new: the chat header's action menu already offers Pin under the legacy sidebar. Gating the shortcut would have made it disagree with the menu item beside it.



Model: Claude Opus 5. Harness: Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `thread.pin` keyboard command bound to `mod+shift+p`
> - Adds `thread.pin` to the `THREAD_KEYBINDING_COMMANDS` union type and registers a default keybinding of `mod+shift+p` with a `!terminalFocus` when-clause in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/8440/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06).
> - Integrates the command into the global keydown handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8440/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e): when the server supports pinning and an active server thread exists, the handler toggles pin state via `pinThread`/`unpinThread` from `useThreadActions`, surfacing errors through a toast.
> - Updates [keybindings.test.ts](https://github.com/pingdotgg/t3code/pull/8440/files#diff-7cdcaa91f266fd337d189836ac52dd8f055d807b8309bb3b551dedc118740a3a) to assert the default binding, and documents the shortcut in [keybindings.md](https://github.com/pingdotgg/t3code/pull/8440/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43) and [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/8440/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1950a4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, capability-gated UI change that reuses existing pin/unpin actions; no auth or data-model changes.
> 
> **Overview**
> Adds a **`thread.pin`** keybinding so keyboard users can pin or unpin the active thread without opening the sidebar or header menus, matching other thread lifecycle shortcuts like **`thread.settle`**.
> 
> The command is registered in contracts and **`DEFAULT_KEYBINDINGS`** as **`mod+shift+p`** with **`when: "!terminalFocus"`**. In **`ChatView`**, the global keydown handler toggles pin state via existing **`pinThread`** / **`unpinThread`** when the server exposes **`threadPinning`**, and shows the same error toasts on failure. User docs for keybindings and the thread sidebar describe the shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1950a4c2d23bce2e5467d887650f7fe1a245f422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->