### PR TITLE
feat(mobile): add terminal toolbar paste button

### DIFF
--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -6,6 +6,7 @@ import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/Stac
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Platform, Pressable, View } from "react-native";
+import * as Clipboard from "expo-clipboard";
 import {
   KeyboardController,
   KeyboardEvents,
@@ -66,6 +67,7 @@ import {
   type TerminalMenuSession,
 } from "./terminalMenu";
 import { cacheTerminalGridSize, getCachedTerminalGridSize } from "./terminalUiState";
+import { encodeTerminalPaste } from "./encodeTerminalPaste";
 
 const DEFAULT_TERMINAL_COLS = 80;
 const DEFAULT_TERMINAL_ROWS = 24;
@@ -78,6 +80,7 @@ type HostPlatform = "mac" | "linux" | "windows" | "unknown";
 type TerminalToolbarAction =
   | { readonly kind: "send"; readonly key: string; readonly label: string; readonly data: string }
   | { readonly kind: "clear"; readonly key: string; readonly label: string }
+  | { readonly kind: "paste"; readonly key: string; readonly label: string }
   | {
       readonly kind: "modifier";
       readonly key: string;
@@ -488,6 +491,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       { kind: "send", key: "esc", label: "esc", data: "\u001b" },
       ...modifierActions,
       { kind: "send", key: "tab", label: "tab", data: "\t" },
+      { kind: "paste", key: "paste", label: "paste" },
       { kind: "clear", key: "clear", label: "clear" },
       { kind: "send", key: "up", label: "↑", data: "\u001b[A" },
       { kind: "send", key: "down", label: "↓", data: "\u001b[B" },
@@ -1003,6 +1007,29 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     });
   }, [clearTerminal, selectedThread, terminalId]);
 
