### PR TITLE
feat(web): continue conversations in new threads

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -111,6 +111,7 @@ import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
+import { continueThreadInNewDraft } from "../threadContinuation";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
 import {
@@ -3078,6 +3079,7 @@ export default function Sidebar() {
           api.contextMenu.show(
             buildThreadActionMenuItems({
               branch: thread.branch ?? null,
+              hasConversation: thread.latestUserMessageAt !== null,
               isPinned,
               isSettled,
               isSnoozed,
@@ -3105,6 +3107,38 @@ export default function Sidebar() {
           return;
         }
         switch (clicked.value) {
+          case "continue-in-new-thread": {
+            const result = await continueThreadInNewDraft({
+              threadRef,
+              createDraft: () =>
+                handleNewThreadRef.current(
+                  scopeProjectRef(thread.environmentId, thread.projectId),
+                  {
+                    branch: thread.branch,
+                    worktreePath: thread.worktreePath,
+                    envMode: thread.worktreePath ? "worktree" : "local",
+                    startFromOrigin: false,
+                  },
+                ),
+            });
+            if (!result.ok) {
+              toastManager.add(
+                stackedThreadToast({
+                  type: "error",
+                  title: "Could not continue thread",
+                  description:
+                    result.error instanceof Error ? result.error.message : "An error occurred.",
+                }),
+              );
+              return;
+            }
+            toastManager.add({
+              type: "success",
+              title: "Conversation context added",
+              description: "Choose any provider, edit the handoff if needed, then send.",
+            });
+            return;
+          }
           case "new-thread-on-branch": {
             // Explicit branch carry-over: reuse the thread's worktree when it
             // has one, otherwise its branch on the local checkout.

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -4,6 +4,7 @@ import { buildThreadActionMenuItems, type ThreadActionMenuState } from "./thread
 
 const baseState: ThreadActionMenuState = {
   branch: null,
+  hasConversation: true,
   isPinned: false,
   isSettled: false,
   isSnoozed: false,
@@ -33,7 +34,7 @@ describe("buildThreadActionMenuItems", () => {
         ...baseState,
         supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
       }),
-    ).toEqual(["rename", "mark-unread", "copy", "archive", "delete"]);
+    ).toEqual(["continue-in-new-thread", "rename", "mark-unread", "copy", "archive", "delete"]);
   });
 
   it("includes branch items only for threads with a branch", () => {
@@ -64,6 +65,20 @@ describe("buildThreadActionMenuItems", () => {
       (candidate) => candidate.id === "regenerate-title",
     );
     expect(item).toMatchObject({ label: "Regenerating…", disabled: true });
+  });
+
+  it("disables continuation without settled conversation context", () => {
+    const withoutMessages = buildThreadActionMenuItems({
+      ...baseState,
+      hasConversation: false,
+    }).find((candidate) => candidate.id === "continue-in-new-thread");
+    const whileRunning = buildThreadActionMenuItems({
+      ...baseState,
+      isRunning: true,
+    }).find((candidate) => candidate.id === "continue-in-new-thread");
+
+    expect(withoutMessages?.disabled).toBe(true);
+    expect(whileRunning?.disabled).toBe(true);
   });
 
   it("marks delete as destructive and keeps it last", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -7,6 +7,7 @@ import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled"
  * remains data-driven.
  */
 export type ThreadActionMenuId =
+  | "continue-in-new-thread"
   | "new-thread-on-branch"
   | "pin"
   | "unpin"
@@ -27,6 +28,7 @@ export type ThreadActionMenuId =
 
 export interface ThreadActionMenuState {
   readonly branch: string | null;
+  readonly hasConversation: boolean;
   readonly isPinned: boolean;
   readonly isSettled: boolean;
   readonly isSnoozed: boolean;
@@ -52,6 +54,12 @@ export function buildThreadActionMenuItems(
   state: ThreadActionMenuState,
 ): ReadonlyArray<ContextMenuItem<ThreadActionMenuId>> {
   return [
+    {
+      id: "continue-in-new-thread",
+      label: "Continue in new thread",
+      icon: "message-square-plus",
+      disabled: !state.hasConversation || state.isRunning,
+    },
     ...(state.branch
       ? [
           {

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -30,6 +30,7 @@ import {
   readThreadShell,
 } from "../state/entities";
 import { readLocalApi } from "../localApi";
+import { continueThreadInNewDraft } from "../threadContinuation";
 import { useUiStateStore } from "../uiStateStore";
 import { useCopyToClipboard } from "./useCopyToClipboard";
 import { useNewThreadHandler } from "./useHandleNewThread";
@@ -126,6 +127,7 @@ export function useThreadActionMenu(input: {
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,
+          hasConversation: thread.latestUserMessageAt !== null,
           isPinned: thread.pinnedAt != null,
           isSettled:
             supports.settlement &&
@@ -187,6 +189,28 @@ export function useThreadActionMenu(input: {
           }
         };
         switch (action) {
+          case "continue-in-new-thread": {
+            const result = await continueThreadInNewDraft({
+              threadRef,
+              createDraft: () =>
+                handleNewThread(scopeProjectRef(threadRef.environmentId, thread.projectId), {
+                  branch: thread.branch,
+                  worktreePath: thread.worktreePath,
+                  envMode: thread.worktreePath ? "worktree" : "local",
+                  startFromOrigin: false,
+                }),
+            });
+            if (!result.ok) {
+              failureToast("Could not continue thread", result.error);
+              return;
+            }
+            toastManager.add({
+              type: "success",
+              title: "Conversation context added",
+              description: "Choose any provider, edit the handoff if needed, then send.",
+            });
+            return;
+          }
           case "new-thread-on-branch": {
             // Explicit branch carry-over: reuse the thread's worktree when it
             // has one, otherwise its branch on the local checkout.

--- a/apps/web/src/threadContinuation.test.ts
+++ b/apps/web/src/threadContinuation.test.ts
@@ -1,0 +1,138 @@
+import {
+  EnvironmentId,
+  MessageId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type OrchestrationMessage,
+} from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const drafts = vi.hoisted(() => ({
+  setModelSelection: vi.fn(),
+  setRuntimeMode: vi.fn(),
+  setInteractionMode: vi.fn(),
+  setPrompt: vi.fn(),
+}));
+
+vi.mock("./composerDraftStore", () => ({
+  useComposerDraftStore: { getState: () => drafts },
+}));
+vi.mock("./state/entities", () => ({ readThreadDetail: vi.fn() }));
+vi.mock("./state/threads", () => ({
+  environmentThreadDetails: { detailAtom: vi.fn(() => Symbol("detail")) },
+}));
+vi.mock("./rpc/atomRegistry", () => ({
+  appAtomRegistry: { subscribe: vi.fn() },
+}));
+
+import type { DraftId } from "./composerDraftStore";
+import { appAtomRegistry } from "./rpc/atomRegistry";
+import { readThreadDetail } from "./state/entities";
+import { continueThreadInNewDraft } from "./threadContinuation";
+
+const threadRef = {
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: ThreadId.make("thread-1"),
+};
+const draftId = "draft-1" as DraftId;
+
+function message(role: OrchestrationMessage["role"], text: string): OrchestrationMessage {
+  return {
+    id: MessageId.make(`message-${role}`),
+    role,
+    text,
+    turnId: TurnId.make("turn-1"),
+    streaming: false,
+    createdAt: "2026-08-28T00:00:00.000Z",
+    updatedAt: "2026-08-28T00:00:00.000Z",
+  };
+}
+
+function sourceThread(messages: ReadonlyArray<OrchestrationMessage>) {
+  return {
+    title: "Source thread",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("claude"),
+      model: "claude-opus-5",
+      options: [{ id: "effort", value: "high" }],
+    },
+    runtimeMode: "full-access" as const,
+    interactionMode: "plan" as const,
+    messages,
+  } as unknown as NonNullable<ReturnType<typeof readThreadDetail>>;
+}
+
+describe("continueThreadInNewDraft", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a draft with source context and source provider state", async () => {
+    vi.mocked(readThreadDetail).mockReturnValue(
+      sourceThread([message("user", "Diagnose it"), message("assistant", "Found the cause")]),
+    );
+    const createDraft = vi.fn(async () => ({ draftId }));
+
+    const result = await continueThreadInNewDraft({ threadRef, createDraft });
+
+    expect(result).toEqual({ ok: true });
+    expect(createDraft).toHaveBeenCalledOnce();
+    expect(drafts.setModelSelection).toHaveBeenCalledWith(
+      draftId,
+      expect.objectContaining({ instanceId: "claude", model: "claude-opus-5" }),
+      { replaceOptions: true },
+    );
+    expect(drafts.setRuntimeMode).toHaveBeenCalledWith(draftId, "full-access");
+    expect(drafts.setInteractionMode).toHaveBeenCalledWith(draftId, "plan");
+    expect(drafts.setPrompt).toHaveBeenCalledWith(
+      draftId,
+      expect.stringContaining("### Assistant\n\nFound the cause"),
+    );
+  });
+
+  it("loads uncached thread detail through the subscribed atom", async () => {
+    const source = sourceThread([message("user", "Load this context")]);
+    vi.mocked(readThreadDetail).mockReturnValue(null);
+    const dispose = vi.fn();
+    vi.mocked(appAtomRegistry.subscribe).mockImplementation((_atom, listener) => {
+      listener(source);
+      return dispose;
+    });
+
+    const result = await continueThreadInNewDraft({
+      threadRef,
+      createDraft: async () => ({ draftId }),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(drafts.setPrompt).toHaveBeenCalledWith(
+      draftId,
+      expect.stringContaining("Load this context"),
+    );
+  });
+
+  it("does not create a draft when no completed portable context exists", async () => {
+    vi.mocked(readThreadDetail).mockReturnValue(sourceThread([message("system", "hidden")]));
+    const createDraft = vi.fn(async () => ({ draftId }));
+
+    const result = await continueThreadInNewDraft({ threadRef, createDraft });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(createDraft).not.toHaveBeenCalled();
+    expect(drafts.setPrompt).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing destination without mutating composer state", async () => {
+    vi.mocked(readThreadDetail).mockReturnValue(sourceThread([message("user", "Continue")]));
+
+    const result = await continueThreadInNewDraft({
+      threadRef,
+      createDraft: async () => null,
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(drafts.setPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/threadContinuation.ts
+++ b/apps/web/src/threadContinuation.ts
@@ -1,0 +1,97 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import { useComposerDraftStore, type DraftId } from "./composerDraftStore";
+import { appAtomRegistry } from "./rpc/atomRegistry";
+import { readThreadDetail } from "./state/entities";
+import { environmentThreadDetails } from "./state/threads";
+import { buildThreadHandoffPrompt } from "./threadHandoff";
+
+async function waitForThreadDetail(
+  threadRef: ScopedThreadRef,
+  timeoutMs = 10_000,
+): Promise<NonNullable<ReturnType<typeof readThreadDetail>> | null> {
+  const existing = readThreadDetail(threadRef);
+  if (existing !== null) {
+    return existing;
+  }
+
+  const detailAtom = environmentThreadDetails.detailAtom(threadRef);
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+    let unsubscribe = () => {};
+    const finish = (detail: NonNullable<ReturnType<typeof readThreadDetail>> | null) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId !== null) {
+        globalThis.clearTimeout(timeoutId);
+      }
+      unsubscribe();
+      resolve(detail);
+    };
+
+    unsubscribe = appAtomRegistry.subscribe(detailAtom, (detail) => {
+      if (detail !== null) {
+        finish(detail);
+      }
+    });
+    // Atom registries are allowed to synchronously deliver the current value
+    // during subscribe. In that case finish ran before subscribe returned,
+    // so perform the deferred cleanup now that we have the real disposer.
+    if (settled) {
+      unsubscribe();
+      return;
+    }
+
+    const loaded = readThreadDetail(threadRef);
+    if (loaded !== null) {
+      finish(loaded);
+      return;
+    }
+
+    timeoutId = globalThis.setTimeout(() => finish(null), timeoutMs);
+  });
+}
+
+type ContinueThreadResult = { readonly ok: true } | { readonly ok: false; readonly error: unknown };
+
+export async function continueThreadInNewDraft(input: {
+  readonly threadRef: ScopedThreadRef;
+  readonly createDraft: () => Promise<{ readonly draftId: DraftId } | null>;
+}): Promise<ContinueThreadResult> {
+  const sourceThread = await waitForThreadDetail(input.threadRef);
+  if (sourceThread === null) {
+    return { ok: false, error: new Error("Conversation context could not be loaded.") };
+  }
+
+  const prompt = buildThreadHandoffPrompt({
+    sourceTitle: sourceThread.title,
+    messages: sourceThread.messages,
+  });
+  if (prompt === null) {
+    return {
+      ok: false,
+      error: new Error("The thread does not have completed conversation context yet."),
+    };
+  }
+
+  try {
+    const destination = await input.createDraft();
+    if (destination === null) {
+      return { ok: false, error: new Error("The source project is no longer available.") };
+    }
+    const drafts = useComposerDraftStore.getState();
+    // Sidebar actions can target a thread other than the one currently open.
+    // Override the generic new-thread carry state with the actual source
+    // thread before the user optionally picks a different provider.
+    drafts.setModelSelection(destination.draftId, sourceThread.modelSelection, {
+      replaceOptions: true,
+    });
+    drafts.setRuntimeMode(destination.draftId, sourceThread.runtimeMode);
+    drafts.setInteractionMode(destination.draftId, sourceThread.interactionMode);
+    drafts.setPrompt(destination.draftId, prompt);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}

--- a/apps/web/src/threadHandoff.test.ts
+++ b/apps/web/src/threadHandoff.test.ts
@@ -1,0 +1,111 @@
+import { MessageId, TurnId, type OrchestrationMessage } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildThreadHandoffPrompt, THREAD_HANDOFF_MAX_CHARS } from "./threadHandoff";
+
+function message(
+  role: OrchestrationMessage["role"],
+  text: string,
+  options?: Partial<OrchestrationMessage>,
+): OrchestrationMessage {
+  return {
+    id: MessageId.make(`message-${role}-${text.length}`),
+    role,
+    text,
+    turnId: TurnId.make("turn-1"),
+    streaming: false,
+    createdAt: "2026-08-28T00:00:00.000Z",
+    updatedAt: "2026-08-28T00:00:00.000Z",
+    ...options,
+  };
+}
+
+describe("buildThreadHandoffPrompt", () => {
+  it("formats portable user and assistant context", () => {
+    const prompt = buildThreadHandoffPrompt({
+      sourceTitle: "Fix the login flow",
+      messages: [
+        message("user", "Please diagnose the redirect."),
+        message("assistant", "The callback drops the state parameter."),
+      ],
+    });
+
+    expect(prompt).toContain("Source thread: Fix the login flow");
+    expect(prompt).toContain("### User\n\nPlease diagnose the redirect.");
+    expect(prompt).toContain("### Assistant\n\nThe callback drops the state parameter.");
+  });
+
+  it("normalizes and bounds the source title", () => {
+    const prompt = buildThreadHandoffPrompt({
+      sourceTitle: `  Multi\nline ${"x".repeat(1_000)}  `,
+      messages: [message("user", "Continue")],
+    });
+
+    expect(prompt).toContain("Source thread: Multi line ");
+    expect(prompt).not.toContain("Multi\nline");
+    expect(prompt!.length).toBeLessThanOrEqual(THREAD_HANDOFF_MAX_CHARS);
+  });
+
+  it("ignores system, streaming, and empty messages", () => {
+    const prompt = buildThreadHandoffPrompt({
+      sourceTitle: "Source",
+      messages: [
+        message("system", "hidden instructions"),
+        message("assistant", "partial response", { streaming: true }),
+        message("user", "  "),
+      ],
+    });
+
+    expect(prompt).toBeNull();
+  });
+
+  it("retains attachment names without trying to copy provider-local attachment data", () => {
+    const prompt = buildThreadHandoffPrompt({
+      sourceTitle: "Image review",
+      messages: [
+        message("user", "Review this screenshot", {
+          attachments: [
+            {
+              type: "image",
+              id: "attachment-1",
+              name: "broken-layout.png",
+              mimeType: "image/png",
+              sizeBytes: 512,
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(prompt).toContain("Attachments: broken-layout.png");
+  });
+
+  it("keeps the newest context when the transcript exceeds the send limit", () => {
+    const prompt = buildThreadHandoffPrompt({
+      sourceTitle: "Large thread",
+      messages: [
+        message("user", `old-context-${"a".repeat(THREAD_HANDOFF_MAX_CHARS)}`),
+        message("assistant", "newest-result"),
+      ],
+    });
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!.length).toBeLessThanOrEqual(THREAD_HANDOFF_MAX_CHARS);
+    expect(prompt).toContain("Earlier conversation omitted");
+    expect(prompt).toContain("newest-result");
+    expect(prompt).not.toContain("old-context");
+  });
+
+  it("truncates a single oversized recent message from the start", () => {
+    const prompt = buildThreadHandoffPrompt({
+      sourceTitle: "Large latest message",
+      messages: [message("assistant", `old-prefix-${"z".repeat(THREAD_HANDOFF_MAX_CHARS)}-tail`)],
+    });
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!.length).toBeLessThanOrEqual(THREAD_HANDOFF_MAX_CHARS);
+    expect(prompt).toContain("Earlier content in this message omitted");
+    expect(prompt).toContain("-tail");
+    expect(prompt).not.toContain("old-prefix");
+  });
+});

--- a/apps/web/src/threadHandoff.ts
+++ b/apps/web/src/threadHandoff.ts
@@ -1,0 +1,89 @@
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS, type OrchestrationMessage } from "@t3tools/contracts";
+
+export const THREAD_HANDOFF_MAX_CHARS = Math.min(
+  80_000,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS - 1_000,
+);
+
+const OMITTED_MESSAGE_MARKER = "[Earlier conversation omitted to fit the provider input limit.]";
+const OMITTED_TEXT_MARKER = "[Earlier content in this message omitted.]";
+
+function formatMessage(message: OrchestrationMessage): string | null {
+  if (message.streaming || (message.role !== "user" && message.role !== "assistant")) {
+    return null;
+  }
+
+  const text = message.text.trim();
+  const attachments = message.attachments?.map((attachment) => attachment.name) ?? [];
+  if (text.length === 0 && attachments.length === 0) {
+    return null;
+  }
+
+  const attachmentLine = attachments.length > 0 ? `\n\nAttachments: ${attachments.join(", ")}` : "";
+  return `### ${message.role === "user" ? "User" : "Assistant"}\n\n${text}${attachmentLine}`;
+}
+
+function truncateSectionFromStart(section: string, maxChars: number): string {
+  if (section.length <= maxChars) {
+    return section;
+  }
+
+  const headingEnd = section.indexOf("\n\n");
+  const heading = headingEnd >= 0 ? section.slice(0, headingEnd) : "### Message";
+  const marker = `\n\n${OMITTED_TEXT_MARKER}\n\n`;
+  const availableTail = Math.max(0, maxChars - heading.length - marker.length);
+  return `${heading}${marker}${section.slice(-availableTail)}`;
+}
+
+export function buildThreadHandoffPrompt(input: {
+  readonly sourceTitle: string;
+  readonly messages: ReadonlyArray<OrchestrationMessage>;
+}): string | null {
+  const sections = input.messages.flatMap((message) => {
+    const formatted = formatMessage(message);
+    return formatted === null ? [] : [formatted];
+  });
+  if (sections.length === 0) {
+    return null;
+  }
+
+  const sourceTitle = input.sourceTitle.replace(/\s+/g, " ").trim().slice(0, 500);
+
+  const header = [
+    "Continue the work from another T3 Code thread using the recent conversation below as prior context.",
+    "Re-check the current workspace before changing files because repository state may have moved on.",
+    "Do not repeat work that is already complete unless verification requires it.",
+    "",
+    `Source thread: ${sourceTitle}`,
+    "Attachment names are references only; ask the user to reattach anything you need to inspect.",
+    "",
+    "## Recent conversation",
+    "",
+  ].join("\n");
+
+  const selected: string[] = [];
+  // Reserve the omission marker up front. A long transcript is discovered
+  // from newest to oldest, and trimming the final string would otherwise cut
+  // the newest context to make room for the marker at the front.
+  let remaining = THREAD_HANDOFF_MAX_CHARS - header.length - OMITTED_MESSAGE_MARKER.length - 2;
+  let omitted = false;
+
+  for (let index = sections.length - 1; index >= 0; index -= 1) {
+    const section = sections[index]!;
+    const separatorLength = selected.length > 0 ? 2 : 0;
+    if (section.length + separatorLength <= remaining) {
+      selected.unshift(section);
+      remaining -= section.length + separatorLength;
+      continue;
+    }
+
+    omitted = true;
+    if (selected.length === 0 && remaining > OMITTED_TEXT_MARKER.length + 20) {
+      selected.unshift(truncateSectionFromStart(section, remaining));
+    }
+    break;
+  }
+
+  const omissionPrefix = omitted ? `${OMITTED_MESSAGE_MARKER}\n\n` : "";
+  return `${header}${omissionPrefix}${selected.join("\n\n")}`;
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -1,5 +1,16 @@
 # Organizing threads
 
+## Continue in a new thread
+
+On web and desktop, open a thread's context menu and choose **Continue in new thread** to put its
+recent completed conversation into a fresh, editable draft. The draft stays in the same workspace
+and initially keeps the source provider, model, permission mode, and interaction mode. Choose any
+other configured provider before sending to hand the work to a different coding harness.
+
+This is a portable conversation handoff, not a copy of the provider's private session state. Tool
+state and image data do not transfer; attachment names remain in the handoff so you know what may
+need to be attached again.
+
 Pin a thread from its context menu to keep it in the pinned section above your active work.
 Pinned threads are shown independently of their project, including when you connect to more than
 one environment.


### PR DESCRIPTION
## Problem

Once a T3 Code thread has conversation state, moving the work to another coding harness means manually reconstructing its context. The existing **New thread on branch** action carries workspace state, but intentionally starts with an empty conversation.

## Solution

Add **Continue in new thread** to the shared thread action menu on web and desktop. It:

- loads the source thread's recent completed user/assistant conversation
- creates an editable draft in the same workspace
- initially carries the source model, permission mode, and interaction mode
- leaves the provider/model selector available so the user can choose another configured harness before sending
- bounds the portable handoff to the provider input limit while retaining the newest context
- keeps attachment names as reminders without attempting to copy provider-local attachment data

This is deliberately a first, provider-agnostic slice. It does not clone a provider's private session, tool state, or image data, and it does not yet add the action to mobile. Native same-provider forks and provider-specific session capabilities can build on this separately.

## Verification

- `pnpm --dir apps/web exec vp test run --passWithNoTests --project unit src/threadHandoff.test.ts src/threadContinuation.test.ts src/components/threadActionMenu.logic.test.ts` (20 tests passed)
- `pnpm --filter @t3tools/web typecheck`
- targeted `vp lint` for the changed TypeScript/TSX files
- `vp fmt --check` for all changed files
- `git diff --check`
- integrated browser pass using an isolated T3 home and browser profile

## Screenshots

| Thread action | Editable continued draft |
| --- | --- |
| ![Continue in new thread action](https://github.com/user-attachments/assets/9c9bd9e1-c363-47bc-9434-7b4ffb4b67d1) | ![Continued conversation draft with source settings](https://github.com/user-attachments/assets/b0f1d3ca-6320-47ad-88f4-e3163b1d5b7e) |

Model: GPT-5 | Harness: Codex


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `continue-in-new-thread` action to thread context menus
> - Adds a `continue-in-new-thread` menu item to thread context menus in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/8452/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [useThreadActionMenu.ts](https://github.com/pingdotgg/t3code/pull/8452/files#diff-d31aea23d18521fa1c03e05a4d3c2e45d0ca6fab34084d74f072cecc48d21e17). The item is disabled when the thread has no conversation content or is running.
> - Introduces `continueThreadInNewDraft` in [threadContinuation.ts](https://github.com/pingdotgg/t3code/pull/8452/files#diff-5f824ed36d52b93ed5eb649b70f029dc72c6b223dbab6324a34364d64bde0a6a) to create a new draft populated with the source thread's provider, model, runtime, and interaction settings.
> - Adds `buildThreadHandoffPrompt` in [threadHandoff.ts](https://github.com/pingdotgg/t3code/pull/8452/files#diff-3d833cc1ffff990514aa679800c5b78e4c44ed525f990f99bda04351b2cbfe56) to generate a bounded, portable prompt from the thread's recent messages, ignoring system, streaming, and empty messages.
> - Behavioral Change: Thread context menus now render a new `continue-in-new-thread` item at the top.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30e33a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->