### PR TITLE
fix(desktop): recover preview automation after snapshot timeouts

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -28,6 +28,13 @@ vi.mock("electron", () => ({
   },
 }));
 
+const snapshotInput = {
+  tabId: "runtime-tab",
+  connectionId: "connection-1",
+  requestId: "request-1",
+  timeoutMs: 15_000,
+} as const;
+
 describe("preview IPC methods", () => {
   beforeEach(() => {
     fromPartition.mockClear();
@@ -94,4 +101,61 @@ describe("preview IPC methods", () => {
       }),
     ).toThrow();
   });
+
+  effectIt.effect("encodes Manager deadline errors as timeout results", () =>
+    Effect.gen(function* () {
+      const error = new PreviewManager.PreviewAutomationDeadlineExceededError({
+        operation: "snapshot",
+        tabId: snapshotInput.tabId,
+        webContentsId: 42,
+        connectionId: snapshotInput.connectionId,
+        requestId: snapshotInput.requestId,
+        timeoutMs: snapshotInput.timeoutMs,
+        stage: "execution",
+      });
+      const automationSnapshot = vi.fn(() => Effect.fail(error));
+
+      const result = yield* PreviewIpc.automationSnapshot
+        .handler(snapshotInput)
+        .pipe(
+          Effect.provideService(
+            PreviewManager.PreviewManager,
+            PreviewManager.PreviewManager.of({ automationSnapshot } as never),
+          ),
+        );
+
+      expect(automationSnapshot).toHaveBeenCalledWith(snapshotInput);
+      expect(result).toEqual({
+        _tag: "Timeout",
+        stage: "execution",
+        timeoutMs: snapshotInput.timeoutMs,
+      });
+    }),
+  );
+
+  effectIt.effect("keeps unexpected Manager failures rejected", () =>
+    Effect.gen(function* () {
+      const error = new PreviewManager.PreviewOperationError({
+        operation: "automationSnapshot.capturePage",
+        tabId: snapshotInput.tabId,
+        webContentsId: 42,
+        cause: new Error("capture failed"),
+      });
+      const automationSnapshot = vi.fn(() => Effect.fail(error));
+
+      const exit = yield* PreviewIpc.automationSnapshot
+        .handler(snapshotInput)
+        .pipe(
+          Effect.provideService(
+            PreviewManager.PreviewManager,
+            PreviewManager.PreviewManager.of({ automationSnapshot } as never),
+          ),
+          Effect.exit,
+        );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isSuccess(exit)) return;
+      expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toBe(error);
+    }),
+  );
 });

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -298,13 +298,14 @@ export const automationSnapshot = DesktopIpc.makeIpcMethod({
     const manager = yield* PreviewManager.PreviewManager;
     return yield* manager.automationSnapshot(input).pipe(
       Effect.map((snapshot) => ({ _tag: "Success" as const, snapshot })),
-      Effect.catchTag("PreviewAutomationDeadlineExceededError", (error) =>
-        Effect.succeed({
-          _tag: "Timeout" as const,
-          stage: error.stage,
-          timeoutMs: error.timeoutMs,
-        }),
-      ),
+      Effect.catchTags({
+        PreviewAutomationDeadlineExceededError: (error) =>
+          Effect.succeed({
+            _tag: "Timeout" as const,
+            stage: error.stage,
+            timeoutMs: error.timeoutMs,
+          }),
+      }),
     );
   }),
 });

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -5,6 +5,8 @@ import {
   DesktopPreviewAutomationEvaluateInputSchema,
   DesktopPreviewAutomationPressInputSchema,
   DesktopPreviewAutomationScrollInputSchema,
+  DesktopPreviewAutomationSnapshotInputSchema,
+  DesktopPreviewAutomationSnapshotResultSchema,
   DesktopPreviewAutomationStatusSchema,
   DesktopPreviewAutomationTypeInputSchema,
   DesktopPreviewAutomationWaitForInputSchema,
@@ -20,7 +22,6 @@ import {
   DesktopPreviewTabInputSchema,
   DesktopPreviewWebviewConfigSchema,
   PreviewAnnotationSubmissionResultSchema,
-  PreviewAutomationSnapshot,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
@@ -291,11 +292,20 @@ export const automationStatus = DesktopIpc.makeIpcMethod({
 
 export const automationSnapshot = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL,
-  payload: DesktopPreviewTabInputSchema,
-  result: PreviewAutomationSnapshot,
-  handler: Effect.fn("desktop.ipc.preview.automationSnapshot")(function* ({ tabId }) {
+  payload: DesktopPreviewAutomationSnapshotInputSchema,
+  result: DesktopPreviewAutomationSnapshotResultSchema,
+  handler: Effect.fn("desktop.ipc.preview.automationSnapshot")(function* (input) {
     const manager = yield* PreviewManager.PreviewManager;
-    return yield* manager.automationSnapshot(tabId);
+    return yield* manager.automationSnapshot(input).pipe(
+      Effect.map((snapshot) => ({ _tag: "Success" as const, snapshot })),
+      Effect.catchTag("PreviewAutomationDeadlineExceededError", (error) =>
+        Effect.succeed({
+          _tag: "Timeout" as const,
+          stage: error.stage,
+          timeoutMs: error.timeoutMs,
+        }),
+      ),
+    );
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -234,8 +234,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     automation: {
       status: (tabId) =>
         ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_STATUS_CHANNEL, { tabId }),
-      snapshot: (tabId) =>
-        ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL, { tabId }),
+      snapshot: (input) =>
+        ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL, input),
       click: (tabId, input) =>
         ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_CLICK_CHANNEL, { tabId, input }),
       type: (tabId, input) =>

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -188,6 +188,101 @@ const makeTestPreviewWebContents = (
     capturePage,
   }) as never;
 
+const makeAutomationImage = (width = 800, height = 600) => {
+  const image = {
+    getSize: () => ({ width, height }),
+    resize: vi.fn(() => image),
+    toJPEG: () => Buffer.from("jpeg"),
+    toPNG: () => Buffer.from("png"),
+  };
+  return image;
+};
+
+const makeAutomationWebContents = (options: {
+  readonly capturePage: () => Promise<ReturnType<typeof makeAutomationImage>>;
+  readonly id?: number;
+  readonly sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+}) => {
+  let attached = false;
+  let destroyed = false;
+  let devToolsOpen = false;
+  const listeners = new Map<string, (...args: never[]) => void>();
+  const attach = vi.fn(() => {
+    attached = true;
+  });
+  const detach = vi.fn(() => {
+    attached = false;
+  });
+  const on = vi.fn((event: string, listener: (...args: never[]) => void) => {
+    listeners.set(event, listener);
+  });
+  const off = vi.fn();
+  const debuggerOn = vi.fn();
+  const debuggerOff = vi.fn();
+  const sendCommand = vi.fn(options.sendCommand);
+  const capturePage = vi.fn(options.capturePage);
+  const webContents = {
+    id: options.id ?? 42,
+    isDestroyed: () => destroyed,
+    isDevToolsOpened: () => devToolsOpen,
+    getType: () => "webview",
+    getURL: () => "https://example.com",
+    getTitle: () => "Example",
+    isLoading: () => false,
+    getZoomFactor: () => 1,
+    setZoomFactor: vi.fn(),
+    setAudioMuted: vi.fn(),
+    isCurrentlyAudible: () => false,
+    on,
+    once: on,
+    off,
+    ipc: { on: vi.fn(), off: vi.fn() },
+    send: webviewSend,
+    navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+    setWindowOpenHandler: vi.fn(),
+    debugger: {
+      isAttached: () => attached,
+      attach,
+      detach,
+      sendCommand,
+      on: debuggerOn,
+      off: debuggerOff,
+    },
+    capturePage,
+  };
+  return {
+    attach,
+    capturePage,
+    debuggerOn,
+    debuggerOff,
+    detach,
+    listeners,
+    sendCommand,
+    setDestroyed: (value: boolean) => {
+      destroyed = value;
+    },
+    setDevToolsOpen: (value: boolean) => {
+      devToolsOpen = value;
+    },
+    webContents: webContents as never,
+  };
+};
+
+const snapshotPageValue = {
+  url: "https://example.com",
+  title: "Example",
+  loading: false,
+  visibleText: "Example",
+  interactiveElements: [],
+};
+
+const snapshotInput = (tabId: string, timeoutMs = 1_000) => ({
+  tabId,
+  connectionId: "connection-1",
+  requestId: `request-${tabId}`,
+  timeoutMs,
+});
+
 const TEST_FAVICON = "data:image/png;base64,cG5n";
 
 const makeSourcePng = (width = 1, height = 1): Buffer => {
@@ -3383,4 +3478,640 @@ describe("Preview automation diagnostics", () => {
     expect(JSON.stringify(error)).not.toContain(selector);
     expect("locator" in error).toBe(false);
   });
+
+  effectIt.effect("does not let stalled debugger initialization block another tab", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const stalled = new Promise<unknown>(() => undefined);
+        const first = makeAutomationWebContents({
+          id: 41,
+          capturePage: async () => makeAutomationImage(),
+          sendCommand: async (method) => {
+            if (method === "Runtime.enable") return await stalled;
+            if (method === "Runtime.evaluate") return { result: { value: snapshotPageValue } };
+            if (method === "Accessibility.getFullAXTree") return { nodes: [] };
+            return undefined;
+          },
+        });
+        const second = makeAutomationWebContents({
+          id: 42,
+          capturePage: async () => makeAutomationImage(),
+          sendCommand: async (method) =>
+            method === "Runtime.evaluate"
+              ? { result: { value: { ready: true } } }
+              : method === "Accessibility.getFullAXTree"
+                ? { nodes: [] }
+                : undefined,
+        });
+        const byId = new Map([
+          [41, first.webContents],
+          [42, second.webContents],
+        ]);
+        fromId.mockImplementation((id) => (id === undefined ? null : (byId.get(id) ?? null)));
+
+        first.setDevToolsOpen(true);
+        yield* manager.createTab("tab_stalled");
+        yield* manager.registerWebview("tab_stalled", 41);
+        first.setDevToolsOpen(false);
+        yield* manager.createTab("tab_ready");
+        yield* manager.registerWebview("tab_ready", 42);
+        yield* settle(() => second.attach.mock.calls.length > 0);
+
+        const stalledSnapshot = yield* manager
+          .automationSnapshot(snapshotInput("tab_stalled", 100))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() =>
+          first.sendCommand.mock.calls.some(([method]) => method === "Runtime.enable"),
+        );
+
+        expect(yield* manager.automationEvaluate("tab_ready", { expression: "ready" })).toEqual({
+          ready: true,
+        });
+
+        yield* TestClock.adjust(100);
+        const exit = yield* Fiber.await(stalledSnapshot);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+            _tag: "PreviewAutomationDeadlineExceededError",
+            stage: "initialization",
+          });
+        }
+        expect(first.detach).toHaveBeenCalledOnce();
+        const messageListener = first.debuggerOn.mock.calls.find(
+          ([event]) => event === "message",
+        )?.[1];
+        expect(messageListener).toBeTypeOf("function");
+        expect(first.debuggerOff).toHaveBeenCalledWith("message", messageListener);
+      }),
+    ),
+  );
+
+  effectIt.effect("keeps an active attachment when a queued snapshot expires", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () => void 0;
+        const pendingCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveCapture = resolve;
+        });
+        let markCaptureStarted: () => void = () => void 0;
+        const captureStarted = new Promise<void>((resolve) => {
+          markCaptureStarted = resolve;
+        });
+        const preview = makeAutomationWebContents({
+          capturePage: () => {
+            markCaptureStarted();
+            return pendingCapture;
+          },
+          sendCommand: async (method) =>
+            method === "Runtime.evaluate"
+              ? { result: { value: snapshotPageValue } }
+              : method === "Accessibility.getFullAXTree"
+                ? { nodes: [] }
+                : undefined,
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_queue_deadline");
+        yield* manager.registerWebview("tab_queue_deadline", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+
+        const active = yield* manager
+          .automationSnapshot(snapshotInput("tab_queue_deadline", 1_000))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => captureStarted);
+        const queued = yield* manager
+          .automationSnapshot({
+            ...snapshotInput("tab_queue_deadline", 50),
+            requestId: "request-queued",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        expect(queued.pollUnsafe()).toBeUndefined();
+        expect(
+          preview.sendCommand.mock.calls.filter(([method]) => method === "Runtime.evaluate"),
+        ).toHaveLength(1);
+
+        yield* TestClock.adjust(50);
+        expect(active.pollUnsafe()).toBeUndefined();
+        expect(
+          preview.sendCommand.mock.calls.filter(([method]) => method === "Runtime.evaluate"),
+        ).toHaveLength(1);
+        const queuedExit = yield* Fiber.await(queued);
+        expect(Exit.isFailure(queuedExit)).toBe(true);
+        if (Exit.isFailure(queuedExit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(queuedExit.cause))).toMatchObject({
+            _tag: "PreviewAutomationDeadlineExceededError",
+            stage: "queue",
+            requestId: "request-queued",
+          });
+        }
+        expect(preview.detach).not.toHaveBeenCalled();
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+
+        resolveCapture(makeAutomationImage());
+        expect(Exit.isSuccess(yield* Fiber.await(active))).toBe(true);
+      }),
+    ),
+  );
+
+  effectIt.effect("fails ordinary captures while a native snapshot capture is pending", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () => void 0;
+        const pendingCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveCapture = resolve;
+        });
+        let markCaptureStarted: () => void = () => void 0;
+        const captureStarted = new Promise<void>((resolve) => {
+          markCaptureStarted = resolve;
+        });
+        const preview = makeAutomationWebContents({
+          capturePage: () => {
+            markCaptureStarted();
+            return pendingCapture;
+          },
+          sendCommand: async (method) =>
+            method === "Runtime.evaluate"
+              ? { result: { value: snapshotPageValue } }
+              : method === "Accessibility.getFullAXTree"
+                ? { nodes: [] }
+                : undefined,
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_capture_busy");
+        yield* manager.registerWebview("tab_capture_busy", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+
+        const snapshot = yield* manager
+          .automationSnapshot(snapshotInput("tab_capture_busy"))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => captureStarted);
+
+        const screenshotExit = yield* Effect.exit(manager.captureScreenshot("tab_capture_busy"));
+        expect(Exit.isFailure(screenshotExit)).toBe(true);
+        if (Exit.isFailure(screenshotExit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(screenshotExit.cause))).toMatchObject({
+            _tag: "PreviewOperationError",
+            operation: "captureScreenshot.capturePage",
+          });
+        }
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+
+        resolveCapture(makeAutomationImage());
+        expect(Exit.isSuccess(yield* Fiber.await(snapshot))).toBe(true);
+      }),
+    ),
+  );
+
+  effectIt.effect("rejects an in-flight capture after an exact guest replacement", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveOldCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () =>
+          void 0;
+        const oldCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveOldCapture = resolve;
+        });
+        let markOldCaptureStarted: () => void = () => void 0;
+        const oldCaptureStarted = new Promise<void>((resolve) => {
+          markOldCaptureStarted = resolve;
+        });
+        const sendCommand = async (method: string) =>
+          method === "Runtime.evaluate"
+            ? { result: { value: snapshotPageValue } }
+            : method === "Accessibility.getFullAXTree"
+              ? { nodes: [] }
+              : undefined;
+        const previous = makeAutomationWebContents({
+          capturePage: () => {
+            markOldCaptureStarted();
+            return oldCapture;
+          },
+          sendCommand,
+        });
+        const replacement = makeAutomationWebContents({
+          capturePage: async () => makeAutomationImage(),
+          sendCommand,
+        });
+        let current = previous.webContents;
+        fromId.mockImplementation(() => current);
+        yield* manager.createTab("tab_retired_capture");
+        yield* manager.registerWebview("tab_retired_capture", 42);
+        yield* settle(() => previous.attach.mock.calls.length > 0);
+
+        const screenshot = yield* manager
+          .captureScreenshot("tab_retired_capture")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => oldCaptureStarted);
+
+        current = replacement.webContents;
+        yield* manager.registerWebview("tab_retired_capture", 42);
+        yield* settle(() => replacement.attach.mock.calls.length > 0);
+        resolveOldCapture(makeAutomationImage());
+
+        expect(Exit.isFailure(yield* Fiber.await(screenshot))).toBe(true);
+        expect(previous.capturePage).toHaveBeenCalledOnce();
+        expect(replacement.detach).not.toHaveBeenCalled();
+
+        const recovered = yield* manager.automationSnapshot({
+          ...snapshotInput("tab_retired_capture"),
+          requestId: "request-replacement-capture",
+        });
+        expect(recovered.url).toBe(snapshotPageValue.url);
+        expect(replacement.capturePage).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("recovers evaluation while a timed-out native capture is still pending", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveFirstCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () =>
+          void 0;
+        const firstCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveFirstCapture = resolve;
+        });
+        let nativeCaptureCount = 0;
+        const preview = makeAutomationWebContents({
+          capturePage: () => {
+            nativeCaptureCount += 1;
+            return nativeCaptureCount === 1 ? firstCapture : Promise.resolve(makeAutomationImage());
+          },
+          sendCommand: async (method) =>
+            method === "Runtime.evaluate"
+              ? { result: { value: snapshotPageValue } }
+              : method === "Accessibility.getFullAXTree"
+                ? { nodes: [] }
+                : undefined,
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_capture_recovery");
+        yield* manager.registerWebview("tab_capture_recovery", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+        yield* manager.setColorScheme("tab_capture_recovery", "dark");
+        preview.sendCommand.mockClear();
+
+        const first = yield* manager
+          .automationSnapshot(snapshotInput("tab_capture_recovery", 100))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() => nativeCaptureCount === 1);
+        yield* TestClock.adjust(100);
+        expect(Exit.isFailure(yield* Fiber.await(first))).toBe(true);
+        expect(preview.detach).toHaveBeenCalledOnce();
+
+        expect(
+          yield* manager.automationEvaluate("tab_capture_recovery", {
+            expression: "location.href",
+          }),
+        ).toEqual(snapshotPageValue);
+        expect(preview.sendCommand).toHaveBeenCalledWith("Emulation.setEmulatedMedia", {
+          features: [{ name: "prefers-color-scheme", value: "dark" }],
+        });
+
+        const second = yield* manager
+          .automationSnapshot({
+            ...snapshotInput("tab_capture_recovery", 100),
+            requestId: "request-second-timeout",
+          })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        expect(nativeCaptureCount).toBe(1);
+        yield* TestClock.adjust(100);
+        expect(Exit.isFailure(yield* Fiber.await(second))).toBe(true);
+        expect(nativeCaptureCount).toBe(1);
+
+        resolveFirstCapture(makeAutomationImage());
+        yield* Effect.promise(
+          () => new Promise<void>((resolve) => globalThis.setImmediate(resolve)),
+        );
+        const recovered = yield* manager.automationSnapshot({
+          ...snapshotInput("tab_capture_recovery"),
+          requestId: "request-recovered",
+        });
+        expect(nativeCaptureCount).toBe(2);
+        expect(recovered.actionTimeline.some((event) => event.error?.includes("timed out"))).toBe(
+          true,
+        );
+        expect(
+          preview.sendCommand.mock.calls.filter(([method]) => method === "Accessibility.disable")
+            .length,
+        ).toBeGreaterThanOrEqual(3);
+      }),
+    ),
+  );
+
+  effectIt.effect(
+    "bounds AX output and disables Accessibility on success and capture failure",
+    () =>
+      withManager((manager) =>
+        Effect.gen(function* () {
+          const preview = makeAutomationWebContents({
+            capturePage: async () => makeAutomationImage(),
+            sendCommand: async (method) =>
+              method === "Runtime.evaluate"
+                ? { result: { value: snapshotPageValue } }
+                : method === "Accessibility.getFullAXTree"
+                  ? { nodes: Array.from({ length: 1_050 }, (_, id) => ({ nodeId: id })) }
+                  : undefined,
+          });
+          fromId.mockReturnValue(preview.webContents);
+          yield* manager.createTab("tab_ax_bounds");
+          yield* manager.registerWebview("tab_ax_bounds", 42);
+          yield* settle(() => preview.attach.mock.calls.length > 0);
+          preview.sendCommand.mockClear();
+
+          yield* manager.automationEvaluate("tab_ax_bounds", { expression: "location.href" });
+          expect(preview.sendCommand).not.toHaveBeenCalledWith("Accessibility.enable", undefined);
+          preview.sendCommand.mockClear();
+
+          const snapshot = yield* manager.automationSnapshot(snapshotInput("tab_ax_bounds"));
+          expect(snapshot.accessibilityTree).toMatchObject({
+            nodes: expect.arrayContaining([{ nodeId: 0 }, { nodeId: 999 }]),
+          });
+          expect((snapshot.accessibilityTree as { nodes: unknown[] }).nodes).toHaveLength(1_000);
+          expect(preview.sendCommand).toHaveBeenCalledWith("Accessibility.getFullAXTree", {
+            depth: 12,
+          });
+          expect(preview.sendCommand).toHaveBeenCalledWith("Accessibility.disable", undefined);
+
+          preview.sendCommand.mockClear();
+          preview.capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
+          const failed = yield* Effect.exit(
+            manager.automationSnapshot({
+              ...snapshotInput("tab_ax_bounds"),
+              requestId: "request-capture-failure",
+            }),
+          );
+          expect(Exit.isFailure(failed)).toBe(true);
+          if (Exit.isFailure(failed)) {
+            expect(Option.getOrThrow(Cause.findErrorOption(failed.cause))).toMatchObject({
+              _tag: "PreviewOperationError",
+              operation: "automationSnapshot.capturePage",
+            });
+          }
+          expect(preview.sendCommand).toHaveBeenCalledWith("Accessibility.disable", undefined);
+        }),
+      ),
+  );
+
+  effectIt.effect("disables Accessibility and releases the queue when the deadline expires", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const stalledAccessibility = new Promise<unknown>(() => undefined);
+        let accessibilityRequestCount = 0;
+        const preview = makeAutomationWebContents({
+          capturePage: async () => makeAutomationImage(),
+          sendCommand: async (method) => {
+            if (method === "Runtime.evaluate") {
+              return { result: { value: snapshotPageValue } };
+            }
+            if (method === "Accessibility.getFullAXTree") {
+              accessibilityRequestCount += 1;
+              return accessibilityRequestCount === 1 ? await stalledAccessibility : { nodes: [] };
+            }
+            return undefined;
+          },
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_ax_timeout");
+        yield* manager.registerWebview("tab_ax_timeout", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+        preview.sendCommand.mockClear();
+
+        const pending = yield* manager
+          .automationSnapshot(snapshotInput("tab_ax_timeout", 1_000))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(
+            ([method]) => method === "Accessibility.getFullAXTree",
+          ),
+        );
+        yield* TestClock.adjust(900);
+
+        const exit = yield* Fiber.await(pending);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+            _tag: "PreviewAutomationDeadlineExceededError",
+            stage: "execution",
+          });
+        }
+        expect(preview.sendCommand).toHaveBeenCalledWith("Accessibility.disable", undefined);
+        expect(preview.detach).toHaveBeenCalledOnce();
+        const disableCallOrder = preview.sendCommand.mock.invocationCallOrder.find(
+          (_, index) => preview.sendCommand.mock.calls[index]?.[0] === "Accessibility.disable",
+        );
+        expect(disableCallOrder).toBeLessThan(preview.detach.mock.invocationCallOrder[0]!);
+
+        const retry = yield* manager.automationSnapshot({
+          ...snapshotInput("tab_ax_timeout"),
+          requestId: "request-after-local-deadline",
+        });
+        expect(retry.url).toBe(snapshotPageValue.url);
+        expect(preview.attach).toHaveBeenCalledTimes(2);
+      }),
+    ),
+  );
+
+  effectIt.effect("recovers after Accessibility cleanup exceeds the deadline budget", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const stalledCleanup = new Promise<unknown>(() => undefined);
+        const preview = makeAutomationWebContents({
+          capturePage: async () => makeAutomationImage(),
+          sendCommand: async (method) => {
+            if (method === "Runtime.evaluate") {
+              return { result: { value: snapshotPageValue } };
+            }
+            if (method === "Accessibility.getFullAXTree") return { nodes: [] };
+            if (method === "Accessibility.disable") return await stalledCleanup;
+            return undefined;
+          },
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_ax_cleanup_timeout");
+        yield* manager.registerWebview("tab_ax_cleanup_timeout", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+        preview.sendCommand.mockClear();
+
+        const pending = yield* manager
+          .automationSnapshot(snapshotInput("tab_ax_cleanup_timeout", 1_000))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(([method]) => method === "Accessibility.disable"),
+        );
+        yield* TestClock.adjust(225);
+
+        const exit = yield* Fiber.await(pending);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+            _tag: "PreviewAutomationDeadlineExceededError",
+            stage: "cleanup",
+          });
+        }
+        expect(preview.detach).toHaveBeenCalledOnce();
+        expect(
+          yield* manager.automationEvaluate("tab_ax_cleanup_timeout", {
+            expression: "location.href",
+          }),
+        ).toEqual(snapshotPageValue);
+        expect(preview.attach).toHaveBeenCalledTimes(2);
+      }),
+    ),
+  );
+
+  effectIt.effect("keeps the cleanup stage when execution and cleanup both stall", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const stalledCommand = new Promise<unknown>(() => undefined);
+        const preview = makeAutomationWebContents({
+          capturePage: async () => makeAutomationImage(),
+          sendCommand: async (method) => {
+            if (method === "Runtime.evaluate") {
+              return { result: { value: snapshotPageValue } };
+            }
+            if (method === "Accessibility.getFullAXTree" || method === "Accessibility.disable") {
+              return await stalledCommand;
+            }
+            return undefined;
+          },
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_ax_execution_cleanup_timeout");
+        yield* manager.registerWebview("tab_ax_execution_cleanup_timeout", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+        preview.sendCommand.mockClear();
+
+        const pending = yield* manager
+          .automationSnapshot(snapshotInput("tab_ax_execution_cleanup_timeout", 1_000))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(
+            ([method]) => method === "Accessibility.getFullAXTree",
+          ),
+        );
+        yield* TestClock.adjust(900);
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(([method]) => method === "Accessibility.disable"),
+        );
+        yield* TestClock.adjust(75);
+
+        const exit = yield* Fiber.await(pending);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+            _tag: "PreviewAutomationDeadlineExceededError",
+            stage: "cleanup",
+          });
+        }
+        expect(preview.detach).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("preserves a screenshot failure while late cleanup uses the reserve", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const captureCause = new Error("late capture failure");
+        let rejectCapture: (error: Error) => void = () => void 0;
+        const capture = new Promise<ReturnType<typeof makeAutomationImage>>((_, reject) => {
+          rejectCapture = reject;
+        });
+        const stalledCommand = new Promise<unknown>(() => undefined);
+        const preview = makeAutomationWebContents({
+          capturePage: () => capture,
+          sendCommand: async (method) => {
+            if (method === "Runtime.evaluate") {
+              return { result: { value: snapshotPageValue } };
+            }
+            if (method === "Accessibility.getFullAXTree" || method === "Accessibility.disable") {
+              return await stalledCommand;
+            }
+            return undefined;
+          },
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_late_capture_failure");
+        yield* manager.registerWebview("tab_late_capture_failure", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+        preview.sendCommand.mockClear();
+
+        const pending = yield* manager
+          .automationSnapshot(snapshotInput("tab_late_capture_failure", 1_000))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() => preview.capturePage.mock.calls.length === 1);
+        yield* TestClock.adjust(850);
+        rejectCapture(captureCause);
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(([method]) => method === "Accessibility.disable"),
+        );
+        yield* TestClock.adjust(125);
+
+        const exit = yield* Fiber.await(pending);
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+            _tag: "PreviewOperationError",
+            operation: "automationSnapshot.capturePage",
+            cause: captureCause,
+          });
+        }
+        expect(preview.detach).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
+  effectIt.effect("rejects stale snapshot work after a same-id guest replacement", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveOldCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () =>
+          void 0;
+        const oldCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveOldCapture = resolve;
+        });
+        const sendCommand = async (method: string) =>
+          method === "Runtime.evaluate"
+            ? { result: { value: snapshotPageValue } }
+            : method === "Accessibility.getFullAXTree"
+              ? { nodes: [] }
+              : undefined;
+        const previous = makeAutomationWebContents({
+          capturePage: () => oldCapture,
+          sendCommand,
+        });
+        const replacement = makeAutomationWebContents({
+          capturePage: async () => makeAutomationImage(),
+          sendCommand,
+        });
+        let current = previous.webContents;
+        fromId.mockImplementation(() => current);
+        yield* manager.createTab("tab_replaced_capture");
+        yield* manager.registerWebview("tab_replaced_capture", 42);
+        yield* settle(() => previous.attach.mock.calls.length > 0);
+
+        const stale = yield* manager
+          .automationSnapshot(snapshotInput("tab_replaced_capture", 1_000))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() => previous.capturePage.mock.calls.length === 1);
+        current = replacement.webContents;
+        yield* manager.registerWebview("tab_replaced_capture", 42);
+        yield* settle(() => replacement.attach.mock.calls.length > 0);
+        resolveOldCapture(makeAutomationImage());
+
+        const staleExit = yield* Fiber.await(stale);
+        expect(Exit.isFailure(staleExit)).toBe(true);
+        if (Exit.isFailure(staleExit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(staleExit.cause))).toMatchObject({
+            _tag: "PreviewAutomationControlInterruptedError",
+          });
+        }
+        expect(replacement.detach).not.toHaveBeenCalled();
+        expect(
+          yield* manager.automationEvaluate("tab_replaced_capture", {
+            expression: "location.href",
+          }),
+        ).toEqual(snapshotPageValue);
+      }),
+    ),
+  );
 });

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3663,6 +3663,129 @@ describe("Preview automation diagnostics", () => {
     ),
   );
 
