### PR TITLE
feat(providers): resolve Claude skills per project cwd

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -66,6 +66,8 @@ import {
 } from "@t3tools/shared/searchRanking";
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
+import { useEnvironmentQuery } from "../../state/query";
+import { serverEnvironment } from "../../state/server";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
 import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
 import {
@@ -355,6 +357,25 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       ) ?? null
     );
   }, [props.serverConfig, props.selectedThread.modelSelection.instanceId]);
+  // Project-scope skills depend on the thread's cwd, so they ride a per-cwd
+  // request rather than the global provider snapshot. Falls back to the
+  // snapshot while the request is in flight (or when the
+  // server predates the RPC), so the picker never regresses.
+  const providerSkillsQuery = useEnvironmentQuery(
+    props.projectCwd !== null
+      ? serverEnvironment.providerSkills({
+          environmentId: props.environmentId,
+          input: {
+            instanceId: props.selectedThread.modelSelection.instanceId,
+            cwd: props.projectCwd,
+          },
+        })
+      : null,
+  );
+  const providerSkills = useMemo(
+    () => providerSkillsQuery.data?.skills ?? selectedProviderStatus?.skills ?? [],
+    [providerSkillsQuery.data, selectedProviderStatus],
+  );
 
   // ── Trigger detection ────────────────────────────────────
   const [composerSelection, setComposerSelection] = useState(() => ({
@@ -445,7 +466,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
 
     if (composerTrigger.kind === "skill") {
-      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((s) => s.enabled);
+      const enabledSkills = providerSkills.filter((s) => s.enabled);
       const normalizedQuery = normalizeSearchQuery(composerTrigger.query, {
         trimLeadingPattern: /^\$+/,
       });
@@ -542,7 +563,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
 
     return [];
-  }, [composerTrigger, pathSearch.entries, selectedProviderStatus]);
+  }, [composerTrigger, pathSearch.entries, providerSkills, selectedProviderStatus]);
 
   // ── Handle command selection ──────────────────────────────
   const { onChangeDraftMessage, onUpdateInteractionMode, draftMessage, onSendMessage } = props;
@@ -797,7 +818,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               ref={inputRef}
               multiline
               value={props.draftMessage}
-              skills={selectedProviderStatus?.skills ?? []}
+              skills={providerSkills}
               selection={composerSelection}
               onChangeText={props.onChangeDraftMessage}
               onSelectionChange={handleSelectionChange}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -59,6 +59,8 @@ import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { CHAT_CONTENT_MAX_WIDTH, type LayoutVariant } from "../../lib/layout";
 import { IOS_NAV_BAR_HEIGHT } from "../../lib/layoutMetrics";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { useEnvironmentQuery } from "../../state/query";
