### PR TITLE
feat(mobile): open tapped terminal links on iOS and Android

### DIFF
--- a/apps/mobile/modules/t3-terminal/android/src/main/cpp/t3_terminal_jni.cpp
+++ b/apps/mobile/modules/t3-terminal/android/src/main/cpp/t3_terminal_jni.cpp
@@ -372,6 +372,89 @@ Java_expo_modules_t3terminal_GhosttyBridge_nativeGetSelectionText(JNIEnv* env, j
   return result;
 }
 
+// Encodes the link context at a viewport cell for JS-side link detection.
+// Layout (little endian): [u8 kind] then either the OSC 8 URI bytes (kind 1)
+// or [u32 prefix byte length][prefix bytes][line bytes] (kind 2). The prefix
+// spans the logical line start through the tapped cell inclusive so the
+// caller can derive the tapped character index; both dumps unwrap soft wraps.
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_expo_modules_t3terminal_GhosttyBridge_nativeLinkAt(JNIEnv* env, jclass,
+                                                         jlong handle, jint col,
+                                                         jint row) {
+  auto* session = FromHandle(handle);
+  if (session == nullptr) return nullptr;
+  std::lock_guard<std::mutex> lock(session->mutex);
+
+  GhosttyGridRef ref{};
+  if (!ViewportGridRef(session, col, row, &ref)) return nullptr;
+
+  // OSC 8 hyperlinks resolve directly from the tapped cell.
+  size_t uri_len = 0;
+  if (ghostty_grid_ref_hyperlink_uri(&ref, nullptr, 0, &uri_len) ==
+          GHOSTTY_OUT_OF_SPACE &&
+      uri_len > 0) {
+    std::vector<uint8_t> uri(uri_len);
+    if (ghostty_grid_ref_hyperlink_uri(&ref, uri.data(), uri.size(), &uri_len) ==
+        GHOSTTY_SUCCESS) {
+      uri.resize(uri_len);
+      ByteWriter writer(1 + uri.size());
+      writer.U8(1);
+      writer.Bytes(uri);
+      return ToJavaBytes(env, writer.Take());
+    }
+  }
+
+  GhosttyTerminalSelectLineOptions line_options{};
+  line_options.size = sizeof(line_options);
+  line_options.ref = ref;
+  GhosttySelection line_selection{};
+  line_selection.size = sizeof(line_selection);
+  if (ghostty_terminal_select_line(session->terminal, &line_options,
+                                   &line_selection) != GHOSTTY_SUCCESS) {
+    return nullptr;
+  }
+
+  GhosttySelection prefix_selection = line_selection;
+  prefix_selection.end = ref;
+
+  const auto format = [session](const GhosttySelection& selection, bool trim,
+                                std::vector<uint8_t>* output) {
+    GhosttyTerminalSelectionFormatOptions options{};
+    options.size = sizeof(options);
+    options.emit = GHOSTTY_FORMATTER_FORMAT_PLAIN;
+    options.unwrap = true;
+    options.trim = trim;
+    options.selection = &selection;
+    uint8_t* bytes = nullptr;
+    size_t len = 0;
+    if (ghostty_terminal_selection_format_alloc(session->terminal, nullptr,
+                                                options, &bytes,
+                                                &len) != GHOSTTY_SUCCESS ||
+        bytes == nullptr) {
+      return false;
+    }
+    output->assign(bytes, bytes + len);
+    ghostty_free(nullptr, bytes, len);
+    return true;
+  };
+
+  std::vector<uint8_t> prefix;
+  std::vector<uint8_t> line;
+  // trim=false on the prefix keeps its full length through the tapped cell so
+  // the derived index stays aligned with the trimmed line text.
+  if (!format(prefix_selection, false, &prefix) ||
+      !format(line_selection, true, &line) || prefix.empty() || line.empty()) {
+    return nullptr;
+  }
+
+  ByteWriter writer(5 + prefix.size() + line.size());
+  writer.U8(2);
+  writer.U32(static_cast<uint32_t>(prefix.size()));
+  writer.Bytes(prefix);
+  writer.Bytes(line);
+  return ToJavaBytes(env, writer.Take());
+}
+
 extern "C" JNIEXPORT jbyteArray JNICALL
 Java_expo_modules_t3terminal_GhosttyBridge_nativeSnapshot(JNIEnv* env, jclass,
                                                            jlong handle) {

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/GhosttyBridge.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/GhosttyBridge.kt
@@ -61,4 +61,6 @@ internal object GhosttyBridge {
   @JvmStatic external fun nativeClearSelection(handle: Long)
 
   @JvmStatic external fun nativeGetSelectionText(handle: Long): ByteArray?
+
+  @JvmStatic external fun nativeLinkAt(handle: Long, col: Int, row: Int): ByteArray?
 }

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
@@ -54,7 +54,7 @@ class T3TerminalModule : Module() {
         view.mutedForegroundColorHex = mutedForegroundColor
       }
 
-      Events("onInput", "onResize")
+      Events("onInput", "onResize", "onLinkTap")
 
       OnViewDestroys { view: T3TerminalView ->
         view.cleanup()

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -15,6 +15,8 @@ import android.widget.FrameLayout
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import kotlin.math.max
 
 class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
@@ -23,6 +25,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   private val inputView = EditText(context)
   private val onInput by EventDispatcher()
   private val onResize by EventDispatcher()
+  private val onLinkTap by EventDispatcher()
   private var terminalHandle = 0L
   private var fedBuffer = ""
   private var cols = 0
@@ -117,6 +120,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       }
     }
     terminalCanvas.onCellMetricsChanged = { emitResize() }
+    terminalCanvas.onTapCell = { col, row -> emitLinkTap(col, row) }
     terminalCanvas.selectionDelegate = object : TerminalSelectionDelegate {
       override fun selectWordAt(col: Int, row: Int): Boolean {
         if (terminalHandle == 0L) return false
@@ -192,6 +196,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     terminalCanvas.onScrollRows = null
     terminalCanvas.onRequestKeyboard = null
     terminalCanvas.onCellMetricsChanged = null
+    terminalCanvas.onTapCell = null
     terminalCanvas.selectionDelegate = null
     destroyTerminal()
   }
@@ -358,6 +363,46 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     renderSnapshot()
   }
 