+  const handlePasteFromClipboard = useCallback(() => {
+    setPendingModifierState({ terminalId, value: null });
+    void (async () => {
+      let text: string;
+      try {
+        text = await Clipboard.getStringAsync();
+      } catch {
+        return;
+      }
+      if (text.length === 0) {
+        return;
+      }
+      // Bracketed paste (DECSET 2004) is not exposed from the mobile native
+      // surface yet, so encode like Ghostty with bracketed=false: sanitize and
+      // map newlines to CR without wrapping ESC[200~/ESC[201~.
+      const encoded = encodeTerminalPaste(text);
+      if (encoded.length === 0) {
+        return;
+      }
+      writeInput(encoded);
+    })();
+  }, [terminalId, writeInput]);
+
   const handleToolbarActionPress = useCallback(
     (action: TerminalToolbarAction) => {
       if (action.kind === "modifier") {
@@ -1021,6 +1048,11 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         return;
       }
 
+      if (action.kind === "paste") {
+        handlePasteFromClipboard();
+        return;
+      }
+
       setPendingModifierState({ terminalId, value: null });
       if (pendingModifier === "ctrl") {
         writeInput(applyCtrlModifier(action.data));
@@ -1030,7 +1062,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         writeInput(action.data);
       }
     },
-    [handleClearTerminal, pendingModifier, terminalId, writeInput],
+    [handleClearTerminal, handlePasteFromClipboard, pendingModifier, terminalId, writeInput],
   );
 
   const handleDismissKeyboard = useCallback(() => {

--- a/apps/mobile/src/features/terminal/encodeTerminalPaste.test.ts
+++ b/apps/mobile/src/features/terminal/encodeTerminalPaste.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { encodeTerminalPaste } from "./encodeTerminalPaste";
+
+describe("encodeTerminalPaste", () => {
+  it("returns empty for empty input", () => {
+    expect(encodeTerminalPaste("")).toBe("");
+  });
+
+  it("passes through plain text when not bracketed", () => {
+    expect(encodeTerminalPaste("hello")).toBe("hello");
+  });
+
+  it("replaces newlines with carriage returns when not bracketed", () => {
+    expect(encodeTerminalPaste("one\ntwo\r\nthree")).toBe("one\rtwo\rthree");
+  });
+
+  it("strips bracketed-paste end sequences to block injection", () => {
+    expect(encodeTerminalPaste("safe\u001b[201~; rm -rf /\n")).toBe("safe; rm -rf /\r");
+    expect(encodeTerminalPaste("\u001b[201~\u001b[201~")).toBe("");
+  });
+
+  it("wraps only when bracketed is explicitly enabled", () => {
+    expect(encodeTerminalPaste("a\nb", { bracketed: true })).toBe("\u001b[200~a\nb\u001b[201~");
+  });
+
+  it("still strips embedded end sequences before wrapping", () => {
+    expect(encodeTerminalPaste("x\u001b[201~y", { bracketed: true })).toBe(
+      "\u001b[200~xy\u001b[201~",
+    );
+  });
+});

--- a/apps/mobile/src/features/terminal/encodeTerminalPaste.ts
+++ b/apps/mobile/src/features/terminal/encodeTerminalPaste.ts
@@ -1,0 +1,33 @@
+/**
+ * Encode clipboard text for PTY write, matching web Ghostty `encodePaste`
+ * semantics as closely as we can without a native mode query.
+ *
+ * Web reads DECSET 2004 (bracketed paste) from libghostty and only wraps when
+ * active. Mobile's native surface does not expose that mode yet, so callers
+ * default to `bracketed: false` — never emit literal ESC[200~/ESC[201~ into
+ * shells that have not enabled the mode.
+ *
+ * Always strips ESC[201~ from the payload to block paste-end injection.
+ */
+
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
+export function encodeTerminalPaste(
+  text: string,
+  options: { readonly bracketed?: boolean } = {},
+): string {
+  // Split/join so every occurrence is removed, including adjacent repeats.
+  const sanitized = text.split(BRACKETED_PASTE_END).join("");
+  if (sanitized.length === 0) {
+    return "";
+  }
+
+  if (options.bracketed === true) {
+    return `${BRACKETED_PASTE_START}${sanitized}${BRACKETED_PASTE_END}`;
+  }
+
+  // Ghostty replaces newlines with CR when bracketed paste is off so each
+  // line is a carriage return rather than a bare LF (Ctrl+J in raw mode).
+  return sanitized.replace(/\r\n/g, "\r").replace(/\n/g, "\r");
+}


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/48746ece-49d2-4548-b4c3-d00ef8ceb84f


- Adds a **paste** button to the mobile terminal keyboard accessory toolbar (thread terminal route).
- Reads clipboard via `expo-clipboard`, sanitizes bracketed-paste end sequences (`ESC[201~`), and encodes newlines as CR for PTY input — matching web Ghostty behavior when bracketed paste is off.
- Does not emit `ESC[200~`/`ESC[201~` wrappers unless bracketed mode is explicitly enabled later (native DECSET 2004 is not exposed on mobile yet).

## Test plan

- [x] `vp test run apps/mobile/src/features/terminal/encodeTerminalPaste.test.ts` (6 tests)
- [x] Mobile typecheck clean
- [x] Verified on physical iPhone (personal build): terminal → keyboard accessory → paste inserts clipboard text with expected newline behavior


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `paste` button to mobile terminal toolbar
> - Adds a new `paste` action to the terminal toolbar in [ThreadTerminalRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/8454/files#diff-0815b7fd5b544c4241d321358e819d5904da641dfefcb502e256ad3173f71df2) that reads system clipboard text and writes it to the terminal
> - Introduces `encodeTerminalPaste` in [encodeTerminalPaste.ts](https://github.com/pingdotgg/t3code/pull/8454/files#diff-1b5b34ef38ed565e439a3a9d85a37dbc4777b0f111b57a7dba5d38364640ace7) to sanitize pasted text: strips `ESC[201~` sequences to prevent injection, maps newlines to carriage returns in non-bracketed mode, and optionally wraps text in bracketed paste sequences when `bracketed: true`
> - Clipboard read failures or empty content result in no terminal write
> >
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3f16be4. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->