### PR TITLE
feat(server): resolve project icons from .t3/icon.png

### DIFF
--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -62,6 +62,20 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("prefers a .t3 icon over other well-known files", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, ".t3/icon.png", "image");
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain(".t3/icon.png");
+      }),
+    );
+
     it.effect("prefers a t3.json iconPath over well-known files", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -18,8 +18,12 @@ import * as Schema from "effect/Schema";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import * as T3ProjectFileLoader from "./T3ProjectFileLoader.ts";
 
-// Well-known favicon paths checked in order.
+// Well-known favicon paths checked in order. The `.t3` entries come first: a
+// project that has no icon of its own can be given one without touching a path
+// the repository tracks, since `.t3` is already local-state territory.
 const FAVICON_CANDIDATES = [
+  ".t3/icon.png",
+  ".t3/icon.svg",
   "favicon.svg",
   "favicon.ico",
   "favicon.png",


### PR DESCRIPTION
Projects that aren't a repo with a favicon have nowhere to put an icon that doesn't end up in the repository: every well-known candidate T3 Code checks is a tracked path, and the UI-saved override is an absolute path that has to be re-picked on every machine.

`ProjectFaviconResolver` now checks `.t3/icon.png` and `.t3/icon.svg` first, ahead of the other well-known files. `.t3` is already local-state territory and already gitignored in every project that uses it, so an icon dropped there is discovered automatically and never shows up in `git status`. An explicit `t3.json` `iconPath` and a saved override still win, so nothing that works today changes.

How I use it: I keep a dozen projects in the sidebar, several of them different worktrees or subdirectories of the same monorepo, which all resolve to the same repo favicon and are impossible to tell apart at a glance. Dropping a distinct `icon.png` into each one's `.t3/` gives every row its own icon without asking anyone to review a PR that adds a picture to a shared repo, and without a per-machine override I have to redo on my laptop and my remote box.

Model: Claude Opus 5 (1M context), harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to favicon candidate ordering with test coverage; no auth, data, or API surface changes.
> 
> **Overview**
> **Project favicon discovery** now checks **`.t3/icon.png`** and **`.t3/icon.svg`** before other well-known paths (`favicon.svg`, `public/favicon.*`, etc.) in `ProjectFaviconResolver`.
> 
> That lets per-project icons live under gitignored `.t3/` local state instead of tracked repo paths, while **saved overrides** and **`t3.json` `iconPath`** still take precedence when present.
> 
> A new test asserts that when both `.t3/icon.png` and `favicon.svg` exist, the `.t3` file wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c38a1220dd5047f7f5e654640dadff66cc64d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer `.t3/icon.png` and `.t3/icon.svg` in `ProjectFaviconResolver`
> - Prepends `.t3/icon.png` and `.t3/icon.svg` to the `FAVICON_CANDIDATES` array in [ProjectFaviconResolver.ts](https://github.com/pingdotgg/t3code/pull/8487/files#diff-326ea26189bf71bd26429a43747f009862cf90147e00f0f77fcfde9540fd74cc)
> - Adds a test confirming `.t3/icon.png` takes priority over `favicon.svg` when both exist
> - Behavioral Change: `resolvePath` now uses `.t3/icon.*` files if present, overriding all previously well-known favicon paths
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c38a12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->