### PR TITLE
fix(server): identify spawned terminals as T3 Code

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -27,6 +27,7 @@ import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 
+import packageJson from "../../package.json" with { type: "json" };
 import * as ProcessRunner from "../processRunner.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
@@ -1509,6 +1510,41 @@ it.layer(
     }),
   );
 
+  it.effect("identifies spawned terminals as T3 Code", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, { env: {} });
+
+      yield* manager.open(openInput());
+
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      expect(spawnInput.env.TERM_PROGRAM).toBe("t3code");
+      expect(spawnInput.env.TERM_PROGRAM_VERSION).toBe(packageJson.version);
+    }),
+  );
+
+  it.effect("overrides inherited parent terminal identity", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: {
+          TERM_PROGRAM: "Apple_Terminal",
+          TERM_PROGRAM_VERSION: "2.14",
+        },
+      });
+
+      yield* manager.open(openInput());
+
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      expect(spawnInput.env.TERM_PROGRAM).toBe("t3code");
+      expect(spawnInput.env.TERM_PROGRAM_VERSION).toBe(packageJson.version);
+    }),
+  );
+
   it.effect("strips AppImage runtime env from terminal sessions", () =>
     Effect.gen(function* () {
       const appDir = "/tmp/.mount_T3Codeabc123";
@@ -1582,6 +1618,8 @@ it.layer(
             T3CODE_PROJECT_ROOT: "/repo",
             T3CODE_WORKTREE_PATH: "/repo/worktree-a",
             CUSTOM_FLAG: "1",
+            TERM_PROGRAM: "custom-terminal",
+            TERM_PROGRAM_VERSION: "custom-version",
           },
         }),
       );
@@ -1592,6 +1630,8 @@ it.layer(
       assert.equal(spawnInput.env.T3CODE_PROJECT_ROOT, "/repo");
       assert.equal(spawnInput.env.T3CODE_WORKTREE_PATH, "/repo/worktree-a");
       assert.equal(spawnInput.env.CUSTOM_FLAG, "1");
+      assert.equal(spawnInput.env.TERM_PROGRAM, "custom-terminal");
+      assert.equal(spawnInput.env.TERM_PROGRAM_VERSION, "custom-version");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -51,6 +51,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
+import packageJson from "../../package.json" with { type: "json" };
 import * as ServerConfig from "../config.ts";
 import {
   increment,
@@ -1091,6 +1092,8 @@ function createTerminalSpawnEnv(
     if (shouldExcludeTerminalEnvKey(key)) continue;
     spawnEnv[key] = value;
   }
+  spawnEnv.TERM_PROGRAM = "t3code";
+  spawnEnv.TERM_PROGRAM_VERSION = packageJson.version;
   if (runtimeEnv) {
     for (const [key, value] of Object.entries(runtimeEnv)) {
       spawnEnv[key] = value;


### PR DESCRIPTION
## What Changed

Set `TERM_PROGRAM` to `t3code` and `TERM_PROGRAM_VERSION` to the server package version for integrated terminal processes.

T3 Code applies these values after copying the parent environment and before applying `runtimeEnv`. Launcher values such as `Apple_Terminal` no longer leak into the PTY, while explicit per-terminal overrides still take precedence.

Added focused coverage for:

- Missing parent values
- Inherited parent terminal identity
- Explicit runtime overrides

## Why

Shell configuration and terminal-aware tools use `TERM_PROGRAM` to select the correct integration. T3 Code currently leaves both variables unset or inherits the identity of the terminal that launched it.

Fixes #8450.

This PR does not change `COLORTERM`. #7680 is intended to address that variable.

## UI Changes

The application UI does not change. These screenshots show the integrated terminal environment before and after the fix.

### Before

<img width="1084" height="768" alt="Integrated terminal with both terminal identity variables undefined" src="https://github.com/user-attachments/assets/30b00664-0107-433f-bee7-9eac52f1c058" />

### After

<img width="1084" height="768" alt="Integrated terminal identifying T3 Code and version 0.0.35" src="https://github.com/user-attachments/assets/b3888047-5d0e-4fc8-a516-f0f6cb7473b8" />

## Testing

- `cd apps/server && vp test src/terminal/Manager.test.ts --run` (56 tests passed)
- `vp run --filter t3 typecheck`
- Launched the development app with both parent variables unset
- Launched the development app with inherited `Apple_Terminal` and version `2.14`
- Confirmed that explicit `runtimeEnv` values still take precedence

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots
- [x] A video is not required because this change has no animation or interaction behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to terminal spawn environment with tests; no auth, data, or UI impact beyond env vars shells and tools read.
> 
> **Overview**
> Integrated terminal PTY processes now advertise **T3 Code** via `TERM_PROGRAM=t3code` and `TERM_PROGRAM_VERSION` set from the server `package.json`, applied in `createTerminalSpawnEnv` after the filtered parent env copy and **before** per-open `runtimeEnv` merges.
> 
> That replaces unset values or leaked launcher identity (e.g. `Apple_Terminal`) while still allowing explicit `runtimeEnv` overrides for `TERM_PROGRAM` / `TERM_PROGRAM_VERSION`. Tests cover defaults, parent override, and runtime precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56db790ac592a539ced8ae3721b909298763b1c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` in spawned terminals
> Sets `TERM_PROGRAM` to `'t3code'` and `TERM_PROGRAM_VERSION` to the app version from `package.json` in `createTerminalSpawnEnv` before applying `runtimeEnv` overrides. This lets spawned terminal processes identify as T3 Code. Risk: `runtimeEnv` entries for `TERM_PROGRAM` or `TERM_PROGRAM_VERSION` now override defaults instead of the other way around; check [Manager.ts](https://github.com/pingdotgg/t3code/pull/8473/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) if callers relied on inherited parent values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56db790.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->