### PR TITLE
fix(web): let empty-provider composer open settings

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -117,6 +117,7 @@ import { ComposerPendingApprovalPanel } from "./ComposerPendingApprovalPanel";
 import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
 import { ComposerControl, ComposerControlIcon, ComposerSelectControl } from "./ComposerControl";
+import { ComposerNoProviderControl } from "./ComposerNoProviderControl";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
 import { searchSlashCommandItems } from "./composerSlashCommandSearch";
 import {
@@ -3474,17 +3475,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               >
                 <div className="-m-1 -ms-3.5 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto p-1 ps-3.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                   {noProviderAvailable ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      disabled
-                      data-chat-provider-unavailable="true"
-                      className="shrink-0 gap-2 px-2 text-secondary-label sm:px-3"
-                    >
-                      <CircleAlertIcon className="size-4" />
-                      No provider available
-                    </Button>
+                    <ComposerNoProviderControl />
                   ) : (
                     <ProviderModelPicker
                       compact={isComposerFooterCompact}

--- a/apps/web/src/components/chat/ComposerNoProviderControl.test.tsx
+++ b/apps/web/src/components/chat/ComposerNoProviderControl.test.tsx
@@ -1,0 +1,23 @@
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ to, children, ...props }: { to: string; children?: ReactNode }) =>
+    createElement("a", { href: to, ...props }, children),
+}));
+
+import { ComposerNoProviderControl } from "./ComposerNoProviderControl";
+
+describe("ComposerNoProviderControl", () => {
+  it("links the empty-provider chip to provider settings", () => {
+    const markup = renderToStaticMarkup(<ComposerNoProviderControl />);
+
+    expect(markup).toContain('href="/settings/providers"');
+    expect(markup).toContain("No provider available");
+    expect(markup).toContain('data-chat-provider-unavailable="true"');
+    expect(markup).toContain("Open provider settings");
+    expect(markup).not.toContain('disabled=""');
+    expect(markup).not.toContain("aria-disabled");
+  });
+});

--- a/apps/web/src/components/chat/ComposerNoProviderControl.tsx
+++ b/apps/web/src/components/chat/ComposerNoProviderControl.tsx
@@ -1,0 +1,24 @@
+import { Link } from "@tanstack/react-router";
+import { CircleAlertIcon } from "lucide-react";
+
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { ComposerControl, ComposerControlIcon } from "./ComposerControl";
+
+export function ComposerNoProviderControl() {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="flex shrink-0" />}>
+        <ComposerControl
+          render={<Link to="/settings/providers" />}
+          aria-label="Open provider settings"
+          className="-ms-2.5"
+          data-chat-provider-unavailable="true"
+        >
+          <ComposerControlIcon icon={CircleAlertIcon} />
+          No provider available
+        </ComposerControl>
+      </TooltipTrigger>
+      <TooltipPopup>Open provider settings</TooltipPopup>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## What Changed

When no provider is available, the composer footer used to render a disabled **No provider available** chip. That chip is now a link to **Settings → Providers**. Hovering it shows "Open provider settings". Send stays disabled until a provider is enabled.

Web and desktop share this composer. Mobile does not: providers are configured on the host.

## Why

The empty-provider composer already told people to enable a provider in Settings, but the only control in that slot was disabled. There was no way through from the screen they were stuck on.

This keeps the same empty state and makes the obvious control do the thing the copy already promised.

## UI Changes

**Before:** disabled status chip in the model-picker slot. Placeholder says to enable a provider in Settings, but nothing in the composer navigates there.

**After:** same chip, now a link. Click opens `/settings/providers`. Tooltip: "Open provider settings".

Verified on desktop with every provider disabled: the chip appears, click lands on provider settings, enabling a provider restores the model picker.

Please drop before/after screenshots into this description (the empty composer chip, then the same chip after hover/click). I could not attach image files from the CLI.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes