### PR TITLE
fix(opencode): handle child approvals, stops, and model catalogs

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -648,6 +648,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const settingsRouteSession = useMemo<ExistingThreadSettingsRouteSession>(
     () => ({
       ownerId: settingsOwnerId,
+      environmentId: props.environmentId,
       providerGroups: threadProviderGroups,
       selectedModel: currentModelSelection,
       onSelectModel: (option) => props.onUpdateModelSelection(option.selection),

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -1,4 +1,5 @@
 import type {
+  EnvironmentId,
   ModelSelection,
   ProviderOptionDescriptor,
   ProviderOptionSelection,
@@ -27,7 +28,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { Platform, Pressable, ScrollView, TextInput, View } from "react-native";
+import { Alert, Platform, Pressable, ScrollView, TextInput, View } from "react-native";
 import Animated, { FadeIn, FadeOut, LinearTransition } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -47,7 +48,13 @@ import {
   nativeHeaderScrollEdgeEffects,
 } from "../../native/StackHeader";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
+import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
 import { useNewTaskFlow } from "./new-task-flow-provider";
+import {
+  createProviderCatalogRefreshRunner,
+  providerCatalogRefreshError,
+} from "./provider-catalog-refresh";
 import {
   createNativeMailSearchToolbarItem,
   NATIVE_MAIL_SEARCH_TOOLBAR_CONTENT_INSET,
@@ -281,6 +288,7 @@ type ThreadSettingsSubmenuPage =
   | { readonly kind: "runtime" };
 
 type ThreadSettingsSessionProps = {
+  readonly environmentId: EnvironmentId | null;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly selectedModel: ModelSelection | null;
   readonly onSelectModel: (option: ModelOption) => void;
@@ -332,6 +340,7 @@ export function useExistingThreadSettingsRoutePresentation() {
 }
 
 type ThreadSettingsSessionValue = {
+  readonly environmentId: EnvironmentId | null;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly runtimeMode: RuntimeMode;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
@@ -450,6 +459,7 @@ function ThreadSettingsSessionProvider(
 
   const value = useMemo<ThreadSettingsSessionValue>(
     () => ({
+      environmentId: props.environmentId,
       providerGroups: props.providerGroups,
       runtimeMode: props.runtimeMode,
       onUpdateRuntimeMode: props.onUpdateRuntimeMode,
@@ -478,6 +488,7 @@ function ThreadSettingsSessionProvider(
       hasLegacyModels,
       isApplied,
       isDisplayed,
+      props.environmentId,
       pendingModel,
       pressModel,
       providerFilter,
@@ -946,6 +957,23 @@ function ThreadSettingsModelsScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<ThreadSettingsPickerStackParams>>();
   const usesNativeMailSearchToolbar = Platform.OS === "ios" && NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED;
   const hasCustomCatalogFilter = session.providerFilter !== null || session.showLegacy;
+  const refreshProvidersCommand = useAtomCommand(serverEnvironment.refreshProviders, {
+    reportFailure: false,
+  });
+  const refreshProviderCatalog = useMemo(
+    () => createProviderCatalogRefreshRunner(refreshProvidersCommand),
+    [refreshProvidersCommand],
+  );
+  const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
+  const refreshProviders = useCallback(() => {
+    if (!session.environmentId || isRefreshingProviders) return;
+    setIsRefreshingProviders(true);
+    void refreshProviderCatalog(session.environmentId).then((result) => {
+      setIsRefreshingProviders(false);
+      const error = providerCatalogRefreshError(result);
+      if (error) Alert.alert("Could not refresh models", error);
+    });
+  }, [isRefreshingProviders, refreshProviderCatalog, session.environmentId]);
   const commitAndClose = useCallback(() => {
     session.commitPendingModel();
     presentation.onClose();
@@ -993,6 +1021,12 @@ function ThreadSettingsModelsScreen() {
       {Platform.OS === "android" ? (
         <AndroidScreenHeader
           actions={[
+            {
+              accessibilityLabel: "Refresh models",
+              disabled: isRefreshingProviders || session.environmentId === null,
+              icon: "arrow.clockwise",
+              onPress: refreshProviders,
+            },
             {
               accessibilityLabel: session.pendingModel ? "Save thread settings" : "Done",
               icon: "checkmark",
@@ -1058,6 +1092,13 @@ function ThreadSettingsModelsScreen() {
         />
       </NativeHeaderToolbar>
       <NativeHeaderToolbar placement="right">
+        <NativeHeaderToolbar.Button
+          accessibilityLabel="Refresh models"
+          disabled={isRefreshingProviders || session.environmentId === null}
+          icon="arrow.clockwise"
+          onPress={refreshProviders}
+          separateBackground
+        />
         <NativeHeaderToolbar.Button
           accessibilityLabel={session.pendingModel ? "Save thread settings" : "Done"}
           label={session.pendingModel ? "Save" : "Done"}
@@ -1217,6 +1258,7 @@ export function NewTaskThreadSettingsRouteScreen() {
 
   return (
     <ThreadSettingsSessionProvider
+      environmentId={flow.selectedEnvironmentId}
       providerGroups={flow.providerGroups}
       selectedModel={flow.selectedModel}
       onSelectModel={(option) => flow.setSelectedModelKey(option.key, option.selection.options)}

--- a/apps/mobile/src/features/threads/provider-catalog-refresh.test.ts
+++ b/apps/mobile/src/features/threads/provider-catalog-refresh.test.ts
@@ -1,0 +1,46 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  createProviderCatalogRefreshRunner,
+  providerCatalogRefreshError,
+} from "./provider-catalog-refresh";
+
+describe("mobile provider catalog refresh", () => {
+  it("calls server discovery for the selected environment and deduplicates pending taps", async () => {
+    let resolveRefresh: ((value: "refreshed") => void) | undefined;
+    const refreshProviders = vi.fn(
+      () =>
+        new Promise<"refreshed">((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    const refresh = createProviderCatalogRefreshRunner(refreshProviders);
+    const environmentId = EnvironmentId.make("environment-mobile");
+
+    const first = refresh(environmentId);
+    const second = refresh(environmentId);
+
+    expect(second).toBe(first);
+    expect(refreshProviders).toHaveBeenCalledOnce();
+    expect(refreshProviders).toHaveBeenCalledWith({ environmentId, input: {} });
+
+    resolveRefresh?.("refreshed");
+    await expect(first).resolves.toBe("refreshed");
+  });
+
+  it("reports a discovery error and allows retry after the failed command settles", async () => {
+    const failure = AsyncResult.failure<never, Error>(Cause.fail(new Error("discovery failed")));
+    const success = AsyncResult.success("refreshed");
+    let callCount = 0;
+    const refreshProviders = vi.fn(async () => (callCount++ === 0 ? failure : success));
+    const refresh = createProviderCatalogRefreshRunner(refreshProviders);
+    const environmentId = EnvironmentId.make("environment-mobile");
+
+    expect(providerCatalogRefreshError(await refresh(environmentId))).toBe("discovery failed");
+    expect(providerCatalogRefreshError(await refresh(environmentId))).toBeNull();
+    expect(refreshProviders).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/src/features/threads/provider-catalog-refresh.ts
+++ b/apps/mobile/src/features/threads/provider-catalog-refresh.ts
@@ -1,0 +1,34 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+
+type RefreshProvidersTarget = {
+  readonly environmentId: EnvironmentId;
+  readonly input: Record<never, never>;
+};
+
+/** Deduplicates taps while the server refresh command is still running. */
+export function createProviderCatalogRefreshRunner<Result>(
+  refreshProviders: (target: RefreshProvidersTarget) => Promise<Result>,
+) {
+  let pending: Promise<Result> | null = null;
+
+  return (environmentId: EnvironmentId): Promise<Result> => {
+    if (pending) return pending;
+    pending = refreshProviders({ environmentId, input: {} }).finally(() => {
+      pending = null;
+    });
+    return pending;
+  };
+}
+
+export function providerCatalogRefreshError(
+  result: AtomCommandResult<unknown, unknown>,
+): string | null {
+  if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return null;
+  const error = squashAtomCommandFailure(result);
+  return error instanceof Error ? error.message : "Provider discovery failed.";
+}

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -34,7 +34,7 @@ import {
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import { OpenCodeRuntime } from "../opencodeRuntime.ts";
-import { makeOpenCodeServerOwner } from "../OpenCodeServerOwner.ts";
+import * as OpenCodeServerOwner from "../OpenCodeServerOwner.ts";
 import {
   defaultProviderContinuationIdentity,
   type ProviderDriver,
@@ -142,22 +142,23 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       });
-      const serverOwner = yield* makeOpenCodeServerOwner({
+      const serverOwner = yield* OpenCodeServerOwner.make({
         binaryPath: effectiveConfig.binaryPath,
         environment: processEnv,
       });
-      const textGeneration = yield* makeOpenCodeTextGeneration(
-        effectiveConfig,
-        processEnv,
-        serverOwner,
+      const textGeneration = yield* makeOpenCodeTextGeneration(effectiveConfig).pipe(
+        Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
       );
 
       const checkProvider = checkOpenCodeProviderStatus(
         effectiveConfig,
         serverConfig.cwd,
         processEnv,
-        serverOwner,
-      ).pipe(Effect.map(stampIdentity), Effect.provideService(OpenCodeRuntime, openCodeRuntime));
+      ).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
+        Effect.provideService(OpenCodeRuntime, openCodeRuntime),
+      );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OpenCodeSettings>>(

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -34,6 +34,7 @@ import {
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import { OpenCodeRuntime } from "../opencodeRuntime.ts";
+import { makeOpenCodeServerOwner } from "../OpenCodeServerOwner.ts";
 import {
   defaultProviderContinuationIdentity,
   type ProviderDriver,
@@ -141,12 +142,21 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         environment: processEnv,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       });
-      const textGeneration = yield* makeOpenCodeTextGeneration(effectiveConfig, processEnv);
+      const serverOwner = yield* makeOpenCodeServerOwner({
+        binaryPath: effectiveConfig.binaryPath,
+        environment: processEnv,
+      });
+      const textGeneration = yield* makeOpenCodeTextGeneration(
+        effectiveConfig,
+        processEnv,
+        serverOwner,
+      );
 
       const checkProvider = checkOpenCodeProviderStatus(
         effectiveConfig,
         serverConfig.cwd,
         processEnv,
+        serverOwner,
       ).pipe(Effect.map(stampIdentity), Effect.provideService(OpenCodeRuntime, openCodeRuntime));
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
@@ -156,6 +166,8 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
           getSettings: snapshotSettings.getSettings,
           streamSettings: snapshotSettings.streamSettings,
           haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+          checkProviderOnSettingsChange: () => false,
+          refreshOnInterval: false,
           initialSnapshot: (settings) =>
             makePendingOpenCodeProvider(settings.provider).pipe(Effect.map(stampIdentity)),
           checkProvider,

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -144,6 +144,10 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
       });
       const serverOwner = yield* OpenCodeServerOwner.make({
         binaryPath: effectiveConfig.binaryPath,
+        directory: serverConfig.cwd,
+        ...(effectiveConfig.serverPassword
+          ? { serverPassword: effectiveConfig.serverPassword }
+          : {}),
         environment: processEnv,
       });
       const textGeneration = yield* makeOpenCodeTextGeneration(effectiveConfig).pipe(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -16,6 +16,7 @@ import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
 
 import {
+  ApprovalRequestId,
   OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -61,13 +62,19 @@ const runtimeMock = {
     sessionCreateInputs: [] as Array<Record<string, unknown>>,
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
+    abortImplementation: null as ((sessionID: string) => Promise<void>) | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
-    subscribedEvents: [] as unknown[],
+    subscribedEvents: [] as Array<unknown | Promise<unknown>>,
+    permissionReplyCalls: [] as Array<{ requestID: string; reply: string }>,
+    questionReplyCalls: [] as Array<{
+      requestID: string;
+      answers: ReadonlyArray<ReadonlyArray<string>>;
+    }>,
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -81,6 +88,7 @@ const runtimeMock = {
     this.state.sessionCreateInputs.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
+    this.state.abortImplementation = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
@@ -88,6 +96,8 @@ const runtimeMock = {
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.permissionReplyCalls.length = 0;
+    this.state.questionReplyCalls.length = 0;
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -176,6 +186,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
+          await runtimeMock.state.abortImplementation?.(sessionID);
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -207,10 +218,26 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         subscribe: async () => ({
           stream: (async function* () {
             for (const event of runtimeMock.state.subscribedEvents) {
-              yield event;
+              yield await event;
             }
           })(),
         }),
+      },
+      permission: {
+        reply: async ({ requestID, reply }: { requestID: string; reply: string }) => {
+          runtimeMock.state.permissionReplyCalls.push({ requestID, reply });
+        },
+      },
+      question: {
+        reply: async ({
+          requestID,
+          answers,
+        }: {
+          requestID: string;
+          answers: ReadonlyArray<ReadonlyArray<string>>;
+        }) => {
+          runtimeMock.state.questionReplyCalls.push({ requestID, answers });
+        },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -279,6 +306,16 @@ beforeEach(() => {
 
 const advanceTestClock = (ms: number) =>
   TestClock.adjust(`${ms} millis`).pipe(Effect.andThen(Effect.yieldNow));
+
+function promiseWithResolvers<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
   it.effect("reuses a configured OpenCode server URL instead of spawning a local server", () =>
@@ -809,6 +846,418 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("routes child-session approval requests and replies through the parent thread", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-approval");
+      const permissionReply = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        {
+          id: "evt-child-created",
+          type: "session.created",
+          properties: {
+            sessionID: "ses_child",
+            info: {
+              id: "ses_child",
+              parentID: "http://127.0.0.1:9999/session",
+              title: "Child session",
+            },
+          },
+        },
+        {
+          id: "evt-child-permission",
+          type: "permission.asked",
+          properties: {
+            id: "per_child",
+            sessionID: "ses_child",
+            permission: "external_directory",
+            patterns: ["/tmp/external/*"],
+            metadata: { source: "child" },
+            always: ["/tmp/external/*"],
+          },
+        },
+        permissionReply.promise,
+      ];
+
+      const openedEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+
+      const openedEvents = Array.from(
+        yield* Fiber.join(openedEventsFiber).pipe(Effect.timeout("1 second")),
+      );
+      const opened = openedEvents.find((event) => event.type === "request.opened");
+      NodeAssert.ok(opened);
+      NodeAssert.equal(opened.requestId, "per_child");
+      NodeAssert.equal(
+        opened.raw?.source === "opencode.sdk.event" &&
+          typeof opened.raw.payload === "object" &&
+          opened.raw.payload !== null &&
+          "properties" in opened.raw.payload
+          ? (opened.raw.payload.properties as { sessionID?: string }).sessionID
+          : undefined,
+        "ses_child",
+      );
+
+      yield* adapter.respondToRequest(
+        threadId,
+        ApprovalRequestId.make("per_child"),
+        "acceptForSession",
+      );
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, [
+        { requestID: "per_child", reply: "always" },
+      ]);
+
+      const resolvedEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(1),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      permissionReply.resolve({
+        id: "evt-child-permission-replied",
+        type: "permission.replied",
+        properties: {
+          sessionID: "ses_child",
+          requestID: "per_child",
+          reply: "always",
+        },
+      });
+      const resolved = yield* Fiber.join(resolvedEventFiber).pipe(Effect.timeout("1 second"));
+      NodeAssert.equal(Option.getOrUndefined(resolved)?.type, "request.resolved");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("routes child-session questions and replies through the parent thread", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-question");
+      const questionReply = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        {
+          id: "evt-child-created",
+          type: "session.created",
+          properties: {
+            sessionID: "ses_child_question",
+            info: {
+              id: "ses_child_question",
+              parentID: "http://127.0.0.1:9999/session",
+              title: "Child session",
+            },
+          },
+        },
+        {
+          id: "evt-child-question",
+          type: "question.asked",
+          properties: {
+            id: "que_child",
+            sessionID: "ses_child_question",
+            questions: [
+              {
+                header: "Scope",
+                question: "Which scope should OpenCode use?",
+                options: [{ label: "Workspace", description: "Use this workspace." }],
+              },
+            ],
+          },
+        },
+        questionReply.promise,
+      ];
+
+      const requestedEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+
+      const requestedEvents = Array.from(
+        yield* Fiber.join(requestedEventsFiber).pipe(Effect.timeout("1 second")),
+      );
+      const requested = requestedEvents.find((event) => event.type === "user-input.requested");
+      NodeAssert.ok(requested);
+      NodeAssert.equal(requested.requestId, "que_child");
+
+      yield* adapter.respondToUserInput(threadId, ApprovalRequestId.make("que_child"), {
+        Scope: "Workspace",
+      });
+      NodeAssert.deepEqual(runtimeMock.state.questionReplyCalls, [
+        { requestID: "que_child", answers: [["Workspace"]] },
+      ]);
+
+      const resolvedEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(1),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      questionReply.resolve({
+        id: "evt-child-question-replied",
+        type: "question.replied",
+        properties: {
+          sessionID: "ses_child_question",
+          requestID: "que_child",
+          answers: [["Workspace"]],
+        },
+      });
+      const resolved = yield* Fiber.join(resolvedEventFiber).pipe(Effect.timeout("1 second"));
+      NodeAssert.equal(Option.getOrUndefined(resolved)?.type, "user-input.resolved");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps an idle event from completing a turn while its abort request is pending", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-idle-race");
+      const idleEvent = promiseWithResolvers<unknown>();
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [idleEvent.promise];
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep working",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      idleEvent.resolve({
+        id: "evt-idle-after-stop",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.yieldNow;
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(interruptFiber);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events
+          .filter((event) => event.type === "turn.completed" || event.type === "turn.aborted")
+          .map((event) => event.type),
+        ["turn.aborted"],
+      );
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("treats MessageAbortedError as the acknowledgment for a pending user stop", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-error-race");
+      const abortedEvent = promiseWithResolvers<unknown>();
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [abortedEvent.promise];
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep working",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      abortedEvent.resolve({
+        id: "evt-aborted-after-stop",
+        type: "session.error",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      });
+      yield* Effect.yieldNow;
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(interruptFiber);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events
+          .filter(
+            (event) =>
+              event.type === "turn.completed" ||
+              event.type === "turn.aborted" ||
+              event.type === "runtime.error",
+          )
+          .map((event) => event.type),
+        ["turn.aborted"],
+      );
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("does not claim a turn stopped when the abort request fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-request-failure");
+      runtimeMock.state.abortImplementation = async () => {
+        throw new Error("abort failed");
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep working",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const exit = yield* Effect.exit(adapter.interruptTurn(threadId, turn.turnId));
+      NodeAssert.equal(Exit.isFailure(exit), true);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "running");
+      NodeAssert.equal(session?.activeTurnId, turn.turnId);
+    }),
+  );
+
+  it.effect("keeps a genuine provider error visible during a pending user stop", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-provider-error");
+      const errorEvent = promiseWithResolvers<unknown>();
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [errorEvent.promise];
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep working",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      errorEvent.resolve({
+        id: "evt-provider-error-after-stop",
+        type: "session.error",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          error: {
+            name: "APIError",
+            data: { message: "Upstream failed", isRetryable: false },
+          },
+        },
+      });
+      yield* Effect.yieldNow;
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(interruptFiber);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events
+          .filter(
+            (event) =>
+              event.type === "turn.completed" ||
+              event.type === "turn.aborted" ||
+              event.type === "runtime.error",
+          )
+          .map((event) => event.type),
+        ["turn.completed", "runtime.error"],
+      );
+      const failed = events.find((event) => event.type === "turn.completed");
+      NodeAssert.equal(
+        failed?.type === "turn.completed" ? failed.payload.state : undefined,
+        "failed",
+      );
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("passes agent and variant options for the adapter's bound custom instance id", () => {
     const instanceId = ProviderInstanceId.make("opencode_zen");
     const adapterLayer = Layer.effect(
@@ -1287,6 +1736,39 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
               id: "msg-other-session",
               role: "assistant",
             },
+          },
+        },
+        {
+          id: "evt-unrelated-child",
+          type: "session.created",
+          properties: {
+            sessionID: "ses_unrelated_child",
+            info: {
+              id: "ses_unrelated_child",
+              parentID: "ses_unrelated_parent",
+              title: "Unrelated child",
+            },
+          },
+        },
+        {
+          id: "evt-unrelated-permission",
+          type: "permission.asked",
+          properties: {
+            id: "per_unrelated",
+            sessionID: "ses_unrelated_child",
+            permission: "bash",
+            patterns: ["pwd"],
+            metadata: {},
+            always: [],
+          },
+        },
+        {
+          id: "evt-unrelated-question",
+          type: "question.asked",
+          properties: {
+            id: "que_unrelated",
+            sessionID: "ses_unrelated_child",
+            questions: [],
           },
         },
         {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -76,6 +76,7 @@ const runtimeMock = {
       answers: ReadonlyArray<ReadonlyArray<string>>;
     }>,
     sessionStatus: "idle" as "idle" | "busy",
+    sessionStatusFailures: 0,
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -100,6 +101,7 @@ const runtimeMock = {
     this.state.permissionReplyCalls.length = 0;
     this.state.questionReplyCalls.length = 0;
     this.state.sessionStatus = "idle";
+    this.state.sessionStatusFailures = 0;
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -190,12 +192,18 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           runtimeMock.state.abortCalls.push(sessionID);
           await runtimeMock.state.abortImplementation?.(sessionID);
         },
-        status: async () => ({
-          data:
-            runtimeMock.state.sessionStatus === "idle"
-              ? {}
-              : { "http://127.0.0.1:9999/session": { type: "busy" as const } },
-        }),
+        status: async () => {
+          if (runtimeMock.state.sessionStatusFailures > 0) {
+            runtimeMock.state.sessionStatusFailures -= 1;
+            throw new Error("status failed");
+          }
+          return {
+            data:
+              runtimeMock.state.sessionStatus === "idle"
+                ? {}
+                : { "http://127.0.0.1:9999/session": { type: "busy" as const } },
+          };
+        },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
           if (runtimeMock.state.promptAsyncError) {
@@ -1249,16 +1257,18 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("ignores delayed stop events after the next turn becomes busy", () =>
+  it.effect("ignores delayed stop events around the next turn startup", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-delayed-interrupt-events");
+      const staleIdleBeforeBusy = promiseWithResolvers<unknown>();
       const nextBusy = promiseWithResolvers<unknown>();
       const staleAbort = promiseWithResolvers<unknown>();
       const staleIdle = promiseWithResolvers<unknown>();
       const secondStaleIdle = promiseWithResolvers<unknown>();
       const nextIdle = promiseWithResolvers<unknown>();
       runtimeMock.state.subscribedEvents = [
+        staleIdleBeforeBusy.promise,
         nextBusy.promise,
         staleAbort.promise,
         staleIdle.promise,
@@ -1294,6 +1304,24 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           "opencode/kimi-k3",
         ),
       });
+
+      staleIdleBeforeBusy.resolve({
+        id: "evt-delayed-idle-before-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      for (let index = 0; index < 2; index += 1) {
+        yield* Effect.yieldNow;
+      }
+      const sessionsBeforeBusy = yield* adapter.listSessions();
+      const sessionBeforeBusy = sessionsBeforeBusy.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionBeforeBusy?.status, "running");
+      NodeAssert.equal(sessionBeforeBusy?.activeTurnId, secondTurn.turnId);
 
       runtimeMock.state.sessionStatus = "busy";
       nextBusy.resolve({
@@ -1340,6 +1368,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(sessionBeforeRealIdle?.activeTurnId, secondTurn.turnId);
 
       runtimeMock.state.sessionStatus = "idle";
+      runtimeMock.state.sessionStatusFailures = 2;
       nextIdle.resolve({
         id: "evt-next-idle",
         type: "session.status",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -75,6 +75,7 @@ const runtimeMock = {
       requestID: string;
       answers: ReadonlyArray<ReadonlyArray<string>>;
     }>,
+    sessionStatus: "idle" as "idle" | "busy",
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -98,6 +99,7 @@ const runtimeMock = {
     this.state.subscribedEvents = [];
     this.state.permissionReplyCalls.length = 0;
     this.state.questionReplyCalls.length = 0;
+    this.state.sessionStatus = "idle";
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -188,6 +190,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           runtimeMock.state.abortCalls.push(sessionID);
           await runtimeMock.state.abortImplementation?.(sessionID);
         },
+        status: async () => ({
+          data:
+            runtimeMock.state.sessionStatus === "idle"
+              ? {}
+              : { "http://127.0.0.1:9999/session": { type: "busy" as const } },
+        }),
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
           if (runtimeMock.state.promptAsyncError) {
@@ -1218,10 +1226,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const firstInterrupt = yield* adapter
         .interruptTurn(threadId, turn.turnId)
         .pipe(Effect.forkChild);
-      yield* Effect.promise(() => abortStarted.promise);
       const secondInterrupt = yield* adapter
         .interruptTurn(threadId, turn.turnId)
         .pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
       yield* Effect.yieldNow;
       NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
 
@@ -1241,18 +1249,20 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("ignores delayed stop events until the next turn becomes busy", () =>
+  it.effect("ignores delayed stop events after the next turn becomes busy", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-delayed-interrupt-events");
+      const nextBusy = promiseWithResolvers<unknown>();
       const staleAbort = promiseWithResolvers<unknown>();
       const staleIdle = promiseWithResolvers<unknown>();
-      const nextBusy = promiseWithResolvers<unknown>();
+      const secondStaleIdle = promiseWithResolvers<unknown>();
       const nextIdle = promiseWithResolvers<unknown>();
       runtimeMock.state.subscribedEvents = [
+        nextBusy.promise,
         staleAbort.promise,
         staleIdle.promise,
-        nextBusy.promise,
+        secondStaleIdle.promise,
         nextIdle.promise,
       ];
 
@@ -1285,6 +1295,15 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         ),
       });
 
+      runtimeMock.state.sessionStatus = "busy";
+      nextBusy.resolve({
+        id: "evt-next-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
       staleAbort.resolve({
         id: "evt-delayed-abort",
         type: "session.error",
@@ -1301,25 +1320,26 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           status: { type: "idle" },
         },
       });
+      secondStaleIdle.resolve({
+        id: "evt-second-delayed-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
       for (let index = 0; index < 4; index += 1) {
         yield* Effect.yieldNow;
       }
 
-      const sessionsBeforeBusy = yield* adapter.listSessions();
-      const sessionBeforeBusy = sessionsBeforeBusy.find(
+      const sessionsBeforeRealIdle = yield* adapter.listSessions();
+      const sessionBeforeRealIdle = sessionsBeforeRealIdle.find(
         (candidate) => candidate.threadId === threadId,
       );
-      NodeAssert.equal(sessionBeforeBusy?.status, "running");
-      NodeAssert.equal(sessionBeforeBusy?.activeTurnId, secondTurn.turnId);
+      NodeAssert.equal(sessionBeforeRealIdle?.status, "running");
+      NodeAssert.equal(sessionBeforeRealIdle?.activeTurnId, secondTurn.turnId);
 
-      nextBusy.resolve({
-        id: "evt-next-busy",
-        type: "session.status",
-        properties: {
-          sessionID: "http://127.0.0.1:9999/session",
-          status: { type: "busy" },
-        },
-      });
+      runtimeMock.state.sessionStatus = "idle";
       nextIdle.resolve({
         id: "evt-next-idle",
         type: "session.status",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -61,17 +61,24 @@ const runtimeMock = {
     startCalls: [] as string[],
     sessionCreateUrls: [] as string[],
     sessionCreateInputs: [] as Array<Record<string, unknown>>,
+    createdSessionIds: [] as string[],
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
     abortImplementation: null as ((sessionID: string) => Promise<void>) | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
+    messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
+    messageFailures: 0,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
     promptAsyncImplementation: null as (() => Promise<void>) | null,
+    autoPromptEcho: true,
+    autoConnect: true,
+    promptEchoEvents: [] as Array<unknown>,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as Array<unknown | Promise<unknown>>,
+    eventSubscribeObserved: null as (() => void) | null,
     permissionReplyCalls: [] as Array<{ requestID: string; reply: string }>,
     questionReplyCalls: [] as Array<{
       requestID: string;
@@ -100,17 +107,24 @@ const runtimeMock = {
     this.state.startCalls.length = 0;
     this.state.sessionCreateUrls.length = 0;
     this.state.sessionCreateInputs.length = 0;
+    this.state.createdSessionIds.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
     this.state.abortImplementation = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
+    this.state.messageCalls.length = 0;
+    this.state.messageFailures = 0;
     this.state.promptCalls.length = 0;
     this.state.promptAsyncError = null;
     this.state.promptAsyncImplementation = null;
+    this.state.autoPromptEcho = true;
+    this.state.autoConnect = true;
+    this.state.promptEchoEvents.length = 0;
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.eventSubscribeObserved = null;
     this.state.permissionReplyCalls.length = 0;
     this.state.questionReplyCalls.length = 0;
     this.state.sessionStatus = "idle";
@@ -150,6 +164,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       return {
         url,
         exitCode: Effect.never,
+        isRunning: Effect.succeed(true),
       };
     }),
   connectToOpenCodeServer: ({ serverUrl }) =>
@@ -181,7 +196,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           runtimeMock.state.authHeaders.push(
             serverPassword ? `Basic ${btoa(`opencode:${serverPassword}`)}` : null,
           );
-          return { data: { id: `${baseUrl}/session` } };
+          return {
+            data: { id: runtimeMock.state.createdSessionIds.shift() ?? `${baseUrl}/session` },
+          };
         },
         get: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.sessionGetIds.push(sessionID);
@@ -245,8 +262,40 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           if (runtimeMock.state.promptAsyncError) {
             throw runtimeMock.state.promptAsyncError;
           }
+          if (
+            runtimeMock.state.autoPromptEcho &&
+            typeof input === "object" &&
+            input !== null &&
+            "sessionID" in input &&
+            "messageID" in input &&
+            typeof input.sessionID === "string" &&
+            typeof input.messageID === "string"
+          ) {
+            runtimeMock.state.promptEchoEvents.push({
+              id: `evt-auto-user-${input.messageID}`,
+              type: "message.updated",
+              properties: {
+                sessionID: input.sessionID,
+                info: { id: input.messageID, role: "user" },
+              },
+            });
+          }
         },
         messages: async () => ({ data: runtimeMock.state.messages }),
+        message: async ({ sessionID, messageID }: { sessionID: string; messageID: string }) => {
+          runtimeMock.state.messageCalls.push({ sessionID, messageID });
+          if (runtimeMock.state.messageFailures > 0) {
+            runtimeMock.state.messageFailures -= 1;
+            throw new Error("message lookup failed", { cause: { status: 500 } });
+          }
+          const message = runtimeMock.state.messages.find((entry) => entry.info.id === messageID);
+          if (!message) {
+            throw new Error(`Message not found: ${messageID}`, {
+              cause: { status: 404, body: { name: "NotFoundError" } },
+            });
+          }
+          return { data: message };
+        },
         revert: async ({ sessionID, messageID }: { sessionID: string; messageID?: string }) => {
           runtimeMock.state.revertCalls.push({
             sessionID,
@@ -267,13 +316,23 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
       },
       event: {
-        subscribe: async () => ({
-          stream: (async function* () {
-            for (const event of runtimeMock.state.subscribedEvents) {
-              yield await event;
-            }
-          })(),
-        }),
+        subscribe: async () => {
+          runtimeMock.state.eventSubscribeObserved?.();
+          return {
+            stream: (async function* () {
+              if (runtimeMock.state.autoConnect) {
+                yield { id: "evt-auto-connected", type: "server.connected", properties: {} };
+              }
+              for (const event of runtimeMock.state.subscribedEvents) {
+                const resolved = await event;
+                while (runtimeMock.state.promptEchoEvents.length > 0) {
+                  yield runtimeMock.state.promptEchoEvents.shift();
+                }
+                yield resolved;
+              }
+            })(),
+          };
+        },
       },
       permission: {
         list: async () => {
@@ -424,6 +483,103 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.deepEqual(runtimeMock.state.authHeaders, [
         `Basic ${btoa("opencode:secret-password")}`,
       ]);
+    }),
+  );
+
+  it.effect("fails startup when the OpenCode event stream does not connect", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-connect-timeout");
+      runtimeMock.state.autoConnect = false;
+
+      const startFiber = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.yieldNow;
+      yield* advanceTestClock(10_000);
+
+      const result = yield* Fiber.join(startFiber);
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterRequestError");
+      NodeAssert.equal(result.failure.method, "event.subscribe");
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
+
+  it.effect("closes an unpublished session when startup is interrupted", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-connect-interrupted");
+      const eventSubscribeObserved = promiseWithResolvers<void>();
+      runtimeMock.state.autoConnect = false;
+      runtimeMock.state.eventSubscribeObserved = () => eventSubscribeObserved.resolve(undefined);
+
+      const startFiber = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => eventSubscribeObserved.promise);
+      yield* Effect.yieldNow;
+      yield* Fiber.interrupt(startFiber);
+
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, ["http://127.0.0.1:9999/session"]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
+
+  it.effect("keeps one session when concurrent starts cross the connection barrier", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-concurrent-start");
+      const connectionEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoConnect = false;
+      runtimeMock.state.createdSessionIds.push("ses_race_a", "ses_race_b");
+      runtimeMock.state.subscribedEvents = [connectionEvent.promise];
+
+      const firstStart = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.forkChild);
+      const secondStart = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      connectionEvent.resolve({
+        id: "evt-concurrent-start-connected",
+        type: "server.connected",
+        properties: {},
+      });
+
+      const [firstSession, secondSession] = yield* Effect.all([
+        Fiber.join(firstStart),
+        Fiber.join(secondStart),
+      ]);
+      const sessions = yield* adapter.listSessions();
+      const threadSessions = sessions.filter((session) => session.threadId === threadId);
+      NodeAssert.equal(threadSessions.length, 1);
+      NodeAssert.deepEqual(firstSession.resumeCursor, secondSession.resumeCursor);
+      const winnerId = (threadSessions[0]?.resumeCursor as { sessionId?: string } | undefined)
+        ?.sessionId;
+      NodeAssert.ok(winnerId === "ses_race_a" || winnerId === "ses_race_b");
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, [
+        winnerId === "ses_race_a" ? "ses_race_b" : "ses_race_a",
+      ]);
+      yield* adapter.stopSession(threadId);
     }),
   );
 
@@ -1046,6 +1202,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-steer-admission-only-idle");
+      runtimeMock.state.autoPromptEcho = false;
       const firstUserMessageEvent = promiseWithResolvers<unknown>();
       const staleIdleEvent = promiseWithResolvers<unknown>();
       const userMessageEvent = promiseWithResolvers<unknown>();
@@ -1141,6 +1298,190 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       );
       NodeAssert.equal(completed?.turnId, activeTurn.turnId);
       NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 1);
+    }),
+  );
+
+  it.effect("keeps steer admission until its user message arrives after prompt acceptance", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-steer-message-after-acceptance");
+      runtimeMock.state.autoPromptEcho = false;
+      const firstUserMessageEvent = promiseWithResolvers<unknown>();
+      const staleIdleEvent = promiseWithResolvers<unknown>();
+      const steerUserMessageEvent = promiseWithResolvers<unknown>();
+      const validIdleEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        firstUserMessageEvent.promise,
+        staleIdleEvent.promise,
+        steerUserMessageEvent.promise,
+        validIdleEvent.promise,
+      ];
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Start work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const firstMessageId = (runtimeMock.state.promptCalls[0] as { messageID?: string }).messageID;
+      firstUserMessageEvent.resolve({
+        id: "evt-first-user-message-before-steer",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: firstMessageId, role: "user" },
+        },
+      });
+      yield* Effect.yieldNow;
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Add another task",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const steerMessageId = (runtimeMock.state.promptCalls[1] as { messageID?: string }).messageID;
+
+      staleIdleEvent.resolve({
+        id: "evt-stale-idle-after-steer-acceptance",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.yieldNow;
+      const sessionsAfterStaleIdle = yield* adapter.listSessions();
+      const sessionAfterStaleIdle = sessionsAfterStaleIdle.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionAfterStaleIdle?.status, "running");
+      NodeAssert.equal(sessionAfterStaleIdle?.activeTurnId, activeTurn.turnId);
+
+      steerUserMessageEvent.resolve({
+        id: "evt-steer-user-message-after-acceptance",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: steerMessageId, role: "user" },
+        },
+      });
+      validIdleEvent.resolve({
+        id: "evt-valid-idle-after-steer-message",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+    }),
+  );
+
+  it.effect("recovers steer admission when reconnect happens before prompt acceptance", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-steer-reconnect-before-acceptance");
+      const firstUserMessageEvent = promiseWithResolvers<unknown>();
+      const reconnectEvent = promiseWithResolvers<unknown>();
+      const steerStarted = promiseWithResolvers<void>();
+      const steerRelease = promiseWithResolvers<void>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [firstUserMessageEvent.promise, reconnectEvent.promise];
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 2) {
+          steerStarted.resolve(undefined);
+          await steerRelease.promise;
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Start work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const firstMessageId = (runtimeMock.state.promptCalls[0] as { messageID?: string }).messageID;
+      firstUserMessageEvent.resolve({
+        id: "evt-first-user-before-reconnect-steer",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: firstMessageId, role: "user" },
+        },
+      });
+      yield* Effect.yieldNow;
+
+      const steerFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Add another task",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => steerStarted.promise);
+      const steerMessageId = (runtimeMock.state.promptCalls[1] as { messageID?: string }).messageID;
+      NodeAssert.ok(steerMessageId);
+      runtimeMock.state.messages.push({
+        info: { id: steerMessageId, role: "user" },
+        parts: [],
+      });
+      runtimeMock.state.messageFailures = 1;
+      reconnectEvent.resolve({
+        id: "evt-reconnected-during-steer",
+        type: "server.connected",
+        properties: {},
+      });
+      yield* Effect.yieldNow;
+
+      steerRelease.resolve(undefined);
+      yield* Fiber.join(steerFiber);
+      yield* advanceTestClock(250);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+      NodeAssert.equal(
+        runtimeMock.state.messageCalls.filter((call) => call.messageID === steerMessageId).length,
+        2,
+      );
+      const abortCallsAfterCompletion = runtimeMock.state.abortCalls.length;
+      yield* adapter.interruptTurn(threadId, activeTurn.turnId);
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, abortCallsAfterCompletion);
     }),
   );
 
@@ -1987,6 +2328,71 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
 
       NodeAssert.notEqual(nextTurn.turnId, stoppedTurn.turnId);
       NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+    }),
+  );
+
+  it.effect("fails a turn waiting on cancellation when the session stops", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-stop-during-cancellation");
+      const firstAbortStarted = promiseWithResolvers<void>();
+      const teardownAbortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.abortImplementation = async () => {
+        if (runtimeMock.state.abortCalls.length === 1) {
+          firstAbortStarted.resolve(undefined);
+        } else {
+          teardownAbortStarted.resolve(undefined);
+        }
+        await abortRelease.promise;
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, activeTurn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => firstAbortStarted.promise);
+
+      const sendFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Must not be sent",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+
+      const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      const sendResult = yield* Fiber.join(sendFiber);
+      NodeAssert.equal(sendResult._tag, "Failure");
+      NodeAssert.equal(sendResult.failure._tag, "ProviderAdapterRequestError");
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+
+      yield* Effect.promise(() => teardownAbortStarted.promise);
+      yield* advanceTestClock(1_000);
+      yield* Fiber.join(stopFiber);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(interruptFiber);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -14,6 +14,7 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
+import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
 
 import {
   ApprovalRequestId,
@@ -67,6 +68,7 @@ const runtimeMock = {
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
+    promptAsyncImplementation: null as (() => Promise<void>) | null,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as Array<unknown | Promise<unknown>>,
@@ -77,10 +79,20 @@ const runtimeMock = {
     }>,
     sessionStatus: "idle" as "idle" | "busy",
     sessionStatusFailures: 0,
+    sessionStatusCalls: 0,
+    sessionStatusImplementation: null as (() => Promise<unknown>) | null,
     sessionGetIds: [] as string[],
+    sessionGetObserved: null as ((sessionID: string) => void) | null,
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
     sessionDirectoryById: new Map<string, string>(),
+    sessionParentById: new Map<string, string>(),
+    pendingPermissions: [] as Array<PermissionRequest>,
+    pendingQuestions: [] as Array<QuestionRequest>,
+    permissionListCalls: 0,
+    questionListCalls: 0,
+    permissionListImplementation: null as (() => Promise<Array<PermissionRequest>>) | null,
+    questionListImplementation: null as (() => Promise<Array<QuestionRequest>>) | null,
     sessionUpdateCalls: [] as Array<{ sessionID: string; permission: unknown }>,
     forkCalls: [] as Array<{ sessionID: string; directory?: string }>,
   },
@@ -95,6 +107,7 @@ const runtimeMock = {
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
     this.state.promptAsyncError = null;
+    this.state.promptAsyncImplementation = null;
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
@@ -102,10 +115,20 @@ const runtimeMock = {
     this.state.questionReplyCalls.length = 0;
     this.state.sessionStatus = "idle";
     this.state.sessionStatusFailures = 0;
+    this.state.sessionStatusCalls = 0;
+    this.state.sessionStatusImplementation = null;
     this.state.sessionGetIds.length = 0;
+    this.state.sessionGetObserved = null;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
     this.state.sessionDirectoryById.clear();
+    this.state.sessionParentById.clear();
+    this.state.pendingPermissions = [];
+    this.state.pendingQuestions = [];
+    this.state.permissionListCalls = 0;
+    this.state.questionListCalls = 0;
+    this.state.permissionListImplementation = null;
+    this.state.questionListImplementation = null;
     this.state.sessionUpdateCalls.length = 0;
     this.state.forkCalls.length = 0;
   },
@@ -162,6 +185,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         get: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.sessionGetIds.push(sessionID);
+          runtimeMock.state.sessionGetObserved?.(sessionID);
           // The real client is `throwOnError: true`: non-2xx rejects rather
           // than resolving, so missing → 404 throw, transient → 500 throw.
           if (runtimeMock.state.transientErrorSessionIds.has(sessionID)) {
@@ -173,7 +197,14 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             });
           }
           const directory = runtimeMock.state.sessionDirectoryById.get(sessionID);
-          return { data: { id: sessionID, ...(directory ? { directory } : {}) } };
+          const parentID = runtimeMock.state.sessionParentById.get(sessionID);
+          return {
+            data: {
+              id: sessionID,
+              ...(directory ? { directory } : {}),
+              ...(parentID ? { parentID } : {}),
+            },
+          };
         },
         update: async ({ sessionID, permission }: { sessionID: string; permission: unknown }) => {
           runtimeMock.state.sessionUpdateCalls.push({ sessionID, permission });
@@ -193,6 +224,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           await runtimeMock.state.abortImplementation?.(sessionID);
         },
         status: async () => {
+          runtimeMock.state.sessionStatusCalls += 1;
+          if (runtimeMock.state.sessionStatusImplementation) {
+            return await runtimeMock.state.sessionStatusImplementation();
+          }
           if (runtimeMock.state.sessionStatusFailures > 0) {
             runtimeMock.state.sessionStatusFailures -= 1;
             throw new Error("status failed");
@@ -206,6 +241,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
+          await runtimeMock.state.promptAsyncImplementation?.();
           if (runtimeMock.state.promptAsyncError) {
             throw runtimeMock.state.promptAsyncError;
           }
@@ -240,11 +276,27 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         }),
       },
       permission: {
+        list: async () => {
+          runtimeMock.state.permissionListCalls += 1;
+          return {
+            data: runtimeMock.state.permissionListImplementation
+              ? await runtimeMock.state.permissionListImplementation()
+              : runtimeMock.state.pendingPermissions,
+          };
+        },
         reply: async ({ requestID, reply }: { requestID: string; reply: string }) => {
           runtimeMock.state.permissionReplyCalls.push({ requestID, reply });
         },
       },
       question: {
+        list: async () => {
+          runtimeMock.state.questionListCalls += 1;
+          return {
+            data: runtimeMock.state.questionListImplementation
+              ? await runtimeMock.state.questionListImplementation()
+              : runtimeMock.state.pendingQuestions,
+          };
+        },
         reply: async ({
           requestID,
           answers,
@@ -332,6 +384,27 @@ function promiseWithResolvers<T>() {
   });
   return { promise, resolve, reject };
 }
+
+const permissionRequest = (id: string, sessionID: string): PermissionRequest => ({
+  id,
+  sessionID,
+  permission: "bash",
+  patterns: ["pwd"],
+  metadata: {},
+  always: [],
+});
+
+const questionRequest = (id: string, sessionID: string): QuestionRequest => ({
+  id,
+  sessionID,
+  questions: [
+    {
+      header: "Scope",
+      question: "Which scope should OpenCode use?",
+      options: [{ label: "Workspace", description: "Use this workspace." }],
+    },
+  ],
+});
 
 it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
   it.effect("reuses a configured OpenCode server URL instead of spawning a local server", () =>
@@ -862,6 +935,373 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("does not let an old idle status complete a successful steer", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-steer-idle-admission");
+      const busyBeforeSteer = promiseWithResolvers<unknown>();
+      const idleBeforeSteer = promiseWithResolvers<unknown>();
+      const idleAfterSteer = promiseWithResolvers<unknown>();
+      const statusStarted = promiseWithResolvers<void>();
+      const statusRelease = promiseWithResolvers<void>();
+      const steerStarted = promiseWithResolvers<void>();
+      const steerRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [
+        busyBeforeSteer.promise,
+        idleBeforeSteer.promise,
+        idleAfterSteer.promise,
+      ];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        statusStarted.resolve(undefined);
+        await statusRelease.promise;
+        return { data: {} };
+      };
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 3) {
+          steerStarted.resolve(undefined);
+          await steerRelease.promise;
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Start the next turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyBeforeSteer.resolve({
+        id: "evt-busy-before-steer",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      idleBeforeSteer.resolve({
+        id: "evt-idle-before-steer",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.promise(() => statusStarted.promise);
+      const steerFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Add one more task",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => steerStarted.promise);
+      statusRelease.resolve(undefined);
+      steerRelease.resolve(undefined);
+      yield* Fiber.join(steerFiber);
+
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "running");
+      NodeAssert.equal(session?.activeTurnId, activeTurn.turnId);
+
+      idleAfterSteer.resolve({
+        id: "evt-idle-after-steer",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+    }),
+  );
+
+  it.effect("waits for steer admission before accepting the only idle event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-steer-admission-only-idle");
+      const firstUserMessageEvent = promiseWithResolvers<unknown>();
+      const staleIdleEvent = promiseWithResolvers<unknown>();
+      const userMessageEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const steerStarted = promiseWithResolvers<void>();
+      const steerRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [
+        firstUserMessageEvent.promise,
+        staleIdleEvent.promise,
+        userMessageEvent.promise,
+        idleEvent.promise,
+      ];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 2) {
+          steerStarted.resolve(undefined);
+          await steerRelease.promise;
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Start work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const steerFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Add another task",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => steerStarted.promise);
+      const firstMessageId = (runtimeMock.state.promptCalls[0] as { messageID?: string }).messageID;
+      const steerMessageId = (runtimeMock.state.promptCalls[1] as { messageID?: string }).messageID;
+      NodeAssert.match(firstMessageId ?? "", /^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+      NodeAssert.match(steerMessageId ?? "", /^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+      firstUserMessageEvent.resolve({
+        id: "evt-delayed-first-user-message",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: firstMessageId, role: "user" },
+        },
+      });
+      staleIdleEvent.resolve({
+        id: "evt-stale-idle-during-steer",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      userMessageEvent.resolve({
+        id: "evt-steer-user-message",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: steerMessageId, role: "user" },
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-only-idle-during-steer",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 0);
+      steerRelease.resolve(undefined);
+      yield* Fiber.join(steerFiber);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 1);
+    }),
+  );
+
+  it.effect("restores idle reconciliation after a steer prompt fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-failed-steer-idle");
+      const busyEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const firstStatusStarted = promiseWithResolvers<void>();
+      const firstStatusRelease = promiseWithResolvers<void>();
+      const steerStarted = promiseWithResolvers<void>();
+      const steerRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [busyEvent.promise, idleEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (runtimeMock.state.sessionStatusCalls === 1) {
+          firstStatusStarted.resolve(undefined);
+          await firstStatusRelease.promise;
+        }
+        return { data: {} };
+      };
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 3) {
+          steerStarted.resolve(undefined);
+          await steerRelease.promise;
+          throw new Error("steer failed");
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Start the next turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-failed-steer-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-failed-steer-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.promise(() => firstStatusStarted.promise);
+      const steerFiber = yield* Effect.exit(
+        adapter.sendTurn({
+          threadId,
+          input: "This steer fails",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        }),
+      ).pipe(Effect.forkChild);
+      yield* Effect.promise(() => steerStarted.promise);
+      firstStatusRelease.resolve(undefined);
+      steerRelease.resolve(undefined);
+      const steerExit = yield* Fiber.join(steerFiber);
+      NodeAssert.equal(Exit.isFailure(steerExit), true);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 2);
+    }),
+  );
+
+  it.effect("accepts the only idle event after a steer fails before creating its message", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-failed-steer-admission-idle");
+      const idleEvent = promiseWithResolvers<unknown>();
+      const steerStarted = promiseWithResolvers<void>();
+      const steerRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [idleEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 2) {
+          steerStarted.resolve(undefined);
+          await steerRelease.promise;
+          throw new Error("steer failed before message creation");
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Start work",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const steerFiber = yield* Effect.exit(
+        adapter.sendTurn({
+          threadId,
+          input: "This steer fails",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        }),
+      ).pipe(Effect.forkChild);
+      yield* Effect.promise(() => steerStarted.promise);
+      idleEvent.resolve({
+        id: "evt-idle-during-failed-admission",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      steerRelease.resolve(undefined);
+      NodeAssert.equal(Exit.isFailure(yield* Fiber.join(steerFiber)), true);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+    }),
+  );
+
   it.effect("routes child-session approval requests and replies through the parent thread", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -1035,6 +1475,251 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(Option.getOrUndefined(resolved)?.type, "user-input.resolved");
 
       yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("recovers pending requests from existing nested child sessions on resume", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-resume-child-requests");
+      runtimeMock.state.sessionParentById.set("ses_child", "ses_parent");
+      runtimeMock.state.sessionParentById.set("ses_nested", "ses_child");
+      runtimeMock.state.pendingPermissions = [permissionRequest("per_existing", "ses_nested")];
+      runtimeMock.state.pendingQuestions = [questionRequest("que_existing", "ses_child")];
+
+      const requestsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.opened" || event.type === "user-input.requested"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_parent" },
+      });
+
+      const requests = Array.from(
+        yield* Fiber.join(requestsFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.deepEqual(requests.map((event) => [event.type, event.requestId]).sort(), [
+        ["request.opened", "per_existing"],
+        ["user-input.requested", "que_existing"],
+      ]);
+      yield* adapter.respondToRequest(threadId, ApprovalRequestId.make("per_existing"), "accept");
+      yield* adapter.respondToUserInput(threadId, ApprovalRequestId.make("que_existing"), {
+        Scope: "Workspace",
+      });
+      NodeAssert.deepEqual(runtimeMock.state.permissionReplyCalls, [
+        { requestID: "per_existing", reply: "once" },
+      ]);
+      NodeAssert.deepEqual(runtimeMock.state.questionReplyCalls, [
+        { requestID: "que_existing", answers: [["Workspace"]] },
+      ]);
+    }),
+  );
+
+  it.effect("retries ancestry for one live child request after a transient failure", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-request-ancestry-retry");
+      const parentId = "http://127.0.0.1:9999/session";
+      const ancestryAttempted = promiseWithResolvers<void>();
+      runtimeMock.state.sessionParentById.set("ses_existing_child", parentId);
+      runtimeMock.state.transientErrorSessionIds.add("ses_existing_child");
+      runtimeMock.state.sessionGetObserved = (sessionID) => {
+        if (sessionID === "ses_existing_child") {
+          ancestryAttempted.resolve(undefined);
+        }
+      };
+      runtimeMock.state.subscribedEvents = [
+        {
+          id: "evt-existing-child-permission",
+          type: "permission.asked",
+          properties: permissionRequest("per_retry", "ses_existing_child"),
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "runtime.warning" || event.type === "request.opened"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Effect.promise(() => ancestryAttempted.promise);
+      runtimeMock.state.transientErrorSessionIds.delete("ses_existing_child");
+      yield* advanceTestClock(250);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["runtime.warning", "request.opened"],
+      );
+      yield* adapter.respondToRequest(threadId, ApprovalRequestId.make("per_retry"), "accept");
+    }),
+  );
+
+  it.effect("does not resurrect a recovered child request after its live reply", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-stale-child-request-recovery");
+      const listStarted = promiseWithResolvers<void>();
+      const listRelease = promiseWithResolvers<void>();
+      const stale = permissionRequest("per_stale", "ses_existing_child");
+      runtimeMock.state.sessionParentById.set("ses_existing_child", "ses_parent");
+      runtimeMock.state.permissionListImplementation = async () => {
+        listStarted.resolve(undefined);
+        await listRelease.promise;
+        return [stale];
+      };
+      runtimeMock.state.subscribedEvents = [
+        {
+          id: "evt-stale-child-replied",
+          type: "permission.replied",
+          properties: {
+            sessionID: "ses_existing_child",
+            requestID: stale.id,
+            reply: "once",
+          },
+        },
+      ];
+
+      const resolvedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.opened" || event.type === "request.resolved"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_parent" },
+      });
+      yield* Effect.promise(() => listStarted.promise);
+      const resolved = Option.getOrUndefined(
+        yield* Fiber.join(resolvedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(resolved?.type, "request.resolved");
+      listRelease.resolve(undefined);
+      yield* Effect.yieldNow;
+
+      const response = yield* Effect.exit(
+        adapter.respondToRequest(threadId, ApprovalRequestId.make(stale.id), "accept"),
+      );
+      NodeAssert.equal(Exit.isFailure(response), true);
+    }),
+  );
+
+  it.effect("lets a child reply supersede an ask while ancestry lookup is retrying", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-terminal-during-ancestry");
+      const ancestryAttempted = promiseWithResolvers<void>();
+      const childId = "ses_terminal_child";
+      const request = permissionRequest("per_terminal", childId);
+      runtimeMock.state.sessionParentById.set(childId, "http://127.0.0.1:9999/session");
+      runtimeMock.state.transientErrorSessionIds.add(childId);
+      runtimeMock.state.sessionGetObserved = (sessionID) => {
+        if (sessionID === childId) {
+          ancestryAttempted.resolve(undefined);
+        }
+      };
+      runtimeMock.state.subscribedEvents = [
+        { id: "evt-terminal-ask", type: "permission.asked", properties: request },
+        {
+          id: "evt-terminal-reply",
+          type: "permission.replied",
+          properties: { sessionID: childId, requestID: request.id, reply: "once" },
+        },
+      ];
+
+      const terminalFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.opened" || event.type === "request.resolved"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Effect.promise(() => ancestryAttempted.promise);
+      runtimeMock.state.transientErrorSessionIds.delete(childId);
+      yield* advanceTestClock(250);
+
+      const terminal = Option.getOrUndefined(
+        yield* Fiber.join(terminalFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(terminal?.type, "request.resolved");
+      const response = yield* Effect.exit(
+        adapter.respondToRequest(threadId, ApprovalRequestId.make(request.id), "accept"),
+      );
+      NodeAssert.equal(Exit.isFailure(response), true);
+    }),
+  );
+
+  it.effect("reruns recovery when the event stream connects during the startup snapshot", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-connected-recovery-rerun");
+      const firstListStarted = promiseWithResolvers<void>();
+      const firstListRelease = promiseWithResolvers<void>();
+      const pending = permissionRequest("per_connected", "ses_existing_child");
+      runtimeMock.state.sessionParentById.set("ses_existing_child", "ses_parent");
+      runtimeMock.state.permissionListImplementation = async () => {
+        if (runtimeMock.state.permissionListCalls === 1) {
+          firstListStarted.resolve(undefined);
+          await firstListRelease.promise;
+          return [];
+        }
+        return [pending];
+      };
+      runtimeMock.state.subscribedEvents = [
+        { id: "evt-connected", type: "server.connected", properties: {} },
+      ];
+
+      const openedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_parent" },
+      });
+      yield* Effect.promise(() => firstListStarted.promise);
+      firstListRelease.resolve(undefined);
+
+      const opened = Option.getOrUndefined(
+        yield* Fiber.join(openedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(opened?.requestId, pending.id);
+      NodeAssert.equal(runtimeMock.state.permissionListCalls, 2);
     }),
   );
 
@@ -1257,6 +1942,359 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("waits for a pending stop before starting the next turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-send-during-stop");
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const stopFiber = yield* adapter
+        .interruptTurn(threadId, stoppedTurn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      const sendFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Second turn",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(stopFiber);
+      const nextTurn = yield* Fiber.join(sendFiber);
+
+      NodeAssert.notEqual(nextTurn.turnId, stoppedTurn.turnId);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+    }),
+  );
+
+  it.effect("rechecks a newer idle after an older status call returns busy", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-newer-idle-during-status");
+      const busyEvent = promiseWithResolvers<unknown>();
+      const staleIdle = promiseWithResolvers<unknown>();
+      const realIdle = promiseWithResolvers<unknown>();
+      const statusStarted = promiseWithResolvers<void>();
+      const statusRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [busyEvent.promise, staleIdle.promise, realIdle.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (runtimeMock.state.sessionStatusCalls === 1) {
+          statusStarted.resolve(undefined);
+          await statusRelease.promise;
+          return {
+            data: { "http://127.0.0.1:9999/session": { type: "busy" as const } },
+          };
+        }
+        return { data: {} };
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, firstTurn.turnId);
+      const secondTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Second turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-new-turn-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      staleIdle.resolve({
+        id: "evt-old-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.promise(() => statusStarted.promise);
+      realIdle.resolve({
+        id: "evt-new-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      statusRelease.resolve(undefined);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, secondTurn.turnId);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 2);
+    }),
+  );
+
+  it.effect("completes after transient status failures without another idle event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-status-retry");
+      const busyEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const failuresObserved = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [busyEvent.promise, idleEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (runtimeMock.state.sessionStatusCalls <= 2) {
+          if (runtimeMock.state.sessionStatusCalls === 2) {
+            failuresObserved.resolve(undefined);
+          }
+          throw new Error("status failed");
+        }
+        return { data: {} };
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, firstTurn.turnId);
+      const secondTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Second turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-retry-turn-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-retry-turn-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.promise(() => failuresObserved.promise);
+      yield* advanceTestClock(250);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, secondTurn.turnId);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 3);
+    }),
+  );
+
+  it.effect("keeps idle reconciliation after a delayed abort from the stopped turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-stale-abort-during-idle-check");
+      const busyEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const staleAbortEvent = promiseWithResolvers<unknown>();
+      const statusStarted = promiseWithResolvers<void>();
+      const statusRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [
+        busyEvent.promise,
+        idleEvent.promise,
+        staleAbortEvent.promise,
+      ];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        statusStarted.resolve(undefined);
+        await statusRelease.promise;
+        return { data: {} };
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Second turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-stale-abort-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-stale-abort-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.promise(() => statusStarted.promise);
+      staleAbortEvent.resolve({
+        id: "evt-delayed-old-abort",
+        type: "session.error",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      });
+      statusRelease.resolve(undefined);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+    }),
+  );
+
+  it.effect("keeps the newer turn running while status lookup keeps failing", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-status-permanent-failure");
+      const busyEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const firstAttemptFailed = promiseWithResolvers<void>();
+      const retryAttemptFailed = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [busyEvent.promise, idleEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (runtimeMock.state.sessionStatusCalls === 2) {
+          firstAttemptFailed.resolve(undefined);
+        }
+        if (runtimeMock.state.sessionStatusCalls === 4) {
+          retryAttemptFailed.resolve(undefined);
+        }
+        throw new Error("status remains unavailable");
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Second turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-permanent-failure-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-permanent-failure-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.promise(() => firstAttemptFailed.promise);
+      yield* advanceTestClock(250);
+      yield* Effect.promise(() => retryAttemptFailed.promise);
+
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "running");
+      NodeAssert.equal(session?.activeTurnId, activeTurn.turnId);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("ignores delayed stop events around the next turn startup", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -1368,7 +2406,6 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(sessionBeforeRealIdle?.activeTurnId, secondTurn.turnId);
 
       runtimeMock.state.sessionStatus = "idle";
-      runtimeMock.state.sessionStatusFailures = 2;
       nextIdle.resolve({
         id: "evt-next-idle",
         type: "session.status",
@@ -1506,7 +2543,12 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         ),
       });
 
-      NodeAssert.deepEqual(runtimeMock.state.promptCalls.at(-1), {
+      const { messageID, ...prompt } = runtimeMock.state.promptCalls.at(-1) as {
+        messageID: string;
+        [key: string]: unknown;
+      };
+      NodeAssert.match(messageID, /^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+      NodeAssert.deepEqual(prompt, {
         sessionID: "http://127.0.0.1:9999/session",
         model: {
           providerID: "anthropic",
@@ -1550,7 +2592,12 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         input: "Fix it",
       });
 
-      NodeAssert.deepEqual(runtimeMock.state.promptCalls.at(-1), {
+      const { messageID, ...prompt } = runtimeMock.state.promptCalls.at(-1) as {
+        messageID: string;
+        [key: string]: unknown;
+      };
+      NodeAssert.match(messageID, /^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+      NodeAssert.deepEqual(prompt, {
         sessionID: "http://127.0.0.1:9999/session",
         model: {
           providerID: "anthropic",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1184,6 +1184,171 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("shares one abort request across concurrent stops", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-concurrent-interrupt");
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep working",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      const firstInterrupt = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      const secondInterrupt = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(firstInterrupt);
+      yield* Fiber.join(secondInterrupt);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events
+          .filter((event) => event.type === "turn.completed" || event.type === "turn.aborted")
+          .map((event) => event.type),
+        ["turn.aborted"],
+      );
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("ignores delayed stop events until the next turn becomes busy", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-delayed-interrupt-events");
+      const staleAbort = promiseWithResolvers<unknown>();
+      const staleIdle = promiseWithResolvers<unknown>();
+      const nextBusy = promiseWithResolvers<unknown>();
+      const nextIdle = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        staleAbort.promise,
+        staleIdle.promise,
+        nextBusy.promise,
+        nextIdle.promise,
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(6),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, firstTurn.turnId);
+      const secondTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Second turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+
+      staleAbort.resolve({
+        id: "evt-delayed-abort",
+        type: "session.error",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      });
+      staleIdle.resolve({
+        id: "evt-delayed-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      for (let index = 0; index < 4; index += 1) {
+        yield* Effect.yieldNow;
+      }
+
+      const sessionsBeforeBusy = yield* adapter.listSessions();
+      const sessionBeforeBusy = sessionsBeforeBusy.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionBeforeBusy?.status, "running");
+      NodeAssert.equal(sessionBeforeBusy?.activeTurnId, secondTurn.turnId);
+
+      nextBusy.resolve({
+        id: "evt-next-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      nextIdle.resolve({
+        id: "evt-next-idle",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events
+          .filter(
+            (event) =>
+              event.type === "turn.completed" ||
+              event.type === "turn.aborted" ||
+              event.type === "runtime.error",
+          )
+          .map((event) => ({ type: event.type, turnId: event.turnId })),
+        [
+          { type: "turn.aborted", turnId: firstTurn.turnId },
+          { type: "turn.completed", turnId: secondTurn.turnId },
+        ],
+      );
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("keeps a genuine provider error visible during a pending user stop", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -751,6 +751,59 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("replaces a stopped connecting session while its teardown is held", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stopped-connecting-retry");
+      const eventSubscribeObserved = promiseWithResolvers<void>();
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.autoConnect = false;
+      runtimeMock.state.eventSubscribeObserved = () => eventSubscribeObserved.resolve(undefined);
+      runtimeMock.state.createdSessionIds.push("ses_connecting_old", "ses_connecting_replacement");
+
+      const oldStart = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.promise(() => eventSubscribeObserved.promise);
+
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+      const oldStop = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+
+      runtimeMock.state.autoConnect = true;
+      runtimeMock.state.abortImplementation = null;
+      const replacement = yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      NodeAssert.equal(replacement.status, "ready");
+      NodeAssert.deepEqual(replacement.resumeCursor, {
+        schemaVersion: 1,
+        sessionId: "ses_connecting_replacement",
+      });
+
+      abortRelease.resolve(undefined);
+      const oldStartResult = yield* Fiber.join(oldStart);
+      yield* Fiber.join(oldStop);
+      NodeAssert.equal(oldStartResult._tag, "Failure");
+      const current = (yield* adapter.listSessions()).find(
+        (session) => session.threadId === threadId,
+      );
+      NodeAssert.deepEqual(current?.resumeCursor, replacement.resumeCursor);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("returns a durable resume cursor for a freshly created session", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -510,7 +510,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("closes an unpublished session when startup is interrupted", () =>
+  it.effect("closes a connecting session when startup is interrupted", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-opencode-connect-interrupted");
@@ -531,6 +531,77 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
 
       NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
       NodeAssert.deepEqual(runtimeMock.state.abortCalls, ["http://127.0.0.1:9999/session"]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
+
+  it.effect("stops a connecting session and rejects its waiting send", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stop-connecting");
+      const eventSubscribeObserved = promiseWithResolvers<void>();
+      runtimeMock.state.autoConnect = false;
+      runtimeMock.state.eventSubscribeObserved = () => eventSubscribeObserved.resolve(undefined);
+
+      const startFiber = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.promise(() => eventSubscribeObserved.promise);
+      const connecting = (yield* adapter.listSessions()).find(
+        (session) => session.threadId === threadId,
+      );
+      NodeAssert.equal(connecting?.status, "connecting");
+
+      const sendFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Must not be sent",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 0);
+
+      yield* adapter.stopSession(threadId);
+      const startResult = yield* Fiber.join(startFiber);
+      const sendResult = yield* Fiber.join(sendFiber);
+      NodeAssert.equal(startResult._tag, "Failure");
+      NodeAssert.equal(sendResult._tag, "Failure");
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 0);
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
+
+  it.effect("stopAll closes a connecting session and releases startup", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stop-all-connecting");
+      const eventSubscribeObserved = promiseWithResolvers<void>();
+      runtimeMock.state.autoConnect = false;
+      runtimeMock.state.eventSubscribeObserved = () => eventSubscribeObserved.resolve(undefined);
+
+      const startFiber = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.promise(() => eventSubscribeObserved.promise);
+      const sessionCount = (yield* adapter.listSessions()).length;
+
+      yield* adapter.stopAll();
+      const startResult = yield* Fiber.join(startFiber);
+      NodeAssert.equal(startResult._tag, "Failure");
+      NodeAssert.equal(runtimeMock.state.closeCalls.length, sessionCount);
       NodeAssert.equal(yield* adapter.hasSession(threadId), false);
     }),
   );
@@ -573,12 +644,102 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const threadSessions = sessions.filter((session) => session.threadId === threadId);
       NodeAssert.equal(threadSessions.length, 1);
       NodeAssert.deepEqual(firstSession.resumeCursor, secondSession.resumeCursor);
+      NodeAssert.equal(firstSession.status, "ready");
+      NodeAssert.equal(secondSession.status, "ready");
       const winnerId = (threadSessions[0]?.resumeCursor as { sessionId?: string } | undefined)
         ?.sessionId;
       NodeAssert.ok(winnerId === "ses_race_a" || winnerId === "ses_race_b");
       NodeAssert.deepEqual(runtimeMock.state.abortCalls, [
         winnerId === "ses_race_a" ? "ses_race_b" : "ses_race_a",
       ]);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("reuses a published connecting session after it becomes ready", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-reuse-connecting");
+      const connectionEvent = promiseWithResolvers<unknown>();
+      const eventSubscribeObserved = promiseWithResolvers<void>();
+      runtimeMock.state.autoConnect = false;
+      runtimeMock.state.eventSubscribeObserved = () => eventSubscribeObserved.resolve(undefined);
+      runtimeMock.state.subscribedEvents = [connectionEvent.promise];
+
+      const owningStart = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => eventSubscribeObserved.promise);
+      const reusedStart = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.sessionCreateUrls.length, 1);
+
+      connectionEvent.resolve({
+        id: "evt-reused-start-connected",
+        type: "server.connected",
+        properties: {},
+      });
+      const [ownedSession, reusedSession] = yield* Effect.all([
+        Fiber.join(owningStart),
+        Fiber.join(reusedStart),
+      ]);
+      NodeAssert.equal(ownedSession.status, "ready");
+      NodeAssert.equal(reusedSession.status, "ready");
+      NodeAssert.deepEqual(ownedSession.resumeCursor, reusedSession.resumeCursor);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("does not let an old held stop delete its replacement", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-old-stop-replacement");
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.createdSessionIds.push("ses_old", "ses_replacement");
+
+      const oldSession = yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+      };
+      const oldStop = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+
+      const replacement = yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      NodeAssert.deepEqual(oldSession.resumeCursor, { schemaVersion: 1, sessionId: "ses_old" });
+      NodeAssert.deepEqual(replacement.resumeCursor, {
+        schemaVersion: 1,
+        sessionId: "ses_replacement",
+      });
+
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(oldStop);
+      const current = (yield* adapter.listSessions()).find(
+        (session) => session.threadId === threadId,
+      );
+      NodeAssert.deepEqual(current?.resumeCursor, replacement.resumeCursor);
+
+      runtimeMock.state.abortImplementation = null;
       yield* adapter.stopSession(threadId);
     }),
   );
@@ -2129,6 +2290,69 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("ignores late busy and idle status after an interrupted turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-late-status-after-interrupt");
+      const lateBusy = promiseWithResolvers<unknown>();
+      const lateIdle = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [lateBusy.promise, lateIdle.promise];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, turn.turnId);
+
+      lateBusy.resolve({
+        id: "evt-late-busy-after-interrupt",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      lateIdle.resolve({
+        id: "evt-late-idle-after-interrupt",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.yieldNow;
+
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events
+          .filter((event) => event.type === "turn.completed" || event.type === "turn.aborted")
+          .map((event) => event.type),
+        ["turn.aborted"],
+      );
+    }),
+  );
+
   it.effect("treats MessageAbortedError as the acknowledgment for a pending user stop", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -2278,6 +2502,184 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           .map((event) => event.type),
         ["turn.aborted"],
       );
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("accepts a native turnless abort before its request fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-turnless-interrupt");
+      const abortEvent = promiseWithResolvers<unknown>();
+      const markerEvent = promiseWithResolvers<unknown>();
+      const abortStarted = promiseWithResolvers<void>();
+      const abortRelease = promiseWithResolvers<void>();
+      runtimeMock.state.subscribedEvents = [abortEvent.promise, markerEvent.promise];
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await abortRelease.promise;
+        throw new Error("abort response failed after native acknowledgment");
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_existing" },
+      });
+      const acknowledgmentFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" ||
+              event.type === "turn.aborted" ||
+              event.type === "runtime.error" ||
+              event.type === "thread.metadata.updated"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const firstInterrupt = yield* adapter.interruptTurn(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      const secondInterrupt = yield* adapter.interruptTurn(threadId).pipe(Effect.forkChild);
+      const sendFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Start after the session abort",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 0);
+
+      abortEvent.resolve({
+        id: "evt-turnless-abort",
+        type: "session.error",
+        properties: {
+          sessionID: "ses_existing",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      });
+      markerEvent.resolve({
+        id: "evt-after-turnless-abort",
+        type: "session.updated",
+        properties: {
+          info: { id: "ses_existing", title: "Turnless abort acknowledged" },
+        },
+      });
+      const acknowledgment = Option.getOrUndefined(yield* Fiber.join(acknowledgmentFiber));
+      NodeAssert.equal(acknowledgment?.type, "thread.metadata.updated");
+      const unexpectedEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" ||
+              event.type === "turn.aborted" ||
+              event.type === "runtime.error"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      abortRelease.resolve(undefined);
+      yield* Fiber.join(firstInterrupt);
+      yield* Fiber.join(secondInterrupt);
+      yield* Fiber.join(sendFiber);
+
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+      NodeAssert.equal(unexpectedEventFiber.pollUnsafe(), undefined);
+      yield* Fiber.interrupt(unexpectedEventFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("ignores a native turnless abort after its request succeeds", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-late-turnless-abort");
+      const abortEvent = promiseWithResolvers<unknown>();
+      const markerEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [abortEvent.promise, markerEvent.promise];
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_existing" },
+      });
+      const acknowledgmentFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" ||
+              event.type === "turn.aborted" ||
+              event.type === "runtime.error" ||
+              event.type === "thread.metadata.updated"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      yield* adapter.interruptTurn(threadId);
+      abortEvent.resolve({
+        id: "evt-late-turnless-abort",
+        type: "session.error",
+        properties: {
+          sessionID: "ses_existing",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      });
+      markerEvent.resolve({
+        id: "evt-after-late-turnless-abort",
+        type: "session.updated",
+        properties: {
+          info: { id: "ses_existing", title: "Late turnless abort ignored" },
+        },
+      });
+      const acknowledgment = Option.getOrUndefined(yield* Fiber.join(acknowledgmentFiber));
+
+      NodeAssert.equal(acknowledgment?.type, "thread.metadata.updated");
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("clears a failed turnless interrupt before the next turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-turnless-interrupt-failure");
+      runtimeMock.state.abortImplementation = async () => {
+        throw new Error("abort failed");
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_existing" },
+      });
+      const interruptExit = yield* Effect.exit(adapter.interruptTurn(threadId));
+      NodeAssert.equal(Exit.isFailure(interruptExit), true);
+
+      runtimeMock.state.abortImplementation = null;
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Start after the failed session abort",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
 
       yield* adapter.stopSession(threadId);
     }),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -64,7 +64,10 @@ const runtimeMock = {
     createdSessionIds: [] as string[],
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
-    abortImplementation: null as ((sessionID: string) => Promise<void>) | null,
+    abortSignals: [] as AbortSignal[],
+    abortImplementation: null as
+      | ((sessionID: string, signal?: AbortSignal) => Promise<void>)
+      | null,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
@@ -110,6 +113,7 @@ const runtimeMock = {
     this.state.createdSessionIds.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
+    this.state.abortSignals.length = 0;
     this.state.abortImplementation = null;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
@@ -236,9 +240,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           }
           return { data: { id: forkedId, ...(directory ? { directory } : {}) } };
         },
-        abort: async ({ sessionID }: { sessionID: string }) => {
+        abort: async ({ sessionID }: { sessionID: string }, options?: { signal?: AbortSignal }) => {
           runtimeMock.state.abortCalls.push(sessionID);
-          await runtimeMock.state.abortImplementation?.(sessionID);
+          if (options?.signal) {
+            runtimeMock.state.abortSignals.push(options.signal);
+          }
+          await runtimeMock.state.abortImplementation?.(sessionID, options?.signal);
         },
         status: async () => {
           runtimeMock.state.sessionStatusCalls += 1;
@@ -2450,6 +2457,97 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("releases stop and send waiters when a native abort times out", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-timeout");
+      const abortStarted = promiseWithResolvers<void>();
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await new Promise<void>(() => {});
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Keep working",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const unexpectedEventFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" || event.type === "turn.aborted"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      const firstInterrupt = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+      const secondInterrupt = yield* adapter
+        .interruptTurn(threadId, turn.turnId)
+        .pipe(Effect.result, Effect.forkChild);
+      const sendFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Wait for the stop request",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* Effect.yieldNow;
+
+      yield* advanceTestClock(9_999);
+      NodeAssert.equal(firstInterrupt.pollUnsafe(), undefined);
+      NodeAssert.equal(secondInterrupt.pollUnsafe(), undefined);
+      NodeAssert.equal(sendFiber.pollUnsafe(), undefined);
+      yield* advanceTestClock(1);
+
+      const firstResult = yield* Fiber.join(firstInterrupt);
+      const secondResult = yield* Fiber.join(secondInterrupt);
+      const sendResult = yield* Fiber.join(sendFiber);
+      NodeAssert.equal(firstResult._tag, "Failure");
+      NodeAssert.equal(secondResult._tag, "Failure");
+      NodeAssert.equal(sendResult._tag, "Failure");
+      if (firstResult._tag === "Failure") {
+        NodeAssert.equal(firstResult.failure._tag, "ProviderAdapterRequestError");
+        NodeAssert.equal(
+          firstResult.failure.detail,
+          "OpenCode session abort did not complete within 10 seconds.",
+        );
+      }
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      NodeAssert.equal(runtimeMock.state.abortSignals.length, 1);
+      NodeAssert.equal(runtimeMock.state.abortSignals[0]?.aborted, true);
+      NodeAssert.equal(unexpectedEventFiber.pollUnsafe(), undefined);
+
+      runtimeMock.state.abortImplementation = null;
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Continue after the failed stop request",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+
+      yield* Fiber.interrupt(unexpectedEventFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("shares one abort request across concurrent stops", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -2507,19 +2605,17 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("accepts a native turnless abort before its request fails", () =>
+  it.effect("accepts a native turnless abort before its request times out", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-turnless-interrupt");
       const abortEvent = promiseWithResolvers<unknown>();
       const markerEvent = promiseWithResolvers<unknown>();
       const abortStarted = promiseWithResolvers<void>();
-      const abortRelease = promiseWithResolvers<void>();
       runtimeMock.state.subscribedEvents = [abortEvent.promise, markerEvent.promise];
       runtimeMock.state.abortImplementation = async () => {
         abortStarted.resolve(undefined);
-        await abortRelease.promise;
-        throw new Error("abort response failed after native acknowledgment");
+        await new Promise<void>(() => {});
       };
 
       yield* adapter.startSession({
@@ -2586,14 +2682,16 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         Stream.runHead,
         Effect.forkChild,
       );
-      abortRelease.resolve(undefined);
+      yield* advanceTestClock(10_000);
       yield* Fiber.join(firstInterrupt);
       yield* Fiber.join(secondInterrupt);
       yield* Fiber.join(sendFiber);
 
       NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
+      NodeAssert.equal(runtimeMock.state.abortSignals[0]?.aborted, true);
       NodeAssert.equal(unexpectedEventFiber.pollUnsafe(), undefined);
       yield* Fiber.interrupt(unexpectedEventFiber);
+      runtimeMock.state.abortImplementation = null;
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1,6 +1,7 @@
 import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -153,7 +154,7 @@ const runtimeMock = {
 };
 
 const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
-  startOpenCodeServerProcess: ({ binaryPath }) =>
+  startOpenCodeServerProcess: ({ binaryPath, serverPassword }) =>
     Effect.gen(function* () {
       runtimeMock.state.startCalls.push(binaryPath);
       const url = "http://127.0.0.1:4301";
@@ -167,11 +168,13 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       );
       return {
         url,
+        version: "1.15.13",
+        ...(serverPassword ? { serverPassword } : {}),
         exitCode: Effect.never,
         isRunning: Effect.succeed(true),
       };
     }),
-  connectToOpenCodeServer: ({ serverUrl }) =>
+  connectToOpenCodeServer: ({ serverUrl, serverPassword }) =>
     Effect.gen(function* () {
       const url = serverUrl ?? "http://127.0.0.1:4301";
       // Always register a finalizer so the closeCalls/closeError probes fire;
@@ -186,6 +189,8 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       );
       return {
         url,
+        version: "1.15.13",
+        ...(serverPassword ? { serverPassword } : {}),
         exitCode: null,
         external: Boolean(serverUrl),
       };
@@ -278,6 +283,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             typeof input.sessionID === "string" &&
             typeof input.messageID === "string"
           ) {
+            runtimeMock.state.messages.push({
+              info: { id: input.messageID, role: "user" },
+              parts: [],
+            });
             runtimeMock.state.promptEchoEvents.push({
               id: `evt-auto-user-${input.messageID}`,
               type: "message.updated",
@@ -572,7 +581,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
             "opencode/kimi-k3",
           ),
         })
-        .pipe(Effect.result, Effect.forkChild);
+        .pipe(Effect.exit, Effect.forkChild);
       yield* Effect.yieldNow;
       NodeAssert.equal(runtimeMock.state.promptCalls.length, 0);
 
@@ -596,7 +605,6 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         abortStarted.resolve(undefined);
         await new Promise<void>(() => {});
       };
-
       yield* adapter.startSession({
         provider: ProviderDriverKind.make("opencode"),
         threadId,
@@ -1542,7 +1550,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       });
       yield* Effect.yieldNow;
-      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 0);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls > 0, true);
       steerRelease.resolve(undefined);
       yield* Fiber.join(steerFiber);
 
@@ -1550,7 +1558,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
       );
       NodeAssert.equal(completed?.turnId, activeTurn.turnId);
-      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 1);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls > 0, true);
     }),
   );
 
@@ -1735,6 +1743,368 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const abortCallsAfterCompletion = runtimeMock.state.abortCalls.length;
       yield* adapter.interruptTurn(threadId, activeTurn.turnId);
       NodeAssert.equal(runtimeMock.state.abortCalls.length, abortCallsAfterCompletion);
+    }),
+  );
+
+  it.effect("resolves admission without a prompt echo when busy and idle still arrive", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-admission-without-echo");
+      const busyEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [busyEvent.promise, idleEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        const prompt = runtimeMock.state.promptCalls.at(-1) as { messageID?: string } | undefined;
+        if (prompt?.messageID) {
+          runtimeMock.state.messages.push({
+            info: { id: prompt.messageID, role: "user" },
+            parts: [],
+          });
+        }
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run without an echo event",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-busy-without-echo",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-idle-without-echo",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* advanceTestClock(1_000);
+
+      NodeAssert.equal(
+        runtimeMock.state.messageCalls.some(
+          (call) => call.messageID === runtimeMock.state.messages[0]?.info.id,
+        ),
+        true,
+      );
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls > 0, true);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+      NodeAssert.equal(turn.turnId !== undefined, true);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("reconciles a sole idle when the matching prompt echo arrives later", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-before-delayed-echo");
+      const idleEvent = promiseWithResolvers<unknown>();
+      const userMessageEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [idleEvent.promise, userMessageEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Finish before the echo arrives",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const messageId = (runtimeMock.state.promptCalls[0] as { messageID?: string }).messageID;
+      idleEvent.resolve({
+        id: "evt-idle-before-delayed-echo",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      userMessageEvent.resolve({
+        id: "evt-delayed-matching-echo",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: messageId, role: "user" },
+        },
+      });
+      yield* advanceTestClock(250);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, turn.turnId);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("reconciles the only idle after a stopped turn when the prompt echo is missing", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-only-without-echo-after-stop");
+      const idleEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [idleEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        const prompt = runtimeMock.state.promptCalls.at(-1) as { messageID?: string } | undefined;
+        if (prompt?.messageID) {
+          runtimeMock.state.messages.push({
+            info: { id: prompt.messageID, role: "user" },
+            parts: [],
+          });
+        }
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run after the stop",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const activeMessageId = (
+        runtimeMock.state.promptCalls.at(-1) as { messageID?: string } | undefined
+      )?.messageID;
+      idleEvent.resolve({
+        id: "evt-only-idle-without-echo-after-stop",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* advanceTestClock(1_000);
+
+      NodeAssert.equal(
+        runtimeMock.state.messageCalls.some((call) => call.messageID === activeMessageId),
+        true,
+      );
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls > 0, true);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+      NodeAssert.notEqual(activeTurn.turnId, stoppedTurn.turnId);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("reconciles a sole idle after a stop when the exact prompt echo arrives", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-before-exact-echo-after-stop");
+      const idleEvent = promiseWithResolvers<unknown>();
+      const userMessageEvent = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [idleEvent.promise, userMessageEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run after the stop",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const activeMessageId = (
+        runtimeMock.state.promptCalls.at(-1) as { messageID?: string } | undefined
+      )?.messageID;
+      idleEvent.resolve({
+        id: "evt-only-idle-before-exact-echo-after-stop",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.yieldNow;
+      const sessionsBeforeEcho = yield* adapter.listSessions();
+      const sessionBeforeEcho = sessionsBeforeEcho.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionBeforeEcho?.status, "running");
+      NodeAssert.equal(sessionBeforeEcho?.activeTurnId, activeTurn.turnId);
+
+      userMessageEvent.resolve({
+        id: "evt-exact-prompt-echo-after-stop",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: activeMessageId, role: "user" },
+        },
+      });
+      yield* advanceTestClock(250);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("recovers an idle before the exact prompt echo while acceptance is held", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-and-echo-before-acceptance-after-stop");
+      const idleEvent = promiseWithResolvers<unknown>();
+      const userMessageEvent = promiseWithResolvers<unknown>();
+      const activePromptStarted = promiseWithResolvers<void>();
+      const activePromptRelease = promiseWithResolvers<void>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [idleEvent.promise, userMessageEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => ({ data: {} });
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 2) {
+          activePromptStarted.resolve(undefined);
+          await activePromptRelease.promise;
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+
+      const activeTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Run after the stop",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => activePromptStarted.promise);
+      const activeMessageId = (runtimeMock.state.promptCalls.at(-1) as { messageID: string })
+        .messageID;
+      idleEvent.resolve({
+        id: "evt-idle-before-held-prompt-acceptance",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      yield* Effect.yieldNow;
+      userMessageEvent.resolve({
+        id: "evt-exact-echo-before-held-prompt-acceptance",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: activeMessageId, role: "user" },
+        },
+      });
+      yield* Effect.yieldNow;
+      NodeAssert.equal(activeTurnFiber.pollUnsafe(), undefined);
+
+      activePromptRelease.resolve(undefined);
+      const activeTurn = yield* Fiber.join(activeTurnFiber);
+      yield* advanceTestClock(250);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
     }),
   );
 
@@ -2445,6 +2815,149 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("rejects a prompt accepted after its turn was interrupted", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-during-prompt-admission");
+      const promptStarted = promiseWithResolvers<void>();
+      const promptRelease = promiseWithResolvers<void>();
+      const lateBusy = promiseWithResolvers<unknown>();
+      const lateMessage = promiseWithResolvers<unknown>();
+      const latePart = promiseWithResolvers<unknown>();
+      const lateIdle = promiseWithResolvers<unknown>();
+      const marker = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [
+        lateBusy.promise,
+        lateMessage.promise,
+        latePart.promise,
+        lateIdle.promise,
+        marker.promise,
+      ];
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 1) {
+          promptStarted.resolve(undefined);
+          await promptRelease.promise;
+        }
+      };
+
+      const firstLateOutput = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "content.delta" || event.type === "thread.metadata.updated"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const sendFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "This request is still pending",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.exit, Effect.forkChild);
+      yield* Effect.promise(() => promptStarted.promise);
+
+      yield* adapter.interruptTurn(threadId);
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      const sessionsAfterStop = yield* adapter.listSessions();
+      const sessionAfterStop = sessionsAfterStop.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionAfterStop?.status, "ready");
+      NodeAssert.equal(sessionAfterStop?.activeTurnId, undefined);
+
+      promptRelease.resolve(undefined);
+      const sendResult = yield* Fiber.join(sendFiber);
+      lateBusy.resolve({
+        id: "evt-busy-after-late-prompt-acceptance",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "busy" },
+        },
+      });
+      lateMessage.resolve({
+        id: "evt-assistant-after-late-prompt-acceptance",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: "msg-late-assistant", role: "assistant" },
+        },
+      });
+      latePart.resolve({
+        id: "evt-part-after-late-prompt-acceptance",
+        type: "message.part.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          part: {
+            id: "part-late-assistant",
+            sessionID: "http://127.0.0.1:9999/session",
+            messageID: "msg-late-assistant",
+            type: "text",
+            text: "Late output",
+            time: { start: 1 },
+          },
+          time: 1,
+        },
+      });
+      lateIdle.resolve({
+        id: "evt-idle-after-late-prompt-acceptance",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      marker.resolve({
+        id: "evt-marker-after-late-prompt-acceptance",
+        type: "session.updated",
+        properties: {
+          info: {
+            id: "http://127.0.0.1:9999/session",
+            title: "Late prompt cleaned up",
+          },
+        },
+      });
+
+      const firstOutput = Option.getOrUndefined(
+        yield* Fiber.join(firstLateOutput).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(firstOutput?.type, "thread.metadata.updated");
+      NodeAssert.equal(Exit.isFailure(sendResult), true);
+      if (Exit.isFailure(sendResult)) {
+        NodeAssert.equal(Cause.hasInterruptsOnly(sendResult.cause), true);
+      }
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Start after late cleanup",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      const sessionsAfterNextTurn = yield* adapter.listSessions();
+      const sessionAfterNextTurn = sessionsAfterNextTurn.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionAfterNextTurn?.status, "running");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("treats MessageAbortedError as the acknowledgment for a pending user stop", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -2551,6 +3064,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         abortStarted.resolve(undefined);
         await new Promise<void>(() => {});
       };
+      runtimeMock.state.sessionStatus = "busy";
 
       yield* adapter.startSession({
         provider: ProviderDriverKind.make("opencode"),
@@ -2724,6 +3238,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const firstInterrupt = yield* adapter.interruptTurn(threadId).pipe(Effect.forkChild);
       yield* Effect.promise(() => abortStarted.promise);
       const secondInterrupt = yield* adapter.interruptTurn(threadId).pipe(Effect.forkChild);
+      runtimeMock.state.sessionStatusImplementation = async () => ({
+        data: { ses_existing: { type: "busy" as const } },
+      });
       const sendFiber = yield* adapter
         .sendTurn({
           threadId,
@@ -2916,7 +3433,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("fails a turn waiting on cancellation when the session stops", () =>
+  it.effect("interrupts a turn waiting on cancellation when the session stops", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-stop-during-cancellation");
@@ -2959,14 +3476,16 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
             "opencode/kimi-k3",
           ),
         })
-        .pipe(Effect.result, Effect.forkChild);
+        .pipe(Effect.exit, Effect.forkChild);
       yield* Effect.yieldNow;
       NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
 
       const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
       const sendResult = yield* Fiber.join(sendFiber);
-      NodeAssert.equal(sendResult._tag, "Failure");
-      NodeAssert.equal(sendResult.failure._tag, "ProviderAdapterRequestError");
+      NodeAssert.equal(Exit.isFailure(sendResult), true);
+      if (Exit.isFailure(sendResult)) {
+        NodeAssert.equal(Cause.hasInterruptsOnly(sendResult.cause), true);
+      }
       NodeAssert.equal(runtimeMock.state.promptCalls.length, 1);
 
       yield* Effect.promise(() => teardownAbortStarted.promise);
@@ -3292,13 +3811,16 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const threadId = asThreadId("thread-delayed-interrupt-events");
       const staleIdleBeforeBusy = promiseWithResolvers<unknown>();
       const nextBusy = promiseWithResolvers<unknown>();
+      const nextUserMessage = promiseWithResolvers<unknown>();
       const staleAbort = promiseWithResolvers<unknown>();
       const staleIdle = promiseWithResolvers<unknown>();
       const secondStaleIdle = promiseWithResolvers<unknown>();
       const nextIdle = promiseWithResolvers<unknown>();
+      runtimeMock.state.autoPromptEcho = false;
       runtimeMock.state.subscribedEvents = [
         staleIdleBeforeBusy.promise,
         nextBusy.promise,
+        nextUserMessage.promise,
         staleAbort.promise,
         staleIdle.promise,
         secondStaleIdle.promise,
@@ -3333,6 +3855,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           "opencode/kimi-k3",
         ),
       });
+      const secondMessageId = (runtimeMock.state.promptCalls.at(-1) as { messageID: string })
+        .messageID;
 
       staleIdleBeforeBusy.resolve({
         id: "evt-delayed-idle-before-busy",
@@ -3359,6 +3883,14 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         properties: {
           sessionID: "http://127.0.0.1:9999/session",
           status: { type: "busy" },
+        },
+      });
+      nextUserMessage.resolve({
+        id: "evt-next-user-message",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: secondMessageId, role: "user" },
         },
       });
       staleAbort.resolve({

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -2888,6 +2888,75 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("caps terminal ancestry retries after a request finishes", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-terminal-ancestry-retry-cap");
+      const childId = "ses_terminal_retry_cap_child";
+      const request = permissionRequest("per_terminal_retry_cap", childId);
+      const terminalEvent = promiseWithResolvers<unknown>();
+      const askedAttempted = promiseWithResolvers<void>();
+      const terminalAttempted = promiseWithResolvers<void>();
+      let terminalReleased = false;
+      runtimeMock.state.transientErrorSessionIds.add(childId);
+      runtimeMock.state.sessionGetObserved = (sessionID) => {
+        if (sessionID !== childId) {
+          return;
+        }
+        if (terminalReleased) {
+          terminalAttempted.resolve(undefined);
+        } else {
+          askedAttempted.resolve(undefined);
+        }
+      };
+      runtimeMock.state.subscribedEvents = [
+        { id: "evt-terminal-cap-ask", type: "permission.asked", properties: request },
+        terminalEvent.promise,
+      ];
+
+      const unexpectedRequestFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "request.opened" || event.type === "request.resolved"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "approval-required",
+      });
+      yield* Effect.promise(() => askedAttempted.promise);
+      const askedAttempts = runtimeMock.state.sessionGetIds.filter(
+        (sessionID) => sessionID === childId,
+      ).length;
+
+      terminalReleased = true;
+      terminalEvent.resolve({
+        id: "evt-terminal-cap-reply",
+        type: "permission.replied",
+        properties: { sessionID: childId, requestID: request.id, reply: "once" },
+      });
+      yield* Effect.promise(() => terminalAttempted.promise);
+      yield* advanceTestClock(10_000);
+      const callsAfterCap = runtimeMock.state.sessionGetIds.filter(
+        (sessionID) => sessionID === childId,
+      ).length;
+      NodeAssert.equal(callsAfterCap - askedAttempts, 5);
+
+      yield* advanceTestClock(30_000);
+      NodeAssert.equal(
+        runtimeMock.state.sessionGetIds.filter((sessionID) => sessionID === childId).length,
+        callsAfterCap,
+      );
+      NodeAssert.equal(unexpectedRequestFiber.pollUnsafe(), undefined);
+      yield* Fiber.interrupt(unexpectedRequestFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("reruns recovery when the event stream connects during the startup snapshot", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1550,7 +1550,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       });
       yield* Effect.yieldNow;
-      NodeAssert.equal(runtimeMock.state.sessionStatusCalls > 0, true);
+      NodeAssert.equal(runtimeMock.state.sessionStatusCalls, 0);
       steerRelease.resolve(undefined);
       yield* Fiber.join(steerFiber);
 
@@ -1808,6 +1808,249 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(session?.status, "ready");
       NodeAssert.equal(session?.activeTurnId, undefined);
       NodeAssert.equal(turn.turnId !== undefined, true);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("uses polled busy status to admit output after a stopped turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-polled-busy-after-stop");
+      const firstUserMessageEvent = promiseWithResolvers<unknown>();
+      const assistantMessageEvent = promiseWithResolvers<unknown>();
+      const assistantPartEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const busyStatusPolled = promiseWithResolvers<void>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [
+        firstUserMessageEvent.promise,
+        assistantMessageEvent.promise,
+        assistantPartEvent.promise,
+        idleEvent.promise,
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "content.delta" || event.type === "turn.completed"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop this turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const stoppedMessageId = (runtimeMock.state.promptCalls.at(-1) as { messageID: string })
+        .messageID;
+      firstUserMessageEvent.resolve({
+        id: "evt-first-user-before-polled-busy-turn",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: stoppedMessageId, role: "user" },
+        },
+      });
+      yield* Effect.yieldNow;
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+
+      runtimeMock.state.sessionStatusCalls = 0;
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (runtimeMock.state.sessionStatusCalls === 1) {
+          busyStatusPolled.resolve(undefined);
+          return {
+            data: { "http://127.0.0.1:9999/session": { type: "busy" as const } },
+          };
+        }
+        return { data: {} };
+      };
+      const activeTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Run without echo or busy events",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* Effect.promise(() => busyStatusPolled.promise);
+      yield* Effect.yieldNow;
+
+      assistantMessageEvent.resolve({
+        id: "evt-assistant-after-polled-busy",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: "msg-assistant-after-polled-busy", role: "assistant" },
+        },
+      });
+      assistantPartEvent.resolve({
+        id: "evt-part-after-polled-busy",
+        type: "message.part.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          part: {
+            id: "part-after-polled-busy",
+            sessionID: "http://127.0.0.1:9999/session",
+            messageID: "msg-assistant-after-polled-busy",
+            type: "text",
+            text: "Visible output",
+            time: { start: 1 },
+          },
+          time: 1,
+        },
+      });
+      idleEvent.resolve({
+        id: "evt-idle-after-polled-busy",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["content.delta", "turn.completed"],
+      );
+      const delta = events[0];
+      if (delta?.type === "content.delta") {
+        NodeAssert.equal(delta.payload.delta, "Visible output");
+      }
+      NodeAssert.equal(events[1]?.turnId, activeTurn.turnId);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("ignores a stale admission status response after the next turn starts", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-stale-admission-status-after-stop");
+      const idleEvent = promiseWithResolvers<unknown>();
+      const userMessageEvent = promiseWithResolvers<unknown>();
+      const staleStatusStarted = promiseWithResolvers<void>();
+      const staleStatusRelease = promiseWithResolvers<void>();
+      const staleStatusReturned = promiseWithResolvers<void>();
+      const activePromptStarted = promiseWithResolvers<void>();
+      const activePromptRelease = promiseWithResolvers<void>();
+      runtimeMock.state.autoPromptEcho = false;
+      runtimeMock.state.subscribedEvents = [idleEvent.promise, userMessageEvent.promise];
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (runtimeMock.state.sessionStatusCalls === 1) {
+          staleStatusStarted.resolve(undefined);
+          await staleStatusRelease.promise;
+          staleStatusReturned.resolve(undefined);
+          return {
+            data: { "http://127.0.0.1:9999/session": { type: "busy" as const } },
+          };
+        }
+        return { data: {} };
+      };
+      runtimeMock.state.promptAsyncImplementation = async () => {
+        if (runtimeMock.state.promptCalls.length === 2) {
+          activePromptStarted.resolve(undefined);
+          await activePromptRelease.promise;
+        }
+      };
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stoppedTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Stop while status is pending",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      yield* Effect.promise(() => staleStatusStarted.promise);
+      yield* adapter.interruptTurn(threadId, stoppedTurn.turnId);
+
+      const activeTurnFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Start while the old status is pending",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => activePromptStarted.promise);
+      const activeMessageId = (runtimeMock.state.promptCalls.at(-1) as { messageID: string })
+        .messageID;
+
+      staleStatusRelease.resolve(undefined);
+      yield* Effect.promise(() => staleStatusReturned.promise);
+      for (let index = 0; index < 2; index += 1) {
+        yield* Effect.yieldNow;
+      }
+      idleEvent.resolve({
+        id: "evt-idle-after-stale-admission-status",
+        type: "session.status",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          status: { type: "idle" },
+        },
+      });
+      for (let index = 0; index < 4; index += 1) {
+        yield* Effect.yieldNow;
+      }
+      NodeAssert.equal(activeTurnFiber.pollUnsafe(), undefined);
+      NodeAssert.equal(completedFiber.pollUnsafe(), undefined);
+      const sessionsBeforeAcceptance = yield* adapter.listSessions();
+      const sessionBeforeAcceptance = sessionsBeforeAcceptance.find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      NodeAssert.equal(sessionBeforeAcceptance?.status, "running");
+      NodeAssert.notEqual(sessionBeforeAcceptance?.activeTurnId, stoppedTurn.turnId);
+
+      userMessageEvent.resolve({
+        id: "evt-user-after-stale-admission-status",
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: { id: activeMessageId, role: "user" },
+        },
+      });
+      yield* Effect.yieldNow;
+      activePromptRelease.resolve(undefined);
+      const activeTurn = yield* Fiber.join(activeTurnFiber);
+      yield* advanceTestClock(250);
+
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completed?.turnId, activeTurn.turnId);
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
 
       yield* adapter.stopSession(threadId);
     }),
@@ -3092,6 +3335,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         .interruptTurn(threadId, turn.turnId)
         .pipe(Effect.result, Effect.forkChild);
       yield* Effect.promise(() => abortStarted.promise);
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
+      NodeAssert.equal(runtimeMock.state.abortSignals.length, 1);
+      const abortSignal = runtimeMock.state.abortSignals[0];
       const secondInterrupt = yield* adapter
         .interruptTurn(threadId, turn.turnId)
         .pipe(Effect.result, Effect.forkChild);
@@ -3106,6 +3352,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         })
         .pipe(Effect.result, Effect.forkChild);
       yield* Effect.yieldNow;
+      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
 
       yield* advanceTestClock(9_999);
       NodeAssert.equal(firstInterrupt.pollUnsafe(), undefined);
@@ -3126,9 +3373,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           "OpenCode session abort did not complete within 10 seconds.",
         );
       }
-      NodeAssert.equal(runtimeMock.state.abortCalls.length, 1);
-      NodeAssert.equal(runtimeMock.state.abortSignals.length, 1);
-      NodeAssert.equal(runtimeMock.state.abortSignals[0]?.aborted, true);
+      NodeAssert.equal(abortSignal?.aborted, true);
       NodeAssert.equal(unexpectedEventFiber.pollUnsafe(), undefined);
 
       runtimeMock.state.abortImplementation = null;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -587,6 +587,38 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("aborts a held teardown request before closing the session scope", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-teardown-timeout");
+      const abortStarted = promiseWithResolvers<void>();
+      runtimeMock.state.abortImplementation = async () => {
+        abortStarted.resolve(undefined);
+        await new Promise<void>(() => {});
+      };
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => abortStarted.promise);
+
+      yield* advanceTestClock(999);
+      NodeAssert.equal(stopFiber.pollUnsafe(), undefined);
+      NodeAssert.equal(runtimeMock.state.abortSignals.length, 1);
+      NodeAssert.equal(runtimeMock.state.abortSignals[0]?.aborted, false);
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, []);
+
+      yield* advanceTestClock(1);
+      yield* Fiber.join(stopFiber);
+      NodeAssert.equal(runtimeMock.state.abortSignals[0]?.aborted, true);
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
+
   it.effect("stopAll closes a connecting session and releases startup", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2082,7 +2082,7 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
-          if (existing.session.status === "connecting") {
+          if (existing.session.status === "connecting" && !(yield* Ref.get(existing.stopped))) {
             return (yield* awaitOpenCodeContextReady(existing)).session;
           }
           yield* stopOpenCodeContext(existing);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -19,9 +19,11 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
@@ -181,10 +183,60 @@ type OpenCodeSessionStatusEvent = Extract<
   { readonly type: "session.status" }
 >;
 
+const OpenCodeSessionStatusMap = Schema.Record(
+  Schema.String,
+  Schema.Struct({ type: Schema.String }),
+);
+const decodeOpenCodeSessionStatusMap = Schema.decodeUnknownOption(OpenCodeSessionStatusMap);
+
 interface OpenCodeCancellation {
   readonly turnId: TurnId;
   readonly completion: Deferred.Deferred<void, ProviderAdapterRequestError>;
   deferredIdleEvent?: OpenCodeSessionStatusEvent;
+}
+
+interface OpenCodeIdleReconciliation {
+  readonly turnId: TurnId;
+  readonly promptGeneration: number;
+  raw: unknown;
+  warned: boolean;
+  dirty: boolean;
+  fiber?: Fiber.Fiber<void, never>;
+}
+
+interface OpenCodePromptAdmission {
+  readonly generation: number;
+  readonly turnId: TurnId;
+  readonly messageId: string;
+  readonly priorAwaitingBusy: boolean;
+  readonly priorIdle: { readonly turnId: TurnId; readonly raw: unknown } | undefined;
+  idleDuringAdmission: { readonly turnId: TurnId; readonly raw: unknown } | undefined;
+  idleObservedAfterMessage: boolean;
+  messageObserved: boolean;
+}
+
+type OpenCodeTerminalRequestEvent = Extract<
+  OpenCodeSubscribedEvent,
+  {
+    readonly type: "permission.replied" | "question.replied" | "question.rejected";
+  }
+>;
+
+type OpenCodeAskedRequestEvent = Extract<
+  OpenCodeSubscribedEvent,
+  { readonly type: "permission.asked" | "question.asked" }
+>;
+
+type OpenCodeRoutedRequestEvent = OpenCodeAskedRequestEvent | OpenCodeTerminalRequestEvent;
+
+interface OpenCodeRequestRelationRetry {
+  warned: boolean;
+  fiber?: Fiber.Fiber<void, never>;
+}
+
+interface OpenCodePendingRequestRecovery {
+  warned: boolean;
+  rerun: boolean;
 }
 
 function trimText(value: string | undefined | null): string | undefined {
@@ -262,6 +314,9 @@ interface OpenCodeSessionContext {
   readonly directory: string;
   readonly openCodeSessionId: string;
   readonly relatedSessionIds: Set<string>;
+  readonly resolvedRequestIds: Set<string>;
+  readonly emittedTerminalRequestIds: Set<string>;
+  readonly requestRelationRetries: Map<string, OpenCodeRequestRelationRetry>;
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
@@ -276,6 +331,10 @@ interface OpenCodeSessionContext {
   interruptedTurnId: TurnId | undefined;
   reconcileIdleStatus: boolean;
   awaitingBusyAfterInterruption: boolean;
+  pendingIdleReconciliation: OpenCodeIdleReconciliation | undefined;
+  pendingRequestRecovery: OpenCodePendingRequestRecovery | undefined;
+  promptGeneration: number;
+  promptAdmission: OpenCodePromptAdmission | undefined;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
    * The session lifecycle is owned by `sessionScope`; this Ref exists only
@@ -653,6 +712,37 @@ export function makeOpenCodeAdapter(
           }),
       ),
     );
+    let messageIdEpochMillis = -1;
+    let messageIdCounter = 0;
+    // T3 supplies the message ID to match prompt admission events. Keep OpenCode's sortable native shape so equal-time messages retain their upstream order.
+    const makeOpenCodeMessageId = Effect.fn("makeOpenCodeMessageId")(function* () {
+      const epochMillis = DateTime.toEpochMillis(yield* DateTime.now);
+      if (epochMillis !== messageIdEpochMillis) {
+        messageIdEpochMillis = epochMillis;
+        messageIdCounter = 0;
+      }
+      messageIdCounter += 1;
+      const encodedTime = BigInt.asUintN(
+        48,
+        BigInt(epochMillis) * 0x1000n + BigInt(messageIdCounter),
+      )
+        .toString(16)
+        .padStart(12, "0");
+      const randomBytes = yield* crypto.randomBytes(14).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "crypto/randomBytes",
+              detail: "Failed to generate an OpenCode message identifier.",
+              cause,
+            }),
+        ),
+      );
+      const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+      const random = Array.from(randomBytes, (byte) => alphabet[byte % alphabet.length]).join("");
+      return `msg_${encodedTime}${random}`;
+    });
     const buildEventBase = (input: EventBaseInput) =>
       Effect.all({
         eventId: randomUUIDv4.pipe(Effect.map(EventId.make)),
@@ -722,19 +812,14 @@ export function makeOpenCodeAdapter(
       },
     ) => writeNativeEvent(threadId, event).pipe(Effect.catchCause(() => Effect.void));
 
-    const shouldAcceptOpenCodeIdleEvent = Effect.fn("shouldAcceptOpenCodeIdleEvent")(function* (
+    const cancelIdleReconciliation = Effect.fn("cancelIdleReconciliation")(function* (
       context: OpenCodeSessionContext,
     ) {
-      const response = yield* runOpenCodeSdk("session.status", () =>
-        context.client.session.status(),
-      ).pipe(
-        Effect.retry({ times: 1 }),
-        Effect.orElseSucceed(() => undefined),
-      );
-      const status = response?.data?.[context.openCodeSessionId];
-      // A streamed idle remains the fallback after the status request fails.
-      // The busy-event gate below already rejects stale idles from the stopped turn.
-      return response?.data === undefined || (status?.type ?? "idle") === "idle";
+      const pending = context.pendingIdleReconciliation;
+      context.pendingIdleReconciliation = undefined;
+      if (pending?.fiber) {
+        yield* Fiber.interrupt(pending.fiber);
+      }
     });
 
     const completeOpenCodeTurn = Effect.fn("completeOpenCodeTurn")(function* (
@@ -745,10 +830,12 @@ export function makeOpenCodeAdapter(
       if (context.activeTurnId !== turnId) {
         return;
       }
+      yield* cancelIdleReconciliation(context);
       context.activeTurnId = undefined;
       context.activeAgent = undefined;
       context.activeVariant = undefined;
       context.awaitingBusyAfterInterruption = false;
+      context.reconcileIdleStatus = false;
       yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
       yield* emit({
         ...(yield* buildEventBase({
@@ -763,6 +850,113 @@ export function makeOpenCodeAdapter(
       });
     });
 
+    const scheduleIdleReconciliation = Effect.fn("scheduleIdleReconciliation")(function* (
+      context: OpenCodeSessionContext,
+      turnId: TurnId,
+      raw: unknown,
+    ) {
+      const existing = context.pendingIdleReconciliation;
+      if (existing?.turnId === turnId && existing.promptGeneration === context.promptGeneration) {
+        existing.raw = raw;
+        existing.dirty = true;
+        return;
+      }
+      yield* cancelIdleReconciliation(context);
+
+      const pending: OpenCodeIdleReconciliation = {
+        turnId,
+        promptGeneration: context.promptGeneration,
+        raw,
+        warned: false,
+        dirty: false,
+      };
+      context.pendingIdleReconciliation = pending;
+      const reconcile = Effect.gen(function* () {
+        let retryCount = 0;
+        while (context.pendingIdleReconciliation === pending) {
+          if (
+            context.activeTurnId !== turnId ||
+            context.awaitingBusyAfterInterruption ||
+            context.promptGeneration !== pending.promptGeneration
+          ) {
+            context.pendingIdleReconciliation = undefined;
+            return;
+          }
+          const result = yield* runOpenCodeSdk("session.status", () =>
+            context.client.session.status(),
+          ).pipe(
+            Effect.retry({ times: 1 }),
+            Effect.match({
+              onFailure: (cause) => ({ type: "unknown" as const, cause }),
+              onSuccess: (response) => {
+                const data = Option.getOrUndefined(decodeOpenCodeSessionStatusMap(response.data));
+                if (data === undefined) {
+                  return { type: "unknown" as const, cause: undefined };
+                }
+                const status = data[context.openCodeSessionId];
+                if (status === undefined || status.type === "idle") {
+                  return { type: "idle" as const };
+                }
+                if (status.type === "busy" || status.type === "retry") {
+                  return { type: "busy" as const };
+                }
+                return { type: "unknown" as const, cause: undefined };
+              },
+            }),
+          );
+
+          if (
+            context.pendingIdleReconciliation !== pending ||
+            context.activeTurnId !== turnId ||
+            context.promptGeneration !== pending.promptGeneration
+          ) {
+            return;
+          }
+          if (result.type === "idle") {
+            context.pendingIdleReconciliation = undefined;
+            context.interruptedTurnId = undefined;
+            yield* completeOpenCodeTurn(context, turnId, pending.raw);
+            return;
+          }
+          if (result.type === "busy") {
+            if (pending.dirty) {
+              pending.dirty = false;
+              continue;
+            }
+            context.pendingIdleReconciliation = undefined;
+            return;
+          }
+          if (!pending.warned) {
+            pending.warned = true;
+            yield* emit({
+              ...(yield* buildEventBase({ threadId: context.session.threadId, turnId })),
+              type: "runtime.warning",
+              payload: {
+                message: "OpenCode turn completion is waiting for session status.",
+                detail:
+                  result.cause === undefined
+                    ? "session.status returned missing or invalid status data."
+                    : openCodeRuntimeErrorDetail(result.cause),
+              },
+            });
+          }
+          const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
+          retryCount += 1;
+          yield* Effect.sleep(`${delayMs} millis`);
+        }
+      }).pipe(
+        Effect.catchCause(() => Effect.void),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (context.pendingIdleReconciliation === pending) {
+              context.pendingIdleReconciliation = undefined;
+            }
+          }),
+        ),
+      );
+      pending.fiber = yield* reconcile.pipe(Effect.forkIn(context.sessionScope));
+    });
+
     const interruptOpenCodeTurn = Effect.fn("interruptOpenCodeTurn")(function* (
       context: OpenCodeSessionContext,
       turnId: TurnId,
@@ -771,6 +965,7 @@ export function makeOpenCodeAdapter(
       if (context.interruptedTurnId === turnId) {
         return;
       }
+      yield* cancelIdleReconciliation(context);
       context.interruptedTurnId = turnId;
       context.reconcileIdleStatus = true;
       context.awaitingBusyAfterInterruption = false;
@@ -916,10 +1111,350 @@ export function makeOpenCodeAdapter(
       }
     });
 
+    const isRelatedOpenCodeSession = Effect.fn("isRelatedOpenCodeSession")(function* (
+      context: OpenCodeSessionContext,
+      candidateSessionId: string,
+    ) {
+      if (context.relatedSessionIds.has(candidateSessionId)) {
+        return true;
+      }
+
+      const seen = new Set<string>();
+      const getSession = (sessionID: string) =>
+        runOpenCodeSdk("session.get", () => context.client.session.get({ sessionID })).pipe(
+          Effect.catchIf(
+            (cause) => isOpenCodeNotFound(cause),
+            () => Effect.succeed(undefined),
+          ),
+        );
+      let sessionId: string | undefined = candidateSessionId;
+      for (let depth = 0; sessionId !== undefined && depth < 32; depth += 1) {
+        if (context.relatedSessionIds.has(sessionId)) {
+          context.relatedSessionIds.add(candidateSessionId);
+          return true;
+        }
+        if (seen.has(sessionId)) {
+          return false;
+        }
+        seen.add(sessionId);
+        const currentSessionId: string = sessionId;
+        const response = yield* getSession(currentSessionId);
+        if (response === undefined) {
+          return false;
+        }
+        if (!response.data) {
+          return yield* new OpenCodeRuntimeError({
+            operation: "session.get",
+            detail: `OpenCode session.get returned no session payload for '${currentSessionId}'.`,
+          });
+        }
+        sessionId = response.data.parentID;
+      }
+      return false;
+    });
+
+    const emitPendingOpenCodeRequest = Effect.fn("emitPendingOpenCodeRequest")(function* (
+      context: OpenCodeSessionContext,
+      event: OpenCodeAskedRequestEvent,
+      raw: unknown,
+    ) {
+      if (context.resolvedRequestIds.has(event.properties.id)) {
+        return;
+      }
+      if (event.type === "permission.asked") {
+        const request = event.properties;
+        if (context.pendingPermissions.has(request.id)) {
+          return;
+        }
+        context.pendingPermissions.set(request.id, request);
+        yield* emit({
+          ...(yield* buildEventBase({
+            threadId: context.session.threadId,
+            turnId: context.activeTurnId,
+            requestId: request.id,
+            raw,
+          })),
+          type: "request.opened",
+          payload: {
+            requestType: mapPermissionToRequestType(request.permission),
+            detail: request.patterns.length > 0 ? request.patterns.join("\n") : request.permission,
+            args: request.metadata,
+          },
+        });
+        return;
+      }
+
+      const request = event.properties;
+      if (context.pendingQuestions.has(request.id)) {
+        return;
+      }
+      context.pendingQuestions.set(request.id, request);
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: context.activeTurnId,
+          requestId: request.id,
+          raw,
+        })),
+        type: "user-input.requested",
+        payload: { questions: normalizeQuestionRequest(request) },
+      });
+    });
+
+    const resolvePendingOpenCodeRequest = Effect.fn("resolvePendingOpenCodeRequest")(function* (
+      context: OpenCodeSessionContext,
+      requestId: string,
+    ) {
+      context.resolvedRequestIds.add(requestId);
+      const retry = context.requestRelationRetries.get(requestId);
+      context.requestRelationRetries.delete(requestId);
+      if (retry?.fiber) {
+        yield* Fiber.interrupt(retry.fiber);
+      }
+    });
+
+    const emitTerminalOpenCodeRequest = Effect.fn("emitTerminalOpenCodeRequest")(function* (
+      context: OpenCodeSessionContext,
+      event: OpenCodeTerminalRequestEvent,
+    ) {
+      const requestId = event.properties.requestID;
+      if (context.emittedTerminalRequestIds.has(requestId)) {
+        return;
+      }
+      context.emittedTerminalRequestIds.add(requestId);
+      if (event.type === "permission.replied") {
+        yield* emit({
+          ...(yield* buildEventBase({
+            threadId: context.session.threadId,
+            turnId: context.activeTurnId,
+            requestId,
+            raw: event,
+          })),
+          type: "request.resolved",
+          payload: {
+            requestType: "unknown",
+            decision: mapPermissionDecision(event.properties.reply),
+          },
+        });
+        return;
+      }
+
+      const request = context.pendingQuestions.get(requestId);
+      const answers =
+        event.type === "question.replied" && request
+          ? Object.fromEntries(
+              request.questions.map((question, index) => [
+                openCodeQuestionId(index, question),
+                event.properties.answers[index]?.join(", ") ?? "",
+              ]),
+            )
+          : {};
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: context.activeTurnId,
+          requestId,
+          raw: event,
+        })),
+        type: "user-input.resolved",
+        payload: { answers },
+      });
+    });
+
+    const scheduleRequestRelationRetry = Effect.fn("scheduleRequestRelationRetry")(function* (
+      context: OpenCodeSessionContext,
+      event: OpenCodeRoutedRequestEvent,
+      raw: unknown = event,
+    ) {
+      const requestId =
+        event.type === "permission.asked" || event.type === "question.asked"
+          ? event.properties.id
+          : event.properties.requestID;
+      if (context.requestRelationRetries.has(requestId)) {
+        return;
+      }
+      if (
+        (event.type === "permission.asked" || event.type === "question.asked") &&
+        context.resolvedRequestIds.has(requestId)
+      ) {
+        return;
+      }
+      const retry: OpenCodeRequestRelationRetry = { warned: false };
+      context.requestRelationRetries.set(requestId, retry);
+      const run = Effect.gen(function* () {
+        let retryCount = 0;
+        while (context.requestRelationRetries.get(requestId) === retry) {
+          const relation = yield* isRelatedOpenCodeSession(
+            context,
+            event.properties.sessionID,
+          ).pipe(
+            Effect.match({
+              onFailure: (cause) => ({ type: "unknown" as const, cause }),
+              onSuccess: (related) => ({ type: "known" as const, related }),
+            }),
+          );
+          if (context.requestRelationRetries.get(requestId) !== retry) {
+            return;
+          }
+          if (relation.type === "known") {
+            context.requestRelationRetries.delete(requestId);
+            if (relation.related) {
+              if (event.type === "permission.asked" || event.type === "question.asked") {
+                yield* emitPendingOpenCodeRequest(context, event, raw);
+              } else {
+                yield* emitTerminalOpenCodeRequest(context, event);
+              }
+            }
+            return;
+          }
+          if (!retry.warned) {
+            retry.warned = true;
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                requestId,
+              })),
+              type: "runtime.warning",
+              payload: {
+                message: "OpenCode request routing is waiting for session ancestry.",
+                detail: openCodeRuntimeErrorDetail(relation.cause),
+              },
+            });
+          }
+          const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
+          retryCount += 1;
+          yield* Effect.sleep(`${delayMs} millis`);
+        }
+      }).pipe(
+        Effect.catchCause(() => Effect.void),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (context.requestRelationRetries.get(requestId) === retry) {
+              context.requestRelationRetries.delete(requestId);
+            }
+          }),
+        ),
+      );
+      retry.fiber = yield* run.pipe(Effect.forkIn(context.sessionScope));
+    });
+
+    const schedulePendingRequestRecovery = Effect.fn("schedulePendingRequestRecovery")(function* (
+      context: OpenCodeSessionContext,
+    ) {
+      if (context.pendingRequestRecovery) {
+        context.pendingRequestRecovery.rerun = true;
+        return;
+      }
+      const recovery: OpenCodePendingRequestRecovery = { warned: false, rerun: false };
+      context.pendingRequestRecovery = recovery;
+      const run = Effect.gen(function* () {
+        let retryCount = 0;
+        while (context.pendingRequestRecovery === recovery) {
+          const responses = yield* Effect.all({
+            permissions: runOpenCodeSdk("permission.list", () => context.client.permission.list()),
+            questions: runOpenCodeSdk("question.list", () => context.client.question.list()),
+          }).pipe(
+            Effect.match({
+              onFailure: (cause) => ({ type: "failure" as const, cause }),
+              onSuccess: (value) => ({ type: "success" as const, value }),
+            }),
+          );
+          if (context.pendingRequestRecovery !== recovery) {
+            return;
+          }
+          if (responses.type === "failure") {
+            if (!recovery.warned) {
+              recovery.warned = true;
+              yield* emit({
+                ...(yield* buildEventBase({ threadId: context.session.threadId })),
+                type: "runtime.warning",
+                payload: {
+                  message: "OpenCode pending request recovery failed and will retry.",
+                  detail: openCodeRuntimeErrorDetail(responses.cause),
+                },
+              });
+            }
+            const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
+            retryCount += 1;
+            yield* Effect.sleep(`${delayMs} millis`);
+            continue;
+          }
+          const permissions = responses.value.permissions.data;
+          const questions = responses.value.questions.data;
+          if (permissions === undefined || questions === undefined) {
+            if (!recovery.warned) {
+              recovery.warned = true;
+              yield* emit({
+                ...(yield* buildEventBase({ threadId: context.session.threadId })),
+                type: "runtime.warning",
+                payload: {
+                  message: "OpenCode pending request recovery returned no data and will retry.",
+                },
+              });
+            }
+            const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
+            retryCount += 1;
+            yield* Effect.sleep(`${delayMs} millis`);
+            continue;
+          }
+          yield* Effect.forEach(
+            permissions,
+            (request) =>
+              scheduleRequestRelationRetry(
+                context,
+                { id: `recovered:${request.id}`, type: "permission.asked", properties: request },
+                { type: "permission.asked", properties: request, recovered: true },
+              ),
+            { discard: true },
+          );
+          yield* Effect.forEach(
+            questions,
+            (request) =>
+              scheduleRequestRelationRetry(
+                context,
+                { id: `recovered:${request.id}`, type: "question.asked", properties: request },
+                { type: "question.asked", properties: request, recovered: true },
+              ),
+            { discard: true },
+          );
+          if (recovery.rerun) {
+            recovery.rerun = false;
+            recovery.warned = false;
+            continue;
+          }
+          context.pendingRequestRecovery = undefined;
+          return;
+        }
+      }).pipe(
+        Effect.catchCause(() => Effect.void),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (context.pendingRequestRecovery === recovery) {
+              context.pendingRequestRecovery = undefined;
+            }
+          }),
+        ),
+      );
+      yield* run.pipe(Effect.forkIn(context.sessionScope));
+    });
+
     const handleSubscribedEvent = Effect.fn("handleSubscribedEvent")(function* (
       context: OpenCodeSessionContext,
       event: OpenCodeSubscribedEvent,
     ) {
+      if (event.type === "server.connected") {
+        yield* schedulePendingRequestRecovery(context);
+        return;
+      }
+      const terminalRequestId =
+        event.type === "permission.replied" ||
+        event.type === "question.replied" ||
+        event.type === "question.rejected"
+          ? event.properties.requestID
+          : undefined;
+      if (terminalRequestId !== undefined) {
+        yield* resolvePendingOpenCodeRequest(context, terminalRequestId);
+      }
       if (event.type === "session.created" || event.type === "session.updated") {
         const session = event.properties.info;
         if (session.parentID && context.relatedSessionIds.has(session.parentID)) {
@@ -931,10 +1466,34 @@ export function makeOpenCodeAdapter(
 
       const payloadSessionId = openCodeEventSessionId(event);
       const isParentEvent = payloadSessionId === context.openCodeSessionId;
+      let isKnownPendingTerminalEvent = false;
+      if (
+        payloadSessionId !== undefined &&
+        !context.relatedSessionIds.has(payloadSessionId) &&
+        isOpenCodeChildRequestEvent(event)
+      ) {
+        if (event.type === "permission.asked") {
+          yield* scheduleRequestRelationRetry(context, event);
+        } else if (event.type === "question.asked") {
+          yield* scheduleRequestRelationRetry(context, event);
+        } else if (
+          event.type === "permission.replied" ||
+          event.type === "question.replied" ||
+          event.type === "question.rejected"
+        ) {
+          const requestId = event.properties.requestID;
+          isKnownPendingTerminalEvent =
+            context.pendingPermissions.has(requestId) || context.pendingQuestions.has(requestId);
+          if (!isKnownPendingTerminalEvent) {
+            yield* scheduleRequestRelationRetry(context, event);
+            return;
+          }
+        }
+      }
       const isChildRequestEvent =
         payloadSessionId !== undefined &&
-        context.relatedSessionIds.has(payloadSessionId) &&
-        isOpenCodeChildRequestEvent(event);
+        isOpenCodeChildRequestEvent(event) &&
+        (context.relatedSessionIds.has(payloadSessionId) || isKnownPendingTerminalEvent);
       if (!isParentEvent && !isChildRequestEvent) {
         return;
       }
@@ -975,6 +1534,12 @@ export function makeOpenCodeAdapter(
         }
 
         case "message.updated": {
+          if (
+            event.properties.info.role === "user" &&
+            context.promptAdmission?.messageId === event.properties.info.id
+          ) {
+            context.promptAdmission.messageObserved = true;
+          }
           context.messageRoleById.set(event.properties.info.id, event.properties.info.role);
           if (event.properties.info.role === "assistant") {
             for (const part of context.partById.values()) {
@@ -1088,101 +1653,36 @@ export function makeOpenCodeAdapter(
         }
 
         case "permission.asked": {
-          context.pendingPermissions.set(event.properties.id, event.properties);
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.id,
-              raw: event,
-            })),
-            type: "request.opened",
-            payload: {
-              requestType: mapPermissionToRequestType(event.properties.permission),
-              detail:
-                event.properties.patterns.length > 0
-                  ? event.properties.patterns.join("\n")
-                  : event.properties.permission,
-              args: event.properties.metadata,
-            },
-          });
+          yield* emitPendingOpenCodeRequest(context, event, event);
           break;
         }
 
         case "permission.replied": {
           context.pendingPermissions.delete(event.properties.requestID);
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.requestID,
-              raw: event,
-            })),
-            type: "request.resolved",
-            payload: {
-              requestType: "unknown",
-              decision: mapPermissionDecision(event.properties.reply),
-            },
-          });
+          yield* emitTerminalOpenCodeRequest(context, event);
           break;
         }
 
         case "question.asked": {
-          context.pendingQuestions.set(event.properties.id, event.properties);
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.id,
-              raw: event,
-            })),
-            type: "user-input.requested",
-            payload: {
-              questions: normalizeQuestionRequest(event.properties),
-            },
-          });
+          yield* emitPendingOpenCodeRequest(context, event, event);
           break;
         }
 
         case "question.replied": {
-          const request = context.pendingQuestions.get(event.properties.requestID);
+          yield* emitTerminalOpenCodeRequest(context, event);
           context.pendingQuestions.delete(event.properties.requestID);
-          const answers = Object.fromEntries(
-            (request?.questions ?? []).map((question, index) => [
-              openCodeQuestionId(index, question),
-              event.properties.answers[index]?.join(", ") ?? "",
-            ]),
-          );
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.requestID,
-              raw: event,
-            })),
-            type: "user-input.resolved",
-            payload: { answers },
-          });
           break;
         }
 
         case "question.rejected": {
           context.pendingQuestions.delete(event.properties.requestID);
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.requestID,
-              raw: event,
-            })),
-            type: "user-input.resolved",
-            payload: { answers: {} },
-          });
+          yield* emitTerminalOpenCodeRequest(context, event);
           break;
         }
 
         case "session.status": {
           if (event.properties.status.type === "busy") {
+            yield* cancelIdleReconciliation(context);
             if (turnId !== undefined) {
               context.awaitingBusyAfterInterruption = false;
             }
@@ -1216,7 +1716,14 @@ export function makeOpenCodeAdapter(
             if (context.awaitingBusyAfterInterruption) {
               break;
             }
-            if (context.reconcileIdleStatus && !(yield* shouldAcceptOpenCodeIdleEvent(context))) {
+            if (context.promptAdmission?.turnId === turnId) {
+              context.promptAdmission.idleDuringAdmission = { turnId, raw: event };
+              context.promptAdmission.idleObservedAfterMessage =
+                context.promptAdmission.messageObserved;
+              break;
+            }
+            if (context.reconcileIdleStatus) {
+              yield* scheduleIdleReconciliation(context, turnId, event);
               break;
             }
             context.interruptedTurnId = undefined;
@@ -1239,12 +1746,14 @@ export function makeOpenCodeAdapter(
             }
             break;
           }
+          yield* cancelIdleReconciliation(context);
           if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
             context.cancellation = undefined;
           }
           context.activeTurnId = undefined;
           context.activeAgent = undefined;
           context.activeVariant = undefined;
+          context.reconcileIdleStatus = false;
           yield* updateProviderSession(
             context,
             {
@@ -1543,6 +2052,9 @@ export function makeOpenCodeAdapter(
           directory,
           openCodeSessionId: started.openCodeSession.id,
           relatedSessionIds: new Set([started.openCodeSession.id]),
+          resolvedRequestIds: new Set(),
+          emittedTerminalRequestIds: new Set(),
+          requestRelationRetries: new Map(),
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),
           partById: new Map(),
@@ -1557,11 +2069,18 @@ export function makeOpenCodeAdapter(
           interruptedTurnId: undefined,
           reconcileIdleStatus: false,
           awaitingBusyAfterInterruption: false,
+          pendingIdleReconciliation: undefined,
+          pendingRequestRecovery: undefined,
+          promptGeneration: 0,
+          promptAdmission: undefined,
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
         sessions.set(input.threadId, context);
         yield* startEventPump(context);
+        if (!started.created) {
+          yield* schedulePendingRequestRecovery(context);
+        }
 
         yield* emit({
           ...(yield* buildEventBase({ threadId: input.threadId })),
@@ -1584,11 +2103,6 @@ export function makeOpenCodeAdapter(
 
     const sendTurn: OpenCodeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
       const context = yield* ensureSessionContext(sessions, input.threadId);
-      // A sendTurn while a turn is active is a steer: OpenCode queues the
-      // prompt into the busy session and the work continues as one turn, so
-      // the active turn id is reused instead of opening a new turn.
-      const steeringTurnId = context.activeTurnId;
-      const turnId = steeringTurnId ?? TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
       const modelSelection =
         input.modelSelection ??
         (context.session.model
@@ -1629,14 +2143,49 @@ export function makeOpenCodeAdapter(
         });
       }
 
+      const freshTurnId = TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
+      const messageId = yield* makeOpenCodeMessageId();
+      const pendingCancellation = context.cancellation;
+      if (pendingCancellation) {
+        yield* Deferred.await(pendingCancellation.completion);
+      }
+      // A sendTurn while a turn is active is a steer. OpenCode queues the
+      // prompt into the running session, so the active turn id is reused.
+      const steeringTurnId = context.activeTurnId;
+      const turnId = steeringTurnId ?? freshTurnId;
       const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
       const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
+      const pendingIdleReconciliation = context.pendingIdleReconciliation;
+      const priorAwaitingBusy = context.awaitingBusyAfterInterruption;
+      const priorIdleCandidate = pendingIdleReconciliation
+        ? {
+            turnId: pendingIdleReconciliation.turnId,
+            raw: pendingIdleReconciliation.raw,
+          }
+        : undefined;
+      context.pendingIdleReconciliation = undefined;
+      const promptGeneration = context.promptGeneration + 1;
+      const promptAdmission: OpenCodePromptAdmission = {
+        generation: promptGeneration,
+        turnId,
+        messageId,
+        priorAwaitingBusy,
+        priorIdle: priorIdleCandidate,
+        idleDuringAdmission: undefined,
+        idleObservedAfterMessage: false,
+        messageObserved: false,
+      };
+      context.promptGeneration = promptGeneration;
+      context.promptAdmission = promptAdmission;
 
       context.activeTurnId = turnId;
       context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
       context.activeVariant = variant;
       if (steeringTurnId === undefined) {
         context.awaitingBusyAfterInterruption = context.interruptedTurnId !== undefined;
+      }
+      if (pendingIdleReconciliation?.fiber) {
+        yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
       }
       yield* updateProviderSession(
         context,
@@ -1662,6 +2211,7 @@ export function makeOpenCodeAdapter(
       yield* runOpenCodeSdk("session.promptAsync", () =>
         context.client.session.promptAsync({
           sessionID: context.openCodeSessionId,
+          messageID: messageId,
           model: parsedModel,
           ...(context.activeAgent ? { agent: context.activeAgent } : {}),
           ...(context.activeVariant ? { variant: context.activeVariant } : {}),
@@ -1675,34 +2225,61 @@ export function makeOpenCodeAdapter(
         // here — `toRequestError` already produced the right shape. A failed
         // steer leaves the still-running original turn untouched.
         Effect.tapError((requestError) =>
-          steeringTurnId !== undefined
+          context.promptAdmission !== promptAdmission || context.activeTurnId !== turnId
             ? Effect.void
-            : Effect.gen(function* () {
-                context.activeTurnId = undefined;
-                context.activeAgent = undefined;
-                context.activeVariant = undefined;
-                yield* updateProviderSession(
-                  context,
-                  {
-                    status: "ready",
-                    model: modelSelection?.model ?? context.session.model,
-                    lastError: requestError.detail,
-                  },
-                  { clearActiveTurnId: true },
-                );
-                yield* emit({
-                  ...(yield* buildEventBase({
-                    threadId: input.threadId,
-                    turnId,
-                  })),
-                  type: "turn.aborted",
-                  payload: {
-                    reason: requestError.detail,
-                  },
-                });
-              }),
+            : steeringTurnId !== undefined
+              ? Effect.gen(function* () {
+                  context.promptAdmission = undefined;
+                  context.awaitingBusyAfterInterruption = promptAdmission.priorAwaitingBusy;
+                  const idle = promptAdmission.idleDuringAdmission ?? promptAdmission.priorIdle;
+                  if (idle) {
+                    yield* scheduleIdleReconciliation(context, idle.turnId, idle.raw);
+                  }
+                })
+              : Effect.gen(function* () {
+                  context.promptAdmission = undefined;
+                  context.activeTurnId = undefined;
+                  context.activeAgent = undefined;
+                  context.activeVariant = undefined;
+                  yield* updateProviderSession(
+                    context,
+                    {
+                      status: "ready",
+                      model: modelSelection?.model ?? context.session.model,
+                      lastError: requestError.detail,
+                    },
+                    { clearActiveTurnId: true },
+                  );
+                  yield* emit({
+                    ...(yield* buildEventBase({
+                      threadId: input.threadId,
+                      turnId,
+                    })),
+                    type: "turn.aborted",
+                    payload: {
+                      reason: requestError.detail,
+                    },
+                  });
+                }),
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (context.promptAdmission === promptAdmission) {
+              context.promptAdmission = undefined;
+            }
+          }),
         ),
       );
+      if (
+        context.activeTurnId === turnId &&
+        context.promptGeneration === promptAdmission.generation &&
+        promptAdmission.idleObservedAfterMessage
+      ) {
+        const idle = promptAdmission.idleDuringAdmission;
+        if (idle) {
+          yield* scheduleIdleReconciliation(context, turnId, idle.raw);
+        }
+      }
 
       return {
         threadId: input.threadId,
@@ -1723,6 +2300,7 @@ export function makeOpenCodeAdapter(
           return;
         }
         const interruptedTurnId = turnId ?? activeTurnId;
+        yield* cancelIdleReconciliation(context);
         if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
           return;
         }
@@ -1755,7 +2333,7 @@ export function makeOpenCodeAdapter(
           if (cancellation && context.cancellation === cancellation) {
             context.cancellation = undefined;
             if (cancellation.deferredIdleEvent) {
-              yield* completeOpenCodeTurn(
+              yield* scheduleIdleReconciliation(
                 context,
                 cancellation.turnId,
                 cancellation.deferredIdleEvent,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -213,6 +213,10 @@ interface OpenCodePromptAdmission {
   idleDuringAdmission: { readonly turnId: TurnId; readonly raw: unknown } | undefined;
   idleObservedAfterMessage: boolean;
   messageObserved: boolean;
+  accepted: boolean;
+  readonly acceptance: Deferred.Deferred<void>;
+  recoveryFiber?: Fiber.Fiber<void, never>;
+  recoveryRaw: unknown;
 }
 
 type OpenCodeTerminalRequestEvent = Extract<
@@ -335,6 +339,7 @@ interface OpenCodeSessionContext {
   pendingRequestRecovery: OpenCodePendingRequestRecovery | undefined;
   promptGeneration: number;
   promptAdmission: OpenCodePromptAdmission | undefined;
+  readonly firstConnection: Deferred.Deferred<void, ProviderAdapterRequestError>;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
    * The session lifecycle is owned by `sessionScope`; this Ref exists only
@@ -635,23 +640,83 @@ function updateProviderSession(
   },
 ): Effect.Effect<ProviderSession> {
   return Effect.gen(function* () {
-    const updatedAt = yield* nowIso;
-    const nextSession = {
-      ...context.session,
-      ...patch,
-      updatedAt,
-    } as ProviderSession & Record<string, unknown>;
-    const mutableSession = nextSession as Record<string, unknown>;
-    if (options?.clearActiveTurnId) {
-      delete mutableSession.activeTurnId;
-    }
-    if (options?.clearLastError) {
-      delete mutableSession.lastError;
-    }
-    context.session = nextSession;
-    return nextSession;
+    return applyProviderSessionUpdate(context, patch, options, yield* nowIso);
   });
 }
+
+function applyProviderSessionUpdate(
+  context: OpenCodeSessionContext,
+  patch: Partial<ProviderSession>,
+  options:
+    | {
+        readonly clearActiveTurnId?: boolean;
+        readonly clearLastError?: boolean;
+      }
+    | undefined,
+  updatedAt: string,
+): ProviderSession {
+  const nextSession = {
+    ...context.session,
+    ...patch,
+    updatedAt,
+  } as ProviderSession & Record<string, unknown>;
+  const mutableSession = nextSession as Record<string, unknown>;
+  if (options?.clearActiveTurnId) {
+    delete mutableSession.activeTurnId;
+  }
+  if (options?.clearLastError) {
+    delete mutableSession.lastError;
+  }
+  context.session = nextSession;
+  return nextSession;
+}
+
+const failPendingOpenCodeCancellation = Effect.fn("failPendingOpenCodeCancellation")(function* (
+  context: OpenCodeSessionContext,
+  detail: string,
+) {
+  const cancellation = context.cancellation;
+  if (!cancellation) {
+    return;
+  }
+  context.cancellation = undefined;
+  yield* Deferred.fail(
+    cancellation.completion,
+    new ProviderAdapterRequestError({
+      provider: PROVIDER,
+      method: "session.abort",
+      detail,
+    }),
+  ).pipe(Effect.ignore);
+});
+
+const abortOpenCodeSessionForTeardown = (context: OpenCodeSessionContext) =>
+  runOpenCodeSdk("session.abort", () =>
+    context.client.session.abort({ sessionID: context.openCodeSessionId }),
+  ).pipe(Effect.timeout("1 second"), Effect.ignore({ log: true }));
+
+const closeUnpublishedOpenCodeContext = Effect.fn("closeUnpublishedOpenCodeContext")(function* (
+  context: OpenCodeSessionContext,
+  abortRemote: boolean,
+) {
+  if (yield* Ref.getAndSet(context.stopped, true)) {
+    return;
+  }
+  yield* Deferred.fail(
+    context.firstConnection,
+    new ProviderAdapterRequestError({
+      provider: PROVIDER,
+      method: "event.subscribe",
+      detail: "OpenCode session startup ended before the event stream connected.",
+    }),
+  ).pipe(Effect.ignore);
+  yield* failPendingOpenCodeCancellation(context, "OpenCode session startup was cancelled.");
+  context.promptAdmission = undefined;
+  if (abortRemote) {
+    yield* abortOpenCodeSessionForTeardown(context);
+  }
+  yield* Scope.close(context.sessionScope, Exit.void).pipe(Effect.ignore);
+});
 
 const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
@@ -660,13 +725,21 @@ const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   if (yield* Ref.getAndSet(context.stopped, true)) {
     return false;
   }
+  yield* Deferred.fail(
+    context.firstConnection,
+    new ProviderAdapterRequestError({
+      provider: PROVIDER,
+      method: "event.subscribe",
+      detail: "OpenCode session stopped before the event stream connected.",
+    }),
+  ).pipe(Effect.ignore);
+  yield* failPendingOpenCodeCancellation(context, "OpenCode session stopped during cancellation.");
+  context.promptAdmission = undefined;
 
   // Best-effort remote abort. The scope close below tears down the local
   // handles (event-pump fiber, server-exit fiber, event-subscribe fetch),
   // but we still want to tell OpenCode that this session is done.
-  yield* runOpenCodeSdk("session.abort", () =>
-    context.client.session.abort({ sessionID: context.openCodeSessionId }),
-  ).pipe(Effect.ignore({ log: true }));
+  yield* abortOpenCodeSessionForTeardown(context);
 
   // Closing the session scope interrupts every fiber forked into it and
   // runs each finalizer we registered — the `AbortController.abort()` call,
@@ -825,18 +898,41 @@ export function makeOpenCodeAdapter(
     const completeOpenCodeTurn = Effect.fn("completeOpenCodeTurn")(function* (
       context: OpenCodeSessionContext,
       turnId: TurnId,
+      promptGeneration: number,
       raw: unknown,
     ) {
-      if (context.activeTurnId !== turnId) {
+      const updatedAt = yield* nowIso;
+      const stopped = yield* Ref.get(context.stopped);
+      if (
+        stopped ||
+        context.activeTurnId !== turnId ||
+        context.promptGeneration !== promptGeneration ||
+        context.cancellation?.turnId === turnId
+      ) {
         return;
       }
-      yield* cancelIdleReconciliation(context);
+      const pendingIdleReconciliation = context.pendingIdleReconciliation;
+      if (
+        pendingIdleReconciliation?.turnId === turnId &&
+        pendingIdleReconciliation.promptGeneration === promptGeneration
+      ) {
+        context.pendingIdleReconciliation = undefined;
+      }
       context.activeTurnId = undefined;
       context.activeAgent = undefined;
       context.activeVariant = undefined;
+      context.interruptedTurnId = undefined;
       context.awaitingBusyAfterInterruption = false;
       context.reconcileIdleStatus = false;
-      yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+      applyProviderSessionUpdate(
+        context,
+        { status: "ready" },
+        { clearActiveTurnId: true },
+        updatedAt,
+      );
+      if (pendingIdleReconciliation?.fiber) {
+        yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
+      }
       yield* emit({
         ...(yield* buildEventBase({
           threadId: context.session.threadId,
@@ -914,8 +1010,7 @@ export function makeOpenCodeAdapter(
           }
           if (result.type === "idle") {
             context.pendingIdleReconciliation = undefined;
-            context.interruptedTurnId = undefined;
-            yield* completeOpenCodeTurn(context, turnId, pending.raw);
+            yield* completeOpenCodeTurn(context, turnId, pending.promptGeneration, pending.raw);
             return;
           }
           if (result.type === "busy") {
@@ -955,6 +1050,61 @@ export function makeOpenCodeAdapter(
         ),
       );
       pending.fiber = yield* reconcile.pipe(Effect.forkIn(context.sessionScope));
+    });
+
+    const schedulePromptAdmissionRecovery = Effect.fn("schedulePromptAdmissionRecovery")(function* (
+      context: OpenCodeSessionContext,
+      raw: unknown,
+    ) {
+      const promptAdmission = context.promptAdmission;
+      if (!promptAdmission || promptAdmission.messageObserved) {
+        return;
+      }
+      promptAdmission.recoveryRaw = raw;
+      if (promptAdmission.recoveryFiber) {
+        return;
+      }
+      const recover = Effect.gen(function* () {
+        yield* Deferred.await(promptAdmission.acceptance);
+        let retryCount = 0;
+        while (context.promptAdmission === promptAdmission) {
+          const response = yield* runOpenCodeSdk("session.message", () =>
+            context.client.session.message({
+              sessionID: context.openCodeSessionId,
+              messageID: promptAdmission.messageId,
+            }),
+          ).pipe(Effect.option);
+          const message = Option.isSome(response) ? response.value.data : undefined;
+          if (
+            message?.info.id === promptAdmission.messageId &&
+            message.info.role === "user" &&
+            context.promptAdmission === promptAdmission &&
+            context.activeTurnId === promptAdmission.turnId &&
+            context.promptGeneration === promptAdmission.generation
+          ) {
+            promptAdmission.messageObserved = true;
+            context.messageRoleById.set(promptAdmission.messageId, "user");
+            context.promptAdmission = undefined;
+            yield* scheduleIdleReconciliation(
+              context,
+              promptAdmission.turnId,
+              promptAdmission.recoveryRaw,
+            );
+            return;
+          }
+          const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
+          retryCount += 1;
+          yield* Effect.sleep(`${delayMs} millis`);
+        }
+      }).pipe(
+        Effect.catchCause(() => Effect.void),
+        Effect.ensuring(
+          Effect.sync(() => {
+            delete promptAdmission.recoveryFiber;
+          }),
+        ),
+      );
+      promptAdmission.recoveryFiber = yield* recover.pipe(Effect.forkIn(context.sessionScope));
     });
 
     const interruptOpenCodeTurn = Effect.fn("interruptOpenCodeTurn")(function* (
@@ -1006,6 +1156,19 @@ export function makeOpenCodeAdapter(
       if (yield* Ref.getAndSet(context.stopped, true)) {
         return;
       }
+      yield* Deferred.fail(
+        context.firstConnection,
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "event.subscribe",
+          detail: "OpenCode session exited before the event stream connected.",
+        }),
+      ).pipe(Effect.ignore);
+      yield* failPendingOpenCodeCancellation(
+        context,
+        "OpenCode session exited during cancellation.",
+      );
+      context.promptAdmission = undefined;
       const turnId = context.activeTurnId;
       sessions.delete(context.session.threadId);
       // Emit lifecycle events BEFORE tearing down the scope. Both call sites
@@ -1038,9 +1201,7 @@ export function makeOpenCodeAdapter(
       // Inline the teardown that `stopOpenCodeContext` would do; we can't
       // delegate to it because our `getAndSet` above already flipped the
       // one-shot guard, so the call would no-op.
-      yield* runOpenCodeSdk("session.abort", () =>
-        context.client.session.abort({ sessionID: context.openCodeSessionId }),
-      ).pipe(Effect.ignore({ log: true }));
+      yield* abortOpenCodeSessionForTeardown(context);
       yield* Scope.close(context.sessionScope, Exit.void);
     });
 
@@ -1443,7 +1604,11 @@ export function makeOpenCodeAdapter(
       event: OpenCodeSubscribedEvent,
     ) {
       if (event.type === "server.connected") {
+        const firstConnection = yield* Deferred.succeed(context.firstConnection, undefined);
         yield* schedulePendingRequestRecovery(context);
+        if (!firstConnection) {
+          yield* schedulePromptAdmissionRecovery(context, event);
+        }
         return;
       }
       const terminalRequestId =
@@ -1534,11 +1699,18 @@ export function makeOpenCodeAdapter(
         }
 
         case "message.updated": {
+          const promptAdmission = context.promptAdmission;
           if (
             event.properties.info.role === "user" &&
-            context.promptAdmission?.messageId === event.properties.info.id
+            promptAdmission?.messageId === event.properties.info.id
           ) {
-            context.promptAdmission.messageObserved = true;
+            promptAdmission.messageObserved = true;
+            if (promptAdmission.accepted) {
+              context.promptAdmission = undefined;
+              if (promptAdmission.recoveryFiber) {
+                yield* Fiber.interrupt(promptAdmission.recoveryFiber);
+              }
+            }
           }
           context.messageRoleById.set(event.properties.info.id, event.properties.info.role);
           if (event.properties.info.role === "assistant") {
@@ -1726,8 +1898,7 @@ export function makeOpenCodeAdapter(
               yield* scheduleIdleReconciliation(context, turnId, event);
               break;
             }
-            context.interruptedTurnId = undefined;
-            yield* completeOpenCodeTurn(context, turnId, event);
+            yield* completeOpenCodeTurn(context, turnId, context.promptGeneration, event);
           }
           break;
         }
@@ -2007,24 +2178,6 @@ export function makeOpenCodeAdapter(
           return startedExit.value;
         });
 
-        // Guard against a concurrent startSession call that may have raced
-        // and already inserted a session while we were awaiting async work.
-        const raceWinner = sessions.get(input.threadId);
-        if (raceWinner) {
-          // Another call won the race — clean up. Only abort the remote
-          // session if we created it here; a resumed one is shared upstream
-          // state the winner is now using.
-          if (started.created) {
-            yield* runOpenCodeSdk("session.abort", () =>
-              started.client.session.abort({
-                sessionID: started.openCodeSession.id,
-              }),
-            ).pipe(Effect.ignore);
-          }
-          yield* Scope.close(started.sessionScope, Exit.void).pipe(Effect.ignore);
-          return raceWinner.session;
-        }
-
         const createdAt = yield* nowIso;
         const session: ProviderSession = {
           provider: PROVIDER,
@@ -2073,11 +2226,38 @@ export function makeOpenCodeAdapter(
           pendingRequestRecovery: undefined,
           promptGeneration: 0,
           promptAdmission: undefined,
+          firstConnection: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
-        sessions.set(input.threadId, context);
         yield* startEventPump(context);
+        const connectionExit = yield* Deferred.await(context.firstConnection).pipe(
+          Effect.timeout("10 seconds"),
+          Effect.mapError(
+            (cause) =>
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "event.subscribe",
+                detail: "OpenCode event stream did not connect within 10 seconds.",
+                cause,
+              }),
+          ),
+          Effect.onInterrupt(() => closeUnpublishedOpenCodeContext(context, started.created)),
+          Effect.exit,
+        );
+        if (Exit.isFailure(connectionExit)) {
+          yield* closeUnpublishedOpenCodeContext(context, started.created);
+          return yield* Effect.failCause(connectionExit.cause);
+        }
+        const connectedRaceWinner = sessions.get(input.threadId);
+        if (connectedRaceWinner) {
+          // Another start crossed the connection barrier first. A newly
+          // created remote session belongs to this loser and must be aborted;
+          // a resumed session is shared upstream state and must stay alive.
+          yield* closeUnpublishedOpenCodeContext(context, started.created);
+          return connectedRaceWinner.session;
+        }
+        sessions.set(input.threadId, context);
         if (!started.created) {
           yield* schedulePendingRequestRecovery(context);
         }
@@ -2149,6 +2329,13 @@ export function makeOpenCodeAdapter(
       if (pendingCancellation) {
         yield* Deferred.await(pendingCancellation.completion);
       }
+      const currentContext = yield* ensureSessionContext(sessions, input.threadId);
+      if (currentContext !== context) {
+        return yield* new ProviderAdapterSessionClosedError({
+          provider: PROVIDER,
+          threadId: input.threadId,
+        });
+      }
       // A sendTurn while a turn is active is a steer. OpenCode queues the
       // prompt into the running session, so the active turn id is reused.
       const steeringTurnId = context.activeTurnId;
@@ -2174,6 +2361,9 @@ export function makeOpenCodeAdapter(
         idleDuringAdmission: undefined,
         idleObservedAfterMessage: false,
         messageObserved: false,
+        accepted: false,
+        acceptance: Deferred.makeUnsafe<void>(),
+        recoveryRaw: undefined,
       };
       context.promptGeneration = promptGeneration;
       context.promptAdmission = promptAdmission;
@@ -2262,21 +2452,28 @@ export function makeOpenCodeAdapter(
                   });
                 }),
         ),
-        Effect.ensuring(
-          Effect.sync(() => {
-            if (context.promptAdmission === promptAdmission) {
-              context.promptAdmission = undefined;
-            }
-          }),
+        Effect.onExit((exit) =>
+          Exit.isSuccess(exit)
+            ? Effect.void
+            : Effect.gen(function* () {
+                if (context.promptAdmission === promptAdmission) {
+                  context.promptAdmission = undefined;
+                }
+                yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
+              }),
         ),
       );
+      promptAdmission.accepted = true;
+      yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
       if (
+        context.promptAdmission === promptAdmission &&
         context.activeTurnId === turnId &&
         context.promptGeneration === promptAdmission.generation &&
-        promptAdmission.idleObservedAfterMessage
+        promptAdmission.messageObserved
       ) {
+        context.promptAdmission = undefined;
         const idle = promptAdmission.idleDuringAdmission;
-        if (idle) {
+        if (idle && promptAdmission.idleObservedAfterMessage) {
           yield* scheduleIdleReconciliation(context, turnId, idle.raw);
         }
       }
@@ -2296,7 +2493,10 @@ export function makeOpenCodeAdapter(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
         const activeTurnId = context.activeTurnId;
-        if (turnId !== undefined && activeTurnId !== undefined && turnId !== activeTurnId) {
+        if (
+          (turnId !== undefined && activeTurnId !== turnId) ||
+          (turnId === undefined && activeTurnId === undefined)
+        ) {
           return;
         }
         const interruptedTurnId = turnId ?? activeTurnId;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -175,6 +175,16 @@ type OpenCodeSubscribedEvent =
     ? TEvent
     : never;
 
+type OpenCodeSessionStatusEvent = Extract<
+  OpenCodeSubscribedEvent,
+  { readonly type: "session.status" }
+>;
+
+interface OpenCodeCancellation {
+  readonly turnId: TurnId;
+  deferredIdleEvent?: OpenCodeSessionStatusEvent;
+}
+
 function trimText(value: string | undefined | null): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -214,6 +224,28 @@ function openCodeEventSessionTitle(event: OpenCodeSubscribedEvent): string | und
   return title;
 }
 
+function isOpenCodeAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "MessageAbortedError"
+  );
+}
+
+function isOpenCodeChildRequestEvent(event: OpenCodeSubscribedEvent): boolean {
+  switch (event.type) {
+    case "permission.asked":
+    case "permission.replied":
+    case "question.asked":
+    case "question.replied":
+    case "question.rejected":
+      return true;
+    default:
+      return false;
+  }
+}
+
 const OPENCODE_DEFAULT_TITLE_PATTERN =
   /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -227,6 +259,7 @@ interface OpenCodeSessionContext {
   readonly server: OpenCodeServerConnection;
   readonly directory: string;
   readonly openCodeSessionId: string;
+  readonly relatedSessionIds: Set<string>;
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
@@ -237,6 +270,8 @@ interface OpenCodeSessionContext {
   activeTurnId: TurnId | undefined;
   activeAgent: string | undefined;
   activeVariant: string | undefined;
+  cancellation: OpenCodeCancellation | undefined;
+  interruptedTurnId: TurnId | undefined;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
    * The session lifecycle is owned by `sessionScope`; this Ref exists only
@@ -683,6 +718,66 @@ export function makeOpenCodeAdapter(
       },
     ) => writeNativeEvent(threadId, event).pipe(Effect.catchCause(() => Effect.void));
 
+    const completeOpenCodeTurn = Effect.fn("completeOpenCodeTurn")(function* (
+      context: OpenCodeSessionContext,
+      turnId: TurnId,
+      raw: unknown,
+    ) {
+      if (context.activeTurnId !== turnId) {
+        return;
+      }
+      context.activeTurnId = undefined;
+      context.activeAgent = undefined;
+      context.activeVariant = undefined;
+      yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId,
+          raw,
+        })),
+        type: "turn.completed",
+        payload: {
+          state: "completed",
+        },
+      });
+    });
+
+    const interruptOpenCodeTurn = Effect.fn("interruptOpenCodeTurn")(function* (
+      context: OpenCodeSessionContext,
+      turnId: TurnId,
+      raw?: unknown,
+    ) {
+      if (context.interruptedTurnId === turnId) {
+        return;
+      }
+      context.interruptedTurnId = turnId;
+      if (context.cancellation?.turnId === turnId) {
+        context.cancellation = undefined;
+      }
+      if (context.activeTurnId === turnId) {
+        context.activeTurnId = undefined;
+        context.activeAgent = undefined;
+        context.activeVariant = undefined;
+        yield* updateProviderSession(
+          context,
+          { status: "ready" },
+          { clearActiveTurnId: true, clearLastError: true },
+        );
+      }
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId,
+          raw,
+        })),
+        type: "turn.aborted",
+        payload: {
+          reason: "Interrupted by user.",
+        },
+      });
+    });
+
     const emitUnexpectedExit = Effect.fn("emitUnexpectedExit")(function* (
       context: OpenCodeSessionContext,
       message: string,
@@ -803,8 +898,22 @@ export function makeOpenCodeAdapter(
       context: OpenCodeSessionContext,
       event: OpenCodeSubscribedEvent,
     ) {
+      if (event.type === "session.created" || event.type === "session.updated") {
+        const session = event.properties.info;
+        if (session.parentID && context.relatedSessionIds.has(session.parentID)) {
+          context.relatedSessionIds.add(session.id);
+        }
+      } else if (event.type === "session.deleted") {
+        context.relatedSessionIds.delete(event.properties.info.id);
+      }
+
       const payloadSessionId = openCodeEventSessionId(event);
-      if (payloadSessionId !== context.openCodeSessionId) {
+      const isParentEvent = payloadSessionId === context.openCodeSessionId;
+      const isChildRequestEvent =
+        payloadSessionId !== undefined &&
+        context.relatedSessionIds.has(payloadSessionId) &&
+        isOpenCodeChildRequestEvent(event);
+      if (!isParentEvent && !isChildRequestEvent) {
         return;
       }
 
@@ -817,6 +926,7 @@ export function makeOpenCodeAdapter(
           providerThreadId: context.openCodeSessionId,
           type: event.type,
           ...(turnId ? { turnId } : {}),
+          ...(!isParentEvent && payloadSessionId ? { childSessionId: payloadSessionId } : {}),
           payload: event,
         },
       });
@@ -1051,6 +1161,13 @@ export function makeOpenCodeAdapter(
 
         case "session.status": {
           if (event.properties.status.type === "busy") {
+            if (
+              context.interruptedTurnId !== undefined &&
+              context.activeTurnId !== undefined &&
+              context.interruptedTurnId !== context.activeTurnId
+            ) {
+              context.interruptedTurnId = undefined;
+            }
             yield* updateProviderSession(context, {
               status: "running",
               activeTurnId: turnId,
@@ -1074,19 +1191,11 @@ export function makeOpenCodeAdapter(
           }
 
           if (event.properties.status.type === "idle" && turnId) {
-            context.activeTurnId = undefined;
-            yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
-            yield* emit({
-              ...(yield* buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                raw: event,
-              })),
-              type: "turn.completed",
-              payload: {
-                state: "completed",
-              },
-            });
+            if (context.cancellation?.turnId === turnId) {
+              context.cancellation.deferredIdleEvent = event;
+              break;
+            }
+            yield* completeOpenCodeTurn(context, turnId, event);
           }
           break;
         }
@@ -1094,7 +1203,29 @@ export function makeOpenCodeAdapter(
         case "session.error": {
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
+          const cancellation = context.cancellation;
+          if (
+            isOpenCodeAbortError(event.properties.error) &&
+            ((activeTurnId !== undefined && cancellation?.turnId === activeTurnId) ||
+              context.interruptedTurnId !== undefined)
+          ) {
+            if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
+              yield* interruptOpenCodeTurn(context, activeTurnId, event);
+            } else {
+              yield* updateProviderSession(
+                context,
+                { status: "ready" },
+                { clearActiveTurnId: true, clearLastError: true },
+              );
+            }
+            break;
+          }
+          if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
+            context.cancellation = undefined;
+          }
           context.activeTurnId = undefined;
+          context.activeAgent = undefined;
+          context.activeVariant = undefined;
           yield* updateProviderSession(
             context,
             {
@@ -1392,6 +1523,7 @@ export function makeOpenCodeAdapter(
           server: started.server,
           directory,
           openCodeSessionId: started.openCodeSession.id,
+          relatedSessionIds: new Set([started.openCodeSession.id]),
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),
           partById: new Map(),
@@ -1402,6 +1534,8 @@ export function makeOpenCodeAdapter(
           activeTurnId: undefined,
           activeAgent: undefined,
           activeVariant: undefined,
+          cancellation: undefined,
+          interruptedTurnId: undefined,
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
@@ -1560,20 +1694,42 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        yield* runOpenCodeSdk("session.abort", () =>
-          context.client.session.abort({ sessionID: context.openCodeSessionId }),
-        ).pipe(Effect.mapError(toRequestError));
-        if (turnId ?? context.activeTurnId) {
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId,
-              turnId: turnId ?? context.activeTurnId,
-            })),
-            type: "turn.aborted",
-            payload: {
-              reason: "Interrupted by user.",
-            },
-          });
+        const activeTurnId = context.activeTurnId;
+        if (turnId !== undefined && activeTurnId !== undefined && turnId !== activeTurnId) {
+          return;
+        }
+        const interruptedTurnId = turnId ?? activeTurnId;
+        const cancellation: OpenCodeCancellation | undefined = interruptedTurnId
+          ? { turnId: interruptedTurnId }
+          : undefined;
+        if (cancellation) {
+          context.cancellation = cancellation;
+        }
+
+        const abortExit = yield* Effect.exit(
+          runOpenCodeSdk("session.abort", () =>
+            context.client.session.abort({ sessionID: context.openCodeSessionId }),
+          ).pipe(Effect.mapError(toRequestError)),
+        );
+        if (Exit.isFailure(abortExit)) {
+          if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
+            return;
+          }
+          if (cancellation && context.cancellation === cancellation) {
+            context.cancellation = undefined;
+            if (cancellation.deferredIdleEvent) {
+              yield* completeOpenCodeTurn(
+                context,
+                cancellation.turnId,
+                cancellation.deferredIdleEvent,
+              );
+            }
+          }
+          return yield* Effect.failCause(abortExit.cause);
+        }
+
+        if (cancellation && context.cancellation === cancellation) {
+          yield* interruptOpenCodeTurn(context, cancellation.turnId);
         }
       },
     );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -275,6 +275,7 @@ interface OpenCodeSessionContext {
   cancellation: OpenCodeCancellation | undefined;
   interruptedTurnId: TurnId | undefined;
   reconcileIdleStatus: boolean;
+  awaitingBusyAfterInterruption: boolean;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
    * The session lifecycle is owned by `sessionScope`; this Ref exists only
@@ -721,14 +722,19 @@ export function makeOpenCodeAdapter(
       },
     ) => writeNativeEvent(threadId, event).pipe(Effect.catchCause(() => Effect.void));
 
-    const isOpenCodeSessionCurrentlyIdle = Effect.fn("isOpenCodeSessionCurrentlyIdle")(function* (
+    const shouldAcceptOpenCodeIdleEvent = Effect.fn("shouldAcceptOpenCodeIdleEvent")(function* (
       context: OpenCodeSessionContext,
     ) {
       const response = yield* runOpenCodeSdk("session.status", () =>
         context.client.session.status(),
-      ).pipe(Effect.orElseSucceed(() => undefined));
+      ).pipe(
+        Effect.retry({ times: 1 }),
+        Effect.orElseSucceed(() => undefined),
+      );
       const status = response?.data?.[context.openCodeSessionId];
-      return response?.data !== undefined && (status?.type ?? "idle") === "idle";
+      // A streamed idle remains the fallback after the status request fails.
+      // The busy-event gate below already rejects stale idles from the stopped turn.
+      return response?.data === undefined || (status?.type ?? "idle") === "idle";
     });
 
     const completeOpenCodeTurn = Effect.fn("completeOpenCodeTurn")(function* (
@@ -742,6 +748,7 @@ export function makeOpenCodeAdapter(
       context.activeTurnId = undefined;
       context.activeAgent = undefined;
       context.activeVariant = undefined;
+      context.awaitingBusyAfterInterruption = false;
       yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
       yield* emit({
         ...(yield* buildEventBase({
@@ -766,6 +773,7 @@ export function makeOpenCodeAdapter(
       }
       context.interruptedTurnId = turnId;
       context.reconcileIdleStatus = true;
+      context.awaitingBusyAfterInterruption = false;
       if (context.cancellation?.turnId === turnId) {
         context.cancellation = undefined;
       }
@@ -1175,6 +1183,9 @@ export function makeOpenCodeAdapter(
 
         case "session.status": {
           if (event.properties.status.type === "busy") {
+            if (turnId !== undefined) {
+              context.awaitingBusyAfterInterruption = false;
+            }
             yield* updateProviderSession(context, {
               status: "running",
               activeTurnId: turnId,
@@ -1202,7 +1213,10 @@ export function makeOpenCodeAdapter(
               context.cancellation.deferredIdleEvent = event;
               break;
             }
-            if (context.reconcileIdleStatus && !(yield* isOpenCodeSessionCurrentlyIdle(context))) {
+            if (context.awaitingBusyAfterInterruption) {
+              break;
+            }
+            if (context.reconcileIdleStatus && !(yield* shouldAcceptOpenCodeIdleEvent(context))) {
               break;
             }
             context.interruptedTurnId = undefined;
@@ -1365,7 +1379,7 @@ export function makeOpenCodeAdapter(
               const client = openCodeRuntime.createOpenCodeSdkClient({
                 baseUrl: server.url,
                 directory,
-                ...(server.external && serverPassword ? { serverPassword } : {}),
+                ...(serverPassword ? { serverPassword } : {}),
               });
               const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
               if (mcpSession && !server.external) {
@@ -1542,6 +1556,7 @@ export function makeOpenCodeAdapter(
           cancellation: undefined,
           interruptedTurnId: undefined,
           reconcileIdleStatus: false,
+          awaitingBusyAfterInterruption: false,
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
@@ -1620,6 +1635,9 @@ export function makeOpenCodeAdapter(
       context.activeTurnId = turnId;
       context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
       context.activeVariant = variant;
+      if (steeringTurnId === undefined) {
+        context.awaitingBusyAfterInterruption = context.interruptedTurnId !== undefined;
+      }
       yield* updateProviderSession(
         context,
         {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1631,17 +1631,12 @@ export function makeOpenCodeAdapter(
       event: OpenCodeRoutedRequestEvent,
       raw: unknown = event,
     ) {
-      const requestId =
-        event.type === "permission.asked" || event.type === "question.asked"
-          ? event.properties.id
-          : event.properties.requestID;
+      const isAskedEvent = event.type === "permission.asked" || event.type === "question.asked";
+      const requestId = isAskedEvent ? event.properties.id : event.properties.requestID;
       if (context.requestRelationRetries.has(requestId)) {
         return;
       }
-      if (
-        (event.type === "permission.asked" || event.type === "question.asked") &&
-        context.resolvedRequestIds.has(requestId)
-      ) {
+      if (isAskedEvent && context.resolvedRequestIds.has(requestId)) {
         return;
       }
       const retry: OpenCodeRequestRelationRetry = { warned: false };
@@ -1664,7 +1659,7 @@ export function makeOpenCodeAdapter(
           if (relation.type === "known") {
             context.requestRelationRetries.delete(requestId);
             if (relation.related) {
-              if (event.type === "permission.asked" || event.type === "question.asked") {
+              if (isAskedEvent) {
                 yield* emitPendingOpenCodeRequest(context, event, raw);
               } else {
                 yield* emitTerminalOpenCodeRequest(context, event);
@@ -1688,6 +1683,9 @@ export function makeOpenCodeAdapter(
           }
           const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
           retryCount += 1;
+          if (!isAskedEvent && retryCount >= 5) {
+            return;
+          }
           yield* Effect.sleep(`${delayMs} millis`);
         }
       }).pipe(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -15,6 +15,7 @@ import {
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
@@ -182,6 +183,7 @@ type OpenCodeSessionStatusEvent = Extract<
 
 interface OpenCodeCancellation {
   readonly turnId: TurnId;
+  readonly completion: Deferred.Deferred<void, ProviderAdapterRequestError>;
   deferredIdleEvent?: OpenCodeSessionStatusEvent;
 }
 
@@ -1195,6 +1197,9 @@ export function makeOpenCodeAdapter(
               context.cancellation.deferredIdleEvent = event;
               break;
             }
+            if (context.interruptedTurnId !== undefined && context.interruptedTurnId !== turnId) {
+              break;
+            }
             yield* completeOpenCodeTurn(context, turnId, event);
           }
           break;
@@ -1211,12 +1216,6 @@ export function makeOpenCodeAdapter(
           ) {
             if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
               yield* interruptOpenCodeTurn(context, activeTurnId, event);
-            } else {
-              yield* updateProviderSession(
-                context,
-                { status: "ready" },
-                { clearActiveTurnId: true, clearLastError: true },
-              );
             }
             break;
           }
@@ -1699,8 +1698,18 @@ export function makeOpenCodeAdapter(
           return;
         }
         const interruptedTurnId = turnId ?? activeTurnId;
+        if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
+          return;
+        }
+        const existingCancellation = context.cancellation;
+        if (interruptedTurnId && existingCancellation?.turnId === interruptedTurnId) {
+          return yield* Deferred.await(existingCancellation.completion);
+        }
         const cancellation: OpenCodeCancellation | undefined = interruptedTurnId
-          ? { turnId: interruptedTurnId }
+          ? {
+              turnId: interruptedTurnId,
+              completion: yield* Deferred.make<void, ProviderAdapterRequestError>(),
+            }
           : undefined;
         if (cancellation) {
           context.cancellation = cancellation;
@@ -1713,6 +1722,9 @@ export function makeOpenCodeAdapter(
         );
         if (Exit.isFailure(abortExit)) {
           if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
+            if (cancellation) {
+              yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
+            }
             return;
           }
           if (cancellation && context.cancellation === cancellation) {
@@ -1725,11 +1737,17 @@ export function makeOpenCodeAdapter(
               );
             }
           }
+          if (cancellation) {
+            yield* Deferred.done(cancellation.completion, abortExit).pipe(Effect.ignore);
+          }
           return yield* Effect.failCause(abortExit.cause);
         }
 
         if (cancellation && context.cancellation === cancellation) {
           yield* interruptOpenCodeTurn(context, cancellation.turnId);
+        }
+        if (cancellation) {
+          yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
         }
       },
     );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -190,8 +190,9 @@ const OpenCodeSessionStatusMap = Schema.Record(
 const decodeOpenCodeSessionStatusMap = Schema.decodeUnknownOption(OpenCodeSessionStatusMap);
 
 interface OpenCodeCancellation {
-  readonly turnId: TurnId;
+  readonly turnId: TurnId | undefined;
   readonly completion: Deferred.Deferred<void, ProviderAdapterRequestError>;
+  acknowledged?: boolean;
   deferredIdleEvent?: OpenCodeSessionStatusEvent;
 }
 
@@ -695,7 +696,7 @@ const abortOpenCodeSessionForTeardown = (context: OpenCodeSessionContext) =>
     context.client.session.abort({ sessionID: context.openCodeSessionId }),
   ).pipe(Effect.timeout("1 second"), Effect.ignore({ log: true }));
 
-const closeUnpublishedOpenCodeContext = Effect.fn("closeUnpublishedOpenCodeContext")(function* (
+const closeStartingOpenCodeContext = Effect.fn("closeStartingOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
   abortRemote: boolean,
 ) {
@@ -774,6 +775,24 @@ export function makeOpenCodeAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
     const runtimeEvents = yield* Queue.unbounded<ProviderRuntimeEvent>();
     const sessions = new Map<ThreadId, OpenCodeSessionContext>();
+    const deleteContextIfCurrent = (context: OpenCodeSessionContext) => {
+      if (sessions.get(context.session.threadId) === context) {
+        sessions.delete(context.session.threadId);
+      }
+    };
+    const awaitOpenCodeContextReady = Effect.fn("awaitOpenCodeContextReady")(function* (
+      context: OpenCodeSessionContext,
+    ) {
+      yield* Deferred.await(context.firstConnection);
+      const current = yield* ensureSessionContext(sessions, context.session.threadId);
+      if (current !== context) {
+        return yield* new ProviderAdapterSessionClosedError({
+          provider: PROVIDER,
+          threadId: context.session.threadId,
+        });
+      }
+      return current;
+    });
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
       Effect.mapError(
         (cause) =>
@@ -1170,7 +1189,7 @@ export function makeOpenCodeAdapter(
       );
       context.promptAdmission = undefined;
       const turnId = context.activeTurnId;
-      sessions.delete(context.session.threadId);
+      deleteContextIfCurrent(context);
       // Emit lifecycle events BEFORE tearing down the scope. Both call sites
       // run this inside a fiber forked via `Effect.forkIn(context.sessionScope)`;
       // closing that scope triggers the fiber-interrupt finalizer, so any
@@ -1604,9 +1623,28 @@ export function makeOpenCodeAdapter(
       event: OpenCodeSubscribedEvent,
     ) {
       if (event.type === "server.connected") {
-        const firstConnection = yield* Deferred.succeed(context.firstConnection, undefined);
+        if (
+          (yield* Ref.get(context.stopped)) ||
+          sessions.get(context.session.threadId) !== context
+        ) {
+          return;
+        }
+        const isFirstConnection = !(yield* Deferred.isDone(context.firstConnection));
+        if (isFirstConnection) {
+          const updatedAt = yield* nowIso;
+          if (
+            (yield* Ref.get(context.stopped)) ||
+            sessions.get(context.session.threadId) !== context
+          ) {
+            return;
+          }
+          applyProviderSessionUpdate(context, { status: "ready" }, undefined, updatedAt);
+          if (!(yield* Deferred.succeed(context.firstConnection, undefined))) {
+            return;
+          }
+        }
         yield* schedulePendingRequestRecovery(context);
-        if (!firstConnection) {
+        if (!isFirstConnection) {
           yield* schedulePromptAdmissionRecovery(context, event);
         }
         return;
@@ -1854,10 +1892,11 @@ export function makeOpenCodeAdapter(
 
         case "session.status": {
           if (event.properties.status.type === "busy") {
-            yield* cancelIdleReconciliation(context);
-            if (turnId !== undefined) {
-              context.awaitingBusyAfterInterruption = false;
+            if (turnId === undefined) {
+              break;
             }
+            yield* cancelIdleReconciliation(context);
+            context.awaitingBusyAfterInterruption = false;
             yield* updateProviderSession(context, {
               status: "running",
               activeTurnId: turnId,
@@ -1907,15 +1946,18 @@ export function makeOpenCodeAdapter(
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
           const cancellation = context.cancellation;
-          if (
-            isOpenCodeAbortError(event.properties.error) &&
-            ((activeTurnId !== undefined && cancellation?.turnId === activeTurnId) ||
-              context.interruptedTurnId !== undefined)
-          ) {
+          if (isOpenCodeAbortError(event.properties.error)) {
+            if (cancellation !== undefined && cancellation.turnId === undefined) {
+              cancellation.acknowledged = true;
+              break;
+            }
             if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
               yield* interruptOpenCodeTurn(context, activeTurnId, event);
+              break;
             }
-            break;
+            if (context.interruptedTurnId !== undefined || context.reconcileIdleStatus) {
+              break;
+            }
           }
           yield* cancelIdleReconciliation(context);
           if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
@@ -2040,8 +2082,11 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
+          if (existing.session.status === "connecting") {
+            return (yield* awaitOpenCodeContextReady(existing)).session;
+          }
           yield* stopOpenCodeContext(existing);
-          sessions.delete(input.threadId);
+          deleteContextIfCurrent(existing);
         }
 
         const started = yield* Effect.gen(function* () {
@@ -2182,7 +2227,7 @@ export function makeOpenCodeAdapter(
         const session: ProviderSession = {
           provider: PROVIDER,
           providerInstanceId: boundInstanceId,
-          status: "ready",
+          status: "connecting",
           runtimeMode: input.runtimeMode,
           cwd: directory,
           ...(input.modelSelection ? { model: input.modelSelection.model } : {}),
@@ -2230,34 +2275,40 @@ export function makeOpenCodeAdapter(
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
-        yield* startEventPump(context);
-        const connectionExit = yield* Deferred.await(context.firstConnection).pipe(
-          Effect.timeout("10 seconds"),
-          Effect.mapError(
-            (cause) =>
-              new ProviderAdapterRequestError({
-                provider: PROVIDER,
-                method: "event.subscribe",
-                detail: "OpenCode event stream did not connect within 10 seconds.",
-                cause,
-              }),
-          ),
-          Effect.onInterrupt(() => closeUnpublishedOpenCodeContext(context, started.created)),
+        const raceWinner = sessions.get(input.threadId);
+        if (raceWinner) {
+          // Another start published first. A newly created remote session
+          // belongs to this loser; a resumed session is shared upstream state.
+          yield* closeStartingOpenCodeContext(context, started.created);
+          return (yield* awaitOpenCodeContextReady(raceWinner)).session;
+        }
+        sessions.set(input.threadId, context);
+        const cleanupStartingContext = closeStartingOpenCodeContext(context, started.created).pipe(
+          Effect.ensuring(Effect.sync(() => deleteContextIfCurrent(context))),
+        );
+        const connectionExit = yield* Effect.gen(function* () {
+          yield* startEventPump(context);
+          yield* Deferred.await(context.firstConnection).pipe(
+            Effect.timeout("10 seconds"),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "event.subscribe",
+                  detail: "OpenCode event stream did not connect within 10 seconds.",
+                  cause,
+                }),
+            ),
+          );
+        }).pipe(
+          Effect.onInterrupt(() => cleanupStartingContext),
           Effect.exit,
         );
         if (Exit.isFailure(connectionExit)) {
-          yield* closeUnpublishedOpenCodeContext(context, started.created);
+          yield* cleanupStartingContext;
           return yield* Effect.failCause(connectionExit.cause);
         }
-        const connectedRaceWinner = sessions.get(input.threadId);
-        if (connectedRaceWinner) {
-          // Another start crossed the connection barrier first. A newly
-          // created remote session belongs to this loser and must be aborted;
-          // a resumed session is shared upstream state and must stay alive.
-          yield* closeUnpublishedOpenCodeContext(context, started.created);
-          return connectedRaceWinner.session;
-        }
-        sessions.set(input.threadId, context);
+        yield* awaitOpenCodeContextReady(context);
         if (!started.created) {
           yield* schedulePendingRequestRecovery(context);
         }
@@ -2277,12 +2328,13 @@ export function makeOpenCodeAdapter(
           },
         });
 
-        return session;
+        return context.session;
       },
     );
 
     const sendTurn: OpenCodeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
       const context = yield* ensureSessionContext(sessions, input.threadId);
+      yield* awaitOpenCodeContextReady(context);
       const modelSelection =
         input.modelSelection ??
         (context.session.model
@@ -2493,10 +2545,7 @@ export function makeOpenCodeAdapter(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
         const activeTurnId = context.activeTurnId;
-        if (
-          (turnId !== undefined && activeTurnId !== turnId) ||
-          (turnId === undefined && activeTurnId === undefined)
-        ) {
+        if (turnId !== undefined && activeTurnId !== turnId) {
           return;
         }
         const interruptedTurnId = turnId ?? activeTurnId;
@@ -2505,18 +2554,17 @@ export function makeOpenCodeAdapter(
           return;
         }
         const existingCancellation = context.cancellation;
-        if (interruptedTurnId && existingCancellation?.turnId === interruptedTurnId) {
+        if (
+          existingCancellation !== undefined &&
+          existingCancellation.turnId === interruptedTurnId
+        ) {
           return yield* Deferred.await(existingCancellation.completion);
         }
-        const cancellation: OpenCodeCancellation | undefined = interruptedTurnId
-          ? {
-              turnId: interruptedTurnId,
-              completion: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
-            }
-          : undefined;
-        if (cancellation) {
-          context.cancellation = cancellation;
-        }
+        const cancellation: OpenCodeCancellation = {
+          turnId: interruptedTurnId,
+          completion: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
+        };
+        context.cancellation = cancellation;
 
         const abortExit = yield* Effect.exit(
           runOpenCodeSdk("session.abort", () =>
@@ -2525,14 +2573,20 @@ export function makeOpenCodeAdapter(
         );
         if (Exit.isFailure(abortExit)) {
           if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
-            if (cancellation) {
-              yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
-            }
+            yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
             return;
           }
-          if (cancellation && context.cancellation === cancellation) {
+          if (cancellation.turnId === undefined && cancellation.acknowledged) {
+            if (context.cancellation === cancellation) {
+              context.cancellation = undefined;
+              context.reconcileIdleStatus = true;
+            }
+            yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
+            return;
+          }
+          if (context.cancellation === cancellation) {
             context.cancellation = undefined;
-            if (cancellation.deferredIdleEvent) {
+            if (cancellation.turnId !== undefined && cancellation.deferredIdleEvent) {
               yield* scheduleIdleReconciliation(
                 context,
                 cancellation.turnId,
@@ -2540,18 +2594,19 @@ export function makeOpenCodeAdapter(
               );
             }
           }
-          if (cancellation) {
-            yield* Deferred.done(cancellation.completion, abortExit).pipe(Effect.ignore);
-          }
+          yield* Deferred.done(cancellation.completion, abortExit).pipe(Effect.ignore);
           return yield* Effect.failCause(abortExit.cause);
         }
 
-        if (cancellation && context.cancellation === cancellation) {
-          yield* interruptOpenCodeTurn(context, cancellation.turnId);
+        if (context.cancellation === cancellation) {
+          if (cancellation.turnId !== undefined) {
+            yield* interruptOpenCodeTurn(context, cancellation.turnId);
+          } else {
+            context.cancellation = undefined;
+            context.reconcileIdleStatus = true;
+          }
         }
-        if (cancellation) {
-          yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
-        }
+        yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
       },
     );
 
@@ -2606,7 +2661,7 @@ export function makeOpenCodeAdapter(
           });
         }
         const stopped = yield* stopOpenCodeContext(context);
-        sessions.delete(threadId);
+        deleteContextIfCurrent(context);
         if (!stopped) {
           return;
         }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1199,6 +1199,17 @@ export function makeOpenCodeAdapter(
                 { signal },
               ),
             ).pipe(Effect.timeout("1 second"), Effect.option);
+            const stopped = yield* Ref.get(context.stopped);
+            if (
+              stopped ||
+              sessions.get(context.session.threadId) !== context ||
+              context.promptAdmission !== promptAdmission ||
+              context.activeTurnId !== promptAdmission.turnId ||
+              context.promptGeneration !== promptAdmission.generation ||
+              promptAdmission.cancelled
+            ) {
+              return;
+            }
             const message = Option.isSome(response) ? response.value.data : undefined;
             if (message?.info.id === promptAdmission.messageId && message.info.role === "user") {
               promptAdmission.messageObserved = true;
@@ -1209,6 +1220,17 @@ export function makeOpenCodeAdapter(
           const statusResponse = yield* runOpenCodeSdk("session.status", (signal) =>
             context.client.session.status(undefined, { signal }),
           ).pipe(Effect.timeout("1 second"), Effect.option);
+          const stopped = yield* Ref.get(context.stopped);
+          if (
+            stopped ||
+            sessions.get(context.session.threadId) !== context ||
+            context.promptAdmission !== promptAdmission ||
+            context.activeTurnId !== promptAdmission.turnId ||
+            context.promptGeneration !== promptAdmission.generation ||
+            promptAdmission.cancelled
+          ) {
+            return;
+          }
           const statusData = Option.isSome(statusResponse)
             ? Option.getOrUndefined(decodeOpenCodeSessionStatusMap(statusResponse.value.data))
             : undefined;
@@ -1219,6 +1241,7 @@ export function makeOpenCodeAdapter(
           if (isBusy) {
             promptAdmission.busyObserved = true;
             promptAdmission.idleStatusConfirmations = 0;
+            context.awaitingBusyAfterInterruption = false;
             context.promptAdmission = undefined;
             return;
           }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -25,6 +25,7 @@ import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
@@ -214,8 +215,13 @@ interface OpenCodePromptAdmission {
   idleDuringAdmission: { readonly turnId: TurnId; readonly raw: unknown } | undefined;
   idleObservedAfterMessage: boolean;
   messageObserved: boolean;
+  busyObserved: boolean;
+  idleStatusConfirmations: number;
   accepted: boolean;
+  cancelled: boolean;
   readonly acceptance: Deferred.Deferred<void>;
+  readonly submissionSettled: Deferred.Deferred<void>;
+  promptFiber?: Fiber.Fiber<void, ProviderAdapterRequestError>;
   recoveryFiber?: Fiber.Fiber<void, never>;
   recoveryRaw: unknown;
 }
@@ -340,6 +346,7 @@ interface OpenCodeSessionContext {
   pendingRequestRecovery: OpenCodePendingRequestRecovery | undefined;
   promptGeneration: number;
   promptAdmission: OpenCodePromptAdmission | undefined;
+  readonly promptSemaphore: Semaphore.Semaphore;
   readonly firstConnection: Deferred.Deferred<void, ProviderAdapterRequestError>;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
@@ -696,6 +703,20 @@ const abortOpenCodeSessionForTeardown = (context: OpenCodeSessionContext) =>
     context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
   ).pipe(Effect.timeout("1 second"), Effect.ignore({ log: true }));
 
+const cancelPendingOpenCodePrompt = Effect.fn("cancelPendingOpenCodePrompt")(function* (
+  context: OpenCodeSessionContext,
+) {
+  const admission = context.promptAdmission;
+  if (!admission) {
+    return;
+  }
+  admission.cancelled = true;
+  if (admission.promptFiber) {
+    yield* Fiber.interrupt(admission.promptFiber);
+  }
+  yield* Deferred.await(admission.submissionSettled);
+});
+
 const closeStartingOpenCodeContext = Effect.fn("closeStartingOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
   abortRemote: boolean,
@@ -711,6 +732,7 @@ const closeStartingOpenCodeContext = Effect.fn("closeStartingOpenCodeContext")(f
       detail: "OpenCode session startup ended before the event stream connected.",
     }),
   ).pipe(Effect.ignore);
+  yield* cancelPendingOpenCodePrompt(context);
   yield* failPendingOpenCodeCancellation(context, "OpenCode session startup was cancelled.");
   context.promptAdmission = undefined;
   if (abortRemote) {
@@ -734,7 +756,12 @@ const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
       detail: "OpenCode session stopped before the event stream connected.",
     }),
   ).pipe(Effect.ignore);
-  yield* failPendingOpenCodeCancellation(context, "OpenCode session stopped during cancellation.");
+  yield* cancelPendingOpenCodePrompt(context);
+  const cancellation = context.cancellation;
+  context.cancellation = undefined;
+  if (cancellation) {
+    yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
+  }
   context.promptAdmission = undefined;
 
   // Best-effort remote abort. The scope close below tears down the local
@@ -997,9 +1024,10 @@ export function makeOpenCodeAdapter(
             context.pendingIdleReconciliation = undefined;
             return;
           }
-          const result = yield* runOpenCodeSdk("session.status", () =>
-            context.client.session.status(),
+          const result = yield* runOpenCodeSdk("session.status", (signal) =>
+            context.client.session.status(undefined, { signal }),
           ).pipe(
+            Effect.timeout("1 second"),
             Effect.retry({ times: 1 }),
             Effect.match({
               onFailure: (cause) => ({ type: "unknown" as const, cause }),
@@ -1071,39 +1099,167 @@ export function makeOpenCodeAdapter(
       pending.fiber = yield* reconcile.pipe(Effect.forkIn(context.sessionScope));
     });
 
+    const failPromptAdmissionRecovery = Effect.fn("failPromptAdmissionRecovery")(function* (
+      context: OpenCodeSessionContext,
+      promptAdmission: OpenCodePromptAdmission,
+    ) {
+      if (
+        context.promptAdmission !== promptAdmission ||
+        context.activeTurnId !== promptAdmission.turnId ||
+        context.promptGeneration !== promptAdmission.generation
+      ) {
+        return;
+      }
+      const detail =
+        "OpenCode accepted the prompt, but T3 Code could not confirm its message or session status.";
+      const abortExit = yield* Effect.exit(
+        runOpenCodeSdk("session.abort", (signal) =>
+          context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
+        ).pipe(Effect.timeout("1 second")),
+      );
+      if (Exit.isFailure(abortExit)) {
+        yield* emitUnexpectedExit(
+          context,
+          `${detail} The cleanup abort also failed: ${openCodeRuntimeErrorDetail(Cause.squash(abortExit.cause))}`,
+        );
+        deleteContextIfCurrent(context);
+        return;
+      }
+      context.promptAdmission = undefined;
+      context.activeTurnId = undefined;
+      context.activeAgent = undefined;
+      context.activeVariant = undefined;
+      context.awaitingBusyAfterInterruption = false;
+      context.reconcileIdleStatus = false;
+      yield* updateProviderSession(
+        context,
+        { status: "error", lastError: detail },
+        { clearActiveTurnId: true },
+      );
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: promptAdmission.turnId,
+          raw: promptAdmission.recoveryRaw,
+        })),
+        type: "turn.completed",
+        payload: {
+          state: "failed",
+          errorMessage: detail,
+        },
+      });
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: promptAdmission.turnId,
+          raw: promptAdmission.recoveryRaw,
+        })),
+        type: "runtime.error",
+        payload: {
+          message: detail,
+          class: "transport_error",
+        },
+      });
+    });
+
     const schedulePromptAdmissionRecovery = Effect.fn("schedulePromptAdmissionRecovery")(function* (
       context: OpenCodeSessionContext,
       raw: unknown,
     ) {
       const promptAdmission = context.promptAdmission;
-      if (!promptAdmission || promptAdmission.messageObserved) {
+      if (!promptAdmission || promptAdmission.cancelled) {
         return;
       }
-      promptAdmission.recoveryRaw = raw;
+      if (raw !== undefined) {
+        promptAdmission.recoveryRaw = raw;
+      }
       if (promptAdmission.recoveryFiber) {
         return;
       }
       const recover = Effect.gen(function* () {
         yield* Deferred.await(promptAdmission.acceptance);
-        let retryCount = 0;
-        while (context.promptAdmission === promptAdmission) {
-          const response = yield* runOpenCodeSdk("session.message", () =>
-            context.client.session.message({
-              sessionID: context.openCodeSessionId,
-              messageID: promptAdmission.messageId,
-            }),
-          ).pipe(Effect.option);
-          const message = Option.isSome(response) ? response.value.data : undefined;
+        for (let retryCount = 0; retryCount < 5; retryCount += 1) {
           if (
-            message?.info.id === promptAdmission.messageId &&
-            message.info.role === "user" &&
-            context.promptAdmission === promptAdmission &&
-            context.activeTurnId === promptAdmission.turnId &&
-            context.promptGeneration === promptAdmission.generation
+            context.promptAdmission !== promptAdmission ||
+            context.activeTurnId !== promptAdmission.turnId ||
+            context.promptGeneration !== promptAdmission.generation ||
+            promptAdmission.cancelled ||
+            (yield* Ref.get(context.stopped))
           ) {
-            promptAdmission.messageObserved = true;
-            context.messageRoleById.set(promptAdmission.messageId, "user");
+            return;
+          }
+
+          if (!promptAdmission.messageObserved) {
+            const response = yield* runOpenCodeSdk("session.message", (signal) =>
+              context.client.session.message(
+                {
+                  sessionID: context.openCodeSessionId,
+                  messageID: promptAdmission.messageId,
+                },
+                { signal },
+              ),
+            ).pipe(Effect.timeout("1 second"), Effect.option);
+            const message = Option.isSome(response) ? response.value.data : undefined;
+            if (message?.info.id === promptAdmission.messageId && message.info.role === "user") {
+              promptAdmission.messageObserved = true;
+              context.messageRoleById.set(promptAdmission.messageId, "user");
+            }
+          }
+
+          const statusResponse = yield* runOpenCodeSdk("session.status", (signal) =>
+            context.client.session.status(undefined, { signal }),
+          ).pipe(Effect.timeout("1 second"), Effect.option);
+          const statusData = Option.isSome(statusResponse)
+            ? Option.getOrUndefined(decodeOpenCodeSessionStatusMap(statusResponse.value.data))
+            : undefined;
+          const status = statusData?.[context.openCodeSessionId];
+          const isIdle =
+            statusData !== undefined && (status === undefined || status.type === "idle");
+          const isBusy = status?.type === "busy" || status?.type === "retry";
+          if (isBusy) {
+            promptAdmission.busyObserved = true;
+            promptAdmission.idleStatusConfirmations = 0;
             context.promptAdmission = undefined;
+            return;
+          }
+
+          const idle = promptAdmission.idleDuringAdmission ?? promptAdmission.priorIdle;
+          if (
+            isIdle &&
+            idle !== undefined &&
+            (promptAdmission.messageObserved || promptAdmission.busyObserved)
+          ) {
+            context.promptAdmission = undefined;
+            context.awaitingBusyAfterInterruption = false;
+            yield* scheduleIdleReconciliation(context, promptAdmission.turnId, idle.raw);
+            return;
+          }
+          if (isIdle && promptAdmission.messageObserved) {
+            promptAdmission.idleStatusConfirmations += 1;
+            if (promptAdmission.idleStatusConfirmations >= 2) {
+              context.promptAdmission = undefined;
+              context.awaitingBusyAfterInterruption = false;
+              yield* completeOpenCodeTurn(
+                context,
+                promptAdmission.turnId,
+                promptAdmission.generation,
+                {
+                  type: "session.status.recovered",
+                  status: statusData,
+                },
+              );
+              return;
+            }
+          } else if (!isIdle) {
+            promptAdmission.idleStatusConfirmations = 0;
+          }
+          if (
+            isIdle &&
+            promptAdmission.messageObserved &&
+            promptAdmission.recoveryRaw !== undefined
+          ) {
+            context.promptAdmission = undefined;
+            context.awaitingBusyAfterInterruption = false;
             yield* scheduleIdleReconciliation(
               context,
               promptAdmission.turnId,
@@ -1111,10 +1267,11 @@ export function makeOpenCodeAdapter(
             );
             return;
           }
-          const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
-          retryCount += 1;
+
+          const delayMs = Math.min(250 * 2 ** retryCount, 2_000);
           yield* Effect.sleep(`${delayMs} millis`);
         }
+        yield* failPromptAdmissionRecovery(context, promptAdmission);
       }).pipe(
         Effect.catchCause(() => Effect.void),
         Effect.ensuring(
@@ -1138,7 +1295,9 @@ export function makeOpenCodeAdapter(
       context.interruptedTurnId = turnId;
       context.reconcileIdleStatus = true;
       context.awaitingBusyAfterInterruption = false;
-      if (context.cancellation?.turnId === turnId) {
+      const cancellation =
+        context.cancellation?.turnId === turnId ? context.cancellation : undefined;
+      if (cancellation) {
         context.cancellation = undefined;
       }
       if (context.activeTurnId === turnId) {
@@ -1162,6 +1321,9 @@ export function makeOpenCodeAdapter(
           reason: "Interrupted by user.",
         },
       });
+      if (cancellation) {
+        yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
+      }
     });
 
     const emitUnexpectedExit = Effect.fn("emitUnexpectedExit")(function* (
@@ -1715,6 +1877,18 @@ export function makeOpenCodeAdapter(
         },
       });
 
+      const suppressInterruptedParentOutput =
+        isParentEvent &&
+        ((context.activeTurnId === undefined &&
+          (context.interruptedTurnId !== undefined || context.reconcileIdleStatus)) ||
+          context.awaitingBusyAfterInterruption) &&
+        (event.type === "message.part.delta" ||
+          event.type === "message.part.updated" ||
+          (event.type === "message.updated" && event.properties.info.role === "assistant"));
+      if (suppressInterruptedParentOutput) {
+        return;
+      }
+
       switch (event.type) {
         case "session.updated": {
           const title = openCodeEventSessionTitle(event);
@@ -1744,9 +1918,14 @@ export function makeOpenCodeAdapter(
           ) {
             promptAdmission.messageObserved = true;
             if (promptAdmission.accepted) {
+              const idle = promptAdmission.idleDuringAdmission;
+              context.awaitingBusyAfterInterruption = false;
               context.promptAdmission = undefined;
               if (promptAdmission.recoveryFiber) {
                 yield* Fiber.interrupt(promptAdmission.recoveryFiber);
+              }
+              if (idle) {
+                yield* scheduleIdleReconciliation(context, idle.turnId, idle.raw);
               }
             }
           }
@@ -1897,6 +2076,10 @@ export function makeOpenCodeAdapter(
             }
             yield* cancelIdleReconciliation(context);
             context.awaitingBusyAfterInterruption = false;
+            if (context.promptAdmission?.turnId === turnId) {
+              context.promptAdmission.busyObserved = true;
+              yield* schedulePromptAdmissionRecovery(context, event);
+            }
             yield* updateProviderSession(context, {
               status: "running",
               activeTurnId: turnId,
@@ -1924,13 +2107,14 @@ export function makeOpenCodeAdapter(
               context.cancellation.deferredIdleEvent = event;
               break;
             }
-            if (context.awaitingBusyAfterInterruption) {
-              break;
-            }
             if (context.promptAdmission?.turnId === turnId) {
               context.promptAdmission.idleDuringAdmission = { turnId, raw: event };
               context.promptAdmission.idleObservedAfterMessage =
                 context.promptAdmission.messageObserved;
+              yield* schedulePromptAdmissionRecovery(context, event);
+              break;
+            }
+            if (context.awaitingBusyAfterInterruption) {
               break;
             }
             if (context.reconcileIdleStatus) {
@@ -1949,6 +2133,9 @@ export function makeOpenCodeAdapter(
           if (isOpenCodeAbortError(event.properties.error)) {
             if (cancellation !== undefined && cancellation.turnId === undefined) {
               cancellation.acknowledged = true;
+              context.cancellation = undefined;
+              context.reconcileIdleStatus = true;
+              yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
               break;
             }
             if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
@@ -1962,6 +2149,7 @@ export function makeOpenCodeAdapter(
           yield* cancelIdleReconciliation(context);
           if (activeTurnId !== undefined && cancellation?.turnId === activeTurnId) {
             context.cancellation = undefined;
+            yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);
           }
           context.activeTurnId = undefined;
           context.activeAgent = undefined;
@@ -2098,13 +2286,15 @@ export function makeOpenCodeAdapter(
               // process automatically. No manual `server.close()` needed.
               const server = yield* openCodeRuntime.connectToOpenCodeServer({
                 binaryPath,
+                directory,
                 serverUrl,
+                ...(serverPassword ? { serverPassword } : {}),
                 ...(options?.environment ? { environment: options.environment } : {}),
               });
               const client = openCodeRuntime.createOpenCodeSdkClient({
                 baseUrl: server.url,
                 directory,
-                ...(serverPassword ? { serverPassword } : {}),
+                ...(server.serverPassword ? { serverPassword: server.serverPassword } : {}),
               });
               const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
               if (mcpSession && !server.external) {
@@ -2271,6 +2461,7 @@ export function makeOpenCodeAdapter(
           pendingRequestRecovery: undefined,
           promptGeneration: 0,
           promptAdmission: undefined,
+          promptSemaphore: Semaphore.makeUnsafe(1),
           firstConnection: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
@@ -2375,170 +2566,307 @@ export function makeOpenCodeAdapter(
         });
       }
 
-      const freshTurnId = TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
-      const messageId = yield* makeOpenCodeMessageId();
-      const pendingCancellation = context.cancellation;
-      if (pendingCancellation) {
-        yield* Deferred.await(pendingCancellation.completion);
-      }
-      const currentContext = yield* ensureSessionContext(sessions, input.threadId);
-      if (currentContext !== context) {
-        return yield* new ProviderAdapterSessionClosedError({
-          provider: PROVIDER,
-          threadId: input.threadId,
-        });
-      }
-      // A sendTurn while a turn is active is a steer. OpenCode queues the
-      // prompt into the running session, so the active turn id is reused.
-      const steeringTurnId = context.activeTurnId;
-      const turnId = steeringTurnId ?? freshTurnId;
-      const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
-      const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
-      const pendingIdleReconciliation = context.pendingIdleReconciliation;
-      const priorAwaitingBusy = context.awaitingBusyAfterInterruption;
-      const priorIdleCandidate = pendingIdleReconciliation
-        ? {
-            turnId: pendingIdleReconciliation.turnId,
-            raw: pendingIdleReconciliation.raw,
+      return yield* context.promptSemaphore.withPermit(
+        Effect.gen(function* () {
+          const freshTurnId = TurnId.make(`opencode-turn-${yield* randomUUIDv4}`);
+          const messageId = yield* makeOpenCodeMessageId();
+          const pendingCancellation = context.cancellation;
+          if (pendingCancellation) {
+            const cancellationResult = yield* Deferred.await(pendingCancellation.completion).pipe(
+              Effect.result,
+            );
+            if ((yield* Ref.get(context.stopped)) || sessions.get(input.threadId) !== context) {
+              return yield* Effect.interrupt;
+            }
+            if (cancellationResult._tag === "Failure") {
+              return yield* cancellationResult.failure;
+            }
           }
-        : undefined;
-      context.pendingIdleReconciliation = undefined;
-      const promptGeneration = context.promptGeneration + 1;
-      const promptAdmission: OpenCodePromptAdmission = {
-        generation: promptGeneration,
-        turnId,
-        messageId,
-        priorAwaitingBusy,
-        priorIdle: priorIdleCandidate,
-        idleDuringAdmission: undefined,
-        idleObservedAfterMessage: false,
-        messageObserved: false,
-        accepted: false,
-        acceptance: Deferred.makeUnsafe<void>(),
-        recoveryRaw: undefined,
-      };
-      context.promptGeneration = promptGeneration;
-      context.promptAdmission = promptAdmission;
+          if (sessions.get(input.threadId) !== context || (yield* Ref.get(context.stopped))) {
+            return yield* Effect.interrupt;
+          }
+          // A sendTurn while a turn is active is a steer. OpenCode queues the
+          // prompt into the running session, so the active turn id is reused.
+          const steeringTurnId = context.activeTurnId;
+          const turnId = steeringTurnId ?? freshTurnId;
+          const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
+          const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
+          const pendingIdleReconciliation = context.pendingIdleReconciliation;
+          const priorAwaitingBusy = context.awaitingBusyAfterInterruption;
+          const priorIdleCandidate = pendingIdleReconciliation
+            ? {
+                turnId: pendingIdleReconciliation.turnId,
+                raw: pendingIdleReconciliation.raw,
+              }
+            : undefined;
+          context.pendingIdleReconciliation = undefined;
+          const promptGeneration = context.promptGeneration + 1;
+          const promptAdmission: OpenCodePromptAdmission = {
+            generation: promptGeneration,
+            turnId,
+            messageId,
+            priorAwaitingBusy,
+            priorIdle: priorIdleCandidate,
+            idleDuringAdmission: undefined,
+            idleObservedAfterMessage: false,
+            messageObserved: false,
+            busyObserved: false,
+            idleStatusConfirmations: 0,
+            accepted: false,
+            cancelled: false,
+            acceptance: Deferred.makeUnsafe<void>(),
+            submissionSettled: Deferred.makeUnsafe<void>(),
+            recoveryRaw: undefined,
+          };
+          context.promptGeneration = promptGeneration;
+          context.promptAdmission = promptAdmission;
 
-      context.activeTurnId = turnId;
-      context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
-      context.activeVariant = variant;
-      if (steeringTurnId === undefined) {
-        context.awaitingBusyAfterInterruption = context.interruptedTurnId !== undefined;
-      }
-      if (pendingIdleReconciliation?.fiber) {
-        yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
-      }
-      yield* updateProviderSession(
-        context,
-        {
-          status: "running",
-          activeTurnId: turnId,
-          model: modelSelection?.model ?? context.session.model,
-        },
-        { clearLastError: true },
-      );
+          context.activeTurnId = turnId;
+          context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
+          context.activeVariant = variant;
+          if (steeringTurnId === undefined) {
+            context.awaitingBusyAfterInterruption = context.interruptedTurnId !== undefined;
+          }
+          if (pendingIdleReconciliation?.fiber) {
+            yield* Fiber.interrupt(pendingIdleReconciliation.fiber);
+          }
+          yield* updateProviderSession(
+            context,
+            {
+              status: "running",
+              activeTurnId: turnId,
+              model: modelSelection?.model ?? context.session.model,
+            },
+            { clearLastError: true },
+          );
 
-      if (steeringTurnId === undefined) {
-        yield* emit({
-          ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
-          type: "turn.started",
-          payload: {
-            model: modelSelection?.model ?? context.session.model,
-            ...(variant ? { effort: variant } : {}),
-          },
-        });
-      }
+          if (steeringTurnId === undefined) {
+            yield* emit({
+              ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
+              type: "turn.started",
+              payload: {
+                model: modelSelection?.model ?? context.session.model,
+                ...(variant ? { effort: variant } : {}),
+              },
+            });
+          }
 
-      yield* runOpenCodeSdk("session.promptAsync", () =>
-        context.client.session.promptAsync({
-          sessionID: context.openCodeSessionId,
-          messageID: messageId,
-          model: parsedModel,
-          ...(context.activeAgent ? { agent: context.activeAgent } : {}),
-          ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-          parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
-        }),
-      ).pipe(
-        Effect.mapError(toRequestError),
-        // On failure of a fresh turn: clear active-turn state, flip the
-        // session back to ready with lastError set, emit turn.aborted, then
-        // let the typed error propagate. We don't need to rebuild the error
-        // here — `toRequestError` already produced the right shape. A failed
-        // steer leaves the still-running original turn untouched.
-        Effect.tapError((requestError) =>
-          context.promptAdmission !== promptAdmission || context.activeTurnId !== turnId
-            ? Effect.void
-            : steeringTurnId !== undefined
-              ? Effect.gen(function* () {
-                  context.promptAdmission = undefined;
-                  context.awaitingBusyAfterInterruption = promptAdmission.priorAwaitingBusy;
-                  const idle = promptAdmission.idleDuringAdmission ?? promptAdmission.priorIdle;
-                  if (idle) {
-                    yield* scheduleIdleReconciliation(context, idle.turnId, idle.raw);
-                  }
-                })
-              : Effect.gen(function* () {
-                  context.promptAdmission = undefined;
-                  context.activeTurnId = undefined;
-                  context.activeAgent = undefined;
-                  context.activeVariant = undefined;
-                  yield* updateProviderSession(
-                    context,
-                    {
-                      status: "ready",
-                      model: modelSelection?.model ?? context.session.model,
-                      lastError: requestError.detail,
-                    },
-                    { clearActiveTurnId: true },
+          if (promptAdmission.cancelled || (yield* Ref.get(context.stopped))) {
+            yield* Deferred.succeed(promptAdmission.submissionSettled, undefined).pipe(
+              Effect.ignore,
+            );
+            const cancellation = context.cancellation;
+            if (cancellation?.turnId === turnId) {
+              yield* Deferred.await(cancellation.completion).pipe(Effect.result);
+            }
+            return yield* Effect.interrupt;
+          }
+
+          let promptTimedOut = false;
+          const promptEffect = runOpenCodeSdk("session.promptAsync", (signal) =>
+            context.client.session.promptAsync(
+              {
+                sessionID: context.openCodeSessionId,
+                messageID: messageId,
+                model: parsedModel,
+                ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+                ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+                parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+              },
+              { signal },
+            ),
+          ).pipe(
+            Effect.timeout("10 seconds"),
+            Effect.mapError((cause) => {
+              if (OpenCodeRuntimeError.is(cause)) {
+                return toRequestError(cause);
+              }
+              promptTimedOut = true;
+              return new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session.promptAsync",
+                detail: "OpenCode prompt submission did not complete within 10 seconds.",
+                cause,
+              });
+            }),
+            Effect.tapError((requestError) =>
+              context.promptAdmission !== promptAdmission || context.activeTurnId !== turnId
+                ? Effect.void
+                : Effect.gen(function* () {
+                    if (!promptTimedOut) {
+                      if (steeringTurnId !== undefined) {
+                        context.promptAdmission = undefined;
+                        context.awaitingBusyAfterInterruption = promptAdmission.priorAwaitingBusy;
+                        const idle =
+                          promptAdmission.idleDuringAdmission ?? promptAdmission.priorIdle;
+                        if (idle) {
+                          yield* scheduleIdleReconciliation(context, idle.turnId, idle.raw);
+                        }
+                        return;
+                      }
+                      context.promptAdmission = undefined;
+                      context.activeTurnId = undefined;
+                      context.activeAgent = undefined;
+                      context.activeVariant = undefined;
+                      yield* updateProviderSession(
+                        context,
+                        {
+                          status: "ready",
+                          model: modelSelection?.model ?? context.session.model,
+                          lastError: requestError.detail,
+                        },
+                        { clearActiveTurnId: true },
+                      );
+                      yield* emit({
+                        ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
+                        type: "turn.aborted",
+                        payload: { reason: requestError.detail },
+                      });
+                      return;
+                    }
+                    const cleanupExit = yield* Effect.exit(
+                      runOpenCodeSdk("session.abort", (signal) =>
+                        context.client.session.abort(
+                          { sessionID: context.openCodeSessionId },
+                          { signal },
+                        ),
+                      ).pipe(Effect.timeout("1 second")),
+                    );
+                    if (Exit.isFailure(cleanupExit)) {
+                      yield* emit({
+                        ...(yield* buildEventBase({ threadId: input.threadId, turnId })),
+                        type: "runtime.warning",
+                        payload: {
+                          message:
+                            "OpenCode prompt submission failed and its cleanup abort did not complete.",
+                          detail: openCodeRuntimeErrorDetail(Cause.squash(cleanupExit.cause)),
+                        },
+                      });
+                      yield* schedulePromptAdmissionRecovery(context, {
+                        requestError,
+                        cleanupError: Cause.squash(cleanupExit.cause),
+                      });
+                      return;
+                    }
+                    context.promptAdmission = undefined;
+                    context.activeTurnId = undefined;
+                    context.activeAgent = undefined;
+                    context.activeVariant = undefined;
+                    context.awaitingBusyAfterInterruption = false;
+                    context.reconcileIdleStatus = false;
+                    yield* updateProviderSession(
+                      context,
+                      {
+                        status: "ready",
+                        model: modelSelection?.model ?? context.session.model,
+                        lastError: requestError.detail,
+                      },
+                      { clearActiveTurnId: true },
+                    );
+                    yield* emit({
+                      ...(yield* buildEventBase({
+                        threadId: input.threadId,
+                        turnId,
+                      })),
+                      type: "turn.aborted",
+                      payload: {
+                        reason: requestError.detail,
+                      },
+                    });
+                  }),
+            ),
+            Effect.onExit((exit) =>
+              Effect.gen(function* () {
+                yield* Deferred.succeed(promptAdmission.submissionSettled, undefined).pipe(
+                  Effect.ignore,
+                );
+                if (Exit.isFailure(exit)) {
+                  yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(
+                    Effect.ignore,
                   );
-                  yield* emit({
-                    ...(yield* buildEventBase({
-                      threadId: input.threadId,
-                      turnId,
-                    })),
-                    type: "turn.aborted",
-                    payload: {
-                      reason: requestError.detail,
-                    },
-                  });
-                }),
-        ),
-        Effect.onExit((exit) =>
-          Exit.isSuccess(exit)
-            ? Effect.void
-            : Effect.gen(function* () {
-                if (context.promptAdmission === promptAdmission) {
-                  context.promptAdmission = undefined;
                 }
-                yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
               }),
-        ),
-      );
-      promptAdmission.accepted = true;
-      yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
-      if (
-        context.promptAdmission === promptAdmission &&
-        context.activeTurnId === turnId &&
-        context.promptGeneration === promptAdmission.generation &&
-        promptAdmission.messageObserved
-      ) {
-        context.promptAdmission = undefined;
-        const idle = promptAdmission.idleDuringAdmission;
-        if (idle && promptAdmission.idleObservedAfterMessage) {
-          yield* scheduleIdleReconciliation(context, turnId, idle.raw);
-        }
-      }
+            ),
+            Effect.asVoid,
+          );
+          const promptFiber = yield* promptEffect.pipe(Effect.forkIn(context.sessionScope));
+          promptAdmission.promptFiber = promptFiber;
+          const promptExit = yield* Effect.exit(Fiber.join(promptFiber));
+          delete promptAdmission.promptFiber;
 
-      return {
-        threadId: input.threadId,
-        turnId,
-        // Re-surface the durable cursor on every turn so the persisted binding
-        // is refreshed alongside last-seen/runtime state (mirrors Grok/Codex).
-        ...(context.session.resumeCursor !== undefined
-          ? { resumeCursor: context.session.resumeCursor }
-          : {}),
-      };
+          const intentionallyCancelled =
+            promptAdmission.cancelled ||
+            (yield* Ref.get(context.stopped)) ||
+            sessions.get(input.threadId) !== context;
+          if (Exit.isFailure(promptExit) && !intentionallyCancelled) {
+            return yield* Effect.failCause(promptExit.cause);
+          }
+          const cancelled =
+            intentionallyCancelled ||
+            context.activeTurnId !== turnId ||
+            context.promptGeneration !== promptAdmission.generation;
+          if (cancelled) {
+            const cancellation = context.cancellation;
+            if (cancellation?.turnId === turnId) {
+              yield* Deferred.await(cancellation.completion).pipe(Effect.result);
+            }
+            if (context.promptAdmission === promptAdmission) {
+              context.promptAdmission = undefined;
+            }
+            return yield* Effect.interrupt;
+          }
+          promptAdmission.accepted = true;
+          yield* Deferred.succeed(promptAdmission.acceptance, undefined).pipe(Effect.ignore);
+          if (
+            context.promptAdmission === promptAdmission &&
+            context.activeTurnId === turnId &&
+            context.promptGeneration === promptAdmission.generation &&
+            promptAdmission.messageObserved
+          ) {
+            context.awaitingBusyAfterInterruption = false;
+            const idle = promptAdmission.idleDuringAdmission;
+            if (idle && !promptAdmission.idleObservedAfterMessage) {
+              yield* schedulePromptAdmissionRecovery(context, idle.raw);
+            } else {
+              context.promptAdmission = undefined;
+            }
+            if (idle && promptAdmission.idleObservedAfterMessage) {
+              yield* scheduleIdleReconciliation(context, turnId, idle.raw);
+            }
+          } else {
+            yield* schedulePromptAdmissionRecovery(context, promptAdmission.recoveryRaw);
+          }
+
+          const stopped = yield* Ref.get(context.stopped);
+          const finalCancellation = context.cancellation;
+          if (
+            stopped ||
+            sessions.get(input.threadId) !== context ||
+            promptAdmission.cancelled ||
+            context.activeTurnId !== turnId ||
+            context.promptGeneration !== promptAdmission.generation ||
+            finalCancellation?.turnId === turnId
+          ) {
+            if (finalCancellation?.turnId === turnId) {
+              yield* Deferred.await(finalCancellation.completion).pipe(Effect.result);
+            }
+            if (context.promptAdmission === promptAdmission) {
+              context.promptAdmission = undefined;
+            }
+            return yield* Effect.interrupt;
+          }
+
+          return {
+            threadId: input.threadId,
+            turnId,
+            // Re-surface the durable cursor on every turn so the persisted binding
+            // is refreshed alongside last-seen/runtime state (mirrors Grok/Codex).
+            ...(context.session.resumeCursor !== undefined
+              ? { resumeCursor: context.session.resumeCursor }
+              : {}),
+          };
+        }),
+      );
     });
 
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
@@ -2565,8 +2893,16 @@ export function makeOpenCodeAdapter(
           completion: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
         };
         context.cancellation = cancellation;
+        const promptAdmission = context.promptAdmission;
+        if (promptAdmission !== undefined && promptAdmission.turnId === interruptedTurnId) {
+          promptAdmission.cancelled = true;
+          if (promptAdmission.promptFiber) {
+            yield* Fiber.interrupt(promptAdmission.promptFiber);
+          }
+          yield* Deferred.await(promptAdmission.submissionSettled);
+        }
 
-        const abortExit = yield* Effect.exit(
+        const abortOutcome = yield* Effect.raceFirst(
           runOpenCodeSdk("session.abort", (signal) =>
             context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
           ).pipe(
@@ -2581,8 +2917,20 @@ export function makeOpenCodeAdapter(
                     cause,
                   }),
             ),
+            Effect.exit,
+            Effect.map((exit) => ({ source: "request" as const, exit })),
+          ),
+          Deferred.await(cancellation.completion).pipe(
+            Effect.exit,
+            Effect.map((exit) => ({ source: "event" as const, exit })),
           ),
         );
+        if (abortOutcome.source === "event") {
+          return Exit.isFailure(abortOutcome.exit)
+            ? yield* Effect.failCause(abortOutcome.exit.cause)
+            : undefined;
+        }
+        const abortExit = abortOutcome.exit;
         if (Exit.isFailure(abortExit)) {
           if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {
             yield* Deferred.succeed(cancellation.completion, undefined).pipe(Effect.ignore);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2567,9 +2567,21 @@ export function makeOpenCodeAdapter(
         context.cancellation = cancellation;
 
         const abortExit = yield* Effect.exit(
-          runOpenCodeSdk("session.abort", () =>
-            context.client.session.abort({ sessionID: context.openCodeSessionId }),
-          ).pipe(Effect.mapError(toRequestError)),
+          runOpenCodeSdk("session.abort", (signal) =>
+            context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
+          ).pipe(
+            Effect.timeout("10 seconds"),
+            Effect.mapError((cause) =>
+              OpenCodeRuntimeError.is(cause)
+                ? toRequestError(cause)
+                : new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "session.abort",
+                    detail: "OpenCode session abort did not complete within 10 seconds.",
+                    cause,
+                  }),
+            ),
+          ),
         );
         if (Exit.isFailure(abortExit)) {
           if (interruptedTurnId && context.interruptedTurnId === interruptedTurnId) {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -274,6 +274,7 @@ interface OpenCodeSessionContext {
   activeVariant: string | undefined;
   cancellation: OpenCodeCancellation | undefined;
   interruptedTurnId: TurnId | undefined;
+  reconcileIdleStatus: boolean;
   /**
    * One-shot guard flipped by `stopOpenCodeContext` / `emitUnexpectedExit`.
    * The session lifecycle is owned by `sessionScope`; this Ref exists only
@@ -720,6 +721,16 @@ export function makeOpenCodeAdapter(
       },
     ) => writeNativeEvent(threadId, event).pipe(Effect.catchCause(() => Effect.void));
 
+    const isOpenCodeSessionCurrentlyIdle = Effect.fn("isOpenCodeSessionCurrentlyIdle")(function* (
+      context: OpenCodeSessionContext,
+    ) {
+      const response = yield* runOpenCodeSdk("session.status", () =>
+        context.client.session.status(),
+      ).pipe(Effect.orElseSucceed(() => undefined));
+      const status = response?.data?.[context.openCodeSessionId];
+      return response?.data !== undefined && (status?.type ?? "idle") === "idle";
+    });
+
     const completeOpenCodeTurn = Effect.fn("completeOpenCodeTurn")(function* (
       context: OpenCodeSessionContext,
       turnId: TurnId,
@@ -754,6 +765,7 @@ export function makeOpenCodeAdapter(
         return;
       }
       context.interruptedTurnId = turnId;
+      context.reconcileIdleStatus = true;
       if (context.cancellation?.turnId === turnId) {
         context.cancellation = undefined;
       }
@@ -1163,13 +1175,6 @@ export function makeOpenCodeAdapter(
 
         case "session.status": {
           if (event.properties.status.type === "busy") {
-            if (
-              context.interruptedTurnId !== undefined &&
-              context.activeTurnId !== undefined &&
-              context.interruptedTurnId !== context.activeTurnId
-            ) {
-              context.interruptedTurnId = undefined;
-            }
             yield* updateProviderSession(context, {
               status: "running",
               activeTurnId: turnId,
@@ -1197,9 +1202,10 @@ export function makeOpenCodeAdapter(
               context.cancellation.deferredIdleEvent = event;
               break;
             }
-            if (context.interruptedTurnId !== undefined && context.interruptedTurnId !== turnId) {
+            if (context.reconcileIdleStatus && !(yield* isOpenCodeSessionCurrentlyIdle(context))) {
               break;
             }
+            context.interruptedTurnId = undefined;
             yield* completeOpenCodeTurn(context, turnId, event);
           }
           break;
@@ -1535,6 +1541,7 @@ export function makeOpenCodeAdapter(
           activeVariant: undefined,
           cancellation: undefined,
           interruptedTurnId: undefined,
+          reconcileIdleStatus: false,
           stopped: yield* Ref.make(false),
           sessionScope: started.sessionScope,
         };
@@ -1708,7 +1715,7 @@ export function makeOpenCodeAdapter(
         const cancellation: OpenCodeCancellation | undefined = interruptedTurnId
           ? {
               turnId: interruptedTurnId,
-              completion: yield* Deferred.make<void, ProviderAdapterRequestError>(),
+              completion: Deferred.makeUnsafe<void, ProviderAdapterRequestError>(),
             }
           : undefined;
         if (cancellation) {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -692,8 +692,8 @@ const failPendingOpenCodeCancellation = Effect.fn("failPendingOpenCodeCancellati
 });
 
 const abortOpenCodeSessionForTeardown = (context: OpenCodeSessionContext) =>
-  runOpenCodeSdk("session.abort", () =>
-    context.client.session.abort({ sessionID: context.openCodeSessionId }),
+  runOpenCodeSdk("session.abort", (signal) =>
+    context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
   ).pipe(Effect.timeout("1 second"), Effect.ignore({ log: true }));
 
 const closeStartingOpenCodeContext = Effect.fn("closeStartingOpenCodeContext")(function* (

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2698,17 +2698,19 @@ export function makeOpenCodeAdapter(
             ),
           ).pipe(
             Effect.timeout("10 seconds"),
-            Effect.mapError((cause) => {
-              if (OpenCodeRuntimeError.is(cause)) {
-                return toRequestError(cause);
-              }
-              promptTimedOut = true;
-              return new ProviderAdapterRequestError({
-                provider: PROVIDER,
-                method: "session.promptAsync",
-                detail: "OpenCode prompt submission did not complete within 10 seconds.",
-                cause,
-              });
+            Effect.catchTags({
+              OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
+              TimeoutError: (cause) => {
+                promptTimedOut = true;
+                return Effect.fail(
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "session.promptAsync",
+                    detail: "OpenCode prompt submission did not complete within 10 seconds.",
+                    cause,
+                  }),
+                );
+              },
             }),
             Effect.tapError((requestError) =>
               context.promptAdmission !== promptAdmission || context.activeTurnId !== turnId
@@ -2928,16 +2930,18 @@ export function makeOpenCodeAdapter(
             context.client.session.abort({ sessionID: context.openCodeSessionId }, { signal }),
           ).pipe(
             Effect.timeout("10 seconds"),
-            Effect.mapError((cause) =>
-              OpenCodeRuntimeError.is(cause)
-                ? toRequestError(cause)
-                : new ProviderAdapterRequestError({
+            Effect.catchTags({
+              OpenCodeRuntimeError: (cause) => Effect.fail(toRequestError(cause)),
+              TimeoutError: (cause) =>
+                Effect.fail(
+                  new ProviderAdapterRequestError({
                     provider: PROVIDER,
                     method: "session.abort",
                     detail: "OpenCode session abort did not complete within 10 seconds.",
                     cause,
                   }),
-            ),
+                ),
+            }),
             Effect.exit,
             Effect.map((exit) => ({ source: "request" as const, exit })),
           ),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -14,6 +14,7 @@ import {
   OpenCodeRuntimeError,
   type OpenCodeRuntimeShape,
 } from "../opencodeRuntime.ts";
+import * as OpenCodeServerOwner from "../OpenCodeServerOwner.ts";
 import { checkOpenCodeProviderStatus } from "./OpenCodeProvider.ts";
 import type { OpenCodeInventory } from "../opencodeRuntime.ts";
 const decodeOpenCodeSettings = Schema.decodeSync(OpenCodeSettings);
@@ -64,9 +65,16 @@ const runtimeMock = {
 
 const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
   startOpenCodeServerProcess: () =>
-    Effect.succeed({
-      url: "http://127.0.0.1:4301",
-      exitCode: Effect.never,
+    Effect.gen(function* () {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          runtimeMock.state.closeCalls += 1;
+        }),
+      );
+      return {
+        url: "http://127.0.0.1:4301",
+        exitCode: Effect.never,
+      };
     }),
   connectToOpenCodeServer: ({ serverUrl }) =>
     Effect.gen(function* () {
@@ -140,11 +148,29 @@ const makeOpenCodeSettings = (overrides?: Partial<OpenCodeSettings>): OpenCodeSe
     ...overrides,
   });
 
+const checkProvider = Effect.fn("checkProvider")(function* (
+  settings: OpenCodeSettings,
+  cwd = process.cwd(),
+  environment?: NodeJS.ProcessEnv,
+) {
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const serverOwner = yield* OpenCodeServerOwner.make({
+        binaryPath: settings.binaryPath,
+        ...(environment ? { environment } : {}),
+      });
+      return yield* checkOpenCodeProviderStatus(settings, cwd, environment).pipe(
+        Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
+      );
+    }),
+  );
+});
+
 it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
   it.effect("shows a codex-style missing binary message", () =>
     Effect.gen(function* () {
       runtimeMock.state.runVersionError = new Error("spawn opencode ENOENT");
-      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const snapshot = yield* checkProvider(makeOpenCodeSettings());
 
       NodeAssert.equal(snapshot.status, "error");
       NodeAssert.equal(snapshot.installed, false);
@@ -158,7 +184,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
   it.effect("hides generic Effect.tryPromise text for local CLI probe failures", () =>
     Effect.gen(function* () {
       runtimeMock.state.runVersionError = new Error("An error occurred in Effect.tryPromise");
-      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const snapshot = yield* checkProvider(makeOpenCodeSettings());
 
       NodeAssert.equal(snapshot.status, "error");
       NodeAssert.equal(snapshot.installed, true);
@@ -198,7 +224,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
         ],
       };
 
-      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const snapshot = yield* checkProvider(makeOpenCodeSettings());
       const model = snapshot.models.find((entry) => entry.slug === "openai/gpt-5.4");
 
       NodeAssert.ok(model);
@@ -261,7 +287,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
         ],
       };
 
-      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const snapshot = yield* checkProvider(makeOpenCodeSettings());
 
       NodeAssert.deepEqual(
         snapshot.skills.map((skill) => ({
@@ -290,10 +316,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
 
   it.effect("loads local inventory from a scoped OpenCode server", () =>
     Effect.gen(function* () {
-      yield* checkOpenCodeProviderStatus(
-        makeOpenCodeSettings({ serverPassword: "secret-password" }),
-        process.cwd(),
-      );
+      yield* checkProvider(makeOpenCodeSettings({ serverPassword: "secret-password" }));
 
       NodeAssert.deepEqual(runtimeMock.state.sdkClientInputs, [
         {
@@ -310,7 +333,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
   it.effect("reports local model inventory failures without treating them as empty", () =>
     Effect.gen(function* () {
       runtimeMock.state.inventoryError = new Error("opencode models failed");
-      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const snapshot = yield* checkProvider(makeOpenCodeSettings());
 
       NodeAssert.equal(snapshot.status, "error");
       NodeAssert.equal(snapshot.installed, true);
@@ -327,12 +350,11 @@ it.layer(testLayer)("checkOpenCodeProviderStatus with configured server URL", (i
   it.effect("surfaces a friendly auth error for configured servers", () =>
     Effect.gen(function* () {
       runtimeMock.state.inventoryError = new Error("401 Unauthorized");
-      const snapshot = yield* checkOpenCodeProviderStatus(
+      const snapshot = yield* checkProvider(
         makeOpenCodeSettings({
           serverUrl: "http://127.0.0.1:9999",
           serverPassword: "secret-password",
         }),
-        process.cwd(),
       );
 
       NodeAssert.equal(snapshot.status, "error");
@@ -349,12 +371,11 @@ it.layer(testLayer)("checkOpenCodeProviderStatus with configured server URL", (i
       runtimeMock.state.inventoryError = new Error(
         "fetch failed: connect ECONNREFUSED 127.0.0.1:9999",
       );
-      const snapshot = yield* checkOpenCodeProviderStatus(
+      const snapshot = yield* checkProvider(
         makeOpenCodeSettings({
           serverUrl: "http://127.0.0.1:9999",
           serverPassword: "secret-password",
         }),
-        process.cwd(),
       );
 
       NodeAssert.equal(snapshot.status, "error");

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -36,6 +36,11 @@ const runtimeMock = {
     inventoryError: null as Error | null,
     inventoryCwd: null as string | null,
     closeCalls: 0,
+    sdkClientInputs: [] as Array<{
+      baseUrl: string;
+      directory: string;
+      serverPassword?: string;
+    }>,
     inventory: {
       providerList: { connected: [] as string[], all: [] as unknown[], default: {} },
       agents: [] as unknown[],
@@ -48,6 +53,7 @@ const runtimeMock = {
     this.state.inventoryError = null;
     this.state.inventoryCwd = null;
     this.state.closeCalls = 0;
+    this.state.sdkClientInputs.length = 0;
     this.state.inventory = {
       providerList: { connected: [], all: [] as unknown[], default: {} },
       agents: [] as unknown[],
@@ -87,8 +93,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           }),
         )
       : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
-  createOpenCodeSdkClient: () =>
-    ({}) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
+  createOpenCodeSdkClient: (input) => {
+    runtimeMock.state.sdkClientInputs.push(input);
+    return {} as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>;
+  },
   loadOpenCodeInventory: () =>
     runtimeMock.state.inventoryError
       ? Effect.fail(
@@ -280,12 +288,18 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
     }),
   );
 
-  it.effect("does not spawn a local server for health check (uses CLI instead)", () =>
+  it.effect("loads local inventory from a scoped OpenCode server", () =>
     Effect.gen(function* () {
       yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
 
-      NodeAssert.equal(runtimeMock.state.closeCalls, 0);
-      NodeAssert.equal(runtimeMock.state.inventoryCwd, process.cwd());
+      NodeAssert.deepEqual(runtimeMock.state.sdkClientInputs, [
+        {
+          baseUrl: "http://127.0.0.1:4301",
+          directory: process.cwd(),
+        },
+      ]);
+      NodeAssert.equal(runtimeMock.state.closeCalls, 1);
+      NodeAssert.equal(runtimeMock.state.inventoryCwd, null);
     }),
   );
 
@@ -299,7 +313,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       NodeAssert.equal(snapshot.models.length, 0);
       NodeAssert.equal(
         snapshot.message,
-        "Failed to execute OpenCode CLI health check: opencode models failed",
+        "Failed to load OpenCode provider inventory: opencode models failed",
       );
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -73,6 +73,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       );
       return {
         url: "http://127.0.0.1:4301",
+        isRunning: Effect.succeed(true),
         exitCode: Effect.never,
       };
     }),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -290,12 +290,16 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
 
   it.effect("loads local inventory from a scoped OpenCode server", () =>
     Effect.gen(function* () {
-      yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      yield* checkOpenCodeProviderStatus(
+        makeOpenCodeSettings({ serverPassword: "secret-password" }),
+        process.cwd(),
+      );
 
       NodeAssert.deepEqual(runtimeMock.state.sdkClientInputs, [
         {
           baseUrl: "http://127.0.0.1:4301",
           directory: process.cwd(),
+          serverPassword: "secret-password",
         },
       ]);
       NodeAssert.equal(runtimeMock.state.closeCalls, 1);

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -12,6 +12,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   OpenCodeRuntime,
   OpenCodeRuntimeError,
+  resolveOpenCodeServerPassword,
   type OpenCodeRuntimeShape,
 } from "../opencodeRuntime.ts";
 import * as OpenCodeServerOwner from "../OpenCodeServerOwner.ts";
@@ -35,6 +36,7 @@ const runtimeMock = {
     runVersionError: null as Error | null,
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
+    connectionError: null as Error | null,
     inventoryCwd: null as string | null,
     closeCalls: 0,
     sdkClientInputs: [] as Array<{
@@ -52,6 +54,7 @@ const runtimeMock = {
     this.state.runVersionError = null;
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
+    this.state.connectionError = null;
     this.state.inventoryCwd = null;
     this.state.closeCalls = 0;
     this.state.sdkClientInputs.length = 0;
@@ -64,21 +67,37 @@ const runtimeMock = {
 };
 
 const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
-  startOpenCodeServerProcess: () =>
+  startOpenCodeServerProcess: ({ serverPassword, environment }) =>
     Effect.gen(function* () {
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
           runtimeMock.state.closeCalls += 1;
         }),
       );
+      const effectiveServerPassword = resolveOpenCodeServerPassword({
+        external: false,
+        ...(serverPassword !== undefined ? { serverPassword } : {}),
+        ...(environment !== undefined ? { environment } : {}),
+      });
       return {
         url: "http://127.0.0.1:4301",
+        ...(effectiveServerPassword !== undefined
+          ? { serverPassword: effectiveServerPassword }
+          : {}),
+        version: "1.14.19",
         isRunning: Effect.succeed(true),
         exitCode: Effect.never,
       };
     }),
-  connectToOpenCodeServer: ({ serverUrl }) =>
+  connectToOpenCodeServer: ({ serverUrl, serverPassword }) =>
     Effect.gen(function* () {
+      if (runtimeMock.state.connectionError) {
+        return yield* new OpenCodeRuntimeError({
+          operation: "global.health",
+          detail: runtimeMock.state.connectionError.message,
+          cause: runtimeMock.state.connectionError,
+        });
+      }
       if (!serverUrl) {
         yield* Effect.addFinalizer(() =>
           Effect.sync(() => {
@@ -88,6 +107,8 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       }
       return {
         url: serverUrl ?? "http://127.0.0.1:4301",
+        ...(serverPassword ? { serverPassword } : {}),
+        version: "1.14.19",
         exitCode: null,
         external: Boolean(serverUrl),
       };
@@ -158,6 +179,8 @@ const checkProvider = Effect.fn("checkProvider")(function* (
     Effect.gen(function* () {
       const serverOwner = yield* OpenCodeServerOwner.make({
         binaryPath: settings.binaryPath,
+        directory: cwd,
+        ...(settings.serverPassword ? { serverPassword: settings.serverPassword } : {}),
         ...(environment ? { environment } : {}),
       });
       return yield* checkOpenCodeProviderStatus(settings, cwd, environment).pipe(
@@ -331,6 +354,34 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
     }),
   );
 
+  it.effect("uses an environment-only password for local inventory", () =>
+    Effect.gen(function* () {
+      yield* checkProvider(makeOpenCodeSettings(), process.cwd(), {
+        OPENCODE_SERVER_PASSWORD: "environment-password",
+      });
+
+      NodeAssert.deepEqual(runtimeMock.state.sdkClientInputs, [
+        {
+          baseUrl: "http://127.0.0.1:4301",
+          directory: process.cwd(),
+          serverPassword: "environment-password",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("uses the settings password when local environment auth differs", () =>
+    Effect.gen(function* () {
+      yield* checkProvider(
+        makeOpenCodeSettings({ serverPassword: "settings-password" }),
+        process.cwd(),
+        { OPENCODE_SERVER_PASSWORD: "environment-password" },
+      );
+
+      NodeAssert.equal(runtimeMock.state.sdkClientInputs[0]?.serverPassword, "settings-password");
+    }),
+  );
+
   it.effect("reports local model inventory failures without treating them as empty", () =>
     Effect.gen(function* () {
       runtimeMock.state.inventoryError = new Error("opencode models failed");
@@ -348,9 +399,43 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
 });
 
 it.layer(testLayer)("checkOpenCodeProviderStatus with configured server URL", (it) => {
+  it.effect("does not send a local environment password to a configured server", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkProvider(
+        makeOpenCodeSettings({ serverUrl: "http://127.0.0.1:9999" }),
+        process.cwd(),
+        { OPENCODE_SERVER_PASSWORD: "local-secret" },
+      );
+
+      NodeAssert.equal(snapshot.version, "1.14.19");
+      NodeAssert.deepEqual(runtimeMock.state.sdkClientInputs, [
+        {
+          baseUrl: "http://127.0.0.1:9999",
+          directory: process.cwd(),
+        },
+      ]);
+    }),
+  );
+
+  it.effect("rejects an unsupported server before loading inventory", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.connectionError = new Error(
+        "OpenCode v1.14.18 is too old. Upgrade to v1.14.19 or newer.",
+      );
+      const snapshot = yield* checkProvider(
+        makeOpenCodeSettings({ serverUrl: "http://127.0.0.1:9999" }),
+      );
+
+      NodeAssert.equal(snapshot.status, "error");
+      NodeAssert.equal(snapshot.models.length, 0);
+      NodeAssert.match(snapshot.message ?? "", /v1\.14\.18 is too old/);
+      NodeAssert.equal(runtimeMock.state.sdkClientInputs.length, 0);
+    }),
+  );
+
   it.effect("surfaces a friendly auth error for configured servers", () =>
     Effect.gen(function* () {
-      runtimeMock.state.inventoryError = new Error("401 Unauthorized");
+      runtimeMock.state.connectionError = new Error("401 Unauthorized");
       const snapshot = yield* checkProvider(
         makeOpenCodeSettings({
           serverUrl: "http://127.0.0.1:9999",
@@ -369,7 +454,7 @@ it.layer(testLayer)("checkOpenCodeProviderStatus with configured server URL", (i
 
   it.effect("surfaces a friendly connection error for configured servers", () =>
     Effect.gen(function* () {
-      runtimeMock.state.inventoryError = new Error(
+      runtimeMock.state.connectionError = new Error(
         "fetch failed: connect ECONNREFUSED 127.0.0.1:9999",
       );
       const snapshot = yield* checkProvider(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -437,7 +437,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
           openCodeRuntime.createOpenCodeSdkClient({
             baseUrl: server.url,
             directory: cwd,
-            ...(server.external && openCodeSettings.serverPassword
+            ...(openCodeSettings.serverPassword
               ? { serverPassword: openCodeSettings.serverPassword }
               : {}),
           }),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -24,7 +24,7 @@ import {
   type OpenCodeInventory,
 } from "../opencodeRuntime.ts";
 import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
-import type { OpenCodeServerOwner } from "../OpenCodeServerOwner.ts";
+import * as OpenCodeServerOwner from "../OpenCodeServerOwner.ts";
 
 const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
@@ -330,9 +330,13 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   openCodeSettings: OpenCodeSettings,
   cwd: string,
   environment?: NodeJS.ProcessEnv,
-  serverOwner?: OpenCodeServerOwner,
-): Effect.fn.Return<ServerProviderDraft, never, OpenCodeRuntime> {
+): Effect.fn.Return<
+  ServerProviderDraft,
+  never,
+  OpenCodeRuntime | OpenCodeServerOwner.OpenCodeServerOwner
+> {
   const openCodeRuntime = yield* OpenCodeRuntime;
+  const serverOwner = yield* OpenCodeServerOwner.OpenCodeServerOwner;
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const customModels = openCodeSettings.customModels;
@@ -439,16 +443,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     );
   const inventoryEffect = isExternalServer
     ? loadInventory({ url: openCodeSettings.serverUrl })
-    : serverOwner
-      ? serverOwner.withServer(loadInventory)
-      : Effect.scoped(
-          openCodeRuntime
-            .connectToOpenCodeServer({
-              binaryPath: openCodeSettings.binaryPath,
-              environment: resolvedEnvironment,
-            })
-            .pipe(Effect.flatMap(loadInventory)),
-        );
+    : serverOwner.withServer(loadInventory);
   const inventoryExit = yield* Effect.exit(
     inventoryEffect.pipe(
       Effect.mapError(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -65,6 +65,7 @@ function normalizedErrorMessage(cause: unknown): string | undefined {
 function formatOpenCodeProbeError(input: {
   readonly cause: unknown;
   readonly isExternalServer: boolean;
+  readonly phase: "version" | "inventory";
   readonly serverUrl: string;
 }): { readonly installed: boolean; readonly message: string } {
   const detail = normalizedErrorMessage(input.cause);
@@ -127,11 +128,13 @@ function formatOpenCodeProbeError(input: {
     };
   }
 
+  const failureLabel =
+    input.phase === "inventory"
+      ? "Failed to load OpenCode provider inventory"
+      : "Failed to execute OpenCode CLI health check";
   return {
     installed: true,
-    message: detail
-      ? `Failed to execute OpenCode CLI health check: ${detail}`
-      : "Failed to execute OpenCode CLI health check.",
+    message: detail ? `${failureLabel}: ${detail}` : `${failureLabel}.`,
   };
 }
 
@@ -333,10 +336,15 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   const customModels = openCodeSettings.customModels;
   const isExternalServer = openCodeSettings.serverUrl.trim().length > 0;
 
-  const fallback = (cause: unknown, version: string | null = null) => {
+  const fallback = (
+    cause: unknown,
+    version: string | null = null,
+    phase: "version" | "inventory" = "version",
+  ) => {
     const failure = formatOpenCodeProbeError({
       cause,
       isExternalServer,
+      phase,
       serverUrl: openCodeSettings.serverUrl,
     });
     return buildServerProvider({
@@ -418,30 +426,23 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   }
 
   const inventoryExit = yield* Effect.exit(
-    (isExternalServer
-      ? Effect.scoped(
-          Effect.gen(function* () {
-            const server = yield* openCodeRuntime.connectToOpenCodeServer({
-              binaryPath: openCodeSettings.binaryPath,
-              serverUrl: openCodeSettings.serverUrl,
-              environment: resolvedEnvironment,
-            });
-            return yield* openCodeRuntime.loadOpenCodeInventory(
-              openCodeRuntime.createOpenCodeSdkClient({
-                baseUrl: server.url,
-                directory: cwd,
-                ...(openCodeSettings.serverPassword
-                  ? { serverPassword: openCodeSettings.serverPassword }
-                  : {}),
-              }),
-            );
-          }),
-        )
-      : openCodeRuntime.loadInventoryFromCli({
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* openCodeRuntime.connectToOpenCodeServer({
           binaryPath: openCodeSettings.binaryPath,
-          cwd,
+          ...(isExternalServer ? { serverUrl: openCodeSettings.serverUrl } : {}),
           environment: resolvedEnvironment,
-        })
+        });
+        return yield* openCodeRuntime.loadOpenCodeInventory(
+          openCodeRuntime.createOpenCodeSdkClient({
+            baseUrl: server.url,
+            directory: cwd,
+            ...(server.external && openCodeSettings.serverPassword
+              ? { serverPassword: openCodeSettings.serverPassword }
+              : {}),
+          }),
+        );
+      }),
     ).pipe(
       Effect.mapError(
         (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
@@ -449,7 +450,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     ),
   );
   if (inventoryExit._tag === "Failure") {
-    return fallback(Cause.squash(inventoryExit.cause), version);
+    return fallback(Cause.squash(inventoryExit.cause), version, "inventory");
   }
 
   const models = providerModelsFromSettings(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -24,6 +24,7 @@ import {
   type OpenCodeInventory,
 } from "../opencodeRuntime.ts";
 import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
+import type { OpenCodeServerOwner } from "../OpenCodeServerOwner.ts";
 
 const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
@@ -329,6 +330,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   openCodeSettings: OpenCodeSettings,
   cwd: string,
   environment?: NodeJS.ProcessEnv,
+  serverOwner?: OpenCodeServerOwner,
 ): Effect.fn.Return<ServerProviderDraft, never, OpenCodeRuntime> {
   const openCodeRuntime = yield* OpenCodeRuntime;
   const resolvedEnvironment = environment ?? process.env;
@@ -425,25 +427,30 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     }
   }
 
-  const inventoryExit = yield* Effect.exit(
-    Effect.scoped(
-      Effect.gen(function* () {
-        const server = yield* openCodeRuntime.connectToOpenCodeServer({
-          binaryPath: openCodeSettings.binaryPath,
-          ...(isExternalServer ? { serverUrl: openCodeSettings.serverUrl } : {}),
-          environment: resolvedEnvironment,
-        });
-        return yield* openCodeRuntime.loadOpenCodeInventory(
-          openCodeRuntime.createOpenCodeSdkClient({
-            baseUrl: server.url,
-            directory: cwd,
-            ...(openCodeSettings.serverPassword
-              ? { serverPassword: openCodeSettings.serverPassword }
-              : {}),
-          }),
-        );
+  const loadInventory = (server: { readonly url: string }) =>
+    openCodeRuntime.loadOpenCodeInventory(
+      openCodeRuntime.createOpenCodeSdkClient({
+        baseUrl: server.url,
+        directory: cwd,
+        ...(openCodeSettings.serverPassword
+          ? { serverPassword: openCodeSettings.serverPassword }
+          : {}),
       }),
-    ).pipe(
+    );
+  const inventoryEffect = isExternalServer
+    ? loadInventory({ url: openCodeSettings.serverUrl })
+    : serverOwner
+      ? serverOwner.withServer(loadInventory)
+      : Effect.scoped(
+          openCodeRuntime
+            .connectToOpenCodeServer({
+              binaryPath: openCodeSettings.binaryPath,
+              environment: resolvedEnvironment,
+            })
+            .pipe(Effect.flatMap(loadInventory)),
+        );
+  const inventoryExit = yield* Effect.exit(
+    inventoryEffect.pipe(
       Effect.mapError(
         (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
       ),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -19,6 +19,7 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import {
+  MINIMUM_OPENCODE_VERSION,
   OpenCodeRuntime,
   openCodeRuntimeErrorDetail,
   type OpenCodeInventory,
@@ -30,7 +31,6 @@ const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
   showInteractionModeToggle: false,
 } as const;
-const MINIMUM_OPENCODE_VERSION = "1.14.19";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
   readonly cause: unknown;
@@ -431,18 +431,31 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     }
   }
 
-  const loadInventory = (server: { readonly url: string }) =>
-    openCodeRuntime.loadOpenCodeInventory(
-      openCodeRuntime.createOpenCodeSdkClient({
-        baseUrl: server.url,
-        directory: cwd,
-        ...(openCodeSettings.serverPassword
-          ? { serverPassword: openCodeSettings.serverPassword }
-          : {}),
-      }),
-    );
+  const loadInventory = (server: {
+    readonly url: string;
+    readonly serverPassword?: string;
+    readonly version: string;
+  }) =>
+    openCodeRuntime
+      .loadOpenCodeInventory(
+        openCodeRuntime.createOpenCodeSdkClient({
+          baseUrl: server.url,
+          directory: cwd,
+          ...(server.serverPassword !== undefined ? { serverPassword: server.serverPassword } : {}),
+        }),
+      )
+      .pipe(Effect.map((inventory) => ({ inventory, version: server.version })));
   const inventoryEffect = isExternalServer
-    ? loadInventory({ url: openCodeSettings.serverUrl })
+    ? openCodeRuntime
+        .connectToOpenCodeServer({
+          binaryPath: openCodeSettings.binaryPath,
+          directory: cwd,
+          serverUrl: openCodeSettings.serverUrl,
+          ...(openCodeSettings.serverPassword
+            ? { serverPassword: openCodeSettings.serverPassword }
+            : {}),
+        })
+        .pipe(Effect.flatMap(loadInventory), Effect.scoped)
     : serverOwner.withServer(loadInventory);
   const inventoryExit = yield* Effect.exit(
     inventoryEffect.pipe(
@@ -455,13 +468,15 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     return fallback(Cause.squash(inventoryExit.cause), version, "inventory");
   }
 
+  version = inventoryExit.value.version;
+
   const models = providerModelsFromSettings(
-    flattenOpenCodeModels(inventoryExit.value),
+    flattenOpenCodeModels(inventoryExit.value.inventory),
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
   );
-  const skills = flattenOpenCodeSkills(inventoryExit.value);
-  const connectedCount = inventoryExit.value.providerList.connected.length;
+  const skills = flattenOpenCodeSkills(inventoryExit.value.inventory);
+  const connectedCount = inventoryExit.value.inventory.providerList.connected.length;
   return buildServerProvider({
     presentation: OPENCODE_PRESENTATION,
     enabled: true,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -589,18 +589,35 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               }),
             },
           ],
-          slashCommands: [],
-          skills: [],
+          slashCommands: [{ name: "review", description: "Review changes" }],
+          skills: [
+            {
+              name: "typescript",
+              description: "TypeScript help",
+              path: "/skills/typescript/SKILL.md",
+              enabled: true,
+            },
+          ],
         } as const satisfies ServerProvider;
         const refreshedProvider = {
           ...previousProvider,
           checkedAt: "2026-04-14T00:01:00.000Z",
           models: [],
+          slashCommands: [],
+          skills: [],
         } satisfies ServerProvider;
 
         assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
           ...previousProvider.models,
         ]);
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).slashCommands,
+          [],
+        );
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).skills,
+          [],
+        );
       });
 
       it("drops stale OpenCode models missing from a successful refresh", () => {
@@ -670,8 +687,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               capabilities: null,
             },
           ],
-          slashCommands: [],
-          skills: [],
+          slashCommands: [{ name: "review", description: "Review changes" }],
+          skills: [
+            {
+              name: "typescript",
+              description: "TypeScript help",
+              path: "/skills/typescript/SKILL.md",
+              enabled: true,
+            },
+          ],
         } as const satisfies ServerProvider;
         const refreshedProvider = {
           ...previousProvider,
@@ -685,6 +709,14 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
           ...previousProvider.models,
         ]);
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).slashCommands,
+          previousProvider.slashCommands,
+        );
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).skills,
+          previousProvider.skills,
+        );
       });
 
       it("classifies pending, logout, uninstall, and reconnect OpenCode inventories", () => {
@@ -713,8 +745,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               capabilities: null,
             },
           ],
-          slashCommands: [],
-          skills: [],
+          slashCommands: [{ name: "review", description: "Review changes" }],
+          skills: [
+            {
+              name: "typescript",
+              description: "TypeScript help",
+              path: "/skills/typescript/SKILL.md",
+              enabled: true,
+            },
+          ],
         } as const satisfies ServerProvider;
         const pendingProvider = {
           ...previousProvider,
@@ -732,6 +771,8 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           auth: { status: "unknown" },
           checkedAt: "2026-07-17T00:02:00.000Z",
           models: [],
+          slashCommands: [],
+          skills: [],
           message: "OpenCode is available, but it did not report any connected upstream providers.",
         } satisfies ServerProvider;
         const missingProvider = {
@@ -763,6 +804,14 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ]);
         assert.deepStrictEqual(
           mergeProviderSnapshot(previousProvider, loggedOutProvider).models,
+          [],
+        );
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, loggedOutProvider).slashCommands,
+          [],
+        );
+        assert.deepStrictEqual(
+          mergeProviderSnapshot(previousProvider, loggedOutProvider).skills,
           [],
         );
         assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, missingProvider).models, []);
@@ -893,6 +942,107 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             assert.deepStrictEqual(yield* registry.getProviders, [initialProvider]);
             assert.strictEqual(yield* Ref.get(refreshCalls), 0);
           }).pipe(Effect.provide(runtimeServices));
+        }),
+      );
+
+      it.effect("refreshes other providers while excluding OpenCode", () =>
+        Effect.gen(function* () {
+          const codexDriver = ProviderDriverKind.make("codex");
+          const openCodeDriver = ProviderDriverKind.make("opencode");
+          const codexInstanceId = ProviderInstanceId.make("codex");
+          const openCodeInstanceId = ProviderInstanceId.make("opencode");
+          const codexRefreshCalls = yield* Ref.make(0);
+          const openCodeRefreshCalls = yield* Ref.make(0);
+          const makeProvider = (
+            instanceId: ProviderInstanceId,
+            driver: ProviderDriverKind,
+          ): ServerProvider => ({
+            instanceId,
+            driver,
+            status: "ready",
+            enabled: true,
+            installed: true,
+            auth: { status: "authenticated" },
+            checkedAt: "2026-06-10T00:00:00.000Z",
+            version: "1.0.0",
+            models: [],
+            slashCommands: [],
+            skills: [],
+          });
+          const makeInstance = (input: {
+            readonly instanceId: ProviderInstanceId;
+            readonly driver: ProviderDriverKind;
+            readonly refreshCalls: Ref.Ref<number>;
+          }): ProviderInstance => {
+            const provider = makeProvider(input.instanceId, input.driver);
+            return {
+              instanceId: input.instanceId,
+              driverKind: input.driver,
+              continuationIdentity: {
+                driverKind: input.driver,
+                continuationKey: `${input.driver}:instance:${input.instanceId}`,
+              },
+              displayName: undefined,
+              enabled: true,
+              snapshot: {
+                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: input.driver,
+                  packageName: null,
+                }),
+                getSnapshot: Effect.succeed(provider),
+                refresh: Ref.update(input.refreshCalls, (count) => count + 1).pipe(
+                  Effect.as(provider),
+                ),
+                streamChanges: Stream.empty,
+              },
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+            };
+          };
+          const instances = [
+            makeInstance({
+              instanceId: codexInstanceId,
+              driver: codexDriver,
+              refreshCalls: codexRefreshCalls,
+            }),
+            makeInstance({
+              instanceId: openCodeInstanceId,
+              driver: openCodeDriver,
+              refreshCalls: openCodeRefreshCalls,
+            }),
+          ];
+          const instanceRegistryLayer = Layer.succeed(
+            ProviderInstanceRegistry.ProviderInstanceRegistry,
+            {
+              getInstance: (instanceId) =>
+                Effect.succeed(instances.find((instance) => instance.instanceId === instanceId)),
+              listInstances: Effect.succeed(instances),
+              listUnavailable: Effect.succeed([]),
+              streamChanges: Stream.empty,
+              subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+            },
+          );
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const runtimeServices = yield* Layer.build(
+            ProviderRegistryLive.pipe(
+              Layer.provideMerge(instanceRegistryLayer),
+              Layer.provideMerge(
+                ServerConfig.layerTest(process.cwd(), {
+                  prefix: "t3-provider-registry-excluded-refresh-",
+                }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ).pipe(Scope.provide(scope));
+
+          yield* Effect.gen(function* () {
+            const registry = yield* ProviderRegistry.ProviderRegistry;
+            yield* registry.refresh(undefined, { exclude: new Set([openCodeDriver]) });
+          }).pipe(Effect.provide(runtimeServices));
+
+          assert.strictEqual(yield* Ref.get(codexRefreshCalls), 1);
+          assert.strictEqual(yield* Ref.get(openCodeRefreshCalls), 0);
         }),
       );
 

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -945,7 +945,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
-      it.effect("refreshes other providers while excluding OpenCode", () =>
+      it.effect("refreshes OpenCode catalogs and preserves other providers", () =>
         Effect.gen(function* () {
           const codexDriver = ProviderDriverKind.make("codex");
           const openCodeDriver = ProviderDriverKind.make("opencode");
@@ -953,12 +953,9 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const openCodeInstanceId = ProviderInstanceId.make("opencode");
           const codexRefreshCalls = yield* Ref.make(0);
           const openCodeRefreshCalls = yield* Ref.make(0);
-          const makeProvider = (
-            instanceId: ProviderInstanceId,
-            driver: ProviderDriverKind,
-          ): ServerProvider => ({
-            instanceId,
-            driver,
+          const codexProvider = {
+            instanceId: codexInstanceId,
+            driver: codexDriver,
             status: "ready",
             enabled: true,
             installed: true,
@@ -968,49 +965,99 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             models: [],
             slashCommands: [],
             skills: [],
-          });
-          const makeInstance = (input: {
-            readonly instanceId: ProviderInstanceId;
-            readonly driver: ProviderDriverKind;
-            readonly refreshCalls: Ref.Ref<number>;
-          }): ProviderInstance => {
-            const provider = makeProvider(input.instanceId, input.driver);
-            return {
-              instanceId: input.instanceId,
-              driverKind: input.driver,
+          } as const satisfies ServerProvider;
+          const failedOpenCodeProvider = {
+            instanceId: openCodeInstanceId,
+            driver: openCodeDriver,
+            status: "error",
+            enabled: true,
+            installed: true,
+            auth: { status: "unknown" },
+            checkedAt: "2026-06-10T00:00:00.000Z",
+            version: "1.0.0",
+            message: "Failed to refresh OpenCode models.",
+            models: [],
+            slashCommands: [],
+            skills: [],
+          } as const satisfies ServerProvider;
+          const recoveredOpenCodeProvider = {
+            ...failedOpenCodeProvider,
+            status: "ready",
+            auth: { status: "authenticated" },
+            checkedAt: "2026-06-10T00:01:00.000Z",
+            message: "One upstream provider connected through OpenCode.",
+            models: [
+              {
+                slug: "github/gpt-5",
+                name: "GPT-5",
+                subProvider: "GitHub",
+                isCustom: false,
+                capabilities: null,
+              },
+            ],
+          } as const satisfies ServerProvider;
+          const changedCatalogProvider = {
+            ...recoveredOpenCodeProvider,
+            checkedAt: "2026-06-10T00:02:00.000Z",
+            models: [
+              {
+                slug: "anthropic/claude-sonnet-4",
+                name: "Claude Sonnet 4",
+                subProvider: "Anthropic",
+                isCustom: false,
+                capabilities: null,
+              },
+            ],
+          } as const satisfies ServerProvider;
+          const catalogSnapshot = yield* Ref.make<ServerProvider>(recoveredOpenCodeProvider);
+          const instances = [
+            {
+              instanceId: codexInstanceId,
+              driverKind: codexDriver,
               continuationIdentity: {
-                driverKind: input.driver,
-                continuationKey: `${input.driver}:instance:${input.instanceId}`,
+                driverKind: codexDriver,
+                continuationKey: "codex:instance:codex",
               },
               displayName: undefined,
               enabled: true,
               snapshot: {
                 maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                  provider: input.driver,
+                  provider: codexDriver,
                   packageName: null,
                 }),
-                getSnapshot: Effect.succeed(provider),
-                refresh: Ref.update(input.refreshCalls, (count) => count + 1).pipe(
-                  Effect.as(provider),
+                getSnapshot: Effect.succeed(codexProvider),
+                refresh: Ref.update(codexRefreshCalls, (count) => count + 1).pipe(
+                  Effect.as(codexProvider),
                 ),
                 streamChanges: Stream.empty,
               },
               adapter: {} as ProviderInstance["adapter"],
               textGeneration: {} as ProviderInstance["textGeneration"],
-            };
-          };
-          const instances = [
-            makeInstance({
-              instanceId: codexInstanceId,
-              driver: codexDriver,
-              refreshCalls: codexRefreshCalls,
-            }),
-            makeInstance({
+            },
+            {
               instanceId: openCodeInstanceId,
-              driver: openCodeDriver,
-              refreshCalls: openCodeRefreshCalls,
-            }),
-          ];
+              driverKind: openCodeDriver,
+              continuationIdentity: {
+                driverKind: openCodeDriver,
+                continuationKey: "opencode:instance:opencode",
+              },
+              displayName: undefined,
+              enabled: true,
+              snapshot: {
+                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: openCodeDriver,
+                  packageName: null,
+                }),
+                getSnapshot: Effect.succeed(failedOpenCodeProvider),
+                refresh: Ref.update(openCodeRefreshCalls, (count) => count + 1).pipe(
+                  Effect.andThen(Ref.get(catalogSnapshot)),
+                ),
+                streamChanges: Stream.empty,
+              },
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+            },
+          ] satisfies ReadonlyArray<ProviderInstance>;
           const instanceRegistryLayer = Layer.succeed(
             ProviderInstanceRegistry.ProviderInstanceRegistry,
             {
@@ -1029,7 +1076,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
-                  prefix: "t3-provider-registry-excluded-refresh-",
+                  prefix: "t3-provider-registry-reconnect-refresh-",
                 }),
               ),
               Layer.provideMerge(NodeServices.layer),
@@ -1038,11 +1085,39 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
           yield* Effect.gen(function* () {
             const registry = yield* ProviderRegistry.ProviderRegistry;
-            yield* registry.refresh(undefined, { exclude: new Set([openCodeDriver]) });
+            const initialProviders = yield* registry.getProviders;
+            assert.strictEqual(
+              initialProviders.find((provider) => provider.instanceId === openCodeInstanceId)
+                ?.status,
+              "error",
+            );
+
+            const recoveredProviders = yield* registry.refresh();
+            assert.deepStrictEqual(
+              recoveredProviders.find((provider) => provider.instanceId === openCodeInstanceId)
+                ?.models,
+              recoveredOpenCodeProvider.models,
+            );
+            assert.deepStrictEqual(
+              recoveredProviders.find((provider) => provider.instanceId === codexInstanceId),
+              codexProvider,
+            );
+
+            yield* Ref.set(catalogSnapshot, changedCatalogProvider);
+            const changedProviders = yield* registry.refresh();
+            assert.deepStrictEqual(
+              changedProviders.find((provider) => provider.instanceId === openCodeInstanceId)
+                ?.models,
+              changedCatalogProvider.models,
+            );
+            assert.deepStrictEqual(
+              changedProviders.find((provider) => provider.instanceId === codexInstanceId),
+              codexProvider,
+            );
           }).pipe(Effect.provide(runtimeServices));
 
-          assert.strictEqual(yield* Ref.get(codexRefreshCalls), 1);
-          assert.strictEqual(yield* Ref.get(openCodeRefreshCalls), 0);
+          assert.strictEqual(yield* Ref.get(codexRefreshCalls), 2);
+          assert.strictEqual(yield* Ref.get(openCodeRefreshCalls), 2);
         }),
       );
 

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -95,6 +95,10 @@ const shouldRetainMissingProviderModels = (provider: ServerProvider): boolean =>
   return isPendingInitialProbe || didInstalledProviderProbeFail;
 };
 
+const shouldRetainMissingOpenCodeMetadata = (provider: ServerProvider): boolean =>
+  provider.driver === ProviderDriverKind.make("opencode") &&
+  shouldRetainMissingProviderModels(provider);
+
 const mergeProviderModels = (
   provider: ServerProvider,
   previousModels: ReadonlyArray<ServerProvider["models"][number]>,
@@ -132,6 +136,16 @@ export const mergeProviderSnapshot = (
     : {
         ...nextProvider,
         models: mergeProviderModels(nextProvider, previousProvider.models, nextProvider.models),
+        ...(shouldRetainMissingOpenCodeMetadata(nextProvider)
+          ? {
+              slashCommands:
+                nextProvider.slashCommands.length === 0
+                  ? previousProvider.slashCommands
+                  : nextProvider.slashCommands,
+              skills:
+                nextProvider.skills.length === 0 ? previousProvider.skills : nextProvider.skills,
+            }
+          : {}),
       };
 
 export const mergeProviderSnapshots = (
@@ -461,17 +475,25 @@ export const ProviderRegistryLive = Layer.effect(
       );
     });
 
-    const refreshAll = Effect.fn("refreshAll")(function* () {
+    const refreshAll = Effect.fn("refreshAll")(function* (
+      exclude?: ReadonlySet<ProviderDriverKind>,
+    ) {
       const sources = yield* getLiveSources;
-      return yield* Effect.forEach(sources, (source) => refreshOneSource(source), {
+      const sourcesToRefresh = exclude
+        ? sources.filter((source) => !exclude.has(source.driverKind))
+        : sources;
+      return yield* Effect.forEach(sourcesToRefresh, (source) => refreshOneSource(source), {
         concurrency: "unbounded",
         discard: true,
       }).pipe(Effect.andThen(Ref.get(providersRef)));
     });
 
-    const refresh = Effect.fn("refresh")(function* (provider?: ProviderDriverKind) {
+    const refresh = Effect.fn("refresh")(function* (
+      provider?: ProviderDriverKind,
+      options?: { readonly exclude?: ReadonlySet<ProviderDriverKind> },
+    ) {
       if (provider === undefined) {
-        return yield* refreshAll();
+        return yield* refreshAll(options?.exclude);
       }
       // Kind-scoped refreshes target the default instance for that driver.
       const defaultInstanceId = defaultInstanceIdForDriver(provider);
@@ -706,8 +728,10 @@ export const ProviderRegistryLive = Layer.effect(
 
     return {
       getProviders: Ref.get(providersRef),
-      refresh: (provider?: ProviderDriverKind) =>
-        refresh(provider).pipe(Effect.catchCause(recoverRefreshFailure)),
+      refresh: (
+        provider?: ProviderDriverKind,
+        options?: { readonly exclude?: ReadonlySet<ProviderDriverKind> },
+      ) => refresh(provider, options).pipe(Effect.catchCause(recoverRefreshFailure)),
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
       getProviderMaintenanceCapabilitiesForInstance,

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -475,25 +475,17 @@ export const ProviderRegistryLive = Layer.effect(
       );
     });
 
-    const refreshAll = Effect.fn("refreshAll")(function* (
-      exclude?: ReadonlySet<ProviderDriverKind>,
-    ) {
+    const refreshAll = Effect.fn("refreshAll")(function* () {
       const sources = yield* getLiveSources;
-      const sourcesToRefresh = exclude
-        ? sources.filter((source) => !exclude.has(source.driverKind))
-        : sources;
-      return yield* Effect.forEach(sourcesToRefresh, (source) => refreshOneSource(source), {
+      return yield* Effect.forEach(sources, (source) => refreshOneSource(source), {
         concurrency: "unbounded",
         discard: true,
       }).pipe(Effect.andThen(Ref.get(providersRef)));
     });
 
-    const refresh = Effect.fn("refresh")(function* (
-      provider?: ProviderDriverKind,
-      options?: { readonly exclude?: ReadonlySet<ProviderDriverKind> },
-    ) {
+    const refresh = Effect.fn("refresh")(function* (provider?: ProviderDriverKind) {
       if (provider === undefined) {
-        return yield* refreshAll(options?.exclude);
+        return yield* refreshAll();
       }
       // Kind-scoped refreshes target the default instance for that driver.
       const defaultInstanceId = defaultInstanceIdForDriver(provider);
@@ -728,10 +720,8 @@ export const ProviderRegistryLive = Layer.effect(
 
     return {
       getProviders: Ref.get(providersRef),
-      refresh: (
-        provider?: ProviderDriverKind,
-        options?: { readonly exclude?: ReadonlySet<ProviderDriverKind> },
-      ) => refresh(provider, options).pipe(Effect.catchCause(recoverRefreshFailure)),
+      refresh: (provider?: ProviderDriverKind) =>
+        refresh(provider).pipe(Effect.catchCause(recoverRefreshFailure)),
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
       getProviderMaintenanceCapabilitiesForInstance,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -24,6 +24,8 @@ import {
 import { createModelSelection } from "@t3tools/shared/model";
 import { it, assert, describe, vi } from "@effect/vitest";
 
+import * as Cause from "effect/Cause";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -1526,6 +1528,67 @@ routing.layer("ProviderServiceLive routing", (it) => {
           assert.equal(runtimePayload.activeTurnId, `turn-${String(session.threadId)}`);
           assert.equal(runtimePayload.lastError, null);
           assert.equal(runtimePayload.lastRuntimeEvent, "provider.sendTurn");
+        }
+      }
+    }),
+  );
+
+  it.effect("does not persist running after a concurrent send is interrupted", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+      const sendStarted = yield* Deferred.make<void>();
+      const interrupted = yield* Deferred.make<void>();
+      routing.codex.sendTurn.mockImplementationOnce(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(sendStarted, undefined);
+          yield* Deferred.await(interrupted);
+          return yield* Effect.interrupt;
+        }),
+      );
+      routing.codex.interruptTurn.mockImplementationOnce(() =>
+        Deferred.succeed(interrupted, undefined).pipe(Effect.asVoid),
+      );
+
+      const threadId = asThreadId("thread-interrupted-send-directory");
+      const session = yield* provider.startSession(threadId, {
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const sendExitFiber = yield* provider
+        .sendTurn({
+          threadId: session.threadId,
+          input: "hold this prompt",
+          attachments: [],
+        })
+        .pipe(Effect.exit, Effect.forkChild);
+      yield* Deferred.await(sendStarted);
+      yield* provider.interruptTurn({ threadId: session.threadId });
+      const sendExit = yield* Fiber.join(sendExitFiber);
+
+      assert.equal(Exit.isFailure(sendExit), true);
+      if (Exit.isFailure(sendExit)) {
+        assert.equal(Cause.hasInterruptsOnly(sendExit.cause), true);
+      }
+      const persisted = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(persisted), true);
+      if (Option.isSome(persisted)) {
+        // The directory folds both adapter "ready" and "running" into its
+        // runtime "running" state. The payload proves sendTurn did not upsert.
+        assert.equal(persisted.value.status, "running");
+        const payload = persisted.value.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          const runtimePayload = payload as {
+            activeTurnId?: string | null;
+            lastRuntimeEvent?: string | null;
+          };
+          assert.equal(runtimePayload.activeTurnId ?? null, null);
+          assert.notEqual(runtimePayload.lastRuntimeEvent, "provider.sendTurn");
         }
       }
     }),

--- a/apps/server/src/provider/OpenCodeServerOwner.test.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.test.ts
@@ -1,0 +1,208 @@
+import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Ref from "effect/Ref";
+import * as TestClock from "effect/testing/TestClock";
+import { expect } from "vite-plus/test";
+
+import {
+  OpenCodeRuntime,
+  OpenCodeRuntimeError,
+  type OpenCodeRuntimeShape,
+} from "./opencodeRuntime.ts";
+import { makeOpenCodeServerOwner } from "./OpenCodeServerOwner.ts";
+
+const unusedRuntimeMethod = () =>
+  Effect.fail(
+    new OpenCodeRuntimeError({
+      operation: "unused",
+      detail: "unused test method",
+    }),
+  );
+
+const makeRuntime = Effect.gen(function* () {
+  const starts = yield* Ref.make(0);
+  const closes = yield* Ref.make(0);
+  const failNextStart = yield* Ref.make(false);
+  const started = yield* Deferred.make<void>();
+  const closed = yield* Deferred.make<void>();
+  const runtime: OpenCodeRuntimeShape = {
+    startOpenCodeServerProcess: () =>
+      Effect.gen(function* () {
+        if (yield* Ref.getAndSet(failNextStart, false)) {
+          return yield* new OpenCodeRuntimeError({
+            operation: "startOpenCodeServerProcess",
+            detail: "start failed",
+          });
+        }
+        const index = yield* Ref.updateAndGet(starts, (count) => count + 1);
+        yield* Deferred.succeed(started, undefined).pipe(Effect.ignore);
+        yield* Effect.addFinalizer(() =>
+          Ref.update(closes, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(closed, undefined)),
+            Effect.ignore,
+          ),
+        );
+        return { url: `http://127.0.0.1:${index}`, exitCode: Effect.never };
+      }),
+    connectToOpenCodeServer: unusedRuntimeMethod,
+    runOpenCodeCommand: unusedRuntimeMethod,
+    createOpenCodeSdkClient: () => ({}) as never,
+    loadOpenCodeInventory: unusedRuntimeMethod,
+    loadInventoryFromCli: unusedRuntimeMethod,
+  };
+  return { runtime, starts, closes, failNextStart, started, closed };
+});
+
+it.effect("shares concurrent borrowers and closes after the idle TTL", () =>
+  Effect.gen(function* () {
+    const testRuntime = yield* makeRuntime;
+    const release = yield* Deferred.make<void>();
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const useServer = owner.withServer((server) =>
+          Deferred.await(release).pipe(Effect.as(server.url)),
+        );
+        const fibers = yield* Effect.all([useServer, useServer], {
+          concurrency: "unbounded",
+        }).pipe(Effect.forkChild);
+        yield* Deferred.await(testRuntime.started);
+        expect(yield* Ref.get(testRuntime.starts)).toBe(1);
+        yield* Deferred.succeed(release, undefined);
+        expect(yield* Fiber.join(fibers)).toEqual(["http://127.0.0.1:1", "http://127.0.0.1:1"]);
+        yield* TestClock.adjust(Duration.seconds(31));
+        yield* Deferred.await(testRuntime.closed);
+        expect(yield* Ref.get(testRuntime.closes)).toBe(1);
+      }),
+    ).pipe(Effect.provideService(OpenCodeRuntime, testRuntime.runtime));
+  }).pipe(Effect.provide(TestClock.layer())),
+);
+
+it.effect("retries a failed start and closes on owner scope shutdown", () =>
+  Effect.gen(function* () {
+    const testRuntime = yield* makeRuntime;
+    yield* Ref.set(testRuntime.failNextStart, true);
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        expect(
+          (yield* Effect.exit(owner.withServer((server) => Effect.succeed(server.url))))._tag,
+        ).toBe("Failure");
+        expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
+          "http://127.0.0.1:1",
+        );
+      }),
+    ).pipe(Effect.provideService(OpenCodeRuntime, testRuntime.runtime));
+    expect(yield* Ref.get(testRuntime.starts)).toBe(1);
+    expect(yield* Ref.get(testRuntime.closes)).toBe(1);
+  }),
+);
+
+it.effect("invalidates an exited process so the next borrower starts a new one", () =>
+  Effect.gen(function* () {
+    const starts = yield* Ref.make(0);
+    const processExits: Array<Deferred.Deferred<number>> = [];
+    const processClosed = yield* Deferred.make<void>();
+    const runtime: OpenCodeRuntimeShape = {
+      startOpenCodeServerProcess: () =>
+        Effect.gen(function* () {
+          const index = yield* Ref.updateAndGet(starts, (count) => count + 1);
+          const exitCode = yield* Deferred.make<number>();
+          processExits.push(exitCode);
+          yield* Effect.addFinalizer(() =>
+            Deferred.succeed(processClosed, undefined).pipe(Effect.ignore),
+          );
+          return { url: `http://127.0.0.1:${index}`, exitCode: Deferred.await(exitCode) };
+        }),
+      connectToOpenCodeServer: unusedRuntimeMethod,
+      runOpenCodeCommand: unusedRuntimeMethod,
+      createOpenCodeSdkClient: () => ({}) as never,
+      loadOpenCodeInventory: unusedRuntimeMethod,
+      loadInventoryFromCli: unusedRuntimeMethod,
+    };
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
+          "http://127.0.0.1:1",
+        );
+        yield* Deferred.succeed(processExits[0]!, 1);
+        yield* Deferred.await(processClosed);
+        expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
+          "http://127.0.0.1:2",
+        );
+      }),
+    ).pipe(Effect.provideService(OpenCodeRuntime, runtime));
+    expect(yield* Ref.get(starts)).toBe(2);
+  }),
+);
+
+it.effect("cleans up an interrupted startup and allows a retry", () =>
+  Effect.gen(function* () {
+    const starts = yield* Ref.make(0);
+    const firstStartEntered = yield* Deferred.make<void>();
+    const firstStartClosed = yield* Deferred.make<void>();
+    const runtime: OpenCodeRuntimeShape = {
+      startOpenCodeServerProcess: () =>
+        Effect.gen(function* () {
+          const index = yield* Ref.updateAndGet(starts, (count) => count + 1);
+          yield* Effect.addFinalizer(() =>
+            index === 1
+              ? Deferred.succeed(firstStartClosed, undefined).pipe(Effect.ignore)
+              : Effect.void,
+          );
+          if (index === 1) {
+            yield* Deferred.succeed(firstStartEntered, undefined);
+            return yield* Effect.never;
+          }
+          return { url: `http://127.0.0.1:${index}`, exitCode: Effect.never };
+        }),
+      connectToOpenCodeServer: unusedRuntimeMethod,
+      runOpenCodeCommand: unusedRuntimeMethod,
+      createOpenCodeSdkClient: () => ({}) as never,
+      loadOpenCodeInventory: unusedRuntimeMethod,
+      loadInventoryFromCli: unusedRuntimeMethod,
+    };
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const firstBorrower = yield* owner
+          .withServer((server) => Effect.succeed(server.url))
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(firstStartEntered);
+        yield* Fiber.interrupt(firstBorrower);
+        yield* Deferred.await(firstStartClosed);
+        expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
+          "http://127.0.0.1:2",
+        );
+      }),
+    ).pipe(Effect.provideService(OpenCodeRuntime, runtime));
+  }),
+);
+
+it.effect("releases an interrupted borrower and closes after the idle TTL", () =>
+  Effect.gen(function* () {
+    const testRuntime = yield* makeRuntime;
+    const borrowerEntered = yield* Deferred.make<void>();
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const borrower = yield* owner
+          .withServer(() =>
+            Deferred.succeed(borrowerEntered, undefined).pipe(Effect.andThen(Effect.never)),
+          )
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(borrowerEntered);
+        yield* Fiber.interrupt(borrower);
+        yield* TestClock.adjust(Duration.seconds(31));
+        yield* Deferred.await(testRuntime.closed);
+        expect(yield* Ref.get(testRuntime.closes)).toBe(1);
+      }),
+    ).pipe(Effect.provideService(OpenCodeRuntime, testRuntime.runtime));
+  }).pipe(Effect.provide(TestClock.layer())),
+);

--- a/apps/server/src/provider/OpenCodeServerOwner.test.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.test.ts
@@ -12,7 +12,7 @@ import {
   OpenCodeRuntimeError,
   type OpenCodeRuntimeShape,
 } from "./opencodeRuntime.ts";
-import { makeOpenCodeServerOwner } from "./OpenCodeServerOwner.ts";
+import * as OpenCodeServerOwner from "./OpenCodeServerOwner.ts";
 
 const unusedRuntimeMethod = () =>
   Effect.fail(
@@ -62,7 +62,7 @@ it.effect("shares concurrent borrowers and closes after the idle TTL", () =>
     const release = yield* Deferred.make<void>();
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
         const useServer = owner.withServer((server) =>
           Deferred.await(release).pipe(Effect.as(server.url)),
         );
@@ -87,7 +87,7 @@ it.effect("retries a failed start and closes on owner scope shutdown", () =>
     yield* Ref.set(testRuntime.failNextStart, true);
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
         expect(
           (yield* Effect.exit(owner.withServer((server) => Effect.succeed(server.url))))._tag,
         ).toBe("Failure");
@@ -126,7 +126,7 @@ it.effect("invalidates an exited process so the next borrower starts a new one",
 
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
         expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
           "http://127.0.0.1:1",
         );
@@ -170,7 +170,7 @@ it.effect("cleans up an interrupted startup and allows a retry", () =>
 
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
         const firstBorrower = yield* owner
           .withServer((server) => Effect.succeed(server.url))
           .pipe(Effect.forkChild);
@@ -191,7 +191,7 @@ it.effect("releases an interrupted borrower and closes after the idle TTL", () =
     const borrowerEntered = yield* Deferred.make<void>();
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* makeOpenCodeServerOwner({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
         const borrower = yield* owner
           .withServer(() =>
             Deferred.succeed(borrowerEntered, undefined).pipe(Effect.andThen(Effect.never)),

--- a/apps/server/src/provider/OpenCodeServerOwner.test.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.test.ts
@@ -45,7 +45,11 @@ const makeRuntime = Effect.gen(function* () {
             Effect.ignore,
           ),
         );
-        return { url: `http://127.0.0.1:${index}`, exitCode: Effect.never };
+        return {
+          url: `http://127.0.0.1:${index}`,
+          isRunning: Effect.succeed(true),
+          exitCode: Effect.never,
+        };
       }),
     connectToOpenCodeServer: unusedRuntimeMethod,
     runOpenCodeCommand: unusedRuntimeMethod,
@@ -115,7 +119,11 @@ it.effect("invalidates an exited process so the next borrower starts a new one",
           yield* Effect.addFinalizer(() =>
             Deferred.succeed(processClosed, undefined).pipe(Effect.ignore),
           );
-          return { url: `http://127.0.0.1:${index}`, exitCode: Deferred.await(exitCode) };
+          return {
+            url: `http://127.0.0.1:${index}`,
+            isRunning: Effect.succeed(true),
+            exitCode: Deferred.await(exitCode),
+          };
         }),
       connectToOpenCodeServer: unusedRuntimeMethod,
       runOpenCodeCommand: unusedRuntimeMethod,
@@ -141,6 +149,49 @@ it.effect("invalidates an exited process so the next borrower starts a new one",
   }),
 );
 
+it.effect("replaces a dead cached process before its exit watcher runs", () =>
+  Effect.gen(function* () {
+    const starts = yield* Ref.make(0);
+    const closes = yield* Ref.make(0);
+    const processRunning: Array<Ref.Ref<boolean>> = [];
+    const runtime: OpenCodeRuntimeShape = {
+      startOpenCodeServerProcess: () =>
+        Effect.gen(function* () {
+          const index = yield* Ref.updateAndGet(starts, (count) => count + 1);
+          const isRunning = yield* Ref.make(true);
+          processRunning.push(isRunning);
+          yield* Effect.addFinalizer(() => Ref.update(closes, (count) => count + 1));
+          return {
+            url: `http://127.0.0.1:${index}`,
+            isRunning: Ref.get(isRunning),
+            exitCode: Effect.never,
+          };
+        }),
+      connectToOpenCodeServer: unusedRuntimeMethod,
+      runOpenCodeCommand: unusedRuntimeMethod,
+      createOpenCodeSdkClient: () => ({}) as never,
+      loadOpenCodeInventory: unusedRuntimeMethod,
+      loadInventoryFromCli: unusedRuntimeMethod,
+    };
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
+          "http://127.0.0.1:1",
+        );
+        yield* Ref.set(processRunning[0]!, false);
+
+        expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
+          "http://127.0.0.1:2",
+        );
+        expect(yield* Ref.get(starts)).toBe(2);
+        expect(yield* Ref.get(closes)).toBe(1);
+      }),
+    ).pipe(Effect.provideService(OpenCodeRuntime, runtime));
+  }),
+);
+
 it.effect("cleans up an interrupted startup and allows a retry", () =>
   Effect.gen(function* () {
     const starts = yield* Ref.make(0);
@@ -159,7 +210,11 @@ it.effect("cleans up an interrupted startup and allows a retry", () =>
             yield* Deferred.succeed(firstStartEntered, undefined);
             return yield* Effect.never;
           }
-          return { url: `http://127.0.0.1:${index}`, exitCode: Effect.never };
+          return {
+            url: `http://127.0.0.1:${index}`,
+            isRunning: Effect.succeed(true),
+            exitCode: Effect.never,
+          };
         }),
       connectToOpenCodeServer: unusedRuntimeMethod,
       runOpenCodeCommand: unusedRuntimeMethod,

--- a/apps/server/src/provider/OpenCodeServerOwner.test.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.test.ts
@@ -47,6 +47,7 @@ const makeRuntime = Effect.gen(function* () {
         );
         return {
           url: `http://127.0.0.1:${index}`,
+          version: "1.14.19",
           isRunning: Effect.succeed(true),
           exitCode: Effect.never,
         };
@@ -66,7 +67,10 @@ it.effect("shares concurrent borrowers and closes after the idle TTL", () =>
     const release = yield* Deferred.make<void>();
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({
+          binaryPath: "opencode",
+          directory: "/project",
+        });
         const useServer = owner.withServer((server) =>
           Deferred.await(release).pipe(Effect.as(server.url)),
         );
@@ -91,7 +95,10 @@ it.effect("retries a failed start and closes on owner scope shutdown", () =>
     yield* Ref.set(testRuntime.failNextStart, true);
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({
+          binaryPath: "opencode",
+          directory: "/project",
+        });
         expect(
           (yield* Effect.exit(owner.withServer((server) => Effect.succeed(server.url))))._tag,
         ).toBe("Failure");
@@ -121,6 +128,7 @@ it.effect("invalidates an exited process so the next borrower starts a new one",
           );
           return {
             url: `http://127.0.0.1:${index}`,
+            version: "1.14.19",
             isRunning: Effect.succeed(true),
             exitCode: Deferred.await(exitCode),
           };
@@ -134,7 +142,10 @@ it.effect("invalidates an exited process so the next borrower starts a new one",
 
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({
+          binaryPath: "opencode",
+          directory: "/project",
+        });
         expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
           "http://127.0.0.1:1",
         );
@@ -163,6 +174,7 @@ it.effect("replaces a dead cached process before its exit watcher runs", () =>
           yield* Effect.addFinalizer(() => Ref.update(closes, (count) => count + 1));
           return {
             url: `http://127.0.0.1:${index}`,
+            version: "1.14.19",
             isRunning: Ref.get(isRunning),
             exitCode: Effect.never,
           };
@@ -176,7 +188,10 @@ it.effect("replaces a dead cached process before its exit watcher runs", () =>
 
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({
+          binaryPath: "opencode",
+          directory: "/project",
+        });
         expect(yield* owner.withServer((server) => Effect.succeed(server.url))).toBe(
           "http://127.0.0.1:1",
         );
@@ -212,6 +227,7 @@ it.effect("cleans up an interrupted startup and allows a retry", () =>
           }
           return {
             url: `http://127.0.0.1:${index}`,
+            version: "1.14.19",
             isRunning: Effect.succeed(true),
             exitCode: Effect.never,
           };
@@ -225,7 +241,10 @@ it.effect("cleans up an interrupted startup and allows a retry", () =>
 
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({
+          binaryPath: "opencode",
+          directory: "/project",
+        });
         const firstBorrower = yield* owner
           .withServer((server) => Effect.succeed(server.url))
           .pipe(Effect.forkChild);
@@ -246,7 +265,10 @@ it.effect("releases an interrupted borrower and closes after the idle TTL", () =
     const borrowerEntered = yield* Deferred.make<void>();
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const owner = yield* OpenCodeServerOwner.make({ binaryPath: "opencode" });
+        const owner = yield* OpenCodeServerOwner.make({
+          binaryPath: "opencode",
+          directory: "/project",
+        });
         const borrower = yield* owner
           .withServer(() =>
             Deferred.succeed(borrowerEntered, undefined).pipe(Effect.andThen(Effect.never)),

--- a/apps/server/src/provider/OpenCodeServerOwner.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.ts
@@ -1,0 +1,167 @@
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+
+import {
+  OpenCodeRuntime,
+  type OpenCodeRuntimeError,
+  type OpenCodeServerProcess,
+} from "./opencodeRuntime.ts";
+
+export const OPENCODE_SERVER_IDLE_TTL = "30 seconds";
+
+interface OpenCodeServerOwnerState {
+  server: OpenCodeServerProcess | null;
+  serverScope: Scope.Closeable | null;
+  borrowers: number;
+  idleCloseFiber: Fiber.Fiber<void, never> | null;
+}
+
+export interface OpenCodeServerOwner {
+  readonly withServer: <A, E, R>(
+    use: (server: OpenCodeServerProcess) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | OpenCodeRuntimeError, R>;
+}
+
+/** Owns the lazy local OpenCode server shared by one provider instance. */
+export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(function* (input: {
+  readonly binaryPath: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}) {
+  const runtime = yield* OpenCodeRuntime;
+  const ownerScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+    Scope.close(scope, Exit.void),
+  );
+  const mutex = yield* Semaphore.make(1);
+  const state: OpenCodeServerOwnerState = {
+    server: null,
+    serverScope: null,
+    borrowers: 0,
+    idleCloseFiber: null,
+  };
+
+  const cancelIdleClose = Effect.fn("OpenCodeServerOwner.cancelIdleClose")(function* () {
+    const fiber = state.idleCloseFiber;
+    state.idleCloseFiber = null;
+    if (fiber !== null) {
+      yield* Fiber.interrupt(fiber).pipe(Effect.ignore);
+    }
+  });
+
+  const closeServer = Effect.fn("OpenCodeServerOwner.closeServer")(function* (
+    expected?: OpenCodeServerProcess,
+  ) {
+    if (expected !== undefined && state.server !== expected) {
+      return;
+    }
+    const scope = state.serverScope;
+    state.server = null;
+    state.serverScope = null;
+    if (scope !== null) {
+      yield* Scope.close(scope, Exit.void).pipe(Effect.ignore);
+    }
+  });
+
+  const watchServerExit = Effect.fn("OpenCodeServerOwner.watchServerExit")(function* (
+    server: OpenCodeServerProcess,
+  ) {
+    yield* server.exitCode;
+    yield* mutex.withPermit(
+      Effect.gen(function* () {
+        if (state.server !== server) {
+          return;
+        }
+        yield* cancelIdleClose();
+        yield* closeServer(server);
+      }),
+    );
+  });
+
+  const acquireServer = mutex.withPermit(
+    Effect.gen(function* () {
+      yield* cancelIdleClose();
+      if (state.server !== null) {
+        state.borrowers += 1;
+        return state.server;
+      }
+
+      return yield* Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const serverScope = yield* Scope.make();
+          const started = yield* Effect.exit(
+            restore(
+              runtime
+                .startOpenCodeServerProcess({
+                  binaryPath: input.binaryPath,
+                  ...(input.environment ? { environment: input.environment } : {}),
+                })
+                .pipe(Effect.provideService(Scope.Scope, serverScope)),
+            ),
+          );
+          if (Exit.isFailure(started)) {
+            yield* Scope.close(serverScope, Exit.void).pipe(Effect.ignore);
+            return yield* Effect.failCause(started.cause);
+          }
+
+          const server = started.value;
+          state.server = server;
+          state.serverScope = serverScope;
+          state.borrowers = 1;
+          yield* watchServerExit(server).pipe(Effect.forkIn(ownerScope));
+          return server;
+        }),
+      );
+    }),
+  );
+
+  const releaseServer = (server: OpenCodeServerProcess) =>
+    mutex.withPermit(
+      Effect.gen(function* () {
+        if (state.server !== server) {
+          return;
+        }
+        state.borrowers = Math.max(0, state.borrowers - 1);
+        if (state.borrowers > 0) {
+          return;
+        }
+        yield* cancelIdleClose();
+        state.idleCloseFiber = yield* Effect.sleep(OPENCODE_SERVER_IDLE_TTL).pipe(
+          Effect.andThen(
+            mutex.withPermit(
+              Effect.gen(function* () {
+                if (state.server !== server || state.borrowers > 0) {
+                  return;
+                }
+                state.idleCloseFiber = null;
+                yield* closeServer(server);
+              }),
+            ),
+          ),
+          Effect.forkIn(ownerScope),
+        );
+      }),
+    );
+
+  yield* Effect.addFinalizer(() =>
+    mutex.withPermit(
+      Effect.gen(function* () {
+        yield* cancelIdleClose();
+        state.borrowers = 0;
+        yield* closeServer();
+      }),
+    ),
+  );
+
+  return {
+    withServer: (use) =>
+      Effect.uninterruptibleMask((restore) =>
+        restore(acquireServer).pipe(
+          Effect.flatMap((server) =>
+            restore(use(server)).pipe(Effect.ensuring(releaseServer(server))),
+          ),
+        ),
+      ),
+  } satisfies OpenCodeServerOwner;
+});

--- a/apps/server/src/provider/OpenCodeServerOwner.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.ts
@@ -1,36 +1,37 @@
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 
-import {
-  OpenCodeRuntime,
-  type OpenCodeRuntimeError,
-  type OpenCodeServerProcess,
-} from "./opencodeRuntime.ts";
+import * as OpenCodeRuntime from "./opencodeRuntime.ts";
 
 export const OPENCODE_SERVER_IDLE_TTL = "30 seconds";
 
 interface OpenCodeServerOwnerState {
-  server: OpenCodeServerProcess | null;
+  server: OpenCodeRuntime.OpenCodeServerProcess | null;
   serverScope: Scope.Closeable | null;
   borrowers: number;
   idleCloseFiber: Fiber.Fiber<void, never> | null;
 }
 
-export interface OpenCodeServerOwner {
-  readonly withServer: <A, E, R>(
-    use: (server: OpenCodeServerProcess) => Effect.Effect<A, E, R>,
-  ) => Effect.Effect<A, E | OpenCodeRuntimeError, R>;
-}
+export class OpenCodeServerOwner extends Context.Service<
+  OpenCodeServerOwner,
+  {
+    readonly withServer: <A, E, R>(
+      use: (server: OpenCodeRuntime.OpenCodeServerProcess) => Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | OpenCodeRuntime.OpenCodeRuntimeError, R>;
+  }
+>()("t3/provider/OpenCodeServerOwner") {}
 
 /** Owns the lazy local OpenCode server shared by one provider instance. */
-export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(function* (input: {
+export const make = Effect.fn("OpenCodeServerOwner.make")(function* (input: {
   readonly binaryPath: string;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
-  const runtime = yield* OpenCodeRuntime;
+  const runtime = yield* OpenCodeRuntime.OpenCodeRuntime;
   const ownerScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
     Scope.close(scope, Exit.void),
   );
@@ -51,7 +52,7 @@ export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(func
   });
 
   const closeServer = Effect.fn("OpenCodeServerOwner.closeServer")(function* (
-    expected?: OpenCodeServerProcess,
+    expected?: OpenCodeRuntime.OpenCodeServerProcess,
   ) {
     if (expected !== undefined && state.server !== expected) {
       return;
@@ -65,7 +66,7 @@ export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(func
   });
 
   const watchServerExit = Effect.fn("OpenCodeServerOwner.watchServerExit")(function* (
-    server: OpenCodeServerProcess,
+    server: OpenCodeRuntime.OpenCodeServerProcess,
   ) {
     yield* server.exitCode;
     yield* mutex.withPermit(
@@ -116,7 +117,7 @@ export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(func
     }),
   );
 
-  const releaseServer = (server: OpenCodeServerProcess) =>
+  const releaseServer = (server: OpenCodeRuntime.OpenCodeServerProcess) =>
     mutex.withPermit(
       Effect.gen(function* () {
         if (state.server !== server) {
@@ -154,7 +155,7 @@ export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(func
     ),
   );
 
-  return {
+  return OpenCodeServerOwner.of({
     withServer: (use) =>
       Effect.uninterruptibleMask((restore) =>
         restore(acquireServer).pipe(
@@ -163,5 +164,10 @@ export const makeOpenCodeServerOwner = Effect.fn("makeOpenCodeServerOwner")(func
           ),
         ),
       ),
-  } satisfies OpenCodeServerOwner;
+  });
 });
+
+export const layer = (input: {
+  readonly binaryPath: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}) => Layer.effect(OpenCodeServerOwner, make(input));

--- a/apps/server/src/provider/OpenCodeServerOwner.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.ts
@@ -84,8 +84,11 @@ export const make = Effect.fn("OpenCodeServerOwner.make")(function* (input: {
     Effect.gen(function* () {
       yield* cancelIdleClose();
       if (state.server !== null) {
-        state.borrowers += 1;
-        return state.server;
+        if (yield* state.server.isRunning) {
+          state.borrowers += 1;
+          return state.server;
+        }
+        yield* closeServer(state.server);
       }
 
       return yield* Effect.uninterruptibleMask((restore) =>

--- a/apps/server/src/provider/OpenCodeServerOwner.ts
+++ b/apps/server/src/provider/OpenCodeServerOwner.ts
@@ -29,6 +29,8 @@ export class OpenCodeServerOwner extends Context.Service<
 /** Owns the lazy local OpenCode server shared by one provider instance. */
 export const make = Effect.fn("OpenCodeServerOwner.make")(function* (input: {
   readonly binaryPath: string;
+  readonly directory: string;
+  readonly serverPassword?: string;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   const runtime = yield* OpenCodeRuntime.OpenCodeRuntime;
@@ -99,6 +101,10 @@ export const make = Effect.fn("OpenCodeServerOwner.make")(function* (input: {
               runtime
                 .startOpenCodeServerProcess({
                   binaryPath: input.binaryPath,
+                  directory: input.directory,
+                  ...(input.serverPassword !== undefined
+                    ? { serverPassword: input.serverPassword }
+                    : {}),
                   ...(input.environment ? { environment: input.environment } : {}),
                 })
                 .pipe(Effect.provideService(Scope.Scope, serverScope)),
@@ -172,5 +178,7 @@ export const make = Effect.fn("OpenCodeServerOwner.make")(function* (input: {
 
 export const layer = (input: {
   readonly binaryPath: string;
+  readonly directory: string;
+  readonly serverPassword?: string;
   readonly environment?: NodeJS.ProcessEnv;
 }) => Layer.effect(OpenCodeServerOwner, make(input));

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -36,7 +36,10 @@ export interface ProviderRegistryShape {
    *
    * @deprecated prefer `refreshInstance` for new call sites.
    */
-  readonly refresh: (provider?: ProviderDriverKind) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+  readonly refresh: (
+    provider?: ProviderDriverKind,
+    options?: { readonly exclude?: ReadonlySet<ProviderDriverKind> },
+  ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
 
   /**
    * Refresh the specific configured instance. Returns the updated snapshot

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -36,10 +36,7 @@ export interface ProviderRegistryShape {
    *
    * @deprecated prefer `refreshInstance` for new call sites.
    */
-  readonly refresh: (
-    provider?: ProviderDriverKind,
-    options?: { readonly exclude?: ReadonlySet<ProviderDriverKind> },
-  ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+  readonly refresh: (provider?: ProviderDriverKind) => Effect.Effect<ReadonlyArray<ServerProvider>>;
 
   /**
    * Refresh the specific configured instance. Returns the updated snapshot

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -355,6 +355,41 @@ describe("makeManagedServerProvider", () => {
     ).pipe(Effect.provide(AlwaysRunTestLayer)),
   );
 
+  it.effect("can update settings and disable periodic checks without probing again", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settingsChanges = yield* PubSub.unbounded<TestSettings>();
+        const checkCalls = yield* Ref.make(0);
+        const initialCheckDone = yield* Deferred.make<void>();
+        const enrichmentCalls = yield* Ref.make(0);
+        yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.fromPubSub(settingsChanges),
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          checkProviderOnSettingsChange: () => false,
+          refreshOnInterval: false,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+            Effect.tap(() => Deferred.succeed(initialCheckDone, undefined).pipe(Effect.ignore)),
+            Effect.as(refreshedSnapshot),
+          ),
+          enrichSnapshot: () => Ref.update(enrichmentCalls, (count) => count + 1),
+          refreshInterval: "1 second",
+        });
+
+        yield* Deferred.await(initialCheckDone);
+        yield* PubSub.publish(settingsChanges, { enabled: false });
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("1 second");
+        yield* Effect.yieldNow;
+
+        assert.strictEqual(yield* Ref.get(checkCalls), 1);
+        assert.strictEqual(yield* Ref.get(enrichmentCalls), 2);
+      }),
+    ).pipe(Effect.provide(Layer.mergeAll(AlwaysRunTestLayer, TestClock.layer()))),
+  );
+
   it.effect("streams supplemental snapshot updates after the base provider check completes", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -250,6 +250,40 @@ describe("makeManagedServerProvider", () => {
     ).pipe(Effect.provide(Layer.mergeAll(AlwaysRunTestLayer, TestClock.layer()))),
   );
 
+  it.effect("keeps manual refresh when interval refresh is disabled", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const checkCalls = yield* Ref.make(0);
+        const initialCheckDone = yield* Deferred.make<void>();
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              count === 1
+                ? Deferred.succeed(initialCheckDone, undefined).pipe(Effect.ignore)
+                : Effect.void,
+            ),
+            Effect.as(refreshedSnapshot),
+          ),
+          refreshInterval: "1 second",
+          refreshOnInterval: false,
+        });
+
+        yield* Deferred.await(initialCheckDone);
+        yield* TestClock.adjust("5 minutes");
+        yield* Effect.yieldNow;
+        assert.strictEqual(yield* Ref.get(checkCalls), 1);
+
+        yield* provider.refresh;
+        assert.strictEqual(yield* Ref.get(checkCalls), 2);
+      }),
+    ).pipe(Effect.provide(Layer.mergeAll(AlwaysRunTestLayer, TestClock.layer()))),
+  );
+
   it.effect("wakes a sleeping provider refresh loop when its interval changes", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -40,6 +40,8 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
   }) => Effect.Effect<void>;
   readonly refreshInterval?: Duration.Input;
+  readonly refreshOnInterval?: boolean;
+  readonly checkProviderOnSettingsChange?: (previous: Settings, next: Settings) => boolean;
 }): Effect.fn.Return<
   ServerProviderShape,
   ServerSettingsError,
@@ -121,6 +123,21 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
       return yield* Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot));
     }
 
+    if (
+      !forceRefresh &&
+      input.checkProviderOnSettingsChange?.(previousSettings, nextSettings) === false
+    ) {
+      const state = yield* Ref.get(snapshotStateRef);
+      const nextGeneration = state.enrichmentGeneration + 1;
+      yield* Ref.set(snapshotStateRef, {
+        ...state,
+        enrichmentGeneration: nextGeneration,
+      });
+      yield* Ref.set(settingsRef, nextSettings);
+      yield* restartSnapshotEnrichment(nextSettings, state.snapshot, nextGeneration);
+      return state.snapshot;
+    }
+
     const nextSnapshot = yield* input.checkProvider;
     const nextGeneration = yield* Ref.modify(snapshotStateRef, (state) => {
       const generation = input.enrichSnapshot
@@ -199,7 +216,9 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
           Queue.take(refreshIntervalChanges).pipe(Effect.as(false)),
         ).pipe(
           Effect.flatMap((intervalElapsed) =>
-            intervalElapsed && Duration.toMillis(Duration.fromInputUnsafe(refreshInterval)) > 0
+            input.refreshOnInterval !== false &&
+            intervalElapsed &&
+            Duration.toMillis(Duration.fromInputUnsafe(refreshInterval)) > 0
               ? hasProviderStatusDemand.pipe(
                   Effect.flatMap((shouldRefresh) =>
                     shouldRefresh ? refreshSnapshot().pipe(Effect.asVoid) : Effect.void,

--- a/apps/server/src/provider/opencodeRuntime.environment.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.environment.test.ts
@@ -1,6 +1,16 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2";
+import { it as effectIt } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveOpenCodeConfigContent } from "./opencodeRuntime.ts";
+import {
+  OpenCodeRuntimeError,
+  resolveOpenCodeConfigContent,
+  resolveOpenCodeServerPassword,
+  verifyOpenCodeServerVersion,
+} from "./opencodeRuntime.ts";
 
 describe("resolveOpenCodeConfigContent", () => {
   it("prefers the caller environment over the inherited environment", () => {
@@ -20,4 +30,123 @@ describe("resolveOpenCodeConfigContent", () => {
     ).toBe('{"source":"process"}');
     expect(resolveOpenCodeConfigContent(undefined, {})).toBe("{}");
   });
+});
+
+describe("resolveOpenCodeServerPassword", () => {
+  it("uses the local environment password when settings do not provide one", () => {
+    expect(
+      resolveOpenCodeServerPassword(
+        { external: false, environment: { OPENCODE_SERVER_PASSWORD: " env password " } },
+        {},
+      ),
+    ).toBe(" env password ");
+  });
+
+  it("uses the settings password for a local server", () => {
+    expect(
+      resolveOpenCodeServerPassword({ external: false, serverPassword: " settings password " }, {}),
+    ).toBe(" settings password ");
+  });
+
+  it("uses the settings password when local settings and environment differ", () => {
+    expect(
+      resolveOpenCodeServerPassword(
+        {
+          external: false,
+          serverPassword: "settings-password",
+          environment: { OPENCODE_SERVER_PASSWORD: "environment-password" },
+        },
+        {},
+      ),
+    ).toBe("settings-password");
+  });
+
+  it("does not send an inherited local password to an external server", () => {
+    expect(
+      resolveOpenCodeServerPassword(
+        { external: true, environment: { OPENCODE_SERVER_PASSWORD: "local-secret" } },
+        { OPENCODE_SERVER_PASSWORD: "inherited-secret" },
+      ),
+    ).toBeUndefined();
+  });
+});
+
+function makeHealthClient(
+  result: (options?: { readonly signal?: AbortSignal }) => Promise<unknown>,
+): OpencodeClient {
+  return {
+    global: {
+      health: result,
+    },
+  } as unknown as OpencodeClient;
+}
+
+describe("verifyOpenCodeServerVersion", () => {
+  effectIt.effect("accepts a supported server version", () =>
+    Effect.gen(function* () {
+      const version = yield* verifyOpenCodeServerVersion(
+        makeHealthClient(() => Promise.resolve({ data: { healthy: true, version: "1.14.19" } })),
+      );
+      expect(version).toBe("1.14.19");
+    }),
+  );
+
+  effectIt.effect("rejects a server below the supported version", () =>
+    Effect.gen(function* () {
+      const error = yield* verifyOpenCodeServerVersion(
+        makeHealthClient(() => Promise.resolve({ data: { healthy: true, version: "1.14.18" } })),
+      ).pipe(Effect.flip);
+      expect(error).toBeInstanceOf(OpenCodeRuntimeError);
+      expect(error.detail).toContain("v1.14.18 is too old");
+    }),
+  );
+
+  for (const data of [
+    { healthy: true },
+    { healthy: true, version: "not-a-version" },
+    { healthy: false, version: "1.14.19" },
+  ]) {
+    effectIt.effect(`rejects an invalid health response: ${JSON.stringify(data)}`, () =>
+      Effect.gen(function* () {
+        const error = yield* verifyOpenCodeServerVersion(
+          makeHealthClient(() => Promise.resolve({ data })),
+        ).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(OpenCodeRuntimeError);
+        expect(error.detail).toContain("requires OpenCode v1.14.19 or newer");
+      }),
+    );
+  }
+
+  effectIt.effect("preserves an unauthorized health error", () =>
+    Effect.gen(function* () {
+      const error = yield* verifyOpenCodeServerVersion(
+        makeHealthClient(() =>
+          Promise.reject({ response: { status: 401 }, error: { message: "Unauthorized" } }),
+        ),
+      ).pipe(Effect.flip);
+      expect(error).toBeInstanceOf(OpenCodeRuntimeError);
+      expect(error.detail).toContain("status=401");
+      expect(error.detail).toContain("Unauthorized");
+    }),
+  );
+
+  effectIt.effect("aborts a health request when the version check times out", () =>
+    Effect.gen(function* () {
+      let requestSignal: AbortSignal | undefined;
+      const checkFiber = yield* verifyOpenCodeServerVersion(
+        makeHealthClient((options) => {
+          requestSignal = options?.signal;
+          return new Promise(() => undefined);
+        }),
+      ).pipe(Effect.flip, Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      expect(requestSignal).toBeDefined();
+      yield* TestClock.adjust("6 seconds");
+
+      const error = yield* Fiber.join(checkFiber);
+      expect(error.detail).toBe("Timed out while checking the OpenCode server version.");
+      expect(requestSignal?.aborted).toBe(true);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
 });

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -18,6 +18,34 @@ import { OpenCodeRuntime, OpenCodeRuntimeLive } from "./opencodeRuntime.ts";
 const testLayer = OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer));
 
 it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
+  it.effect("keeps provider inventory when agent discovery fails", () =>
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const client = {
+        provider: {
+          list: () =>
+            Promise.resolve({
+              data: {
+                connected: ["openai"],
+                all: [],
+                default: {},
+              },
+            }),
+        },
+        app: {
+          agents: () => Promise.reject(new Error("agents endpoint unavailable")),
+          skills: () => Promise.resolve({ data: [] }),
+        },
+      } as unknown as OpencodeClient;
+
+      const inventory = yield* runtime.loadOpenCodeInventory(client);
+
+      NodeAssert.deepEqual(inventory.providerList.connected, ["openai"]);
+      NodeAssert.deepEqual(inventory.agents, []);
+      NodeAssert.deepEqual(inventory.skills, []);
+    }),
+  );
+
   it.effect("keeps provider inventory when skill discovery fails", () =>
     Effect.gen(function* () {
       const runtime = yield* OpenCodeRuntime;

--- a/apps/server/src/provider/opencodeRuntime.permissions.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.permissions.test.ts
@@ -39,6 +39,7 @@ describe("buildOpenCodePermissionRules", () => {
   it("allows everything only under full access", () => {
     NodeAssert.deepEqual(buildOpenCodePermissionRules("full-access"), [
       { permission: "*", pattern: "*", action: "allow" },
+      { permission: "external_directory", pattern: "*", action: "allow" },
     ]);
   });
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -97,7 +97,7 @@ export function openCodeRuntimeErrorDetail(cause: unknown): string {
 
 export const runOpenCodeSdk = <A>(
   operation: string,
-  fn: () => Promise<A>,
+  fn: (signal: AbortSignal) => Promise<A>,
 ): Effect.Effect<A, OpenCodeRuntimeError> =>
   Effect.tryPromise({
     try: fn,

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -398,7 +398,10 @@ export function toOpenCodeFileParts(input: {
 
 export function buildOpenCodePermissionRules(runtimeMode: RuntimeMode): PermissionRuleset {
   if (runtimeMode === "full-access") {
-    return [{ permission: "*", pattern: "*", action: "allow" }];
+    return [
+      { permission: "*", pattern: "*", action: "allow" },
+      { permission: "external_directory", pattern: "*", action: "allow" },
+    ];
   }
 
   // "Auto-accept edits" is documented as "auto-approve edits, ask before other

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -54,6 +54,7 @@ const DEFAULT_HOSTNAME = "127.0.0.1";
 const OPENCODE_SKILL_DISCOVERY_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 export interface OpenCodeServerProcess {
   readonly url: string;
+  readonly isRunning: Effect.Effect<boolean>;
   readonly exitCode: Effect.Effect<number, never>;
 }
 
@@ -675,6 +676,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
 
       return {
         url: readyOption.value,
+        isRunning: child.isRunning.pipe(Effect.orElseSucceed(() => false)),
         exitCode: child.exitCode.pipe(
           Effect.map(Number),
           Effect.orElseSucceed(() => 0),

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -741,6 +741,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
   const loadAgents = (client: OpencodeClient) =>
     runOpenCodeSdk("app.agents", () => client.app.agents()).pipe(
       Effect.map((result) => result.data ?? []),
+      Effect.orElseSucceed((): ReadonlyArray<Agent> => []),
     );
 
   const loadSkills = (client: OpencodeClient) =>

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -33,9 +33,19 @@ import { isWindowsCommandNotFound } from "../processRunner.ts";
 import { collectStreamAsString } from "./providerSnapshot.ts";
 import * as NetService from "@t3tools/shared/Net";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { compareSemverVersions, parseSemver } from "@t3tools/shared/semver";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
+
+export const MINIMUM_OPENCODE_VERSION = "1.14.19";
+const OPENCODE_HEALTH_TIMEOUT = "5 seconds";
+
+const OpenCodeHealthSchema = Schema.Struct({
+  healthy: Schema.Literal(true),
+  version: Schema.String,
+});
+const decodeOpenCodeHealth = Schema.decodeUnknownEffect(OpenCodeHealthSchema);
 
 export function resolveOpenCodeConfigContent(
   inputEnvironment: Readonly<Record<string, string | undefined>> | undefined,
@@ -48,18 +58,41 @@ export function resolveOpenCodeConfigContent(
   );
 }
 
+export function resolveOpenCodeServerPassword(
+  input: {
+    readonly external: boolean;
+    readonly serverPassword?: string;
+    readonly environment?: Readonly<Record<string, string | undefined>>;
+  },
+  inheritedEnvironment: Readonly<Record<string, string | undefined>> = process.env,
+): string | undefined {
+  if (input.serverPassword !== undefined) {
+    return input.serverPassword;
+  }
+  if (input.external) {
+    return undefined;
+  }
+  return input.environment === undefined
+    ? inheritedEnvironment.OPENCODE_SERVER_PASSWORD
+    : input.environment.OPENCODE_SERVER_PASSWORD;
+}
+
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
 const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 30_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 const OPENCODE_SKILL_DISCOVERY_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 export interface OpenCodeServerProcess {
   readonly url: string;
+  readonly serverPassword?: string;
+  readonly version: string;
   readonly isRunning: Effect.Effect<boolean>;
   readonly exitCode: Effect.Effect<number, never>;
 }
 
 export interface OpenCodeServerConnection {
   readonly url: string;
+  readonly serverPassword?: string;
+  readonly version: string;
   readonly exitCode: Effect.Effect<number, never> | null;
   readonly external: boolean;
 }
@@ -105,6 +138,44 @@ export const runOpenCodeSdk = <A>(
       new OpenCodeRuntimeError({ operation, detail: openCodeRuntimeErrorDetail(cause), cause }),
   }).pipe(Effect.withSpan(`opencode.${operation}`));
 
+export const verifyOpenCodeServerVersion = Effect.fn("verifyOpenCodeServerVersion")(function* (
+  client: OpencodeClient,
+) {
+  const healthOption = yield* runOpenCodeSdk("global.health", (signal) =>
+    client.global.health({ signal }),
+  ).pipe(Effect.timeoutOption(OPENCODE_HEALTH_TIMEOUT));
+  if (Option.isNone(healthOption)) {
+    return yield* new OpenCodeRuntimeError({
+      operation: "global.health",
+      detail: "Timed out while checking the OpenCode server version.",
+    });
+  }
+
+  const health = yield* decodeOpenCodeHealth(healthOption.value.data).pipe(
+    Effect.mapError(
+      (cause) =>
+        new OpenCodeRuntimeError({
+          operation: "global.health",
+          detail: `OpenCode server returned an invalid health response. T3 Code requires OpenCode v${MINIMUM_OPENCODE_VERSION} or newer.`,
+          cause,
+        }),
+    ),
+  );
+  if (parseSemver(health.version) === null) {
+    return yield* new OpenCodeRuntimeError({
+      operation: "global.health",
+      detail: `OpenCode server returned an invalid version. T3 Code requires OpenCode v${MINIMUM_OPENCODE_VERSION} or newer.`,
+    });
+  }
+  if (compareSemverVersions(health.version, MINIMUM_OPENCODE_VERSION) < 0) {
+    return yield* new OpenCodeRuntimeError({
+      operation: "global.health",
+      detail: `OpenCode v${health.version} is too old. Upgrade to v${MINIMUM_OPENCODE_VERSION} or newer.`,
+    });
+  }
+  return health.version;
+});
+
 export interface OpenCodeCommandResult {
   readonly stdout: string;
   readonly stderr: string;
@@ -146,6 +217,8 @@ export interface OpenCodeRuntimeShape {
    */
   readonly startOpenCodeServerProcess: (input: {
     readonly binaryPath: string;
+    readonly directory: string;
+    readonly serverPassword?: string;
     readonly environment?: NodeJS.ProcessEnv;
     readonly port?: number;
     readonly hostname?: string;
@@ -158,7 +231,9 @@ export interface OpenCodeRuntimeShape {
    */
   readonly connectToOpenCodeServer: (input: {
     readonly binaryPath: string;
+    readonly directory: string;
     readonly serverUrl?: string | null;
+    readonly serverPassword?: string;
     readonly environment?: NodeJS.ProcessEnv;
     readonly port?: number;
     readonly hostname?: string;
@@ -518,6 +593,20 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       ),
     );
 
+  const createOpenCodeSdkClient: OpenCodeRuntimeShape["createOpenCodeSdkClient"] = (input) =>
+    createOpencodeClient({
+      baseUrl: input.baseUrl,
+      directory: input.directory,
+      ...(input.serverPassword
+        ? {
+            headers: {
+              Authorization: `Basic ${Buffer.from(`opencode:${input.serverPassword}`, "utf8").toString("base64")}`,
+            },
+          }
+        : {}),
+      throwOnError: true,
+    });
+
   const startOpenCodeServerProcess: OpenCodeRuntimeShape["startOpenCodeServerProcess"] = (input) =>
     Effect.gen(function* () {
       // Bind this server's lifetime to the caller's scope. When the caller's
@@ -541,6 +630,11 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const timeoutMs = input.timeoutMs ?? DEFAULT_OPENCODE_SERVER_TIMEOUT_MS;
       const args = ["serve", `--hostname=${hostname}`, `--port=${port}`];
       const spawnCommand = yield* resolveCommand(input.binaryPath, args, input.environment);
+      const serverPassword = resolveOpenCodeServerPassword({
+        external: false,
+        ...(input.serverPassword !== undefined ? { serverPassword: input.serverPassword } : {}),
+        ...(input.environment !== undefined ? { environment: input.environment } : {}),
+      });
 
       const child = yield* spawner
         .spawn(
@@ -549,6 +643,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
             shell: spawnCommand.shell,
             env: {
               ...input.environment,
+              ...(serverPassword !== undefined ? { OPENCODE_SERVER_PASSWORD: serverPassword } : {}),
               // Respect an OPENCODE_CONFIG_CONTENT provided by the caller or
               // the inherited process environment, only falling back to the
               // empty config when neither is set. Setting it unconditionally
@@ -674,8 +769,19 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         });
       }
 
+      const url = readyOption.value;
+      const version = yield* verifyOpenCodeServerVersion(
+        createOpenCodeSdkClient({
+          baseUrl: url,
+          directory: input.directory,
+          ...(serverPassword !== undefined ? { serverPassword } : {}),
+        }),
+      );
+
       return {
-        url: readyOption.value,
+        url,
+        ...(serverPassword !== undefined ? { serverPassword } : {}),
+        version,
         isRunning: child.isRunning.pipe(Effect.orElseSucceed(() => false)),
         exitCode: child.exitCode.pipe(
           Effect.map(Number),
@@ -687,16 +793,31 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
   const connectToOpenCodeServer: OpenCodeRuntimeShape["connectToOpenCodeServer"] = (input) => {
     const serverUrl = input.serverUrl?.trim();
     if (serverUrl) {
-      // We don't own externally-configured servers — no scope interaction.
-      return Effect.succeed({
-        url: serverUrl,
-        exitCode: null,
+      const serverPassword = resolveOpenCodeServerPassword({
         external: true,
+        ...(input.serverPassword !== undefined ? { serverPassword: input.serverPassword } : {}),
       });
+      return verifyOpenCodeServerVersion(
+        createOpenCodeSdkClient({
+          baseUrl: serverUrl,
+          directory: input.directory,
+          ...(serverPassword !== undefined ? { serverPassword } : {}),
+        }),
+      ).pipe(
+        Effect.map((version) => ({
+          url: serverUrl,
+          ...(serverPassword !== undefined ? { serverPassword } : {}),
+          version,
+          exitCode: null,
+          external: true,
+        })),
+      );
     }
 
     return startOpenCodeServerProcess({
       binaryPath: input.binaryPath,
+      directory: input.directory,
+      ...(input.serverPassword !== undefined ? { serverPassword: input.serverPassword } : {}),
       ...(input.environment !== undefined ? { environment: input.environment } : {}),
       ...(input.port !== undefined ? { port: input.port } : {}),
       ...(input.hostname !== undefined ? { hostname: input.hostname } : {}),
@@ -704,25 +825,13 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
     }).pipe(
       Effect.map((server) => ({
         url: server.url,
+        ...(server.serverPassword !== undefined ? { serverPassword: server.serverPassword } : {}),
+        version: server.version,
         exitCode: server.exitCode,
         external: false,
       })),
     );
   };
-
-  const createOpenCodeSdkClient: OpenCodeRuntimeShape["createOpenCodeSdkClient"] = (input) =>
-    createOpencodeClient({
-      baseUrl: input.baseUrl,
-      directory: input.directory,
-      ...(input.serverPassword
-        ? {
-            headers: {
-              Authorization: `Basic ${Buffer.from(`opencode:${input.serverPassword}`, "utf8").toString("base64")}`,
-            },
-          }
-        : {}),
-      throwOnError: true,
-    });
 
   const loadProviders = (client: OpencodeClient) =>
     runOpenCodeSdk("provider.list", () => client.provider.list()).pipe(

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4874,28 +4874,22 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  it.effect("skips OpenCode only for the subscribeServerConfig background refresh", () =>
+  it.effect("refreshes providers for each subscribeServerConfig connection", () =>
     Effect.gen(function* () {
-      const refreshCalls = yield* Ref.make<
-        ReadonlyArray<{
-          readonly provider: ProviderDriverKind | undefined;
-          readonly exclude: ReadonlySet<ProviderDriverKind> | undefined;
-        }>
-      >([]);
-      const subscriptionRefreshDone = yield* Deferred.make<void>();
+      const refreshCalls = yield* Ref.make(0);
+      const firstRefreshDone = yield* Deferred.make<void>();
+      const secondRefreshDone = yield* Deferred.make<void>();
 
       yield* buildAppUnderTest({
         layers: {
           providerRegistry: {
-            refresh: (provider, options) =>
-              Ref.update(refreshCalls, (calls) => [
-                ...calls,
-                { provider, exclude: options?.exclude },
-              ]).pipe(
-                Effect.andThen(
-                  options?.exclude
-                    ? Deferred.succeed(subscriptionRefreshDone, undefined).pipe(Effect.ignore)
-                    : Effect.void,
+            refresh: () =>
+              Ref.updateAndGet(refreshCalls, (count) => count + 1).pipe(
+                Effect.tap((count) =>
+                  Deferred.succeed(
+                    count === 1 ? firstRefreshDone : secondRefreshDone,
+                    undefined,
+                  ).pipe(Effect.ignore),
                 ),
                 Effect.as([]),
               ),
@@ -4907,25 +4901,21 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
           Effect.gen(function* () {
-            const snapshotFiber = yield* client[WS_METHODS.subscribeServerConfig]({}).pipe(
-              Stream.runHead,
-              Effect.forkChild,
-            );
-            yield* Deferred.await(subscriptionRefreshDone);
-            yield* client[WS_METHODS.serverRefreshProviders]({});
-            yield* Fiber.join(snapshotFiber);
+            yield* client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.runHead);
+            yield* Deferred.await(firstRefreshDone);
+          }),
+        ),
+      );
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            yield* client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.runHead);
+            yield* Deferred.await(secondRefreshDone);
           }),
         ),
       );
 
-      const calls = yield* Ref.get(refreshCalls);
-      assert.equal(calls.length, 2);
-      assert.equal(calls[0]?.provider, undefined);
-      assert.deepEqual(calls[0]?.exclude ? Array.from(calls[0].exclude) : [], [
-        ProviderDriverKind.make("opencode"),
-      ]);
-      assert.equal(calls[1]?.provider, undefined);
-      assert.equal(calls[1]?.exclude, undefined);
+      assert.equal(yield* Ref.get(refreshCalls), 2);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -56,6 +56,7 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
@@ -4870,6 +4871,61 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         type: "keybindingsUpdated",
         payload: { keybindings: [], issues: [] },
       });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("skips OpenCode only for the subscribeServerConfig background refresh", () =>
+    Effect.gen(function* () {
+      const refreshCalls = yield* Ref.make<
+        ReadonlyArray<{
+          readonly provider: ProviderDriverKind | undefined;
+          readonly exclude: ReadonlySet<ProviderDriverKind> | undefined;
+        }>
+      >([]);
+      const subscriptionRefreshDone = yield* Deferred.make<void>();
+
+      yield* buildAppUnderTest({
+        layers: {
+          providerRegistry: {
+            refresh: (provider, options) =>
+              Ref.update(refreshCalls, (calls) => [
+                ...calls,
+                { provider, exclude: options?.exclude },
+              ]).pipe(
+                Effect.andThen(
+                  options?.exclude
+                    ? Deferred.succeed(subscriptionRefreshDone, undefined).pipe(Effect.ignore)
+                    : Effect.void,
+                ),
+                Effect.as([]),
+              ),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            const snapshotFiber = yield* client[WS_METHODS.subscribeServerConfig]({}).pipe(
+              Stream.runHead,
+              Effect.forkChild,
+            );
+            yield* Deferred.await(subscriptionRefreshDone);
+            yield* client[WS_METHODS.serverRefreshProviders]({});
+            yield* Fiber.join(snapshotFiber);
+          }),
+        ),
+      );
+
+      const calls = yield* Ref.get(refreshCalls);
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0]?.provider, undefined);
+      assert.deepEqual(calls[0]?.exclude ? Array.from(calls[0].exclude) : [], [
+        ProviderDriverKind.make("opencode"),
+      ]);
+      assert.equal(calls[1]?.provider, undefined);
+      assert.equal(calls[1]?.exclude, undefined);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -57,6 +57,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntime.OpenCodeRuntimeShape = {
       );
       return {
         url,
+        isRunning: Effect.succeed(true),
         exitCode: Effect.never,
       };
     }),

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -163,6 +163,10 @@ const OpenCodeTextGenerationExistingServerTestLayer = Layer.succeed(
 const DEFAULT_OPENCODE_SETTINGS = Schema.decodeSync(OpenCodeSettings)({
   binaryPath: "fake-opencode",
 });
+const LOCAL_AUTH_OPENCODE_SETTINGS = Schema.decodeSync(OpenCodeSettings)({
+  binaryPath: "fake-opencode",
+  serverPassword: "secret-password",
+});
 const EXISTING_SERVER_OPENCODE_SETTINGS = Schema.decodeSync(OpenCodeSettings)({
   binaryPath: "fake-opencode",
   serverUrl: "http://127.0.0.1:9999",
@@ -224,6 +228,19 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
         expect(runtimeMock.state.promptParts[0]).toEqual([
           expect.objectContaining({ type: "text" }),
           expect.objectContaining({ type: "file", filename: "screenshot.png" }),
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("passes configured authentication to a locally spawned server", () =>
+    withOpenCodeTextGeneration(LOCAL_AUTH_OPENCODE_SETTINGS, (textGeneration) =>
+      Effect.gen(function* () {
+        yield* textGeneration.generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT);
+
+        expect(runtimeMock.state.startCalls).toEqual(["fake-opencode"]);
+        expect(runtimeMock.state.authHeaders).toEqual([
+          `Basic ${btoa("opencode:secret-password")}`,
         ]);
       }),
     ),

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, expect } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
 import * as OpenCodeRuntime from "../provider/opencodeRuntime.ts";
+import * as OpenCodeServerOwner from "../provider/OpenCodeServerOwner.ts";
 import * as OpenCodeTextGeneration from "./OpenCodeTextGeneration.ts";
 import * as TextGeneration from "./TextGeneration.ts";
 
@@ -178,7 +179,10 @@ function withOpenCodeTextGeneration<A, E, R>(
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
 ) {
   return Effect.gen(function* () {
-    const textGeneration = yield* OpenCodeTextGeneration.makeOpenCodeTextGeneration(settings);
+    const serverOwner = yield* OpenCodeServerOwner.make({ binaryPath: settings.binaryPath });
+    const textGeneration = yield* OpenCodeTextGeneration.makeOpenCodeTextGeneration(settings).pipe(
+      Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
+    );
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
 }

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -22,6 +22,8 @@ const runtimeMock = {
     promptParts: [] as ReadonlyArray<unknown>[],
     authHeaders: [] as Array<string | null>,
     closeCalls: [] as string[],
+    sessionCreateCalls: 0,
+    connectionError: undefined as Error | undefined,
     sessionCreateError: undefined as unknown,
     sessionResult: undefined as { data?: { id: string } } | undefined,
     promptRequestError: undefined as unknown,
@@ -35,6 +37,8 @@ const runtimeMock = {
     this.state.promptParts.length = 0;
     this.state.authHeaders.length = 0;
     this.state.closeCalls.length = 0;
+    this.state.sessionCreateCalls = 0;
+    this.state.connectionError = undefined;
     this.state.sessionCreateError = undefined;
     this.state.sessionResult = undefined;
     this.state.promptRequestError = undefined;
@@ -43,7 +47,7 @@ const runtimeMock = {
 };
 
 const OpenCodeRuntimeTestDouble: OpenCodeRuntime.OpenCodeRuntimeShape = {
-  startOpenCodeServerProcess: ({ binaryPath }) =>
+  startOpenCodeServerProcess: ({ binaryPath, serverPassword, environment }) =>
     Effect.gen(function* () {
       const index = runtimeMock.state.startCalls.length + 1;
       const url = `http://127.0.0.1:${4_300 + index}`;
@@ -55,23 +59,43 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntime.OpenCodeRuntimeShape = {
           runtimeMock.state.closeCalls.push(url);
         }),
       );
+      const effectiveServerPassword = OpenCodeRuntime.resolveOpenCodeServerPassword({
+        external: false,
+        ...(serverPassword !== undefined ? { serverPassword } : {}),
+        ...(environment !== undefined ? { environment } : {}),
+      });
       return {
         url,
+        ...(effectiveServerPassword !== undefined
+          ? { serverPassword: effectiveServerPassword }
+          : {}),
+        version: "1.14.19",
         isRunning: Effect.succeed(true),
         exitCode: Effect.never,
       };
     }),
-  connectToOpenCodeServer: ({ serverUrl }) =>
-    Effect.succeed({
-      url: serverUrl ?? "http://127.0.0.1:4301",
-      exitCode: null,
-      external: Boolean(serverUrl),
-    }),
+  connectToOpenCodeServer: ({ serverUrl, serverPassword }) =>
+    runtimeMock.state.connectionError
+      ? Effect.fail(
+          new OpenCodeRuntime.OpenCodeRuntimeError({
+            operation: "global.health",
+            detail: runtimeMock.state.connectionError.message,
+            cause: runtimeMock.state.connectionError,
+          }),
+        )
+      : Effect.succeed({
+          url: serverUrl ?? "http://127.0.0.1:4301",
+          ...(serverPassword ? { serverPassword } : {}),
+          version: "1.14.19",
+          exitCode: null,
+          external: Boolean(serverUrl),
+        }),
   runOpenCodeCommand: () => Effect.succeed({ stdout: "", stderr: "", code: 0 }),
   createOpenCodeSdkClient: ({ baseUrl, serverPassword }) =>
     ({
       session: {
         create: async () => {
+          runtimeMock.state.sessionCreateCalls += 1;
           if (runtimeMock.state.sessionCreateError !== undefined) {
             throw runtimeMock.state.sessionCreateError;
           }
@@ -174,13 +198,23 @@ const EXISTING_SERVER_OPENCODE_SETTINGS = Schema.decodeSync(OpenCodeSettings)({
   serverUrl: "http://127.0.0.1:9999",
   serverPassword: "secret-password",
 });
+const EXTERNAL_SERVER_WITHOUT_AUTH_OPENCODE_SETTINGS = Schema.decodeSync(OpenCodeSettings)({
+  binaryPath: "fake-opencode",
+  serverUrl: "http://127.0.0.1:9999",
+});
 
 function withOpenCodeTextGeneration<A, E, R>(
   settings: OpenCodeSettings,
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
+  environment?: NodeJS.ProcessEnv,
 ) {
   return Effect.gen(function* () {
-    const serverOwner = yield* OpenCodeServerOwner.make({ binaryPath: settings.binaryPath });
+    const serverOwner = yield* OpenCodeServerOwner.make({
+      binaryPath: settings.binaryPath,
+      directory: process.cwd(),
+      ...(settings.serverPassword ? { serverPassword: settings.serverPassword } : {}),
+      ...(environment ? { environment } : {}),
+    });
     const textGeneration = yield* OpenCodeTextGeneration.makeOpenCodeTextGeneration(settings).pipe(
       Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
     );
@@ -248,6 +282,36 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
           `Basic ${btoa("opencode:secret-password")}`,
         ]);
       }),
+    ),
+  );
+
+  it.effect("uses an environment-only password for a locally spawned server", () =>
+    withOpenCodeTextGeneration(
+      DEFAULT_OPENCODE_SETTINGS,
+      (textGeneration) =>
+        Effect.gen(function* () {
+          yield* textGeneration.generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT);
+
+          expect(runtimeMock.state.authHeaders).toEqual([
+            `Basic ${btoa("opencode:environment-password")}`,
+          ]);
+        }),
+      { OPENCODE_SERVER_PASSWORD: "environment-password" },
+    ),
+  );
+
+  it.effect("uses settings auth when the local environment password differs", () =>
+    withOpenCodeTextGeneration(
+      LOCAL_AUTH_OPENCODE_SETTINGS,
+      (textGeneration) =>
+        Effect.gen(function* () {
+          yield* textGeneration.generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT);
+
+          expect(runtimeMock.state.authHeaders).toEqual([
+            `Basic ${btoa("opencode:secret-password")}`,
+          ]);
+        }),
+      { OPENCODE_SERVER_PASSWORD: "environment-password" },
     ),
   );
 
@@ -482,6 +546,36 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
 it.layer(OpenCodeTextGenerationExistingServerTestLayer)(
   "OpenCodeTextGeneration with configured server URL",
   (it) => {
+    it.effect("does not send a local environment password to a configured server", () =>
+      withOpenCodeTextGeneration(
+        EXTERNAL_SERVER_WITHOUT_AUTH_OPENCODE_SETTINGS,
+        (textGeneration) =>
+          Effect.gen(function* () {
+            yield* textGeneration.generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT);
+            expect(runtimeMock.state.authHeaders).toEqual([null]);
+          }),
+        { OPENCODE_SERVER_PASSWORD: "local-secret" },
+      ),
+    );
+
+    it.effect("does not create a session when the server version is unsupported", () =>
+      withOpenCodeTextGeneration(EXISTING_SERVER_OPENCODE_SETTINGS, (textGeneration) =>
+        Effect.gen(function* () {
+          runtimeMock.state.connectionError = new Error(
+            "OpenCode v1.14.18 is too old. Upgrade to v1.14.19 or newer.",
+          );
+
+          const error = yield* textGeneration
+            .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+            .pipe(Effect.flip);
+
+          expect(error).toBeInstanceOf(TextGenerationError);
+          expect(error.message).toContain("v1.14.18 is too old");
+          expect(runtimeMock.state.sessionCreateCalls).toBe(0);
+        }),
+      ),
+    );
+
     it.effect("reuses a configured OpenCode server URL without spawning or applying idle TTL", () =>
       withOpenCodeTextGeneration(EXISTING_SERVER_OPENCODE_SETTINGS, (textGeneration) =>
         Effect.gen(function* () {

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -1,9 +1,5 @@
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
-import * as Fiber from "effect/Fiber";
 import * as Schema from "effect/Schema";
-import * as Scope from "effect/Scope";
-import * as Semaphore from "effect/Semaphore";
 
 import {
   NonNegativeInt,
@@ -31,8 +27,10 @@ import {
   sanitizeThreadTitle,
 } from "./TextGenerationUtils.ts";
 import * as OpenCodeRuntime from "../provider/opencodeRuntime.ts";
-
-const OPENCODE_TEXT_GENERATION_IDLE_TTL = "30 seconds";
+import {
+  makeOpenCodeServerOwner,
+  type OpenCodeServerOwner,
+} from "../provider/OpenCodeServerOwner.ts";
 
 const OpenCodeTextGenerationOperation = Schema.Literals([
   "generateCommitMessage",
@@ -175,188 +173,19 @@ function getOpenCodeTextResponse(parts: ReadonlyArray<unknown> | undefined): str
     .trim();
 }
 
-interface SharedOpenCodeTextGenerationServerState {
-  server: OpenCodeRuntime.OpenCodeServerProcess | null;
-  /**
-   * The scope that owns the shared server's lifetime. Closing this scope
-   * terminates the OpenCode child process and interrupts any fibers the
-   * runtime forked during startup. We don't hold a `close()` function on
-   * the server handle anymore — the scope is the only lifecycle handle.
-   */
-  serverScope: Scope.Closeable | null;
-  binaryPath: string | null;
-  activeRequests: number;
-  idleCloseFiber: Fiber.Fiber<void, never> | null;
-}
-
 export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration")(function* (
   openCodeSettings: OpenCodeSettings,
   environment?: NodeJS.ProcessEnv,
+  serverOwner?: OpenCodeServerOwner,
 ) {
   const serverConfig = yield* ServerConfig.ServerConfig;
   const openCodeRuntime = yield* OpenCodeRuntime.OpenCodeRuntime;
-  const resolvedEnvironment = environment ?? process.env;
-  const idleFiberScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
-    Scope.close(scope, Exit.void),
-  );
-  const sharedServerMutex = yield* Semaphore.make(1);
-  const sharedServerState: SharedOpenCodeTextGenerationServerState = {
-    server: null,
-    serverScope: null,
-    binaryPath: null,
-    activeRequests: 0,
-    idleCloseFiber: null,
-  };
-
-  const closeSharedServer = Effect.fn("closeSharedServer")(function* () {
-    const scope = sharedServerState.serverScope;
-    sharedServerState.server = null;
-    sharedServerState.serverScope = null;
-    sharedServerState.binaryPath = null;
-    if (scope !== null) {
-      yield* Scope.close(scope, Exit.void).pipe(Effect.ignore);
-    }
-  });
-
-  const cancelIdleCloseFiber = Effect.fn("cancelIdleCloseFiber")(function* () {
-    const idleCloseFiber = sharedServerState.idleCloseFiber;
-    sharedServerState.idleCloseFiber = null;
-    if (idleCloseFiber !== null) {
-      yield* Fiber.interrupt(idleCloseFiber).pipe(Effect.ignore);
-    }
-  });
-
-  const scheduleIdleClose = Effect.fn("scheduleIdleClose")(function* (
-    server: OpenCodeRuntime.OpenCodeServerProcess,
-  ) {
-    yield* cancelIdleCloseFiber();
-    const fiber = yield* Effect.sleep(OPENCODE_TEXT_GENERATION_IDLE_TTL).pipe(
-      Effect.andThen(
-        sharedServerMutex.withPermit(
-          Effect.gen(function* () {
-            if (sharedServerState.server !== server || sharedServerState.activeRequests > 0) {
-              return;
-            }
-            sharedServerState.idleCloseFiber = null;
-            yield* closeSharedServer();
-          }),
-        ),
-      ),
-      Effect.forkIn(idleFiberScope),
-    );
-    sharedServerState.idleCloseFiber = fiber;
-  });
-
-  const acquireSharedServer = (input: {
-    readonly binaryPath: string;
-    readonly operation:
-      | "generateCommitMessage"
-      | "generatePrContent"
-      | "generateBranchName"
-      | "generateThreadTitle";
-  }) =>
-    sharedServerMutex.withPermit(
-      Effect.gen(function* () {
-        yield* cancelIdleCloseFiber();
-
-        const existingServer = sharedServerState.server;
-        if (existingServer !== null) {
-          if (
-            sharedServerState.binaryPath !== input.binaryPath &&
-            sharedServerState.activeRequests === 0
-          ) {
-            yield* closeSharedServer();
-          } else {
-            if (sharedServerState.binaryPath !== input.binaryPath) {
-              yield* Effect.logWarning(
-                "OpenCode shared server binary path mismatch: requested " +
-                  input.binaryPath +
-                  " but active server uses " +
-                  sharedServerState.binaryPath +
-                  "; reusing existing server because there are active requests",
-              );
-            }
-            sharedServerState.activeRequests += 1;
-            return existingServer;
-          }
-        }
-
-        // Create a fresh scope that owns this shared server. The runtime
-        // will attach its child-process and fiber finalizers to this scope;
-        // closing it kills the server and interrupts those fibers.
-        //
-        // The `Scope.make` / spawn / record-or-close transitions run inside
-        // `uninterruptibleMask` so an interrupt arriving between any two
-        // steps can't orphan the scope (and the child process attached to
-        // it) before we either close it on failure or hand ownership to
-        // `sharedServerState`. `restore` keeps the actual spawn
-        // interruptible; an interrupt during the spawn is captured by
-        // `Effect.exit` and drives us through the failure branch that
-        // closes the fresh scope.
-        return yield* Effect.uninterruptibleMask((restore) =>
-          Effect.gen(function* () {
-            const serverScope = yield* Scope.make();
-            const startedExit = yield* Effect.exit(
-              restore(
-                openCodeRuntime
-                  .startOpenCodeServerProcess({
-                    binaryPath: input.binaryPath,
-                    environment: resolvedEnvironment,
-                  })
-                  .pipe(
-                    Effect.provideService(Scope.Scope, serverScope),
-                    Effect.mapError(
-                      (cause) =>
-                        new TextGenerationError({
-                          operation: input.operation,
-                          detail: OpenCodeRuntime.openCodeRuntimeErrorDetail(cause),
-                          cause,
-                        }),
-                    ),
-                  ),
-              ),
-            );
-            if (startedExit._tag === "Failure") {
-              yield* Scope.close(serverScope, Exit.void).pipe(Effect.ignore);
-              return yield* Effect.failCause(startedExit.cause);
-            }
-
-            const server = startedExit.value;
-            sharedServerState.server = server;
-            sharedServerState.serverScope = serverScope;
-            sharedServerState.binaryPath = input.binaryPath;
-            sharedServerState.activeRequests = 1;
-            return server;
-          }),
-        );
-      }),
-    );
-
-  const releaseSharedServer = (server: OpenCodeRuntime.OpenCodeServerProcess) =>
-    sharedServerMutex.withPermit(
-      Effect.gen(function* () {
-        if (sharedServerState.server !== server) {
-          return;
-        }
-        sharedServerState.activeRequests = Math.max(0, sharedServerState.activeRequests - 1);
-        if (sharedServerState.activeRequests === 0) {
-          yield* scheduleIdleClose(server);
-        }
-      }),
-    );
-
-  // Module-level finalizer: on layer shutdown, cancel the idle close fiber
-  // and close the shared server scope. Consumers therefore cannot leak
-  // the shared OpenCode server by forgetting to call anything.
-  yield* Effect.addFinalizer(() =>
-    sharedServerMutex.withPermit(
-      Effect.gen(function* () {
-        yield* cancelIdleCloseFiber();
-        sharedServerState.activeRequests = 0;
-        yield* closeSharedServer();
-      }),
-    ),
-  );
+  const effectiveServerOwner =
+    serverOwner ??
+    (yield* makeOpenCodeServerOwner({
+      binaryPath: openCodeSettings.binaryPath,
+      environment: environment ?? process.env,
+    }));
 
   const runOpenCodeJson = Effect.fn("runOpenCodeJson")(function* <S extends Schema.Top>(input: {
     readonly operation: OpenCodeTextGenerationOperation;
@@ -499,13 +328,16 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
     const rawOutput =
       openCodeSettings.serverUrl.length > 0
         ? yield* runAgainstServer({ url: openCodeSettings.serverUrl })
-        : yield* Effect.acquireUseRelease(
-            acquireSharedServer({
-              binaryPath: openCodeSettings.binaryPath,
-              operation: input.operation,
-            }),
-            runAgainstServer,
-            releaseSharedServer,
+        : yield* effectiveServerOwner.withServer(runAgainstServer).pipe(
+            Effect.mapError((cause) =>
+              OpenCodeRuntime.OpenCodeRuntimeError.is(cause)
+                ? new TextGenerationError({
+                    operation: input.operation,
+                    detail: OpenCodeRuntime.openCodeRuntimeErrorDetail(cause),
+                    cause,
+                  })
+                : cause,
+            ),
           );
 
     const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(input.outputSchemaJson));

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -385,7 +385,7 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
         const client = openCodeRuntime.createOpenCodeSdkClient({
           baseUrl: server.url,
           directory: input.cwd,
-          ...(openCodeSettings.serverUrl.length > 0 && openCodeSettings.serverPassword
+          ...(openCodeSettings.serverPassword
             ? { serverPassword: openCodeSettings.serverPassword }
             : {}),
         });

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -27,10 +27,7 @@ import {
   sanitizeThreadTitle,
 } from "./TextGenerationUtils.ts";
 import * as OpenCodeRuntime from "../provider/opencodeRuntime.ts";
-import {
-  makeOpenCodeServerOwner,
-  type OpenCodeServerOwner,
-} from "../provider/OpenCodeServerOwner.ts";
+import * as OpenCodeServerOwner from "../provider/OpenCodeServerOwner.ts";
 
 const OpenCodeTextGenerationOperation = Schema.Literals([
   "generateCommitMessage",
@@ -175,17 +172,10 @@ function getOpenCodeTextResponse(parts: ReadonlyArray<unknown> | undefined): str
 
 export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration")(function* (
   openCodeSettings: OpenCodeSettings,
-  environment?: NodeJS.ProcessEnv,
-  serverOwner?: OpenCodeServerOwner,
 ) {
   const serverConfig = yield* ServerConfig.ServerConfig;
   const openCodeRuntime = yield* OpenCodeRuntime.OpenCodeRuntime;
-  const effectiveServerOwner =
-    serverOwner ??
-    (yield* makeOpenCodeServerOwner({
-      binaryPath: openCodeSettings.binaryPath,
-      environment: environment ?? process.env,
-    }));
+  const serverOwner = yield* OpenCodeServerOwner.OpenCodeServerOwner;
 
   const runOpenCodeJson = Effect.fn("runOpenCodeJson")(function* <S extends Schema.Top>(input: {
     readonly operation: OpenCodeTextGenerationOperation;
@@ -328,7 +318,7 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
     const rawOutput =
       openCodeSettings.serverUrl.length > 0
         ? yield* runAgainstServer({ url: openCodeSettings.serverUrl })
-        : yield* effectiveServerOwner.withServer(runAgainstServer).pipe(
+        : yield* serverOwner.withServer(runAgainstServer).pipe(
             Effect.mapError((cause) =>
               OpenCodeRuntime.OpenCodeRuntimeError.is(cause)
                 ? new TextGenerationError({

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -200,13 +200,16 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
     });
 
     const runAgainstServer = Effect.fn("runOpenCodeJson.runAgainstServer")(
-      function* (server: Pick<OpenCodeRuntime.OpenCodeServerConnection, "url">) {
+      function* (
+        server: Pick<
+          OpenCodeRuntime.OpenCodeServerConnection,
+          "url" | "serverPassword" | "version"
+        >,
+      ) {
         const client = openCodeRuntime.createOpenCodeSdkClient({
           baseUrl: server.url,
           directory: input.cwd,
-          ...(openCodeSettings.serverPassword
-            ? { serverPassword: openCodeSettings.serverPassword }
-            : {}),
+          ...(server.serverPassword !== undefined ? { serverPassword: server.serverPassword } : {}),
         });
         const session = yield* Effect.tryPromise({
           try: () =>
@@ -315,20 +318,30 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
       }),
     );
 
-    const rawOutput =
+    const serverOutput =
       openCodeSettings.serverUrl.length > 0
-        ? yield* runAgainstServer({ url: openCodeSettings.serverUrl })
-        : yield* serverOwner.withServer(runAgainstServer).pipe(
-            Effect.mapError((cause) =>
-              OpenCodeRuntime.OpenCodeRuntimeError.is(cause)
-                ? new TextGenerationError({
-                    operation: input.operation,
-                    detail: OpenCodeRuntime.openCodeRuntimeErrorDetail(cause),
-                    cause,
-                  })
-                : cause,
-            ),
-          );
+        ? openCodeRuntime
+            .connectToOpenCodeServer({
+              binaryPath: openCodeSettings.binaryPath,
+              directory: input.cwd,
+              serverUrl: openCodeSettings.serverUrl,
+              ...(openCodeSettings.serverPassword
+                ? { serverPassword: openCodeSettings.serverPassword }
+                : {}),
+            })
+            .pipe(Effect.flatMap(runAgainstServer), Effect.scoped)
+        : serverOwner.withServer(runAgainstServer);
+    const rawOutput = yield* serverOutput.pipe(
+      Effect.mapError((cause) =>
+        OpenCodeRuntime.OpenCodeRuntimeError.is(cause)
+          ? new TextGenerationError({
+              operation: input.operation,
+              detail: OpenCodeRuntime.openCodeRuntimeErrorDetail(cause),
+              cause,
+            })
+          : cause,
+      ),
+    );
 
     const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(input.outputSchemaJson));
     return yield* decodeOutput(extractJsonObject(rawOutput)).pipe(

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -332,15 +332,16 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
             .pipe(Effect.flatMap(runAgainstServer), Effect.scoped)
         : serverOwner.withServer(runAgainstServer);
     const rawOutput = yield* serverOutput.pipe(
-      Effect.mapError((cause) =>
-        OpenCodeRuntime.OpenCodeRuntimeError.is(cause)
-          ? new TextGenerationError({
+      Effect.catchTags({
+        OpenCodeRuntimeError: (cause) =>
+          Effect.fail(
+            new TextGenerationError({
               operation: input.operation,
               detail: OpenCodeRuntime.openCodeRuntimeErrorDetail(cause),
               cause,
-            })
-          : cause,
-      ),
+            }),
+          ),
+      }),
     );
 
     const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(input.outputSchemaJson));

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -49,7 +49,6 @@ import {
   ProjectSearchEntriesError,
   ProjectWriteFileError,
   ProviderUploadFeedbackError,
-  ProviderDriverKind,
   RelayClientInstallFailedError,
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
@@ -2396,9 +2395,7 @@ const makeWsRpcLayer = (
               );
 
               yield* providerRegistry
-                .refresh(undefined, {
-                  exclude: new Set([ProviderDriverKind.make("opencode")]),
-                })
+                .refresh()
                 .pipe(Effect.ignoreCause({ log: true }), Effect.forkScoped);
 
               const liveUpdates = Stream.merge(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -49,6 +49,7 @@ import {
   ProjectSearchEntriesError,
   ProjectWriteFileError,
   ProviderUploadFeedbackError,
+  ProviderDriverKind,
   RelayClientInstallFailedError,
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
@@ -2395,7 +2396,9 @@ const makeWsRpcLayer = (
               );
 
               yield* providerRegistry
-                .refresh()
+                .refresh(undefined, {
+                  exclude: new Set([ProviderDriverKind.make("opencode")]),
+                })
                 .pipe(Effect.ignoreCause({ log: true }), Effect.forkScoped);
 
               const liveUpdates = Stream.merge(

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -997,16 +997,24 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Instance-keyed option list so the picker can show each configured
   // instance (built-in + custom) as a first-class sidebar entry. The
   // options are server-reported models plus that exact instance's
-  // configured custom models; selected slugs are not injected into lists.
+  // configured custom models. A missing OpenCode selection is included as
+  // an unavailable row until the catalog reports it again.
   const modelOptionsByInstance = useMemo<
     ReadonlyMap<ProviderInstanceId, ReadonlyArray<AppModelOption>>
   >(() => {
     const out = new Map<ProviderInstanceId, ReadonlyArray<AppModelOption>>();
     for (const entry of providerInstanceEntries) {
-      out.set(entry.instanceId, getAppModelOptionsForInstance(settings, entry));
+      out.set(
+        entry.instanceId,
+        getAppModelOptionsForInstance(
+          settings,
+          entry,
+          entry.instanceId === selectedInstanceId ? selectedModelForPicker : null,
+        ),
+      );
     }
     return out;
-  }, [providerInstanceEntries, settings]);
+  }, [providerInstanceEntries, selectedInstanceId, selectedModelForPicker, settings]);
   const selectedModelForPickerWithCustomFallback = useMemo(() => {
     const currentOptions = modelOptionsByInstance.get(selectedInstanceId) ?? [];
     return currentOptions.some((option) => option.slug === selectedModelForPicker)

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -34,6 +34,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
   preferShortName?: boolean;
   useTriggerLabel?: boolean;
   showNewBadge?: boolean;
+  unavailable?: boolean;
   jumpLabel?: string | null;
   disabledReason?: string | null;
   onToggleFavorite: () => void;
@@ -73,6 +74,11 @@ export const ModelListRow = memo(function ModelListRow(props: {
               aria-label="New model"
             >
               New
+            </span>
+          ) : null}
+          {props.unavailable ? (
+            <span className="shrink-0 rounded border border-border bg-muted/50 px-1 py-px text-[10px] font-medium leading-none text-muted-foreground">
+              Unavailable
             </span>
           ) : null}
         </div>

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -9,6 +9,7 @@ import {
 } from "./providerIconUtils";
 import { ComboboxItem } from "../ui/combobox";
 import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
 import { Kbd } from "../ui/kbd";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "~/lib/utils";
@@ -77,9 +78,9 @@ export const ModelListRow = memo(function ModelListRow(props: {
             </span>
           ) : null}
           {props.unavailable ? (
-            <span className="shrink-0 rounded border border-border bg-muted/50 px-1 py-px text-[10px] font-medium leading-none text-muted-foreground">
+            <Badge variant="outline" size="sm">
               Unavailable
-            </span>
+            </Badge>
           ) : null}
         </div>
         {props.showProvider && (

--- a/apps/web/src/components/chat/ModelPickerContent.test.ts
+++ b/apps/web/src/components/chat/ModelPickerContent.test.ts
@@ -1,0 +1,67 @@
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveProviderInstanceEntries } from "../../providerInstances";
+import { shouldIncludeModelPickerOption } from "./ModelPickerContent";
+
+function entry(status: ServerProvider["status"]) {
+  return deriveProviderInstanceEntries([
+    {
+      instanceId: ProviderInstanceId.make("opencode_work"),
+      driver: ProviderDriverKind.make("opencode"),
+      enabled: true,
+      installed: true,
+      version: null,
+      status,
+      auth: { status: "authenticated" },
+      checkedAt: "2026-08-28T00:00:00.000Z",
+      models: [],
+      slashCommands: [],
+      skills: [],
+    },
+  ])[0]!;
+}
+
+describe("shouldIncludeModelPickerOption", () => {
+  it.each(["error", "warning"] as const)(
+    "keeps only the active synthetic OpenCode row when the provider status is %s",
+    (status) => {
+      const providerEntry = entry(status);
+      const activeInstanceId = ProviderInstanceId.make("opencode_work");
+      const activeModel = "openrouter/kimi-k3";
+
+      expect(
+        shouldIncludeModelPickerOption({
+          entry: providerEntry,
+          option: {
+            slug: activeModel,
+            name: activeModel,
+            isUnavailable: true,
+          },
+          activeInstanceId,
+          activeModel,
+        }),
+      ).toBe(true);
+      expect(
+        shouldIncludeModelPickerOption({
+          entry: providerEntry,
+          option: { slug: "stale/model", name: "Stale model" },
+          activeInstanceId,
+          activeModel,
+        }),
+      ).toBe(false);
+      expect(
+        shouldIncludeModelPickerOption({
+          entry: providerEntry,
+          option: {
+            slug: "other/missing",
+            name: "Other missing",
+            isUnavailable: true,
+          },
+          activeInstanceId,
+          activeModel,
+        }),
+      ).toBe(false);
+    },
+  );
+});

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -53,7 +53,24 @@ type ModelPickerItem = {
   instanceAccentColor?: string | undefined;
   continuationGroupKey?: string | undefined;
   isLegacy?: boolean | undefined;
+  isUnavailable?: boolean | undefined;
 };
+
+export function shouldIncludeModelPickerOption(input: {
+  readonly entry: ProviderInstanceEntry;
+  readonly option: ModelEsque;
+  readonly activeInstanceId: ProviderInstanceId;
+  readonly activeModel: string;
+}): boolean {
+  if (isProviderInstancePickerReady(input.entry)) return true;
+  return (
+    input.entry.enabled &&
+    input.entry.driverKind === "opencode" &&
+    input.entry.instanceId === input.activeInstanceId &&
+    input.option.slug === input.activeModel &&
+    input.option.isUnavailable === true
+  );
+}
 
 const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
 
@@ -107,9 +124,23 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   const modelListRef = useRef<LegendListRef | null>(null);
   const highlightedModelKeyRef = useRef<string | null>(null);
   const favorites = useClientSettings((s) => s.favorites ?? []);
+  const activeEntry = props.instanceEntries.find(
+    (entry) => entry.instanceId === props.activeInstanceId,
+  );
+  const activeInstanceHasSelectableUnavailableModel =
+    activeEntry !== undefined &&
+    (modelOptionsByInstance.get(props.activeInstanceId) ?? []).some((option) =>
+      shouldIncludeModelPickerOption({
+        entry: activeEntry,
+        option,
+        activeInstanceId: props.activeInstanceId,
+        activeModel: props.model,
+      }),
+    ) &&
+    !isProviderInstancePickerReady(activeEntry);
   const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | "favorites">(
     () => {
-      if (props.lockedProvider !== null) {
+      if (props.lockedProvider !== null || activeInstanceHasSelectableUnavailableModel) {
         // When locked, prime the sidebar to the currently-active instance
         // so jumping into the picker keeps the focused instance visible.
         return props.activeInstanceId;
@@ -189,15 +220,12 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     [props.lockedContinuationGroupKey, props.lockedProvider],
   );
 
-  const readyInstanceSet = useMemo(() => {
-    const ready = new Set<ProviderInstanceId>();
-    for (const entry of instanceEntries) {
-      if (isProviderInstancePickerReady(entry)) {
-        ready.add(entry.instanceId);
-      }
+  const selectableUnavailableInstanceIds = useMemo(() => {
+    if (!activeInstanceHasSelectableUnavailableModel) {
+      return undefined;
     }
-    return ready;
-  }, [instanceEntries]);
+    return new Set([props.activeInstanceId]);
+  }, [activeInstanceHasSelectableUnavailableModel, props.activeInstanceId]);
 
   // Flatten models into a searchable array. One pass over the
   // instance-keyed map; each model carries its instance id + driver kind
@@ -212,16 +240,24 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         // its models — stale options shouldn't appear in the picker.
         continue;
       }
-      if (!readyInstanceSet.has(instanceId)) {
-        continue;
-      }
       for (const model of models) {
+        if (
+          !shouldIncludeModelPickerOption({
+            entry,
+            option: model,
+            activeInstanceId: props.activeInstanceId,
+            activeModel: props.model,
+          })
+        ) {
+          continue;
+        }
         out.push({
           slug: model.slug,
           name: model.name,
           ...(model.shortName ? { shortName: model.shortName } : {}),
           ...(model.subProvider ? { subProvider: model.subProvider } : {}),
           ...(model.isLegacy ? { isLegacy: true } : {}),
+          ...(model.isUnavailable ? { isUnavailable: true } : {}),
           instanceId,
           driverKind: entry.driverKind,
           instanceDisplayName: entry.displayName,
@@ -233,7 +269,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       }
     }
     return out;
-  }, [modelOptionsByInstance, entryByInstanceId, readyInstanceSet]);
+  }, [modelOptionsByInstance, entryByInstanceId, props.activeInstanceId, props.model]);
 
   const isLocked = props.lockedProvider !== null;
   const isSearching = searchQuery.trim().length > 0;
@@ -609,6 +645,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             onSelectInstance={handleSelectInstance}
             instanceEntries={sidebarInstanceEntries}
             showFavorites
+            {...(selectableUnavailableInstanceIds ? { selectableUnavailableInstanceIds } : {})}
             {...(lockedDisabledInstanceIds
               ? {
                   disabledInstanceIds: lockedDisabledInstanceIds,
@@ -768,6 +805,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                         preferShortName={!isLocked}
                         useTriggerLabel={false}
                         showNewBadge={isModelPickerNewModel(model.driverKind, model.slug)}
+                        unavailable={model.isUnavailable === true}
                         jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
                         disabledReason={disabledReason}
                         onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -173,7 +173,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
                 disabled={isDisabled}
                 type="button"
                 aria-label={
-                  isUnavailable
+                  isUnavailable || isContextDisabled
                     ? tooltip
                     : showNewBadge
                       ? `${entry.displayName}, new`

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -54,6 +54,8 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
   showFavorites?: boolean;
   /** Instance ids shown in the rail but unavailable for the current picker context. */
   disabledInstanceIds?: ReadonlySet<ProviderInstanceId>;
+  /** Non-ready instances whose selected unavailable model remains reachable. */
+  selectableUnavailableInstanceIds?: ReadonlySet<ProviderInstanceId>;
   getDisabledInstanceTooltip?: (entry: ProviderInstanceEntry) => string;
   /**
    * Instance id values that should render the "new" sparkle badge. Callers
@@ -135,7 +137,10 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
           {props.instanceEntries.map((entry) => {
             const isUnavailable = !isProviderInstancePickerReady(entry);
             const isContextDisabled = props.disabledInstanceIds?.has(entry.instanceId) ?? false;
-            const isDisabled = isUnavailable || isContextDisabled;
+            const unavailableSelectionIsReachable =
+              props.selectableUnavailableInstanceIds?.has(entry.instanceId) ?? false;
+            const isDisabled =
+              (isUnavailable && !unavailableSelectionIsReachable) || isContextDisabled;
             const isSelected = props.selectedInstanceId === entry.instanceId;
             const isHovered = hoveredInstanceId === entry.instanceId;
             const showNewBadge = props.newBadgeInstanceIds?.has(entry.instanceId) ?? false;
@@ -168,7 +173,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
                 disabled={isDisabled}
                 type="button"
                 aria-label={
-                  isDisabled
+                  isUnavailable
                     ? tooltip
                     : showNewBadge
                       ? `${entry.displayName}, new`

--- a/apps/web/src/components/chat/ProviderModelPicker.test.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.test.tsx
@@ -1,0 +1,102 @@
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveProviderInstanceEntries } from "../../providerInstances";
+import { ProviderModelPicker } from "./ProviderModelPicker";
+import type { ModelEsque } from "./providerIconUtils";
+
+function providerEntry(instanceId: string, driver: string) {
+  const provider: ServerProvider = {
+    instanceId: ProviderInstanceId.make(instanceId),
+    driver: ProviderDriverKind.make(driver),
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-08-28T00:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+  };
+  return deriveProviderInstanceEntries([provider])[0]!;
+}
+
+function renderPicker(input: {
+  instanceId: string;
+  driver: string;
+  model: string;
+  options: ReadonlyArray<ModelEsque>;
+  includeEntry?: boolean;
+}) {
+  const instanceId = ProviderInstanceId.make(input.instanceId);
+  const entry = providerEntry(input.instanceId, input.driver);
+  return renderToStaticMarkup(
+    <ProviderModelPicker
+      activeInstanceId={instanceId}
+      model={input.model}
+      lockedProvider={null}
+      instanceEntries={input.includeEntry === false ? [] : [entry]}
+      modelOptionsByInstance={new Map([[instanceId, input.options]])}
+      onInstanceModelChange={() => {}}
+    />,
+  );
+}
+
+describe("ProviderModelPicker", () => {
+  it("shows a missing model slug for a custom OpenCode instance", () => {
+    const markup = renderPicker({
+      instanceId: "team_runtime",
+      driver: "opencode",
+      model: "openrouter/missing-model",
+      options: [{ slug: "openrouter/fallback", name: "Fallback model" }],
+    });
+
+    expect(markup).toContain("openrouter/missing-model");
+    expect(markup).not.toContain("Fallback model");
+  });
+
+  it.each(["codex", "claudeAgent", "cursor", "grok"])(
+    "uses the first option label for a missing %s model",
+    (driver) => {
+      const markup = renderPicker({
+        instanceId: `${driver}_work`,
+        driver,
+        model: "missing-model",
+        options: [{ slug: "fallback-model", name: "Fallback model" }],
+      });
+
+      expect(markup).toContain("Fallback model");
+      expect(markup).not.toContain(">missing-model<");
+    },
+  );
+
+  it("prefers a matching model for OpenCode", () => {
+    const markup = renderPicker({
+      instanceId: "custom_runtime",
+      driver: "opencode",
+      model: "openrouter/selected",
+      options: [
+        { slug: "openrouter/fallback", name: "Fallback model" },
+        { slug: "openrouter/selected", name: "Selected model" },
+      ],
+    });
+
+    expect(markup).toContain("Selected model");
+    expect(markup).not.toContain("Fallback model");
+  });
+
+  it("uses the first option when the active instance entry is missing", () => {
+    const markup = renderPicker({
+      instanceId: "missing_instance",
+      driver: "opencode",
+      model: "missing-model",
+      options: [{ slug: "fallback-model", name: "Fallback model" }],
+      includeEntry: false,
+    });
+
+    expect(markup).toContain("Fallback model");
+    expect(markup).not.toContain(">missing-model<");
+  });
+});

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -58,13 +58,10 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 
   const activeInstanceId = props.activeInstanceId;
   const selectedInstanceOptions = props.modelOptionsByInstance.get(activeInstanceId) ?? [];
-  // If the current slug belongs to a different instance (for example after
-  // a provider switch or disable), prefer the active instance's first
-  // option so the trigger icon and label stay in sync instead of showing
-  // a stale foreign slug.
-  const selectedModel =
-    selectedInstanceOptions.find((option) => option.slug === props.model) ??
-    selectedInstanceOptions[0];
+  // A running thread can keep a model while a transient catalog refresh no
+  // longer reports it. Show the stored identifier instead of naming a
+  // different model that the next message will not use.
+  const selectedModel = selectedInstanceOptions.find((option) => option.slug === props.model);
   const triggerTitle = selectedModel ? getTriggerDisplayModelName(selectedModel) : props.model;
   const triggerLabel = selectedModel ? getTriggerDisplayModelLabel(selectedModel) : props.model;
   const showInstanceBadge =

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -63,7 +63,9 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   // different model that the next message will not use.
   const selectedModel = selectedInstanceOptions.find((option) => option.slug === props.model);
   const triggerTitle = selectedModel ? getTriggerDisplayModelName(selectedModel) : props.model;
-  const triggerLabel = selectedModel ? getTriggerDisplayModelLabel(selectedModel) : props.model;
+  const triggerLabel = selectedModel
+    ? `${getTriggerDisplayModelLabel(selectedModel)}${selectedModel.isUnavailable ? " (Unavailable)" : ""}`
+    : props.model;
   const showInstanceBadge =
     activeEntry !== null && shouldShowInstanceBadge(activeEntry, props.instanceEntries);
 
@@ -176,6 +178,11 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             </TooltipTrigger>
             <TooltipPopup side="top">{triggerLabel}</TooltipPopup>
           </Tooltip>
+          {selectedModel?.isUnavailable ? (
+            <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
+              Unavailable
+            </span>
+          ) : null}
         </span>
         <span aria-hidden="true" className="flex items-center">
           <ComposerControlChevron />

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { memo, useEffect, useMemo, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
+import { Badge } from "../ui/badge";
 import { buttonVariants } from "../ui/button";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -180,9 +181,9 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             <TooltipPopup side="top">{triggerLabel}</TooltipPopup>
           </Tooltip>
           {selectedModel?.isUnavailable ? (
-            <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
+            <Badge variant="outline" size="sm">
               Unavailable
-            </span>
+            </Badge>
           ) : null}
         </span>
         <span aria-hidden="true" className="flex items-center">

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -58,10 +58,11 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 
   const activeInstanceId = props.activeInstanceId;
   const selectedInstanceOptions = props.modelOptionsByInstance.get(activeInstanceId) ?? [];
-  // A running thread can keep a model while a transient catalog refresh no
-  // longer reports it. Show the stored identifier instead of naming a
-  // different model that the next message will not use.
-  const selectedModel = selectedInstanceOptions.find((option) => option.slug === props.model);
+  // OpenCode can keep a model through a transient catalog refresh. Other
+  // providers keep the active instance's first option as their normal fallback.
+  const selectedModel =
+    selectedInstanceOptions.find((option) => option.slug === props.model) ??
+    (activeEntry?.driverKind === "opencode" ? undefined : selectedInstanceOptions[0]);
   const triggerTitle = selectedModel ? getTriggerDisplayModelName(selectedModel) : props.model;
   const triggerLabel = selectedModel
     ? `${getTriggerDisplayModelLabel(selectedModel)}${selectedModel.isUnavailable ? " (Unavailable)" : ""}`

--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { ProviderDriverKind, type ProviderOptionDescriptor } from "@t3tools/contracts";
-import { buildTraitsTriggerDisplay } from "./TraitsPicker";
+import { buildTraitsTriggerDisplay, buildUnavailableModelOptionDescriptors } from "./TraitsPicker";
 
 function selectDescriptor(
   id: string,
@@ -153,5 +153,38 @@ describe("buildTraitsTriggerDisplay", () => {
         ultrathinkPromptControlled: true,
       }),
     ).toEqual({ label: "Ultrathink", showFastModeIcon: true });
+  });
+});
+
+describe("buildUnavailableModelOptionDescriptors", () => {
+  it("shows only saved values without inventing alternatives", () => {
+    expect(
+      buildUnavailableModelOptionDescriptors([
+        { id: "variant", value: "max" },
+        { id: "agent", value: "build" },
+        { id: "fastMode", value: true },
+      ]),
+    ).toEqual([
+      {
+        id: "variant",
+        label: "Variant",
+        type: "select",
+        options: [{ id: "max", label: "max" }],
+        currentValue: "max",
+      },
+      {
+        id: "agent",
+        label: "Agent",
+        type: "select",
+        options: [{ id: "build", label: "build" }],
+        currentValue: "build",
+      },
+      {
+        id: "fastMode",
+        label: "Fast Mode",
+        type: "boolean",
+        currentValue: true,
+      },
+    ]);
   });
 });

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -13,6 +13,7 @@ import {
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
+  normalizeModelSlug,
 } from "@t3tools/shared/model";
 import { memo, useCallback, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
@@ -34,6 +35,42 @@ import { Badge } from "../ui/badge";
 import { ComposerControl, ComposerControlChevron, ComposerControlIcon } from "./ComposerControl";
 
 type ProviderOptions = ReadonlyArray<ProviderOptionSelection>;
+
+const SAVED_OPTION_LABELS: Readonly<Record<string, string>> = {
+  agent: "Agent",
+  effort: "Effort",
+  reasoningEffort: "Reasoning effort",
+  variant: "Variant",
+};
+
+function savedOptionLabel(id: string): string {
+  return (
+    SAVED_OPTION_LABELS[id] ??
+    id.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/^./, (character) => character.toUpperCase())
+  );
+}
+
+/** Read-only descriptors for saved values whose OpenCode model metadata is unavailable. */
+export function buildUnavailableModelOptionDescriptors(
+  selections: ProviderOptions | null | undefined,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  return (selections ?? []).map((selection) =>
+    typeof selection.value === "boolean"
+      ? {
+          id: selection.id,
+          label: savedOptionLabel(selection.id),
+          type: "boolean" as const,
+          currentValue: selection.value,
+        }
+      : {
+          id: selection.id,
+          label: savedOptionLabel(selection.id),
+          type: "select" as const,
+          options: [{ id: selection.value, label: selection.value }],
+          currentValue: selection.value,
+        },
+  );
+}
 
 type TraitsPersistence =
   | {
@@ -99,10 +136,19 @@ function getSelectedTraits(
   planModeEnabled: boolean,
 ) {
   const caps = getProviderModelCapabilities(models, model, provider, planModeEnabled);
-  const descriptors = getProviderOptionDescriptors({
-    caps,
-    selections: modelOptions,
-  });
+  const modelIsUnavailable =
+    provider === "opencode" &&
+    !models.some((candidate) => candidate.slug === normalizeModelSlug(model, provider));
+  const descriptors = modelIsUnavailable
+    ? buildUnavailableModelOptionDescriptors(
+        planModeEnabled
+          ? modelOptions
+          : modelOptions?.filter((option) => option.id !== "agent" || option.value !== "plan"),
+      )
+    : getProviderOptionDescriptors({
+        caps,
+        selections: modelOptions,
+      });
   const selectDescriptors = descriptors.filter(
     (descriptor): descriptor is Extract<ProviderOptionDescriptor, { type: "select" }> =>
       descriptor.type === "select",
@@ -158,6 +204,7 @@ function getSelectedTraits(
     ultrathinkInBodyText,
     selectedAgent,
     selectedAgentLabel,
+    modelIsUnavailable,
   };
 }
 
@@ -193,7 +240,13 @@ function getTraitsSectionVisibility(input: {
     showFastMode,
     showContextWindow,
     showAgent,
-    hasAnyControls: showEffort || showThinking || showFastMode || showContextWindow || showAgent,
+    hasAnyControls:
+      showEffort ||
+      showThinking ||
+      showFastMode ||
+      showContextWindow ||
+      showAgent ||
+      (selected.modelIsUnavailable && selected.descriptors.length > 0),
   };
 }
 
@@ -262,6 +315,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     ultrathinkPromptControlled,
     ultrathinkInBodyText,
     hasAnyControls,
+    modelIsUnavailable,
   } = getTraitsSectionVisibility({
     provider,
     models,
@@ -298,6 +352,32 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
 
   if (!hasAnyControls) {
     return null;
+  }
+
+  if (modelIsUnavailable) {
+    return (
+      <>
+        {descriptors.map((descriptor, index) => {
+          const value = getProviderOptionCurrentLabel(descriptor);
+          if (!value) return null;
+          return (
+            <div key={descriptor.id}>
+              {index > 0 ? <MenuDivider /> : null}
+              <MenuGroup>
+                <div className="px-2 pt-1.5 pb-1 font-medium text-muted-foreground text-xs">
+                  {descriptor.label}
+                </div>
+                <MenuRadioGroup value={value}>
+                  <MenuRadioItem value={value} hideIndicator disabled>
+                    {value}
+                  </MenuRadioItem>
+                </MenuRadioGroup>
+              </MenuGroup>
+            </div>
+          );
+        })}
+      </>
+    );
   }
 
   return (

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -367,11 +367,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 <div className="px-2 pt-1.5 pb-1 font-medium text-muted-foreground text-xs">
                   {descriptor.label}
                 </div>
-                <MenuRadioGroup value={value}>
-                  <MenuRadioItem value={value} hideIndicator disabled>
-                    {value}
-                  </MenuRadioItem>
-                </MenuRadioGroup>
+                <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">{value}</div>
               </MenuGroup>
             </div>
           );

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -238,6 +238,79 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("preserves explicit options when the selected model is absent from the catalog", () => {
+    const state = getComposerProviderState({
+      provider: ProviderDriverKind.make("opencode"),
+      model: "opencode/kimi-k3",
+      models: [
+        {
+          slug: "opencode/big-pickle",
+          name: "Big Pickle",
+          isCustom: false,
+          capabilities: {},
+        },
+      ],
+      modelOptions: selections(["variant", "max"], ["agent", "build"]),
+      planModeEnabled: false,
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(
+      selections(["variant", "max"], ["agent", "build"]),
+    );
+  });
+
+  it("preserves explicit options while the catalog is empty", () => {
+    const state = getComposerProviderState({
+      provider: ProviderDriverKind.make("opencode"),
+      model: "opencode/kimi-k3",
+      models: [],
+      modelOptions: selections(["variant", "max"], ["agent", "build"]),
+      planModeEnabled: false,
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(
+      selections(["variant", "max"], ["agent", "build"]),
+    );
+  });
+
+  it("validates options for a known model selected through a legacy alias", () => {
+    const state = getComposerProviderState({
+      provider: ProviderDriverKind.make("claudeAgent"),
+      model: "opus",
+      models: [
+        {
+          slug: "claude-opus-5",
+          name: "Claude Opus 5",
+          isCustom: false,
+          capabilities: {
+            optionDescriptors: [
+              selectDescriptor("effort", [
+                { id: "low", label: "Low" },
+                { id: "high", label: "High", isDefault: true },
+              ]),
+            ],
+          },
+        },
+      ],
+      modelOptions: selections(["effort", "low"], ["unknown", "value"]),
+      planModeEnabled: false,
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(selections(["effort", "low"]));
+  });
+
+  it("still drops the plan agent when an absent model has a saved plan selection", () => {
+    const state = getComposerProviderState({
+      provider: ProviderDriverKind.make("opencode"),
+      model: "opencode/kimi-k3",
+      models: [],
+      modelOptions: selections(["variant", "max"], ["agent", "plan"]),
+      planModeEnabled: false,
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(selections(["variant", "max"]));
+  });
+
   it("adds ultrathink class names when the prompt triggers a promptInjectedValues descriptor", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -259,6 +259,21 @@ describe("getComposerProviderState", () => {
     );
   });
 
+  it.each(["codex", "claudeAgent", "cursor", "grok"])(
+    "does not preserve unknown options for a missing %s model",
+    (provider) => {
+      const state = getComposerProviderState({
+        provider: ProviderDriverKind.make(provider),
+        model: "missing-model",
+        models: modelWith([]),
+        modelOptions: selections(["unknown", "value"]),
+        planModeEnabled: true,
+      });
+
+      expect(state.modelOptionsForDispatch).toBeUndefined();
+    },
+  );
+
   it("preserves explicit options while the catalog is empty", () => {
     const state = getComposerProviderState({
       provider: ProviderDriverKind.make("opencode"),

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -10,6 +10,7 @@ import {
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
+  normalizeModelSlug,
 } from "@t3tools/shared/model";
 import type { ReactNode } from "react";
 
@@ -63,6 +64,19 @@ export function getComposerProviderState(input: ComposerProviderStateInput): Com
     promptInjectionState = "none",
     planModeEnabled,
   } = input;
+  const normalizedModel = normalizeModelSlug(model, provider);
+  const modelIsInCatalog = models.some((candidate) => candidate.slug === normalizedModel);
+  if (!modelIsInCatalog) {
+    const preservedOptions = modelOptions?.filter(
+      (option) => planModeEnabled || option.id !== "agent" || option.value !== "plan",
+    );
+    return {
+      provider,
+      promptEffort: null,
+      modelOptionsForDispatch:
+        preservedOptions && preservedOptions.length > 0 ? preservedOptions : undefined,
+    };
+  }
   const caps = getProviderModelCapabilities(models, model, provider, planModeEnabled);
   const descriptors = getProviderOptionDescriptors({ caps, selections: modelOptions });
   const primarySelectDescriptor = descriptors.find(

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -64,18 +64,20 @@ export function getComposerProviderState(input: ComposerProviderStateInput): Com
     promptInjectionState = "none",
     planModeEnabled,
   } = input;
-  const normalizedModel = normalizeModelSlug(model, provider);
-  const modelIsInCatalog = models.some((candidate) => candidate.slug === normalizedModel);
-  if (!modelIsInCatalog) {
-    const preservedOptions = modelOptions?.filter(
-      (option) => planModeEnabled || option.id !== "agent" || option.value !== "plan",
-    );
-    return {
-      provider,
-      promptEffort: null,
-      modelOptionsForDispatch:
-        preservedOptions && preservedOptions.length > 0 ? preservedOptions : undefined,
-    };
+  if (provider === "opencode") {
+    const normalizedModel = normalizeModelSlug(model, provider);
+    const modelIsInCatalog = models.some((candidate) => candidate.slug === normalizedModel);
+    if (!modelIsInCatalog) {
+      const preservedOptions = modelOptions?.filter(
+        (option) => planModeEnabled || option.id !== "agent" || option.value !== "plan",
+      );
+      return {
+        provider,
+        promptEffort: null,
+        modelOptionsForDispatch:
+          preservedOptions && preservedOptions.length > 0 ? preservedOptions : undefined,
+      };
+    }
   }
   const caps = getProviderModelCapabilities(models, model, provider, planModeEnabled);
   const descriptors = getProviderOptionDescriptors({ caps, selections: modelOptions });

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -27,6 +27,7 @@ export type ModelEsque = {
   shortName?: string | undefined;
   subProvider?: string | undefined;
   isLegacy?: boolean | undefined;
+  isUnavailable?: boolean | undefined;
 };
 
 function escapeRegExp(value: string): string {

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -417,6 +417,8 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   // ----- default model -----
   const storedSelection = representative.defaultModelSelection;
   const resolvedSelection = resolveDefaultProviderModelSelection(serverProviders, storedSelection);
+  const resolvedInstanceId = resolvedSelection?.instanceId ?? null;
+  const resolvedModel = resolvedSelection?.model ?? null;
   const instanceEntries = useMemo(
     () =>
       sortProviderInstanceEntries(
@@ -425,12 +427,11 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
     [serverProviders, settings],
   );
   const modelOptionsByInstance = useMemo(
-    () => getCustomModelOptionsByInstance(settings, serverProviders),
-    [serverProviders, settings],
+    () =>
+      getCustomModelOptionsByInstance(settings, serverProviders, resolvedInstanceId, resolvedModel),
+    [resolvedInstanceId, resolvedModel, serverProviders, settings],
   );
-  const activeEntry = instanceEntries.find(
-    (entry) => entry.instanceId === resolvedSelection?.instanceId,
-  );
+  const activeEntry = instanceEntries.find((entry) => entry.instanceId === resolvedInstanceId);
   const setDefaultModel = useCallback(
     (selection: ModelSelection | null) =>
       void updateAllMembers({ defaultModelSelection: selection }, "Failed to update default model"),

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1014,6 +1014,10 @@ export function deriveEffectiveComposerModelState(input: {
 }): EffectiveComposerModelState {
   const baseModelCandidate =
     input.threadModelSelection?.model ?? input.projectModelSelection?.model ?? null;
+  const preserveThreadModel =
+    input.selectedInstanceId !== null &&
+    input.selectedInstanceId !== undefined &&
+    input.threadModelSelection?.instanceId === input.selectedInstanceId;
   const baseModel =
     (input.selectedInstanceId
       ? resolveAppModelSelectionForInstance(
@@ -1021,6 +1025,7 @@ export function deriveEffectiveComposerModelState(input: {
           input.settings,
           input.providers,
           baseModelCandidate,
+          { preserveUnavailableSelection: preserveThreadModel },
         )
       : null) ??
     resolveAppModelSelection(
@@ -1044,12 +1049,16 @@ export function deriveEffectiveComposerModelState(input: {
   const activeSelectionInstanceId = instanceSelection
     ? (input.selectedInstanceId ?? ProviderInstanceId.make(input.selectedProvider))
     : ProviderInstanceId.make(input.selectedProvider);
+  const preserveActiveSelection =
+    input.threadModelSelection?.instanceId === activeSelectionInstanceId &&
+    input.selectedInstanceId === activeSelectionInstanceId;
   const selectedModel = activeSelection?.model
     ? (resolveAppModelSelectionForInstance(
         activeSelectionInstanceId,
         input.settings,
         input.providers,
         activeSelection.model,
+        { preserveUnavailableSelection: preserveActiveSelection },
       ) ??
       resolveAppModelSelection(
         input.selectedProvider,

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1049,16 +1049,13 @@ export function deriveEffectiveComposerModelState(input: {
   const activeSelectionInstanceId = instanceSelection
     ? (input.selectedInstanceId ?? ProviderInstanceId.make(input.selectedProvider))
     : ProviderInstanceId.make(input.selectedProvider);
-  const preserveActiveSelection =
-    input.threadModelSelection?.instanceId === activeSelectionInstanceId &&
-    input.selectedInstanceId === activeSelectionInstanceId;
   const selectedModel = activeSelection?.model
     ? (resolveAppModelSelectionForInstance(
         activeSelectionInstanceId,
         input.settings,
         input.providers,
         activeSelection.model,
-        { preserveUnavailableSelection: preserveActiveSelection },
+        { preserveUnavailableSelection: true },
       ) ??
       resolveAppModelSelection(
         input.selectedProvider,

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -299,6 +299,34 @@ describe("instance-scoped model selection", () => {
     ).toBe("claude-sonnet-4-6");
   });
 
+  it("preserves an existing OpenCode model when a catalog refresh no longer contains it", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("opencode"),
+        instanceId: "opencode",
+        models: ["opencode/big-pickle"],
+      }),
+    ];
+
+    expect(
+      resolveAppModelSelectionForInstance(
+        ProviderInstanceId.make("opencode"),
+        settingsWithProviderInstances(),
+        providers,
+        "opencode/kimi-k3",
+        { preserveUnavailableSelection: true },
+      ),
+    ).toBe("opencode/kimi-k3");
+    expect(
+      resolveAppModelSelectionForInstance(
+        ProviderInstanceId.make("opencode"),
+        settingsWithProviderInstances(),
+        providers,
+        "opencode/kimi-k3",
+      ),
+    ).toBe("opencode/big-pickle");
+  });
+
   it("preserves custom provider instances in settings model selection", () => {
     const providers = [
       provider({

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -2,6 +2,8 @@ import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3
 import { DEFAULT_UNIFIED_SETTINGS, type UnifiedSettings } from "@t3tools/contracts/settings";
 import { describe, expect, it } from "vite-plus/test";
 import { createModelSelection } from "@t3tools/shared/model";
+import { deriveEffectiveComposerModelState } from "./composerDraftStore";
+import { getComposerProviderState } from "./components/chat/composerProviderState";
 import { deriveProviderInstanceEntries } from "./providerInstances";
 import {
   getAppModelOptionsForInstance,
@@ -325,6 +327,74 @@ describe("instance-scoped model selection", () => {
         "opencode/kimi-k3",
       ),
     ).toBe("opencode/big-pickle");
+  });
+
+  it("preserves saved options through dispatch when the model is absent from the catalog", () => {
+    const instanceId = ProviderInstanceId.make("opencode");
+    const driver = ProviderDriverKind.make("opencode");
+    const providers = [provider({ provider: driver, instanceId, models: ["opencode/big-pickle"] })];
+    const saved = createModelSelection(instanceId, "opencode/kimi-k3", [
+      { id: "variant", value: "max" },
+      { id: "agent", value: "build" },
+    ]);
+    const state = deriveEffectiveComposerModelState({
+      draft: null,
+      providers,
+      selectedProvider: driver,
+      selectedInstanceId: instanceId,
+      threadModelSelection: saved,
+      projectModelSelection: null,
+      settings: settingsWithProviderInstances(),
+    });
+    const dispatch = getComposerProviderState({
+      provider: driver,
+      model: state.selectedModel,
+      models: providers[0]!.models,
+      modelOptions: state.modelOptions?.[instanceId],
+      planModeEnabled: false,
+    });
+
+    expect(
+      createModelSelection(instanceId, state.selectedModel, dispatch.modelOptionsForDispatch),
+    ).toEqual(saved);
+  });
+
+  it("keeps an intentional custom-instance draft override through dispatch", () => {
+    const instanceId = ProviderInstanceId.make("claude_openrouter");
+    const driver = ProviderDriverKind.make("claudeAgent");
+    const providers = [
+      provider({ provider: driver, instanceId: "claudeAgent", models: ["claude-opus-5"] }),
+      provider({ provider: driver, instanceId, models: ["claude-opus-5"] }),
+    ];
+    const threadSelection = createModelSelection(instanceId, "claude-opus-5", [
+      { id: "effort", value: "high" },
+    ]);
+    const draftSelection = createModelSelection(instanceId, "openai/draft-model", [
+      { id: "effort", value: "max" },
+    ]);
+    const state = deriveEffectiveComposerModelState({
+      draft: {
+        activeProvider: instanceId,
+        modelSelectionByProvider: { [instanceId]: draftSelection },
+      },
+      providers,
+      selectedProvider: driver,
+      selectedInstanceId: instanceId,
+      threadModelSelection: threadSelection,
+      projectModelSelection: null,
+      settings: settingsWithProviderInstances(),
+    });
+    const dispatch = getComposerProviderState({
+      provider: driver,
+      model: state.selectedModel,
+      models: providers[1]!.models,
+      modelOptions: state.modelOptions?.[instanceId],
+      planModeEnabled: false,
+    });
+
+    expect(
+      createModelSelection(instanceId, state.selectedModel, dispatch.modelOptionsForDispatch),
+    ).toEqual(draftSelection);
   });
 
   it("preserves custom provider instances in settings model selection", () => {

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -6,6 +6,7 @@ import { deriveEffectiveComposerModelState } from "./composerDraftStore";
 import { getComposerProviderState } from "./components/chat/composerProviderState";
 import { deriveProviderInstanceEntries } from "./providerInstances";
 import {
+  getCustomModelOptionsByInstance,
   getAppModelOptionsForInstance,
   resolveAppModelSelectionForInstance,
   resolveAppModelSelectionState,
@@ -277,6 +278,15 @@ describe("instance-scoped model selection", () => {
         "claude-opus-4-6",
       ),
     ).toBe("claude-sonnet-4-6");
+    expect(
+      resolveAppModelSelectionForInstance(
+        ProviderInstanceId.make("claudeAgent"),
+        settings,
+        providers,
+        "claude-opus-4-6",
+        { preserveUnavailableSelection: true },
+      ),
+    ).toBe("claude-sonnet-4-6");
   });
 
   it("falls back instead of resolving a custom slug against the wrong instance", () => {
@@ -329,6 +339,191 @@ describe("instance-scoped model selection", () => {
     ).toBe("opencode/big-pickle");
   });
 
+  it("adds the selected missing OpenCode model as an unavailable option", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("opencode"),
+        instanceId: "opencode",
+        models: ["opencode/big-pickle"],
+      }),
+    ];
+    const entry = deriveProviderInstanceEntries(providers)[0]!;
+
+    expect(
+      getAppModelOptionsForInstance(settingsWithProviderInstances(), entry, "opencode/kimi-k3"),
+    ).toEqual([
+      expect.objectContaining({ slug: "opencode/big-pickle" }),
+      expect.objectContaining({
+        slug: "opencode/kimi-k3",
+        name: "opencode/kimi-k3",
+        isUnavailable: true,
+      }),
+    ]);
+  });
+
+  it("keeps a missing OpenCode option scoped to the selected instance", () => {
+    const selectedInstanceId = ProviderInstanceId.make("opencode_work");
+    const otherInstanceId = ProviderInstanceId.make("opencode_personal");
+    const driver = ProviderDriverKind.make("opencode");
+    const providers = [
+      provider({ provider: driver, instanceId: selectedInstanceId, models: [] }),
+      provider({ provider: driver, instanceId: otherInstanceId, models: [] }),
+    ];
+    const options = getCustomModelOptionsByInstance(
+      settingsWithProviderInstances(),
+      providers,
+      selectedInstanceId,
+      "openrouter/kimi-k3",
+    );
+
+    expect(options.get(selectedInstanceId)).toEqual([
+      expect.objectContaining({ slug: "openrouter/kimi-k3", isUnavailable: true }),
+    ]);
+    expect(options.get(otherInstanceId)).toEqual([]);
+  });
+
+  it("replaces the unavailable marker with catalog metadata after recovery", () => {
+    const instanceId = ProviderInstanceId.make("opencode");
+    const driver = ProviderDriverKind.make("opencode");
+    const selectedModel = "opencode/kimi-k3";
+    const pendingProviders = [
+      provider({ provider: driver, instanceId, models: ["opencode/big-pickle"] }),
+    ];
+    const recoveredProviders = [
+      provider({ provider: driver, instanceId, models: ["opencode/big-pickle", selectedModel] }),
+    ];
+
+    expect(
+      getAppModelOptionsForInstance(
+        settingsWithProviderInstances(),
+        deriveProviderInstanceEntries(pendingProviders)[0]!,
+        selectedModel,
+      ).find((option) => option.slug === selectedModel)?.isUnavailable,
+    ).toBe(true);
+    expect(
+      getAppModelOptionsForInstance(
+        settingsWithProviderInstances(),
+        deriveProviderInstanceEntries(recoveredProviders)[0]!,
+        selectedModel,
+      ).find((option) => option.slug === selectedModel)?.isUnavailable,
+    ).toBeUndefined();
+    expect(
+      resolveAppModelSelectionForInstance(
+        instanceId,
+        settingsWithProviderInstances(),
+        recoveredProviders,
+        selectedModel,
+        { preserveUnavailableSelection: true },
+      ),
+    ).toBe(selectedModel);
+  });
+
+  it("does not resurrect a hidden OpenCode model when the raw catalog omits it", () => {
+    const instanceId = ProviderInstanceId.make("opencode");
+    const driver = ProviderDriverKind.make("opencode");
+    const settings: UnifiedSettings = {
+      ...settingsWithProviderInstances(),
+      providerModelPreferences: {
+        [instanceId]: {
+          hiddenModels: ["opencode/kimi-k3"],
+          modelOrder: [],
+        },
+      },
+    };
+    const providers = [provider({ provider: driver, instanceId, models: [] })];
+    const entry = deriveProviderInstanceEntries(providers)[0]!;
+
+    expect(getAppModelOptionsForInstance(settings, entry, "opencode/kimi-k3")).toEqual([]);
+    expect(
+      resolveAppModelSelectionForInstance(instanceId, settings, providers, "opencode/kimi-k3", {
+        preserveUnavailableSelection: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not add unavailable options for other providers", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: "codex",
+        models: ["gpt-5.6-sol"],
+      }),
+    ];
+    const entry = deriveProviderInstanceEntries(providers)[0]!;
+
+    expect(
+      getAppModelOptionsForInstance(settingsWithProviderInstances(), entry, "gpt-missing").map(
+        (option) => option.slug,
+      ),
+    ).toEqual(["gpt-5.6-sol"]);
+    expect(
+      resolveAppModelSelectionForInstance(
+        ProviderInstanceId.make("codex"),
+        settingsWithProviderInstances(),
+        providers,
+        "gpt-missing",
+        { preserveUnavailableSelection: true },
+      ),
+    ).toBe("gpt-5.6-sol");
+  });
+
+  it("falls back from an explicit non-OpenCode draft with a missing model", () => {
+    const instanceId = ProviderInstanceId.make("codex");
+    const driver = ProviderDriverKind.make("codex");
+    const providers = [provider({ provider: driver, instanceId, models: ["gpt-5.6-sol"] })];
+    const state = deriveEffectiveComposerModelState({
+      draft: {
+        activeProvider: instanceId,
+        modelSelectionByProvider: {
+          [instanceId]: createModelSelection(instanceId, "gpt-missing", [
+            { id: "effort", value: "max" },
+          ]),
+        },
+      },
+      providers,
+      selectedProvider: driver,
+      selectedInstanceId: instanceId,
+      threadModelSelection: null,
+      projectModelSelection: null,
+      settings: settingsWithProviderInstances(),
+    });
+    const dispatch = getComposerProviderState({
+      provider: driver,
+      model: state.selectedModel,
+      models: providers[0]!.models,
+      modelOptions: state.modelOptions?.[instanceId],
+      planModeEnabled: false,
+    });
+
+    expect(state.selectedModel).toBe("gpt-5.6-sol");
+    expect(dispatch.modelOptionsForDispatch).toBeUndefined();
+  });
+
+  it("preserves an explicit draft OpenCode selection while the catalog is empty", () => {
+    const instanceId = ProviderInstanceId.make("opencode_work");
+    const driver = ProviderDriverKind.make("opencode");
+    const draftSelection = createModelSelection(instanceId, "openrouter/kimi-k3", [
+      { id: "variant", value: "max" },
+      { id: "agent", value: "build" },
+    ]);
+    const providers = [provider({ provider: driver, instanceId, models: [] })];
+    const state = deriveEffectiveComposerModelState({
+      draft: {
+        activeProvider: instanceId,
+        modelSelectionByProvider: { [instanceId]: draftSelection },
+      },
+      providers,
+      selectedProvider: driver,
+      selectedInstanceId: instanceId,
+      threadModelSelection: null,
+      projectModelSelection: null,
+      settings: settingsWithProviderInstances(),
+    });
+
+    expect(state.selectedModel).toBe("openrouter/kimi-k3");
+    expect(state.modelOptions?.[instanceId]).toEqual(draftSelection.options);
+  });
+
   it("preserves saved options through dispatch when the model is absent from the catalog", () => {
     const instanceId = ProviderInstanceId.make("opencode");
     const driver = ProviderDriverKind.make("opencode");
@@ -369,7 +564,7 @@ describe("instance-scoped model selection", () => {
     const threadSelection = createModelSelection(instanceId, "claude-opus-5", [
       { id: "effort", value: "high" },
     ]);
-    const draftSelection = createModelSelection(instanceId, "openai/draft-model", [
+    const draftSelection = createModelSelection(instanceId, "openai/gpt-5.5", [
       { id: "effort", value: "max" },
     ]);
     const state = deriveEffectiveComposerModelState({

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -554,7 +554,7 @@ describe("instance-scoped model selection", () => {
     ).toEqual(saved);
   });
 
-  it("keeps an intentional custom-instance draft override through dispatch", () => {
+  it("keeps a custom-instance draft model while dropping unsupported options", () => {
     const instanceId = ProviderInstanceId.make("claude_openrouter");
     const driver = ProviderDriverKind.make("claudeAgent");
     const providers = [
@@ -589,7 +589,7 @@ describe("instance-scoped model selection", () => {
 
     expect(
       createModelSelection(instanceId, state.selectedModel, dispatch.modelOptionsForDispatch),
-    ).toEqual(draftSelection);
+    ).toEqual(createModelSelection(instanceId, "openai/gpt-5.5"));
   });
 
   it("preserves custom provider instances in settings model selection", () => {

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -244,14 +244,24 @@ export function resolveAppModelSelectionForInstance(
   settings: UnifiedSettings,
   providers: ReadonlyArray<ServerProvider>,
   selectedModel: string | null | undefined,
+  resolutionOptions?: { readonly preserveUnavailableSelection?: boolean },
 ): string | null {
   const entry = deriveProviderInstanceEntries(providers).find(
     (candidate) => candidate.instanceId === instanceId,
   );
   if (!entry) return null;
   const options = getAppModelOptionsForInstance(settings, entry);
+  const resolvedSelection = resolveSelectableModel(entry.driverKind, selectedModel, options);
+  if (resolvedSelection) {
+    return resolvedSelection;
+  }
+  if (resolutionOptions?.preserveUnavailableSelection) {
+    const unavailableSelection = normalizeCustomModelSlug(selectedModel);
+    if (unavailableSelection) {
+      return unavailableSelection;
+    }
+  }
   return (
-    resolveSelectableModel(entry.driverKind, selectedModel, options) ??
     options.find((option) => option.isDefault)?.slug ??
     options[0]?.slug ??
     entry.models.find((model) => model.isDefault)?.slug ??

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -78,6 +78,27 @@ export interface AppModelOption {
   isCustom: boolean;
   isDefault?: boolean;
   isLegacy?: boolean;
+  isUnavailable?: boolean;
+}
+
+function appendUnavailableOpenCodeSelection(
+  options: AppModelOption[],
+  rawModels: ReadonlyArray<ServerProvider["models"][number]>,
+  provider: ProviderDriverKind,
+  selectedModel: string | null | undefined,
+  hiddenModels: ReadonlyArray<string>,
+): AppModelOption[] {
+  if (provider !== "opencode") return options;
+  const slug = normalizeCustomModelSlug(selectedModel);
+  if (!slug) return options;
+
+  // A model that exists in the raw catalog can be absent from `options`
+  // because the user hid it. Keep that preference authoritative.
+  if (rawModels.some((model) => model.slug === slug)) return options;
+  if (hiddenModels.includes(slug)) return options;
+  if (options.some((option) => option.slug === slug)) return options;
+
+  return [...options, { slug, name: slug, isCustom: false, isUnavailable: true }];
 }
 
 function toAppModelOption(model: ServerProvider["models"][number]): AppModelOption {
@@ -151,9 +172,10 @@ export function getAppModelOptions(
   settings: UnifiedSettings,
   providers: ReadonlyArray<ServerProvider>,
   provider: ProviderDriverKind,
-  _selectedModel?: string | null,
+  selectedModel?: string | null,
 ): AppModelOption[] {
-  const options: AppModelOption[] = getProviderModels(providers, provider).map(toAppModelOption);
+  const rawModels = getProviderModels(providers, provider);
+  const options: AppModelOption[] = rawModels.map(toAppModelOption);
   const seen = new Set(options.map((option) => option.slug));
   const builtInModelSlugs = new Set(
     Arr.filterMap(getProviderModels(providers, provider), (model) =>
@@ -180,9 +202,13 @@ export function getAppModelOptions(
     });
   }
 
-  return applyInstanceModelPreferences(
-    options,
-    readInstanceModelPreferences(settings, defaultInstanceId),
+  const preferences = readInstanceModelPreferences(settings, defaultInstanceId);
+  return appendUnavailableOpenCodeSelection(
+    applyInstanceModelPreferences(options, preferences),
+    rawModels,
+    provider,
+    selectedModel,
+    preferences.hiddenModels,
   );
 }
 
@@ -200,6 +226,7 @@ export function getAppModelOptions(
 export function getAppModelOptionsForInstance(
   settings: UnifiedSettings,
   entry: ProviderInstanceEntry,
+  selectedModel?: string | null,
 ): AppModelOption[] {
   const options: AppModelOption[] = entry.models.map(toAppModelOption);
   const seen = new Set(options.map((option) => option.slug));
@@ -219,9 +246,13 @@ export function getAppModelOptionsForInstance(
     options.push({ slug, name: slug, isCustom: true });
   }
 
-  return applyInstanceModelPreferences(
-    options,
-    readInstanceModelPreferences(settings, entry.instanceId),
+  const preferences = readInstanceModelPreferences(settings, entry.instanceId);
+  return appendUnavailableOpenCodeSelection(
+    applyInstanceModelPreferences(options, preferences),
+    entry.models,
+    entry.driverKind,
+    selectedModel,
+    preferences.hiddenModels,
   );
 }
 
@@ -250,14 +281,19 @@ export function resolveAppModelSelectionForInstance(
     (candidate) => candidate.instanceId === instanceId,
   );
   if (!entry) return null;
-  const options = getAppModelOptionsForInstance(settings, entry);
+  const options = getAppModelOptionsForInstance(
+    settings,
+    entry,
+    resolutionOptions?.preserveUnavailableSelection ? selectedModel : null,
+  );
   const resolvedSelection = resolveSelectableModel(entry.driverKind, selectedModel, options);
   if (resolvedSelection) {
     return resolvedSelection;
   }
-  if (resolutionOptions?.preserveUnavailableSelection) {
+  if (resolutionOptions?.preserveUnavailableSelection && entry.driverKind === "opencode") {
     const unavailableSelection = normalizeCustomModelSlug(selectedModel);
-    if (unavailableSelection) {
+    const hiddenModels = readInstanceModelPreferences(settings, entry.instanceId).hiddenModels;
+    if (unavailableSelection && !hiddenModels.includes(unavailableSelection)) {
       return unavailableSelection;
     }
   }
@@ -278,12 +314,19 @@ export function resolveAppModelSelectionForInstance(
 export function getCustomModelOptionsByInstance(
   settings: UnifiedSettings,
   providers: ReadonlyArray<ServerProvider>,
-  _selectedInstanceId?: ProviderInstanceId | null,
-  _selectedModel?: string | null,
+  selectedInstanceId?: ProviderInstanceId | null,
+  selectedModel?: string | null,
 ): ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>> {
   const out = new Map<ProviderInstanceId, ReadonlyArray<ModelEsque>>();
   for (const entry of deriveProviderInstanceEntries(providers)) {
-    out.set(entry.instanceId, getAppModelOptionsForInstance(settings, entry));
+    out.set(
+      entry.instanceId,
+      getAppModelOptionsForInstance(
+        settings,
+        entry,
+        entry.instanceId === selectedInstanceId ? selectedModel : null,
+      ),
+    );
   }
   return out;
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)
-- Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
+- Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md) · [OpenCode](./user/providers-opencode.md)
 
 Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -39,6 +39,31 @@ directory to route session and turn operations for a thread, so callers name a t
 Adding a driver means writing the driver plus adapter and adding it to `BUILT_IN_DRIVERS`. No
 orchestration, contract, or client change is required for the common case.
 
+## OpenCode server ownership and catalog
+
+Each OpenCode provider instance owns one lazy local server for catalog discovery and
+text-generation helpers through [`OpenCodeServerOwner.ts`][opencode-server-owner]. Concurrent
+borrowers share startup. The server closes 30 seconds after the last borrower releases it, or
+when the provider instance closes. A failed or exited process can be started again on the next
+use. An externally configured OpenCode server remains externally owned.
+
+Chat adapters keep their own server per thread. They register a thread-specific `t3-code` MCP
+connection, while OpenCode stores MCP connections by directory. Sharing these chat servers
+without changing MCP routing would let two threads in one directory replace each other's
+connection.
+
+OpenCode loads its catalog through the HTTP API once when an enabled provider instance starts.
+The provider registry keeps the snapshot in memory and persists it in the existing per-instance
+cache. Routine config subscriptions and periodic health checks do not reload this catalog.
+Explicit provider refresh reloads it. Changes to the provider configuration or environment
+replace the instance and start a new discovery. Changes to unrelated settings only update
+snapshot enrichment. Other providers retain their existing refresh policy.
+
+The shared server's idle shutdown does not clear the catalog. Failed discovery keeps the last
+known model metadata through the registry's existing merge rules. A successful empty inventory
+is authoritative. Existing threads keep their explicit model identifier and options when catalog
+metadata is missing; the catalog is not permission to choose a different model for a thread.
+
 ## Model manifest
 
 The model picker's legacy section is driven by `apps/server/src/provider/model-manifest.json`, which
@@ -121,6 +146,7 @@ when a request opens (approval) or user input is requested, via
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts
 [opencode]: ../../apps/server/src/provider/Drivers/OpenCodeDriver.ts
+[opencode-server-owner]: ../../apps/server/src/provider/OpenCodeServerOwner.ts
 [adapter]: ../../apps/server/src/provider/Services/ProviderAdapter.ts
 [instances]: ../../apps/server/src/provider/Services/ProviderInstanceRegistry.ts
 [registry]: ../../apps/server/src/provider/Services/ProviderAdapterRegistry.ts

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -47,22 +47,41 @@ borrowers share startup. The server closes 30 seconds after the last borrower re
 when the provider instance closes. A failed or exited process can be started again on the next
 use. An externally configured OpenCode server remains externally owned.
 
+The local server and its SDK clients use one resolved password. An explicit provider password
+overrides `OPENCODE_SERVER_PASSWORD` in the spawned environment. Without an explicit password,
+the client uses the password from the environment that the process inherits. External servers use
+only their explicit provider password and never inherit the host's local password.
+
+Every server connection must pass the authenticated `/global/health` check before inventory or
+session operations start. The response must contain a valid version at or above 1.14.19. Local
+owners cache this result for the lifetime of the spawned process. External actions check once when
+they create their server connection, not for each model or SDK request.
+
 Chat adapters keep their own server per thread. They register a thread-specific `t3-code` MCP
 connection, while OpenCode stores MCP connections by directory. Sharing these chat servers
 without changing MCP routing would let two threads in one directory replace each other's
 connection.
 
-OpenCode loads its catalog through the HTTP API once when an enabled provider instance starts.
-The provider registry keeps the snapshot in memory and persists it in the existing per-instance
-cache. Routine config subscriptions and periodic health checks do not reload this catalog.
-Explicit provider refresh reloads it. Changes to the provider configuration or environment
-replace the instance and start a new discovery. Changes to unrelated settings only update
-snapshot enrichment. Other providers retain their existing refresh policy.
+OpenCode loads its catalog through the HTTP API when an enabled provider instance starts. The
+provider registry keeps the snapshot in memory and persists it in the existing per-instance cache.
+Each `subscribeServerConfig` connection refreshes all providers, so a client reconnect reloads the
+OpenCode catalog from the current helper. The `serverRefreshProviders` request also refreshes it.
+Periodic OpenCode probes remain disabled. OpenCode reads credentials for each inventory request,
+but its native configuration files can remain cached for the lifetime of the helper process. The
+helper closes 30 seconds after its last inventory or text-generation borrower releases it. A
+refresh after that idle period starts a new helper and reads file changes. Repeated refreshes and
+active text-generation work can extend process reuse. Changes to the provider configuration or
+environment replace the instance and start a new discovery. Changes to unrelated settings only
+update snapshot enrichment. Other providers retain their existing refresh policy.
+
+T3 Code does not own an external OpenCode process. Native configuration changes there can require
+an external reload or restart before T3 Code's next refresh sees them.
 
 The shared server's idle shutdown does not clear the catalog. Failed discovery keeps the last
-known model metadata through the registry's existing merge rules. A successful empty inventory
-is authoritative. Existing threads keep their explicit model identifier and options when catalog
-metadata is missing; the catalog is not permission to choose a different model for a thread.
+known models, slash commands, and skills through the registry's existing merge rules. A successful
+empty inventory is authoritative. Existing threads keep their explicit model identifier and
+options when catalog metadata is missing; the catalog is not permission to choose a different
+model for a thread.
 
 ## Model manifest
 

--- a/docs/user/providers-opencode.md
+++ b/docs/user/providers-opencode.md
@@ -1,0 +1,26 @@
+# OpenCode
+
+T3 Code uses the OpenCode setup on the connected environment. With a remote environment, its
+OpenCode login and configuration apply, not the setup on your desktop or phone.
+
+## Refresh the model list
+
+T3 Code loads the model list when an enabled OpenCode provider starts and keeps the list in its
+cache. Opening a thread or reconnecting a client does not reload the list. The periodic provider
+health setting does not refresh OpenCode's catalog.
+
+After changing an OpenCode login or configuration outside T3 Code, open **Settings > Providers**,
+select the environment, and choose **Refresh provider status**. Changing the provider's
+configuration in T3 Code reloads the list automatically.
+
+If a refresh fails, T3 Code keeps the last known models. A successful refresh can remove models
+that OpenCode no longer offers.
+
+## Continue an existing thread
+
+An existing thread keeps its selected model and options when that model is temporarily absent
+from the catalog. The picker shows the model identifier if its display name is unavailable.
+T3 Code does not switch the thread to the first model in the list.
+
+The stored selection does not guarantee that OpenCode can still run the model. If the provider
+rejects it, select an available model before trying again.

--- a/docs/user/providers-opencode.md
+++ b/docs/user/providers-opencode.md
@@ -3,24 +3,51 @@
 T3 Code uses the OpenCode setup on the connected environment. With a remote environment, its
 OpenCode login and configuration apply, not the setup on your desktop or phone.
 
+T3 Code requires OpenCode 1.14.19 or newer. It checks the server version before it loads models or
+starts work. If the check fails, update OpenCode or fix the server URL and password, then refresh
+the provider status. Reconnecting the client also runs the check again.
+
+## Server authentication
+
+Without a server URL, T3 Code starts a local OpenCode server. The process inherits
+`OPENCODE_SERVER_PASSWORD` from the environment. A password in the provider settings overrides
+that environment value for both the local process and T3 Code.
+
+With a server URL, T3 Code connects to that external server and uses only the password in the
+provider settings. It does not send a local `OPENCODE_SERVER_PASSWORD` to an external server.
+OpenCode uses this password for HTTP Basic authentication.
+
 ## Refresh the model list
 
 T3 Code loads the model list when an enabled OpenCode provider starts and keeps the list in its
-cache. Opening a thread or reconnecting a client does not reload the list. The periodic provider
-health setting does not refresh OpenCode's catalog.
+cache. Reconnecting a client or using a refresh control asks OpenCode for the list again. The
+periodic provider health setting does not refresh OpenCode's catalog.
 
 After changing an OpenCode login or configuration outside T3 Code, open **Settings > Providers**,
 select the environment, and choose **Refresh provider status**. Changing the provider's
-configuration in T3 Code reloads the list automatically.
+configuration in T3 Code also replaces that provider connection.
 
-If a refresh fails, T3 Code keeps the last known models. A successful refresh can remove models
-that OpenCode no longer offers.
+On mobile, open the thread settings and select **Refresh models**. The control stays disabled while
+the refresh runs and shows an error if the refresh fails.
+
+OpenCode reads credential changes on each model-list request. Native OpenCode configuration files
+can stay cached while the local helper is running. The helper closes after 30 seconds with no
+model-list or text-generation work. Refresh after that idle period to start a new helper and read
+the file changes. Repeated refreshes or active helper work can extend this wait.
+
+T3 Code does not own an external OpenCode server. Native configuration changes on that server can
+require its own reload or restart before a refresh returns the new list.
+
+If a refresh fails, T3 Code keeps the last known models, slash commands, and skills. Fix the
+connection, then refresh again. A successful refresh can remove entries that OpenCode no longer
+offers.
 
 ## Continue an existing thread
 
 An existing thread keeps its selected model and options when that model is temporarily absent
-from the catalog. The picker shows the model identifier if its display name is unavailable.
-T3 Code does not switch the thread to the first model in the list.
+from the catalog. The web picker shows an **Unavailable** row and keeps saved option values visible
+until the model metadata returns. T3 Code does not switch the thread to the first model in the
+list.
 
 The stored selection does not guarantee that OpenCode can still run the model. If the provider
 rejects it, select an available model before trying again.


### PR DESCRIPTION
OpenCode could hide approval and question prompts from child sessions after a resume or reconnect. Turn races could also accept work after a stop, complete the wrong turn, or leave stop callers waiting. Model refresh, server authentication, and missing catalog entries had separate consistency problems.

This change verifies session ancestry, recovers pending child requests, and limits recovery work to the current prompt generation. Asked-event ancestry recovery continues while the native request is live. If a terminal event supersedes that request but ancestry remains unknown, terminal recovery stops after five attempts and removes its retry entry. Each session serializes prompt sends. A stop cancels a pending prompt request before it sends the native abort, and a canceled send exits as interrupted instead of persisting a running turn. Admission recovery keeps a buffered idle when the exact prompt echo arrives before or after the prompt HTTP response. Bounded message and status checks then reconcile that idle and the first idle after an interruption without reconnecting SSE. Both recovery requests read the stopped state first, then verify the current session, admission, turn, prompt generation, and cancellation before they change state. A stale response cannot clear the next prompt's admission. A polled busy status immediately enables output after an interruption. A final cancellation check runs before `sendTurn` returns. A genuine session error now releases pending stop callers.

OpenCode inventory and text generation share one lazy local server. Local settings passwords override `OPENCODE_SERVER_PASSWORD`; otherwise the inherited environment password is used by the server and every SDK client. External servers use only their configured password. Every connection passes an authenticated health and minimum-version check before inventory or session work.

OpenCode catalogs refresh when a client subscribes to server config or requests a manual refresh. Periodic OpenCode catalog polling remains off. A failed refresh keeps the last good models, slash commands, and skills. The shared helper closes 30 seconds after its last borrower releases it, so a later refresh rereads native configuration files. T3 Code does not own external OpenCode servers, which can need their own reload or restart.

Web scopes both missing-model option dispatch and trigger-label handling to OpenCode. If an OpenCode model is missing from the catalog, dispatch keeps the thread or draft's exact provider instance, model, and saved option values. The trigger shows the stored model identifier instead of falling back to the first catalog option. The picker shows an **Unavailable** row, respects hidden models, and remains usable while the provider reports a warning or error. Other providers validate dispatch options against live descriptors and keep their existing first-option trigger fallback. Mobile thread settings include the shared manual model refresh action.

Verification: 334 focused tests pass. This includes 179 server tests across seven files, 80 of which are adapter tests, one selected `ProviderService` interruption test, three `subscribeServerConfig` tests, 149 web tests across six files, and two mobile refresh tests. Scoped server, web, and mobile typechecks pass. Targeted lint, formatting, and `git diff --check` pass.

A loopback fault test reproduced the send-after-stop race on commit `3d0dc050` and verified the repaired code. The baseline accepted the held prompt after stop completed and wrote the sandbox file after `turn.aborted`. The repaired code canceled the prompt before the proxy forwarded it, made zero model calls, and did not write the file. A separate authenticated OpenCode 1.18.23 control recovered and resolved two child requests, left no pending requests, and completed the parent with five loopback model calls. No live data or real model account was used. No browser or emulator verification was run.

Made by GPT-5.6 Sol with the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sit in OpenCode session lifecycle, stop/interrupt coordination, and child approval routing—areas where race bugs directly affect correctness and user safety.
> 
> **Overview**
> **Mobile thread settings** now carry an `environmentId` through the settings session and expose a **Refresh models** header action (Android and iOS). Refresh runs `serverEnvironment.refreshProviders` for that environment via a small helper that **deduplicates in-flight taps** and surfaces discovery failures in an alert.
> 
> **OpenCode driver wiring** constructs a shared **`OpenCodeServerOwner`** for text generation and provider checks, and turns off **settings-triggered and interval catalog polling** for the managed OpenCode snapshot (`checkProviderOnSettingsChange: false`, `refreshOnInterval: false`).
> 
> **OpenCode adapter tests** expand heavily: the runtime mock gains session status, permissions, questions, abort signals, and richer event streaming. New cases cover connection timeouts, concurrent session starts, stop/teardown races, steer **admission vs idle/status ordering**, interrupt and turnless abort behavior, and **child-session approval/question routing** plus recovery on resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e3e7ac309b0481ebc6cceeb0a563f934c26832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rework `OpenCodeAdapter` child approvals, stops, and unavailable model catalog handling
> - Reworks `sendTurn`, `interrupt`, and session startup in `OpenCodeAdapter` to serialize prompt submissions with a `Semaphore`, correlate by generated messageID, and coordinate cancellation via `Deferred` so aborts are acknowledged by either API or event stream
> - Adds routing for child-session permission/question events via `isOpenCodeChildRequestEvent`, `emitPendingOpenCodeRequest`, and `emitTerminalOpenCodeRequest` with de-duplication and parent-session relation retries
> - Introduces `OpenCodeServerOwner` for shared, lazily-started local OpenCode servers with a 30s idle TTL, concurrent borrower tracking, and process-exit invalidation
> - Adds server version validation against `MINIMUM_OPENCODE_VERSION` ("1.14.19") via `verifyOpenCodeServerVersion` with a 5s health-check timeout; local servers inject `OPENCODE_SERVER_PASSWORD` into the child environment, external servers receive only settings-provided passwords
> - Preserves unavailable OpenCode model selections across catalog refreshes: `mergeProviderSnapshot` retains prior `slashCommands`/`skills` under retention conditions, and the web/mobile pickers render an "Unavailable" badge while keeping saved options for dispatch
> - Risk: `runOpenCodeSdk` signature changed to require an `AbortSignal` parameter; all callers in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/8480/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) are updated. `makeOpenCodeTextGeneration` no longer accepts an `environment` argument and delegates server lifecycle to `OpenCodeServerOwner` — out-of-tree callers of either will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e3e7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