+import { serverEnvironment } from "../../state/server";
 import type {
   PendingApproval,
   PendingUserInput,
@@ -447,11 +449,25 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
+  // Project-scope skills depend on the thread's cwd, so they ride a per-cwd
+  // request rather than the global provider snapshot. Falls back to the
+  // snapshot while the request is in flight (or when the
+  // server predates the RPC).
+  const providerSkillsQuery = useEnvironmentQuery(
+    props.threadCwd !== null
+      ? serverEnvironment.providerSkills({
+          environmentId: props.environmentId,
+          input: { instanceId: selectedInstanceId, cwd: props.threadCwd },
+        })
+      : null,
+  );
   const selectedProviderSkills = useMemo(
     () =>
+      providerSkillsQuery.data?.skills ??
       props.serverConfig?.providers.find((provider) => provider.instanceId === selectedInstanceId)
-        ?.skills ?? [],
-    [props.serverConfig, selectedInstanceId],
+        ?.skills ??
+      [],
+    [providerSkillsQuery.data, props.serverConfig, selectedInstanceId],
   );
 
   useLayoutEffect(() => {

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -38,6 +38,7 @@ import {
 import { scopedProjectKey } from "../../lib/scopedEntities";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { projectEnvironment } from "../../state/projects";
+import { serverEnvironment } from "../../state/server";
 import { useEnvironmentQuery } from "../../state/query";
 import {
   appendComposerDraftAttachments,
@@ -444,12 +445,26 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         option.selection.instanceId === selectedModel.instanceId &&
         option.selection.model === selectedModel.model,
     ) ?? null;
+  // Project-scope skills depend on the project's cwd, so they ride a per-cwd
+  // request rather than the global provider snapshot. Falls back to the
+  // snapshot while the request is in flight (or when the
+  // server predates the RPC).
+  const providerSkillsQuery = useEnvironmentQuery(
+    selectedProject !== null && selectedProject.workspaceRoot !== "" && selectedModel !== null
+      ? serverEnvironment.providerSkills({
+          environmentId: selectedProject.environmentId,
+          input: { instanceId: selectedModel.instanceId, cwd: selectedProject.workspaceRoot },
+        })
+      : null,
+  );
   const selectedProviderSkills = useMemo(
     () =>
+      providerSkillsQuery.data?.skills ??
       selectedEnvironmentServerConfig?.providers.find(
         (provider) => provider.instanceId === selectedModel?.instanceId,
-      )?.skills ?? [],
-    [selectedEnvironmentServerConfig, selectedModel?.instanceId],
+      )?.skills ??
+      [],
+    [providerSkillsQuery.data, selectedEnvironmentServerConfig, selectedModel?.instanceId],
   );
   const setSelectedModelKey = useCallback(
     // Options ride along in the same write: a follow-up setSelectedModelOptions

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
+  [WS_METHODS.serverGetProviderSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -33,6 +33,7 @@ import {
   checkClaudeProviderStatus,
   makePendingClaudeProvider,
   probeClaudeCapabilities,
+  resolveClaudeProviderSkills,
 } from "../Layers/ClaudeProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
@@ -166,6 +167,27 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
+      // Per-cwd skills cache for the `$` picker: project scope depends on the
+      // directory a thread runs in, so discovery is keyed by resolved project
+      // cwd with the same TTL pattern as the capabilities probe. The broadcast
+      // snapshot keeps its server-cwd list for clients that never call the
+      // per-cwd RPC (older web and mobile builds).
+      const skillsCache = yield* Cache.make({
+        capacity: 32,
+        timeToLive: CAPABILITIES_PROBE_TTL,
+        lookup: (resolvedCwd: string) =>
+          resolveClaudeProviderSkills(
+            effectiveConfig,
+            resolvedCwd.length > 0 ? resolvedCwd : undefined,
+            processEnv,
+          ),
+      });
+      const resolveSkills = (cwd?: string | undefined) =>
+        Cache.get(skillsCache, cwd === undefined ? "" : path.resolve(cwd)).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+        );
+
       // Kick the TTL-gated manifest refresh in the background and classify
       // with the in-memory manifest, so a slow or hung fetch never delays the
       // provider check. A refresh that lands mid-probe applies on the next one.
@@ -235,6 +257,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        resolveSkills,
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -5,6 +5,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
 import { discoverClaudeSkills } from "./ClaudeSkills.ts";
+import { resolveClaudeProviderSkills } from "../Layers/ClaudeProvider.ts";
 
 const writeSkill = Effect.fn(function* (
   skillsDir: string,
@@ -299,6 +300,134 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
       );
 
       assert.deepEqual(skills, []);
+    }),
+  );
+
+  it.effect("does not leak project skills from a sibling directory", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const projectA = path.join(tempDir, "project-a");
+      const projectB = path.join(tempDir, "project-b");
+
+      yield* writeSkill(
+        path.join(projectA, ".agents", "skills"),
+        "trino-query",
+        ["---", "name: trino-query", "description: Query trino.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(projectB, ".claude", "skills"),
+        "deploy",
+        ["---", "name: deploy", "---"].join("\n"),
+      );
+
+      const skillsA = yield* discoverClaudeSkills({ homePath: configDir }, projectA);
+      assert.deepEqual(
+        skillsA.map((skill) => skill.name),
+        ["trino-query"],
+      );
+      assert.equal(skillsA[0]?.scope, "project");
+
+      // The same config dir with no cwd serves only user scope — project
+      // roots are skipped entirely when no cwd is supplied.
+      const globalSkills = yield* discoverClaudeSkills({ homePath: configDir }, undefined);
+      assert.deepEqual(globalSkills, []);
+    }),
+  );
+
+  it.effect("resolveClaudeProviderSkills serves per-cwd lists across two projects", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const projectA = path.join(tempDir, "project-a");
+      const projectB = path.join(tempDir, "project-b");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "shared",
+        ["---", "name: shared", "description: User scope everywhere.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(projectA, ".claude", "skills"),
+        "trino-query",
+        ["---", "name: trino-query", "description: Query trino.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(projectB, ".agents", "skills"),
+        "deploy",
+        ["---", "name: deploy", "---"].join("\n"),
+      );
+
+      const settings = { homePath: configDir };
+      // The bundled T3 plugin contributes plugin-scoped skills in this repo;
+      // they are global, so filter them out and assert on user/project split.
+      const skillsA = yield* resolveClaudeProviderSkills(settings, projectA);
+      assert.deepEqual(
+        skillsA
+          .filter((skill) => skill.scope !== "plugin")
+          .map((skill) => `${skill.scope}:${skill.name}`),
+        ["user:shared", "project:trino-query"],
+      );
+
+      const skillsB = yield* resolveClaudeProviderSkills(settings, projectB);
+      assert.deepEqual(
+        skillsB
+          .filter((skill) => skill.scope !== "plugin")
+          .map((skill) => `${skill.scope}:${skill.name}`)
+          .sort(),
+        ["project:deploy", "user:shared"],
+      );
+
+      // No cwd: global scopes only.
+      const globalSkills = yield* resolveClaudeProviderSkills(settings, undefined);
+      assert.deepEqual(
+        globalSkills.filter((skill) => skill.scope !== "plugin").map((skill) => skill.name),
+        ["shared"],
+      );
+    }),
+  );
+
+  it.effect("collision precedence holds across the three roots with a project cwd", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const project = path.join(tempDir, "project");
+
+      // "dupe" exists in all three roots; ".claude" beats ".agents" beats user.
+      for (const [root, description] of [
+        [path.join(configDir, "skills"), "user copy"],
+        [path.join(project, ".agents", "skills"), "agents copy"],
+        [path.join(project, ".claude", "skills"), "claude copy"],
+      ] as const) {
+        yield* writeSkill(
+          root,
+          "dupe",
+          ["---", "name: dupe", `description: ${description}`, "---"].join("\n"),
+        );
+      }
+      // "half" exists in user and ".agents" only; ".agents" wins.
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "half",
+        ["---", "name: half", "description: user copy", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(project, ".agents", "skills"),
+        "half",
+        ["---", "name: half", "description: agents copy", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, project);
+      assert.deepEqual(
+        skills.map((skill) => `${skill.name}:${skill.scope}:${skill.description}`),
+        ["dupe:project:claude copy", "half:project:agents copy"],
+      );
     }),
   );
 });

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -3,6 +3,7 @@ import {
   type ModelCapabilities,
   type ModelSelection,
   type ServerProviderModel,
+  type ServerProviderSkill,
   type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
@@ -920,7 +921,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
-  const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
+  // The broadcast snapshot keeps its existing shape — resolved against the
+  // server's cwd — so clients that only read the snapshot (older web and
+  // mobile builds) see what they have always seen. Clients that know
+  // `server.getProviderSkills` override it with the per-project list.
+  const skills = yield* resolveClaudeProviderSkills(claudeSettings, cwd, resolvedEnvironment);
   const slashCommands = [
     {
       name: "compact",
@@ -972,6 +977,19 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
       ...(versionUpgradeMessage ? { message: versionUpgradeMessage } : {}),
     },
   });
