### PR TITLE
fix(desktop): ad-hoc sign local mac builds under their own bundle id

### DIFF
--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2078,8 +2078,16 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       }
     | undefined,
 ) {
+  // A developer's own unsigned mac build, as opposed to any CI artifact
+  // (signed or not) or a Linux/Windows build. macOS keys privacy grants
+  // (Documents folder, etc.) on bundle id + code signature, so such a build
+  // needs a real signature to hold a grant at all, and its own bundle id so
+  // it can sit next to the installed release without the two fighting over
+  // one grant and re-prompting on every launch.
+  const localMacBuild =
+    platform === "mac" && !signed && Option.isNone(yield* Config.string("CI").pipe(Config.option));
   const buildConfig: Record<string, unknown> = {
-    appId: DESKTOP_APP_ID,
+    appId: localMacBuild ? `${DESKTOP_APP_ID}.local` : DESKTOP_APP_ID,
     productName: resolveDesktopProductName(version),
     artifactName: "T3-Code-${version}-${arch}.${ext}",
     electronLanguages: [...DESKTOP_ELECTRON_LANGUAGES],
@@ -2124,7 +2132,12 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
           schemes: ["t3code", "t3code-dev"],
         },
       ],
+      // Ad-hoc sign local builds so the whole bundle (helpers included) has a
+      // stable code signature; a linker-signed Electron binary alone cannot
+      // hold a grant. Hardened runtime stays off: with an ad-hoc signature
+      // its library validation rejects the native addons.
       ...(signed ? { sign: path.join(repoRoot, "scripts/sign-macos.ts") } : {}),
+      ...(localMacBuild ? { identity: "-", hardenedRuntime: false } : {}),
       ...(macPasskeySigning
         ? {
             entitlements: macPasskeySigning.entitlementsPath,


### PR DESCRIPTION
## What Changed

For a developer's own unsigned **mac** build (`vp run dist:desktop:dmg` without `--signed`, outside CI), `scripts/build-desktop-artifact.ts` now:

- ad-hoc signs the bundle via electron-builder's `mac.identity: "-"`, with `hardenedRuntime: false` so an ad-hoc signature doesn't trip library validation on the native addons;
- uses the bundle id `com.t3tools.t3code.local` instead of the release id.

Gated on `platform === "mac" && !signed && !CI`. Signed builds, every CI artifact (including unsigned macOS previews and releases built without signing secrets), and Linux/Windows are unchanged. One file, +14/−1.

## Why

An unsigned local DMG ships an app whose only signature is Electron's linker signature (`codesign -dv` reports `Identifier=Electron`, `flags=adhoc,linker-signed`), under the same bundle id as the installed release build. macOS ties privacy grants such as Documents-folder access to bundle id + code signature, so:

- the local build can't hold a grant at all, and
- it fights the installed release (Nightly/Alpha) over the single `com.t3tools.t3code` TCC entry.

Result on a machine with a release build installed: every launch of the local build re-prompts "access files in your Documents folder" and **Allow never sticks**, for both apps. With this change the same build reports `Identifier=com.t3tools.t3code.local`, `flags=adhoc` on the app and all four helper apps, `codesign --verify --deep --strict` passes, and the grant persists across launches. The separate bundle id lets the local build sit next to the installed release without overwriting its grant.

`identity: "-"` is handled natively by app-builder-lib 26 (`MacTargetHelper.findSigningIdentity`, the `qualifier === "-"` branch), so no custom sign script is involved for the unsigned path.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

Built with Claude Fable 5 in Claude Code.

https://claude.ai/code/session_01Dzo12DZh4ZQF9mUjr26qzj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to unsigned local mac packaging in the desktop build script; release signing and CI paths are untouched.
> 
> **Overview**
> **Local unsigned macOS desktop builds** (not `--signed`, `CI` unset) now get a separate packaging path in `createBuildConfig` so they behave on a dev machine that also has a release install.
> 
> Those builds use bundle id `com.t3tools.t3code.local` instead of the production id, and electron-builder is told to **ad-hoc sign** the full app bundle (`mac.identity: "-"`) with **`hardenedRuntime: false`** so native addons still load. Signed mac builds, CI artifacts, and Linux/Windows configs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a082ab7ac3bb54e0f8ba25751d27407a31778562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ad-hoc sign local mac builds under `.local` bundle id
> Adds a `localMacBuild` flag to `createBuildConfig` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/8466/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) that is true for unsigned mac builds run outside CI. When set, the `appId` gets a `.local` suffix, and the mac config uses `identity: "-"` with `hardenedRuntime: false` for ad-hoc signing. Signed builds and other platforms are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a082ab7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->