### PR TITLE
fix(opencode): settle pending requests during teardown

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -194,6 +194,28 @@ describe("pending approvals", () => {
 
     expect(derivePendingApprovals([requested, resolved])).toEqual([]);
   });
+
+  it("derives unknown provider approvals as actionable generic approvals", () => {
+    const activity = makeActivity({
+      id: EventId.make("approval-unknown"),
+      kind: "approval.requested",
+      summary: "Approval requested",
+      createdAt: "2026-08-24T00:00:00.000Z",
+      payload: {
+        requestId: "req-unknown",
+        requestType: "unknown",
+        detail: "addCommentReaction|eyes|'confused'",
+      },
+    });
+
+    expect(derivePendingApprovals([activity])).toMatchObject([
+      {
+        requestId: "req-unknown",
+        requestKind: "command",
+        detail: "addCommentReaction|eyes|'confused'",
+      },
+    ]);
+  });
 });
 
 function makeActivity(

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1388,9 +1388,11 @@ export function derivePendingApprovals(
         ? (activity.payload as Record<string, unknown>)
         : null;
     const requestId = parseApprovalRequestId(payload?.requestId);
-    const requestKind = isProviderRequestKind(payload?.requestKind)
+    const mappedRequestKind = isProviderRequestKind(payload?.requestKind)
       ? payload.requestKind
       : requestKindFromRequestType(payload?.requestType);
+    const requestKind =
+      activity.kind === "approval.requested" ? (mappedRequestKind ?? "command") : mappedRequestKind;
     const detail = typeof payload?.detail === "string" ? payload.detail : undefined;
     const appName = typeof payload?.appName === "string" ? payload.appName : undefined;
     const options = Array.isArray(payload?.options)

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -16,6 +16,7 @@ import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
 
 import {
+  ApprovalRequestId,
   OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -62,6 +63,11 @@ const runtimeMock = {
     sessionCreateInputs: [] as Array<Record<string, unknown>>,
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
+    abortError: null as Error | null,
+    permissionReplyCalls: [] as Array<{ requestID: string; reply: unknown }>,
+    questionReplyCalls: [] as Array<{ requestID: string; answers: unknown }>,
+    permissionReplyWait: null as Promise<void> | null,
+    onPermissionReply: null as (() => void) | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
@@ -85,6 +91,11 @@ const runtimeMock = {
     this.state.sessionCreateInputs.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
+    this.state.abortError = null;
+    this.state.permissionReplyCalls.length = 0;
+    this.state.questionReplyCalls.length = 0;
+    this.state.permissionReplyWait = null;
+    this.state.onPermissionReply = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
@@ -185,6 +196,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           runtimeMock.state.abortCalls.push(sessionID);
           runtimeMock.state.onAbort?.();
           await runtimeMock.state.abortWait;
+          if (runtimeMock.state.abortError) {
+            throw runtimeMock.state.abortError;
+          }
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -210,6 +224,18 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             targetIndex >= 0
               ? runtimeMock.state.messages.slice(0, targetIndex + 1)
               : runtimeMock.state.messages;
+        },
+      },
+      permission: {
+        reply: async ({ requestID, reply }: { requestID: string; reply: unknown }) => {
+          runtimeMock.state.permissionReplyCalls.push({ requestID, reply });
+          runtimeMock.state.onPermissionReply?.();
+          await runtimeMock.state.permissionReplyWait;
+        },
+      },
+      question: {
+        reply: async ({ requestID, answers }: { requestID: string; answers: unknown }) => {
+          runtimeMock.state.questionReplyCalls.push({ requestID, answers });
         },
       },
       event: {
@@ -768,6 +794,136 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         events[0]?.type === "request.resolved" && events[0].payload.decision,
         "cancel",
       );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("preserves pending requests when interrupt abort fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupt-failure");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "permission-interrupt-failure",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["git status"],
+            metadata: {},
+          },
+        },
+        {
+          type: "question.asked",
+          properties: {
+            id: "question-interrupt-failure",
+            sessionID: "http://127.0.0.1:9999/session",
+            questions: [
+              {
+                question: "Continue?",
+                header: "Continue",
+                options: [{ label: "Yes", description: "Continue the task" }],
+              },
+            ],
+          },
+        },
+      ];
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Fiber.join(openedFiber).pipe(Effect.timeout("1 second"));
+
+      runtimeMock.state.abortError = new Error("abort failed");
+      const result = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-interrupt-failure"))
+        .pipe(Effect.result);
+      NodeAssert.equal(result._tag, "Failure");
+
+      yield* adapter.respondToRequest(
+        threadId,
+        ApprovalRequestId.make("permission-interrupt-failure"),
+        "accept",
+      );
+      yield* adapter.respondToUserInput(
+        threadId,
+        ApprovalRequestId.make("question-interrupt-failure"),
+        { Continue: "Yes" },
+      );
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, [
+        { requestID: "permission-interrupt-failure", reply: "once" },
+      ]);
+      NodeAssert.deepEqual(runtimeMock.state.questionReplyCalls, [
+        { requestID: "question-interrupt-failure", answers: [["Yes"]] },
+      ]);
+
+      runtimeMock.state.abortError = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("serializes permission replies with interruption", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupt-reply-race");
+      const replyStarted = Promise.withResolvers<void>();
+      const releaseReply = Promise.withResolvers<void>();
+      runtimeMock.state.onPermissionReply = replyStarted.resolve;
+      runtimeMock.state.permissionReplyWait = releaseReply.promise;
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "permission-interrupt-race",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["git status"],
+            metadata: {},
+          },
+        },
+      ];
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Fiber.join(openedFiber).pipe(Effect.timeout("1 second"));
+
+      const resolvedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.resolved"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const replyFiber = yield* adapter
+        .respondToRequest(threadId, ApprovalRequestId.make("permission-interrupt-race"), "accept")
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => replyStarted.promise);
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-interrupt-race"))
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+
+      NodeAssert.equal(resolvedFiber.pollUnsafe(), undefined);
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, []);
+      releaseReply.resolve();
+      yield* Fiber.join(replyFiber);
+      yield* Fiber.join(interruptFiber);
+      yield* Fiber.join(resolvedFiber).pipe(Effect.timeout("1 second"));
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -20,6 +20,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   ThreadId,
+  TurnId,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 import { ServerConfig } from "../../config.ts";
@@ -68,6 +69,9 @@ const runtimeMock = {
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
+    subscribedEventStream: null as AsyncIterable<unknown> | null,
+    abortWait: null as Promise<void> | null,
+    onAbort: null as (() => void) | null,
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -88,6 +92,9 @@ const runtimeMock = {
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.subscribedEventStream = null;
+    this.state.abortWait = null;
+    this.state.onAbort = null;
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -176,6 +183,8 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
+          runtimeMock.state.onAbort?.();
+          await runtimeMock.state.abortWait;
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -205,11 +214,13 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       },
       event: {
         subscribe: async () => ({
-          stream: (async function* () {
-            for (const event of runtimeMock.state.subscribedEvents) {
-              yield event;
-            }
-          })(),
+          stream:
+            runtimeMock.state.subscribedEventStream ??
+            (async function* () {
+              for (const event of runtimeMock.state.subscribedEvents) {
+                yield event;
+              }
+            })(),
         }),
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
@@ -628,7 +639,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("renders and cancels unknown OpenCode permissions", () =>
+  it.effect("settles pending permissions and questions when stopping", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-opencode-unknown-permission");
@@ -643,10 +654,24 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
             metadata: {},
           },
         },
+        {
+          type: "question.asked",
+          properties: {
+            id: "question-1",
+            sessionID: "http://127.0.0.1:9999/session",
+            questions: [
+              {
+                question: "Continue?",
+                header: "Continue",
+                options: [{ label: "Yes", description: "Continue the task" }],
+              },
+            ],
+          },
+        },
       ];
       const eventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter((event) => event.threadId === threadId),
-        Stream.take(3),
+        Stream.take(4),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -662,7 +687,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       );
       const stoppedEventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter((event) => event.threadId === threadId),
