### PR TITLE
fix(web): name providers in multi-provider update toasts

### DIFF
--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -292,6 +292,27 @@ describe("provider update launch notification logic", () => {
     });
   });
 
+  it("names providers in the one-click toast when multiple updates are available", () => {
+    const view = getProviderUpdateInitialToastView({
+      updateProviders: [
+        updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" }),
+        updateCandidate({ driver: driver("opencode"), latestVersion: "1.2.0" }),
+      ],
+      oneClickProviders: [
+        updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" }),
+        updateCandidate({ driver: driver("opencode"), latestVersion: "1.2.0" }),
+      ],
+    });
+
+    expect(view).toMatchObject({
+      phase: "initial",
+      type: "warning",
+      title: "Updates Available: 2 providers",
+      description:
+        "Updates available for Codex and OpenCode. Install now or review provider settings.",
+    });
+  });
+
   it("describes settings-only updates without one-click support", () => {
     const view = getProviderUpdateInitialToastView({
       updateProviders: [

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -220,13 +220,16 @@ export function getProviderUpdateInitialToastView(input: {
   readonly updateProviders: ReadonlyArray<ProviderUpdateCandidate>;
   readonly oneClickProviders: ReadonlyArray<ProviderUpdateCandidate>;
 }): ProviderUpdateToastView {
+  const hasMultipleUpdates = input.updateProviders.length > 1;
   return {
     phase: "initial",
     type: "warning",
     title: getProviderUpdateInitialToastTitle(input.updateProviders),
     description:
       input.oneClickProviders.length > 0
-        ? "Install the update now or review provider settings."
+        ? hasMultipleUpdates
+          ? `Updates available for ${formatProviderList(input.updateProviders)}. Install now or review provider settings.`
+          : "Install the update now or review provider settings."
         : `${formatProviderList(input.updateProviders)} can be updated from provider settings.`,
   };
 }


### PR DESCRIPTION
## What Changed

- Formatted provider names in one-click update toast descriptions when multiple updates are available (`Updates available for Codex and OpenCode...`).
- Kept the concise description (`Install the update now or review provider settings.`) for single-provider updates where the title already explicitly names the provider (`Update Available: Claude v2.1.248`).

## Why

When multiple providers have updates available, the one-click toast title displays `Updates Available: 2 providers` without naming which providers are outdated. Including the formatted provider list in the description fills this information gap.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

## Screenshots
Before
<img width="1512" height="863" alt="image" src="https://github.com/user-attachments/assets/f12a81b8-538f-4967-9983-3dfa676ecdef" />

After
<img width="1511" height="860" alt="image" src="https://github.com/user-attachments/assets/5df96454-6d61-4fb9-b340-accaf780de6e" />

---
*Built with Antigravity.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in provider update toast logic with no auth, data, or API impact.
> 
> **Overview**
> When several providers have one-click updates, the launch toast title only says **"Updates Available: N providers"**, so users could not tell which providers were outdated.
> 
> **`getProviderUpdateInitialToastView`** now uses **`formatProviderList`** in the description when there is more than one update and one-click install is available (e.g. *"Updates available for Codex and OpenCode. Install now or review provider settings."*). Single-provider toasts are unchanged—the title already names the provider, so the description stays the generic install/settings line.
> 
> A unit test covers the multi-provider one-click case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7928dd1437d66e01761bb2570e434b9455819a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-provider update toast to name providers in description
> When multiple provider updates are available and one-click updates are supported, the initial toast description now lists provider names (e.g., 'Updates available for Codex and OpenCode. Install now or review provider settings.'). Single-update and no-one-click cases keep the previous generic description.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7928dd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->