### PR TITLE
feat(usage): add OpenCode usage reporting

### DIFF
--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,12 +5,13 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok", "opencode"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
   grok: "Grok Build",
+  opencode: "OpenCode",
 };
 
 /**
@@ -23,5 +24,6 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
     grok: scheme === "dark" ? "#a1a1aa" : "#52525b",
+    opencode: "#8b5cf6",
   };
 }

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -2,7 +2,12 @@
 import * as NodeSqlite from "node:sqlite";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { UsageDay } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceEnvironmentVariableName,
+  ProviderInstanceId,
+  UsageDay,
+} from "@t3tools/contracts";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -26,7 +31,7 @@ const EmptyRatesHttpClient = Layer.succeed(
   ),
 );
 
-it.effect("includes OpenCode SQLite usage and source health in the summary", () =>
+it.effect("includes an OpenCode instance database override in the summary", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -80,12 +85,24 @@ it.effect("includes OpenCode SQLite usage and source health in the summary", () 
               claudeAgent: { homePath: path.join(root, "claude") },
               codex: { homePath: path.join(root, "codex") },
             },
+            providerInstances: {
+              [ProviderInstanceId.make("opencode_custom")]: {
+                driver: ProviderDriverKind.make("opencode"),
+                environment: [
+                  {
+                    name: ProviderInstanceEnvironmentVariableName.make("OPENCODE_DB"),
+                    value: databasePath,
+                    sensitive: false,
+                  },
+                ],
+              },
+            },
           }),
           ServerConfig.layerTest(process.cwd(), path.join(root, "t3-home")),
           EmptyRatesHttpClient,
           Layer.succeed(HostProcessEnvironment, {
             GROK_HOME: path.join(root, "grok"),
-            OPENCODE_DB: databasePath,
+            OPENCODE_DB: path.join(root, "missing-global-opencode.db"),
           }),
         ),
       ),

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -1,0 +1,125 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeSqlite from "node:sqlite";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { UsageDay } from "@t3tools/contracts";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+import * as ServerConfig from "../config.ts";
+import * as ServerSettings from "../serverSettings.ts";
+import * as UsageService from "./UsageService.ts";
+
+const encodeUnknownJson = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+
+const EmptyRatesHttpClient = Layer.succeed(
+  HttpClient.HttpClient,
+  HttpClient.make((request) =>
+    Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({}))),
+  ),
+);
+
+it.effect("includes OpenCode SQLite usage and source health in the summary", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-usage-service-" });
+    const databasePath = path.join(root, "opencode.db");
+    const completedAt = Date.parse("2026-08-27T12:00:00.000Z");
+
+    const database = new NodeSqlite.DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        CREATE TABLE message (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          time_created INTEGER NOT NULL,
+          time_updated INTEGER NOT NULL,
+          data TEXT NOT NULL
+        );
+      `);
+      database
+        .prepare(
+          "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(
+          "message-1",
+          "session-1",
+          completedAt,
+          completedAt,
+          encodeUnknownJson({
+            role: "assistant",
+            time: { completed: completedAt },
+            providerID: "openai",
+            modelID: "gpt-5.4",
+            tokens: {
+              input: 5,
+              output: 2,
+              reasoning: 1,
+              cache: { read: 4, write: 3 },
+            },
+            cost: 0.25,
+          }),
+        );
+    } finally {
+      database.close();
+    }
+
+    const usageService = yield* UsageService.make.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          ServerSettings.layerTest({
+            providers: {
+              claudeAgent: { homePath: path.join(root, "claude") },
+              codex: { homePath: path.join(root, "codex") },
+            },
+          }),
+          ServerConfig.layerTest(process.cwd(), path.join(root, "t3-home")),
+          EmptyRatesHttpClient,
+          Layer.succeed(HostProcessEnvironment, {
+            GROK_HOME: path.join(root, "grok"),
+            OPENCODE_DB: databasePath,
+          }),
+        ),
+      ),
+    );
+
+    const summary = yield* usageService.readSummary({
+      sinceDay: UsageDay.make("2026-08-27"),
+      untilDay: UsageDay.make("2026-08-27"),
+      timeZone: "UTC",
+    });
+
+    expect(
+      summary.sources.find((source) => source.fingerprint.provider === "opencode"),
+    ).toMatchObject({
+      status: "ok",
+      scannedFiles: 1,
+      skippedFiles: 0,
+      malformedRecords: 0,
+      distinctSessions: 1,
+    });
+    expect(summary.buckets.find((bucket) => bucket.provider === "opencode")).toMatchObject({
+      day: "2026-08-27",
+      model: "openai/gpt-5.4",
+      totals: {
+        uncachedInputTokens: 5,
+        cachedInputTokens: 4,
+        cacheCreationTokens: 3,
+        outputTokens: 3,
+        reasoningTokens: 1,
+      },
+      costUsd: 0.25,
+      costSource: "providerReported",
+      records: 1,
+      sessions: 1,
+    });
+  }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+);

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -115,7 +115,11 @@ it.effect("includes an OpenCode instance database override in the summary", () =
     });
 
     expect(
-      summary.sources.find((source) => source.fingerprint.provider === "opencode"),
+      summary.sources.find(
+        (source) =>
+          source.fingerprint.provider === "opencode" &&
+          source.fingerprint.resolvedHomePath === databasePath,
+      ),
     ).toMatchObject({
       status: "ok",
       scannedFiles: 1,
@@ -125,6 +129,7 @@ it.effect("includes an OpenCode instance database override in the summary", () =
     });
     expect(summary.buckets.find((bucket) => bucket.provider === "opencode")).toMatchObject({
       day: "2026-08-27",
+      sourcePath: databasePath,
       model: "openai/gpt-5.4",
       totals: {
         uncachedInputTokens: 5,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -37,6 +37,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
+import { mergeProviderInstanceEnvironment } from "../provider/ProviderInstanceEnvironment.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
@@ -202,7 +203,7 @@ export const make = Effect.gen(function* () {
       return nestedExists ? nested : path.join(homePath, "projects");
     });
 
-  /** Resolves the transcript directory for each provider. */
+  /** Resolves transcript directories and every OpenCode instance environment. */
   const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
     // A settings failure must surface as an error: swallowing it here would
     // present "zero usage from every provider" as a valid answer.
@@ -231,46 +232,71 @@ export const make = Effect.gen(function* () {
         ? path.resolve(expandHomePath(grokHomeEnv))
         : path.join(NodeOS.homedir(), ".grok");
 
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
-      {
-        provider: "grok" as const,
-        dir: path.join(grokHome, "sessions"),
-        fileName: "updates.jsonl",
-      },
-    ];
+    return {
+      dirs: [
+        { provider: "claude" as const, dir: claudeDir },
+        { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+        {
+          provider: "grok" as const,
+          dir: path.join(grokHome, "sessions"),
+          fileName: "updates.jsonl",
+        },
+      ],
+      openCodeEnvironments: [
+        hostEnvironment,
+        ...Object.values(settings.providerInstances)
+          .filter((instance) => instance.driver === "opencode")
+          .map((instance) =>
+            mergeProviderInstanceEnvironment(instance.environment, hostEnvironment),
+          ),
+      ],
+    };
   });
 