+});
+
+/**
+ * Skills for one project cwd: user scope plus the project roots
+ * under `cwd` (`.agents/skills`, `.claude/skills`). This is the cwd-aware
+ * counterpart to the global-only skill list in the broadcast snapshot.
+ */
+export const resolveClaudeProviderSkills = Effect.fn("resolveClaudeProviderSkills")(function* (
+  claudeSettings: Pick<ClaudeSettings, "homePath">,
+  cwd: string | undefined,
+  environment?: NodeJS.ProcessEnv,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  return yield* discoverClaudeSkills(claudeSettings, cwd, environment ?? process.env);
 });
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1354,6 +1354,142 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
+      it.effect("getProviderSkills resolves per cwd and falls back to the snapshot", () =>
+        Effect.gen(function* () {
+          const codexDriver = ProviderDriverKind.make("codex");
+          const codexInstanceId = ProviderInstanceId.make("codex");
+          const claudeDriver = ProviderDriverKind.make("claudeAgent");
+          const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
+          // A driver without `resolveSkills` keeps whatever its snapshot
+          // carries — including project scope, which stays legitimate for
+          // providers that still resolve skills at probe time.
+          const codexProjectSkill = {
+            name: "repo-skill",
+            path: "/repo/.codex/skills/repo-skill/SKILL.md",
+            enabled: true,
+            scope: "project",
+          } as const;
+          const claudeUserSkill = {
+            name: "user-skill",
+            path: "/Users/dev/.claude/skills/user-skill/SKILL.md",
+            enabled: true,
+            scope: "user",
+          } as const;
+          const claudeProjectSkill = {
+            name: "trino-query",
+            path: "/tmp/project-a/.agents/skills/trino-query/SKILL.md",
+            enabled: true,
+            scope: "project",
+          } as const;
+          const codexProvider = {
+            instanceId: codexInstanceId,
+            driver: codexDriver,
+            status: "ready",
+            enabled: true,
+            installed: true,
+            auth: { status: "authenticated" },
+            checkedAt: "2026-04-29T10:00:00.000Z",
+            version: "1.0.0",
+            models: [],
+            slashCommands: [],
+            skills: [codexProjectSkill],
+          } as const satisfies ServerProvider;
+          const claudeProvider = {
+            instanceId: claudeInstanceId,
+            driver: claudeDriver,
+            status: "ready",
+            enabled: true,
+            installed: true,
+            auth: { status: "authenticated" },
+            checkedAt: "2026-04-29T10:01:00.000Z",
+            version: "1.0.0",
+            models: [],
+            slashCommands: [],
+            skills: [claudeUserSkill],
+          } as const satisfies ServerProvider;
+          const resolvedCwds: Array<string | undefined> = [];
+          const makeInstance = (
+            provider: ServerProvider,
+            resolveSkills?: ProviderInstance["resolveSkills"],
+          ): ProviderInstance => ({
+            instanceId: provider.instanceId,
+            driverKind: provider.driver,
+            continuationIdentity: {
+              driverKind: provider.driver,
+              continuationKey: `${provider.driver}:instance:${provider.instanceId}`,
+            },
+            displayName: undefined,
+            enabled: true,
+            snapshot: {
+              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+                provider: provider.driver,
+                packageName: null,
+              }),
+              getSnapshot: Effect.succeed(provider),
+              refresh: Effect.succeed(provider),
+              streamChanges: Stream.empty,
+            },
+            adapter: {} as ProviderInstance["adapter"],
+            textGeneration: {} as ProviderInstance["textGeneration"],
+            ...(resolveSkills ? { resolveSkills } : {}),
+          });
+          const instances = [
+            makeInstance(codexProvider),
+            makeInstance(claudeProvider, (cwd) => {
+              resolvedCwds.push(cwd);
+              return Effect.succeed(
+                cwd === undefined ? [claudeUserSkill] : [claudeUserSkill, claudeProjectSkill],
+              );
+            }),
+          ];
+          const changes = yield* PubSub.unbounded<void>();
+          const instanceRegistryLayer = Layer.succeed(
+            ProviderInstanceRegistry.ProviderInstanceRegistry,
+            {
+              getInstance: (instanceId) =>
+                Effect.succeed(instances.find((instance) => instance.instanceId === instanceId)),
+              listInstances: Effect.succeed(instances),
+              listUnavailable: Effect.succeed([]),
+              streamChanges: Stream.fromPubSub(changes),
+              subscribeChanges: PubSub.subscribe(changes),
+            },
+          );
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const runtimeServices = yield* Layer.build(
+            ProviderRegistryLive.pipe(
+              Layer.provideMerge(instanceRegistryLayer),
+              Layer.provideMerge(
+                ServerConfig.layerTest(process.cwd(), {
+                  prefix: "t3-provider-registry-skills-",
+                }),
+              ),
+              Layer.provideMerge(BackgroundPolicyAlwaysRunLayer),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ).pipe(Scope.provide(scope));
+
+          yield* Effect.gen(function* () {
+            const registry = yield* ProviderRegistry.ProviderRegistry;
+
+            const perCwd = yield* registry.getProviderSkills(claudeInstanceId, "/tmp/project-a");
+            assert.deepStrictEqual(perCwd, [claudeUserSkill, claudeProjectSkill]);
+            const noCwd = yield* registry.getProviderSkills(claudeInstanceId);
+            assert.deepStrictEqual(noCwd, [claudeUserSkill]);
+            assert.deepStrictEqual(resolvedCwds, ["/tmp/project-a", undefined]);
+
+            const fallback = yield* registry.getProviderSkills(codexInstanceId, "/tmp/project-a");
+            assert.deepStrictEqual(fallback, [codexProjectSkill]);
+
+            const unknown = yield* registry.getProviderSkills(
+              ProviderInstanceId.make("missing"),
+              "/tmp/project-a",
+            );
+            assert.deepStrictEqual(unknown, []);
+          }).pipe(Effect.provide(runtimeServices));
+        }),
+      );
+
       // This test intentionally avoids `mockCommandSpawnerLayer` so the real
       // `probeCodexAppServerProvider` path runs — including the full
       // `codex app-server` RPC handshake via `CodexClient.layerChildProcess`.

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -508,6 +508,24 @@ export const ProviderRegistryLive = Layer.effect(
       );
     });
 