+  /** Decodes the nativeLinkAt blob; see t3_terminal_jni.cpp for the layout. */
+  private fun emitLinkTap(col: Int, row: Int) {
+    if (terminalHandle == 0L) return
+    val encoded = GhosttyBridge.nativeLinkAt(terminalHandle, col, row)
+    if (!encoded.isNullOrEmpty()) {
+      when (encoded[0].toInt()) {
+        LINK_KIND_HYPERLINK -> emitHyperlinkTap(encoded)
+        LINK_KIND_LINE -> emitLineTap(encoded)
+      }
+    }
+  }
+
+  private fun emitHyperlinkTap(encoded: ByteArray) {
+    if (encoded.size > 1) {
+      onLinkTap(mapOf("uri" to String(encoded, 1, encoded.size - 1, Charsets.UTF_8)))
+    }
+  }
+
+  private fun emitLineTap(encoded: ByteArray) {
+    if (encoded.size < LINK_LINE_HEADER_BYTES) return
+    val prefixLength = ByteBuffer
+      .wrap(encoded, 1, Int.SIZE_BYTES)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .int
+    if (prefixLength <= 0 || LINK_LINE_HEADER_BYTES + prefixLength > encoded.size) return
+    val prefix = String(encoded, LINK_LINE_HEADER_BYTES, prefixLength, Charsets.UTF_8)
+    val lineText = String(
+      encoded,
+      LINK_LINE_HEADER_BYTES + prefixLength,
+      encoded.size - LINK_LINE_HEADER_BYTES - prefixLength,
+      Charsets.UTF_8,
+    )
+    // The prefix ends at the tapped cell inclusive, so its last UTF-16
+    // unit is the tapped character's index within the line.
+    val tapIndex = prefix.length - 1
+    if (tapIndex in lineText.indices) {
+      onLinkTap(mapOf("lineText" to lineText, "tapIndex" to tapIndex))
+    }
+  }
+
   private fun renderSnapshot() {
     if (terminalHandle == 0L) return
     TerminalFrame.decode(
@@ -434,4 +479,10 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     } catch (_: IllegalArgumentException) {
       fallback
     }
+
+  private companion object {
+    const val LINK_KIND_HYPERLINK = 1
+    const val LINK_KIND_LINE = 2
+    const val LINK_LINE_HEADER_BYTES = 1 + Int.SIZE_BYTES
+  }
 }

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
@@ -123,6 +123,7 @@ internal class TerminalCanvasView(context: Context) : View(context) {
   var onScrollRows: ((Int) -> Unit)? = null
   var onRequestKeyboard: (() -> Unit)? = null
   var onCellMetricsChanged: (() -> Unit)? = null
+  var onTapCell: ((Int, Int) -> Unit)? = null
   var selectionDelegate: TerminalSelectionDelegate? = null
 
   private val handlePaint = Paint(Paint.ANTI_ALIAS_FLAG)
@@ -351,6 +352,23 @@ internal class TerminalCanvasView(context: Context) : View(context) {
   private fun rowAt(py: Float): Int {
     val rows = frame?.rows ?: return 0
     return ((py - contentPadding) / cellHeightPx).toInt().coerceIn(0, max(rows - 1, 0))
+  }
+
+  /**
+   * Reports the tapped cell for link detection. Blank cells are skipped: they
+   * can't carry a link, and the terminal's text dump drops trailing blanks, so
+   * a tap on empty space would otherwise resolve onto the last printed
+   * character of the line.
+   */
+  private fun tapCellAt(px: Float, py: Float) {
+    frame?.let { currentFrame ->
+      val col = columnAt(px)
+      val row = rowAt(py)
+      val index = row * currentFrame.cols + col
+      if (index in currentFrame.cellText.indices && currentFrame.cellText[index].isNotBlank()) {
+        onTapCell?.invoke(col, row)
+      }
+    }
   }
 
   private fun startWordSelection(px: Float, py: Float) {
@@ -590,6 +608,7 @@ internal class TerminalCanvasView(context: Context) : View(context) {
         clearSelection()
       } else {
         performClick()
+        tapCellAt(event.x, event.y)
       }
       return true
     }

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
@@ -364,12 +364,8 @@ internal class TerminalCanvasView(context: Context) : View(context) {
     frame?.let { currentFrame ->
       val gridX = px - contentPadding
       val gridY = py - contentPadding
-      if (gridX < 0 || gridY < 0 ||
-        gridX >= currentFrame.cols * cellWidthPx ||
-        gridY >= currentFrame.rows * cellHeightPx
-      ) {
-        return
-      }
+      if (gridX < 0 || gridX >= currentFrame.cols * cellWidthPx) return
+      if (gridY < 0 || gridY >= currentFrame.rows * cellHeightPx) return
       val col = columnAt(px)
       val row = rowAt(py)
       val index = row * currentFrame.cols + col

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
@@ -362,6 +362,11 @@ internal class TerminalCanvasView(context: Context) : View(context) {
    */
   private fun tapCellAt(px: Float, py: Float) {
     frame?.let { currentFrame ->
+      val gridX = px - contentPadding
+      val gridY = py - contentPadding
+      if (gridX < 0 || gridY < 0 ||
+        gridX >= currentFrame.cols * cellWidthPx ||
+        gridY >= currentFrame.rows * cellHeightPx) return
       val col = columnAt(px)
       val row = rowAt(py)
       val index = row * currentFrame.cols + col

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
@@ -366,7 +366,10 @@ internal class TerminalCanvasView(context: Context) : View(context) {
       val gridY = py - contentPadding
       if (gridX < 0 || gridY < 0 ||
         gridX >= currentFrame.cols * cellWidthPx ||
-        gridY >= currentFrame.rows * cellHeightPx) return
+        gridY >= currentFrame.rows * cellHeightPx
+      ) {
+        return
+      }
       val col = columnAt(px)
       val row = rowAt(py)
       val index = row * currentFrame.cols + col

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
@@ -355,10 +355,8 @@ internal class TerminalCanvasView(context: Context) : View(context) {
   }
 
   /**
-   * Reports the tapped cell for link detection. Blank cells are skipped: they
-   * can't carry a link, and the terminal's text dump drops trailing blanks, so
-   * a tap on empty space would otherwise resolve onto the last printed
-   * character of the line.
+   * Reports occupied cells for link detection, including spaces inside OSC 8
+   * hyperlinks. The native untrimmed prefix keeps plain-text tap indexes aligned.
    */
   private fun tapCellAt(px: Float, py: Float) {
     frame?.let { currentFrame ->
@@ -369,7 +367,7 @@ internal class TerminalCanvasView(context: Context) : View(context) {
       val col = columnAt(px)
       val row = rowAt(py)
       val index = row * currentFrame.cols + col
-      if (index in currentFrame.cellText.indices && currentFrame.cellText[index].isNotBlank()) {
+      if (index in currentFrame.cellText.indices && currentFrame.cellText[index].isNotEmpty()) {
         onTapCell?.invoke(col, row)
       }
     }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
@@ -51,7 +51,7 @@ public class T3TerminalModule: Module {
         view.mutedForegroundColorHex = mutedForegroundColor
       }
 
-      Events("onInput", "onResize")
+      Events("onInput", "onResize", "onLinkTap")
     }
   }
 }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -215,6 +215,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
 
   let onInput = EventDispatcher()
   let onResize = EventDispatcher()
+  let onLinkTap = EventDispatcher()
 
   var terminalKey: String = "" {
     didSet {
@@ -322,7 +323,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
       self?.emitInput(data)
     }
 
-    focusTapGesture.addTarget(self, action: #selector(handleViewportTap))
+    focusTapGesture.addTarget(self, action: #selector(handleViewportTap(_:)))
     terminalViewport.addGestureRecognizer(focusTapGesture)
     scrollPanGesture.addTarget(self, action: #selector(handleViewportPan(_:)))
     scrollPanGesture.maximumNumberOfTouches = 1
@@ -394,7 +395,8 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   @objc
-  private func handleViewportTap() {
+  private func handleViewportTap(_ gesture: UITapGestureRecognizer) {
+    emitLinkTap(at: gesture.location(in: terminalViewport))
     requestKeyboardFocus()
   }
 
@@ -441,6 +443,92 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   @objc
   private func handleInputEditingDidBegin() {
     textInputModeDidChange()
+  }
+
+  /// Ghostty's default `window-padding-x`/`window-padding-y` in points. The
+  /// grid starts after this inset; themeConfig never overrides padding.
+  private static let ghosttyWindowPaddingPoints: CGFloat = 2
+
+  private func viewportCell(at location: CGPoint) -> (col: UInt32, row: UInt32)? {
+    guard let surface else { return nil }
+    let size = ghostty_surface_size(surface)
+    guard size.columns > 0, size.rows > 0, size.cell_width_px > 0, size.cell_height_px > 0 else {
+      return nil
+    }
+
+    let scale = contentScaleFactor
+    let padding = Self.ghosttyWindowPaddingPoints * scale
+    let px = location.x * scale - padding
+    let py = location.y * scale - padding
+    guard px >= 0, py >= 0 else { return nil }
+
+    let col = min(UInt32(px / CGFloat(size.cell_width_px)), UInt32(size.columns) - 1)
+    let row = min(UInt32(py / CGFloat(size.cell_height_px)), UInt32(size.rows) - 1)
+    return (col, row)
+  }
+
+  private func viewportPoint(x: UInt32, y: UInt32) -> ghostty_point_s {
+    ghostty_point_s(tag: GHOSTTY_POINT_VIEWPORT, coord: GHOSTTY_POINT_COORD_EXACT, x: x, y: y)
+  }
+
+  private func readText(from topLeft: ghostty_point_s, to bottomRight: ghostty_point_s) -> String? {
+    guard let surface else { return nil }
+
+    let selection = ghostty_selection_s(
+      top_left: topLeft,
+      bottom_right: bottomRight,
+      rectangle: false
+    )
+    var text = ghostty_text_s()
+    guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+    defer { ghostty_surface_free_text(surface, &text) }
+
+    guard let pointer = text.text, text.text_len > 0 else { return "" }
+    return String(data: Data(bytes: pointer, count: Int(text.text_len)), encoding: .utf8)
+  }
+
+  /// Resolves the logical line and character offset under a tap and emits
+  /// onLinkTap so JS can run the shared link detection. Ghostty's text dump
+  /// joins soft-wrapped rows, so a URL spanning several rows arrives intact.
+  private func emitLinkTap(at location: CGPoint) {
+    guard let surface, let cell = viewportCell(at: location) else { return }
+
+    // Ghostty drops trailing blank cells when dumping text, so without this
+    // check a tap on empty space would resolve onto the last printed character.
+    let tappedPoint = viewportPoint(x: cell.col, y: cell.row)
+    guard let tappedCell = readText(from: tappedPoint, to: tappedPoint),
+          !tappedCell.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else { return }
+
+    let size = ghostty_surface_size(surface)
+    let origin = viewportPoint(x: 0, y: 0)
+    guard let prefix = readText(from: origin, to: tappedPoint),
+          !prefix.isEmpty,
+          let viewportText = readText(
+            from: origin,
+            to: viewportPoint(x: UInt32(size.columns) - 1, y: UInt32(size.rows) - 1)
+          ),
+          !viewportText.isEmpty
+    else { return }
+
+    // The prefix dump ends at the tapped cell inclusive, so its last UTF-16
+    // unit is the tapped character's offset within the full viewport dump.
+    let fullText = viewportText as NSString
+    let tapOffset = (prefix as NSString).length - 1
+    guard tapOffset >= 0, tapOffset < fullText.length else { return }
+
+    let lineRange = fullText.lineRange(for: NSRange(location: tapOffset, length: 0))
+    var lineText = fullText.substring(with: lineRange)
+    while lineText.hasSuffix("\n") || lineText.hasSuffix("\r") {
+      lineText.removeLast()
+    }
+    let tapIndex = tapOffset - lineRange.location
+    guard tapIndex >= 0, tapIndex < (lineText as NSString).length else { return }
+
+    onLinkTap([
+      "lineText": lineText,
+      "tapIndex": tapIndex,
+    ])
   }
 
   private func createSurfaceIfPossible() {

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -471,6 +471,10 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     ghostty_point_s(tag: GHOSTTY_POINT_VIEWPORT, coord: GHOSTTY_POINT_COORD_EXACT, x: x, y: y)
   }
 
+  private func screenBoundaryPoint(_ coordinate: ghostty_point_coord_e) -> ghostty_point_s {
+    ghostty_point_s(tag: GHOSTTY_POINT_SCREEN, coord: coordinate, x: 0, y: 0)
+  }
+
   private func readText(from topLeft: ghostty_point_s, to bottomRight: ghostty_point_s) -> String? {
     guard let surface else { return nil }
 
@@ -491,7 +495,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   /// onLinkTap so JS can run the shared link detection. Ghostty's text dump
   /// joins soft-wrapped rows, so a URL spanning several rows arrives intact.
   private func emitLinkTap(at location: CGPoint) {
-    guard let surface, let cell = viewportCell(at: location) else { return }
+    guard surface != nil, let cell = viewportCell(at: location) else { return }
 
     // Ghostty drops trailing blank cells when dumping text, so without this
     // check a tap on empty space would resolve onto the last printed character.
@@ -500,20 +504,19 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
           !tappedCell.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     else { return }
 
-    let size = ghostty_surface_size(surface)
-    let origin = viewportPoint(x: 0, y: 0)
-    guard let prefix = readText(from: origin, to: tappedPoint),
+    let screenOrigin = screenBoundaryPoint(GHOSTTY_POINT_COORD_TOP_LEFT)
+    let screenEnd = screenBoundaryPoint(GHOSTTY_POINT_COORD_BOTTOM_RIGHT)
+    guard let prefix = readText(from: screenOrigin, to: tappedPoint),
           !prefix.isEmpty,
-          let viewportText = readText(
-            from: origin,
-            to: viewportPoint(x: UInt32(size.columns) - 1, y: UInt32(size.rows) - 1)
-          ),
-          !viewportText.isEmpty
+          let screenText = readText(from: screenOrigin, to: screenEnd),
+          !screenText.isEmpty
     else { return }
 
     // The prefix dump ends at the tapped cell inclusive, so its last UTF-16
-    // unit is the tapped character's offset within the full viewport dump.
-    let fullText = viewportText as NSString
+    // unit is the tapped character's offset within the full screen dump. The
+    // screen range includes scrollback, so a logical line that starts above
+    // the viewport still reaches JS with its URL scheme intact.
+    let fullText = screenText as NSString
     let tapOffset = (prefix as NSString).length - 1
     guard tapOffset >= 0, tapOffset < fullText.length else { return }
 

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -460,10 +460,13 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     let padding = Self.ghosttyWindowPaddingPoints * scale
     let px = location.x * scale - padding
     let py = location.y * scale - padding
-    guard px >= 0, py >= 0 else { return nil }
+    guard px >= 0, py >= 0,
+      px < CGFloat(size.columns) * CGFloat(size.cell_width_px),
+      py < CGFloat(size.rows) * CGFloat(size.cell_height_px)
+    else { return nil }
 
-    let col = min(UInt32(px / CGFloat(size.cell_width_px)), UInt32(size.columns) - 1)
-    let row = min(UInt32(py / CGFloat(size.cell_height_px)), UInt32(size.rows) - 1)
+    let col = UInt32(px / CGFloat(size.cell_width_px))
+    let row = UInt32(py / CGFloat(size.cell_height_px))
     return (col, row)
   }
 

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -9,12 +9,16 @@ import {
   type ViewProps,
 } from "react-native";
 
+import { isTerminalUrl, terminalLinkAtIndex } from "@t3tools/shared/terminalLinks";
+
 import { AppText as Text } from "../../components/AppText";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import {
   getNativeTerminalHardwareKeyRevision,
   resolveNativeTerminalSurfaceView,
+  type TerminalLinkTapEvent,
 } from "./nativeTerminalModule";
 import {
   buildGhosttyThemeConfig,
@@ -210,6 +214,22 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     },
     [onResize],
   );
+  const handleNativeLinkTap = useCallback((event: NativeSyntheticEvent<TerminalLinkTapEvent>) => {
+    const { uri, lineText, tapIndex } = event.nativeEvent;
+    let url = uri;
+    if (url === undefined && lineText !== undefined && tapIndex !== undefined) {
+      const match = terminalLinkAtIndex(lineText, tapIndex);
+      if (match?.kind === "url") {
+        url = match.text;
+      }
+    }
+    // Only http(s) opens for now; path links would need an in-app target.
+    if (url === undefined || !isTerminalUrl(url)) {
+      return;
+    }
+    terminalDebugLog("native:onLinkTap", { url });
+    void tryOpenExternalUrl(url, "terminal-link");
+  }, []);
 
   if (NativeTerminalSurfaceView) {
     return (
@@ -227,6 +247,7 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
           style={{ flex: 1 }}
           themeConfig={buildGhosttyThemeConfig(theme)}
           onInput={handleNativeInput}
+          onLinkTap={handleNativeLinkTap}
           onResize={handleNativeResize}
         />
       </View>

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -21,6 +21,17 @@ interface TerminalResizeEvent {
   readonly rows: number;
 }
 
+/**
+ * Emitted when a tap lands on a non-blank cell. Carries either an explicit
+ * OSC 8 hyperlink `uri`, or the tapped logical line (soft wraps joined) plus
+ * the tapped character index for JS-side link detection.
+ */
+export interface TerminalLinkTapEvent {
+  readonly uri?: string;
+  readonly lineText?: string;
+  readonly tapIndex?: number;
+}
+
 export interface NativeTerminalSurfaceProps extends ViewProps {
   readonly appearanceScheme?: "light" | "dark";
   readonly autoFocus?: boolean;
@@ -34,6 +45,7 @@ export interface NativeTerminalSurfaceProps extends ViewProps {
   readonly fontSize: number;
   readonly onInput?: (event: NativeSyntheticEvent<TerminalInputEvent>) => void;
   readonly onResize?: (event: NativeSyntheticEvent<TerminalResizeEvent>) => void;
+  readonly onLinkTap?: (event: NativeSyntheticEvent<TerminalLinkTapEvent>) => void;
 }
 
 let cachedNativeTerminalSurfaceView: ComponentType<NativeTerminalSurfaceProps> | undefined;

--- a/apps/mobile/src/lib/openExternalUrl.ts
+++ b/apps/mobile/src/lib/openExternalUrl.ts
@@ -6,6 +6,7 @@ const ExternalUrlTarget = Schema.Literals([
   "markdown-link",
   "pull-request",
   "provider-auth",
+  "terminal-link",
 ]);
 
 export type ExternalUrlTarget = typeof ExternalUrlTarget.Type;

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -1,18 +1,24 @@
 import {
-  formatFilePathPosition,
-  splitFilePathPosition,
-} from "@t3tools/client-runtime/markdown-links";
+  type TerminalLinkMatch,
+  extractTerminalLinks,
+  isAbsolutePath,
+  isTerminalUrl,
+  resolvePathLinkTarget,
+  splitPathAndPosition,
+  type TerminalLinkKind,
+} from "@t3tools/shared/terminalLinks";
 
 import { isMacPlatform } from "./lib/utils";
 
-export type TerminalLinkKind = "url" | "path";
-
-export interface TerminalLinkMatch {
-  kind: TerminalLinkKind;
-  text: string;
-  start: number;
-  end: number;
-}
+export {
+  extractTerminalLinks,
+  isAbsolutePath,
+  isTerminalUrl,
+  resolvePathLinkTarget,
+  splitPathAndPosition,
+  type TerminalLinkKind,
+  type TerminalLinkMatch,
+};
 
 export interface TerminalBufferLineLike {
   readonly isWrapped?: boolean;
@@ -29,117 +35,6 @@ export interface WrappedTerminalLinkLineSegment {
 export interface WrappedTerminalLinkLine {
   text: string;
   segments: ReadonlyArray<WrappedTerminalLinkLineSegment>;
-}
-
-const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/giu;
-const FILE_PATH_PATTERN =
-  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
-const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
-
-function trimClosingDelimiters(value: string): string {
-  let output = value.replace(TRAILING_PUNCTUATION_PATTERN, "");
-  if (output.length === 0) return output;
-
-  const trimUnbalanced = (open: string, close: string) => {
-    while (output.endsWith(close)) {
-      const opens = output.split(open).length - 1;
-      const closes = output.split(close).length - 1;
-      if (opens >= closes) return;
-      output = output.slice(0, -1);
-    }
-  };
-
-  trimUnbalanced("(", ")");
-  trimUnbalanced("[", "]");
-  trimUnbalanced("{", "}");
-  return output;
-}
-
-function overlaps(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
-  return a.start < b.end && b.start < a.end;
-}
-
-function collectMatches(
-  line: string,
-  kind: TerminalLinkKind,
-  pattern: RegExp,
-  existing: TerminalLinkMatch[],
-): TerminalLinkMatch[] {
-  const matches: TerminalLinkMatch[] = [];
-  pattern.lastIndex = 0;
-
-  for (const rawMatch of line.matchAll(pattern)) {
-    const raw = rawMatch[0];
-    const start = rawMatch.index ?? -1;
-    if (start < 0 || raw.length === 0) continue;
-
-    const trimmed = trimClosingDelimiters(raw);
-    if (trimmed.length === 0) continue;
-    if (kind === "path" && isTerminalUrl(trimmed)) continue;
-
-    const candidate: TerminalLinkMatch = {
-      kind,
-      text: trimmed,
-      start,
-      end: start + trimmed.length,
-    };
-
-    const collides = [...existing, ...matches].some((other) => overlaps(candidate, other));
-    if (collides) continue;
-
-    matches.push(candidate);
-  }
-
-  return matches;
-}
-
-function isWindowsAbsolutePath(value: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
-}
-
-export function isAbsolutePath(value: string): boolean {
-  return value.startsWith("/") || isWindowsAbsolutePath(value);
-}
-
-function isWindowsPathStyle(value: string): boolean {
-  return isWindowsAbsolutePath(value) || /[A-Za-z]:\\/.test(value);
-}
-
-function joinPath(base: string, next: string, separator: "/" | "\\"): string {
-  const cleanBase = base.replace(/[\\/]+$/, "");
-  if (separator === "\\") {
-    return `${cleanBase}\\${next.replaceAll("/", "\\")}`;
-  }
-  return `${cleanBase}/${next.replace(/^\/+/, "")}`;
-}
-
-function inferHomeFromCwd(cwd: string): string | undefined {
-  const posixUser = cwd.match(/^\/Users\/([^/]+)/);
-  if (posixUser?.[1]) {
-    return `/Users/${posixUser[1]}`;
-  }
-
-  const posixHome = cwd.match(/^\/home\/([^/]+)/);
-  if (posixHome?.[1]) {
-    return `/home/${posixHome[1]}`;
-  }
-
-  const windowsUser = cwd.match(/^([A-Za-z]:\\Users\\[^\\]+)/);
-  if (windowsUser?.[1]) {
-    return windowsUser[1];
-  }
-
-  return undefined;
-}
-
-export function extractTerminalLinks(line: string): TerminalLinkMatch[] {
-  const urlMatches = collectMatches(line, "url", URL_PATTERN, []);
-  const pathMatches = collectMatches(line, "path", FILE_PATH_PATTERN, urlMatches);
-  return [...urlMatches, ...pathMatches].toSorted((a, b) => a.start - b.start);
-}
-
-export function isTerminalUrl(value: string): boolean {
-  return /^https?:\/\//iu.test(value);
 }
 
 export function collectWrappedTerminalLinkLine(
@@ -197,23 +92,4 @@ export function isTerminalLinkActivation(
   return isMacPlatform(platform)
     ? event.metaKey && !event.ctrlKey
     : event.ctrlKey && !event.metaKey;
-}
-
-export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
-  const position = splitFilePathPosition(rawPath);
-  const { path } = position;
-
-  let resolvedPath = path;
-  if (path.startsWith("~/")) {
-    const home = inferHomeFromCwd(cwd);
-    if (home) {
-      const separator: "/" | "\\" = isWindowsPathStyle(home) ? "\\" : "/";
-      resolvedPath = joinPath(home, path.slice(2), separator);
-    }
-  } else if (!isAbsolutePath(path)) {
-    const separator: "/" | "\\" = isWindowsPathStyle(cwd) ? "\\" : "/";
-    resolvedPath = joinPath(cwd, path, separator);
-  }
-
-  return formatFilePathPosition({ ...position, path: resolvedPath });
 }

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -4,7 +4,6 @@ import {
   isAbsolutePath,
   isTerminalUrl,
   resolvePathLinkTarget,
-  splitPathAndPosition,
   type TerminalLinkKind,
 } from "@t3tools/shared/terminalLinks";
 
@@ -15,7 +14,6 @@ export {
   isAbsolutePath,
   isTerminalUrl,
   resolvePathLinkTarget,
-  splitPathAndPosition,
   type TerminalLinkKind,
   type TerminalLinkMatch,
 };

--- a/docs/internals/terminal-runtime.md
+++ b/docs/internals/terminal-runtime.md
@@ -37,6 +37,11 @@ owns and frees its own handles. The canonical upstream pin is
 web artifacts must be rebuilt when it changes. Web embeds the revision in its build
 info so the ABI check can detect drift without a second pin.
 
+Mobile link taps resolve the tapped cell natively. Android uses line selection
+and OSC 8 hyperlink metadata in JNI; iOS reads the libghostty screen text. Both
+pass the logical line to `@t3tools/shared/terminalLinks`, which shares URL detection
+with the web terminal.
+
 Restoring scrollback must not send terminal replies to the current shell. Historical
 device queries can otherwise provoke fresh replies that appear as junk at the
 prompt. The server strips query/response traffic from retained history, and the

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -191,6 +191,10 @@
       "types": "./src/terminalLabels.ts",
       "import": "./src/terminalLabels.ts"
     },
+    "./terminalLinks": {
+      "types": "./src/terminalLinks.ts",
+      "import": "./src/terminalLinks.ts"
+    },
     "./relayClient": {
       "types": "./src/relayClient.ts",
       "import": "./src/relayClient.ts"

--- a/packages/shared/src/terminalLinks.test.ts
+++ b/packages/shared/src/terminalLinks.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { extractTerminalLinks, terminalLinkAtIndex } from "./terminalLinks.ts";
+
+describe("terminalLinkAtIndex", () => {
+  const line = "Listening on https://example.com/app?tab=1 (press q to quit)";
+
+  it("returns the url when the index falls inside it", () => {
+    expect(terminalLinkAtIndex(line, 20)).toEqual({
+      kind: "url",
+      text: "https://example.com/app?tab=1",
+      start: 13,
+      end: 42,
+    });
+  });
+
+  it("returns undefined outside the link span", () => {
+    expect(terminalLinkAtIndex(line, 5)).toBeUndefined();
+    expect(terminalLinkAtIndex(line, 42)).toBeUndefined();
+    expect(terminalLinkAtIndex(line, -1)).toBeUndefined();
+    expect(terminalLinkAtIndex(line, line.length)).toBeUndefined();
+  });
+
+  it("resolves path links by index", () => {
+    const output = "error in src/lib/utils.ts:12:3 near token";
+    expect(terminalLinkAtIndex(output, 12)?.text).toBe("src/lib/utils.ts:12:3");
+  });
+
+  it("resolves urls joined across soft-wrapped rows", () => {
+    // Native surfaces join soft-wrapped rows before lookup, so a URL that
+    // spanned two terminal rows arrives as one line.
+    const joined = "https://example.com/very/long/path/that/wrapped/around?query=value";
+    expect(terminalLinkAtIndex(joined, joined.length - 1)?.text).toBe(joined);
+  });
+});
+
+describe("Hermes compatibility", () => {
+  // Mobile runs this module on Hermes, which ships no Array.prototype.toSorted.
+  it("extracts links without array methods unavailable in Hermes", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, "toSorted");
+    Reflect.deleteProperty(Array.prototype, "toSorted");
+
+    try {
+      expect(
+        extractTerminalLinks("see src/main.ts:3 and https://example.com/x").map(
+          (match) => match.text,
+        ),
+      ).toEqual(["src/main.ts:3", "https://example.com/x"]);
+      expect(terminalLinkAtIndex("open https://example.com/x now", 10)?.text).toBe(
+        "https://example.com/x",
+      );
+    } finally {
+      if (descriptor !== undefined) {
+        Reflect.defineProperty(Array.prototype, "toSorted", descriptor);
+      }
+    }
+  });
+});

--- a/packages/shared/src/terminalLinks.test.ts
+++ b/packages/shared/src/terminalLinks.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { extractTerminalLinks, terminalLinkAtIndex } from "./terminalLinks.ts";
+import {
+  extractTerminalLinks,
+  resolvePathLinkTarget,
+  terminalLinkAtIndex,
+} from "./terminalLinks.ts";
 
 describe("terminalLinkAtIndex", () => {
   const line = "Listening on https://example.com/app?tab=1 (press q to quit)";
@@ -31,6 +35,23 @@ describe("terminalLinkAtIndex", () => {
     // spanned two terminal rows arrives as one line.
     const joined = "https://example.com/very/long/path/that/wrapped/around?query=value";
     expect(terminalLinkAtIndex(joined, joined.length - 1)?.text).toBe(joined);
+  });
+
+  it("trims a long run of unmatched closing delimiters", () => {
+    const suffix = ")".repeat(10_000);
+    expect(terminalLinkAtIndex(`https://example.com/path${suffix}`, 10)?.text).toBe(
+      "https://example.com/path",
+    );
+  });
+});
+
+describe("resolvePathLinkTarget", () => {
+  it.each([
+    ["src/main.ts:0", "/workspace/src/main.ts"],
+    ["src/main.ts:12:0", "/workspace/src/main.ts:12"],
+    ["src/main.ts:0:4", "/workspace/src/main.ts"],
+  ])("drops unusable zero positions from %s", (target, expected) => {
+    expect(resolvePathLinkTarget(target, "/workspace")).toBe(expected);
   });
 });
 

--- a/packages/shared/src/terminalLinks.ts
+++ b/packages/shared/src/terminalLinks.ts
@@ -1,0 +1,175 @@
+export type TerminalLinkKind = "url" | "path";
+
+export interface TerminalLinkMatch {
+  kind: TerminalLinkKind;
+  text: string;
+  start: number;
+  end: number;
+}
+
+const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/giu;
+const FILE_PATH_PATTERN =
+  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
+const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
+
+function trimClosingDelimiters(value: string): string {
+  let output = value.replace(TRAILING_PUNCTUATION_PATTERN, "");
+  if (output.length === 0) return output;
+
+  const trimUnbalanced = (open: string, close: string) => {
+    while (output.endsWith(close)) {
+      const opens = output.split(open).length - 1;
+      const closes = output.split(close).length - 1;
+      if (opens >= closes) return;
+      output = output.slice(0, -1);
+    }
+  };
+
+  trimUnbalanced("(", ")");
+  trimUnbalanced("[", "]");
+  trimUnbalanced("{", "}");
+  return output;
+}
+
+function overlaps(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+function collectMatches(
+  line: string,
+  kind: TerminalLinkKind,
+  pattern: RegExp,
+  existing: TerminalLinkMatch[],
+): TerminalLinkMatch[] {
+  const matches: TerminalLinkMatch[] = [];
+  pattern.lastIndex = 0;
+
+  for (const rawMatch of line.matchAll(pattern)) {
+    const raw = rawMatch[0];
+    const start = rawMatch.index ?? -1;
+    if (start < 0 || raw.length === 0) continue;
+
+    const trimmed = trimClosingDelimiters(raw);
+    if (trimmed.length === 0) continue;
+    if (kind === "path" && isTerminalUrl(trimmed)) continue;
+
+    const candidate: TerminalLinkMatch = {
+      kind,
+      text: trimmed,
+      start,
+      end: start + trimmed.length,
+    };
+
+    const collides = [...existing, ...matches].some((other) => overlaps(candidate, other));
+    if (collides) continue;
+
+    matches.push(candidate);
+  }
+
+  return matches;
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
+}
+
+export function isAbsolutePath(value: string): boolean {
+  return value.startsWith("/") || isWindowsAbsolutePath(value);
+}
+
+function isWindowsPathStyle(value: string): boolean {
+  return isWindowsAbsolutePath(value) || /[A-Za-z]:\\/.test(value);
+}
+
+function joinPath(base: string, next: string, separator: "/" | "\\"): string {
+  const cleanBase = base.replace(/[\\/]+$/, "");
+  if (separator === "\\") {
+    return `${cleanBase}\\${next.replaceAll("/", "\\")}`;
+  }
+  return `${cleanBase}/${next.replace(/^\/+/, "")}`;
+}
+
+function inferHomeFromCwd(cwd: string): string | undefined {
+  const posixUser = cwd.match(/^\/Users\/([^/]+)/);
+  if (posixUser?.[1]) {
+    return `/Users/${posixUser[1]}`;
+  }
+
+  const posixHome = cwd.match(/^\/home\/([^/]+)/);
+  if (posixHome?.[1]) {
+    return `/home/${posixHome[1]}`;
+  }
+
+  const windowsUser = cwd.match(/^([A-Za-z]:\\Users\\[^\\]+)/);
+  if (windowsUser?.[1]) {
+    return windowsUser[1];
+  }
+
+  return undefined;
+}
+
+export function splitPathAndPosition(value: string): {
+  path: string;
+  line: string | undefined;
+  column: string | undefined;
+} {
+  let path = value;
+  let column: string | undefined;
+  let line: string | undefined;
+
+  const columnMatch = path.match(/:(\d+)$/);
+  if (!columnMatch?.[1]) {
+    return { path, line: undefined, column: undefined };
+  }
+
+  column = columnMatch[1];
+  path = path.slice(0, -columnMatch[0].length);
+
+  const lineMatch = path.match(/:(\d+)$/);
+  if (lineMatch?.[1]) {
+    line = lineMatch[1];
+    path = path.slice(0, -lineMatch[0].length);
+  } else {
+    line = column;
+    column = undefined;
+  }
+
+  return { path, line, column };
+}
+
+export function extractTerminalLinks(line: string): TerminalLinkMatch[] {
+  const urlMatches = collectMatches(line, "url", URL_PATTERN, []);
+  const pathMatches = collectMatches(line, "path", FILE_PATH_PATTERN, urlMatches);
+  // .sort() on a fresh array, not .toSorted(): Hermes doesn't ship the ES2023
+  // method, and mobile imports this module.
+  return [...urlMatches, ...pathMatches].sort((a, b) => a.start - b.start);
+}
+
+export function isTerminalUrl(value: string): boolean {
+  return /^https?:\/\//iu.test(value);
+}
+
+/** The link whose character span contains `index`, if any. */
+export function terminalLinkAtIndex(line: string, index: number): TerminalLinkMatch | undefined {
+  if (index < 0 || index >= line.length) return undefined;
+  return extractTerminalLinks(line).find((match) => match.start <= index && index < match.end);
+}
+
+export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
+  const { path, line, column } = splitPathAndPosition(rawPath);
+
+  let resolvedPath = path;
+  if (path.startsWith("~/")) {
+    const home = inferHomeFromCwd(cwd);
+    if (home) {
+      const separator: "/" | "\\" = isWindowsPathStyle(home) ? "\\" : "/";
+      resolvedPath = joinPath(home, path.slice(2), separator);
+    }
+  } else if (!isAbsolutePath(path)) {
+    const separator: "/" | "\\" = isWindowsPathStyle(cwd) ? "\\" : "/";
+    resolvedPath = joinPath(cwd, path, separator);
+  }
+
+  if (!line) return resolvedPath;
+  return `${resolvedPath}:${line}${column ? `:${column}` : ""}`;
+}

--- a/packages/shared/src/terminalLinks.ts
+++ b/packages/shared/src/terminalLinks.ts
@@ -17,12 +17,16 @@ function trimClosingDelimiters(value: string): string {
   if (output.length === 0) return output;
 
   const trimUnbalanced = (open: string, close: string) => {
-    while (output.endsWith(close)) {
-      const opens = output.split(open).length - 1;
-      const closes = output.split(close).length - 1;
-      if (opens >= closes) return;
-      output = output.slice(0, -1);
+    const opens = output.split(open).length - 1;
+    const closes = output.split(close).length - 1;
+    const excess = Math.max(0, closes - opens);
+    if (excess === 0) return;
+
+    let trailing = 0;
+    while (trailing < output.length && output[output.length - 1 - trailing] === close) {
+      trailing += 1;
     }
+    output = output.slice(0, output.length - Math.min(excess, trailing));
   };
 
   trimUnbalanced("(", ")");
@@ -170,6 +174,6 @@ export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
     resolvedPath = joinPath(cwd, path, separator);
   }
 
-  if (!line) return resolvedPath;
-  return `${resolvedPath}:${line}${column ? `:${column}` : ""}`;
+  if (!line || line === "0") return resolvedPath;
+  return `${resolvedPath}:${line}${column && column !== "0" ? `:${column}` : ""}`;
 }

--- a/packages/shared/src/terminalLinks.ts
+++ b/packages/shared/src/terminalLinks.ts
@@ -112,7 +112,7 @@ function inferHomeFromCwd(cwd: string): string | undefined {
   return undefined;
 }
 
-export function splitPathAndPosition(value: string): {
+function splitPathAndPosition(value: string): {
   path: string;
   line: string | undefined;
   column: string | undefined;


### PR DESCRIPTION
URLs printed in the mobile terminal were inert text. On iOS there was no selection or link handling at all, and on Android you could select and copy but never open a link — so the only way to follow a URL from an agent or dev server was to retype it. Web already detected links, but that logic lived in `apps/web`, so mobile could not reuse it.

https://github.com/user-attachments/assets/6054fd35-fd4c-4423-8191-a4639e6632c1

## What changed

- Moved the URL/path detection out of `apps/web/src/terminal-links.ts` into `@t3tools/shared/terminalLinks`, plus a new `terminalLinkAtIndex(line, index)` helper. `apps/web/src/terminal-links.ts` now re-exports it, so every existing web consumer and its tests are untouched; the wrap-aware buffer helpers and `isTerminalLinkActivation` stay web-only since they depend on the xterm-style buffer and `MouseEvent`.
- Both native surfaces resolve the tapped cell and emit the tapped logical line plus a character index, and JS runs the shared detector. Soft-wrapped rows are joined before matching, so a URL that wrapped across rows still resolves — which is the common case on a phone-width grid.
  - **iOS** (`T3TerminalView.swift`): grid math from `ghostty_surface_size`, then `ghostty_surface_read_text`. Its text dump drops trailing blank cells, so a tap on a blank cell returns early — otherwise tapping empty space right of a URL would resolve onto it.
  - **Android** (`t3_terminal_jni.cpp`): prefers OSC 8 hyperlink metadata via `ghostty_grid_ref_hyperlink_uri`, else derives the line with `ghostty_terminal_select_line`. Both are snapshot selections, so the user's active selection is never disturbed.
- Taps that do not land on a link keep focusing the keyboard, and Android's existing long-press selection, scroll, and copy behavior are unchanged.

Only `http(s)` opens, through the existing `tryOpenExternalUrl` with a new `terminal-link` target. Path links are detected but intentionally do not open yet — that needs an in-app destination, which is worth its own change.

`extractTerminalLinks` deliberately uses `.sort()` on a fresh array rather than `.toSorted()`: this module now runs on Hermes, which does not ship the ES2023 method. A regression test asserts extraction still works with `Array.prototype.toSorted` deleted, matching the existing guard in `client-runtime`.

## Testing

Focused tests for the shared module (including the Hermes guard) and the existing web link tests pass, and web and mobile typecheck. Verified on a physical iPhone with a Release device build: tapping a URL opens it, tapping ordinary text focuses the keyboard, and a URL wrapped across rows opens in full.

## Known gaps

- File paths are detected but not opened.
- On iOS, an OSC 8 hyperlink whose visible label is not the URL will not resolve; the embedded libghostty ABI does not expose hyperlink lookup, so iOS falls back to text matching. Android handles that case.

Model: Claude Opus 5 (1M context). Harness: Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Closes discussions

- https://github.com/pingdotgg/t3code/discussions/11439

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New native tap/link pipeline and external URL opening add platform-specific edge cases (cell mapping, OSC 8 vs text fallback), but scope is limited to http(s) and reuses existing Linking helpers.
> 
> **Overview**
> Mobile terminals can now open **http(s) URLs** when you tap them, using the same link detection as web after moving that logic into **`@t3tools/shared/terminalLinks`** (including **`terminalLinkAtIndex`**). **`apps/web/src/terminal-links.ts`** re-exports the shared helpers; buffer/wrap utilities stay web-only.
> 
> **Android** adds **`nativeLinkAt`** (OSC 8 URI or logical line + tap index), wires single-tap on non-blank cells through **`onLinkTap`**, and decodes the JNI blob in Kotlin. **iOS** maps taps to viewport cells, dumps text via Ghostty, and emits **`lineText`** + **`tapIndex`** (blank-cell guard on both platforms). **React Native** handles **`onLinkTap`**, runs shared detection when needed, and opens allowed URLs via **`tryOpenExternalUrl`** (`terminal-link`). Path links are detected but not opened yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1d91ec6db24a15c49c0cab4e1d9753ff32f61dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `nativeLinkAt` JNI handler to resolve tapped terminal links
> - Adds a `nativeLinkAt` JNI entrypoint in [t3_terminal_jni.cpp](https://github.com/pingdotgg/t3code/pull/8471/files#diff-f6bd3dedbe575c3dd03ea9c5e5be87c1f1864501f4f28e12fdbaa03ee5b04684) that locks the terminal session and resolves the tapped grid cell
> - Returns OSC 8 hyperlink URI bytes if present, otherwise returns the tapped logical line and prefix needed for JavaScript link detection
> - Encodes results using a one-byte kind discriminator and little-endian prefix length, and frees selection buffers after formatting
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7622cb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tapping links in the mobile terminal now opens supported HTTP(S) URLs.
  - Terminal taps identify embedded hyperlinks, URLs, and file paths, including line and column references.
  - Link-tap events provide detected URL or surrounding line text and tap position.

- **Improvements**
  - Web and mobile terminals now share link detection and path resolution behavior.

- **Tests**
  - Added coverage for URLs, file paths, wrapped lines, punctuation handling, and runtime compatibility.

- **Documentation**
  - Documented mobile terminal link resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