-  /** Resolves every persisted database the installed OpenCode channel can use. */
-  const resolveOpenCodeDatabases = Effect.fn("UsageService.resolveOpenCodeDatabases")(function* () {
-    const xdgDataHome = hostEnvironment["XDG_DATA_HOME"]?.trim() ?? "";
-    const dataRoot =
-      xdgDataHome.length > 0
-        ? path.resolve(expandHomePath(xdgDataHome))
-        : path.join(NodeOS.homedir(), ".local", "share");
-    const dataDirectory = path.join(dataRoot, "opencode");
-    const directoryEntries = yield* fileSystem
-      .readDirectory(dataDirectory)
-      .pipe(Effect.catchCause(() => Effect.succeed([] as const)));
+  /** Resolves every persisted database the installed OpenCode instances can use. */
+  const resolveOpenCodeDatabases = Effect.fn("UsageService.resolveOpenCodeDatabases")(function* (
+    environments: readonly NodeJS.ProcessEnv[],
+  ) {
+    const resolved = yield* Effect.forEach(environments, (environment) =>
+      Effect.gen(function* () {
+        const xdgDataHome = environment["XDG_DATA_HOME"]?.trim() ?? "";
+        const dataRoot =
+          xdgDataHome.length > 0
+            ? path.resolve(expandHomePath(xdgDataHome))
+            : path.join(NodeOS.homedir(), ".local", "share");
+        const dataDirectory = path.join(dataRoot, "opencode");
+        const directoryEntries = yield* fileSystem
+          .readDirectory(dataDirectory)
+          .pipe(Effect.catchCause(() => Effect.succeed([] as const)));
+        const databasePaths = resolveOpenCodeDatabasePaths({
+          dataDirectory,
+          databaseOverride: environment["OPENCODE_DB"],
+          disableChannelDatabase: environment["OPENCODE_DISABLE_CHANNEL_DB"],
+          directoryEntries,
+          path,
+        });
+        const hasOverride = (environment["OPENCODE_DB"]?.trim().length ?? 0) > 0;
+        return {
+          databasePaths,
+          sourcePath:
+            hasOverride && databasePaths.length === 1
+              ? (databasePaths[0] ?? dataDirectory)
+              : dataDirectory,
+        };
+      }),
+    );
 
-    const databasePaths = resolveOpenCodeDatabasePaths({
-      dataDirectory,
-      databaseOverride: hostEnvironment["OPENCODE_DB"],
-      disableChannelDatabase: hostEnvironment["OPENCODE_DISABLE_CHANNEL_DB"],
-      directoryEntries,
-      path,
-    });
-    const hasOverride = (hostEnvironment["OPENCODE_DB"]?.trim().length ?? 0) > 0;
+    const databasePaths = [...new Set(resolved.flatMap((entry) => entry.databasePaths))].sort(
+      (left, right) => left.localeCompare(right),
+    );
+    const sourcePaths = [...new Set(resolved.map((entry) => entry.sourcePath))].sort(
+      (left, right) => left.localeCompare(right),
+    );
     return {
       databasePaths,
-      // Buckets are provider-scoped rather than source-scoped. Treat all
-      // channel databases as one source so another environment cannot claim
-      // one database and accidentally merge duplicate buckets from another.
-      sourcePath:
-        hasOverride && databasePaths.length === 1
-          ? (databasePaths[0] ?? dataDirectory)
-          : dataDirectory,
+      // Usage buckets are provider-scoped, so all instance databases must be
+      // represented by one deterministic source fingerprint.
+      sourcePath: sourcePaths.join(", "),
     };
   });
 
@@ -378,8 +404,11 @@ export const make = Effect.gen(function* () {
     const hostId = NodeOS.hostname();
     // The home resolvers ask for `Path` themselves; satisfy them from the
     // instance we already hold so `readSummary` stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
-    const openCode = yield* resolveOpenCodeDatabases();
+    const resolvedSources = yield* resolveTranscriptDirs().pipe(
+      Effect.provideService(Path.Path, path),
+    );
+    const dirs = resolvedSources.dirs;
+    const openCode = yield* resolveOpenCodeDatabases(resolvedSources.openCodeEnvironments);
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -461,7 +490,12 @@ export const make = Effect.gen(function* () {
     }
 
     if (openCode.databasePaths.length > 0) {
-      const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(openCode.sourcePath));
+      const volumeIds = yield* Effect.forEach(openCode.databasePaths, (databasePath) =>
+        Effect.promise(() => readDirectoryVolumeId(databasePath)),
+      );
+      const volumeId = [...new Set(volumeIds.filter((id) => id.length > 0))]
+        .sort((left, right) => left.localeCompare(right))
+        .join("|");
       const sessionIds = new Set<string>();
       let existingDatabases = 0;
       let scannedFiles = 0;

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -1,13 +1,15 @@
 /**
  * UsageService - scans provider transcripts and returns priced usage buckets.
  *
- * The scan reads the provider CLIs' own session files (Claude Code, Codex, and
- * Grok Build) rather than T3 Code's orchestration projections, so usage covers
- * turns driven outside T3 Code too. This is the approach `ccusage` takes.
+ * The scan reads the provider CLIs' own session stores (Claude Code, Codex,
+ * Grok Build, and OpenCode) rather than T3 Code's orchestration projections,
+ * so usage covers turns driven outside T3 Code too. This is the approach
+ * `ccusage` takes.
  *
- * Transcripts are append-only, so parsed records are memoised per file by
- * `(size, mtime)`. A cold 30-day scan of ~1.4 GB lands around 2-3 seconds; warm
- * scans only reparse files that changed.
+ * JSONL transcripts are append-only, so parsed records are memoised per file
+ * by `(size, mtime)`. OpenCode's windowed SQLite query is read fresh. A cold
+ * 30-day JSONL scan of ~1.4 GB lands around 2-3 seconds; warm scans only reparse
+ * files that changed.
  *
  * @module UsageService
  */
@@ -15,7 +17,6 @@ import * as NodeOS from "node:os";
 
 import {
   USAGE_CONTRACT_VERSION,
-  type UsageProviderKind,
   type UsageSource,
   type UsageSummary,
   type UsageSummaryInput,
@@ -46,6 +47,7 @@ import {
   readDirectoryVolumeId,
   readTranscriptRecords,
 } from "./usageTranscriptReader.ts";
+import { readOpenCodeUsage, resolveOpenCodeDatabasePaths } from "./usageOpenCode.ts";
 import {
   decodeScanCache,
   dedupeWithinFile,
@@ -53,7 +55,7 @@ import {
   pruneScanCache,
   type ScanCache,
 } from "./usageScanCache.ts";
-import type { UsageRecord } from "./usageTranscripts.ts";
+import type { UsageRecord, UsageTranscriptProviderKind } from "./usageTranscripts.ts";
 
 const LITELLM_RATES_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -240,6 +242,38 @@ export const make = Effect.gen(function* () {
     ];
   });
 
+  /** Resolves every persisted database the installed OpenCode channel can use. */
+  const resolveOpenCodeDatabases = Effect.fn("UsageService.resolveOpenCodeDatabases")(function* () {
+    const xdgDataHome = hostEnvironment["XDG_DATA_HOME"]?.trim() ?? "";
+    const dataRoot =
+      xdgDataHome.length > 0
+        ? path.resolve(expandHomePath(xdgDataHome))
+        : path.join(NodeOS.homedir(), ".local", "share");
+    const dataDirectory = path.join(dataRoot, "opencode");
+    const directoryEntries = yield* fileSystem
+      .readDirectory(dataDirectory)
+      .pipe(Effect.catchCause(() => Effect.succeed([] as const)));
+
+    const databasePaths = resolveOpenCodeDatabasePaths({
+      dataDirectory,
+      databaseOverride: hostEnvironment["OPENCODE_DB"],
+      disableChannelDatabase: hostEnvironment["OPENCODE_DISABLE_CHANNEL_DB"],
+      directoryEntries,
+      path,
+    });
+    const hasOverride = (hostEnvironment["OPENCODE_DB"]?.trim().length ?? 0) > 0;
+    return {
+      databasePaths,
+      // Buckets are provider-scoped rather than source-scoped. Treat all
+      // channel databases as one source so another environment cannot claim
+      // one database and accidentally merge duplicate buckets from another.
+      sourcePath:
+        hasOverride && databasePaths.length === 1
+          ? (databasePaths[0] ?? dataDirectory)
+          : dataDirectory,
+    };
+  });
+
   /**
    * Loads the persisted scan cache exactly once per process.
    *
@@ -277,7 +311,7 @@ export const make = Effect.gen(function* () {
     filePath: string,
     size: number,
     mtimeMs: number,
-    provider: UsageProviderKind,
+    provider: UsageTranscriptProviderKind,
   ): Effect.Effect<readonly UsageRecord[]> =>
     Effect.gen(function* () {
       const cached = fileCache.get(filePath);
@@ -345,6 +379,7 @@ export const make = Effect.gen(function* () {
     // The home resolvers ask for `Path` themselves; satisfy them from the
     // instance we already hold so `readSummary` stays context-free.
     const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    const openCode = yield* resolveOpenCodeDatabases();
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -422,6 +457,61 @@ export const make = Effect.gen(function* () {
         malformedRecords: 0,
         distinctSessions: sessionIds.size,
         message: null,
+      });
+    }
+
+    if (openCode.databasePaths.length > 0) {
+      const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(openCode.sourcePath));
+      const sessionIds = new Set<string>();
+      let existingDatabases = 0;
+      let scannedFiles = 0;
+      let skippedFiles = 0;
+      let malformedRecords = 0;
+
+      for (const databasePath of openCode.databasePaths) {
+        const exists = yield* fileSystem
+          .exists(databasePath)
+          .pipe(Effect.catchCause(() => Effect.succeed(false)));
+        if (!exists) continue;
+        existingDatabases += 1;
+
+        const result = yield* Effect.promise(() => readOpenCodeUsage(databasePath, windowStartMs));
+        if (result === null) {
+          skippedFiles += 1;
+          continue;
+        }
+
+        scannedFiles += 1;
+        malformedRecords += result.malformedRecords;
+        for (const record of result.records) {
+          if (aggregator.add(record) && record.sessionId.length > 0) {
+            sessionIds.add(record.sessionId);
+          }
+        }
+      }
+
+      const missing = existingDatabases === 0;
+      const failed = existingDatabases > 0 && scannedFiles === 0;
+      const partial = !missing && !failed && (skippedFiles > 0 || malformedRecords > 0);
+      sources.push({
+        fingerprint: {
+          hostId,
+          provider: "opencode",
+          resolvedHomePath: openCode.sourcePath,
+          volumeId,
+        },
+        status: missing ? "missing" : failed ? "failed" : partial ? "partial" : "ok",
+        scannedFiles,
+        skippedFiles,
+        malformedRecords,
+        distinctSessions: sessionIds.size,
+        message: missing
+          ? "No usage database on this environment."
+          : failed
+            ? "The usage database could not be read."
+            : partial
+              ? "Some OpenCode usage databases or rows were skipped."
+              : null,
       });
     }
 

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -268,36 +268,17 @@ export const make = Effect.gen(function* () {
         const directoryEntries = yield* fileSystem
           .readDirectory(dataDirectory)
           .pipe(Effect.catchCause(() => Effect.succeed([] as const)));
-        const databasePaths = resolveOpenCodeDatabasePaths({
+        return resolveOpenCodeDatabasePaths({
           dataDirectory,
           databaseOverride: environment["OPENCODE_DB"],
           disableChannelDatabase: environment["OPENCODE_DISABLE_CHANNEL_DB"],
           directoryEntries,
           path,
         });
-        const hasOverride = (environment["OPENCODE_DB"]?.trim().length ?? 0) > 0;
-        return {
-          databasePaths,
-          sourcePath:
-            hasOverride && databasePaths.length === 1
-              ? (databasePaths[0] ?? dataDirectory)
-              : dataDirectory,
-        };
       }),
     );
 
-    const databasePaths = [...new Set(resolved.flatMap((entry) => entry.databasePaths))].sort(
-      (left, right) => left.localeCompare(right),
-    );
-    const sourcePaths = [...new Set(resolved.map((entry) => entry.sourcePath))].sort(
-      (left, right) => left.localeCompare(right),
-    );
-    return {
-      databasePaths,
-      // Usage buckets are provider-scoped, so all instance databases must be
-      // represented by one deterministic source fingerprint.
-      sourcePath: sourcePaths.join(", "),
-    };
+    return [...new Set(resolved.flat())].sort((left, right) => left.localeCompare(right));
   });
 
   /**
@@ -408,7 +389,9 @@ export const make = Effect.gen(function* () {
       Effect.provideService(Path.Path, path),
     );
     const dirs = resolvedSources.dirs;
-    const openCode = yield* resolveOpenCodeDatabases(resolvedSources.openCodeEnvironments);
+    const openCodeDatabasePaths = yield* resolveOpenCodeDatabases(
+      resolvedSources.openCodeEnvironments,
+    );
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -489,62 +472,47 @@ export const make = Effect.gen(function* () {
       });
     }
 
-    if (openCode.databasePaths.length > 0) {
-      const volumeIds = yield* Effect.forEach(openCode.databasePaths, (databasePath) =>
-        Effect.promise(() => readDirectoryVolumeId(databasePath)),
-      );
-      const volumeId = [...new Set(volumeIds.filter((id) => id.length > 0))]
-        .sort((left, right) => left.localeCompare(right))
-        .join("|");
+    for (const databasePath of openCodeDatabasePaths) {
+      const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(databasePath));
       const sessionIds = new Set<string>();
-      let existingDatabases = 0;
-      let scannedFiles = 0;
-      let skippedFiles = 0;
-      let malformedRecords = 0;
+      const exists = yield* fileSystem
+        .exists(databasePath)
+        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      const result = exists
+        ? yield* Effect.promise(() => readOpenCodeUsage(databasePath, windowStartMs))
+        : null;
+      const failed = exists && result === null;
+      const malformedRecords = result?.malformedRecords ?? 0;
 
-      for (const databasePath of openCode.databasePaths) {
-        const exists = yield* fileSystem
-          .exists(databasePath)
-          .pipe(Effect.catchCause(() => Effect.succeed(false)));
-        if (!exists) continue;
-        existingDatabases += 1;
-
-        const result = yield* Effect.promise(() => readOpenCodeUsage(databasePath, windowStartMs));
-        if (result === null) {
-          skippedFiles += 1;
-          continue;
-        }
-
-        scannedFiles += 1;
-        malformedRecords += result.malformedRecords;
+      if (result !== null) {
         for (const record of result.records) {
-          if (aggregator.add(record) && record.sessionId.length > 0) {
+          if (
+            aggregator.add({ ...record, sourcePath: databasePath }) &&
+            record.sessionId.length > 0
+          ) {
             sessionIds.add(record.sessionId);
           }
         }
       }
 
-      const missing = existingDatabases === 0;
-      const failed = existingDatabases > 0 && scannedFiles === 0;
-      const partial = !missing && !failed && (skippedFiles > 0 || malformedRecords > 0);
       sources.push({
         fingerprint: {
           hostId,
           provider: "opencode",
-          resolvedHomePath: openCode.sourcePath,
+          resolvedHomePath: databasePath,
           volumeId,
         },
-        status: missing ? "missing" : failed ? "failed" : partial ? "partial" : "ok",
-        scannedFiles,
-        skippedFiles,
+        status: !exists ? "missing" : failed ? "failed" : malformedRecords > 0 ? "partial" : "ok",
+        scannedFiles: result === null ? 0 : 1,
+        skippedFiles: failed ? 1 : 0,
         malformedRecords,
         distinctSessions: sessionIds.size,
-        message: missing
+        message: !exists
           ? "No usage database on this environment."
           : failed
             ? "The usage database could not be read."
-            : partial
-              ? "Some OpenCode usage databases or rows were skipped."
+            : malformedRecords > 0
+              ? "Some OpenCode usage rows were skipped."
               : null,
       });
     }

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -201,4 +201,16 @@ describe("UsageAggregator", () => {
 
     expect(result.buckets).toHaveLength(3);
   });
+
+  it("keeps independently persisted sources in separate buckets", () => {
+    const result = aggregate([
+      record({ provider: "opencode", sourcePath: "/data/opencode.db" }),
+      record({ provider: "opencode", sourcePath: "/work/opencode.db" }),
+    ]);
+
+    expect(result.buckets.map((bucket) => bucket.sourcePath)).toEqual([
+      "/data/opencode.db",
+      "/work/opencode.db",
+    ]);
+  });
 });

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -1,7 +1,7 @@
 // @effect-diagnostics globalDate:off
 /**
- * Folds parsed transcript records into `(day, hourStart?, provider, model)`
- * buckets.
+ * Folds parsed transcript records into
+ * `(day, hourStart?, provider, sourcePath?, model)` buckets.
  *
  * `Intl.DateTimeFormat` is the only reliable way to resolve a wall-clock day in
  * an arbitrary IANA zone, and it takes a `Date`. That is why the raw `Date`
@@ -145,7 +145,7 @@ export class UsageAggregator {
             this.#hourlyWindow.sinceTimeMs +
               Math.floor((record.timestampMs - this.#hourlyWindow.sinceTimeMs) / HOUR_MS) * HOUR_MS,
           ).toISOString();
-    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.model}`;
+    const key = `${day}\u0000${hourStart}\u0000${record.provider}\u0000${record.sourcePath ?? ""}\u0000${record.model}`;
     let bucket = this.#buckets.get(key);
     if (bucket === undefined) {
       bucket = {
@@ -180,11 +180,13 @@ export class UsageAggregator {
   finish(): AggregateResult {
     const buckets: UsageBucket[] = [];
     for (const [key, bucket] of this.#buckets) {
-      const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
+      const [day = "", hourStart = "", provider = "", sourcePath = "", model = ""] =
+        key.split("\u0000");
       buckets.push({
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
         provider: provider as UsageBucket["provider"],
+        ...(sourcePath === "" ? {} : { sourcePath }),
         model,
         totals: bucket.totals,
         costUsd: bucket.costUsd,
@@ -201,6 +203,7 @@ export class UsageAggregator {
         a.day.localeCompare(b.day) ||
         (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
         a.provider.localeCompare(b.provider) ||
+        (a.sourcePath ?? "").localeCompare(b.sourcePath ?? "") ||
         a.model.localeCompare(b.model),
     );
 

--- a/apps/server/src/usage/usageOpenCode.test.ts
+++ b/apps/server/src/usage/usageOpenCode.test.ts
@@ -1,0 +1,251 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import * as Schema from "effect/Schema";
+
+import {
+  parseOpenCodeUsageRow,
+  readOpenCodeUsage,
+  resolveOpenCodeDatabasePaths,
+} from "./usageOpenCode.ts";
+
+const temporaryDirectories: string[] = [];
+const encodeUnknownJson = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => NodeFSP.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+function projectedRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    messageId: "message-1",
+    sessionId: "session-1",
+    timestampMs: 1_800_000_000_000,
+    providerId: "anthropic",
+    modelId: "claude-sonnet-4-5",
+    inputTokens: 10,
+    outputTokens: 20,
+    reasoningTokens: 5,
+    cacheReadTokens: 30,
+    cacheWriteTokens: 40,
+    costUsd: 0.123,
+    ...overrides,
+  };
+}
+
+describe("parseOpenCodeUsageRow", () => {
+  it("normalises OpenCode's disjoint reasoning tokens and qualifies the model", () => {
+    const record = parseOpenCodeUsageRow(projectedRow());
+
+    expect(record).toMatchObject({
+      provider: "opencode",
+      model: "anthropic/claude-sonnet-4-5",
+      reportedCostUsd: 0.123,
+      dedupeKey: "opencode:message-1",
+      totals: {
+        uncachedInputTokens: 10,
+        cachedInputTokens: 30,
+        cacheCreationTokens: 40,
+        outputTokens: 25,
+        reasoningTokens: 5,
+      },
+    });
+  });
+
+  it("lets shared model pricing estimate subscription-backed zero-cost rows", () => {
+    expect(parseOpenCodeUsageRow(projectedRow({ costUsd: 0 }))?.reportedCostUsd).toBeNull();
+  });
+
+  it("skips placeholders and malformed projections", () => {
+    expect(
+      parseOpenCodeUsageRow(
+        projectedRow({
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        }),
+      ),
+    ).toBeNull();
+    expect(parseOpenCodeUsageRow({ messageId: "missing-everything-else" })).toBeNull();
+  });
+});
+
+describe("resolveOpenCodeDatabasePaths", () => {
+  const resolve = (overrides: Partial<Parameters<typeof resolveOpenCodeDatabasePaths>[0]> = {}) =>
+    resolveOpenCodeDatabasePaths({
+      dataDirectory: "/data/opencode",
+      databaseOverride: undefined,
+      disableChannelDatabase: undefined,
+      directoryEntries: [],
+      path: NodePath,
+      ...overrides,
+    });
+
+  it("honours absolute, relative, and in-memory database overrides", () => {
+    expect(resolve({ databaseOverride: "/custom/usage.db" })).toEqual(["/custom/usage.db"]);
+    expect(resolve({ databaseOverride: "custom.db" })).toEqual(["/data/opencode/custom.db"]);
+    expect(resolve({ databaseOverride: ":memory:" })).toEqual([]);
+  });
+
+  it("discovers stable and channel databases without unrelated files", () => {
+    expect(
+      resolve({
+        directoryEntries: ["opencode-beta.db", "README.md", "opencode.db", "opencode-beta.db"],
+      }),
+    ).toEqual(["/data/opencode/opencode-beta.db", "/data/opencode/opencode.db"]);
+  });
+
+  it("uses only the stable path when channel databases are disabled", () => {
+    expect(
+      resolve({
+        disableChannelDatabase: "true",
+        directoryEntries: ["opencode-beta.db"],
+      }),
+    ).toEqual(["/data/opencode/opencode.db"]);
+  });
+});
+
+describe("readOpenCodeUsage", () => {
+  it("reads current and legacy tables, preferring the current copy of a message", async () => {
+    const temporaryDirectory = await NodeFSP.mkdtemp(
+      NodePath.join(NodeOS.tmpdir(), "t3-opencode-usage-"),
+    );
+    temporaryDirectories.push(temporaryDirectory);
+    const databasePath = NodePath.join(temporaryDirectory, "opencode.db");
+    const database = new NodeSqlite.DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE session_message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+
+    const sinceMs = 1_800_000_000_000;
+    const insertLegacy = database.prepare("INSERT INTO message VALUES (?, ?, ?, ?)");
+    const insertCurrent = database.prepare("INSERT INTO session_message VALUES (?, ?, ?, ?, ?)");
+    insertCurrent.run(
+      "shared-message",
+      "current-session",
+      "assistant",
+      sinceMs + 100,
+      encodeUnknownJson({
+        time: { completed: sinceMs + 100 },
+        model: { providerID: "anthropic", id: "claude-sonnet-4-5" },
+        tokens: {
+          input: 10,
+          output: 20,
+          reasoning: 5,
+          cache: { read: 30, write: 40 },
+        },
+        cost: 0.123,
+        parts: [{ type: "text", text: "must remain inside SQLite" }],
+      }),
+    );
+    insertCurrent.run(
+      "placeholder",
+      "current-session",
+      "assistant",
+      sinceMs + 110,
+      encodeUnknownJson({
+        time: { completed: sinceMs + 110 },
+        model: { providerID: "anthropic", id: "claude-sonnet-4-5" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        cost: 0,
+      }),
+    );
+    insertCurrent.run(
+      "incomplete",
+      "current-session",
+      "assistant",
+      sinceMs + 120,
+      encodeUnknownJson({
+        time: { created: sinceMs + 120 },
+        model: { providerID: "anthropic", id: "claude-sonnet-4-5" },
+        tokens: { input: 100, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
+        cost: 1,
+      }),
+    );
+    insertLegacy.run(
+      "shared-message",
+      "legacy-session",
+      sinceMs + 100,
+      encodeUnknownJson({
+        role: "assistant",
+        time: { completed: sinceMs + 100 },
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-5",
+        tokens: { input: 999, output: 999, reasoning: 0, cache: { read: 0, write: 0 } },
+        cost: 99,
+      }),
+    );
+    insertLegacy.run(
+      "legacy-message",
+      "legacy-session",
+      sinceMs + 200,
+      encodeUnknownJson({
+        role: "assistant",
+        time: { completed: sinceMs + 200 },
+        providerID: "openai",
+        modelID: "gpt-5.4",
+        tokens: { input: 7, output: 8, reasoning: 3, cache: { read: 6, write: 5 } },
+        cost: 0,
+      }),
+    );
+    insertLegacy.run(
+      "old-message",
+      "old-session",
+      sinceMs - 1,
+      encodeUnknownJson({
+        role: "assistant",
+        time: { completed: sinceMs - 1 },
+        providerID: "openai",
+        modelID: "gpt-5.4",
+        tokens: { input: 100, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+    );
+    insertLegacy.run("malformed", "legacy-session", sinceMs + 300, "{");
+    database.close();
+
+    const result = await readOpenCodeUsage(databasePath, sinceMs);
+
+    expect(result?.malformedRecords).toBe(1);
+    expect(result?.records).toHaveLength(2);
+    expect(result?.records.map((record) => record.dedupeKey).sort()).toEqual([
+      "opencode:legacy-message",
+      "opencode:shared-message",
+    ]);
+    const current = result?.records.find(
+      (record) => record.dedupeKey === "opencode:shared-message",
+    );
+    const legacy = result?.records.find((record) => record.dedupeKey === "opencode:legacy-message");
+    expect(current?.sessionId).toBe("current-session");
+    expect(current?.totals.uncachedInputTokens).toBe(10);
+    expect(legacy?.model).toBe("openai/gpt-5.4");
+    expect(legacy?.reportedCostUsd).toBeNull();
+    expect(encodeUnknownJson(result)).not.toContain("must remain inside SQLite");
+    expect(await NodeFSP.readdir(temporaryDirectory)).toEqual(["opencode.db"]);
+  });
+
+  it("returns null when the database cannot be opened", async () => {
+    expect(await readOpenCodeUsage("/definitely/missing/opencode.db", 0)).toBeNull();
+  });
+});

--- a/apps/server/src/usage/usageOpenCode.ts
+++ b/apps/server/src/usage/usageOpenCode.ts
@@ -1,0 +1,306 @@
+// @effect-diagnostics nodeBuiltinImport:off
+/**
+ * Read-only access to OpenCode's SQLite usage store.
+ *
+ * Queries project only message identity, model, timestamp, token, and cost
+ * scalars. Prompt text, assistant output, and tool content never leave SQLite.
+ *
+ * @module usageOpenCode
+ */
+import * as Exit from "effect/Exit";
+import * as Schema from "effect/Schema";
+
+import type { UsageRecord } from "./usageTranscripts.ts";
+
+// Keep this non-literal at runtime so Node-targeted bundles do not try to
+// resolve Bun's built-in module.
+const BUN_SQLITE_MODULE_ID: string = "bun:sqlite";
+
+const OPEN_CODE_DATABASE_NAME = "opencode.db";
+const OPEN_CODE_CHANNEL_DATABASE = /^opencode-[a-zA-Z0-9._-]+\.db$/;
+const SQLITE_BUSY_TIMEOUT_MS = 1_000;
+
+const TABLES_QUERY = `
+  SELECT name
+  FROM sqlite_master
+  WHERE type = 'table' AND name IN ('session_message', 'message')
+`;
+
+const LEGACY_USAGE_QUERY = `
+  SELECT
+    id AS messageId,
+    session_id AS sessionId,
+    json_extract(data, '$.time.completed') AS timestampMs,
+    json_extract(data, '$.providerID') AS providerId,
+    json_extract(data, '$.modelID') AS modelId,
+    json_extract(data, '$.tokens.input') AS inputTokens,
+    json_extract(data, '$.tokens.output') AS outputTokens,
+    json_extract(data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens,
+    json_extract(data, '$.cost') AS costUsd
+  FROM message
+  WHERE time_updated >= ?
+    AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'
+    AND CASE WHEN json_valid(data) THEN json_extract(data, '$.time.completed') END >= ?
+`;
+
+const LEGACY_MALFORMED_QUERY = `
+  SELECT COUNT(*) AS records
+  FROM message
+  WHERE time_updated >= ? AND NOT json_valid(data)
+`;
+
+const CURRENT_USAGE_QUERY = `
+  SELECT
+    id AS messageId,
+    session_id AS sessionId,
+    json_extract(data, '$.time.completed') AS timestampMs,
+    json_extract(data, '$.model.providerID') AS providerId,
+    json_extract(data, '$.model.id') AS modelId,
+    json_extract(data, '$.tokens.input') AS inputTokens,
+    json_extract(data, '$.tokens.output') AS outputTokens,
+    json_extract(data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens,
+    json_extract(data, '$.cost') AS costUsd
+  FROM session_message
+  WHERE type = 'assistant' AND time_updated >= ?
+    AND CASE WHEN json_valid(data) THEN json_extract(data, '$.time.completed') END >= ?
+`;
+
+const CURRENT_MALFORMED_QUERY = `
+  SELECT COUNT(*) AS records
+  FROM session_message
+  WHERE type = 'assistant' AND time_updated >= ? AND NOT json_valid(data)
+`;
+
+const TABLE_QUERIES = {
+  session_message: { usage: CURRENT_USAGE_QUERY, malformed: CURRENT_MALFORMED_QUERY },
+  message: { usage: LEGACY_USAGE_QUERY, malformed: LEGACY_MALFORMED_QUERY },
+} as const;
+
+type OpenCodeMessageTable = keyof typeof TABLE_QUERIES;
+
+const NonEmptyString = Schema.String.check(Schema.isNonEmpty());
+const NullableFinite = Schema.NullOr(Schema.Finite);
+const OpenCodeUsageRow = Schema.Struct({
+  messageId: NonEmptyString,
+  sessionId: NonEmptyString,
+  timestampMs: Schema.Finite,
+  providerId: NonEmptyString,
+  modelId: NonEmptyString,
+  inputTokens: NullableFinite,
+  outputTokens: NullableFinite,
+  reasoningTokens: NullableFinite,
+  cacheReadTokens: NullableFinite,
+  cacheWriteTokens: NullableFinite,
+  costUsd: NullableFinite,
+});
+const decodeOpenCodeUsageRow = Schema.decodeUnknownExit(OpenCodeUsageRow);
+
+const CountRow = Schema.Struct({ records: Schema.Finite });
+const decodeCountRow = Schema.decodeUnknownExit(CountRow);
+
+const TableRow = Schema.Struct({ name: Schema.String });
+const decodeTableRow = Schema.decodeUnknownExit(TableRow);
+
+interface SqliteStatement {
+  readonly all: (...parameters: readonly number[]) => readonly unknown[];
+}
+
+interface SqliteDatabase {
+  readonly prepare: (sql: string) => SqliteStatement;
+  readonly close: () => void;
+}
+
+export interface OpenCodeUsageRead {
+  readonly records: readonly UsageRecord[];
+  readonly malformedRecords: number;
+}
+
+export interface ResolveOpenCodeDatabasePathsInput {
+  readonly dataDirectory: string;
+  readonly databaseOverride: string | undefined;
+  readonly disableChannelDatabase: string | undefined;
+  readonly directoryEntries: readonly string[];
+  readonly path: {
+    readonly isAbsolute: (value: string) => boolean;
+    readonly join: (first: string, ...segments: readonly string[]) => string;
+  };
+}
+
+/** Mirrors OpenCode's explicit override and compile-time channel database naming. */
+export function resolveOpenCodeDatabasePaths({
+  dataDirectory,
+  databaseOverride,
+  disableChannelDatabase,
+  directoryEntries,
+  path,
+}: ResolveOpenCodeDatabasePathsInput): readonly string[] {
+  const override = databaseOverride?.trim();
+  if (override !== undefined && override.length > 0) {
+    if (override === ":memory:") return [];
+    return [path.isAbsolute(override) ? override : path.join(dataDirectory, override)];
+  }
+
+  const stablePath = path.join(dataDirectory, OPEN_CODE_DATABASE_NAME);
+  const channelsDisabled = ["1", "true"].includes(
+    disableChannelDatabase?.trim().toLowerCase() ?? "",
+  );
+  if (channelsDisabled) return [stablePath];
+
+  const databaseNames = directoryEntries.filter(
+    (entry) => entry === OPEN_CODE_DATABASE_NAME || OPEN_CODE_CHANNEL_DATABASE.test(entry),
+  );
+  if (databaseNames.length === 0) return [stablePath];
+
+  return [...new Set(databaseNames)]
+    .sort((left, right) => left.localeCompare(right))
+    .map((entry) => path.join(dataDirectory, entry));
+}
+
+function nonNegativeInt(value: number | null): number {
+  return value !== null && value > 0 ? Math.trunc(value) : 0;
+}
+
+type ParsedOpenCodeUsageRow =
+  | { readonly _tag: "record"; readonly record: UsageRecord }
+  | { readonly _tag: "placeholder" }
+  | { readonly _tag: "malformed" };
+
+function decodeUsageRow(value: unknown): ParsedOpenCodeUsageRow {
+  const decoded = decodeOpenCodeUsageRow(value);
+  if (!Exit.isSuccess(decoded)) return { _tag: "malformed" };
+
+  const row = decoded.value;
+  const reasoningTokens = nonNegativeInt(row.reasoningTokens);
+  const generatedOutputTokens = nonNegativeInt(row.outputTokens);
+  const totals = {
+    uncachedInputTokens: nonNegativeInt(row.inputTokens),
+    cachedInputTokens: nonNegativeInt(row.cacheReadTokens),
+    cacheCreationTokens: nonNegativeInt(row.cacheWriteTokens),
+    // OpenCode stores generated output and reasoning as disjoint counts. The
+    // shared contract carries reasoning as a subset of output.
+    outputTokens: generatedOutputTokens + reasoningTokens,
+    reasoningTokens,
+  };
+
+  const totalTokens =
+    totals.uncachedInputTokens +
+    totals.cachedInputTokens +
+    totals.cacheCreationTokens +
+    totals.outputTokens;
+  // OpenCode can persist an assistant placeholder before any tokens arrive.
+  // It is not usage and should not make an otherwise healthy source partial.
+  if (totalTokens === 0) return { _tag: "placeholder" };
+
+  return {
+    _tag: "record",
+    record: {
+      provider: "opencode",
+      timestampMs: Math.trunc(row.timestampMs),
+      model: `${row.providerId}/${row.modelId}`,
+      sessionId: row.sessionId,
+      totals,
+      // A zero is commonly emitted by subscription-backed providers. Let the
+      // shared LiteLLM table estimate those models instead of claiming $0 API cost.
+      reportedCostUsd: row.costUsd !== null && row.costUsd > 0 ? row.costUsd : null,
+      dedupeKey: `opencode:${row.messageId}`,
+    },
+  };
+}
+
+/** Converts one assistant-message projection into the shared usage shape. */
+export function parseOpenCodeUsageRow(value: unknown): UsageRecord | null {
+  const parsed = decodeUsageRow(value);
+  return parsed._tag === "record" ? parsed.record : null;
+}
+
+async function openDatabase(databasePath: string): Promise<SqliteDatabase> {
+  if (process.versions.bun !== undefined) {
+    const { Database } = (await import(BUN_SQLITE_MODULE_ID)) as typeof import("bun:sqlite");
+    const database = new Database(databasePath, { readonly: true, create: false });
+    database.run(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+    return {
+      prepare: (sql) => {
+        const statement = database.query(sql);
+        return { all: (...parameters) => statement.all(...parameters) };
+      },
+      close: () => database.close(),
+    };
+  }
+
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(databasePath, {
+    readOnly: true,
+    timeout: SQLITE_BUSY_TIMEOUT_MS,
+  });
+  return {
+    prepare: (sql) => {
+      const statement = database.prepare(sql);
+      return { all: (...parameters) => statement.all(...parameters) };
+    },
+    close: () => database.close(),
+  };
+}
+
+/**
+ * Reads completed OpenCode assistant usage at or after `sinceMs`.
+ *
+ * Current databases may carry both the V2 `session_message` projection and the
+ * legacy `message` projection. The current row wins when both contain the same
+ * message ID. Returns `null` when the file or schema cannot be read.
+ */
+export async function readOpenCodeUsage(
+  databasePath: string,
+  sinceMs: number,
+): Promise<OpenCodeUsageRead | null> {
+  let database: SqliteDatabase | undefined;
+  try {
+    database = await openDatabase(databasePath);
+
+    const tables = new Set<OpenCodeMessageTable>();
+    for (const value of database.prepare(TABLES_QUERY).all()) {
+      const decoded = decodeTableRow(value);
+      if (!Exit.isSuccess(decoded)) continue;
+      if (decoded.value.name === "session_message" || decoded.value.name === "message") {
+        tables.add(decoded.value.name);
+      }
+    }
+    if (tables.size === 0) return null;
+
+    const recordsByMessage = new Map<string, UsageRecord>();
+    let malformedRecords = 0;
+    for (const table of ["session_message", "message"] as const) {
+      if (!tables.has(table)) continue;
+      const queries = TABLE_QUERIES[table];
+      for (const value of database.prepare(queries.usage).all(sinceMs, sinceMs)) {
+        const parsed = decodeUsageRow(value);
+        if (parsed._tag === "malformed") {
+          malformedRecords += 1;
+          continue;
+        }
+        if (parsed._tag === "placeholder") continue;
+        const record = parsed.record;
+        if (record.dedupeKey !== null && !recordsByMessage.has(record.dedupeKey)) {
+          recordsByMessage.set(record.dedupeKey, record);
+        }
+      }
+
+      const [countValue] = database.prepare(queries.malformed).all(sinceMs);
+      const count = decodeCountRow(countValue);
+      if (Exit.isSuccess(count)) malformedRecords += Math.max(0, Math.trunc(count.value.records));
+    }
+
+    return { records: [...recordsByMessage.values()], malformedRecords };
+  } catch {
+    return null;
+  } finally {
+    try {
+      database?.close();
+    } catch {
+      // A close failure cannot invalidate an otherwise complete read.
+    }
+  }
+}

--- a/apps/server/src/usage/usageTranscriptReader.ts
+++ b/apps/server/src/usage/usageTranscriptReader.ts
@@ -15,8 +15,6 @@ import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
 import * as NodeReadline from "node:readline";
 
-import type { UsageProviderKind } from "@t3tools/contracts";
-
 import {
   initialCodexScanState,
   mightCarryUsage,
@@ -24,6 +22,7 @@ import {
   parseCodexLine,
   parseGrokLine,
   type UsageRecord,
+  type UsageTranscriptProviderKind,
 } from "./usageTranscripts.ts";
 
 export interface TranscriptFile {
@@ -85,9 +84,9 @@ export async function listTranscriptFiles(
 }
 
 /**
- * Filesystem identity of a directory, as `device:inode`.
+ * Filesystem identity of a source path, as `device:inode`.
  *
- * Used to tell "two servers reading the same transcript directory" apart from
+ * Used to tell "two servers reading the same transcript source" apart from
  * "two machines whose hostname and home path happen to match". Returns an empty
  * string when the directory cannot be stat'd.
  */
@@ -115,7 +114,7 @@ export async function readDirectoryVolumeId(path: string): Promise<string> {
  */
 export async function readTranscriptRecords(
   filePath: string,
-  provider: UsageProviderKind,
+  provider: UsageTranscriptProviderKind,
 ): Promise<readonly UsageRecord[] | null> {
   const records: UsageRecord[] = [];
   const codexState = initialCodexScanState();

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -12,6 +12,8 @@ export type UsageTranscriptProviderKind = Exclude<UsageProviderKind, "opencode">
 
 export interface UsageRecord {
   readonly provider: UsageProviderKind;
+  /** Source provenance for providers that can read several independent stores. */
+  readonly sourcePath?: string;
   readonly timestampMs: number;
   readonly model: string;
   readonly sessionId: string;

--- a/apps/server/src/usage/usageTranscripts.ts
+++ b/apps/server/src/usage/usageTranscripts.ts
@@ -8,6 +8,8 @@
  */
 import type { UsageProviderKind, UsageTokenTotals } from "@t3tools/contracts";
 
+export type UsageTranscriptProviderKind = Exclude<UsageProviderKind, "opencode">;
+
 export interface UsageRecord {
   readonly provider: UsageProviderKind;
   readonly timestampMs: number;
@@ -67,7 +69,7 @@ export function totalTokens(totals: UsageTokenTotals): number {
  * a 30-day window this skips roughly half the lines outright and is worth about
  * an order of magnitude.
  */
-export function mightCarryUsage(line: string, provider: UsageProviderKind): boolean {
+export function mightCarryUsage(line: string, provider: UsageTranscriptProviderKind): boolean {
   if (provider === "claude") return line.includes('"usage"');
   if (provider === "grok") return line.includes('"turn_completed"');
   return line.includes('"token_count"');

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -87,6 +87,7 @@ describe("buildDayColumns", () => {
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
       { provider: "grok", value: 0 },
+      { provider: "opencode", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, GrokIcon, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -29,6 +29,11 @@ export const PROVIDER_PRESENTATION = {
     // Contrast-aware neutral between the Codex series and muted chart chrome.
     color: "color-mix(in oklab, var(--contrast-foreground) 72%, var(--background))",
     mark: GrokIcon,
+  },
+  opencode: {
+    label: "OpenCode",
+    color: "#8b5cf6",
+    mark: OpenCodeIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,12 +1,17 @@
 # Review usage
 
-The Usage page combines Codex, Claude Code, and Grok Build activity from your connected
+The Usage page combines Codex, Claude Code, Grok Build, and OpenCode activity from your connected
 environments. It reads the providers' local session history and shows API-equivalent token cost,
 processed tokens, cache savings, provider shares, and model breakdowns. Subscription billing is
 separate from the raw token cost shown here.
 
 Grok Build totals come from persisted session updates. Interactive turns that never wrote a
 completed-turn record will not appear.
+
+OpenCode totals come from completed assistant messages in its local SQLite database. T3 Code reads
+only usage metadata such as timestamps, model IDs, token counts, and cost; prompt and response
+content stays in the database. If OpenCode reports no cost for a subscription-backed model, the
+page uses its API-equivalent model rate when one is available.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -3,9 +3,10 @@
  *
  * Each environment scans the provider CLIs' own on-disk session transcripts
  * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`,
- * `~/.grok/sessions/**\/updates.jsonl`) rather than relying on T3 Code's own
- * orchestration projections, so usage stays complete even for turns that were
- * never driven through T3 Code. This mirrors the approach `ccusage` takes.
+ * `~/.grok/sessions/**\/updates.jsonl`, and OpenCode's local SQLite store)
+ * rather than relying on T3 Code's own orchestration projections, so usage
+ * stays complete even for turns that were never driven through T3 Code. This
+ * mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
  * buckets. Raw transcript records never cross the wire.
@@ -21,18 +22,18 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds `opencode`.
+ * v4 Claude/Codex buckets remain valid, so mixed-version environments keep
+ * those totals instead of treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok", "opencode"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**
@@ -67,8 +68,9 @@ export type UsageCostSource = typeof UsageCostSource.Type;
  *
  * `cachedInputTokens` and `cacheCreationTokens` are disjoint from
  * `uncachedInputTokens`; summing all three gives total input. `reasoningTokens`
- * is a *subset* of `outputTokens` (Codex reports it that way, and Anthropic
- * folds thinking into output), so it must never be added on top.
+ * is a *subset* of `outputTokens` (Codex reports it that way, Anthropic folds
+ * thinking into output, and the OpenCode adapter normalises its disjoint
+ * counts), so it must never be added on top.
  */
 export const UsageTokenTotals = Schema.Struct({
   uncachedInputTokens: NonNegativeInt,
@@ -111,7 +113,7 @@ export const UsageBucket = Schema.Struct({
 export type UsageBucket = typeof UsageBucket.Type;
 
 /**
- * Identifies the physical transcript directory a source read from.
+ * Identifies the physical transcript directory or database a source read from.
  *
  * Two environments on the same machine (worktree servers, for example) resolve
  * the same provider home and would otherwise double count. The client drops
@@ -122,12 +124,13 @@ export const UsageSourceFingerprint = Schema.Struct({
   provider: UsageProviderKind,
   resolvedHomePath: TrimmedNonEmptyString,
   /**
-   * Filesystem identity of the transcript directory, as `device:inode`.
+   * Filesystem identity of the transcript directory or database, as
+   * `device:inode`.
    *
    * Hostname and path alone are not enough: every Mac in a fleet resolves
    * `/Users/<user>/.claude`, so two machines that happen to share a hostname
    * would look like one source and have their usage silently dropped. The
-   * device/inode pair is stable for two servers reading the same directory and
+   * device/inode pair is stable for two servers reading the same source and
    * effectively never collides across machines. Empty when it cannot be read.
    */
   volumeId: Schema.String,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -8,8 +8,9 @@
  * stays complete even for turns that were never driven through T3 Code. This
  * mirrors the approach `ccusage` takes.
  *
- * Environments return pre-aggregated `(day, hourStart?, provider, model)`
- * buckets. Raw transcript records never cross the wire.
+ * Environments return pre-aggregated
+ * `(day, hourStart?, provider, sourcePath?, model)` buckets. Raw transcript
+ * records never cross the wire.
  *
  * @module usage
  */
@@ -27,7 +28,8 @@ export const USAGE_CONTRACT_VERSION = 6 as const;
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds `opencode`.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds `opencode` and
+ * optional per-source bucket provenance.
  * v4 Claude/Codex buckets remain valid, so mixed-version environments keep
  * those totals instead of treating every older server as stale.
  */
@@ -82,8 +84,10 @@ export const UsageTokenTotals = Schema.Struct({
 export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 
 /**
- * One `(day, hourStart?, provider, model)` cell. `hourStart` is the UTC start
- * instant of a rolling bucket and is present only for hourly requests.
+ * One `(day, hourStart?, provider, sourcePath?, model)` cell. `hourStart` is
+ * the UTC start instant of a rolling bucket and is present only for hourly
+ * requests. `sourcePath` links a bucket to one source when a provider can use
+ * several stores; older summaries and single-source providers omit it.
  *
  * `costUsd` is the raw API-equivalent cost of these tokens. It is not money
  * spent: subscription plans bill separately. `unpricedRecords` counts records
@@ -94,6 +98,7 @@ export const UsageBucket = Schema.Struct({
   day: UsageDay,
   hourStart: Schema.optional(TrimmedNonEmptyString),
   provider: UsageProviderKind,
+  sourcePath: Schema.optional(TrimmedNonEmptyString),
   model: TrimmedNonEmptyString,
   totals: UsageTokenTotals,
   costUsd: Schema.Number,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -257,6 +257,62 @@ describe("mergeUsage", () => {
     expect(merged.duplicateSources).toHaveLength(1);
   });
 
+  it("deduplicates shared provider storage while keeping unique sources", () => {
+    const shared = {
+      provider: "opencode" as const,
+      hostId: "mac",
+      homePath: "/data/opencode.db",
+      volumeId: "16777220:1234",
+    };
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ provider: "opencode", sourcePath: shared.homePath, costUsd: 10 }),
+              bucket({ provider: "opencode", sourcePath: "/work/a.db", costUsd: 3 }),
+            ],
+            [
+              shared,
+              {
+                provider: "opencode",
+                hostId: "mac",
+                homePath: "/work/a.db",
+                volumeId: "16777220:2000",
+              },
+            ],
+          ),
+        ),
+        environment(
+          "env-b",
+          summary(
+            [
+              bucket({ provider: "opencode", sourcePath: shared.homePath, costUsd: 10 }),
+              bucket({ provider: "opencode", sourcePath: "/work/b.db", costUsd: 4 }),
+            ],
+            [
+              shared,
+              {
+                provider: "opencode",
+                hostId: "mac",
+                homePath: "/work/b.db",
+                volumeId: "16777220:3000",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(17);
+    expect(merged.records).toBe(15);
+    expect(merged.sessions).toBe(3);
+    expect(merged.duplicateSources).toEqual(["env-b: /data/opencode.db"]);
+    expect(merged.contributingEnvironments).toEqual(["env-a", "env-b"]);
+  });
+
   it("totals sessions from per-directory distinct counts, not per-bucket sums", () => {
     // One session that spans two days appears in two buckets. Summing bucket
     // sessions would say 2; the source's distinct count says 1.

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -1,5 +1,6 @@
 import {
   USAGE_CONTRACT_VERSION,
+  USAGE_MERGE_COMPATIBLE_SINCE,
   type EnvironmentId,
   type UsageBucket,
   type UsageDay,
@@ -158,7 +159,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket()],
             [{ provider: "claude", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 2,
+            USAGE_MERGE_COMPATIBLE_SINCE - 1,
           ),
         ),
       ],
@@ -169,7 +170,7 @@ describe("mergeUsage", () => {
     expect(merged.staleEnvironments).toEqual(["env-b"]);
   });
 
-  it("keeps the previous compatible contract version so additive provider expansions still merge", () => {
+  it("keeps the oldest compatible contract version so additive provider expansions still merge", () => {
     const merged = mergeUsage(
       [
         environment(
@@ -184,7 +185,7 @@ describe("mergeUsage", () => {
           summary(
             [bucket({ costUsd: 4, provider: "codex", model: "gpt-5.6-sol" })],
             [{ provider: "codex", hostId: "linux", homePath: "/b" }],
-            USAGE_CONTRACT_VERSION - 1,
+            USAGE_MERGE_COMPATIBLE_SINCE,
           ),
         ),
       ],

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -142,6 +142,7 @@ function ownedContribution(
   readonly sessionsByProvider: ReadonlyMap<UsageProviderKind, number>;
 } {
   const ownedProviders = new Set<UsageProviderKind>();
+  const ownedSourcePaths = new Map<UsageProviderKind, Set<string>>();
   const sessionsByProvider = new Map<UsageProviderKind, number>();
   for (const source of environment.summary.sources) {
     if (source.status === "missing") continue;
@@ -149,6 +150,9 @@ function ownedContribution(
     if (ownerByFingerprint.get(key) === environment.environmentId) {
       const provider = source.fingerprint.provider;
       ownedProviders.add(provider);
+      const providerSourcePaths = ownedSourcePaths.get(provider) ?? new Set<string>();
+      providerSourcePaths.add(source.fingerprint.resolvedHomePath);
+      ownedSourcePaths.set(provider, providerSourcePaths);
       // Distinct within a directory. Summing per-bucket session counts instead
       // would count a session once per day and model it spans.
       sessionsByProvider.set(
@@ -158,7 +162,11 @@ function ownedContribution(
     }
   }
   return {
-    buckets: environment.summary.buckets.filter((bucket) => ownedProviders.has(bucket.provider)),
+    buckets: environment.summary.buckets.filter((bucket) =>
+      bucket.sourcePath === undefined
+        ? ownedProviders.has(bucket.provider)
+        : (ownedSourcePaths.get(bucket.provider)?.has(bucket.sourcePath) ?? false),
+    ),
     sessionsByProvider,
   };
 }


### PR DESCRIPTION
## What Changed

- Read completed OpenCode assistant usage from its SQLite store in read-only mode, supporting both the legacy `message` table and current `session_message` table.
- Project only usage metadata from SQLite, normalize OpenCode's disjoint reasoning counts to the shared token contract, de-duplicate migrated rows, and use OpenCode-reported cost when available.
- Discover the standard XDG data path, explicit `OPENCODE_DB` overrides, and channel-specific databases while reporting missing, failed, or partial source health.
- Add OpenCode to the v6 usage contract and the web/mobile provider presentation, then document the behavior.

## Why

Closes #7622. Closes #11121. OpenCode persists its usage in SQLite, so the existing Claude Code, Codex, and Grok JSONL scan could never include it. This keeps sessions run outside T3 Code visible while ensuring prompt, response, and tool content never leave the local database.

This overlaps #7623 and #7221. #7623 covers the contract and presentation but not collection; #7221 is based on an older main and mixes in broader scan behavior. This PR keeps the complete path focused on OpenCode usage against current main.

## UI Changes

| Before | After |
| --- | --- |
| <img src="https://github.com/aflekkas/t3code/releases/download/pr-evidence-opencode-usage/before.png" alt="Usage page before OpenCode support" width="900"> | <img src="https://github.com/aflekkas/t3code/releases/download/pr-evidence-opencode-usage/after.png" alt="Usage page showing OpenCode totals and models" width="900"> |

## Validation

- 92 focused usage tests across server, shared merge logic, and web presentation
- Targeted typechecks for server, contracts, shared, web, and mobile
- Targeted lint, formatting, and `git diff --check`
- Server bundle and web production build
- Integrated Chrome pass against a dedicated `.t3` runtime and the live OpenCode schema

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or interaction change requires a video

Built with GPT-5 Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches usage contract v6, cross-environment merge rules, and read-only SQLite against user-local OpenCode DBs; behavior is heavily tested but affects reported totals and mixed-version clients.
> 
> **Overview**
> Adds **OpenCode** as a first-class usage provider by reading completed assistant usage from local **SQLite** stores (read-only), alongside the existing Claude/Codex/Grok JSONL scans.
> 
> A new `usageOpenCode` adapter discovers databases from XDG data paths, `OPENCODE_DB` / channel DB naming, and per–OpenCode-instance env overrides; it projects only token/cost metadata from `session_message` and legacy `message` tables, normalizes reasoning vs output tokens, dedupes migrated rows, and surfaces missing/failed/partial source health. `UsageService.readSummary` folds those records in with optional **`sourcePath`** on buckets so multiple DBs stay distinct.
> 
> The usage contract bumps to **v6** (`opencode` + optional `sourcePath`); aggregation and **multi-environment merge** respect `sourcePath` when deduplicating shared databases. Web and mobile gain OpenCode label, color, and icon; user docs describe SQLite-backed totals and pricing fallbacks when cost is zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d43e401a3a4c8163062242ffb49f61f2cc3b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenCode usage reporting across server, contracts, and UI
> - Introduces `usageOpenCode.ts` to read OpenCode assistant usage from SQLite databases (current and legacy tables) with cross-runtime Bun/Node support, honoring `OPENCODE_DB` overrides and channel database discovery
> - Extends `UsageService.make` to collect OpenCode environments from the host and `opencode` provider instances, resolve database paths, and aggregate records with `sourcePath` provenance
> - Updates `UsageAggregator` and `usageMerge` to bucket and deduplicate by `sourcePath` so multiple stores under the same provider stay distinct and shared stores are owned correctly
> - Bumps `USAGE_CONTRACT_VERSION` to 6, adds `'opencode'` to `UsageProviderKind`, and adds optional `sourcePath` to `UsageBucket`
> - Adds OpenCode label, color, icon, and stacking order to mobile and web usage charts
> - Behavioral Change: `USAGE_CONTRACT_VERSION` moves from 5 to 6; older clients that only negotiate version 5 will not receive OpenCode summaries. `readFileRecords` and `readTranscriptRecords` now exclude `'opencode'` from their provider type parameter, so any caller passing `'opencode'` to these JSONL readers will get a type error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84d43e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
