### PR TITLE
fix(server): scope the Claude context meter to the parent session

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3897,15 +3897,15 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("clamps oversized Claude usage to the reported context window", () => {
+  it.effect("does not treat total-only Claude result usage as active context", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
-        Stream.runCollect,
-        Effect.forkChild,
-      );
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
 
       yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -3928,7 +3928,7 @@ describe("ClaudeAdapterLive", () => {
         num_turns: 1,
         result: "done",
         stop_reason: "end_turn",
-        session_id: "sdk-session-result-usage-clamped",
+        session_id: "sdk-session-result-total-only",
         usage: {
           total_tokens: 535000,
         },
@@ -3943,16 +3943,104 @@ describe("ClaudeAdapterLive", () => {
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
       const usageEvent = runtimeEvents.find((event) => event.type === "thread.token-usage.updated");
-      assert.equal(usageEvent?.type, "thread.token-usage.updated");
-      if (usageEvent?.type === "thread.token-usage.updated") {
-        assert.deepEqual(usageEvent.payload, {
-          usage: {
-            usedTokens: 200000,
-            lastUsedTokens: 200000,
-            totalProcessedTokens: 535000,
-            maxTokens: 200000,
+      // 535,000 is the session's cumulative spend, not context occupancy. With
+      // no active reading in the turn there is nothing truthful to show, and
+      // clamping it to the window rendered a full meter.
+      assert.equal(usageEvent, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps subagent totals out of parent context when the result is total-only", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-total-only",
+        description: "Thinking through the patch",
+        usage: {
+          total_tokens: 190000,
+        },
+        session_id: "sdk-session-total-only-after-progress",
+        uuid: "task-total-only-progress",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_notification",
+        task_id: "task-total-only",
+        status: "completed",
+        summary: "Task finished",
+        usage: {
+          total_tokens: 250000,
+          tool_uses: 100,
+          duration_ms: 900000,
+        },
+        session_id: "sdk-session-total-only-after-progress",
+        uuid: "task-total-only-completed",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 1234,
+        duration_api_ms: 1200,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-total-only-after-progress",
+        usage: {
+          total_tokens: 535000,
+        },
+        modelUsage: {
+          [SYNTHETIC_CLAUDE_CAPABLE_MODEL]: {
+            contextWindow: 200000,
+            maxOutputTokens: 64000,
           },
-        });
+        },
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      // The parent never reported usage of its own, so neither the children's
+      // totals nor the cumulative result may fabricate a meter reading. The
+      // children's numbers still ride on their task events.
+      assert.deepEqual(usageEvents, []);
+      const progressEvent = runtimeEvents.find((event) => event.type === "task.progress");
+      const completedEvent = runtimeEvents.find((event) => event.type === "task.completed");
+      assert.equal(progressEvent?.type, "task.progress");
+      assert.equal(completedEvent?.type, "task.completed");
+      if (progressEvent?.type === "task.progress") {
+        assert.equal(progressEvent.payload.typedUsage?.totalTokens, 190000);
+      }
+      if (completedEvent?.type === "task.completed") {
+        assert.equal(completedEvent.payload.typedUsage?.totalTokens, 250000);
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2886,7 +2886,7 @@ describe("ClaudeAdapterLive", () => {
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 6).pipe(
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 5).pipe(
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -3144,12 +3144,12 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("emits thread token usage updates from Claude task progress", () => {
+  it.effect("ignores task progress usage before the parent has any usage of its own", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 6).pipe(
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 5).pipe(
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -3177,20 +3177,414 @@ describe("ClaudeAdapterLive", () => {
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
       const usageEvent = runtimeEvents.find((event) => event.type === "thread.token-usage.updated");
       const progressEvent = runtimeEvents.find((event) => event.type === "task.progress");
-      assert.equal(usageEvent?.type, "thread.token-usage.updated");
-      if (usageEvent?.type === "thread.token-usage.updated") {
-        assert.deepEqual(usageEvent.payload, {
-          usage: {
-            usedTokens: 321,
-            lastUsedTokens: 321,
-            toolUses: 2,
-            durationMs: 654,
-          },
-        });
-      }
+      // The subagent's 321 tokens are spent in its own window. With no parent
+      // usage recorded yet there is nothing to attach a running total to, so
+      // the parent meter stays silent rather than adopting the child's count.
+      assert.equal(usageEvent, undefined);
       assert.equal(progressEvent?.type, "task.progress");
-      if (usageEvent && progressEvent) {
-        assert.notStrictEqual(usageEvent.eventId, progressEvent.eventId);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps subagent tokens out of the parent context meter (#5942)", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "delegate this",
+        attachments: [],
+      });
+
+      // The parent finishes a small turn of its own.
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 10,
+        duration_api_ms: 8,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-child-usage",
+        usage: { input_tokens: 4_000, output_tokens: 200 },
+        modelUsage: { "claude-opus-4-6": { contextWindow: 1_000_000 } },
+      } as unknown as SDKMessage);
+
+      // A background subagent then burns far more than the parent ever has.
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-child-1",
+        description: "Background agent doing the heavy work",
+        usage: { total_tokens: 900_000, tool_uses: 40, duration_ms: 1_000 },
+        session_id: "sdk-session-child-usage",
+        uuid: "task-child-progress-1",
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const latest = usageEvents.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        // The parent's own 4,200 stands. The child's 900,000 only advances the
+        // running total. Before this fix usedTokens became 900,000.
+        assert.equal(latest.payload.usage.usedTokens, 4_200);
+        assert.equal(latest.payload.usage.totalProcessedTokens, 900_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("measures the meter against the session model's window, not a subagent's", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-sonnet-5",
+        ),
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "summarize",
+        attachments: [],
+      });
+
+      // A 1M subagent ran alongside a 200k session model.
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        session_id: "sdk-session-window-scope",
+        uuid: "result-window-scope",
+        usage: { input_tokens: 50_000, output_tokens: 1_000 },
+        modelUsage: {
+          "claude-sonnet-5": { contextWindow: 200_000 },
+          "claude-opus-5[1m]": { contextWindow: 1_000_000 },
+        },
+      } as unknown as SDKMessage);
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const latest = usageEvents.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        // Before this fix the Math.max over modelUsage reported 1,000,000.
+        assert.equal(latest.payload.usage.maxTokens, 200_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("uses the init model's window when no model was explicitly selected", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "summarize",
+        attachments: [],
+      });
+
+      // No selection was made, so the session runs Claude Code's default and
+      // init is the first place its name appears.
+      harness.query.emit({
+        type: "system",
+        subtype: "init",
+        model: "claude-sonnet-5",
+        session_id: "sdk-session-init-window",
+        uuid: "init-window",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 10,
+        duration_api_ms: 8,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-init-window",
+        usage: { input_tokens: 50_000, output_tokens: 1_000 },
+        modelUsage: {
+          "claude-sonnet-5": { contextWindow: 200_000 },
+          "claude-opus-5[1m]": { contextWindow: 1_000_000 },
+        },
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const latest = usageEvents.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        assert.equal(latest.payload.usage.maxTokens, 200_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("carries a subagent's running total into the parent's next snapshot", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "delegate this",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        event: {
+          type: "message_delta",
+          delta: { stop_reason: null, stop_sequence: null },
+          usage: { input_tokens: 3_000, output_tokens: 0 },
+        },
+        parent_tool_use_id: null,
+        session_id: "sdk-session-running-total",
+        uuid: "parent-running-total",
+      } as unknown as SDKMessage);
+
+      // The child's spend is real work the thread paid for, so it belongs in
+      // the running total even though it never touches the parent's own
+      // used count.
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-running-total",
+        description: "Child doing the heavy work",
+        usage: { total_tokens: 480_000 },
+        session_id: "sdk-session-running-total",
+        uuid: "task-running-total-progress",
+      } as unknown as SDKMessage);
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const latest = usageEvents.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        assert.equal(latest.payload.usage.totalProcessedTokens, 480_000);
+        assert.equal(latest.payload.usage.usedTokens, 3_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps a subagent's running total when the parent turn completes", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "go", attachments: [] });
+
+      harness.query.emit({
+        type: "stream_event",
+        event: {
+          type: "message_delta",
+          delta: { stop_reason: null, stop_sequence: null },
+          usage: { input_tokens: 3_000, output_tokens: 0 },
+        },
+        parent_tool_use_id: null,
+        session_id: "sdk-session-running-total-result",
+        uuid: "running-total-result-delta",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-running-total-result",
+        description: "Child doing the heavy work",
+        usage: { total_tokens: 900_000 },
+        session_id: "sdk-session-running-total-result",
+        uuid: "running-total-result-task",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 10,
+        duration_api_ms: 8,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-running-total-result",
+        usage: { input_tokens: 4_000, output_tokens: 200 },
+        modelUsage: { "claude-opus-4-6": { contextWindow: 200_000 } },
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      const ev = runtimeEvents.filter((e) => e.type === "thread.token-usage.updated");
+      const latest = ev.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        // The parent's own result is smaller than the running total the child
+        // already raised. Used tokens follow the parent; total processed is
+        // cumulative thread work and must not regress.
+        assert.equal(latest.payload.usage.usedTokens, 4_200);
+        assert.equal(latest.payload.usage.totalProcessedTokens, 900_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("follows a persistent refusal fallback to the model that ran", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "summarize",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "init",
+        model: "claude-sonnet-5",
+        session_id: "sdk-session-refusal",
+        uuid: "refusal-init",
+      } as unknown as SDKMessage);
+
+      // A refusal retry swaps the model for the rest of the session, so the
+      // window has to be measured against the model that actually ran.
+      harness.query.emit({
+        type: "system",
+        subtype: "model_refusal_fallback",
+        trigger: "refusal",
+        direction: "retry",
+        original_model: "claude-sonnet-5",
+        fallback_model: "claude-opus-5[1m]",
+        request_id: null,
+        session_id: "sdk-session-refusal",
+        uuid: "refusal-swap",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 10,
+        duration_api_ms: 8,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-refusal",
+        usage: { input_tokens: 50_000, output_tokens: 1_000 },
+        modelUsage: {
+          "claude-sonnet-5": { contextWindow: 200_000 },
+          "claude-opus-5[1m]": { contextWindow: 1_000_000 },
+        },
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const latest = usageEvents.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        assert.equal(latest.payload.usage.maxTokens, 1_000_000);
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -3335,10 +3729,10 @@ describe("ClaudeAdapterLive", () => {
       return Effect.gen(function* () {
         const adapter = yield* ClaudeAdapter;
 
-        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 9).pipe(
-          Stream.runCollect,
-          Effect.forkChild,
-        );
+        const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+        const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+          Effect.sync(() => runtimeEvents.push(event)),
+        ).pipe(Effect.forkChild);
 
         yield* adapter.startSession({
           threadId: THREAD_ID,
@@ -3351,6 +3745,27 @@ describe("ClaudeAdapterLive", () => {
           input: "hello",
           attachments: [],
         });
+
+        // The parent records usage of its own first, so the task snapshot that
+        // follows is actually retained rather than dropped for want of a
+        // baseline. Without this the assertion below would hold even if
+        // completion silently discarded a recorded task total.
+        harness.query.emit({
+          type: "assistant",
+          message: {
+            id: "msg-parent-baseline",
+            type: "message",
+            role: "assistant",
+            model: "claude-opus-4-6",
+            content: [{ type: "text", text: "working" }],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 12000, output_tokens: 0 },
+          },
+          parent_tool_use_id: null,
+          session_id: "sdk-session-task-usage-clamped",
+          uuid: "parent-baseline-clamped",
+        } as unknown as SDKMessage);
 
         harness.query.emit({
           type: "system",
@@ -3386,17 +3801,21 @@ describe("ClaudeAdapterLive", () => {
         } as unknown as SDKMessage);
         harness.query.finish();
 
-        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        yield* Effect.yieldNow;
+        yield* Fiber.interrupt(runtimeEventsFiber);
         const usageEvents = runtimeEvents.filter(
           (event) => event.type === "thread.token-usage.updated",
         );
         const finalUsageEvent = usageEvents.at(-1);
         assert.equal(finalUsageEvent?.type, "thread.token-usage.updated");
         if (finalUsageEvent?.type === "thread.token-usage.updated") {
+          // The task_progress 190,000 belongs to a subagent, so it survives as
+          // the running total only. The parent's own used count comes from the
+          // result, clamped to the window it reported.
           assert.deepEqual(finalUsageEvent.payload, {
             usage: {
-              usedTokens: 190000,
-              lastUsedTokens: 190000,
+              usedTokens: 200000,
+              lastUsedTokens: 200000,
               totalProcessedTokens: 535000,
               maxTokens: 200000,
             },

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3293,7 +3293,7 @@ describe("ClaudeAdapterLive", () => {
         stop_reason: "end_turn",
         session_id: "sdk-session-child-usage",
         usage: { input_tokens: 4_000, output_tokens: 200 },
-        modelUsage: { "claude-opus-4-6": { contextWindow: 1_000_000 } },
+        modelUsage: { [SYNTHETIC_CLAUDE_CAPABLE_MODEL]: { contextWindow: 1_000_000 } },
       } as unknown as SDKMessage);
 
       // A background subagent then burns far more than the parent ever has.
@@ -3344,7 +3344,8 @@ describe("ClaudeAdapterLive", () => {
         runtimeMode: "full-access",
         modelSelection: createModelSelection(
           ProviderInstanceId.make("claudeAgent"),
-          "claude-sonnet-5",
+          SYNTHETIC_CLAUDE_STANDARD_MODEL,
+          [{ id: "contextWindow", value: "standard" }],
         ),
       });
 
@@ -3363,8 +3364,8 @@ describe("ClaudeAdapterLive", () => {
         uuid: "result-window-scope",
         usage: { input_tokens: 50_000, output_tokens: 1_000 },
         modelUsage: {
-          "claude-sonnet-5": { contextWindow: 200_000 },
-          "claude-opus-5[1m]": { contextWindow: 1_000_000 },
+          [SYNTHETIC_CLAUDE_STANDARD_MODEL]: { contextWindow: 200_000 },
+          [`${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`]: { contextWindow: 1_000_000 },
         },
       } as unknown as SDKMessage);
 
@@ -3411,7 +3412,7 @@ describe("ClaudeAdapterLive", () => {
       harness.query.emit({
         type: "system",
         subtype: "init",
-        model: "claude-sonnet-5",
+        model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
         session_id: "sdk-session-init-window",
         uuid: "init-window",
       } as unknown as SDKMessage);
@@ -3428,8 +3429,8 @@ describe("ClaudeAdapterLive", () => {
         session_id: "sdk-session-init-window",
         usage: { input_tokens: 50_000, output_tokens: 1_000 },
         modelUsage: {
-          "claude-sonnet-5": { contextWindow: 200_000 },
-          "claude-opus-5[1m]": { contextWindow: 1_000_000 },
+          [SYNTHETIC_CLAUDE_STANDARD_MODEL]: { contextWindow: 200_000 },
+          [`${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`]: { contextWindow: 1_000_000 },
         },
       } as unknown as SDKMessage);
       harness.query.finish();
@@ -3564,7 +3565,7 @@ describe("ClaudeAdapterLive", () => {
         stop_reason: "end_turn",
         session_id: "sdk-session-running-total-result",
         usage: { input_tokens: 4_000, output_tokens: 200 },
-        modelUsage: { "claude-opus-4-6": { contextWindow: 200_000 } },
+        modelUsage: { [SYNTHETIC_CLAUDE_CAPABLE_MODEL]: { contextWindow: 200_000 } },
       } as unknown as SDKMessage);
       harness.query.finish();
 
@@ -3610,7 +3611,7 @@ describe("ClaudeAdapterLive", () => {
       harness.query.emit({
         type: "system",
         subtype: "init",
-        model: "claude-sonnet-5",
+        model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
         session_id: "sdk-session-refusal",
         uuid: "refusal-init",
       } as unknown as SDKMessage);
@@ -3622,8 +3623,8 @@ describe("ClaudeAdapterLive", () => {
         subtype: "model_refusal_fallback",
         trigger: "refusal",
         direction: "retry",
-        original_model: "claude-sonnet-5",
-        fallback_model: "claude-opus-5[1m]",
+        original_model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
+        fallback_model: `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
         request_id: null,
         session_id: "sdk-session-refusal",
         uuid: "refusal-swap",
@@ -3641,8 +3642,8 @@ describe("ClaudeAdapterLive", () => {
         session_id: "sdk-session-refusal",
         usage: { input_tokens: 50_000, output_tokens: 1_000 },
         modelUsage: {
-          "claude-sonnet-5": { contextWindow: 200_000 },
-          "claude-opus-5[1m]": { contextWindow: 1_000_000 },
+          [SYNTHETIC_CLAUDE_STANDARD_MODEL]: { contextWindow: 200_000 },
+          [`${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`]: { contextWindow: 1_000_000 },
         },
       } as unknown as SDKMessage);
       harness.query.finish();
@@ -3682,7 +3683,7 @@ describe("ClaudeAdapterLive", () => {
       harness.query.emit({
         type: "system",
         subtype: "init",
-        model: "claude-opus-4-6[1m]",
+        model: `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
         session_id: "sdk-session-switch",
         uuid: "switch-init",
       } as unknown as SDKMessage);
@@ -3692,10 +3693,11 @@ describe("ClaudeAdapterLive", () => {
       yield* adapter.sendTurn({
         threadId: THREAD_ID,
         input: "switch",
-        modelSelection: {
-          instanceId: ProviderInstanceId.make("claudeAgent"),
-          model: "claude-sonnet-5",
-        },
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          SYNTHETIC_CLAUDE_STANDARD_MODEL,
+          [{ id: "contextWindow", value: "standard" }],
+        ),
         attachments: [],
       });
 
@@ -3711,8 +3713,8 @@ describe("ClaudeAdapterLive", () => {
         session_id: "sdk-session-switch",
         usage: { input_tokens: 20_000, output_tokens: 500 },
         modelUsage: {
-          "claude-opus-4-6[1m]": { contextWindow: 1_000_000 },
-          "claude-sonnet-5": { contextWindow: 200_000 },
+          [`${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`]: { contextWindow: 1_000_000 },
+          [SYNTHETIC_CLAUDE_STANDARD_MODEL]: { contextWindow: 200_000 },
         },
       } as unknown as SDKMessage);
       harness.query.finish();
@@ -3751,7 +3753,8 @@ describe("ClaudeAdapterLive", () => {
 
       const selection = createModelSelection(
         ProviderInstanceId.make("claudeAgent"),
-        "claude-opus-4-6",
+        SYNTHETIC_CLAUDE_CAPABLE_MODEL,
+        [{ id: "contextWindow", value: "expanded" }],
       );
       yield* adapter.sendTurn({
         threadId: THREAD_ID,
@@ -3759,15 +3762,17 @@ describe("ClaudeAdapterLive", () => {
         modelSelection: selection,
         attachments: [],
       });
-      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
+      assert.deepEqual(harness.query.setModelCalls, [
+        `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
+      ]);
 
       harness.query.emit({
         type: "system",
         subtype: "model_refusal_fallback",
         trigger: "refusal",
         direction: "retry",
-        original_model: "claude-opus-4-6[1m]",
-        fallback_model: "claude-sonnet-5",
+        original_model: `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
+        fallback_model: SYNTHETIC_CLAUDE_STANDARD_MODEL,
         request_id: null,
         session_id: "sdk-session-refusal-resend",
         uuid: "refusal-resend-swap",
@@ -3794,7 +3799,9 @@ describe("ClaudeAdapterLive", () => {
         modelSelection: selection,
         attachments: [],
       });
-      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
+      assert.deepEqual(harness.query.setModelCalls, [
+        `${SYNTHETIC_CLAUDE_CAPABLE_MODEL}[expanded]`,
+      ]);
 
       yield* Fiber.interrupt(runtimeEventsFiber);
     }).pipe(
@@ -3967,7 +3974,7 @@ describe("ClaudeAdapterLive", () => {
             id: "msg-parent-baseline",
             type: "message",
             role: "assistant",
-            model: "claude-opus-4-6",
+            model: SYNTHETIC_CLAUDE_CAPABLE_MODEL,
             content: [{ type: "text", text: "working" }],
             stop_reason: null,
             stop_sequence: null,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3188,6 +3188,78 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("holds the running total until it exceeds the parent's own usage", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "go", attachments: [] });
+
+      harness.query.emit({
+        type: "stream_event",
+        event: {
+          type: "message_delta",
+          delta: { stop_reason: null, stop_sequence: null },
+          usage: { input_tokens: 3_000, output_tokens: 0 },
+        },
+        parent_tool_use_id: null,
+        session_id: "sdk-session-total-floor",
+        uuid: "total-floor-delta",
+      } as unknown as SDKMessage);
+
+      // A cumulative figure below the parent's active usage would read as
+      // "3,000 of 2,000 total". The child's small tick stays off the meter.
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-total-floor",
+        description: "Child barely started",
+        usage: { total_tokens: 2_000 },
+        session_id: "sdk-session-total-floor",
+        uuid: "total-floor-small",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-total-floor",
+        description: "Child past the parent",
+        usage: { total_tokens: 5_000 },
+        session_id: "sdk-session-total-floor",
+        uuid: "total-floor-large",
+      } as unknown as SDKMessage);
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      assert.equal(usageEvents.length, 2);
+      const [afterDelta, afterLargeTick] = usageEvents;
+      if (afterDelta?.type === "thread.token-usage.updated") {
+        assert.equal(afterDelta.payload.usage.usedTokens, 3_000);
+        assert.equal(afterDelta.payload.usage.totalProcessedTokens, undefined);
+      }
+      if (afterLargeTick?.type === "thread.token-usage.updated") {
+        assert.equal(afterLargeTick.payload.usage.usedTokens, 3_000);
+        assert.equal(afterLargeTick.payload.usage.totalProcessedTokens, 5_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("keeps subagent tokens out of the parent context meter (#5942)", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3664,6 +3664,75 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("does not re-send a refused model on the next turn with the same selection", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.runForEach(
+        adapter.streamEvents,
+        () => Effect.void,
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const selection = createModelSelection(
+        ProviderInstanceId.make("claudeAgent"),
+        "claude-opus-4-6",
+      );
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "first",
+        modelSelection: selection,
+        attachments: [],
+      });
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
+
+      harness.query.emit({
+        type: "system",
+        subtype: "model_refusal_fallback",
+        trigger: "refusal",
+        direction: "retry",
+        original_model: "claude-opus-4-6[1m]",
+        fallback_model: "claude-sonnet-5",
+        request_id: null,
+        session_id: "sdk-session-refusal-resend",
+        uuid: "refusal-resend-swap",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 10,
+        duration_api_ms: 8,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-refusal-resend",
+        usage: { input_tokens: 1_000, output_tokens: 10 },
+      } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+
+      // The selection has not changed, so the second turn must not call
+      // setModel at all — least of all with the model the API just refused.
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "second",
+        modelSelection: selection,
+        attachments: [],
+      });
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("emits Claude context window on result completion usage snapshots", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3664,6 +3664,76 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("measures the window against the model a mid-thread switch selected", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "init",
+        model: "claude-opus-4-6[1m]",
+        session_id: "sdk-session-switch",
+        uuid: "switch-init",
+      } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+
+      // The user switches to a 200k model partway through the thread.
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "switch",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          model: "claude-sonnet-5",
+        },
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 10,
+        duration_api_ms: 8,
+        num_turns: 1,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-switch",
+        usage: { input_tokens: 20_000, output_tokens: 500 },
+        modelUsage: {
+          "claude-opus-4-6[1m]": { contextWindow: 1_000_000 },
+          "claude-sonnet-5": { contextWindow: 200_000 },
+        },
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(runtimeEventsFiber);
+
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const latest = usageEvents.at(-1);
+      assert.equal(latest?.type, "thread.token-usage.updated");
+      if (latest?.type === "thread.token-usage.updated") {
+        assert.equal(latest.payload.usage.maxTokens, 200_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("does not re-send a refused model on the next turn with the same selection", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -4021,13 +4021,14 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(finalUsageEvent?.type, "thread.token-usage.updated");
         if (finalUsageEvent?.type === "thread.token-usage.updated") {
           // The task_progress 190,000 belongs to a subagent, so it survives as
-          // the running total only. The parent's own used count comes from the
-          // result, clamped to the window it reported.
+          // the running total only. The parent's own used count comes from its
+          // last assistant usage, not the cumulative result total.
           assert.deepEqual(finalUsageEvent.payload, {
             usage: {
-              usedTokens: 200000,
-              lastUsedTokens: 200000,
+              usedTokens: 12000,
+              lastUsedTokens: 12000,
               totalProcessedTokens: 535000,
+              inputTokens: 12000,
               maxTokens: 200000,
             },
           });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3317,8 +3317,8 @@ describe("ClaudeAdapterLive", () => {
       const latest = usageEvents.at(-1);
       assert.equal(latest?.type, "thread.token-usage.updated");
       if (latest?.type === "thread.token-usage.updated") {
-        // The parent's own 4,200 stands. The child's 900,000 only advances the
-        // running total. Before this fix usedTokens became 900,000.
+        // The parent's own 4,200 stands; the child's 900,000 only advances
+        // the running total, never usedTokens.
         assert.equal(latest.payload.usage.usedTokens, 4_200);
         assert.equal(latest.payload.usage.totalProcessedTokens, 900_000);
       }
@@ -3376,7 +3376,7 @@ describe("ClaudeAdapterLive", () => {
       const latest = usageEvents.at(-1);
       assert.equal(latest?.type, "thread.token-usage.updated");
       if (latest?.type === "thread.token-usage.updated") {
-        // Before this fix the Math.max over modelUsage reported 1,000,000.
+        // The maximum over modelUsage would report the child's 1,000,000.
         assert.equal(latest.payload.usage.maxTokens, 200_000);
       }
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3239,6 +3239,8 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
 
       yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
 
       const usageEvents = runtimeEvents.filter(
@@ -3309,6 +3311,8 @@ describe("ClaudeAdapterLive", () => {
       harness.query.finish();
 
       yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
 
       const usageEvents = runtimeEvents.filter(
@@ -3369,6 +3373,8 @@ describe("ClaudeAdapterLive", () => {
         },
       } as unknown as SDKMessage);
 
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
       const usageEvents = runtimeEvents.filter(
@@ -3436,6 +3442,8 @@ describe("ClaudeAdapterLive", () => {
       harness.query.finish();
 
       yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
 
       const usageEvents = runtimeEvents.filter(
@@ -3498,6 +3506,8 @@ describe("ClaudeAdapterLive", () => {
         uuid: "task-running-total-progress",
       } as unknown as SDKMessage);
 
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
 
@@ -3569,6 +3579,8 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
       harness.query.finish();
 
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
       const ev = runtimeEvents.filter((e) => e.type === "thread.token-usage.updated");
@@ -3649,6 +3661,8 @@ describe("ClaudeAdapterLive", () => {
       harness.query.finish();
 
       yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
 
       const usageEvents = runtimeEvents.filter(
@@ -3688,6 +3702,8 @@ describe("ClaudeAdapterLive", () => {
         uuid: "switch-init",
       } as unknown as SDKMessage);
       yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
 
       // The user switches to a 200k model partway through the thread.
       yield* adapter.sendTurn({
@@ -3719,6 +3735,8 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
       harness.query.finish();
 
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Effect.yieldNow;
       yield* Fiber.interrupt(runtimeEventsFiber);
 
@@ -3789,6 +3807,8 @@ describe("ClaudeAdapterLive", () => {
         session_id: "sdk-session-refusal-resend",
         usage: { input_tokens: 1_000, output_tokens: 10 },
       } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
       yield* Effect.yieldNow;
 
       // The selection has not changed, so the second turn must not call
@@ -4019,6 +4039,8 @@ describe("ClaudeAdapterLive", () => {
         } as unknown as SDKMessage);
         harness.query.finish();
 
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
         yield* Effect.yieldNow;
         yield* Fiber.interrupt(runtimeEventsFiber);
         const usageEvents = runtimeEvents.filter(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -287,6 +287,11 @@ interface ClaudeSessionContext {
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
   currentApiModelId: string | undefined;
+  /** The model the SDK reports is actually serving this session, which is not
+   * always the selected one: a refusal retry swaps it for the rest of the
+   * session. Kept apart from `currentApiModelId`, which tracks the last id
+   * passed to `setModel` and must keep matching the user's selection. */
+  observedApiModelId: string | undefined;
   /** Effective effort for the session's turns; subagents without an explicit
    * effort override inherit this. */
   currentEffort: string | undefined;
@@ -2265,7 +2270,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   ) {
     const resultContextWindow = claudeContextWindowFromModelUsage(
       result?.modelUsage,
-      context.currentApiModelId,
+      context.observedApiModelId ?? context.currentApiModelId,
     );
     if (resultContextWindow !== undefined) {
       context.lastKnownContextWindow = resultContextWindow;
@@ -3203,13 +3208,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     switch (message.subtype) {
       case "init": {
-        // init is where the SDK first names the model, so record it when no
-        // explicit selection exists. A selection is left alone: setModel
-        // compares against this id to decide whether a mid-thread switch
-        // still needs to be sent.
+        // init is the first place the SDK names the model actually serving the
+        // session, which is the id `modelUsage` is keyed by.
         const initModel = trimmedString(message.model);
-        if (initModel && !context.currentApiModelId) {
-          context.currentApiModelId = initModel;
+        if (initModel) {
+          context.observedApiModelId = initModel;
         }
         yield* offerRuntimeEvent({
           ...base,
@@ -3515,12 +3518,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         return;
       case "model_refusal_fallback": {
         // A refusal retry swaps the model for the rest of the session, so the
-        // recorded id has to follow or the window lookup keys a model that no
-        // longer runs.
+        // window lookup has to follow it. `currentApiModelId` deliberately
+        // does not: it mirrors the user's selection for `setModel`, and moving
+        // it here would make the next turn re-send the refused model.
         if (message.direction === "retry") {
           const fallbackModel = trimmedString(message.fallback_model);
           if (fallbackModel) {
-            context.currentApiModelId = fallbackModel;
+            context.observedApiModelId = fallbackModel;
           }
         }
         return;
@@ -4502,6 +4506,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         startedAt,
         basePermissionMode: permissionMode,
         currentApiModelId: apiModelId,
+        observedApiModelId: undefined,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
         pendingApprovals,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -465,10 +465,19 @@ function asRuntimeItemId(value: string): RuntimeItemId {
   return RuntimeItemId.make(value);
 }
 
-function maxClaudeContextWindowFromModelUsage(
+// `modelUsage` is keyed by every model that ran during the turn, subagents
+// included, so the maximum could be a child's window rather than this
+// session's. Fall back to it only when the session model has no entry.
+function claudeContextWindowFromModelUsage(
   modelUsage: Record<string, ModelUsage> | undefined,
+  sessionModel: string | undefined,
 ): number | undefined {
   if (!modelUsage) return undefined;
+
+  const sessionEntry = sessionModel ? modelUsage[sessionModel] : undefined;
+  if (sessionEntry) {
+    return sessionEntry.contextWindow;
+  }
 
   let maxContextWindow: number | undefined;
   for (const value of Object.values(modelUsage)) {
@@ -629,6 +638,8 @@ function compactBoundaryTokenUsageSnapshot(
   });
 }
 
+// A subagent's tokens are spent in its own context window, so they advance the
+// thread's running total but never the parent's used count (#5942).
 function normalizeClaudeTaskProgressTokenUsage(
   value: unknown,
   context: ClaudeSessionContext,
@@ -638,32 +649,25 @@ function normalizeClaudeTaskProgressTokenUsage(
     return undefined;
   }
 
-  const lastUsedTokens = context.lastKnownTokenUsage?.usedTokens;
-  const activeTokens =
-    lastUsedTokens !== undefined ? Math.max(totalTokens, lastUsedTokens) : totalTokens;
-  if (lastUsedTokens !== undefined && activeTokens === lastUsedTokens) {
+  const lastKnown = context.lastKnownTokenUsage;
+  if (!lastKnown) {
+    return undefined;
+  }
+
+  const totalProcessedTokens = Math.max(
+    totalTokens,
+    context.lastKnownTotalProcessedTokens ?? totalTokens,
+  );
+  if (totalProcessedTokens === context.lastKnownTotalProcessedTokens) {
     return undefined;
   }
 
   const usage = value as Record<string, unknown>;
-  const snapshot = makeClaudeTokenUsageSnapshot({
-    activeTokens,
-    ...(context.lastKnownContextWindow !== undefined
-      ? { contextWindow: context.lastKnownContextWindow }
-      : {}),
-    totalProcessedTokens: Math.max(
-      totalTokens,
-      context.lastKnownTotalProcessedTokens ?? totalTokens,
-    ),
-  });
-  if (!snapshot) {
-    return undefined;
-  }
-
   const toolUses = finiteNonNegativeInteger(usage.tool_uses);
   const durationMs = finiteNonNegativeInteger(usage.duration_ms);
   return {
-    ...snapshot,
+    ...lastKnown,
+    totalProcessedTokens,
     ...(toolUses !== undefined ? { toolUses } : {}),
     ...(durationMs !== undefined ? { durationMs } : {}),
   };
@@ -2251,13 +2255,24 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     errorMessage?: string,
     result?: SDKResultMessage,
   ) {
-    const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
+    const resultContextWindow = claudeContextWindowFromModelUsage(
+      result?.modelUsage,
+      context.currentApiModelId,
+    );
     if (resultContextWindow !== undefined) {
       context.lastKnownContextWindow = resultContextWindow;
     }
 
     const maxTokens = resultContextWindow ?? context.lastKnownContextWindow;
-    const accumulatedTotalProcessedTokens = claudeTotalProcessedTokens(result?.usage);
+    // The result reports the parent's own usage, so it can be smaller than a
+    // running total a subagent already raised. Total processed is cumulative
+    // work for the thread and only ever grows, so keep the larger figure
+    // rather than letting the parent's turn erase the children's.
+    const resultTotalProcessedTokens = claudeTotalProcessedTokens(result?.usage);
+    const accumulatedTotalProcessedTokens =
+      resultTotalProcessedTokens !== undefined
+        ? Math.max(resultTotalProcessedTokens, context.lastKnownTotalProcessedTokens ?? 0)
+        : undefined;
     if (accumulatedTotalProcessedTokens !== undefined) {
       context.lastKnownTotalProcessedTokens = accumulatedTotalProcessedTokens;
     }
@@ -3180,7 +3195,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     switch (message.subtype) {
-      case "init":
+      case "init": {
+        // Without an explicit selection there is no recorded model to key the
+        // context window on, and init is where the SDK first names the default.
+        // A selection is left alone: setModel compares against this id to
+        // decide whether a mid-thread switch still needs to be sent, so
+        // overwriting it with the reported id would suppress that call. A
+        // selected slug that the CLI resolves to a different id therefore
+        // still misses the modelUsage lookup and falls back to the maximum,
+        // which is the behavior that was already there.
+        const initModel = trimmedString(message.model);
+        if (initModel && !context.currentApiModelId) {
+          context.currentApiModelId = initModel;
+        }
         yield* offerRuntimeEvent({
           ...base,
           type: "session.configured",
@@ -3189,6 +3216,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           },
         });
         return;
+      }
       case "status":
         yield* offerRuntimeEvent({
           ...base,
@@ -3482,9 +3510,21 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           yield* emitRuntimeWarning(context, message.text, message);
         }
         return;
+      case "model_refusal_fallback": {
+        // A refusal retry swaps the model for the rest of the session, so the
+        // recorded id has to follow or the window lookup keys a model that no
+        // longer runs. Only "retry" is emitted today; the other directions
+        // remain in the enum for compatibility and do not swap.
+        if (message.direction === "retry") {
+          const fallbackModel = trimmedString(message.fallback_model);
+          if (fallbackModel) {
+            context.currentApiModelId = fallbackModel;
+          }
+        }
+        return;
+      }
       // Inner protocol/UX details with no T3 surface today — consumed
       // deliberately so they don't masquerade as unknown-subtype warnings.
-      case "model_refusal_fallback":
       case "local_command_output":
       case "plugin_install":
       case "commands_changed":

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4633,6 +4633,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
         });
         context.currentApiModelId = apiModelId;
+        // A deliberate switch supersedes whatever init or a refusal observed;
+        // leaving it stale would measure the meter against the old model.
+        context.observedApiModelId = apiModelId;
       }
       context.session = {
         ...context.session,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2304,13 +2304,16 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       resultUsageRecord !== undefined &&
       !resultHasActiveUsage &&
       claudeTotalProcessedTokens(resultUsageRecord) !== undefined;
-    const resultIterationSnapshot = resultUsageRecord
-      ? normalizeClaudeActiveTokenUsage(
-          resultUsageRecord,
-          maxTokens,
-          accumulatedTotalProcessedTokens ?? context.lastKnownTotalProcessedTokens,
-        )
-      : undefined;
+    // A result carrying only cumulative total_tokens is not an active-context
+    // reading; without this gate it would render as a full meter (#6586).
+    const resultIterationSnapshot =
+      resultUsageRecord && resultHasActiveUsage
+        ? normalizeClaudeActiveTokenUsage(
+            resultUsageRecord,
+            maxTokens,
+            accumulatedTotalProcessedTokens ?? context.lastKnownTotalProcessedTokens,
+          )
+        : undefined;
     const latestAssistantSnapshot = normalizeClaudeActiveTokenUsage(
       context.turnState?.latestAssistantUsage,
       maxTokens,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -654,10 +654,9 @@ function normalizeClaudeTaskProgressTokenUsage(
     return undefined;
   }
 
-  // Math.max floors the running total at the largest single contributor
-  // rather than summing per-task totals: the SDK does not say whether the
-  // result usage already aggregates children, and a sum that double-counted
-  // would overstate work, while a floor only ever understates it.
+  // The running total floors at the largest single contributor rather than
+  // summing per-task totals: the SDK does not document whether result usage
+  // already aggregates children, and a floor can only understate.
   const totalProcessedTokens = Math.max(
     totalTokens,
     context.lastKnownTotalProcessedTokens ?? totalTokens,
@@ -665,9 +664,8 @@ function normalizeClaudeTaskProgressTokenUsage(
   if (totalProcessedTokens === context.lastKnownTotalProcessedTokens) {
     return undefined;
   }
-  // A total no larger than the parent's own used count would render as a
-  // cumulative figure smaller than the active usage (review finding). The
-  // snapshot builder drops such totals; skip the no-op event entirely.
+  // Match makeClaudeTokenUsageSnapshot's invariant: a running total is only
+  // meaningful once it exceeds the parent's own used count.
   if (totalProcessedTokens <= lastKnown.usedTokens) {
     return undefined;
   }
@@ -2274,10 +2272,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const maxTokens = resultContextWindow ?? context.lastKnownContextWindow;
-    // The result reports the parent's own usage, so it can be smaller than a
-    // running total a subagent already raised. Total processed is cumulative
-    // work for the thread and only ever grows, so keep the larger figure
-    // rather than letting the parent's turn erase the children's.
+    // The result carries only the parent's own usage, which can be smaller
+    // than a running total a subagent already raised; the thread total only
+    // ever grows.
     const resultTotalProcessedTokens = claudeTotalProcessedTokens(result?.usage);
     const accumulatedTotalProcessedTokens =
       resultTotalProcessedTokens !== undefined
@@ -3206,14 +3203,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     switch (message.subtype) {
       case "init": {
-        // Without an explicit selection there is no recorded model to key the
-        // context window on, and init is where the SDK first names the default.
-        // A selection is left alone: setModel compares against this id to
-        // decide whether a mid-thread switch still needs to be sent, so
-        // overwriting it with the reported id would suppress that call. A
-        // selected slug that the CLI resolves to a different id therefore
-        // still misses the modelUsage lookup and falls back to the maximum,
-        // which is the behavior that was already there.
+        // init is where the SDK first names the model, so record it when no
+        // explicit selection exists. A selection is left alone: setModel
+        // compares against this id to decide whether a mid-thread switch
+        // still needs to be sent.
         const initModel = trimmedString(message.model);
         if (initModel && !context.currentApiModelId) {
           context.currentApiModelId = initModel;
@@ -3523,8 +3516,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       case "model_refusal_fallback": {
         // A refusal retry swaps the model for the rest of the session, so the
         // recorded id has to follow or the window lookup keys a model that no
-        // longer runs. Only "retry" is emitted today; the other directions
-        // remain in the enum for compatibility and do not swap.
+        // longer runs.
         if (message.direction === "retry") {
           const fallbackModel = trimmedString(message.fallback_model);
           if (fallbackModel) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -654,11 +654,21 @@ function normalizeClaudeTaskProgressTokenUsage(
     return undefined;
   }
 
+  // Math.max floors the running total at the largest single contributor
+  // rather than summing per-task totals: the SDK does not say whether the
+  // result usage already aggregates children, and a sum that double-counted
+  // would overstate work, while a floor only ever understates it.
   const totalProcessedTokens = Math.max(
     totalTokens,
     context.lastKnownTotalProcessedTokens ?? totalTokens,
   );
   if (totalProcessedTokens === context.lastKnownTotalProcessedTokens) {
+    return undefined;
+  }
+  // A total no larger than the parent's own used count would render as a
+  // cumulative figure smaller than the active usage (review finding). The
+  // snapshot builder drops such totals; skip the no-op event entirely.
+  if (totalProcessedTokens <= lastKnown.usedTokens) {
     return undefined;
   }
 


### PR DESCRIPTION
## What Changed

The Claude parent Context Window meter now keeps child `task_progress` totals out of the parent's active `usedTokens`. Child work raises the separate `totalProcessedTokens` through positive cumulative deltas keyed by `task_id`, so repeated progress and completion receipts count once while separate tasks add together.

The meter also uses the context window for the model serving the parent session. It follows SDK init, a session refusal fallback, and an explicit model switch. A local fallback for a child or side question does not change the parent model. Results that contain only cumulative totals, including total-only `iterations` entries, do not become active parent-context snapshots.

## Why

`task_progress` reports a child's cumulative usage. The adapter previously treated that number as parent context usage and selected the largest window in `modelUsage`, which could also belong to a child.

[reed-yang reproduced the bug on stable v0.0.38](https://github.com/pingdotgg/t3code/pull/8453#issuecomment-5515138986): a normal parent snapshot showed `628,352 / 1,000,000`, then a child progress event saturated the meter at `1,000,000 / 1,000,000` while the running total was `1,525,466`. Every saturated event in that reproduction came from `task_progress`.

This fixes the task-progress inflation and parent-window denominator reported in #4650 and #5942. Claude Agent SDK task usage is cumulative per task, so the adapter adds only each task's positive delta and keeps token, tool-use, and duration totals monotonic. This does not cover every post-compaction reset case in #4650, and `totalProcessedTokens` remains a meter total rather than SDK cost accounting across every query-pipeline call.

## Verification

- `apps/server/src/provider/Layers/ClaudeAdapter.test.ts`: 143 tests passed for `5a233da9e` using byte-identical candidate files in the installed reference workspace.
- Scoped format and lint passed for `ClaudeAdapter.ts` and `ClaudeAdapter.test.ts`.
- Server typecheck passed for `5a233da9e`.
- Seven selected meter regressions passed with this adapter at `d50d13212`. Replacing only the adapter with the comparison-base version caused six failures. The pre-existing fallback case was the one pass.

The retained cases cover a 4,200-token parent beside a 900,000-token child, cumulative deltas from separate task IDs, a 200k parent beside a 1M child, init and explicit model selection, session and local refusal fallbacks, monotonic cumulative totals, and cumulative-only results. The two carryover cases requested from #6586 remain named `does not treat total-only Claude result usage as active context` and `keeps subagent totals out of parent context when the result is total-only`.

Local validation used Node 26.5.0; the repository requests Node ^24.13.1. Fork CI still requires maintainer approval. The expected required jobs are `Test`, `Check`, `Mobile Native Static Analysis`, and `Release Smoke`.

No new desktop before-and-after capture exists. The incorrect child model and effort labels in #7281 are separate and addressed by #7287. #8617 is related cumulative-result work, not the primary issue fixed here.

## Checklist

- [ ] This PR is small and focused. The scope is one adapter invariant; regression coverage keeps the diff at 1,065 additions and 132 deletions.
- [x] I explained what changed and why
- UI evidence: no new capture; this changes server accounting for the existing meter
- Animation or interaction video: N/A

Originally developed with Claude Fable 5. The refresh and fallback fixes used GPT-6 Astra in Codex and a GPT-5.6 Terra worker. The final cleanup and task aggregation fix used GPT-5.6 Sol in T3 Code through the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider token-usage and context-window semantics for Claude sessions; behavior is well-tested but affects UI meter accuracy and model `setModel` interaction after refusals.
> 
> **Overview**
> Fixes the parent **Context Window** meter incorrectly treating subagent `task_progress` totals as the parent's own context usage and sometimes using a subagent's larger `modelUsage` window as the denominator.
> 
> **Token accounting:** Subagent progress now only bumps **`totalProcessedTokens`** (thread-wide running total), not **`usedTokens`**, and only after the parent already has usage and the cumulative total exceeds the parent's used count. Turn completion keeps that running total when the parent's result is smaller, and skips emitting a meter update when a result carries only **`total_tokens`** with no active input/output usage (avoids a falsely full bar).
> 
> **Context window:** **`max` across `modelUsage`** is replaced by preferring the **session model's** window, keyed via a new **`observedApiModelId`** from SDK **`init`**, **`model_refusal_fallback`**, or an explicit **`setModel`**—kept separate from **`currentApiModelId`** so a refusal fallback does not re-send the refused model on the next turn.
> 
> Tests in **`ClaudeAdapter.test.ts`** were expanded/rewritten to lock in the new contract (including #5942 scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca6331c99a94fde748e99295578c238b51c86fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope Claude context meter to parent session and track observed model for window selection
> - Subagent task-progress token totals no longer create or increase parent `usedTokens`; they only advance `totalProcessedTokens` and only after a parent usage baseline exists
> - Added `observedApiModelId` to `ClaudeSessionContext` to track the SDK-reported serving model separately from `currentApiModelId`; `claudeContextWindowFromModelUsage` now prefers the session model's `contextWindow` over the largest reported window
> - `completeTurn` no longer treats total-only result usage as active context, preserves a larger prior cumulative total when a result reports a smaller one, and resolves `maxTokens` against the observed or selected session model
> - Init, `model_refusal_fallback`, and deliberate model selection each update `observedApiModelId`; subsequent turns with an unchanged selection do not re-call `setModel` after a refusal fallback
> - Risk: `normalizeClaudeTaskProgressTokenUsage` now requires an existing parent `lastKnownTokenUsage` baseline before emitting any usage snapshot — any caller relying on task-progress totals producing parent `usedTokens` events will see those events suppressed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ca6331.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task-progress summaries to distinguish parent usage from subagent usage.
  - Cumulative processed-token totals now remain accurate across multiple tasks and turns.
  - Context-window calculations now reflect the model actively serving the session, including fallbacks and deliberate switches.
  - Context limits now correctly reflect fallback scope.
  - Preserved accurate oversized usage totals.
  - Total-only usage results no longer display an incorrect full progress meter.
  - Improved handling when usage data is unavailable or unchanged.
  - Prevented refused models from being resent on subsequent turns with the same selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



