### PR TITLE
fix(web): give project titles full sidebar width

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1414,12 +1414,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         >
           <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
             <div className="flex h-5 min-w-0 items-center gap-1.5">
-              <ProjectFavicon
-                environmentId={thread.environmentId}
-                cwd={props.projectCwd ?? ""}
-                faviconPath={props.projectFaviconPath}
-                className="size-4 shrink-0"
-              />
               {props.projectTitle ? (
                 <span
                   className={cn(


### PR DESCRIPTION
Project titles in sidebar thread cards were truncating again because the leading project favicon reclaimed the space previously recovered by removing the message icon.

Remove the redundant favicon from regular thread cards so the project name can use the full row width. Project-identifying icons remain in menus and search results where they provide useful context.

Verification:
- `vp test run apps/web/src/components/Sidebar.logic.test.ts`
- `vp run typecheck` in `apps/web`
- `git diff --check`

Implemented with GPT-5.6-Sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large release/CI and desktop identity changes can break packaging or split user data from upstream; mobile cloud is force-disabled by design.
> 
> **Overview**
> This PR **re-targets the repo as a Treher fork** rather than upstream T3 Code: default state lives under **`~/.t3-treher`**, the desktop app is branded **T3 Code (Treher)** with **`dev.treher.t3code`** bundle IDs and **`treher-t3code://`** custom URL schemes, and Electron **Clerk passkeys** are removed. Desktop user data no longer migrates from legacy **T3 Code (Alpha)** paths.
> 
> **CI and release** move off Blacksmith to standard GitHub runners, **relay auto-deploy** and **AUR publish** are dropped or manual-only, **scheduled nightlies** and upstream-only jobs (relay public config, **npm CLI publish**, **Vercel web deploy**, Discord announce) are removed. Linux releases gain **RHEL 8–compatible native prebuilds** (`node-pty`, resource monitor, `fff`) plus **`verify_linux_rhel8`** and an optional **`build:linux-appimage`** PR workflow. Mobile CI is gated on **`vars.T3CODE_ENABLE_MOBILE`**.
> 
> **Mobile** hard-disables T3 Connect via **`CLOUD_FEATURE_DISABLED`**, removes OTLP tracing wiring, and expands thread UX: **provider modes**, **usage** in settings, **Bob session reset**, project-scoped slash commands/skills, and allowing **attachment-only** task/thread sends with **`providerMode`** on creation.
> 
> Docs/env: **IBM Bob** is listed as a supported provider; **`.env.example`** no longer bakes in production relay URL or passkey/mobile telemetry hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac59b94436284b9c5c481d4a105506a0a046aee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rebrand desktop app to 'T3 Code (Treher)' and add IBM Bob provider
> - Rebrands the app from 'T3 Code' to 'T3 Code (Treher)' across desktop, web, and server: changes bundle IDs to `dev.treher.t3code`, URL schemes to `treher-t3code`, default home directory to `~/.t3-treher`, and product display names in [DesktopEnvironment.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-c5eb157ffd36e7b8e67ed02141144a70cf475a58fa222a4465107c2d9600e194), [branding.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-263b2c171d6fb61b78287a0e32a96d726d42e8030c5d2cb7402f53f384648ca1), [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), and related modules
> - Adds IBM Bob as a built-in provider via ACP, including a new `BobDriver`, `BasicAcpAdapter`, session resume/close/set_mode support, text generation, and UI integration with provider mode selection in [BobDriver.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-0abe20361fc7ec3b6f9e18b02b90152d10e3e48bc03674bb1354d513e3d01d9d), [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6), and [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/8462/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> - Removes relay client tracing/observability infrastructure and hard-disables cloud features via `CLOUD_FEATURE_DISABLED` constant across [publicConfig.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-b976915adda4d04db0fb2f517bfeb465aab17a12a3cc0eec3b586cac0db7d868), [deploy.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-bdb031e6973904ea6900bf4f99ff6eaeb7dd1b7da001ab3d8bfb518b62996b75), and [public-config.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-7b8afe1e7beaabd111c161519ddf293c52b1bd3cc5cfa9546ed631722433330f)
> - Removes macOS passkey signing and `@clerk/electron-passkeys` dependency from desktop builds and CI
> - Adds RHEL 8-compatible Linux native prebuilds support with a new `--linux-native-prebuilds` CLI flag and `rockylinux:8` CI validation in [release.yml](https://github.com/pingdotgg/t3code/pull/8462/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)
> - Replaces in-app desktop update download/install with a 'View Release' action that opens the GitHub release page externally in [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/8462/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) and [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/8462/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af)
> - Risk: `ServerDerivedPaths` no longer includes `anonymousIdPath` and the state directory name changed from hardcoded `"userdata"` to `PRODUCTION_STATE_DIRECTORY_NAME`; code accessing `anonymousIdPath` will fail at compile time. URL scheme change from `t3code://` to `treher-t3code://` breaks deep links from older clients. Mobile app is excluded from the pnpm workspace and gated behind `T3CODE_ENABLE_MOBILE`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ac59b94. 136 files reviewed, 39 issues evaluated, 38 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/desktop/src/app/DesktopAppIdentity.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 38](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/desktop/src/app/DesktopAppIdentity.ts#L38): `resolveUserDataPath` now always switches to `userDataDirName` (`t3code-treher`), so upgrading an existing installation that stored Electron state in the previous `t3code` directory no longer reuses its cookies, local storage, window state, or other user-data. The deleted existence check supplied the compatibility path; with no migration/copy, those users are treated as fresh installs while their prior local state remains stranded. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>apps/desktop/src/app/DesktopEnvironment.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 180](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/desktop/src/app/DesktopEnvironment.ts#L180): Changing `userDataDirName` to `t3code-treher` makes every existing packaged installation select a new Electron `userData` directory. The previous legacy-path fallback was removed, so its existing profile (including persisted authentication/session data and Electron preferences) is ignored rather than reused or migrated; users are treated as fresh installs after upgrading. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>apps/desktop/src/app/DesktopStatePaths.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 23](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/desktop/src/app/DesktopStatePaths.ts#L23): When `T3CODE_HOME` is not set, `resolveDesktopBaseDir` now selects `~/.t3-treher` instead of the existing `~/.t3`. The desktop passes this value to the backend as `t3Home`, and `DesktopEnvironment` derives settings, saved-environment records, logs, and the server state/SQLite paths below it. Thus an upgrade of a normal existing installation starts against an empty state directory rather than the user's existing `~/.t3/userdata` data, leaving all local threads and configuration inaccessible without manually setting `T3CODE_HOME` or moving files. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>apps/mobile/src/features/cloud/publicConfig.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 56](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/cloud/publicConfig.ts#L56): `CLOUD_FEATURE_DISABLED` is consulted only by `hasCloudPublicConfig`, but the app always mounts `CloudAuthProvider`, which independently reads `resolveCloudPublicConfig()` and mounts `CloudAuthBridge` whenever the build contains a publishable key and relay URL. That bridge activates relay sessions and supplies Clerk tokens, so a configured build still performs relay authentication despite this claimed compliance kill switch. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/mobile/src/features/threads/NewTaskDraftScreen.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 668](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx#L668): The new attachment-only gate allows the Start button to call `createProjectThread` with an empty prompt, but that helper still invokes `validateProjectThreadCreation`, which rejects every empty `initialMessageText` regardless of `initialAttachments`. Thus an online attachment-only task always fails with “Enter a task” instead of creating the thread; only the offline queue path accepts it. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/mobile/src/features/threads/ThreadComposer.tsx — 0 comments posted, 4 evaluated, 4 filtered</summary>
>
> - [line 400](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/ThreadComposer.tsx#L400): Fetching project metadata is incorrectly gated on truthy `projectCwd`, although `providerProjectMetadata` accepts only `instanceId` and `projectId`. The mobile flow explicitly creates project snapshots with `workspaceRoot: ""` when a queued task has no saved cwd; opening one of those threads makes this condition false and permanently hides its provider modes, project slash commands, and skills despite its valid project ID. Gate on the thread/project identifier and provider capability instead. <b>[ Posting failed ]</b>
> - [line 419](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/ThreadComposer.tsx#L419): The backward walk stops at the newest `context-window.updated` activity even when its payload has no valid `usedTokens`. Malformed updates are explicitly retained by the reducer/projection and older resolvable updates remain available, but this code then derives a null summary from the malformed row and hides usage entirely instead of continuing to the prior valid snapshot. Skip rows whose `usedTokens` fails `finiteUsageNumber` before assigning `tokens`. <b>[ Posting failed ]</b>
> - [line 533](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/ThreadComposer.tsx#L533): The slash-command branch still builds `skillItems` from `selectedProviderStatus?.skills` rather than the newly project-scoped `selectedSkills`. Once `projectMetadata.skills` differs from the provider defaults, typing `/` or `/skill` suggests the wrong skills (and can insert skills unavailable in the active project), while the `$` menu correctly uses project metadata. Use `selectedSkills` here, as the web composer does. <b>[ Posting failed ]</b>
> - [line 765](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/ThreadComposer.tsx#L765): The reset action discards the `resetProviderContext` result while explicitly disabling automatic failure reporting. If the RPC fails (for example, the environment disconnects), tapping “Start new Bob session” produces no error or state change, so the user remains stuck on the broken session without feedback. Handle a non-success result or leave failure reporting enabled; the web implementation handles this result and surfaces the error. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/mobile/src/features/threads/ThreadSettingsSheet.tsx — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 1319](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx#L1319): `providerModes={flow.providerModes}` is derived from `flow.selectedModel`, but this screen stages a different model locally in `ThreadSettingsSessionProvider` until Save. After selecting a model from another provider, the Provider mode row still lists and writes modes for the previously applied provider; choosing one then saves that stale mode together with the new model, so the draft can contain a mode unsupported by its selected provider. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/mobile/src/features/threads/use-project-actions.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 48](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/mobile/src/features/threads/use-project-actions.ts#L48): `validateProjectThreadCreation` is invoked with the trimmed text at line 48 and rejects an empty string unconditionally, even when `initialAttachments` is nonempty. The caller UI explicitly permits attachment-only submission, so an attachment-only new task reaches this path and is rejected as “task required” instead of creating the thread. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/server/scripts/acp-mock-agent.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 309](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/scripts/acp-mock-agent.ts#L309): `agentCapabilities.sessionCapabilities` advertises both `delete` and `list`, but this mock registers neither a list-session handler nor any delete implementation. A client that enables either action from the advertised capabilities receives the framework's missing-handler error for `session/list` (and `session/delete` is not routed at all), so capability-driven session management cannot work against the mock. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/os-jank.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 109](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/os-jank.ts#L109): `resolveBaseDir(undefined)` now points the server at `~/.t3-treher` and contains no compatibility lookup or migration for the former `~/.t3` directory. Existing CLI/desktop users invoking the default server therefore create a new empty `userdata/state.sqlite` and no longer see their projects, threads, settings, or stored provider configuration unless they manually set `T3CODE_HOME` to the old location. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/BasicAcpAdapter.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>
>
> - [line 448](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/Layers/BasicAcpAdapter.ts#L448): The ACP notification consumer is started with `Effect.forkChild`, which is supervised by the `startSession` caller and is interrupted when that effect returns. The stored session scope remains open, but the consumer is already dead, so subsequent `ContentDelta`, tool, plan, and mode notifications are silently dropped for every Basic ACP session. It must be forked into `sessionScope` instead. <b>[ Posting failed ]</b>
> - [line 477](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/Layers/BasicAcpAdapter.ts#L477): `sendTurn` does not acquire the per-thread lock before reading `promptInFlight`. Two concurrent attachment-bearing sends can both observe `false`, suspend independently in `fileSystem.readFile`, then each set it to `true` and call `context.acp.prompt` concurrently. This violates the adapter's declared lack of mid-turn steering and overwrites shared `activeTurnId`/session state, so events and completion state can be attributed to the wrong turn (or the ACP session can reject/corrupt concurrent prompts). <b>[ Posting failed ]</b>
> - [line 565](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/Layers/BasicAcpAdapter.ts#L565): After a successful prompt, the adapter marks the session `ready` but retains `activeTurnId: turnId` and also never clears `context.activeTurnId`. Consequently `listSessions()` reports an idle session as having an active turn, and any late ACP item/content event is incorrectly attached to the completed turn. Other ACP adapters remove the active id when settling the final prompt. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/ProviderRegistry.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 720](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/Layers/ProviderRegistry.ts#L720): `getProjectMetadata` treats a missing instance exactly like an adapter that does not implement metadata and returns `workspaceTrusted: true`. A stale or unknown `instanceId` therefore produces a successful trusted-workspace response, bypassing the caller's failure fallback (which intentionally reports `workspaceTrusted: false`) and misrepresents an unresolvable provider as trusted. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/ProviderService.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 241](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/Layers/ProviderService.ts#L241): `prepareMcpSession` returns without revoking or clearing an existing MCP credential when the newly selected adapter has `t3McpInjection === false`. Switching a thread from an MCP-capable provider to such an adapter reaches this branch before `stopStaleSessionsForThread`, which only stops the old provider session; the old thread token and `McpProviderSession` entry remain valid, so the `/mcp` endpoint can still grant browser-tool access after the new provider was selected as not supporting MCP injection. <b>[ Posting failed ]</b>
> - [line 353](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/Layers/ProviderService.ts#L353): The terminal-event persistence path overwrites `runtimePayload` via `upsertSessionBinding` without preserving the binding's existing `modelSelection`. A session started or turn sent with a selected model initially stores that selection, but after a `session.started` or `turn.completed` event this call replaces it with only session fields and last-event fields. Later recovery reads `modelSelection` solely from `runtimePayload`, so it resumes the thread using the provider default rather than the user's selected model. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/acp/AcpSessionRuntime.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 796](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/acp/AcpSessionRuntime.ts#L796): `cancel` now awaits `acp.agent.cancel(payload)` before interrupting `activePromptFiber`. If the cancel RPC fails (for example, a transport error), `runLoggedRequest` fails and short-circuits lines 797–800, leaving the local prompt fiber running even though the caller attempted cancellation. The prior code issued the remote notification best-effort and always released the local prompt; preserve local interruption in an `ensuring`/error path. <b>[ Posting failed ]</b>
> - [line 809](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/provider/acp/AcpSessionRuntime.ts#L809): `close` performs an unbounded `session/close` RPC. `BasicAcpAdapter.stopInternal` awaits this effect before it interrupts its notification fiber or closes the session scope, so an ACP process that is hung or never responds to `session/close` makes stopping/deleting the session hang indefinitely and prevents the scope from killing that child process. Bound this graceful RPC or ensure local scope cleanup runs independently. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/serverRuntimeStartup.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 510](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/serverRuntimeStartup.ts#L510): The new post-ready presentation block repeats the block already forked at lines 456-474. Every non-desktop startup therefore issues two separate startup pairing credentials and opens the browser twice; headless startup prints two distinct administrative pairing tokens/QR codes. This creates unnecessary active pairing links and makes the startup output ambiguous about which credential to use. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/terminal/Manager.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1259](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/terminal/Manager.ts#L1259): `streamChanges` is subscribed only when the forked `runForEach` starts, after `getSettings` has returned. A settings update that commits between the initial read and that later subscription is dropped by the PubSub, leaving `shellOverride` stale and causing subsequently opened terminals to ignore the configured shell until another settings change occurs. Use `subscribeChanges` to acquire the subscription before reading the initial snapshot. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/ws.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1586](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/server/src/ws.ts#L1586): `serverResetProviderContext` calls `providerRegistry.resetContext` at line 1586, but the Basic ACP implementation of that operation first requires an in-memory session. When recovering a persisted Bob session fails during `session/resume`, `startSession` fails before it installs that session in its map; the UI then exposes this reset specifically for the resulting resume/session-not-found error. The reset therefore fails with `ProviderSessionNotFoundError` instead of starting the requested fresh session, leaving the advertised recovery action unusable. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 5360](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/ChatView.tsx#L5360): `onResetProviderContext` calls `setThreadError(activeThread.id, ...)` after awaiting the reset. If the user navigates from the Bob thread to a draft before a failed reset resolves, `setThreadError` no longer recognizes that id as the current server thread and stores the error under the current `draftId`; the unrelated draft then displays the Bob reset failure banner. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/DiffPanel.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 957](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/DiffPanel.tsx#L957): The changed-files filter computes `filteredFileEntries`/`filteredFilePathItems`, but the popup still renders `renderableFileEntries`. Typing a query therefore leaves every changed file visible instead of filtering the list, so the new “Filter changed files” control does not work. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/LegacySidebar.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 3549](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/LegacySidebar.tsx#L3549): The new release action at `handleDesktopUpdateButtonClick` opens the URL returned for an available update, but that helper is configured for `https://github.com/MTVaught/t3code/releases/tag/...`. The desktop build and all user-facing installation links target `pingdotgg/t3code`; therefore clicking "View ARM release" (or any update release action) sends users to a different repository rather than the release that supplied their update version. <b>[ Cross-file consolidated ]</b>
> - [line 3553](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/LegacySidebar.tsx#L3553): `handleDesktopUpdateButtonClick` no longer tracks an in-flight action or disables the button while `openExternal` is pending. Multiple rapid clicks on "View ARM release" therefore call `bridge.openExternal(releaseUrl)` repeatedly and open multiple release tabs/windows, unlike the previous guarded update action. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/ThreadTerminalDrawer.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 804](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/ThreadTerminalDrawer.tsx#L804): The new bubbling `contextmenu` listener also runs after the canvas surface's `onContextMenu` callback has already started `showTerminalContextMenu`. When text is selected, right-clicking therefore opens a second selection-only menu, increments `selectionActionRequestIdRef`, and supersedes the first menu (the only one containing Paste). Consequently a right-click on selected text cannot reliably show/use the terminal Paste action and issues competing menu requests. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/chat/ChatComposer.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 1212](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/chat/ChatComposer.tsx#L1212): `composerMenuItems` now reads the asynchronously resolved `selectedSkills` and `selectedSlashCommands`, but its dependency list omits both (and `projectMetadata`). When `providerProjectMetadata` resolves after the initial render, the component rerenders but this memo retains the fallback provider-level command/skill items, so project-scoped commands and skills never appear in the `/` or `$` menus until some unrelated dependency changes. <b>[ Exceeded comment limit ]</b>
> - [line 3446](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/chat/ChatComposer.tsx#L3446): The editor is still passed `selectedProviderStatus?.skills` rather than the new project-scoped `selectedSkills`. Thus a project-only skill selected from the new `$`/slash menus is rendered with the fallback raw name and no description instead of its project metadata (and same-named project skills retain stale provider-level metadata). The parallel mobile composer passes `selectedSkills` to its editor. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/chat/MessagesTimeline.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 2489](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/chat/MessagesTimeline.tsx#L2489): The fallback at `buildToolCallExpandedBody` cannot render structured payloads from normal non-MCP activities. `projectThreadDetailSnapshot` and `projectActivityEvent` pass every activity through `projectActivityPayload`, which for non-`mcp_tool_call` records rebuilds `payload.data` without `toolName`, `input`, or `result`; consequently `deriveWorkLogEntries` never assigns `toolData` and this branch is skipped. For example, a non-command `AskUserQuestion`/search tool has no command or changed file, but its structured input is removed before this UI can display it. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/desktopUpdate.logic.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 5](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/desktopUpdate.logic.ts#L5): `getDesktopUpdateReleaseUrl` now always directs an available desktop update to `MTVaught/t3code`, while the desktop updater's publish configuration derives its release repository from `T3CODE_DESKTOP_UPDATE_REPOSITORY` or `GITHUB_REPOSITORY` and the repository's release/docs configuration uses `pingdotgg/t3code`. Thus clicking the newly substituted release action for a version published by this repository opens a different fork (and commonly a missing tag) rather than the release containing that update. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/files/FilePreviewPanel.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 815](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/files/FilePreviewPanel.tsx#L815): `isAsciiDoc` treats every `.asc` file as a renderable document. `.asc` is also the conventional extension for ASCII-armored OpenPGP keys/signatures; once the shared rendered-document preference is enabled, opening such a file routes it to the read-only AsciiDoc renderer rather than the normal editable source surface. Users must manually notice and toggle back before they can inspect or edit an armored key/signature. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 987](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/files/FilePreviewPanel.tsx#L987): The new Reload control also appears for workspace images, but images call `useProjectFileQuery(..., !isImage)`, which selects `EMPTY_PROJECT_FILE_QUERY_ATOM` when `isImage` is true. Consequently `file.refresh` only refreshes that inert atom and never re-requests the asset URL/image; clicking “Reload file” leaves an externally modified image unchanged. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/settings/ProviderInstanceCard.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 820](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/settings/ProviderInstanceCard.tsx#L820): The new fixed `BOB_API_KEY` field cannot clear an already-stored secret. Redacted secrets are supplied to `DraftInput` as `value=""`; after focus, deleting any replacement leaves its draft equal to that empty value, so `useCommitOnBlur` does not invoke `onCommit`. Since this change also filters `BOB_API_KEY` out of the editable table, there is no remove control to send the empty environment value, leaving a revoked/incorrect Bob credential persisted and still used by launches. <b>[ Exceeded comment limit ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/sidebar/SidebarUpdatePill.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 185](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/apps/web/src/components/sidebar/SidebarUpdatePill.tsx#L185): The new `release` action opens a URL generated with `https://github.com/MTVaught/t3code/releases/tag`, but the shipped project’s documented release repository is `pingdotgg/t3code` (for example `README.md` and `docs/user/install.md`). Thus every sidebar update click sends users to a different repository’s tag page rather than the release containing the update they were offered, so they cannot obtain the advertised update from this control. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/contracts/src/orchestration.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 835](https://github.com/pingdotgg/t3code/blob/ac59b94436284b9c5c481d4a105506a0a046aee5/packages/contracts/src/orchestration.ts#L835): `providerMode` is accepted inside `bootstrap.createThread`, but the bootstrap handler constructs the `thread.create` command without forwarding it. A start request that supplies the mode only in this newly supported create-thread payload creates the thread with the default/null mode, so the selected Bob/provider mode is silently lost. <b>[ Exceeded comment limit ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->