-        Stream.take(2),
+        Stream.take(3),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -673,7 +698,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       );
       NodeAssert.deepEqual(
         openedEvents.map((event) => event.type),
-        ["session.started", "thread.started", "request.opened"],
+        ["session.started", "thread.started", "request.opened", "user-input.requested"],
       );
       NodeAssert.equal(
         openedEvents[2]?.type === "request.opened" && openedEvents[2].payload.requestType,
@@ -681,10 +706,147 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       );
       NodeAssert.deepEqual(
         stoppedEvents.map((event) => event.type),
-        ["request.resolved", "session.exited"],
+        ["request.resolved", "user-input.resolved", "session.exited"],
       );
       NodeAssert.equal(
         stoppedEvents[0]?.type === "request.resolved" && stoppedEvents[0].payload.decision,
+        "cancel",
+      );
+      NodeAssert.deepEqual(
+        stoppedEvents[1]?.type === "user-input.resolved" && stoppedEvents[1].payload.answers,
+        {},
+      );
+    }),
+  );
+
+  it.effect("settles pending permissions when interrupting", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupt-permission");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "permission-interrupt",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["git status"],
+            metadata: {},
+          },
+        },
+      ];
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Fiber.join(openedFiber).pipe(Effect.timeout("1 second"));
+
+      const interruptedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.interruptTurn(threadId, TurnId.make("turn-interrupted"));
+
+      const events = Array.from(
+        yield* Fiber.join(interruptedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["request.resolved", "turn.aborted"],
+      );
+      NodeAssert.equal(
+        events[0]?.type === "request.resolved" && events[0].payload.decision,
+        "cancel",
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("handles permission reply and open races during teardown", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-reply-race");
+      const abortStarted = Promise.withResolvers<void>();
+      const releaseAbort = Promise.withResolvers<void>();
+      const releaseRacingEvents = Promise.withResolvers<void>();
+      const racingEventsHandled = Promise.withResolvers<void>();
+      runtimeMock.state.abortWait = releaseAbort.promise;
+      runtimeMock.state.onAbort = abortStarted.resolve;
+      runtimeMock.state.subscribedEventStream = (async function* () {
+        yield {
+          type: "permission.asked",
+          properties: {
+            id: "permission-reply-race",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["git status"],
+            metadata: {},
+          },
+        };
+        await releaseRacingEvents.promise;
+        yield {
+          type: "permission.replied",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            requestID: "permission-reply-race",
+            reply: "once",
+          },
+        };
+        yield {
+          type: "permission.asked",
+          properties: {
+            id: "permission-after-stop",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["git diff"],
+            metadata: {},
+          },
+        };
+        racingEventsHandled.resolve();
+      })();
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Fiber.join(openedFiber).pipe(Effect.timeout("1 second"));
+      const closingFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      releaseRacingEvents.resolve();
+      yield* Effect.promise(() => racingEventsHandled.promise);
+      releaseAbort.resolve();
+      yield* Fiber.join(stopFiber);
+
+      const events = Array.from(yield* Fiber.join(closingFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["request.resolved", "session.exited"],
+      );
+      NodeAssert.equal(
+        events[0]?.type === "request.resolved" && events[0].payload.decision,
         "cancel",
       );
     }),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -628,6 +628,68 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("renders and cancels unknown OpenCode permissions", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-unknown-permission");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "permission-1",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "addCommentReaction",
+            patterns: ["eyes", "confused"],
+            metadata: {},
+          },
+        },
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+
+      const openedEvents = Array.from(
+        yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")),
+      );
+      const stoppedEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.stopSession(threadId);
+
+      const stoppedEvents = Array.from(
+        yield* Fiber.join(stoppedEventsFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.deepEqual(
+        openedEvents.map((event) => event.type),
+        ["session.started", "thread.started", "request.opened"],
+      );
+      NodeAssert.equal(
+        openedEvents[2]?.type === "request.opened" && openedEvents[2].payload.requestType,
+        "dynamic_tool_call",
+      );
+      NodeAssert.deepEqual(
+        stoppedEvents.map((event) => event.type),
+        ["request.resolved", "session.exited"],
+      );
+      NodeAssert.equal(
+        stoppedEvents[0]?.type === "request.resolved" && stoppedEvents[0].payload.decision,
+        "cancel",
+      );
+    }),
+  );
+
   it.effect("clears session state even when cleanup finalizers throw", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -772,6 +772,58 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("aborts OpenCode when a session errors with a pending request", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-session-error");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "permission-session-error",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["git status"],
+            metadata: {},
+          },
+        },
+        {
+          type: "session.error",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            error: { data: { message: "provider failed" } },
+          },
+        },
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        [
+          "session.started",
+          "thread.started",
+          "request.opened",
+          "request.resolved",
+          "runtime.error",
+        ],
+      );
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, ["http://127.0.0.1:9999/session"]);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("handles permission reply and open races during teardown", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -21,6 +21,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
@@ -175,6 +176,16 @@ type OpenCodeSubscribedEvent =
     ? TEvent
     : never;
 
+function isPendingRequestEvent(event: OpenCodeSubscribedEvent): boolean {
+  return (
+    event.type === "permission.asked" ||
+    event.type === "permission.replied" ||
+    event.type === "question.asked" ||
+    event.type === "question.replied" ||
+    event.type === "question.rejected"
+  );
+}
+
 function trimText(value: string | undefined | null): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -229,6 +240,7 @@ interface OpenCodeSessionContext {
   readonly openCodeSessionId: string;
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
+  readonly pendingGate: Semaphore.Semaphore;
   readonly messageRoleById: Map<string, "user" | "assistant">;
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
@@ -561,14 +573,14 @@ function updateProviderSession(
 
 const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
-  cancelPendingPermissions: (context: OpenCodeSessionContext) => Effect.Effect<void>,
+  settlePendingRequests: (context: OpenCodeSessionContext) => Effect.Effect<void>,
 ) {
   // Race-safe one-shot: first caller flips the flag, everyone else no-ops.
   if (yield* Ref.getAndSet(context.stopped, true)) {
     return false;
   }
 
-  yield* cancelPendingPermissions(context).pipe(Effect.ignore);
+  yield* settlePendingRequests(context).pipe(Effect.ignore);
 
   // Best-effort remote abort. The scope close below tears down the local
   // handles (event-pump fiber, server-exit fiber, event-subscribe fetch),
@@ -660,8 +672,7 @@ export function makeOpenCodeAdapter(
         // the remaining cleanups.
         yield* Effect.forEach(
           contexts,
-          (context) =>
-            Effect.ignoreCause(stopOpenCodeContext(context, emitCancelledPendingPermissions)),
+          (context) => Effect.ignoreCause(stopOpenCodeContext(context, settlePendingRequests)),
           { concurrency: "unbounded", discard: true },
         );
         // Close the logger AFTER session teardown so any final lifecycle
@@ -676,29 +687,56 @@ export function makeOpenCodeAdapter(
 
     const emit = (event: ProviderRuntimeEvent) =>
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
-    const emitCancelledPendingPermissions = Effect.fn("emitCancelledPendingPermissions")(function* (
+    const settlePendingRequests = Effect.fn("settlePendingRequests")(function* (
       context: OpenCodeSessionContext,
     ) {
-      yield* Effect.forEach(
-        [...context.pendingPermissions.entries()],
-        ([requestId, permission]) =>
-          Effect.gen(function* () {
-            yield* emit({
-              ...(yield* buildEventBase({
+      yield* context.pendingGate.withPermits(1)(
+        Effect.gen(function* () {
+          yield* Effect.forEach(
+            [...context.pendingPermissions.entries()],
+            ([requestId, permission]) =>
+              buildEventBase({
                 threadId: context.session.threadId,
                 turnId: context.activeTurnId,
                 requestId,
-              })),
-              type: "request.resolved",
-              payload: {
-                requestType: mapPermissionToRequestType(permission.permission),
-                decision: "cancel",
-              },
-            });
-          }),
-        { concurrency: 1, discard: true },
+              }).pipe(
+                Effect.flatMap((base) =>
+                  emit({
+                    ...base,
+                    type: "request.resolved",
+                    payload: {
+                      requestType: mapPermissionToRequestType(permission.permission),
+                      decision: "cancel",
+                    },
+                  }),
+                ),
+                Effect.ignore,
+              ),
+            { concurrency: 1, discard: true },
+          );
+          context.pendingPermissions.clear();
+          yield* Effect.forEach(
+            [...context.pendingQuestions.keys()],
+            (requestId) =>
+              buildEventBase({
+                threadId: context.session.threadId,
+                turnId: context.activeTurnId,
+                requestId,
+              }).pipe(
+                Effect.flatMap((base) =>
+                  emit({
+                    ...base,
+                    type: "user-input.resolved",
+                    payload: { answers: {} },
+                  }),
+                ),
+                Effect.ignore,
+              ),
+            { concurrency: 1, discard: true },
+          );
+          context.pendingQuestions.clear();
+        }),
       );
-      context.pendingPermissions.clear();
     });
     const writeNativeEvent = (
       threadId: ThreadId,
@@ -758,7 +796,7 @@ export function makeOpenCodeAdapter(
       // Inline the teardown that `stopOpenCodeContext` would do; we can't
       // delegate to it because our `getAndSet` above already flipped the
       // one-shot guard, so the call would no-op.
-      yield* emitCancelledPendingPermissions(context).pipe(Effect.ignore);
+      yield* settlePendingRequests(context).pipe(Effect.ignore);
       yield* runOpenCodeSdk("session.abort", () =>
         context.client.session.abort({ sessionID: context.openCodeSessionId }),
       ).pipe(Effect.ignore({ log: true }));
@@ -853,6 +891,9 @@ export function makeOpenCodeAdapter(
           payload: event,
         },
       });
+      if (isPendingRequestEvent(event) && (yield* Ref.get(context.stopped))) {
+        return;
+      }
 
       switch (event.type) {
         case "session.updated": {
@@ -1011,6 +1052,10 @@ export function makeOpenCodeAdapter(
         }
 
         case "permission.replied": {
+          const permission = context.pendingPermissions.get(event.properties.requestID);
+          if (!permission) {
+            break;
+          }
           context.pendingPermissions.delete(event.properties.requestID);
           yield* emit({
             ...(yield* buildEventBase({
@@ -1021,7 +1066,7 @@ export function makeOpenCodeAdapter(
             })),
             type: "request.resolved",
             payload: {
-              requestType: "unknown",
+              requestType: mapPermissionToRequestType(permission.permission),
               decision: mapPermissionDecision(event.properties.reply),
             },
           });
@@ -1047,13 +1092,10 @@ export function makeOpenCodeAdapter(
 
         case "question.replied": {
           const request = context.pendingQuestions.get(event.properties.requestID);
+          if (!request) {
+            break;
+          }
           context.pendingQuestions.delete(event.properties.requestID);
-          const answers = Object.fromEntries(
-            (request?.questions ?? []).map((question, index) => [
-              openCodeQuestionId(index, question),
-              event.properties.answers[index]?.join(", ") ?? "",
-            ]),
-          );
           yield* emit({
             ...(yield* buildEventBase({
               threadId: context.session.threadId,
@@ -1062,13 +1104,22 @@ export function makeOpenCodeAdapter(
               raw: event,
             })),
             type: "user-input.resolved",
-            payload: { answers },
+            payload: {
+              answers: Object.fromEntries(
+                request.questions.map((question, index) => [
+                  openCodeQuestionId(index, question),
+                  event.properties.answers[index]?.join(", ") ?? "",
+                ]),
+              ),
+            },
           });
           break;
         }
 
         case "question.rejected": {
-          context.pendingQuestions.delete(event.properties.requestID);
+          if (!context.pendingQuestions.delete(event.properties.requestID)) {
+            break;
+          }
           yield* emit({
             ...(yield* buildEventBase({
               threadId: context.session.threadId,
@@ -1127,6 +1178,7 @@ export function makeOpenCodeAdapter(
         case "session.error": {
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
+          yield* settlePendingRequests(context).pipe(Effect.ignore);
           context.activeTurnId = undefined;
           yield* updateProviderSession(
             context,
@@ -1198,7 +1250,14 @@ export function makeOpenCodeAdapter(
                 detail: openCodeRuntimeErrorDetail(cause),
                 cause,
               }),
-          ).pipe(Stream.runForEach((event) => handleSubscribedEvent(context, event))),
+          ).pipe(
+            Stream.runForEach((event) => {
+              const handled = handleSubscribedEvent(context, event);
+              return isPendingRequestEvent(event)
+                ? context.pendingGate.withPermits(1)(handled)
+                : handled;
+            }),
+          ),
       ).pipe(
         Effect.exit,
         Effect.flatMap((exit) =>
@@ -1243,7 +1302,7 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
-          yield* stopOpenCodeContext(existing, emitCancelledPendingPermissions);
+          yield* stopOpenCodeContext(existing, settlePendingRequests);
           sessions.delete(input.threadId);
         }
 
@@ -1427,6 +1486,7 @@ export function makeOpenCodeAdapter(
           openCodeSessionId: started.openCodeSession.id,
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),
+          pendingGate: yield* Semaphore.make(1),
           partById: new Map(),
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
@@ -1591,6 +1651,7 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
+        yield* settlePendingRequests(context);
         yield* runOpenCodeSdk("session.abort", () =>
           context.client.session.abort({ sessionID: context.openCodeSessionId }),
         ).pipe(Effect.mapError(toRequestError));
@@ -1659,7 +1720,7 @@ export function makeOpenCodeAdapter(
             threadId,
           });
         }
-        const stopped = yield* stopOpenCodeContext(context, emitCancelledPendingPermissions);
+        const stopped = yield* stopOpenCodeContext(context, settlePendingRequests);
         sessions.delete(threadId);
         if (!stopped) {
           return;
@@ -1743,8 +1804,7 @@ export function makeOpenCodeAdapter(
         // interrupt the sibling fibers. Same pattern as the layer finalizer.
         yield* Effect.forEach(
           contexts,
-          (context) =>
-            Effect.ignoreCause(stopOpenCodeContext(context, emitCancelledPendingPermissions)),
+          (context) => Effect.ignoreCause(stopOpenCodeContext(context, settlePendingRequests)),
           { concurrency: "unbounded", discard: true },
         );
       });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -687,57 +687,57 @@ export function makeOpenCodeAdapter(
 
     const emit = (event: ProviderRuntimeEvent) =>
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
-    const settlePendingRequests = Effect.fn("settlePendingRequests")(function* (
+    const settlePendingRequestsUnlocked = Effect.fn("settlePendingRequestsUnlocked")(function* (
       context: OpenCodeSessionContext,
     ) {
-      yield* context.pendingGate.withPermits(1)(
-        Effect.gen(function* () {
-          yield* Effect.forEach(
-            [...context.pendingPermissions.entries()],
-            ([requestId, permission]) =>
-              buildEventBase({
-                threadId: context.session.threadId,
-                turnId: context.activeTurnId,
-                requestId,
-              }).pipe(
-                Effect.flatMap((base) =>
-                  emit({
-                    ...base,
-                    type: "request.resolved",
-                    payload: {
-                      requestType: mapPermissionToRequestType(permission.permission),
-                      decision: "cancel",
-                    },
-                  }),
-                ),
-                Effect.ignore,
-              ),
-            { concurrency: 1, discard: true },
-          );
-          context.pendingPermissions.clear();
-          yield* Effect.forEach(
-            [...context.pendingQuestions.keys()],
-            (requestId) =>
-              buildEventBase({
-                threadId: context.session.threadId,
-                turnId: context.activeTurnId,
-                requestId,
-              }).pipe(
-                Effect.flatMap((base) =>
-                  emit({
-                    ...base,
-                    type: "user-input.resolved",
-                    payload: { answers: {} },
-                  }),
-                ),
-                Effect.ignore,
-              ),
-            { concurrency: 1, discard: true },
-          );
-          context.pendingQuestions.clear();
-        }),
+      yield* Effect.forEach(
+        [...context.pendingPermissions.entries()],
+        ([requestId, permission]) =>
+          buildEventBase({
+            threadId: context.session.threadId,
+            turnId: context.activeTurnId,
+            requestId,
+          }).pipe(
+            Effect.flatMap((base) =>
+              emit({
+                ...base,
+                type: "request.resolved",
+                payload: {
+                  requestType: mapPermissionToRequestType(permission.permission),
+                  decision: "cancel",
+                },
+              }),
+            ),
+            Effect.ignore,
+          ),
+        { concurrency: 1, discard: true },
       );
+      context.pendingPermissions.clear();
+      yield* Effect.forEach(
+        [...context.pendingQuestions.keys()],
+        (requestId) =>
+          buildEventBase({
+            threadId: context.session.threadId,
+            turnId: context.activeTurnId,
+            requestId,
+          }).pipe(
+            Effect.flatMap((base) =>
+              emit({
+                ...base,
+                type: "user-input.resolved",
+                payload: { answers: {} },
+              }),
+            ),
+            Effect.ignore,
+          ),
+        { concurrency: 1, discard: true },
+      );
+      context.pendingQuestions.clear();
     });
+    const settlePendingRequests = Effect.fn("settlePendingRequests")(
+      (context: OpenCodeSessionContext) =>
+        context.pendingGate.withPermits(1)(settlePendingRequestsUnlocked(context)),
+    );
     const writeNativeEvent = (
       threadId: ThreadId,
       event: {
@@ -1656,10 +1656,14 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        yield* settlePendingRequests(context);
-        yield* runOpenCodeSdk("session.abort", () =>
-          context.client.session.abort({ sessionID: context.openCodeSessionId }),
-        ).pipe(Effect.mapError(toRequestError));
+        yield* context.pendingGate.withPermits(1)(
+          Effect.gen(function* () {
+            yield* runOpenCodeSdk("session.abort", () =>
+              context.client.session.abort({ sessionID: context.openCodeSessionId }),
+            ).pipe(Effect.mapError(toRequestError));
+            yield* settlePendingRequestsUnlocked(context);
+          }),
+        );
         if (turnId ?? context.activeTurnId) {
           yield* emit({
             ...(yield* buildEventBase({
@@ -1679,41 +1683,49 @@ export function makeOpenCodeAdapter(
       "respondToRequest",
     )(function* (threadId, requestId, decision) {
       const context = yield* ensureSessionContext(sessions, threadId);
-      if (!context.pendingPermissions.has(requestId)) {
-        return yield* new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "permission.reply",
-          detail: `Unknown pending permission request: ${requestId}`,
-        });
-      }
+      yield* context.pendingGate.withPermits(1)(
+        Effect.gen(function* () {
+          if (!context.pendingPermissions.has(requestId)) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "permission.reply",
+              detail: `Unknown pending permission request: ${requestId}`,
+            });
+          }
 
-      yield* runOpenCodeSdk("permission.reply", () =>
-        context.client.permission.reply({
-          requestID: requestId,
-          reply: toOpenCodePermissionReply(decision),
+          yield* runOpenCodeSdk("permission.reply", () =>
+            context.client.permission.reply({
+              requestID: requestId,
+              reply: toOpenCodePermissionReply(decision),
+            }),
+          ).pipe(Effect.mapError(toRequestError));
         }),
-      ).pipe(Effect.mapError(toRequestError));
+      );
     });
 
     const respondToUserInput: OpenCodeAdapterShape["respondToUserInput"] = Effect.fn(
       "respondToUserInput",
     )(function* (threadId, requestId, answers) {
       const context = yield* ensureSessionContext(sessions, threadId);
-      const request = context.pendingQuestions.get(requestId);
-      if (!request) {
-        return yield* new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "question.reply",
-          detail: `Unknown pending user-input request: ${requestId}`,
-        });
-      }
+      yield* context.pendingGate.withPermits(1)(
+        Effect.gen(function* () {
+          const request = context.pendingQuestions.get(requestId);
+          if (!request) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "question.reply",
+              detail: `Unknown pending user-input request: ${requestId}`,
+            });
+          }
 
-      yield* runOpenCodeSdk("question.reply", () =>
-        context.client.question.reply({
-          requestID: requestId,
-          answers: toOpenCodeQuestionAnswers(request, answers),
+          yield* runOpenCodeSdk("question.reply", () =>
+            context.client.question.reply({
+              requestID: requestId,
+              answers: toOpenCodeQuestionAnswers(request, answers),
+            }),
+          ).pipe(Effect.mapError(toRequestError));
         }),
-      ).pipe(Effect.mapError(toRequestError));
+      );
     });
 
     const stopSession: OpenCodeAdapterShape["stopSession"] = Effect.fn("stopSession")(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1178,6 +1178,11 @@ export function makeOpenCodeAdapter(
         case "session.error": {
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
+          if (context.pendingPermissions.size > 0 || context.pendingQuestions.size > 0) {
+            yield* runOpenCodeSdk("session.abort", () =>
+              context.client.session.abort({ sessionID: context.openCodeSessionId }),
+            ).pipe(Effect.ignore({ log: true }));
+          }
           yield* settlePendingRequests(context).pipe(Effect.ignore);
           context.activeTurnId = undefined;
           yield* updateProviderSession(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -334,7 +334,11 @@ function toToolLifecycleItemType(toolName: string): ToolLifecycleItemType {
 
 function mapPermissionToRequestType(
   permission: string,
-): "command_execution_approval" | "file_read_approval" | "file_change_approval" | "unknown" {
+):
+  | "command_execution_approval"
+  | "file_read_approval"
+  | "file_change_approval"
+  | "dynamic_tool_call" {
   switch (permission) {
     case "bash":
       return "command_execution_approval";
@@ -343,7 +347,7 @@ function mapPermissionToRequestType(
     case "edit":
       return "file_change_approval";
     default:
-      return "unknown";
+      return "dynamic_tool_call";
   }
 }
 
@@ -557,11 +561,14 @@ function updateProviderSession(
 
 const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
+  cancelPendingPermissions: (context: OpenCodeSessionContext) => Effect.Effect<void>,
 ) {
   // Race-safe one-shot: first caller flips the flag, everyone else no-ops.
   if (yield* Ref.getAndSet(context.stopped, true)) {
     return false;
   }
+
+  yield* cancelPendingPermissions(context).pipe(Effect.ignore);
 
   // Best-effort remote abort. The scope close below tears down the local
   // handles (event-pump fiber, server-exit fiber, event-subscribe fetch),
@@ -653,7 +660,8 @@ export function makeOpenCodeAdapter(
         // the remaining cleanups.
         yield* Effect.forEach(
           contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
+          (context) =>
+            Effect.ignoreCause(stopOpenCodeContext(context, emitCancelledPendingPermissions)),
           { concurrency: "unbounded", discard: true },
         );
         // Close the logger AFTER session teardown so any final lifecycle
@@ -668,6 +676,30 @@ export function makeOpenCodeAdapter(
 
     const emit = (event: ProviderRuntimeEvent) =>
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
+    const emitCancelledPendingPermissions = Effect.fn("emitCancelledPendingPermissions")(function* (
+      context: OpenCodeSessionContext,
+    ) {
+      yield* Effect.forEach(
+        [...context.pendingPermissions.entries()],
+        ([requestId, permission]) =>
+          Effect.gen(function* () {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId: context.activeTurnId,
+                requestId,
+              })),
+              type: "request.resolved",
+              payload: {
+                requestType: mapPermissionToRequestType(permission.permission),
+                decision: "cancel",
+              },
+            });
+          }),
+        { concurrency: 1, discard: true },
+      );
+      context.pendingPermissions.clear();
+    });
     const writeNativeEvent = (
       threadId: ThreadId,
       event: {
@@ -726,6 +758,7 @@ export function makeOpenCodeAdapter(
       // Inline the teardown that `stopOpenCodeContext` would do; we can't
       // delegate to it because our `getAndSet` above already flipped the
       // one-shot guard, so the call would no-op.
+      yield* emitCancelledPendingPermissions(context).pipe(Effect.ignore);
       yield* runOpenCodeSdk("session.abort", () =>
         context.client.session.abort({ sessionID: context.openCodeSessionId }),
       ).pipe(Effect.ignore({ log: true }));
@@ -1210,7 +1243,7 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
-          yield* stopOpenCodeContext(existing);
+          yield* stopOpenCodeContext(existing, emitCancelledPendingPermissions);
           sessions.delete(input.threadId);
         }
 
@@ -1626,7 +1659,7 @@ export function makeOpenCodeAdapter(
             threadId,
           });
         }
-        const stopped = yield* stopOpenCodeContext(context);
+        const stopped = yield* stopOpenCodeContext(context, emitCancelledPendingPermissions);
         sessions.delete(threadId);
         if (!stopped) {
           return;
@@ -1710,7 +1743,8 @@ export function makeOpenCodeAdapter(
         // interrupt the sibling fibers. Same pattern as the layer finalizer.
         yield* Effect.forEach(
           contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
+          (context) =>
+            Effect.ignoreCause(stopOpenCodeContext(context, emitCancelledPendingPermissions)),
           { concurrency: "unbounded", discard: true },
         );
       });

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1516,6 +1516,23 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.detail).toBeUndefined();
   });
 
+  it("does not classify unrelated work entries as command approvals", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "web-search-completed",
+        kind: "tool.completed",
+        summary: "Searched the web",
+        payload: {
+          itemType: "web_search",
+          title: "Search",
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.requestKind).toBeUndefined();
+  });
+
   it("uses grep raw output summaries instead of repeating the generic tool label", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -189,6 +189,31 @@ describe("derivePendingApprovals", () => {
     ]);
   });
 
+  it("derives unknown provider approvals as actionable generic approvals", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-open-unknown",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "approval.requested",
+        summary: "Approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-unknown",
+          requestType: "unknown",
+          detail: "addCommentReaction|eyes|'confused'",
+        },
+      }),
+    ];
+
+    expect(derivePendingApprovals(activities)).toMatchObject([
+      {
+        requestId: "req-unknown",
+        requestKind: "command",
+        detail: "addCommentReaction|eyes|'confused'",
+      },
+    ]);
+  });
+
   it("clears stale pending approvals when provider reports unknown pending request", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -396,7 +396,7 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
     case "mcp_elicitation_approval":
       return "mcp-elicitation";
     default:
-      return null;
+      return "command";
   }
 }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -396,7 +396,7 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
     case "mcp_elicitation_approval":
       return "mcp-elicitation";
     default:
-      return "command";
+      return null;
   }
 }
 
@@ -431,12 +431,14 @@ export function derivePendingApprovals(
       payload && typeof payload.requestId === "string"
         ? ApprovalRequestId.make(payload.requestId)
         : null;
-    const requestKind =
+    const mappedRequestKind =
       payload && isProviderRequestKind(payload.requestKind)
         ? payload.requestKind
         : payload
           ? requestKindFromRequestType(payload.requestType)
           : null;
+    const requestKind =
+      activity.kind === "approval.requested" ? (mappedRequestKind ?? "command") : mappedRequestKind;
     const detail = payload && typeof payload.detail === "string" ? payload.detail : undefined;
     const appName = payload && typeof payload.appName === "string" ? payload.appName : undefined;
     const options = Array.isArray(payload?.options)


### PR DESCRIPTION
## What Changed

- Settle pending OpenCode permissions as cancelled and pending questions with empty answers when an OpenCode session or active turn ends.
- Apply cleanup on stop, interrupt, session replacement, unexpected exit, adapter shutdown, and provider session errors.
- Abort OpenCode before locally cancelling an interrupted turn; if abort fails, preserve pending requests so they remain answerable.
- Serialize request creation, responder check-and-reply sequences, interruption, and teardown with a per-session semaphore so each request resolves once.
- Ignore late permission and question events after teardown starts.
- Map unknown OpenCode permissions to `dynamic_tool_call` so they remain actionable.
- Show unknown approval requests through the generic approval UI on web and mobile.
- Scope the web fallback to `approval.requested` activities so unrelated work-log entries keep their original grouping and timeline behavior.
- Add focused tests for stop, interrupt, provider errors, abort failures, unknown permission types, and deterministic races.

## Why

OpenCode only removed pending requests after receiving a provider reply. If a session ended first, the request remained in `projection_pending_approvals`, kept `pending_approval_count` above zero, and prevented the thread from settling.

This closes the teardown parity gap described in #7113 and follows the cleanup behavior used by the other provider adapters.

The semaphore gives request events, responses, interruption, and teardown one serialized order. A request is either resolved normally or cancelled, never both.

Unknown OpenCode permission types now use the generic approval flow. The fallback is applied only to approval requests, avoiding changes to search grouping, work-log labels, and timeline-anchor behavior.

Session teardown cleanup is best-effort, so cancellation failures do not prevent the OpenCode process and local session scope from closing.

User interruption only settles pending requests after OpenCode confirms the abort. If the abort fails, those requests remain actionable.

This PR does not migrate historical pending rows already stored in existing databases. That recovery path can be handled separately.

### Verification

- OpenCode adapter tests: 38 passed
- Focused web and mobile approval derivation tests
- Deterministic abort-failure, reply-versus-interruption, and request-open race coverage
- Server typecheck
- Targeted formatting and lint checks

Closes #7113  
Closes #4795  
Related to #5119  
Related to #7173

## UI Changes

Previously, unsupported OpenCode permission types could appear as unknown requests without actionable approval UI. They now use the generic approval flow on web and mobile.

### Before

https://github.com/user-attachments/assets/b2c79de2-29ac-46e7-85f4-7dc497944dfa

### After

https://github.com/user-attachments/assets/dd9c6605-74d9-447a-9217-c589602bd853

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built and verified with Codex (GPT-5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenCode session teardown, approval projection, and concurrency around permission/question handling; incorrect settlement could leave threads stuck or double-resolve requests, but behavior is covered by new race and lifecycle tests.
> 
> **Overview**
> Fixes threads that stayed stuck with pending approvals when an OpenCode session ended before the user replied.
> 
> **OpenCode adapter** now cancels open permission prompts (`request.resolved` with `cancel`) and closes open questions (`user-input.resolved` with empty answers) during stop, interrupt, session replacement, unexpected exit, layer shutdown, and `session.error`. A per-session **`pendingGate`** serializes permission/question events with replies and teardown so each request resolves once; late permission/question events are ignored after stop starts. Unknown OpenCode permissions map to **`dynamic_tool_call`** instead of `unknown`, and `permission.replied` uses the stored permission for the resolved request type.
> 
> **Web and mobile** treat `approval.requested` activities with unknown `requestType` as actionable generic **`command`** approvals (only for that activity kind, so work-log entries are not mislabeled).
> 
> Adds adapter tests for stop/interrupt/error paths, failed abort, reply-vs-interrupt races, and teardown event races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9193685815ab4707709d583a0153ceac4a3e6543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle pending permission/question requests during OpenCode teardown and interruptions
> - Adds `settlePendingRequests` to the OpenCode adapter, which emits `request.resolved` (cancel) for pending permissions and `user-input.resolved` (empty answers) for pending questions, then clears them. Wired into session stop, `interruptTurn`, `session.error`, `emitUnexpectedExit`, and replacing an existing session in `startSession`.
> - Introduces a `pendingGate` semaphore on `OpenCodeSessionContext` to serialize permission/question operations with interrupts and stops. `respondToRequest` and `respondToUserInput` now validate presence under the gate and return `ProviderAdapterRequestError` for already-consumed requests.
> - `handleSubscribedEvent` drops pending-request events after stop, and now emits `request.resolved`/`user-input.resolved` only when a matching pending entry exists, using the stored permission's `requestType` instead of `'unknown'`.
> - Maps unknown permission types to `'dynamic_tool_call'` in `mapPermissionToRequestType`; `derivePendingApprovals` in both web and mobile now falls back to `'command'` for unknown `approval.requested` kinds.
> - Risk: `mapPermissionToRequestType` default change means `request.resolved` events for non-bash/read/edit permissions now report `'dynamic_tool_call'` instead of `'unknown'`; downstream consumers keyed on `'unknown'` in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/8441/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) and [session-logic.ts](https://github.com/pingdotgg/t3code/pull/8441/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) may need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9193685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

