### PR TITLE
fix(web): assistant images open in preview

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -52,6 +52,7 @@ import remarkGfm from "remark-gfm";
 import { remarkGithubAlerts } from "../markdown-github-alerts";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
+import type { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import {
   revealInFileExplorerLabelForKind,
@@ -142,6 +143,7 @@ interface ChatMarkdownProps {
   /** Environment that owns non-thread markdown, such as a pull request panel. */
   environmentId?: EnvironmentId | undefined;
   onTaskListChange?: ((input: { markerOffset: number; checked: boolean }) => void) | undefined;
+  onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
   isStreaming?: boolean;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   className?: string;
@@ -242,6 +244,7 @@ type MarkdownHtmlAstNode = {
   tagName?: string;
   properties?: Record<string, unknown>;
   children?: MarkdownHtmlAstNode[];
+  data?: { t3LinkedImage?: boolean };
 };
 
 /** Preserve Windows drive paths through the protocol allowlist in rehype-sanitize. */
@@ -264,6 +267,21 @@ function rehypeNormalizeWindowsImageSrc() {
     };
 
     visit(tree);
+  };
+}
+
+/** Keep an explicit image link as navigation instead of nesting a zoom button inside it. */
+function rehypeMarkLinkedImages() {
+  return (tree: MarkdownHtmlAstNode) => {
+    const visit = (node: MarkdownHtmlAstNode, insideLink: boolean) => {
+      const nextInsideLink = insideLink || (node.type === "element" && node.tagName === "a");
+      if (nextInsideLink && node.type === "element" && node.tagName === "img") {
+        node.data = { ...node.data, t3LinkedImage: true };
+      }
+      node.children?.forEach((child) => visit(child, nextInsideLink));
+    };
+
+    visit(tree, false);
   };
 }
 
@@ -303,6 +321,7 @@ const CHAT_MARKDOWN_REHYPE_PLUGINS = [
   rehypeRaw,
   rehypeNormalizeWindowsImageSrc,
   [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
+  rehypeMarkLinkedImages,
 ] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
 /** GitHub's own five alert kinds, in its colors: the glyph names the urgency, the title says it. */
@@ -1052,8 +1071,78 @@ const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME =
 // rule, keeping workspace images on the same block layout as their placeholder.
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
-  "my-1 block! rounded-lg border border-border/40",
+  "block! rounded-lg border border-border/40",
 );
+
+type ChatMarkdownResolvedImageProps = Omit<React.ComponentPropsWithoutRef<"img">, "src" | "alt"> & {
+  readonly src: string;
+  readonly alt: string;
+  readonly previewName: string;
+  readonly linked: boolean;
+  readonly containerClassName?: string | undefined;
+  readonly unwrappedClassName?: string | undefined;
+  readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+};
+
+function markdownImagePreviewName(alt: string, source: string): string {
+  const trimmedAlt = alt.trim();
+  if (trimmedAlt.length > 0) return trimmedAlt;
+
+  const path = source.split(/[?#]/, 1)[0]?.replaceAll("\\", "/") ?? "";
+  const encodedName = path.slice(path.lastIndexOf("/") + 1);
+  if (encodedName.length === 0 || encodedName.length > 160 || encodedName.includes(":")) {
+    return "Image";
+  }
+  try {
+    return decodeURIComponent(encodedName);
+  } catch {
+    return encodedName;
+  }
+}
+
+function ChatMarkdownResolvedImage({
+  src,
+  alt,
+  previewName,
+  linked,
+  containerClassName,
+  unwrappedClassName,
+  onImageExpand,
+  className,
+  ...props
+}: ChatMarkdownResolvedImageProps) {
+  const interactive = onImageExpand !== undefined && !linked;
+  const image = (
+    <img
+      {...props}
+      src={src}
+      alt={alt}
+      className={cn(className, !interactive && unwrappedClassName)}
+    />
+  );
+
+  if (!interactive) return image;
+
+  return (
+    <button
+      type="button"
+      data-chat-markdown-image-expand
+      className={cn(
+        "max-w-full touch-manipulation cursor-zoom-in rounded-lg bg-transparent p-0 align-top outline-none hover:ring-1 hover:ring-border/70 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        containerClassName ?? "inline-block",
+      )}
+      aria-label={previewName === "Image" ? "Expand image" : `Expand image ${previewName}`}
+      onClick={() =>
+        onImageExpand({
+          images: [{ src, name: previewName }],
+          index: 0,
+        })
+      }
+    >
+      {image}
+    </button>
+  );
+}
 
 function ChatMarkdownImageFallback(props: { readonly alt: string }) {
   return (
@@ -1069,6 +1158,8 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   readonly threadRef: ScopedThreadRef;
   readonly path: string;
   readonly alt: string;
+  readonly linked: boolean;
+  readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
   const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
     _tag: "workspace-file",
@@ -1090,9 +1181,14 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
     );
   }
   return (
-    <img
+    <ChatMarkdownResolvedImage
       src={assetUrl.url}
       alt={props.alt}
+      previewName={markdownImagePreviewName(props.alt, props.path)}
+      linked={props.linked}
+      onImageExpand={props.onImageExpand}
+      containerClassName="my-1 block w-fit max-w-full"
+      unwrappedClassName="my-1"
       loading="lazy"
       draggable={false}
       className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
@@ -1631,6 +1727,7 @@ function ChatMarkdown({
   threadRef,
   environmentId: explicitEnvironmentId,
   onTaskListChange,
+  onImageExpand,
   isStreaming = false,
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
@@ -2146,16 +2243,21 @@ function ChatMarkdown({
           </code>
         );
       },
-      img({ node: _node, title: _title, src, alt, ...props }) {
+      img({ node, title: _title, src, alt, ...props }) {
         const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
         const altText = alt ?? "";
+        const linked =
+          (node?.data as MarkdownHtmlAstNode["data"] | undefined)?.t3LinkedImage === true;
         const imageSource = classifyMarkdownImageSource(srcString, cwd);
         if (imageSource._tag === "Direct") {
           return (
-            <img
+            <ChatMarkdownResolvedImage
               {...props}
               src={imageSource.uri}
               alt={altText}
+              previewName={markdownImagePreviewName(altText, imageSource.uri)}
+              linked={linked}
+              onImageExpand={onImageExpand}
               loading="lazy"
               className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
             />
@@ -2167,6 +2269,8 @@ function ChatMarkdown({
               threadRef={threadRef}
               path={imageSource.path}
               alt={altText}
+              linked={linked}
+              onImageExpand={onImageExpand}
             />
           );
         }
@@ -2215,6 +2319,7 @@ function ChatMarkdown({
     inlineCodeFileLinkMetaByText,
     isStreaming,
     markdownFileLinkMetaByHref,
+    onImageExpand,
     onTaskListChange,
     openFileInPanel,
     openInPreferredEditor,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -42,7 +42,7 @@ import React, {
   useState,
   type ReactNode,
 } from "react";
-import type { Components, Options as ReactMarkdownOptions } from "react-markdown";
+import type { Components, ExtraProps, Options as ReactMarkdownOptions } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { defaultUrlTransform } from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -1084,6 +1084,18 @@ type ChatMarkdownResolvedImageProps = Omit<React.ComponentPropsWithoutRef<"img">
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 };
 
+interface ChatMarkdownImageRenderContextValue {
+  readonly cwd: string | undefined;
+  readonly threadRef: ScopedThreadRef | undefined;
+  readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
+}
+
+const ChatMarkdownImageRenderContext = React.createContext<ChatMarkdownImageRenderContextValue>({
+  cwd: undefined,
+  threadRef: undefined,
+  onImageExpand: undefined,
+});
+
 function markdownImagePreviewName(alt: string, source: string): string {
   const trimmedAlt = alt.trim();
   if (trimmedAlt.length > 0) return trimmedAlt;
@@ -1196,6 +1208,46 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
     />
   );
 });
+
+function ChatMarkdownImageRenderer({
+  node,
+  title: _title,
+  src,
+  alt,
+  ...props
+}: React.ComponentPropsWithoutRef<"img"> & ExtraProps) {
+  const { cwd, threadRef, onImageExpand } = use(ChatMarkdownImageRenderContext);
+  const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
+  const altText = alt ?? "";
+  const linked = (node?.data as MarkdownHtmlAstNode["data"] | undefined)?.t3LinkedImage === true;
+  const imageSource = classifyMarkdownImageSource(srcString, cwd);
+  if (imageSource._tag === "Direct") {
+    return (
+      <ChatMarkdownResolvedImage
+        {...props}
+        src={imageSource.uri}
+        alt={altText}
+        previewName={markdownImagePreviewName(altText, imageSource.uri)}
+        linked={linked}
+        onImageExpand={onImageExpand}
+        loading="lazy"
+        className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
+      />
+    );
+  }
+  if (imageSource._tag === "WorkspaceFile" && threadRef) {
+    return (
+      <ChatMarkdownWorkspaceImage
+        threadRef={threadRef}
+        path={imageSource.path}
+        alt={altText}
+        linked={linked}
+        onImageExpand={onImageExpand}
+      />
+    );
+  }
+  return <ChatMarkdownImageFallback alt={altText} />;
+}
 
 function leadingExternalLinkTextLength(text: string): number {
   const protocol = /^(?:https?:\/\/)/i.exec(text)?.[0];
@@ -1984,6 +2036,10 @@ function ChatMarkdown({
     },
     [cwd, findWorkspaceBasenameMatch, revealFileInFileManager],
   );
+  const imageRenderContext = useMemo<ChatMarkdownImageRenderContextValue>(
+    () => ({ cwd, threadRef, onImageExpand }),
+    [cwd, onImageExpand, threadRef],
+  );
   /* eslint-disable react/no-unstable-nested-components -- ReactMarkdown requires component
    * renderers that close over this message's metadata. useMemo keeps them stable until that
    * metadata changes. */
@@ -2243,39 +2299,7 @@ function ChatMarkdown({
           </code>
         );
       },
-      img({ node, title: _title, src, alt, ...props }) {
-        const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
-        const altText = alt ?? "";
-        const linked =
-          (node?.data as MarkdownHtmlAstNode["data"] | undefined)?.t3LinkedImage === true;
-        const imageSource = classifyMarkdownImageSource(srcString, cwd);
-        if (imageSource._tag === "Direct") {
-          return (
-            <ChatMarkdownResolvedImage
-              {...props}
-              src={imageSource.uri}
-              alt={altText}
-              previewName={markdownImagePreviewName(altText, imageSource.uri)}
-              linked={linked}
-              onImageExpand={onImageExpand}
-              loading="lazy"
-              className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
-            />
-          );
-        }
-        if (imageSource._tag === "WorkspaceFile" && threadRef) {
-          return (
-            <ChatMarkdownWorkspaceImage
-              threadRef={threadRef}
-              path={imageSource.path}
-              alt={altText}
-              linked={linked}
-              onImageExpand={onImageExpand}
-            />
-          );
-        }
-        return <ChatMarkdownImageFallback alt={altText} />;
-      },
+      img: ChatMarkdownImageRenderer,
       table({ node: _node, ...props }) {
         return <MarkdownTable {...props} />;
       },
@@ -2349,17 +2373,19 @@ function ChatMarkdown({
       )}
       onCopy={handleCopy}
     >
-      <ReactMarkdown
-        remarkPlugins={
-          lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
-        }
-        rehypePlugins={parseRawHtml ? CHAT_MARKDOWN_REHYPE_PLUGINS : undefined}
-        skipHtml={false}
-        components={markdownComponents}
-        urlTransform={markdownUrlTransform}
-      >
-        {text}
-      </ReactMarkdown>
+      <ChatMarkdownImageRenderContext value={imageRenderContext}>
+        <ReactMarkdown
+          remarkPlugins={
+            lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
+          }
+          rehypePlugins={parseRawHtml ? CHAT_MARKDOWN_REHYPE_PLUGINS : undefined}
+          skipHtml={false}
+          components={markdownComponents}
+          urlTransform={markdownUrlTransform}
+        >
+          {text}
+        </ReactMarkdown>
+      </ChatMarkdownImageRenderContext>
     </div>
   );
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1128,7 +1128,7 @@ function ChatMarkdownResolvedImage({
       type="button"
       data-chat-markdown-image-expand
       className={cn(
-        "max-w-full touch-manipulation cursor-zoom-in rounded-lg bg-transparent p-0 align-top outline-none hover:ring-1 hover:ring-border/70 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "max-w-full touch-manipulation cursor-zoom-in rounded-lg bg-transparent p-0 align-top outline-none [&>img]:block hover:ring-1 hover:ring-border/70 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         containerClassName ?? "inline-block",
       )}
       aria-label={previewName === "Image" ? "Expand image" : `Expand image ${previewName}`}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1128,7 +1128,7 @@ function ChatMarkdownResolvedImage({
       type="button"
       data-chat-markdown-image-expand
       className={cn(
-        "max-w-full touch-manipulation cursor-zoom-in rounded-lg bg-transparent p-0 align-top outline-none [&>img]:block hover:ring-1 hover:ring-border/70 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "max-w-full touch-manipulation cursor-zoom-in rounded-lg bg-transparent p-0 align-top outline-none [&>img]:block! hover:ring-1 hover:ring-border/70 focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         containerClassName ?? "inline-block",
       )}
       aria-label={previewName === "Image" ? "Expand image" : `Expand image ${previewName}`}

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -54,6 +54,17 @@ function render(markdown: string): string {
   );
 }
 
+function renderInteractive(markdown: string): string {
+  return renderToStaticMarkup(
+    <ChatMarkdown
+      cwd={"C:\\Users\\shawn\\project"}
+      threadRef={threadRef}
+      text={markdown}
+      onImageExpand={() => undefined}
+    />,
+  );
+}
+
 function renderWithoutThread(markdown: string): string {
   return renderToStaticMarkup(<ChatMarkdown cwd={"C:\\Users\\shawn\\project"} text={markdown} />);
 }
@@ -143,5 +154,30 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("max-w-[min(100%,30rem)]");
     expect(html).toContain("max-h-[30rem]");
     expect(html).not.toContain("Image unavailable");
+  });
+
+  it("renders standalone workspace and remote images as accessible zoom buttons", () => {
+    const html = renderInteractive(
+      [
+        "![workspace chart](.t3/workspace-image.svg)",
+        "![](https://example.com/remote-image.png)",
+      ].join("\n\n"),
+    );
+
+    expect(html.match(/data-chat-markdown-image-expand/g)).toHaveLength(2);
+    expect(html).toContain('aria-label="Expand image workspace chart"');
+    expect(html).toContain('aria-label="Expand image remote-image.png"');
+    expect(html).toContain("cursor-zoom-in");
+    expect(html).toContain("focus-visible:ring-2");
+  });
+
+  it("preserves an explicit image link instead of nesting a zoom button inside it", () => {
+    const html = renderInteractive(
+      "[![workspace chart](.t3/workspace-image.svg)](https://example.com/details)",
+    );
+
+    expect(html).toContain('href="https://example.com/details"');
+    expect(html).toContain('alt="workspace chart"');
+    expect(html).not.toContain("data-chat-markdown-image-expand");
   });
 });

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -28,12 +28,6 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
 
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
-        onClose();
-        return;
-      }
       if (preview.images.length <= 1) return;
       if (event.key === "ArrowLeft") {
         event.preventDefault();
@@ -48,7 +42,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [navigateImage, onClose, preview.images.length]);
+  }, [navigateImage, preview.images.length]);
 
   const item = preview.images[index];
   if (!item) return null;
@@ -64,6 +58,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
         <DialogPrimitive.Popup
           initialFocus={closeButtonRef}
           finalFocus={() => restoreFocusRef.current}
+          data-slot="dialog-popup"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 px-4 py-6 outline-none [-webkit-app-region:no-drag]"
           aria-label="Expanded image preview"
         >

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -1,6 +1,7 @@
-import { memo, useCallback, useEffect, useState } from "react";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-react";
-import { Button } from "../ui/button";
+import { Button, buttonVariants } from "../ui/button";
 import type { ExpandedImagePreview } from "./ExpandedImagePreview";
 
 interface ExpandedImageDialogProps {
@@ -13,6 +14,12 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
   onClose,
 }: ExpandedImageDialogProps) {
   const [imageOffset, setImageOffset] = useState(0);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef(
+    typeof document !== "undefined" && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null,
+  );
   const index = (preview.index + imageOffset + preview.images.length) % preview.images.length;
 
   const navigateImage = useCallback((direction: -1 | 1) => {
@@ -47,64 +54,74 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
   if (!item) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 px-4 py-6 [-webkit-app-region:no-drag]"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Expanded image preview"
+    <DialogPrimitive.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
     >
-      <button
-        type="button"
-        className="absolute inset-0 z-0 cursor-zoom-out"
-        aria-label="Close image preview"
-        onClick={onClose}
-      />
-      {preview.images.length > 1 && (
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className="absolute left-2 top-1/2 z-20 -translate-y-1/2 text-white/90 hover:bg-white/10 hover:text-white sm:left-6"
-          aria-label="Previous image"
-          onClick={() => navigateImage(-1)}
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Popup
+          initialFocus={closeButtonRef}
+          finalFocus={() => restoreFocusRef.current}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 px-4 py-6 outline-none [-webkit-app-region:no-drag]"
+          aria-label="Expanded image preview"
         >
-          <ChevronLeftIcon className="size-5" />
-        </Button>
-      )}
-      <div className="relative isolate z-10 max-h-[92vh] max-w-[92vw]">
-        <Button
-          type="button"
-          size="icon-xs"
-          variant="ghost"
-          className="absolute right-2 top-2"
-          onClick={onClose}
-          aria-label="Close image preview"
-        >
-          <XIcon />
-        </Button>
-        <img
-          src={item.src}
-          alt={item.name}
-          className="max-h-[86vh] max-w-[92vw] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl"
-          draggable={false}
-        />
-        <p className="mt-2 max-w-[92vw] truncate text-center text-xs text-muted-foreground/80">
-          {item.name}
-          {preview.images.length > 1 ? ` (${index + 1}/${preview.images.length})` : ""}
-        </p>
-      </div>
-      {preview.images.length > 1 && (
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className="absolute right-2 top-1/2 z-20 -translate-y-1/2 text-white/90 hover:bg-white/10 hover:text-white sm:right-6"
-          aria-label="Next image"
-          onClick={() => navigateImage(1)}
-        >
-          <ChevronRightIcon className="size-5" />
-        </Button>
-      )}
-    </div>
+          <DialogPrimitive.Close
+            tabIndex={-1}
+            className="absolute inset-0 z-0 cursor-zoom-out"
+            aria-label="Close image preview"
+          />
+          {preview.images.length > 1 && (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="absolute left-2 top-1/2 z-20 -translate-y-1/2 text-white/90 hover:bg-white/10 hover:text-white sm:left-6"
+              aria-label="Previous image"
+              onClick={() => navigateImage(-1)}
+            >
+              <ChevronLeftIcon className="size-5" />
+            </Button>
+          )}
+          <div className="relative isolate z-10 max-h-[92vh] max-w-[92vw]">
+            <DialogPrimitive.Close
+              ref={closeButtonRef}
+              data-expanded-image-dialog-close
+              aria-label="Close image preview"
+              className={buttonVariants({
+                size: "icon-xs",
+                variant: "ghost",
+                className: "absolute right-2 top-2",
+              })}
+            >
+              <XIcon />
+            </DialogPrimitive.Close>
+            <img
+              src={item.src}
+              alt={item.name}
+              className="max-h-[86vh] max-w-[92vw] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl"
+              draggable={false}
+            />
+            <p className="mt-2 max-w-[92vw] truncate text-center text-xs text-muted-foreground/80">
+              {item.name}
+              {preview.images.length > 1 ? ` (${index + 1}/${preview.images.length})` : ""}
+            </p>
+          </div>
+          {preview.images.length > 1 && (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="absolute right-2 top-1/2 z-20 -translate-y-1/2 text-white/90 hover:bg-white/10 hover:text-white sm:right-6"
+              aria-label="Next image"
+              onClick={() => navigateImage(1)}
+            >
+              <ChevronRightIcon className="size-5" />
+            </Button>
+          )}
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 });

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -1,7 +1,7 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-react";
-import { Button, buttonVariants } from "../ui/button";
+import { Button } from "../ui/button";
 import type { ExpandedImagePreview } from "./ExpandedImagePreview";
 
 interface ExpandedImageDialogProps {
@@ -89,11 +89,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               ref={closeButtonRef}
               data-expanded-image-dialog-close
               aria-label="Close image preview"
-              className={buttonVariants({
-                size: "icon-xs",
-                variant: "ghost",
-                className: "absolute right-2 top-2",
-              })}
+              render={<Button size="icon-xs" variant="ghost" className="absolute right-2 top-2" />}
             >
               <XIcon />
             </DialogPrimitive.Close>

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -237,6 +237,20 @@ function buildAssistantTimelineEntry(text: string) {
 }
 
 describe("MessagesTimeline", () => {
+  it("makes standalone images in assistant messages expandable", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildAssistantTimelineEntry("![generated chart](https://example.com/chart.png)"),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("data-chat-markdown-image-expand");
+    expect(markup).toContain('aria-label="Expand image generated chart"');
+  });
+
   it("renders a feedback command and its pending response as normal thread messages", () => {
     const submission = {
       id: MessageId.make("feedback-command"),

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1146,6 +1146,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           text={messageText}
           cwd={ctx.markdownCwd}
           threadRef={ctx.threadRef ?? undefined}
+          onImageExpand={ctx.onImageExpand}
           isStreaming={Boolean(row.message.streaming)}
           lineBreaks={shouldPreserveAssistantLineBreaks(messageText)}
           skills={ctx.skills}


### PR DESCRIPTION
Assistant-rendered Markdown images appeared inline, but clicking them did nothing. Prompt attachments already opened the image dialog, so the two image paths behaved differently.

Standalone assistant images now use that existing dialog. Linked images remain links, and keyboard users can open the preview with Enter and return focus to the image after dismissing it.

Tests: 41 focused tests, web typecheck, targeted lint and formatting.

| Inline image | Expanded preview |
| --- | --- |
| <img width="960" alt="Assistant-rendered image shown inline" src="https://github.com/user-attachments/assets/5d50eab9-e3ad-4112-a19f-c37d012b0194" /> | <img width="960" alt="Assistant-rendered image in the expanded preview" src="https://github.com/user-attachments/assets/2b9e161f-1afa-4b80-afb9-58badabc3c53" /> |

https://github.com/user-attachments/assets/cb1552ac-9191-48cc-98c2-77e33f8beaf0

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only chat markdown and dialog behavior with no auth or data-path changes; main regression surface is focus/keyboard dismissal in the image dialog and accidental zoom on linked images.
> 
> **Overview**
> Standalone images in assistant (and other) markdown now open the existing **expanded image preview** when `onImageExpand` is wired—matching prompt attachments instead of dead inline clicks.
> 
> **ChatMarkdown** adds optional `onImageExpand` and wraps image rendering in a small context. Direct and workspace images go through `ChatMarkdownResolvedImage`, which renders a **zoom button** (`data-chat-markdown-image-expand`, accessible labels, focus ring) when expansion is enabled. Images inside explicit links stay plain `<img>`s: a new **`rehypeMarkLinkedImages`** pass tags nested images so zoom is not nested inside `<a>`.
> 
> **ExpandedImageDialog** is rebuilt on **@base-ui/react/dialog** with initial/final focus (close button and restore to the triggering control), overlay close via `DialogPrimitive.Close`, and arrow keys still handled for multi-image navigation (Escape now follows the dialog primitive instead of a custom window listener).
> 
> **MessagesTimeline** passes `ctx.onImageExpand` into assistant `ChatMarkdown`. Tests cover zoom buttons, linked-image behavior, and timeline markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549f89fd537cd065921d22d16d0988bee5da9b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make assistant markdown images open in expanded preview dialog
> - Adds `onImageExpand` callback to `ChatMarkdown` so standalone images render as clickable zoom buttons; images wrapped in links stay plain
> - Introduces a rehype plugin `rehypeMarkLinkedImages` that flags `<img>` nodes inside `<a>` tags via `node.data.t3LinkedImage`\n- Rewrites `ExpandedImageDialog` with `@base-ui/react` dialog primitives, adding managed focus and overlay/`Close`-button dismissal while retaining arrow-key navigation
> - Wires `ctx.onImageExpand` through `AssistantTimelineRow` so assistant message images can expand
> - Risk: custom Escape handling removed from `ExpandedImageDialog` keydown listener; Escape now relies on the dialog primitive's default behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 549f89f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->