+    const getProviderSkills = Effect.fn("getProviderSkills")(function* (
+      instanceId: ProviderInstanceId,
+      cwd?: string | undefined,
+    ) {
+      const instance = Array.from((yield* Ref.get(liveSubsRef)).values()).find(
+        (candidate) => candidate.instanceId === instanceId,
+      );
+      if (instance?.resolveSkills) {
+        return yield* instance.resolveSkills(cwd);
+      }
+      // No cwd-aware discovery (other drivers, unknown instance): serve the
+      // broadcast snapshot as-is — whatever the driver last probed, exactly
+      // what those providers showed before this RPC existed.
+      const providers = yield* Ref.get(providersRef);
+      const snapshot = providers.find((provider) => provider.instanceId === instanceId);
+      return snapshot?.skills ?? [];
+    });
+
     /**
      * Diff the aggregator's live-source set against the current
      * `ProviderInstanceRegistry` and:
@@ -711,6 +729,7 @@ export const ProviderRegistryLive = Layer.effect(
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
       getProviderMaintenanceCapabilitiesForInstance,
+      getProviderSkills,
       setProviderMaintenanceActionState,
       get streamChanges() {
         return Stream.fromPubSub(changesPubSub);

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,6 +25,7 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
@@ -71,6 +72,17 @@ export interface ProviderInstance {
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  /**
+   * Skills for this instance, resolved against a project cwd. The broadcast
+   * snapshot keeps upstream's server-cwd list so snapshot-only clients
+   * (official mobile builds, older web) are unaffected; project scope depends
+   * on the directory a thread runs in. Drivers that support cwd-aware
+   * discovery supply this closure — it should cache per resolved cwd so
+   * switching projects does not rescan on every picker keystroke.
+   */
+  readonly resolveSkills?: (
+    cwd?: string | undefined,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -10,6 +10,7 @@ import type {
   ProviderInstanceId,
   ProviderDriverKind,
   ServerProvider,
+  ServerProviderSkill,
   ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
@@ -68,6 +69,17 @@ export interface ProviderRegistryShape {
     readonly action: ProviderMaintenanceActionKind;
     readonly state: ServerProviderUpdateState | null;
   }) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+
+  /**
+   * Skills for one instance, resolved against a project cwd when the live
+   * driver supports cwd-aware discovery. Drivers without per-cwd discovery
+   * (and unknown instances) fall back to the broadcast snapshot's skills
+   * unchanged, so their behavior stays exactly what it was before this RPC.
+   */
+  readonly getProviderSkills: (
+    instanceId: ProviderInstanceId,
+    cwd?: string | undefined,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
 
   /**
    * Stream of provider snapshot updates — one emission per aggregated

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -192,6 +192,7 @@ function makeRegistry(
       getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
         Effect.succeed(lifecycleFor(provider)),
       setProviderMaintenanceActionState,
+      getProviderSkills: () => Effect.succeed([]),
       streamChanges: Stream.empty,
     };
 

--- a/apps/server/src/provider/testUtils/providerRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerRegistryMock.ts
@@ -14,6 +14,7 @@ export const makeProviderRegistryMock = (
   getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
     Effect.succeed(makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null })),
   setProviderMaintenanceActionState: () => Effect.succeed(providers),
+  getProviderSkills: () => Effect.succeed([]),
   streamChanges: Stream.empty,
 });
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1603,6 +1603,14 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "provider" },
           ),
+        [WS_METHODS.serverGetProviderSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverGetProviderSkills,
+            providerRegistry
+              .getProviderSkills(input.instanceId, input.cwd)
+              .pipe(Effect.map((skills) => ({ skills }))),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverUpdateProvider]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverUpdateProvider,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -99,6 +99,8 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { useEnvironmentQuery } from "../../state/query";
+import { serverEnvironment } from "../../state/server";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -946,6 +948,26 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => selectedProviderEntry?.snapshot ?? null,
     [selectedProviderEntry],
   );
+  // Project-scope skills depend on the thread's cwd, so they ride a per-cwd
+  // request rather than the global provider snapshot. Falls back to the
+  // snapshot while the request is in flight (or when the server predates the
+  // RPC), so the picker never regresses.
+  const skillsCwd = gitCwd;
+  const providerSkillsQuery = useEnvironmentQuery(
+    skillsCwd !== null
+      ? serverEnvironment.providerSkills({
+          environmentId,
+          input: { instanceId: selectedInstanceId, cwd: skillsCwd },
+        })
+      : null,
+  );
+  const providerSkills = useMemo(() => {
+    const perCwdSkills = providerSkillsQuery.data?.skills;
+    if (perCwdSkills !== undefined) {
+      return perCwdSkills;
+    }
+    return selectedProviderStatus?.skills ?? [];
+  }, [providerSkillsQuery.data, selectedProviderStatus]);
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],
     [selectedProviderEntry],
@@ -1198,24 +1220,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(providerSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
   }, [
     composerTrigger,
     planModeUiEnabled,
+    providerSkills,
     selectedProvider,
     selectedProviderStatus,
     settings.showSkillsInSlashMenu,
@@ -3399,7 +3420,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       ? composerTerminalContexts
                       : []
                   }
-                  skills={selectedProviderStatus?.skills ?? []}
+                  skills={providerSkills}
                   {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                   onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                   onChange={onPromptChange}

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -51,6 +51,8 @@ Claude can show its own resume prompt when you continue an old session.
 T3 Code looks for Claude skills in the Claude config directory's `skills` folder, then
 `<workspace>/.agents/skills`, then `<workspace>/.claude/skills`.
 
+`<workspace>` is the project the active thread runs in, so the `$` skill picker follows the project you are working on and updates when you switch threads.
+
 If the same skill name exists in more than one folder, the later folder wins.
 
 ## I Want Work And Personal Claude Accounts

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -745,6 +745,15 @@ export function createServerEnvironmentAtoms<R, E>(
         key: ({ environmentId }) => environmentId,
       },
     }),
+    // Project-scope skills depend on the thread's cwd, so they are fetched per
+    // (instanceId, cwd) instead of riding the global provider snapshot. The
+    // server caches discovery per cwd; a short client stale time keeps
+    // project switching cheap without rescan storms.
+    providerSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:provider-skills",
+      tag: WS_METHODS.serverGetProviderSkills,
+      staleTimeMs: 60_000,
+    }),
     updateProvider: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:update-provider",
       tag: WS_METHODS.serverUpdateProvider,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -173,6 +173,8 @@ import {
   ServerRemoveKeybindingInput,
   ServerRemoveKeybindingResult,
   ServerProviderUpdatedPayload,
+  ServerProviderSkillsInput,
+  ServerProviderSkillsResult,
   ServerSelfUpdateError,
   ServerSelfUpdateInput,
   ServerSelfUpdateProgressEvent,
@@ -273,6 +275,7 @@ export const WS_METHODS = {
   serverProbe: "server.probe",
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
+  serverGetProviderSkills: "server.getProviderSkills",
   serverUpdateProvider: "server.updateProvider",
   serverUpdateServer: "server.updateServer",
   serverUpdateServerWithProgress: "server.updateServerWithProgress",
@@ -368,6 +371,12 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
     instanceId: Schema.optional(ProviderInstanceId),
   }),
   success: ServerProviderUpdatedPayload,
+  error: EnvironmentAuthorizationError,
+});
+
+export const WsServerGetProviderSkillsRpc = Rpc.make(WS_METHODS.serverGetProviderSkills, {
+  payload: ServerProviderSkillsInput,
+  success: ServerProviderSkillsResult,
   error: EnvironmentAuthorizationError,
 });
 
@@ -1021,6 +1030,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
+  WsServerGetProviderSkillsRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
   WsServerUpdateServerWithProgressRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -603,6 +603,23 @@ export const ServerProviderUpdateInput = Schema.Struct({
 });
 export type ServerProviderUpdateInput = typeof ServerProviderUpdateInput.Type;
 
+/**
+ * Skills resolved for one provider instance against a project cwd. The
+ * broadcast snapshot resolves project scope against the server's cwd (the
+ * upstream behavior snapshot-only clients rely on); clients that know this
+ * RPC fetch the correct per-cwd list instead.
+ */
+export const ServerProviderSkillsInput = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  cwd: Schema.optionalKey(Schema.String),
+});
+export type ServerProviderSkillsInput = typeof ServerProviderSkillsInput.Type;
+
+export const ServerProviderSkillsResult = Schema.Struct({
+  skills: Schema.Array(ServerProviderSkill),
+});
+export type ServerProviderSkillsResult = typeof ServerProviderSkillsResult.Type;
+
 export class ServerProviderUpdateError extends Schema.TaggedErrorClass<ServerProviderUpdateError>()(
   "ServerProviderUpdateError",
   {


### PR DESCRIPTION
Claude skill discovery uses `ServerConfig.cwd` — the directory the T3 server process was launched from. On desktop that is `$HOME`, so `<cwd>/.agents/skills` and `<cwd>/.claude/skills` resolve to `~/.claude/skills`: every home-dir skill shows up in the `$` picker mislabeled as "project" scope, and real project skills never show up at all. Because the snapshot is per provider instance and shared across projects, a skill exists either everywhere or nowhere. Codex already does this right — it asks the app-server for skills keyed by each thread's cwd.

Project scope is now served per cwd through a new `server.getProviderSkills` RPC, backed by an Effect `Cache` keyed by resolved project cwd with the same 5-minute TTL as the capabilities probe. Drivers advertise an optional `resolveSkills` closure; instances without one serve their broadcast snapshot unchanged, so Codex, Cursor, Grok, and OpenCode behave exactly as they did before this RPC existed. The broadcast snapshot itself keeps its server-cwd shape so clients that only read it — older web and mobile builds — see what they have always seen; web and mobile merge the per-cwd list into the `$` picker and the inline skill display, falling back to the snapshot while the request is in flight or against a server that predates the RPC.

How I use it: I have a project at `~/rivendell` with a `trino-query` skill in `.agents/skills` (and `.claude/skills` symlinked to it). Inside a thread on that project the agent can already load the skill fine, because the adapter spawns Claude Code with the thread's real cwd — but I could never *find* it: the `$` picker listed my `~/.claude/skills` instead, labeled "project", for every project I opened. I run the server from `$HOME` on desktop, which is the common case, so this was the difference between skills being a discoverable feature and being something I had to remember by name. Now the picker matches what the agent can actually load, per project.

Audit note: Codex's own status probe has the same flaw (`checkCodexProviderStatus` probes with `process.cwd()`), and the Cursor/Grok/OpenCode snapshots are not audited. Both are follow-ups, deliberately not bundled here.

Model: Claude Opus 5 (1M context), harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider discovery and a new read RPC with filesystem scans per cwd; behavior is backward-compatible via snapshot fallback but wrong cwd resolution could still show incorrect skills in the picker.
> 
> **Overview**
> Adds **`server.getProviderSkills`** so clients can load provider skills for a specific **`(instanceId, cwd)`** instead of relying only on the global provider snapshot (which was tied to the server process cwd and mislabeled home skills as project scope on desktop).
> 
> The **Claude driver** exposes optional **`resolveSkills`** with a per-cwd Effect cache (5‑minute TTL); **`ProviderRegistry.getProviderSkills`** uses that when present and otherwise returns the existing snapshot skills unchanged for other drivers. **Web and mobile** composers, thread feed, and new-task flow call the new query and **fall back to the snapshot** while loading or on older servers.
> 
> **Contracts, WS handler, read-scope auth**, client **`providerSkills`** query atom (60s stale time), **tests** for cwd isolation and registry fallback, and **user docs** for workspace-scoped skill loading are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dfddfd44d142c29bdf0d9cf17c37bf0a08aa374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve Claude skills per project cwd in chat composer
> - Adds `serverGetProviderSkills` RPC and an optional `resolveSkills(cwd?)` method to the `ProviderInstance` interface to support cwd-aware skill resolution.
> - Implements a cached `resolveSkills` in `ClaudeDriver` and updates `ProviderRegistry` to prefer this method, falling back to the aggregated snapshot if unavailable.
> - Updates mobile and web clients to query these per-cwd skills for the active thread, populating the `$`-picker and editor with project-specific skills.
> - Behavioral Change: `$`-picker and composer skills now reflect the active project's `cwd` instead of the global snapshot; clients fall back to the snapshot when the instance lacks `resolveSkills`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1dfddfd. 16 files reviewed, 3 issues evaluated, 2 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/mobile/src/features/threads/ThreadComposer.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 455](https://github.com/pingdotgg/t3code/blob/1dfddfd44d142c29bdf0d9cf17c37bf0a08aa374/apps/mobile/src/features/threads/ThreadComposer.tsx#L455): The slash-command menu continues to populate `skillItems` from `selectedProviderStatus?.skills`, i.e. the server-cwd snapshot, rather than the newly resolved `providerSkills`. Typing `/` in a thread whose project/worktree differs from the server cwd can therefore offer stale home/main-checkout skills and omit skills available in the active directory; selecting one inserts a `$skill` token the thread's agent cannot load. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/chat/ChatComposer.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1223](https://github.com/pingdotgg/t3code/blob/1dfddfd44d142c29bdf0d9cf17c37bf0a08aa374/apps/web/src/components/chat/ChatComposer.tsx#L1223): The new per-CWD `providerSkills` list is used only for the `$` trigger at this branch, while the `/` branch immediately above still builds `slashMenuSkills` from `selectedProviderStatus.skills`. Consequently, when `showSkillsInSlashMenu` is enabled, project-local skills are missing from the slash menu and skills discovered from the server's launch directory are still offered there, even though the same composer now resolves `$` and inline skill parsing against the project CWD. <b>[ Already posted ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->