### PR TITLE
fix(desktop): allow preview automation in agent-created threads

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -1,4 +1,5 @@
 import { it as effectIt } from "@effect/vitest";
+import { PreviewAutomationStatus } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -51,4 +52,46 @@ describe("preview IPC methods", () => {
       },
     ),
   );
+
+  effectIt.effect("returns automation status for long runtime tab ids", () =>
+    Effect.gen(function* () {
+      const tabId =
+        `["environment-1","thread:delegated-task:${"a".repeat(120)}",` +
+        `"server-epoch-1","preview-1"]`;
+      const status = {
+        available: false,
+        visible: true,
+        tabId,
+        url: null,
+        title: null,
+        loading: false,
+      };
+      const manager = PreviewManager.PreviewManager.of({
+        automationStatus: () => Effect.succeed(status),
+      } as unknown as PreviewManager.PreviewManager["Service"]);
+
+      expect(tabId.length).toBeGreaterThan(128);
+      expect(
+        yield* PreviewIpc.automationStatus
+          .handler({ tabId })
+          .pipe(Effect.provideService(PreviewManager.PreviewManager, manager)),
+      ).toEqual(status);
+    }),
+  );
+
+  it("keeps the public automation status tab id limit", () => {
+    const encode = Schema.encodeUnknownSync(PreviewAutomationStatus);
+    const tabId = "t".repeat(129);
+
+    expect(() =>
+      encode({
+        available: false,
+        visible: true,
+        tabId,
+        url: null,
+        title: null,
+        loading: false,
+      }),
+    ).toThrow();
+  });
 });

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -5,6 +5,7 @@ import {
   DesktopPreviewAutomationEvaluateInputSchema,
   DesktopPreviewAutomationPressInputSchema,
   DesktopPreviewAutomationScrollInputSchema,
+  DesktopPreviewAutomationStatusSchema,
   DesktopPreviewAutomationTypeInputSchema,
   DesktopPreviewAutomationWaitForInputSchema,
   DesktopPreviewConfigInputSchema,
@@ -20,7 +21,6 @@ import {
   DesktopPreviewWebviewConfigSchema,
   PreviewAnnotationSubmissionResultSchema,
   PreviewAutomationSnapshot,
-  PreviewAutomationStatus,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
@@ -282,7 +282,7 @@ export const copyArtifactToClipboard = DesktopIpc.makeIpcMethod({
 export const automationStatus = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_STATUS_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
-  result: PreviewAutomationStatus,
+  result: DesktopPreviewAutomationStatusSchema,
   handler: Effect.fn("desktop.ipc.preview.automationStatus")(function* ({ tabId }) {
     const manager = yield* PreviewManager.PreviewManager;
     return yield* manager.automationStatus(tabId);

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -7,6 +7,7 @@
  */
 import type {
   DesktopPreviewAnnotationTheme,
+  DesktopPreviewAutomationStatus,
   DesktopPreviewColorScheme,
   DesktopPreviewFavicon,
   DesktopPreviewPointerEvent,
@@ -25,7 +26,6 @@ import type {
   PreviewAutomationNetworkEntry,
   PreviewAutomationScrollInput,
   PreviewAutomationSnapshot,
-  PreviewAutomationStatus,
   PreviewAutomationTypeInput,
   PreviewAutomationWaitForInput,
 } from "@t3tools/contracts";
@@ -4089,7 +4089,7 @@ export class PreviewManager extends Context.Service<
     ) => Effect.Effect<DesktopPreviewRecordingArtifact, PreviewManagerError>;
     readonly automationStatus: (
       tabId: string,
-    ) => Effect.Effect<PreviewAutomationStatus, PreviewManagerError>;
+    ) => Effect.Effect<DesktopPreviewAutomationStatus, PreviewManagerError>;
     readonly automationSnapshot: (
       tabId: string,
     ) => Effect.Effect<PreviewAutomationSnapshot, PreviewManagerError>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -584,6 +584,12 @@ export const DesktopPreviewTabIdSchema = Schema.String.check(Schema.isTrimmed())
   Schema.isNonEmpty(),
 );
 
+export const DesktopPreviewAutomationStatusSchema = Schema.Struct({
+  ...PreviewAutomationStatus.fields,
+  tabId: Schema.NullOr(DesktopPreviewTabIdSchema),
+});
+export type DesktopPreviewAutomationStatus = typeof DesktopPreviewAutomationStatusSchema.Type;
+
 export const DesktopPreviewNavStatusSchema = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("Idle") }),
   Schema.Struct({
@@ -1217,7 +1223,7 @@ export interface DesktopPreviewBridge {
     onFrame: (listener: (frame: DesktopPreviewRecordingFrame) => void) => () => void;
   };
   automation: {
-    status: (tabId: string) => Promise<PreviewAutomationStatus>;
+    status: (tabId: string) => Promise<DesktopPreviewAutomationStatus>;
     snapshot: (tabId: string) => Promise<PreviewAutomationSnapshot>;
     click: (tabId: string, input: PreviewAutomationClickInput) => Promise<void>;
     type: (tabId: string, input: PreviewAutomationTypeInput) => Promise<void>;


### PR DESCRIPTION
Preview automation fails from agent-created threads because their desktop runtime tab IDs can exceed the public 128-character tab ID limit. Desktop IPC rejects the status result after the browser action has already run.

Use a desktop-only status schema for this IPC result. This keeps the public contract limit intact while allowing the internal runtime ID to return through IPC. The manager and bridge types now describe the same boundary.

Tests:
- vp test run apps/desktop/src/ipc/methods/preview.test.ts
- vp run --filter @t3tools/contracts typecheck
- vp run --filter @t3tools/web typecheck
- targeted desktop typecheck for the changed files

Fixes #7720

Made with GPT-5.6 Sol using Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract boundary change limited to desktop IPC and bridge types; public automation status validation stays the same.
> 
> **Overview**
> Fixes preview automation failing on **agent-created threads** when the desktop runtime tab ID exceeds the public **128-character** `PreviewTabId` limit. Automation could run in the browser, but the desktop **automation status** IPC path then rejected the encoded result because it used the public `PreviewAutomationStatus` schema.
> 
> Introduces **`DesktopPreviewAutomationStatusSchema`**, which keeps the public status fields but types `tabId` with **`DesktopPreviewTabIdSchema`** (trimmed, non-empty, no 128-char cap). The preview IPC handler, preview manager, and `DesktopPreviewBridge.automation.status` now use that desktop-only result type so internal runtime IDs can round-trip over IPC.
> 
> The public **`PreviewAutomationStatus`** contract and its 128-character tab ID limit are unchanged for cross-boundary APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d266aae5971d360a6696bbc5d60633401f2919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `preview.automationStatus` IPC to allow null `tabId`
> Introduces `DesktopPreviewAutomationStatusSchema` in [ipc.ts](https://github.com/pingdotgg/t3code/pull/8483/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a) that extends `PreviewAutomationStatus` but permits `tabId` to be `null` instead of requiring a valid tab identifier. The `preview.automationStatus` IPC handler and `PreviewManager.automationStatus` return type are switched to the new schema. Risk: out-of-tree consumers expecting a non-null `tabId` from the `automationStatus` IPC method will now encounter `null` values for agent-created threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90d266a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->