### PR TITLE
fix(web): prevent duplicate terminal paste

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -4,6 +4,7 @@ import type { GhosttyCell, GhosttyRow } from "./core";
 import {
   DEFAULT_TERMINAL_FONT_FAMILY,
   DEFAULT_TERMINAL_FONT_SIZE,
+  GhosttyTerminalSurface,
   advanceTerminalSelectionClickSequence,
   applyTerminalCopyEvent,
   clearPrimedTerminalCopyInput,
@@ -32,6 +33,25 @@ import {
   terminalWheelArrowData,
   terminalWheelDeltaRows,
 } from "./surface";
+
+const terminalSurfaceForPaste = (onData: (data: string) => void) => {
+  const surface = Object.create(GhosttyTerminalSurface.prototype) as GhosttyTerminalSurface;
+  Object.assign(surface, {
+    disposed: false,
+    pasteShortcutToken: 0,
+    options: { onData },
+    core: { encodePaste: (data: string) => `[paste]${data}` },
+  });
+  return surface;
+};
+
+const deferredClipboardText = () => {
+  let resolve: (text: string) => void = () => {};
+  const promise = new Promise<string>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
 
 const cell = (text: string): GhosttyCell => ({
   text,
@@ -346,6 +366,50 @@ describe("isTerminalPasteShortcut", () => {
     expect(isTerminalPasteShortcut(event({ key: "Insert", shiftKey: true }), "MacIntel")).toBe(
       false,
     );
+  });
+});
+
+describe("GhosttyTerminalSurface paste races", () => {
+  it("lets a keyboard paste supersede a pending context-menu read", async () => {
+    const onData = vi.fn();
+    const surface = terminalSurfaceForPaste(onData);
+    const clipboard = deferredClipboardText();
+    const contextMenuPaste = surface.pasteFromClipboard(() => clipboard.promise);
+
+    surface.paste("keyboard");
+    clipboard.resolve("context menu");
+    await contextMenuPaste;
+
+    expect(onData).toHaveBeenCalledOnce();
+    expect(onData).toHaveBeenCalledWith("[paste]keyboard");
+  });
+
+  it("lets a native paste supersede a pending shortcut read", async () => {
+    const onData = vi.fn();
+    const surface = terminalSurfaceForPaste(onData);
+    const clipboard = deferredClipboardText();
+    const shortcutPaste = surface.pasteFromClipboard(() => clipboard.promise);
+
+    surface.paste("native");
+    clipboard.resolve("shortcut");
+    await shortcutPaste;
+
+    expect(onData).toHaveBeenCalledOnce();
+    expect(onData).toHaveBeenCalledWith("[paste]native");
+  });
+
+  it("keeps a pending clipboard read current after an empty paste", async () => {
+    const onData = vi.fn();
+    const surface = terminalSurfaceForPaste(onData);
+    const clipboard = deferredClipboardText();
+    const shortcutPaste = surface.pasteFromClipboard(() => clipboard.promise);
+
+    surface.paste("");
+    clipboard.resolve("shortcut");
+    await shortcutPaste;
+
+    expect(onData).toHaveBeenCalledOnce();
+    expect(onData).toHaveBeenCalledWith("[paste]shortcut");
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -885,6 +885,12 @@ export class GhosttyTerminalSurface {
     this.input.focus({ preventScroll: true });
   }
 
+  paste(data: string): void {
+    if (this.disposed || data.length === 0) return;
+    this.pasteShortcutToken += 1;
+    this.options.onData(this.core.encodePaste(data));
+  }
+
   /**
    * Pastes clipboard text read by the host (context menu) with the same
    * bracketed-paste encoding as a native paste event. The read joins the same
@@ -899,12 +905,7 @@ export class GhosttyTerminalSurface {
     const token = ++this.pasteShortcutToken;
     const text = await readText();
     if (this.disposed || this.pasteShortcutToken !== token || !isCurrent()) return;
-    // As in every paste path, delivering bumps the token so a clipboard read
-    // still in flight cannot land after this text reaches the shell.
-    this.pasteShortcutToken += 1;
-    if (text.length === 0) return;
-    const encoded = this.core.encodePaste(text);
-    if (encoded.length > 0) this.options.onData(encoded);
+    this.paste(text);
   }
 
   hasSelection(): boolean {
@@ -1077,8 +1078,7 @@ export class GhosttyTerminalSurface {
         void clipboard.readText().then(
           (text) => {
             if (this.disposed || this.pasteShortcutToken !== token) return;
-            this.pasteShortcutToken += 1;
-            if (text.length > 0) this.options.onData(this.core.encodePaste(text));
+            this.paste(text);
           },
           () => {
             // Clipboard read denied; the native paste event remains the path.
@@ -1187,8 +1187,7 @@ export class GhosttyTerminalSurface {
     if (data.length === 0) return;
     // The native paste won the race with actual text; a pending clipboard read
     // must not double. An empty native paste leaves the read as the only path.
-    this.pasteShortcutToken += 1;
-    this.options.onData(this.core.encodePaste(data));
+    this.paste(data);
   };
 
   private readonly onCompositionStart = () => {


### PR DESCRIPTION
## What Changed

Centralized terminal paste delivery so every non-empty paste invalidates older clipboard reads before writing to the PTY. Added focused coverage for keyboard/context-menu races, native/shortcut races, and empty paste data.

## Why

Terminal paste can arrive through an async clipboard read or a native paste event. Keeping token invalidation in one method prevents both paths from delivering the same clipboard content.

## Validation

- `vp test run apps/web/src/terminal/ghostty/surface.test.ts` (46 passed)
- Targeted lint for `surface.ts` and `surface.test.ts`
- `vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Implemented with GPT-5.6 Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused change to web terminal input handling with new regression tests; no auth, data persistence, or broader API surface changes.
> 
> **Overview**
> **Centralizes Ghostty terminal paste delivery** in a new `paste()` method so native events, keyboard shortcut clipboard reads, and host `pasteFromClipboard` all share one path to bracketed-paste encode and send data to the PTY.
> 
> When a **non-empty** paste wins, `paste()` bumps `pasteShortcutToken`, which **invalidates slower async reads** that still hold an older token—so context-menu vs keyboard and shortcut vs native races no longer double-send the same clipboard text. **Empty** `paste()` calls are no-ops and **do not** bump the token, so an empty native paste still lets a pending shortcut read complete.
> 
> Adds **unit tests** for those race scenarios using a lightweight surface stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5f26785dee5492bb2c58a59b0dbafad7dd79d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate terminal paste by consolidating delivery in `GhosttyTerminalSurface.paste`
> - Adds a single `paste(data)` method to `GhosttyTerminalSurface` that handles token bumping, encoding, and delivery via `options.onData`; early-returns on disposed surfaces or empty strings.
> - Routes all three paste paths — `onKeyDown` clipboard read, `onPaste` event handler, and `pasteFromClipboard` — through `this.paste()` instead of duplicating the token/dispatch logic inline.
> - Adds unit tests in [surface.test.ts](https://github.com/pingdotgg/t3code/pull/8457/files#diff-4739505f766bda541a0cf14a163fb5321204b64183ba45ffcc1a0026ad6e8029) covering paste race scenarios (keyboard vs context-menu, native vs shortcut) and empty-paste-while-pending behavior.
> - Behavioral Change: `pasteFromClipboard` now calls `onData` for non-empty clipboard text even when `core.encodePaste` returns an empty string; empty input remains a no-op.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e5f267.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->