### PR TITLE
fix(web): stabilize the provider settings editor

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -1,7 +1,14 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
-import type { ServerProviderModel } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 
-import { deriveProviderModelsForDisplay } from "./ProviderInstanceCard";
+import { deriveProviderModelsForDisplay, ProviderInstanceCard } from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
   it("uses current config custom models instead of stale live custom rows", () => {
@@ -32,5 +39,45 @@ describe("deriveProviderModelsForDisplay", () => {
         customModels: ["kept-custom"],
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
+  });
+
+  it("shows a redacted provider email in Configuration", () => {
+    const instanceId = ProviderInstanceId.make("codex");
+    const driver = ProviderDriverKind.make("codex");
+    const liveProvider: ServerProvider = {
+      instanceId,
+      driver,
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: { status: "authenticated", email: "developer@example.com" },
+      checkedAt: "2026-08-27T12:00:00.000Z",
+      models: [],
+      slashCommands: [],
+      skills: [],
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ProviderInstanceCard, {
+        instanceId,
+        instance: { driver },
+        driverOption: undefined,
+        liveProvider,
+        mode: "editor",
+        onUpdate: () => undefined,
+        hiddenModels: [],
+        favoriteModels: [],
+        modelOrder: [],
+        onHiddenModelsChange: () => undefined,
+        onFavoriteModelsChange: () => undefined,
+        onModelOrderChange: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain("Account email");
+    expect(markup).toContain('aria-label="Toggle account email visibility"');
+    expect(markup).toContain("blur-[2px]");
+    expect(markup).not.toContain("developer@example.com");
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -636,12 +636,12 @@ export function ProviderInstanceCard({
   }
 
   return (
-    <div className="min-w-0">
+    <div className="min-w-0 lg:flex lg:h-full lg:min-h-0 lg:flex-col">
       <div
         inert={readOnly}
         aria-disabled={readOnly || undefined}
         className={cn(
-          "flex min-h-16 items-center justify-between gap-3 border-b border-border/70 px-4 py-3",
+          "flex min-h-16 shrink-0 items-center justify-between gap-3 border-b border-border/70 px-4 py-3",
           readOnly && "opacity-50 select-none",
         )}
       >
@@ -755,7 +755,7 @@ export function ProviderInstanceCard({
         </div>
       </div>
 
-      <div className="flex h-11 border-b border-border/70 px-1">
+      <div className="flex h-11 shrink-0 border-b border-border/70 px-1">
         {driverOption !== undefined ? (
           <button
             type="button"
@@ -779,9 +779,12 @@ export function ProviderInstanceCard({
       <div
         inert={readOnly}
         aria-disabled={readOnly || undefined}
-        className={cn("px-4 py-5", readOnly && "opacity-50 select-none")}
+        className={cn("lg:min-h-0 lg:flex-1", readOnly && "opacity-50 select-none")}
       >
-        <div className="space-y-5" hidden={visibleTab !== "configuration"}>
+        <div
+          className="space-y-5 px-4 py-5 lg:h-full lg:overflow-y-auto"
+          hidden={visibleTab !== "configuration"}
+        >
           <div>
             <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
               <span className="text-xs font-medium text-foreground">Display name</span>
@@ -838,7 +841,7 @@ export function ProviderInstanceCard({
           ) : null}
         </div>
         {driverOption !== undefined ? (
-          <div hidden={visibleTab !== "models"}>
+          <div className="px-4 py-5 lg:h-full lg:min-h-0" hidden={visibleTab !== "models"}>
             <ProviderModelsSection
               instanceId={instanceId}
               driverKind={driverKind}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -42,6 +42,7 @@ import { ProviderSettingsForm } from "./ProviderSettingsForm";
 import { ProviderModelsSection } from "./ProviderModelsSection";
 import { ProviderInstanceIcon, providerInstanceInitials } from "../chat/ProviderInstanceIcon";
 import { ProviderAccentColorPicker } from "./ProviderAccentColorPicker";
+import { RedactedSensitiveText } from "./RedactedSensitiveText";
 import {
   getProviderVersionAdvisoryPresentation,
   PROVIDER_STATUS_STYLES,
@@ -147,6 +148,21 @@ export function deriveProviderModelsForDisplay(input: {
       },
   );
   return [...serverModels, ...customModels];
+}
+
+function ProviderAuthEmail(props: { readonly email: string | undefined }) {
+  const email = props.email?.trim();
+  if (!email) return null;
+
+  return (
+    <RedactedSensitiveText
+      value={email}
+      ariaLabel="Toggle account email visibility"
+      revealTooltip="Click to reveal email"
+      hideTooltip="Click to hide email"
+      className="max-w-full truncate"
+    />
+  );
 }
 
 function ProviderEnvironmentSection(props: {
@@ -420,6 +436,7 @@ export function ProviderInstanceCard({
   const statusStyle = PROVIDER_STATUS_STYLES[statusKey];
   const rawSummary = getProviderSummary(liveProvider);
   const summary = enabled ? rawSummary : { headline: "Disabled", detail: null };
+  const authEmail = liveProvider?.auth.email;
   const showEditorStatus = enabled && (statusKey === "warning" || statusKey === "error");
   const versionLabel = getProviderVersionLabel(liveProvider?.version);
   const versionAdvisory = getProviderVersionAdvisoryPresentation(liveProvider?.versionAdvisory);
@@ -785,6 +802,15 @@ export function ProviderInstanceCard({
           className="space-y-5 px-4 py-5 lg:h-full lg:overflow-y-auto"
           hidden={visibleTab !== "configuration"}
         >
+          {authEmail?.trim() ? (
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-foreground">Account email</div>
+              <div className="mt-1.5 flex min-h-8 min-w-0 items-center">
+                <ProviderAuthEmail email={authEmail} />
+              </div>
+            </div>
+          ) : null}
+
           <div>
             <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
               <span className="text-xs font-medium text-foreground">Display name</span>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -185,12 +185,15 @@ export function ProviderModelsSection({
   };
 
   return (
-    <div>
+    <div className="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
       <div className="text-xs font-medium text-foreground">Models</div>
       <div className="mt-1 text-xs text-muted-foreground">
         {models.length} model{models.length === 1 ? "" : "s"} available.
       </div>
-      <div ref={listRef} className="mt-2 max-h-40 overflow-y-auto pb-1">
+      <div
+        ref={listRef}
+        className="mt-2 max-h-40 overflow-y-auto pb-1 lg:min-h-0 lg:max-h-none lg:flex-1"
+      >
         {orderedModels.map((model, index) => {
           const caps = model.capabilities;
           const capLabels: string[] = [];

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -837,14 +837,16 @@ export function EnvironmentProviderSettings({
           />
         ) : null}
         <div className="space-y-1">
-          <div className="overflow-hidden rounded-lg border border-border/70 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)]">
-            <div className="border-b border-border/70 lg:border-r lg:border-b-0">
-              <div className="flex min-h-9 items-center justify-between border-b border-border/70 px-3 text-[11px] font-medium text-muted-foreground">
+          <div className="overflow-hidden rounded-lg border border-border/70 lg:grid lg:h-[min(38rem,calc(100dvh-16rem))] lg:min-h-[30rem] lg:grid-cols-[20rem_minmax(0,1fr)]">
+            <div className="border-b border-border/70 lg:flex lg:min-h-0 lg:flex-col lg:border-r lg:border-b-0">
+              <div className="flex min-h-9 shrink-0 items-center justify-between border-b border-border/70 px-3 text-[11px] font-medium text-muted-foreground">
                 <span>Provider</span>
                 <span>On</span>
               </div>
-              {rows.map((row) => renderProviderInstance(row, "list"))}
-              <div className="flex min-h-10 items-center justify-between px-3">
+              <div className="lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+                {rows.map((row) => renderProviderInstance(row, "list"))}
+              </div>
+              <div className="flex min-h-10 shrink-0 items-center justify-between px-3">
                 <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
                 {!readOnly ? (
                   <Tooltip>
@@ -871,7 +873,7 @@ export function EnvironmentProviderSettings({
               </div>
             </div>
 
-            <div className="min-w-0">
+            <div className="min-w-0 lg:min-h-0">
               {selectedRow ? (
                 renderProviderInstance(selectedRow, "editor")
               ) : (

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -846,7 +846,12 @@ export function EnvironmentProviderSettings({
               <div className="lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
                 {rows.map((row) => renderProviderInstance(row, "list"))}
               </div>
-              <div className="flex min-h-10 shrink-0 items-center justify-between px-3">
+              <div
+                className={cn(
+                  "flex min-h-10 shrink-0 items-center justify-between px-3",
+                  rows.length > 0 && "border-t border-border/60",
+                )}
+              >
                 <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
                 {!readOnly ? (
                   <Tooltip>


### PR DESCRIPTION
The provider editor changed height when users switched between Models and Configuration. The split layout also removed access to the provider account email.

This keeps the desktop editor at a stable, viewport-aware height and scrolls long provider content inside it. Configuration now shows the provider-reported account email behind the existing redacted, click-to-reveal control.

## Screenshots

| Before | After |
| --- | --- |
| ![Configuration without account email](https://files.tslop.org/2026/08/provider-account-email-before-da636901.png) | ![Configuration with redacted account email](https://files.tslop.org/2026/08/provider-account-email-after-e30b2b5f.png) |

## Checks

- `vp test run apps/web/src/components/settings/ProviderInstanceCard.test.ts apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx`
- `vp run --filter @t3tools/web typecheck`
- Targeted lint and formatting
- Chrome at 1536 x 768 and 400 x 786

Made with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and display of already-fetched auth email via an existing redaction component; verify large-screen scrolling at different viewport sizes.
> 
> **Overview**
> Fixes the desktop provider settings editor **jumping height** when switching between **Models** and **Configuration**, and brings back the provider **account email** on Configuration.
> 
> On large screens, `ProviderSettingsPanel` pins the split layout to a **viewport-aware height**; the provider list and editor body **scroll inside** their panes instead of resizing the card. `ProviderInstanceCard` and `ProviderModelsSection` use a **flex column** layout so tab content fills the editor and scrolls (replacing the models list’s fixed `max-h-40` on `lg`).
> 
> When `liveProvider.auth.email` is present, Configuration shows an **Account email** row via new `ProviderAuthEmail`, using the existing **`RedactedSensitiveText`** click-to-reveal control. A test asserts the label and toggle render without exposing the raw address in markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc13b7c076dc68ed3d460102d9cb13e1e54b63d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider settings editor: add redacted account email and stabilize layout
> - Adds `ProviderAuthEmail` component that renders the provider auth email as a redacted, toggleable `RedactedSensitiveText` with aria-label 'Toggle account email visibility', shown above the display name when non-empty.
> - Reworks large-viewport layout across `ProviderInstanceCard`, `ProviderModelsSection`, and `ProviderSettingsPanel` to use flex columns with fixed headers/footers and internal scroll regions, removing fixed max-heights on large screens.
> - Adds a test asserting the email is blurred and not present in static markup.
> - Risk: layout class changes in `ProviderInstanceCard.tsx`, `ProviderModelsSection.tsx`, and `ProviderSettingsPanel.tsx` alter overflow/scroll behavior on large viewports; verify scrolling and height constraints render correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efc13b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->