### PR TITLE
fix(tooling): allow ignored-only staged changes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   },
   staged: {
     // Formatter only for now — no lint or typecheck on commit.
-    "*": "vp fmt",
+    "*": "vp fmt --no-error-on-unmatched-pattern",
   },
   fmt: {
     ignorePatterns: [


### PR DESCRIPTION
## Problem

The pre-commit hook sends every staged path to `vp fmt`, but Oxfmt intentionally ignores files such as `pnpm-lock.yaml` and patch files. When a commit contains only ignored files, the formatter sees zero matches and fails the commit even though there is nothing to format.

## Fix

Pass Oxfmtʼs supported `--no-error-on-unmatched-pattern` option from the Vite staged config. Supported source files are still formatted, while ignored-only commits become a successful no-op.

## Verification

- `vp fmt vite.config.ts --check`
- `vp staged --verbose` formatted the staged Vite config normally
- `vp staged --diff origin/main...79e063e67 --no-stash --verbose` ran against the exact patch/lockfile-only diff from #8467 and succeeded with zero matching files
- the commit completed through the updated pre-commit hook without bypass flags
- `git diff --cached --check`

Generated with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to pre-commit formatting behavior with no runtime, auth, or data impact.
> 
> **Overview**
> Updates the **pre-commit staged formatter** in `vite.config.ts` so `vp fmt` is invoked with **`--no-error-on-unmatched-pattern`**.
> 
> When a commit stages only paths that Oxfmt ignores (e.g. `pnpm-lock.yaml`), the hook no longer fails for “no matching files”; commits that include formattable sources still run the formatter as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6c1bddb2958b1939acbcdff4dd3aee1c811f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--no-error-on-unmatched-pattern` to staged `vp fmt` command
> Updates the staged task in [vite.config.ts](https://github.com/pingdotgg/t3code/pull/8468/files#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd) so the formatter does not error when the glob pattern matches no files. This lets staged changes consisting only of ignored files pass without a false failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed6c1bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->