+  effectIt.effect("waits for an active recording frame before taking a snapshot", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveRecordingCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () =>
+          void 0;
+        const recordingCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveRecordingCapture = resolve;
+        });
+        let markRecordingCaptureStarted: () => void = () => void 0;
+        const recordingCaptureStarted = new Promise<void>((resolve) => {
+          markRecordingCaptureStarted = resolve;
+        });
+        let captureCount = 0;
+        const preview = makeAutomationWebContents({
+          capturePage: () => {
+            captureCount += 1;
+            if (captureCount === 1) {
+              markRecordingCaptureStarted();
+              return recordingCapture;
+            }
+            return Promise.resolve(makeAutomationImage());
+          },
+          sendCommand: async (method) =>
+            method === "Runtime.evaluate"
+              ? { result: { value: snapshotPageValue } }
+              : method === "Accessibility.getFullAXTree"
+                ? { nodes: [] }
+                : undefined,
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_recording_before_snapshot");
+        yield* manager.registerWebview("tab_recording_before_snapshot", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+
+        const recording = yield* manager
+          .startRecording("tab_recording_before_snapshot")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => recordingCaptureStarted);
+        const snapshot = yield* manager
+          .automationSnapshot(snapshotInput("tab_recording_before_snapshot"))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(([method]) => method === "Runtime.evaluate"),
+        );
+
+        expect(snapshot.pollUnsafe()).toBeUndefined();
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+
+        resolveRecordingCapture(makeAutomationImage());
+        yield* settle(() => preview.capturePage.mock.calls.length === 2);
+        expect(preview.capturePage).toHaveBeenCalledTimes(2);
+        expect(Exit.isSuccess(yield* Fiber.await(snapshot))).toBe(true);
+        expect(Exit.isSuccess(yield* Fiber.await(recording))).toBe(true);
+
+        yield* manager.stopRecording("tab_recording_before_snapshot");
+      }),
+    ),
+  );
+
+  effectIt.effect("does not start a recording-blocked snapshot after its deadline", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveRecordingCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () =>
+          void 0;
+        const recordingCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveRecordingCapture = resolve;
+        });
+        let markRecordingCaptureStarted: () => void = () => void 0;
+        const recordingCaptureStarted = new Promise<void>((resolve) => {
+          markRecordingCaptureStarted = resolve;
+        });
+        const preview = makeAutomationWebContents({
+          capturePage: () => {
+            markRecordingCaptureStarted();
+            return recordingCapture;
+          },
+          sendCommand: async (method) =>
+            method === "Runtime.evaluate"
+              ? { result: { value: snapshotPageValue } }
+              : method === "Accessibility.getFullAXTree"
+                ? { nodes: [] }
+                : undefined,
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_recording_snapshot_deadline");
+        yield* manager.registerWebview("tab_recording_snapshot_deadline", 42);
+        yield* settle(() => preview.attach.mock.calls.length > 0);
+
+        const recording = yield* manager
+          .startRecording("tab_recording_snapshot_deadline")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => recordingCaptureStarted);
+        const snapshot = yield* manager
+          .automationSnapshot(snapshotInput("tab_recording_snapshot_deadline", 100))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() =>
+          preview.sendCommand.mock.calls.some(([method]) => method === "Runtime.evaluate"),
+        );
+
+        expect(snapshot.pollUnsafe()).toBeUndefined();
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+
+        yield* TestClock.adjust(100);
+        const snapshotExit = yield* Fiber.await(snapshot);
+        expect(Exit.isFailure(snapshotExit)).toBe(true);
+        if (Exit.isFailure(snapshotExit)) {
+          expect(Option.getOrThrow(Cause.findErrorOption(snapshotExit.cause))).toMatchObject({
+            _tag: "PreviewAutomationDeadlineExceededError",
+            stage: "execution",
+            timeoutMs: 100,
+          });
+        }
+
+        resolveRecordingCapture(makeAutomationImage());
+        expect(Exit.isSuccess(yield* Fiber.await(recording))).toBe(true);
+        yield* Effect.promise(() => Promise.resolve());
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+
+        yield* manager.stopRecording("tab_recording_snapshot_deadline");
+      }),
+    ),
+  );
+
   effectIt.effect("rejects an in-flight capture after an exact guest replacement", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -19,6 +19,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as BrowserSession from "./BrowserSession.ts";
+import { ELEMENT_PICKED_CHANNEL } from "./GuestProtocol.ts";
 import * as PreviewManager from "./Manager.ts";
 
 describe("fitPictureInPictureContentSize", () => {
@@ -192,6 +193,7 @@ const makeAutomationImage = (width = 800, height = 600) => {
   const image = {
     getSize: () => ({ width, height }),
     resize: vi.fn(() => image),
+    toDataURL: () => "data:image/png;base64,cG5n",
     toJPEG: () => Buffer.from("jpeg"),
     toPNG: () => Buffer.from("png"),
   };
@@ -207,6 +209,7 @@ const makeAutomationWebContents = (options: {
   let destroyed = false;
   let devToolsOpen = false;
   const listeners = new Map<string, (...args: never[]) => void>();
+  const ipcListeners = new Map<string, (...args: ReadonlyArray<unknown>) => void>();
   const attach = vi.fn(() => {
     attached = true;
   });
@@ -229,14 +232,26 @@ const makeAutomationWebContents = (options: {
     getURL: () => "https://example.com",
     getTitle: () => "Example",
     isLoading: () => false,
+    isFocused: () => true,
     getZoomFactor: () => 1,
+    focus: vi.fn(),
     setZoomFactor: vi.fn(),
     setAudioMuted: vi.fn(),
     isCurrentlyAudible: () => false,
     on,
     once: on,
     off,
-    ipc: { on: vi.fn(), off: vi.fn() },
+    ipc: {
+      on: vi.fn((channel: string, listener: (...args: ReadonlyArray<unknown>) => void) => {
+        ipcListeners.set(channel, listener);
+      }),
+      off: vi.fn(),
+      removeListener: vi.fn(
+        (channel: string, listener: (...args: ReadonlyArray<unknown>) => void) => {
+          if (ipcListeners.get(channel) === listener) ipcListeners.delete(channel);
+        },
+      ),
+    },
     send: webviewSend,
     navigationHistory: { canGoBack: () => false, canGoForward: () => false },
     setWindowOpenHandler: vi.fn(),
@@ -256,6 +271,7 @@ const makeAutomationWebContents = (options: {
     debuggerOn,
     debuggerOff,
     detach,
+    ipcListeners,
     listeners,
     sendCommand,
     setDestroyed: (value: boolean) => {
@@ -3782,6 +3798,86 @@ describe("Preview automation diagnostics", () => {
         expect(preview.capturePage).toHaveBeenCalledOnce();
 
         yield* manager.stopRecording("tab_recording_snapshot_deadline");
+      }),
+    ),
+  );
+
+  effectIt.effect("waits for an active recording frame before capturing an annotation", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveRecordingCapture: (image: ReturnType<typeof makeAutomationImage>) => void = () =>
+          void 0;
+        const recordingCapture = new Promise<ReturnType<typeof makeAutomationImage>>((resolve) => {
+          resolveRecordingCapture = resolve;
+        });
+        let markRecordingCaptureStarted: () => void = () => void 0;
+        const recordingCaptureStarted = new Promise<void>((resolve) => {
+          markRecordingCaptureStarted = resolve;
+        });
+        let captureCount = 0;
+        const preview = makeAutomationWebContents({
+          capturePage: () => {
+            captureCount += 1;
+            if (captureCount === 1) {
+              markRecordingCaptureStarted();
+              return recordingCapture;
+            }
+            return Promise.resolve(makeAutomationImage());
+          },
+          sendCommand: async () => undefined,
+        });
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_recording_before_annotation");
+        yield* manager.registerWebview("tab_recording_before_annotation", 42);
+
+        const recording = yield* manager
+          .startRecording("tab_recording_before_annotation")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => recordingCaptureStarted);
+        const pick = yield* manager
+          .pickElement("tab_recording_before_annotation")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* settle(() => preview.ipcListeners.has(ELEMENT_PICKED_CHANNEL));
+        preview.ipcListeners.get(ELEMENT_PICKED_CHANNEL)?.(
+          {},
+          {
+            id: "annotation-recording-capture",
+            pageUrl: "https://example.com",
+            pageTitle: "Example",
+            comment: "Capture this state",
+            elements: [],
+            regions: [],
+            strokes: [],
+            styleChanges: [],
+            screenshot: null,
+            createdAt: "2026-08-28T00:00:00.000Z",
+          },
+          null,
+          "attach",
+        );
+        yield* Effect.promise(() => Promise.resolve());
+
+        expect(pick.pollUnsafe()).toBeUndefined();
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+
+        resolveRecordingCapture(makeAutomationImage());
+        const result = yield* Fiber.join(pick);
+        expect(result).toMatchObject({
+          submission: "attach",
+          annotation: {
+            id: "annotation-recording-capture",
+            screenshot: {
+              dataUrl: "data:image/png;base64,cG5n",
+              width: 800,
+              height: 600,
+              cropRect: { x: 0, y: 0, width: 800, height: 600 },
+            },
+          },
+        });
+        expect(Exit.isSuccess(yield* Fiber.await(recording))).toBe(true);
+        expect(preview.capturePage).toHaveBeenCalledTimes(2);
+
+        yield* manager.stopRecording("tab_recording_before_annotation");
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -7,6 +7,7 @@
  */
 import type {
   DesktopPreviewAnnotationTheme,
+  DesktopPreviewAutomationSnapshotInput,
   DesktopPreviewAutomationStatus,
   DesktopPreviewColorScheme,
   DesktopPreviewFavicon,
@@ -44,6 +45,7 @@ import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Predicate from "effect/Predicate";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
@@ -108,6 +110,11 @@ const MAX_EVALUATION_BYTES = 64_000;
 const MAX_VISIBLE_TEXT_LENGTH = 20_000;
 const MAX_INTERACTIVE_ELEMENTS = 200;
 const MAX_SCREENSHOT_WIDTH = 1280;
+const MAX_ACCESSIBILITY_DEPTH = 12;
+const MAX_ACCESSIBILITY_NODES = 1_000;
+const CONTROL_SESSION_RESTORE_TIMEOUT_MS = 5_000;
+const CONTROL_ACTION_CLEANUP_RESERVE_MS = 250;
+const CONTROL_ACTION_RETURN_RESERVE_MS = 25;
 const RECORDING_FRAME_INTERVAL_MS = Math.ceil(1_000 / 12);
 const RECORDING_JPEG_QUALITY = 80;
 const PICTURE_IN_PICTURE_INITIAL_WIDTH = 480;
@@ -296,30 +303,10 @@ const normalizeCaptureRect = (value: unknown): PreviewAnnotationRect | null => {
 };
 
 const captureAnnotationScreenshot = (
-  tabId: string,
-  wc: Electron.WebContents,
   cropRect: PreviewAnnotationRect | null,
+  capture: Effect.Effect<Electron.NativeImage, PreviewManagerError>,
 ): Effect.Effect<PreviewAnnotationPayload["screenshot"], PreviewManagerError> =>
-  Effect.tryPromise({
-    try: () =>
-      wc.capturePage(
-        cropRect
-          ? {
-              x: cropRect.x,
-              y: cropRect.y,
-              width: cropRect.width,
-              height: cropRect.height,
-            }
-          : undefined,
-      ),
-    catch: (cause) =>
-      new PreviewOperationError({
-        operation: "captureAnnotationScreenshot",
-        tabId,
-        webContentsId: wc.id,
-        cause,
-      }),
-  }).pipe(
+  capture.pipe(
     Effect.map((image) => {
       const size = image.getSize();
       return {
@@ -395,8 +382,9 @@ interface PickSession {
 }
 
 interface BrowserControlSession {
+  readonly attachmentId: symbol;
   readonly webContentsId: number;
-  readonly semaphore: Semaphore.Semaphore;
+  readonly webContents: Electron.WebContents;
   readonly scope: Scope.Closeable;
   readonly onMessage: (
     event: Electron.Event,
@@ -405,7 +393,28 @@ interface BrowserControlSession {
   ) => void;
 }
 
+interface BrowserControlQueue {
+  readonly semaphore: Semaphore.Semaphore;
+  retired: boolean;
+}
+
+interface BrowserCaptureQueue {
+  tail: Promise<void>;
+  pending: boolean;
+  retired: boolean;
+}
+
+type PreviewAutomationDeadlineStage = "queue" | "initialization" | "execution" | "cleanup";
+
+interface PreviewAutomationDeadline {
+  readonly connectionId: string;
+  readonly requestId: string;
+  readonly timeoutMs: number;
+  readonly expiresAtNanos: bigint;
+}
+
 interface BrowserDiagnostics {
+  readonly attachmentId: symbol;
   readonly consoleEntries: ReadonlyArray<PreviewAutomationConsoleEntry>;
   readonly networkEntries: ReadonlyArray<PreviewAutomationNetworkEntry>;
   readonly requests: ReadonlyMap<string, { url: string; method: string }>;
@@ -507,11 +516,16 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const controlSessionsRef = yield* SynchronizedRef.make<
     ReadonlyMap<number, BrowserControlSession>
   >(new Map());
+  const debuggerOwners = new WeakMap<Electron.WebContents, symbol>();
+  const controlQueues = new WeakMap<Electron.WebContents, BrowserControlQueue>();
+  const captureQueues = new WeakMap<Electron.WebContents, BrowserCaptureQueue>();
   const diagnosticsRef = yield* Ref.make<ReadonlyMap<number, BrowserDiagnostics>>(new Map());
   const expectedAgentInputsRef = yield* Ref.make<
     ReadonlyMap<string, ReadonlyArray<ExpectedAgentInput>>
   >(new Map());
   const controlEpochRef = yield* Ref.make<ReadonlyMap<string, number>>(new Map());
+  const controllerOwnersRef = yield* Ref.make<ReadonlyMap<string, symbol>>(new Map());
+  const controllerStateSemaphore = yield* Semaphore.make(1);
   const actionTimelineRef = yield* Ref.make<
     ReadonlyMap<string, ReadonlyArray<PreviewAutomationActionEvent>>
   >(new Map());
@@ -548,6 +562,69 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       try: evaluate,
       catch: (cause) => new PreviewOperationError({ ...errorContext, cause }),
     });
+  const capturePage = (
+    errorContext: PreviewOperationContext,
+    wc: Electron.WebContents,
+    options: {
+      readonly busyError?: PreviewManagerError;
+      readonly rect?: Electron.Rectangle;
+    } = {},
+  ): Effect.Effect<Electron.NativeImage, PreviewManagerError> =>
+    Effect.tryPromise({
+      try: (signal) => {
+        const queue = captureQueues.get(wc) ?? {
+          tail: Promise.resolve(),
+          pending: false,
+          retired: false,
+        };
+        captureQueues.set(wc, queue);
+        if (queue.retired) {
+          throw new Error("Preview capture target is no longer active");
+        }
+        if (queue.pending) {
+          throw options.busyError ?? new Error("Another preview capture is still in progress");
+        }
+        queue.pending = true;
+        const capture = queue.tail.then(() => {
+          if (signal.aborted) throw signal.reason;
+          if (queue.retired || wc.isDestroyed()) {
+            throw new Error("Preview capture target is no longer active");
+          }
+          return wc.capturePage(options.rect).then((image) => {
+            if (queue.retired || wc.isDestroyed()) {
+              throw new Error("Preview capture target is no longer active");
+            }
+            return image;
+          });
+        });
+        // Keep the native gate closed until Electron settles, even when the
+        // Effect waiting for this result is interrupted by its deadline.
+        let tail: Promise<void>;
+        tail = capture.then(
+          () => {
+            if (queue.tail === tail) queue.pending = false;
+          },
+          () => {
+            if (queue.tail === tail) queue.pending = false;
+          },
+        );
+        queue.tail = tail;
+        return capture;
+      },
+      catch: (cause) =>
+        options.busyError && cause === options.busyError
+          ? options.busyError
+          : new PreviewOperationError({ ...errorContext, cause }),
+    });
+  const retireCaptureQueue = (wc: Electron.WebContents): void => {
+    const queue = captureQueues.get(wc) ?? {
+      tail: Promise.resolve(),
+      pending: false,
+      retired: false,
+    };
+    queue.retired = true;
+    captureQueues.set(wc, queue);
+  };
   const currentIso = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const currentMillis = Clock.currentTimeMillis;
   const encodeJson = (errorContext: PreviewOperationContext, value: unknown) =>
@@ -826,10 +903,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       ),
     );
 
-  const tabIdForWebContents = Effect.fnUntraced(function* (webContentsId: number) {
+  const tabIdForWebContents = Effect.fnUntraced(function* (wc: Electron.WebContents) {
     const tabs = yield* SynchronizedRef.get(tabsRef);
     return (
-      Array.from(tabs.entries()).find(([, tab]) => tab.webContentsId === webContentsId)?.[0] ?? null
+      Array.from(tabs.entries()).find(
+        ([, tab]) => tab.webContentsId === wc.id && webContents.fromId(wc.id) === wc,
+      )?.[0] ?? null
     );
   });
 
@@ -964,166 +1043,210 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     });
   });
 
-  const detachControlSession = Effect.fn("PreviewManager.detachControlSession")(function* (
-    webContentsId: number,
+  const controlQueueFor = (wc: Electron.WebContents): BrowserControlQueue => {
+    const existing = controlQueues.get(wc);
+    if (existing) return existing;
+    const queue: BrowserControlQueue = { semaphore: Semaphore.makeUnsafe(1), retired: false };
+    controlQueues.set(wc, queue);
+    return queue;
+  };
+
+  const retireControlSession = Effect.fn("PreviewManager.retireControlSession")(function* (
+    control: BrowserControlSession,
   ) {
+    const retired = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => {
+      const current = sessions.get(control.webContentsId);
+      if (current?.attachmentId !== control.attachmentId) return [false, sessions] as const;
+      return [
+        true,
+        replaceMap(sessions, (copy) => {
+          copy.delete(control.webContentsId);
+        }),
+      ] as const;
+    });
+    // Closing an unpublished or superseded attachment is safe because its
+    // finalizer compares the attachment identity before detaching Chromium.
+    yield* Scope.close(control.scope, Exit.void).pipe(Effect.ignore);
+    return retired;
+  }, Effect.uninterruptible);
+
+  const detachControlSession = Effect.fn("PreviewManager.detachControlSession")(function* (
+    wc: Electron.WebContents,
+    retireGuest: boolean,
+  ) {
+    if (retireGuest) {
+      controlQueueFor(wc).retired = true;
+      retireCaptureQueue(wc);
+    }
     const control = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => [
-      sessions.get(webContentsId),
+      sessions.get(wc.id)?.webContents === wc ? sessions.get(wc.id) : undefined,
       replaceMap(sessions, (copy) => {
-        copy.delete(webContentsId);
+        if (copy.get(wc.id)?.webContents === wc) copy.delete(wc.id);
       }),
     ]);
     if (control) {
       yield* Scope.close(control.scope, Exit.void).pipe(Effect.ignore);
-      return;
     }
-    yield* Ref.update(diagnosticsRef, (diagnostics) =>
-      replaceMap(diagnostics, (copy) => {
-        copy.delete(webContentsId);
-      }),
-    );
-  });
+  }, Effect.uninterruptible);
 
   const ensureControlSession = Effect.fn("PreviewManager.ensureControlSession")(function* (
     wc: Electron.WebContents,
   ) {
-    return yield* SynchronizedRef.modifyEffect(
-      controlSessionsRef,
-      (
-        sessions,
-      ): Effect.Effect<
-        readonly [BrowserControlSession, ReadonlyMap<number, BrowserControlSession>],
-        PreviewManagerError
-      > => {
-        const existing = sessions.get(wc.id);
-        if (existing) return Effect.succeed([existing, sessions] as const);
-        if (wc.isDevToolsOpened()) {
-          return Effect.fail(
-            new PreviewAutomationDevToolsOpenError({
-              webContentsId: wc.id,
-            }),
-          );
+    const queue = controlQueueFor(wc);
+    if (queue.retired || wc.isDestroyed() || webContents.fromId(wc.id) !== wc) {
+      return yield* new PreviewOperationError({
+        operation: "ensureControlSession.staleWebContents",
+        webContentsId: wc.id,
+        cause: new Error("Preview WebContents is no longer current"),
+      });
+    }
+    const existing = (yield* SynchronizedRef.get(controlSessionsRef)).get(wc.id);
+    if (existing?.webContents === wc) return existing;
+    if (existing) yield* retireControlSession(existing);
+    if (wc.isDevToolsOpened()) {
+      return yield* new PreviewAutomationDevToolsOpenError({ webContentsId: wc.id });
+    }
+    if (wc.debugger.isAttached()) {
+      return yield* new PreviewAutomationDebuggerAttachedError({ webContentsId: wc.id });
+    }
+
+    const attachmentId = Symbol();
+    const scope = yield* Scope.fork(parentScope, "sequential");
+    const handleDebuggerMessage = Effect.fnUntraced(function* (
+      method: string,
+      params: Record<string, unknown>,
+    ) {
+      if (method === "Page.screencastFrame") {
+        const sessionId = params["sessionId"];
+        if (typeof sessionId === "number") {
+          yield* attemptPromise({ operation: "ackScreencastFrame", webContentsId: wc.id }, () =>
+            wc.debugger.sendCommand("Page.screencastFrameAck", { sessionId }),
+          ).pipe(Effect.ignore);
         }
-        if (wc.debugger.isAttached()) {
-          return Effect.fail(
-            new PreviewAutomationDebuggerAttachedError({
-              webContentsId: wc.id,
-            }),
-          );
-        }
-        const createControlSession = Effect.fn("PreviewManager.createControlSession")(function* () {
-          const semaphore = yield* Semaphore.make(1);
-          const scope = yield* Scope.fork(parentScope, "sequential");
-          const handleDebuggerMessage = Effect.fnUntraced(function* (
-            method: string,
-            params: Record<string, unknown>,
-          ) {
-            if (method === "Page.screencastFrame") {
-              const sessionId = params["sessionId"];
-              if (typeof sessionId === "number") {
-                yield* attemptPromise(
-                  {
-                    operation: "ackScreencastFrame",
-                    webContentsId: wc.id,
-                  },
-                  () => wc.debugger.sendCommand("Page.screencastFrameAck", { sessionId }),
-                ).pipe(Effect.ignore);
-              }
-              const tabId = yield* tabIdForWebContents(wc.id);
-              const metadata =
-                typeof params["metadata"] === "object" && params["metadata"] !== null
-                  ? (params["metadata"] as Record<string, unknown>)
-                  : {};
-              if (tabId && typeof params["data"] === "string") {
-                const captureSession = (yield* SynchronizedRef.get(frameCaptureSessionsRef)).get(
-                  tabId,
-                );
-                if (captureSession?.consumers.has("recording")) {
-                  const receivedAt = yield* currentIso;
-                  const listeners = yield* Ref.get(recordingFrameListenersRef);
-                  const frame: DesktopPreviewRecordingFrame = {
-                    tabId,
-                    data: params["data"],
-                    width:
-                      typeof metadata["deviceWidth"] === "number" ? metadata["deviceWidth"] : 0,
-                    height:
-                      typeof metadata["deviceHeight"] === "number" ? metadata["deviceHeight"] : 0,
-                    receivedAt,
-                  };
-                  yield* Effect.forEach(
-                    listeners,
-                    (listener) =>
-                      deliverEvent("recording-frame", frame.tabId, () => listener(frame)),
-                    { discard: true },
-                  );
-                }
-              }
-            }
-            yield* captureDiagnosticMessage(wc.id, method, params);
-          });
-          const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
-            runFork(handleDebuggerMessage(method, params));
-          };
-          yield* Scope.addFinalizer(
-            scope,
-            Effect.all(
-              [
-                Ref.update(diagnosticsRef, (diagnostics) =>
-                  replaceMap(diagnostics, (copy) => {
-                    copy.delete(wc.id);
-                  }),
-                ),
-                attempt({ operation: "detachControlSession", webContentsId: wc.id }, () => {
-                  wc.debugger.off("message", onMessage);
-                  if (wc.debugger.isAttached()) wc.debugger.detach();
-                }).pipe(Effect.ignore),
-              ],
+        const tabId = yield* tabIdForWebContents(wc);
+        const metadata =
+          typeof params["metadata"] === "object" && params["metadata"] !== null
+            ? (params["metadata"] as Record<string, unknown>)
+            : {};
+        if (tabId && typeof params["data"] === "string") {
+          const captureSession = (yield* SynchronizedRef.get(frameCaptureSessionsRef)).get(tabId);
+          if (captureSession?.consumers.has("recording")) {
+            const receivedAt = yield* currentIso;
+            const listeners = yield* Ref.get(recordingFrameListenersRef);
+            const frame: DesktopPreviewRecordingFrame = {
+              tabId,
+              data: params["data"],
+              width: typeof metadata["deviceWidth"] === "number" ? metadata["deviceWidth"] : 0,
+              height: typeof metadata["deviceHeight"] === "number" ? metadata["deviceHeight"] : 0,
+              receivedAt,
+            };
+            yield* Effect.forEach(
+              listeners,
+              (listener) => deliverEvent("recording-frame", frame.tabId, () => listener(frame)),
               { discard: true },
-            ),
-          );
-          const control: BrowserControlSession = {
-            webContentsId: wc.id,
-            semaphore,
-            scope,
-            onMessage,
-          };
-          const initialize = Effect.fn("PreviewManager.initializeControlSession")(function* () {
-            yield* Ref.update(diagnosticsRef, (diagnostics) =>
-              replaceMap(diagnostics, (copy) => {
-                copy.set(wc.id, {
-                  consoleEntries: [],
-                  networkEntries: [],
-                  requests: new Map(),
-                });
-              }),
             );
-            yield* attempt({ operation: "attachDebuggerListeners", webContentsId: wc.id }, () => {
-              wc.debugger.on("message", onMessage);
-              wc.debugger.attach("1.3");
-            });
-            yield* Effect.all(
-              ["Runtime.enable", "Accessibility.enable", "Network.enable", "Log.enable"].map(
-                (method) =>
-                  attemptPromise(
-                    { operation: `initializeDebugger.${method}`, webContentsId: wc.id },
-                    () => wc.debugger.sendCommand(method),
-                  ),
-              ),
-              { concurrency: "unbounded", discard: true },
-            );
-            return [
-              control,
-              replaceMap(sessions, (copy) => {
-                copy.set(wc.id, control);
-              }),
-            ] as const;
+          }
+        }
+      }
+      const diagnostics = (yield* Ref.get(diagnosticsRef)).get(wc.id);
+      if (diagnostics?.attachmentId === attachmentId) {
+        yield* captureDiagnosticMessage(wc.id, method, params);
+      }
+    });
+    const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
+      runFork(handleDebuggerMessage(method, params));
+    };
+    yield* Scope.addFinalizer(
+      scope,
+      Effect.gen(function* () {
+        const ownsDebugger = debuggerOwners.get(wc) === attachmentId;
+        if (ownsDebugger) debuggerOwners.delete(wc);
+        yield* attempt(
+          { operation: "detachControlSession.removeListener", webContentsId: wc.id },
+          () => wc.debugger.off("message", onMessage),
+        ).pipe(Effect.ignore);
+        if (ownsDebugger) {
+          yield* attempt({ operation: "detachControlSession.detach", webContentsId: wc.id }, () => {
+            if (wc.debugger.isAttached()) wc.debugger.detach();
+          }).pipe(Effect.ignore);
+        }
+        yield* Ref.update(diagnosticsRef, (diagnostics) => {
+          if (diagnostics.get(wc.id)?.attachmentId !== attachmentId) return diagnostics;
+          return replaceMap(diagnostics, (copy) => {
+            copy.delete(wc.id);
           });
-          return yield* initialize().pipe(
-            Effect.onError(() => Scope.close(scope, Exit.void).pipe(Effect.ignore)),
-          );
         });
-        return createControlSession();
-      },
+      }),
+    );
+    const control: BrowserControlSession = {
+      attachmentId,
+      webContentsId: wc.id,
+      webContents: wc,
+      scope,
+      onMessage,
+    };
+    const initialize = Effect.fn("PreviewManager.initializeControlSession")(function* () {
+      yield* Ref.update(diagnosticsRef, (diagnostics) =>
+        replaceMap(diagnostics, (copy) => {
+          copy.set(wc.id, {
+            attachmentId,
+            consoleEntries: [],
+            networkEntries: [],
+            requests: new Map(),
+          });
+        }),
+      );
+      yield* attempt({ operation: "attachDebuggerListeners", webContentsId: wc.id }, () => {
+        wc.debugger.on("message", onMessage);
+        wc.debugger.attach("1.3");
+        debuggerOwners.set(wc, attachmentId);
+      }).pipe(Effect.uninterruptible);
+      const published = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => {
+        if (
+          queue.retired ||
+          wc.isDestroyed() ||
+          webContents.fromId(wc.id) !== wc ||
+          sessions.has(wc.id)
+        ) {
+          return [false, sessions] as const;
+        }
+        return [
+          true,
+          replaceMap(sessions, (copy) => {
+            copy.set(wc.id, control);
+          }),
+        ] as const;
+      });
+      if (!published) {
+        return yield* new PreviewAutomationDebuggerAttachedError({ webContentsId: wc.id });
+      }
+      // Domain initialization can stall in Chromium. It runs outside the map
+      // lock, so a bad guest cannot block control sessions for other tabs.
+      yield* Effect.all(
+        ["Runtime.enable", "Network.enable", "Log.enable"].map((method) =>
+          attemptPromise({ operation: `initializeDebugger.${method}`, webContentsId: wc.id }, () =>
+            wc.debugger.sendCommand(method),
+          ),
+        ),
+        { concurrency: "unbounded", discard: true },
+      );
+      const tabId = yield* tabIdForWebContents(wc);
+      const tab = tabId ? (yield* SynchronizedRef.get(tabsRef)).get(tabId) : undefined;
+      if (tabId && tab?.colorScheme !== undefined && tab.colorScheme !== "system") {
+        yield* attemptPromise(
+          { operation: "initializeDebugger.restoreColorScheme", tabId, webContentsId: wc.id },
+          () =>
+            wc.debugger.sendCommand("Emulation.setEmulatedMedia", {
+              features: [{ name: "prefers-color-scheme", value: tab.colorScheme }],
+            }),
+        );
+      }
+      return control;
+    });
+    return yield* initialize().pipe(
+      Effect.onExit((exit) =>
+        Exit.isSuccess(exit) ? Effect.void : retireControlSession(control).pipe(Effect.asVoid),
+      ),
     );
   });
 
@@ -1167,7 +1290,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     tabId: string,
     wc: Electron.WebContents,
     action: string,
-    use: (send: SendCommand, sendCleanup: SendCommand) => Effect.Effect<A, PreviewManagerError>,
+    use: (
+      send: SendCommand,
+      sendCleanup: SendCommand,
+      recordFailure: (error: PreviewManagerError) => Effect.Effect<void>,
+    ) => Effect.Effect<A, PreviewManagerError>,
+    deadline?: PreviewAutomationDeadline,
   ) {
     const sequence = yield* nextCounter(actionSequenceRef);
     const startedAt = yield* currentIso;
@@ -1180,50 +1308,168 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     };
     yield* pushAction(tabId, actionEvent);
     const epoch = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-    const control = yield* ensureControlSession(wc);
-    const execute = Effect.fn("PreviewManager.executeControlAction")(function* () {
-      yield* update(tabId, { controller: "agent" });
-      const send: SendCommand = Effect.fn("PreviewManager.sendCommand")(
-        function* (method, commandParams) {
-          const before = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-          if (before !== epoch) {
-            return yield* new PreviewAutomationControlInterruptedError({
-              operation: action,
-              tabId,
-              webContentsId: wc.id,
-            });
-          }
-          const result = yield* attemptPromise(
-            { operation: `${action}.${method}`, tabId, webContentsId: wc.id },
-            () => wc.debugger.sendCommand(method, commandParams),
+    const stageRef = yield* Ref.make<PreviewAutomationDeadlineStage>("queue");
+    const ownedAttachmentRef = yield* Ref.make<Option.Option<BrowserControlSession>>(Option.none());
+    const cleanupFailureRef = yield* Ref.make<Option.Option<PreviewManagerError>>(Option.none());
+    const operationFailureRef = yield* Ref.make<Option.Option<PreviewManagerError>>(Option.none());
+    const queue = controlQueueFor(wc);
+    const makeDeadlineError = Ref.get(stageRef).pipe(
+      Effect.map(
+        (stage) =>
+          new PreviewAutomationDeadlineExceededError({
+            operation: action,
+            tabId,
+            webContentsId: wc.id,
+            connectionId: deadline?.connectionId ?? "local",
+            requestId: deadline?.requestId ?? "local",
+            timeoutMs: deadline?.timeoutMs ?? 1,
+            stage,
+          }),
+      ),
+    );
+    const remainingDeadlineMs = Effect.fnUntraced(function* () {
+      if (!deadline) return Number.POSITIVE_INFINITY;
+      const remainingNanos = deadline.expiresAtNanos - (yield* Clock.monotonicTimeNanos);
+      return remainingNanos <= 0n ? 0 : Number(remainingNanos / 1_000_000n);
+    });
+    const assertCurrentAttachment = Effect.fnUntraced(function* (control?: BrowserControlSession) {
+      const currentTab = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
+      const currentControl = (yield* SynchronizedRef.get(controlSessionsRef)).get(wc.id);
+      const controlChanged =
+        control !== undefined && currentControl?.attachmentId !== control.attachmentId;
+      if (
+        currentTab?.webContentsId !== wc.id ||
+        webContents.fromId(wc.id) !== wc ||
+        wc.isDestroyed() ||
+        controlChanged ||
+        ((yield* Ref.get(controlEpochRef)).get(tabId) ?? 0) !== epoch
+      ) {
+        return yield* new PreviewAutomationControlInterruptedError({
+          operation: action,
+          tabId,
+          webContentsId: wc.id,
+        });
+      }
+    });
+    const claimController = Effect.fnUntraced(function* (owner: symbol) {
+      const next = yield* controllerStateSemaphore.withPermit(
+        Effect.gen(function* () {
+          const updatedAt = yield* currentIso;
+          yield* Ref.update(controllerOwnersRef, (owners) =>
+            replaceMap(owners, (copy) => {
+              copy.set(tabId, owner);
+            }),
           );
-          const after = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-          if (after !== epoch) {
-            return yield* new PreviewAutomationControlInterruptedError({
-              operation: action,
-              tabId,
-              webContentsId: wc.id,
-            });
+          return yield* SynchronizedRef.modify(tabsRef, (tabs) => {
+            const current = tabs.get(tabId);
+            if (!current) return [Option.none<PreviewTabState>(), tabs] as const;
+            const state: PreviewTabState = { ...current, controller: "agent", updatedAt };
+            return [
+              Option.some(state),
+              replaceMap(tabs, (copy) => {
+                copy.set(tabId, state);
+              }),
+            ] as const;
+          });
+        }),
+      );
+      if (Option.isSome(next)) runFork(emitIfCurrent(tabId, next.value).pipe(Effect.ignore));
+    });
+    const releaseController = Effect.fnUntraced(function* (owner: symbol) {
+      const next = yield* controllerStateSemaphore.withPermit(
+        Effect.gen(function* () {
+          if ((yield* Ref.get(controllerOwnersRef)).get(tabId) !== owner) {
+            return Option.none<PreviewTabState>();
           }
-          return result;
-        },
-      );
-      // Cleanup commands must still run after human input invalidates the action's
-      // control epoch. Otherwise a partially dispatched input can leave Chromium
-      // with a held key or focus emulation enabled for subsequent actions.
-      const sendCleanup: SendCommand = Effect.fn("PreviewManager.sendCleanupCommand")(
-        function* (method, commandParams) {
-          return yield* attemptPromise(
-            {
-              operation: `${action}.cleanup.${method}`,
-              tabId,
-              webContentsId: wc.id,
-            },
-            () => wc.debugger.sendCommand(method, commandParams),
+          yield* Ref.update(controllerOwnersRef, (owners) =>
+            replaceMap(owners, (copy) => {
+              copy.delete(tabId);
+            }),
           );
-        },
+          const updatedAt = yield* currentIso;
+          return yield* SynchronizedRef.modify(tabsRef, (tabs) => {
+            const current = tabs.get(tabId);
+            if (!current || current.controller !== "agent") {
+              return [Option.none<PreviewTabState>(), tabs] as const;
+            }
+            const state: PreviewTabState = { ...current, controller: "none", updatedAt };
+            return [
+              Option.some(state),
+              replaceMap(tabs, (copy) => {
+                copy.set(tabId, state);
+              }),
+            ] as const;
+          });
+        }),
       );
-      return yield* use(send, sendCleanup);
+      if (Option.isSome(next)) runFork(emitIfCurrent(tabId, next.value).pipe(Effect.ignore));
+    }, Effect.uninterruptible);
+    const execute = Effect.fn("PreviewManager.executeControlAction")(function* (
+      control: BrowserControlSession,
+    ) {
+      const controllerOwner = Symbol();
+      const run = Effect.gen(function* () {
+        yield* claimController(controllerOwner);
+        const send: SendCommand = Effect.fn("PreviewManager.sendCommand")(
+          function* (method, commandParams) {
+            yield* assertCurrentAttachment(control);
+            const result = yield* attemptPromise(
+              { operation: `${action}.${method}`, tabId, webContentsId: wc.id },
+              () => wc.debugger.sendCommand(method, commandParams),
+            );
+            yield* assertCurrentAttachment(control);
+            return result;
+          },
+        );
+        // Cleanup commands must still run after human input invalidates the action's
+        // control epoch. Otherwise a partially dispatched input can leave Chromium
+        // with a held key or focus emulation enabled for subsequent actions.
+        const sendCleanup: SendCommand = Effect.fn("PreviewManager.sendCleanupCommand")(
+          function* (method, commandParams) {
+            const previousStage = yield* Ref.getAndSet(stageRef, "cleanup");
+            const cleanup = attemptPromise(
+              {
+                operation: `${action}.cleanup.${method}`,
+                tabId,
+                webContentsId: wc.id,
+              },
+              () => wc.debugger.sendCommand(method, commandParams),
+            );
+            return yield* Effect.gen(function* () {
+              if (!deadline) return yield* cleanup;
+              const remainingMs = yield* remainingDeadlineMs();
+              const cleanupTimeoutMs = Math.min(
+                CONTROL_ACTION_CLEANUP_RESERVE_MS - CONTROL_ACTION_RETURN_RESERVE_MS,
+                Math.max(0, remainingMs - CONTROL_ACTION_RETURN_RESERVE_MS),
+              );
+              if (cleanupTimeoutMs <= 0) {
+                const error = yield* makeDeadlineError;
+                return yield* error;
+              }
+              const result = yield* cleanup.pipe(Effect.timeoutOption(cleanupTimeoutMs));
+              if (Option.isSome(result)) return result.value;
+              const error = yield* makeDeadlineError;
+              return yield* error;
+            }).pipe(
+              Effect.tapError((error) =>
+                Ref.set(cleanupFailureRef, Option.some(error)).pipe(
+                  Effect.andThen(retireControlSession(control)),
+                  Effect.asVoid,
+                ),
+              ),
+              Effect.ensuring(Ref.set(stageRef, previousStage)),
+            );
+          },
+        );
+        const result = yield* use(send, sendCleanup, (error) =>
+          Ref.set(operationFailureRef, Option.some(error)),
+        );
+        const cleanupFailure = yield* Ref.get(cleanupFailureRef);
+        if (Option.isSome(cleanupFailure)) return yield* cleanupFailure.value;
+        yield* assertCurrentAttachment(control);
+        return result;
+      });
+      return yield* run.pipe(Effect.ensuring(releaseController(controllerOwner)));
     });
     const finalize = Effect.fn("PreviewManager.finalizeControlAction")(function* (
       exit: Exit.Exit<A, PreviewManagerError>,
@@ -1254,10 +1500,59 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           error: errorMessage,
         });
       }
-      const tabs = yield* SynchronizedRef.get(tabsRef);
-      if (tabs.has(tabId)) yield* update(tabId, { controller: "none" });
     });
-    return yield* control.semaphore.withPermit(execute().pipe(Effect.onExit(finalize)));
+    const retirePermitAttachment = Ref.get(ownedAttachmentRef).pipe(
+      Effect.flatMap((owned) => {
+        if (Option.isSome(owned)) return retireControlSession(owned.value).pipe(Effect.asVoid);
+        return SynchronizedRef.get(controlSessionsRef).pipe(
+          Effect.flatMap((sessions) => {
+            const current = sessions.get(wc.id);
+            return current?.webContents === wc
+              ? retireControlSession(current).pipe(Effect.asVoid)
+              : Effect.void;
+          }),
+        );
+      }),
+    );
+    const runWithPermit = Effect.gen(function* () {
+      if (queue.retired) {
+        return yield* new PreviewAutomationControlInterruptedError({
+          operation: action,
+          tabId,
+          webContentsId: wc.id,
+        });
+      }
+      yield* assertCurrentAttachment();
+      yield* Ref.set(stageRef, "initialization");
+      const control = yield* ensureControlSession(wc);
+      yield* Ref.set(ownedAttachmentRef, Option.some(control));
+      yield* assertCurrentAttachment(control);
+      yield* Ref.set(stageRef, "execution");
+      if (!deadline) return yield* execute(control);
+      const remainingMs = yield* remainingDeadlineMs();
+      const executionMs = Math.max(
+        1,
+        remainingMs - Math.min(CONTROL_ACTION_CLEANUP_RESERVE_MS, Math.ceil(remainingMs / 10)),
+      );
+      const result = yield* execute(control).pipe(Effect.timeoutOption(executionMs));
+      if (Option.isSome(result)) return result.value;
+      yield* retireControlSession(control);
+      const operationFailure = yield* Ref.get(operationFailureRef);
+      if (Option.isSome(operationFailure)) return yield* operationFailure.value;
+      const cleanupFailure = yield* Ref.get(cleanupFailureRef);
+      if (Option.isSome(cleanupFailure)) return yield* cleanupFailure.value;
+      return yield* yield* makeDeadlineError;
+    }).pipe(Effect.onInterrupt(() => retirePermitAttachment));
+    const permitted = queue.semaphore.withPermit(runWithPermit);
+    const operation = Effect.gen(function* () {
+      if (!deadline) return yield* permitted;
+      const remainingMs = yield* remainingDeadlineMs();
+      if (remainingMs <= 0) return yield* yield* makeDeadlineError;
+      const result = yield* permitted.pipe(Effect.timeoutOption(remainingMs));
+      if (Option.isSome(result)) return result.value;
+      return yield* yield* makeDeadlineError;
+    });
+    return yield* operation.pipe(Effect.onExit(finalize));
   });
 
   const evaluateWithDebugger = <A = unknown>(
@@ -1343,12 +1638,16 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   const detachListeners = Effect.fn("PreviewManager.detachListeners")(function* (
-    webContentsId: number,
+    expected: ManagedListeners,
   ) {
     const managed = yield* Ref.modify(attachedRef, (attached) => [
-      attached.get(webContentsId),
+      attached.get(expected.webContents.id)?.attachmentId === expected.attachmentId
+        ? attached.get(expected.webContents.id)
+        : undefined,
       replaceMap(attached, (copy) => {
-        copy.delete(webContentsId);
+        if (copy.get(expected.webContents.id)?.attachmentId === expected.attachmentId) {
+          copy.delete(expected.webContents.id);
+        }
       }),
     ]);
     if (managed) {
@@ -1831,8 +2130,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (Option.isNone(tab)) return;
     const closedTab = tab.value;
     if (closedTab.webContentsId != null) {
+      const attached = (yield* Ref.get(attachedRef)).get(closedTab.webContentsId);
+      const control = (yield* SynchronizedRef.get(controlSessionsRef)).get(closedTab.webContentsId);
+      const closedWebContents = attached?.webContents ?? control?.webContents;
       yield* Effect.all(
-        [detachControlSession(closedTab.webContentsId), detachListeners(closedTab.webContentsId)],
+        [
+          ...(closedWebContents ? [detachControlSession(closedWebContents, true)] : []),
+          ...(attached ? [detachListeners(attached)] : []),
+        ],
         { concurrency: 2, discard: true },
       );
     }
@@ -1896,6 +2201,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       return yield* new PreviewWebContentsNotFoundError({ tabId, webContentsId });
     }
     const attached = yield* Ref.get(attachedRef);
+    const controlSessions = yield* SynchronizedRef.get(controlSessionsRef);
     const annotationTheme = yield* Ref.get(annotationThemeRef);
     const currentAttachment = attached.get(webContentsId);
     if (tab.webContentsId === webContentsId && currentAttachment?.webContents === wc) {
@@ -1914,10 +2220,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         ? tab.webContentsId
         : null;
     if (replacedWebContentsId !== null) {
+      const replacedAttachment = attached.get(replacedWebContentsId);
+      const replacedWebContents =
+        replacedAttachment?.webContents ?? controlSessions.get(replacedWebContentsId)?.webContents;
       yield* Effect.all(
         [
-          detachControlSession(replacedWebContentsId),
-          detachListeners(replacedWebContentsId),
+          ...(replacedWebContents ? [detachControlSession(replacedWebContents, true)] : []),
+          ...(replacedAttachment ? [detachListeners(replacedAttachment)] : []),
           cancelPickElement(tabId),
         ],
         { concurrency: 3, discard: true },
@@ -1987,10 +2296,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       }),
     );
     if (Option.isNone(registration)) {
-      yield* Effect.all([detachControlSession(webContentsId), detachListeners(webContentsId)], {
-        concurrency: 2,
-        discard: true,
-      });
+      const failedAttachment = (yield* Ref.get(attachedRef)).get(webContentsId);
+      yield* Effect.all(
+        [
+          detachControlSession(wc, true),
+          ...(failedAttachment?.webContents === wc ? [detachListeners(failedAttachment)] : []),
+        ],
+        {
+          concurrency: 2,
+          discard: true,
+        },
+      );
       return yield* new PreviewTabNotFoundError({ tabId });
     }
     const { state: registered, pendingUrl } = registration.value;
@@ -2100,8 +2416,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           }
           yield* Effect.all(
             [
-              detachControlSession(webContentsId),
-              detachListeners(webContentsId),
+              ...(expectedAttachment
+                ? [detachControlSession(expectedAttachment.webContents, true)]
+                : []),
+              ...(expectedAttachment ? [detachListeners(expectedAttachment)] : []),
               cancelPickElement(tabId),
             ],
             { concurrency: 3, discard: true },
@@ -2165,7 +2483,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       );
       return;
     }
-    yield* detachControlSession(wc.id);
+    yield* detachControlSession(wc, false);
     yield* attempt({ operation: "openDevTools", tabId, webContentsId: wc.id }, () => {
       wc.once("devtools-closed", () => {
         if (!wc.isDestroyed()) runFork(restoreControlSession(tabId, wc));
@@ -2257,7 +2575,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const cropRect = normalizeCaptureRect(args[1]);
           const submission = args[2] === "send" ? "send" : "attach";
           runFork(
-            captureAnnotationScreenshot(tabId, wc, cropRect).pipe(
+            captureAnnotationScreenshot(
+              cropRect,
+              capturePage(
+                { operation: "captureAnnotationScreenshot", tabId, webContentsId: wc.id },
+                wc,
+                cropRect ? { rect: cropRect } : {},
+              ),
+            ).pipe(
               Effect.matchEffect({
                 onFailure: () => Effect.sync(() => settle({ annotation: payload, submission })),
                 onSuccess: (screenshot) =>
@@ -2348,16 +2673,25 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     wc: Electron.WebContents,
     colorScheme: DesktopPreviewColorScheme,
   ) {
-    yield* ensureControlSession(wc);
-    yield* attemptPromise({ operation: "applyColorScheme", tabId, webContentsId: wc.id }, () =>
-      wc.debugger.sendCommand("Emulation.setEmulatedMedia", {
-        features: [
-          {
-            name: "prefers-color-scheme",
-            // An empty value clears the override so the page follows the OS.
-            value: colorScheme === "system" ? "" : colorScheme,
-          },
-        ],
+    const queue = controlQueueFor(wc);
+    yield* queue.semaphore.withPermit(
+      Effect.gen(function* () {
+        const current = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
+        if (queue.retired || current?.webContentsId !== wc.id || webContents.fromId(wc.id) !== wc) {
+          return;
+        }
+        yield* ensureControlSession(wc);
+        yield* attemptPromise({ operation: "applyColorScheme", tabId, webContentsId: wc.id }, () =>
+          wc.debugger.sendCommand("Emulation.setEmulatedMedia", {
+            features: [
+              {
+                name: "prefers-color-scheme",
+                // An empty value clears the override so the page follows the OS.
+                value: colorScheme === "system" ? "" : colorScheme,
+              },
+            ],
+          }),
+        );
       }),
     );
   });
@@ -2368,25 +2702,48 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   // a stale snapshot.
   const restoreControlSession = (tabId: string, wc: Electron.WebContents) =>
     Effect.gen(function* () {
-      const beforeAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
-      if (beforeAttach?.webContentsId !== wc.id) return;
-      yield* ensureControlSession(wc);
-      const afterAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
-      if (afterAttach?.webContentsId !== wc.id) {
-        yield* detachControlSession(wc.id);
-        return;
-      }
-      if (afterAttach.colorScheme !== "system") {
-        yield* attemptPromise({ operation: "applyColorScheme", tabId, webContentsId: wc.id }, () =>
-          wc.debugger.sendCommand("Emulation.setEmulatedMedia", {
-            features: [
-              {
-                name: "prefers-color-scheme",
-                value: afterAttach.colorScheme,
-              },
-            ],
-          }),
-        );
+      const queue = controlQueueFor(wc);
+      if (queue.retired) return;
+      const ownedRef = yield* Ref.make<Option.Option<BrowserControlSession>>(Option.none());
+      const restore = queue.semaphore.withPermit(
+        Effect.gen(function* () {
+          const beforeAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
+          if (
+            queue.retired ||
+            beforeAttach?.webContentsId !== wc.id ||
+            webContents.fromId(wc.id) !== wc
+          ) {
+            return;
+          }
+          const control = yield* ensureControlSession(wc);
+          yield* Ref.set(ownedRef, Option.some(control));
+          const afterAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
+          if (
+            queue.retired ||
+            afterAttach?.webContentsId !== wc.id ||
+            webContents.fromId(wc.id) !== wc
+          ) {
+            yield* retireControlSession(control);
+          }
+        }).pipe(
+          Effect.onInterrupt(() =>
+            Ref.get(ownedRef).pipe(
+              Effect.flatMap(
+                Option.match({
+                  onNone: () => Effect.void,
+                  onSome: (control) => retireControlSession(control).pipe(Effect.asVoid),
+                }),
+              ),
+            ),
+          ),
+        ),
+      );
+      const restored = yield* restore.pipe(
+        Effect.timeoutOption(CONTROL_SESSION_RESTORE_TIMEOUT_MS),
+      );
+      if (Option.isNone(restored)) {
+        const owned = yield* Ref.get(ownedRef);
+        if (Option.isSome(owned)) yield* retireControlSession(owned.value);
       }
     }).pipe(Effect.ignore);
 
@@ -2453,13 +2810,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const [createdAt, millis, image] = yield* Effect.all([
       currentIso,
       currentMillis,
-      attemptPromise(
+      capturePage(
         {
           operation: "captureScreenshot.capturePage",
           tabId,
           webContentsId: wc.id,
         },
-        () => wc.capturePage(),
+        wc,
       ),
     ]);
     const id = `browser-screenshot-${artifactSiteSlug(wc.getURL())}-${millis.toString(36)}`;
@@ -2505,13 +2862,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const captureSession = (yield* SynchronizedRef.get(frameCaptureSessionsRef)).get(tabId);
     if (!captureSession) return;
     const wc = yield* requireWebContents(tabId);
-    const image = yield* attemptPromise(
+    if (captureQueues.get(wc)?.pending) return;
+    const image = yield* capturePage(
       {
         operation: "frameCapture.capturePage",
         tabId,
         webContentsId: wc.id,
       },
-      () => wc.capturePage(),
+      wc,
     );
     const currentCaptureSession = yield* Effect.all(
       [SynchronizedRef.get(frameCaptureSessionsRef), SynchronizedRef.get(tabsRef)],
@@ -3064,11 +3422,15 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   const captureAutomationSnapshot = Effect.fn("PreviewManager.captureAutomationSnapshot")(
-    function* (tabId: string, wc: Electron.WebContents, send: SendCommand) {
-      yield* Effect.all([send("Runtime.enable"), send("Accessibility.enable")], {
-        concurrency: 2,
-        discard: true,
-      });
+    function* (
+      tabId: string,
+      wc: Electron.WebContents,
+      send: SendCommand,
+      sendCleanup: SendCommand,
+      recordFailure: (error: PreviewManagerError) => Effect.Effect<void>,
+      deadline: PreviewAutomationDeadline,
+    ) {
+      yield* send("Runtime.enable");
       const page = yield* evaluateWithDebugger<{
         url: string;
         title: string;
@@ -3131,19 +3493,51 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         })()`,
         true,
       );
-      const [accessibility, sourceImage, diagnostics, timelines] = yield* Effect.all([
-        send("Accessibility.getFullAXTree"),
-        attemptPromise(
-          {
-            operation: "automationSnapshot.capturePage",
-            tabId,
-            webContentsId: wc.id,
-          },
-          () => wc.capturePage(),
+      const readAccessibility = send("Accessibility.enable").pipe(
+        Effect.andThen(
+          send("Accessibility.getFullAXTree", {
+            depth: MAX_ACCESSIBILITY_DEPTH,
+          }),
         ),
-        Ref.get(diagnosticsRef),
-        Ref.get(actionTimelineRef),
-      ]);
+        Effect.tapError(recordFailure),
+        Effect.ensuring(sendCleanup("Accessibility.disable").pipe(Effect.ignore)),
+      );
+      const [rawAccessibility, sourceImage, diagnostics, timelines] = yield* Effect.all(
+        [
+          readAccessibility,
+          capturePage(
+            {
+              operation: "automationSnapshot.capturePage",
+              tabId,
+              webContentsId: wc.id,
+            },
+            wc,
+            {
+              busyError: new PreviewAutomationDeadlineExceededError({
+                operation: "snapshot",
+                tabId,
+                webContentsId: wc.id,
+                connectionId: deadline.connectionId,
+                requestId: deadline.requestId,
+                timeoutMs: deadline.timeoutMs,
+                stage: "queue",
+              }),
+            },
+          ).pipe(Effect.tapError(recordFailure)),
+          Ref.get(diagnosticsRef),
+          Ref.get(actionTimelineRef),
+        ],
+        { concurrency: 4 },
+      );
+      const accessibility =
+        Predicate.isObject(rawAccessibility) &&
+        "nodes" in rawAccessibility &&
+        Array.isArray(rawAccessibility.nodes)
+          ? {
+              ...rawAccessibility,
+              nodes: rawAccessibility.nodes.slice(0, MAX_ACCESSIBILITY_NODES),
+            }
+          : rawAccessibility;
       const sourceSize = sourceImage.getSize();
       const image =
         sourceSize.width > MAX_SCREENSHOT_WIDTH
@@ -3168,11 +3562,23 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   );
 
   const automationSnapshot = Effect.fn("PreviewManager.automationSnapshot")(function* (
-    tabId: string,
+    input: DesktopPreviewAutomationSnapshotInput,
   ) {
-    const wc = yield* requireWebContents(tabId);
-    return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-      captureAutomationSnapshot(tabId, wc, send),
+    const startedAtNanos = yield* Clock.monotonicTimeNanos;
+    const deadline: PreviewAutomationDeadline = {
+      connectionId: input.connectionId,
+      requestId: input.requestId,
+      timeoutMs: input.timeoutMs,
+      expiresAtNanos: startedAtNanos + BigInt(input.timeoutMs) * 1_000_000n,
+    };
+    const wc = yield* requireWebContents(input.tabId);
+    return yield* withControlSession(
+      input.tabId,
+      wc,
+      "snapshot",
+      (send, sendCleanup, recordFailure) =>
+        captureAutomationSnapshot(input.tabId, wc, send, sendCleanup, recordFailure, deadline),
+      deadline,
     );
   });
 
@@ -3985,6 +4391,23 @@ export class PreviewAutomationTimeoutError extends Schema.TaggedErrorClass<Previ
   }
 }
 
+export class PreviewAutomationDeadlineExceededError extends Schema.TaggedErrorClass<PreviewAutomationDeadlineExceededError>()(
+  "PreviewAutomationDeadlineExceededError",
+  {
+    operation: Schema.String,
+    tabId: Schema.String,
+    webContentsId: Schema.Number,
+    connectionId: Schema.String,
+    requestId: Schema.String,
+    timeoutMs: Schema.Int.check(Schema.isGreaterThan(0)),
+    stage: Schema.Literals(["queue", "initialization", "execution", "cleanup"]),
+  },
+) {
+  override get message(): string {
+    return `Preview automation ${this.operation} timed out after ${this.timeoutMs}ms during ${this.stage} in tab ${this.tabId}`;
+  }
+}
+
 export class PreviewAutomationControlInterruptedError extends Schema.TaggedErrorClass<PreviewAutomationControlInterruptedError>()(
   "PreviewAutomationControlInterruptedError",
   {
@@ -4015,6 +4438,7 @@ export const PreviewManagerError = Schema.Union([
   PreviewAutomationInvalidSelectorError,
   PreviewAutomationResultTooLargeError,
   PreviewAutomationTimeoutError,
+  PreviewAutomationDeadlineExceededError,
   PreviewAutomationControlInterruptedError,
 ]);
 export type PreviewManagerError = typeof PreviewManagerError.Type;
@@ -4091,7 +4515,7 @@ export class PreviewManager extends Context.Service<
       tabId: string,
     ) => Effect.Effect<DesktopPreviewAutomationStatus, PreviewManagerError>;
     readonly automationSnapshot: (
-      tabId: string,
+      input: DesktopPreviewAutomationSnapshotInput,
     ) => Effect.Effect<PreviewAutomationSnapshot, PreviewManagerError>;
     readonly automationClick: (
       tabId: string,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -400,7 +400,7 @@ interface BrowserControlQueue {
 
 interface BrowserCaptureQueue {
   tail: Promise<void>;
-  pendingKind: "ordinary" | "snapshot" | null;
+  pendingKind: "background" | "foreground" | null;
   retired: boolean;
 }
 
@@ -566,8 +566,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     errorContext: PreviewOperationContext,
     wc: Electron.WebContents,
     options: {
+      readonly background?: boolean;
       readonly busyError?: PreviewManagerError;
-      readonly queueBehindOrdinaryCapture?: boolean;
       readonly rect?: Electron.Rectangle;
     } = {},
   ): Effect.Effect<Electron.NativeImage, PreviewManagerError> =>
@@ -582,9 +582,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         if (queue.retired) {
           throw new Error("Preview capture target is no longer active");
         }
-        const captureKind = options.queueBehindOrdinaryCapture ? "snapshot" : "ordinary";
+        const captureKind = options.background ? "background" : "foreground";
         const canQueueBehindPendingCapture =
-          captureKind === "snapshot" && queue.pendingKind === "ordinary";
+          captureKind === "foreground" && queue.pendingKind === "background";
         if (queue.pendingKind !== null && !canQueueBehindPendingCapture) {
           throw options.busyError ?? new Error("Another preview capture is still in progress");
         }
@@ -2874,6 +2874,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         webContentsId: wc.id,
       },
       wc,
+      { background: true },
     );
     const currentCaptureSession = yield* Effect.all(
       [SynchronizedRef.get(frameCaptureSessionsRef), SynchronizedRef.get(tabsRef)],
@@ -3526,7 +3527,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                 timeoutMs: deadline.timeoutMs,
                 stage: "queue",
               }),
-              queueBehindOrdinaryCapture: true,
             },
           ).pipe(Effect.tapError(recordFailure)),
           Ref.get(diagnosticsRef),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -400,7 +400,7 @@ interface BrowserControlQueue {
 
 interface BrowserCaptureQueue {
   tail: Promise<void>;
-  pending: boolean;
+  pendingKind: "ordinary" | "snapshot" | null;
   retired: boolean;
 }
 
@@ -567,6 +567,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     wc: Electron.WebContents,
     options: {
       readonly busyError?: PreviewManagerError;
+      readonly queueBehindOrdinaryCapture?: boolean;
       readonly rect?: Electron.Rectangle;
     } = {},
   ): Effect.Effect<Electron.NativeImage, PreviewManagerError> =>
@@ -574,17 +575,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       try: (signal) => {
         const queue = captureQueues.get(wc) ?? {
           tail: Promise.resolve(),
-          pending: false,
+          pendingKind: null,
           retired: false,
         };
         captureQueues.set(wc, queue);
         if (queue.retired) {
           throw new Error("Preview capture target is no longer active");
         }
-        if (queue.pending) {
+        const captureKind = options.queueBehindOrdinaryCapture ? "snapshot" : "ordinary";
+        const canQueueBehindPendingCapture =
+          captureKind === "snapshot" && queue.pendingKind === "ordinary";
+        if (queue.pendingKind !== null && !canQueueBehindPendingCapture) {
           throw options.busyError ?? new Error("Another preview capture is still in progress");
         }
-        queue.pending = true;
+        queue.pendingKind = captureKind;
         const capture = queue.tail.then(() => {
           if (signal.aborted) throw signal.reason;
           if (queue.retired || wc.isDestroyed()) {
@@ -602,10 +606,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         let tail: Promise<void>;
         tail = capture.then(
           () => {
-            if (queue.tail === tail) queue.pending = false;
+            if (queue.tail === tail) queue.pendingKind = null;
           },
           () => {
-            if (queue.tail === tail) queue.pending = false;
+            if (queue.tail === tail) queue.pendingKind = null;
           },
         );
         queue.tail = tail;
@@ -619,7 +623,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const retireCaptureQueue = (wc: Electron.WebContents): void => {
     const queue = captureQueues.get(wc) ?? {
       tail: Promise.resolve(),
-      pending: false,
+      pendingKind: null,
       retired: false,
     };
     queue.retired = true;
@@ -2862,7 +2866,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const captureSession = (yield* SynchronizedRef.get(frameCaptureSessionsRef)).get(tabId);
     if (!captureSession) return;
     const wc = yield* requireWebContents(tabId);
-    if (captureQueues.get(wc)?.pending) return;
+    if (captureQueues.get(wc)?.pendingKind) return;
     const image = yield* capturePage(
       {
         operation: "frameCapture.capturePage",
@@ -3522,6 +3526,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                 timeoutMs: deadline.timeoutMs,
                 stage: "queue",
               }),
+              queueBehindOrdinaryCapture: true,
             },
           ).pipe(Effect.tapError(recordFailure)),
           Ref.get(diagnosticsRef),

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -7,6 +7,7 @@ import {
   PREVIEW_AUTOMATION_OPERATIONS,
   type EnvironmentId,
   type PreviewAutomationNavigateInput,
+  type PreviewAutomationConnectionId,
   type PreviewAutomationOpenInput,
   type PreviewAutomationResizeInput,
   type PreviewAutomationResizeResult,
@@ -52,6 +53,7 @@ import {
   PreviewAutomationOperationError,
   PreviewAutomationOverlayTimeoutError,
   PreviewAutomationRecordingNotActiveError,
+  PreviewAutomationSnapshotTimeoutError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationViewportTimeoutError,
 } from "./previewAutomationErrors";
@@ -73,8 +75,15 @@ import {
 } from "./previewAutomationTarget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
 import { shouldRollbackPreviewViewport } from "./previewViewportRollback";
+import {
+  remainingBudgetMs,
+  requestPreviewAutomationSnapshot,
+  responseBudgetMs,
+  waitForLocalResponse,
+} from "./previewAutomationSnapshot";
 
 const PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS = 500;
+const PREVIEW_AUTOMATION_RESPONSE_MARGIN_MS = 1_000;
 
 const waitForPreviewPresentation = async (runtimeTabId: string): Promise<void> => {
   const deadline = Date.now() + PREVIEW_PRESENTATION_SETTLE_TIMEOUT_MS;
@@ -92,24 +101,35 @@ const waitForDesktopOverlay = async (
   operation: PreviewAutomationRequest["operation"],
   timeoutMs: number,
 ): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
+  const deadline = performance.now() + timeoutMs;
+  const timeoutError = () =>
+    new PreviewAutomationOverlayTimeoutError({
+      requestId,
+      environmentId: threadRef.environmentId,
+      threadId: threadRef.threadId,
+      timeoutMs,
+    });
+  while (true) {
+    const remainingMs = Math.floor(deadline - performance.now());
+    if (remainingMs <= 0) break;
     const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
       operation,
       requestId,
     });
-    if (state.desktopByTabId[tabId] && previewBridge) {
-      const status = await previewBridge.automation.status(runtimeTabId);
+    const bridge = previewBridge;
+    if (state.desktopByTabId[tabId] && bridge) {
+      const status = await waitForLocalResponse(
+        () => bridge.automation.status(runtimeTabId),
+        remainingMs,
+        timeoutError,
+      );
       if (status.available) return;
     }
-    await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
+    const sleepMs = Math.min(50, Math.floor(deadline - performance.now()));
+    if (sleepMs <= 0) break;
+    await new Promise<void>((resolve) => window.setTimeout(resolve, sleepMs));
   }
-  throw new PreviewAutomationOverlayTimeoutError({
-    requestId,
-    environmentId: threadRef.environmentId,
-    threadId: threadRef.threadId,
-    timeoutMs,
-  });
+  throw timeoutError();
 };
 
 interface ExecutablePreviewWebview extends Element {
@@ -301,12 +321,34 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
   const automationConnectionId = useAtomValue(automationConnectionAtom);
 
   const handleRequest = useCallback(
-    async (request: PreviewAutomationRequest): Promise<unknown> => {
+    async (
+      request: PreviewAutomationRequest,
+      connectionId: PreviewAutomationConnectionId,
+    ): Promise<unknown> => {
+      // The server sends a duration. Start a local monotonic budget when this
+      // host receives it and keep time to return a structured response.
+      const hostDeadline =
+        performance.now() +
+        responseBudgetMs(request.timeoutMs, PREVIEW_AUTOMATION_RESPONSE_MARGIN_MS);
       const threadRef: ScopedThreadRef = {
         environmentId,
         threadId: request.threadId,
       };
       let tabId = request.tabId ?? null;
+      const hostTimeoutError = () =>
+        new PreviewAutomationOverlayTimeoutError({
+          requestId: request.requestId,
+          environmentId,
+          threadId: request.threadId,
+          timeoutMs: request.timeoutMs,
+        });
+      const runWithinHostBudget = <A,>(run: () => Promise<A>): Promise<A> =>
+        waitForLocalResponse(run, remainingBudgetMs(hostDeadline), hostTimeoutError).then(
+          (value) => {
+            if (remainingBudgetMs(hostDeadline) <= 0) throw hostTimeoutError();
+            return value;
+          },
+        );
       try {
         let state = readThreadPreviewState(threadRef);
         const needsSessionSync = needsPreviewAutomationSessionSync(state, request.tabId);
@@ -316,7 +358,10 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             input: { threadId: request.threadId },
           } as const;
           registry.refresh(previewEnvironment.list(listTarget));
-          const result = await listPreviews(listTarget);
+          const result =
+            request.operation === "snapshot"
+              ? await runWithinHostBudget(() => listPreviews(listTarget))
+              : await listPreviews(listTarget);
           if (result._tag === "Failure") {
             return raiseAtomCommandFailure(result);
           }
@@ -332,7 +377,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           tabId,
           bridgeAvailable: Boolean(previewBridge),
         };
-        const requireReadyTab = async () => {
+        const requireReadyTab = async (timeoutMs = request.timeoutMs) => {
           const bridge = previewBridge;
           const readyTabId = tabId;
           if (!bridge || !readyTabId) {
@@ -346,7 +391,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             readyTabId,
             runtimeTabId,
             request.operation,
-            request.timeoutMs,
+            timeoutMs,
           );
           return {
             bridge,
@@ -356,7 +401,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
         };
         switch (request.operation) {
           case "status":
-            return await currentStatus(threadRef, tabId);
+            return await runWithinHostBudget(() => currentStatus(threadRef, tabId));
           case "open": {
             const input = request.input as PreviewAutomationOpenInput;
             const resolvedInputUrl = input.url
@@ -469,7 +514,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 request.timeoutMs,
               );
             }
-            return await currentStatus(threadRef, activeTabId);
+            return await runWithinHostBudget(() => currentStatus(threadRef, activeTabId));
           }
           case "navigate": {
             const ready = await requireReadyTab();
@@ -491,7 +536,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               input.readiness ?? "load",
               input.timeoutMs ?? request.timeoutMs,
             );
-            return await currentStatus(threadRef, ready.tabId);
+            return await runWithinHostBudget(() => currentStatus(threadRef, ready.tabId));
           }
           case "resize": {
             const ready = await requireReadyTab();
@@ -583,8 +628,29 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             } satisfies PreviewAutomationSetColorSchemeResult;
           }
           case "snapshot": {
-            const ready = await requireReadyTab();
-            return await ready.bridge.automation.snapshot(ready.runtimeTabId);
+            return await requestPreviewAutomationSnapshot({
+              connectionId,
+              requestId: request.requestId,
+              hostDeadline,
+              requireReady: async (timeoutMs) => {
+                const ready = await requireReadyTab(timeoutMs);
+                return {
+                  tabId: ready.tabId,
+                  runtimeTabId: ready.runtimeTabId,
+                  snapshot: ready.bridge.automation.snapshot,
+                };
+              },
+              onTimeout: (readyTabId) =>
+                readyTabId
+                  ? new PreviewAutomationSnapshotTimeoutError({
+                      requestId: request.requestId,
+                      environmentId,
+                      threadId: request.threadId,
+                      tabId: readyTabId,
+                      timeoutMs: request.timeoutMs,
+                    })
+                  : hostTimeoutError(),
+            });
           }
           case "click": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -514,7 +514,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 request.timeoutMs,
               );
             }
-            return await runWithinHostBudget(() => currentStatus(threadRef, activeTabId));
+            return await currentStatus(threadRef, activeTabId);
           }
           case "navigate": {
             const ready = await requireReadyTab();
@@ -536,7 +536,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               input.readiness ?? "load",
               input.timeoutMs ?? request.timeoutMs,
             );
-            return await runWithinHostBudget(() => currentStatus(threadRef, ready.tabId));
+            return await currentStatus(threadRef, ready.tabId);
           }
           case "resize": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -36,6 +36,25 @@ export class PreviewAutomationOverlayTimeoutError extends Schema.TaggedErrorClas
   }
 }
 
+export class PreviewAutomationSnapshotTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationSnapshotTimeoutError>()(
+  "PreviewAutomationSnapshotTimeoutError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+    timeoutMs: Schema.Int.check(Schema.isGreaterThan(0)),
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTimeoutError" as const;
+  }
+
+  override get message(): string {
+    return `Preview snapshot request ${this.requestId} did not finish within ${this.timeoutMs}ms in tab ${this.tabId}.`;
+  }
+}
+
 export class PreviewAutomationNavigationTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationNavigationTimeoutError>()(
   "PreviewAutomationNavigationTimeoutError",
   {
@@ -207,6 +226,7 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
 
 export const PreviewAutomationHostError = Schema.Union([
   PreviewAutomationOverlayTimeoutError,
+  PreviewAutomationSnapshotTimeoutError,
   PreviewAutomationNavigationTimeoutError,
   PreviewAutomationViewportTimeoutError,
   PreviewAutomationTargetUnavailableError,

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -47,7 +47,12 @@ const requestEvent = (
   request: request(requestId, overrides),
 });
 
-const consumerState = (handleRequest: (request: PreviewAutomationRequest) => Promise<unknown>) => ({
+const consumerState = (
+  handleRequest: (
+    request: PreviewAutomationRequest,
+    connectionId: PreviewAutomationStreamEvent["connectionId"],
+  ) => Promise<unknown>,
+) => ({
   connectionAtom: Atom.make<string | null>(null),
   requestHandlerAtom: Atom.make({ handle: handleRequest }),
 });
@@ -149,6 +154,49 @@ describe("previewAutomationRequestConsumer", () => {
       "request-2",
     ]);
     expect(responses.map((response) => response.requestId)).toEqual(["request-1", "request-2"]);
+    registry.dispose();
+  });
+
+  it("passes each request stream connection ID to the handler", async () => {
+    const requestsAtom = Atom.make<AsyncResult.AsyncResult<PreviewAutomationStreamEvent, Error>>(
+      AsyncResult.initial<PreviewAutomationStreamEvent, Error>(false),
+    );
+    const handleRequest = vi.fn(
+      async (
+        _value: PreviewAutomationRequest,
+        _eventConnectionId: PreviewAutomationStreamEvent["connectionId"],
+      ) => undefined,
+    );
+    const respond = vi.fn(async (_response: PreviewAutomationResponse) => undefined);
+    const state = consumerState(handleRequest);
+    const consumerAtom = createPreviewAutomationRequestConsumerAtom({
+      requestsAtom,
+      clientId,
+      connectionAtom: state.connectionAtom,
+      environmentId,
+      requestHandlerAtom: state.requestHandlerAtom,
+      respond,
+      label: "test:preview-automation-request-connection",
+    });
+    const registry = AtomRegistry.make();
+    registry.mount(consumerAtom);
+
+    registry.set(requestsAtom, AsyncResult.success(requestEvent("request-1")));
+    await vi.waitFor(() => expect(respond).toHaveBeenCalledTimes(1));
+    registry.set(
+      requestsAtom,
+      AsyncResult.success<PreviewAutomationStreamEvent, Error>({
+        type: "connected",
+        connectionId: "connection-2",
+      }),
+    );
+    registry.set(requestsAtom, AsyncResult.success(requestEvent("request-2", {}, "connection-2")));
+
+    await vi.waitFor(() => expect(respond).toHaveBeenCalledTimes(2));
+    expect(handleRequest.mock.calls).toEqual([
+      [expect.objectContaining({ requestId: "request-1" }), "connection-1"],
+      [expect.objectContaining({ requestId: "request-2" }), "connection-2"],
+    ]);
     registry.dispose();
   });
 

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.ts
@@ -29,7 +29,10 @@ export function createPreviewAutomationRequestConsumerAtom<E>(options: {
   readonly connectionAtom: Atom.Writable<PreviewAutomationStreamEvent["connectionId"] | null>;
   readonly environmentId: PreviewAutomationHost["environmentId"];
   readonly requestHandlerAtom: Atom.Atom<{
-    readonly handle: (request: PreviewAutomationRequest) => Promise<unknown>;
+    readonly handle: (
+      request: PreviewAutomationRequest,
+      connectionId: PreviewAutomationStreamEvent["connectionId"],
+    ) => Promise<unknown>;
   }>;
   readonly respond: (response: PreviewAutomationResponse) => Promise<unknown>;
   readonly label: string;
@@ -65,7 +68,7 @@ export function createPreviewAutomationRequestConsumerAtom<E>(options: {
       const request = event.request;
       void get
         .once(options.requestHandlerAtom)
-        .handle(request)
+        .handle(request, event.connectionId)
         .then(
           (value) =>
             options.respond({

--- a/apps/web/src/components/preview/previewAutomationSnapshot.test.ts
+++ b/apps/web/src/components/preview/previewAutomationSnapshot.test.ts
@@ -1,0 +1,167 @@
+import type {
+  DesktopPreviewAutomationSnapshotInput,
+  DesktopPreviewAutomationSnapshotResult,
+  PreviewAutomationSnapshot,
+} from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { requestPreviewAutomationSnapshot, responseBudgetMs } from "./previewAutomationSnapshot";
+
+const snapshot = {
+  url: "https://example.com",
+  title: "Example",
+  loading: false,
+  visibleText: "Example",
+  interactiveElements: [],
+  accessibilityTree: {},
+  consoleEntries: [],
+  networkEntries: [],
+  actionTimeline: [],
+  screenshot: {
+    mimeType: "image/png",
+    data: "cG5n",
+    width: 1,
+    height: 1,
+  },
+} as const satisfies PreviewAutomationSnapshot;
+
+const timeoutError = (tabId: string | null) => new Error(`timed out:${tabId ?? "unready"}`);
+
+describe("preview snapshot host budget", () => {
+  it("keeps a response margin for every positive duration", () => {
+    expect(responseBudgetMs(15_000, 1_000)).toBe(14_000);
+    expect(responseBudgetMs(10, 1_000)).toBe(9);
+    expect(responseBudgetMs(1, 1_000)).toBe(0);
+  });
+
+  it("subtracts readiness time and forwards exact request identity", async () => {
+    let now = 100;
+    const desktopSnapshot = vi.fn(
+      async (
+        _input: DesktopPreviewAutomationSnapshotInput,
+      ): Promise<DesktopPreviewAutomationSnapshotResult> => ({ _tag: "Success", snapshot }),
+    );
+
+    await expect(
+      requestPreviewAutomationSnapshot({
+        connectionId: "connection-from-stream-event",
+        requestId: "request-with-a-long-runtime-tab-id",
+        hostDeadline: 14_100,
+        now: () => now,
+        requireReady: async (timeoutMs) => {
+          expect(timeoutMs).toBe(14_000);
+          now += 2_000;
+          return {
+            tabId: "tab-public",
+            runtimeTabId: `runtime-${"x".repeat(512)}`,
+            snapshot: desktopSnapshot,
+          };
+        },
+        onTimeout: timeoutError,
+      }),
+    ).resolves.toEqual(snapshot);
+
+    expect(desktopSnapshot).toHaveBeenCalledWith({
+      tabId: `runtime-${"x".repeat(512)}`,
+      connectionId: "connection-from-stream-event",
+      requestId: "request-with-a-long-runtime-tab-id",
+      timeoutMs: 11_750,
+    });
+  });
+
+  it("does not call desktop snapshot after readiness exhausts the budget", async () => {
+    let now = 0;
+    const desktopSnapshot = vi.fn(
+      async (): Promise<DesktopPreviewAutomationSnapshotResult> => ({
+        _tag: "Success",
+        snapshot,
+      }),
+    );
+
+    await expect(
+      requestPreviewAutomationSnapshot({
+        connectionId: "connection-1",
+        requestId: "request-1",
+        hostDeadline: 900,
+        now: () => now,
+        requireReady: async () => {
+          now = 900;
+          return {
+            tabId: "tab-public",
+            runtimeTabId: "runtime-tab",
+            snapshot: desktopSnapshot,
+          };
+        },
+        onTimeout: timeoutError,
+      }),
+    ).rejects.toThrow("timed out:tab-public");
+    expect(desktopSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("maps an encoded desktop timeout to the host timeout", async () => {
+    const desktopSnapshot = vi.fn(
+      async (): Promise<DesktopPreviewAutomationSnapshotResult> => ({
+        _tag: "Timeout",
+        stage: "execution",
+        timeoutMs: 800,
+      }),
+    );
+
+    await expect(
+      requestPreviewAutomationSnapshot({
+        connectionId: "connection-1",
+        requestId: "request-1",
+        hostDeadline: 900,
+        now: () => 0,
+        requireReady: async () => ({
+          tabId: "tab-public",
+          runtimeTabId: "runtime-tab",
+          snapshot: desktopSnapshot,
+        }),
+        onTimeout: timeoutError,
+      }),
+    ).rejects.toThrow("timed out:tab-public");
+  });
+
+  it("bounds readiness that never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = requestPreviewAutomationSnapshot({
+        connectionId: "connection-1",
+        requestId: "request-1",
+        hostDeadline: 900,
+        now: () => 0,
+        requireReady: () => new Promise(() => undefined),
+        onTimeout: timeoutError,
+      });
+      const rejected = expect(pending).rejects.toThrow("timed out:unready");
+
+      await vi.advanceTimersByTimeAsync(900);
+      await rejected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a desktop success that arrives after the absolute deadline", async () => {
+    let now = 0;
+
+    await expect(
+      requestPreviewAutomationSnapshot({
+        connectionId: "connection-1",
+        requestId: "request-1",
+        hostDeadline: 900,
+        now: () => now,
+        requireReady: async () => ({
+          tabId: "tab-public",
+          runtimeTabId: "runtime-tab",
+          snapshot: async () => {
+            now = 900;
+            return { _tag: "Success", snapshot };
+          },
+        }),
+        onTimeout: timeoutError,
+      }),
+    ).rejects.toThrow("timed out:tab-public");
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationSnapshot.ts
+++ b/apps/web/src/components/preview/previewAutomationSnapshot.ts
@@ -1,0 +1,83 @@
+import type {
+  DesktopPreviewAutomationSnapshotInput,
+  DesktopPreviewAutomationSnapshotResult,
+  PreviewAutomationSnapshot,
+} from "@t3tools/contracts";
+
+const PREVIEW_DESKTOP_RESPONSE_MARGIN_MS = 250;
+
+export const responseBudgetMs = (timeoutMs: number, maximumMarginMs: number): number =>
+  Math.max(0, timeoutMs - Math.max(1, Math.min(maximumMarginMs, Math.ceil(timeoutMs / 10))));
+
+export const remainingBudgetMs = (deadline: number, now = performance.now()): number =>
+  Math.max(0, Math.floor(deadline - now));
+
+export const waitForLocalResponse = <A>(
+  run: () => Promise<A>,
+  timeoutMs: number,
+  onTimeout: () => Error,
+): Promise<A> => {
+  if (timeoutMs <= 0) return Promise.reject(onTimeout());
+  return new Promise<A>((resolve, reject) => {
+    const timer = globalThis.setTimeout(() => reject(onTimeout()), timeoutMs);
+    void run().then(
+      (value) => {
+        globalThis.clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        globalThis.clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+};
+
+interface ReadySnapshotTarget {
+  readonly tabId: string;
+  readonly runtimeTabId: string;
+  readonly snapshot: (
+    input: DesktopPreviewAutomationSnapshotInput,
+  ) => Promise<DesktopPreviewAutomationSnapshotResult>;
+}
+
+export const requestPreviewAutomationSnapshot = async (options: {
+  readonly connectionId: string;
+  readonly requestId: string;
+  readonly hostDeadline: number;
+  readonly requireReady: (timeoutMs: number) => Promise<ReadySnapshotTarget>;
+  readonly onTimeout: (tabId: string | null) => Error;
+  readonly now?: () => number;
+}): Promise<PreviewAutomationSnapshot> => {
+  const now = options.now ?? (() => performance.now());
+  const readinessBudgetMs = remainingBudgetMs(options.hostDeadline, now());
+  if (readinessBudgetMs <= 0) throw options.onTimeout(null);
+
+  const ready = await waitForLocalResponse(
+    () => options.requireReady(readinessBudgetMs),
+    readinessBudgetMs,
+    () => options.onTimeout(null),
+  );
+  const hostRemainingMs = remainingBudgetMs(options.hostDeadline, now());
+  if (hostRemainingMs <= 0) throw options.onTimeout(ready.tabId);
+
+  const desktopTimeoutMs = responseBudgetMs(hostRemainingMs, PREVIEW_DESKTOP_RESPONSE_MARGIN_MS);
+  if (desktopTimeoutMs <= 0) throw options.onTimeout(ready.tabId);
+
+  const result = await waitForLocalResponse(
+    () =>
+      ready.snapshot({
+        tabId: ready.runtimeTabId,
+        connectionId: options.connectionId,
+        requestId: options.requestId,
+        timeoutMs: desktopTimeoutMs,
+      }),
+    hostRemainingMs,
+    () => options.onTimeout(ready.tabId),
+  );
+  if (remainingBudgetMs(options.hostDeadline, now()) <= 0) {
+    throw options.onTimeout(ready.tabId);
+  }
+  if (result._tag === "Timeout") throw options.onTimeout(ready.tabId);
+  return result.snapshot;
+};

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -1,7 +1,10 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { DesktopEnvironmentBootstrapSchema } from "./ipc.ts";
+import {
+  DesktopEnvironmentBootstrapSchema,
+  DesktopPreviewAutomationSnapshotInputSchema,
+} from "./ipc.ts";
 
 describe("DesktopEnvironmentBootstrapSchema", () => {
   const decode = Schema.decodeUnknownSync(DesktopEnvironmentBootstrapSchema);
@@ -34,5 +37,38 @@ describe("DesktopEnvironmentBootstrapSchema", () => {
         wsBaseUrl: null,
       }).runningDistro,
     ).toBeNull();
+  });
+});
+
+describe("DesktopPreviewAutomationSnapshotInputSchema", () => {
+  const decode = Schema.decodeUnknownSync(DesktopPreviewAutomationSnapshotInputSchema);
+
+  it("requires a positive timeout", () => {
+    expect(() =>
+      decode({
+        tabId: "runtime-tab",
+        connectionId: "connection-1",
+        requestId: "request-1",
+      }),
+    ).toThrow();
+    expect(() =>
+      decode({
+        tabId: "runtime-tab",
+        connectionId: "connection-1",
+        requestId: "request-1",
+        timeoutMs: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("preserves long runtime and request ids at the connection id limit", () => {
+    const input = {
+      tabId: `runtime-${"t".repeat(512)}`,
+      connectionId: "c".repeat(64),
+      requestId: `request-${"r".repeat(512)}`,
+      timeoutMs: 14_750,
+    };
+
+    expect(decode(input)).toEqual(input);
   });
 });

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -64,6 +64,7 @@ import type {
 } from "./preview.ts";
 import {
   PreviewAutomationClickInput,
+  PreviewAutomationConnectionId,
   PreviewAutomationEvaluateInput,
   PreviewAutomationHost,
   PreviewAutomationHostFocus,
@@ -1042,6 +1043,41 @@ export const DesktopPreviewAutomationClickInputSchema = Schema.Struct({
   input: PreviewAutomationClickInput,
 });
 
+/**
+ * Context kept by the local desktop while it executes one remote snapshot.
+ * `timeoutMs` is a remaining duration measured by the renderer, never an
+ * absolute timestamp from the server.
+ */
+export const DesktopPreviewAutomationRequestContextSchema = Schema.Struct({
+  connectionId: PreviewAutomationConnectionId,
+  requestId: Schema.String.check(Schema.isTrimmed()).check(Schema.isNonEmpty()),
+  timeoutMs: Schema.Int.check(Schema.isGreaterThan(0)),
+});
+
+export type DesktopPreviewAutomationRequestContext =
+  typeof DesktopPreviewAutomationRequestContextSchema.Type;
+
+export const DesktopPreviewAutomationSnapshotInputSchema = Schema.Struct({
+  tabId: DesktopPreviewTabIdSchema,
+  ...DesktopPreviewAutomationRequestContextSchema.fields,
+});
+
+export type DesktopPreviewAutomationSnapshotInput =
+  typeof DesktopPreviewAutomationSnapshotInputSchema.Type;
+
+export const DesktopPreviewAutomationSnapshotResultSchema = Schema.Union([
+  Schema.TaggedStruct("Success", {
+    snapshot: PreviewAutomationSnapshot,
+  }),
+  Schema.TaggedStruct("Timeout", {
+    stage: Schema.Literals(["queue", "initialization", "execution", "cleanup"]),
+    timeoutMs: Schema.Int.check(Schema.isGreaterThan(0)),
+  }),
+]);
+
+export type DesktopPreviewAutomationSnapshotResult =
+  typeof DesktopPreviewAutomationSnapshotResultSchema.Type;
+
 export const DesktopPreviewAutomationTypeInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   input: PreviewAutomationTypeInput,
@@ -1224,7 +1260,9 @@ export interface DesktopPreviewBridge {
   };
   automation: {
     status: (tabId: string) => Promise<DesktopPreviewAutomationStatus>;
-    snapshot: (tabId: string) => Promise<PreviewAutomationSnapshot>;
+    snapshot: (
+      input: DesktopPreviewAutomationSnapshotInput,
+    ) => Promise<DesktopPreviewAutomationSnapshotResult>;
     click: (tabId: string, input: PreviewAutomationClickInput) => Promise<void>;
     type: (tabId: string, input: PreviewAutomationTypeInput) => Promise<void>;
     press: (tabId: string, input: PreviewAutomationPressInput) => Promise<void>;


### PR DESCRIPTION
A failed or timed-out `preview_snapshot` could leave the tab's debugger or capture queue occupied. Later snapshot and evaluate calls then timed out until the user opened a fresh tab.

This change gives snapshot one monotonic end-to-end deadline across web and desktop work. Desktop capture, accessibility cleanup, and debugger recovery now use bounded stages and exact guest identity. Structured timeout results preserve enough response time for the host to return a recoverable error instead of poisoning later automation.

Focused tests cover active and queued timeouts, accessibility cleanup, capture contention, same-ID guest replacement, and follow-up snapshot recovery.

Fixes #3713

Made with GPT-5.6 Sol using Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core preview automation concurrency, debugger lifecycle, and capture gating; the snapshot IPC contract is breaking and regressions could block agent browser control on desktop.
> 
> **Overview**
> Timed-out or stalled **preview automation snapshots** could leave a tab’s debugger session and native `capturePage` queue stuck, so later snapshots and evaluates kept failing until the user opened a new tab.
> 
> **Desktop `PreviewManager`** now runs snapshot work under a single monotonic deadline with explicit stages (queue, initialization, execution, cleanup). Control actions are serialized per WebContents with attachment identity, bounded Accessibility usage, and retirement when guests are replaced or deadlines fire. **`capturePage`** is gated per WebContents so overlapping captures (recording, PiP, snapshot, screenshots) don’t corrupt each other.
> 
> **`automation.snapshot`** is a breaking IPC/preload change: callers pass `DesktopPreviewAutomationSnapshotInput` (`tabId`, `connectionId`, `requestId`, `timeoutMs`) and receive a tagged **`Success` | `Timeout`** result instead of a raw snapshot or thrown deadline error.
> 
> The **web automation host** tracks a local response budget, forwards request identity to desktop, maps desktop timeouts to `PreviewAutomationSnapshotTimeoutError`, and passes stream **`connectionId`** into the request handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf180ce6ec4a40a8628428956a081c58fba3461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop preview automation recovery after snapshot timeouts
> - Reworks `Manager.ts` control sessions to track debugger attachments by symbol and `Electron.WebContents` instance, serializing control and capture operations per guest so stale or replaced guests no longer detach or corrupt the wrong session
> - Introduces staged deadlines (`PreviewAutomationDeadline`) with timeout stages (`queue`, `initialization`, `execution`, `cleanup`) and reserved cleanup time windows; a `PreviewAutomationDeadlineExceededError` now retires the attachment and lets subsequent automation recover
> - Adds a `capturePage` helper that serializes `capturePage` calls per `WebContents`, bounds Accessibility output to 1,000 nodes / `MAX_ACCESSIBILITY_DEPTH`, and disables the Accessibility domain in cleanup on both success and failure
> - Updates the `automation.snapshot` IPC contract to accept `DesktopPreviewAutomationSnapshotInput` (tabId, connectionId, requestId, positive timeoutMs) and return a tagged `Success` / `Timeout` result; the web host enforces a monotonic response budget and emits `PreviewAutomationSnapshotTimeoutError` when readiness or execution exceeds the deadline
> - Behavioral Change: `DesktopPreviewBridge.automation.snapshot` signature changes from `(tabId: string) => PreviewAutomationSnapshot` to `(input: DesktopPreviewAutomationSnapshotInput) => DesktopPreviewAutomationSnapshotResult`; all callers (preload bridge, web host, tests) are updated in-tree. Out-of-tree callers using the old `tabId`-only shape will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bf180c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->