### PR TITLE
feat(web): group stacked PRs into a rail in the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.stacks.test.ts
+++ b/apps/web/src/components/Sidebar.stacks.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  planActiveThreadsWithStacks,
+  sidebarStackProjectKey,
+  stackOpenPrListProjectRefs,
+  type SidebarStackPullRequest,
+} from "./Sidebar.stacks";
+
+interface TestThread {
+  environmentId: string;
+  projectId: string;
+  id: string;
+}
+
+const thread = (id: string, projectId = "p1"): TestThread => ({
+  environmentId: "env1",
+  projectId,
+  id,
+});
+const keyOf = (t: TestThread) => `${t.environmentId}:${t.id}`;
+
+const pr = (
+  number: number,
+  headRef: string,
+  baseRef: string,
+  overrides?: Partial<SidebarStackPullRequest>,
+): SidebarStackPullRequest => ({
+  number,
+  title: `PR ${number}`,
+  url: `https://example.com/pull/${number}`,
+  headRef,
+  baseRef,
+  ...overrides,
+});
+
+const projectKey = sidebarStackProjectKey({ environmentId: "env1", projectId: "p1" });
+
+// The motivating fixture: a GitButler workspace with the stack
+// #25448 → #25390 (no thread) → #25356 → #25312, plus unrelated threads.
+const top = pr(25448, "feat/configs", "feat/tour-codes");
+const ghost = pr(25390, "feat/tour-codes", "feat/units");
+const mid = pr(25356, "feat/units", "feat/base");
+const base = pr(25312, "feat/base", "main");
+const unrelated = pr(25366, "feat/passthrough", "main");
+
+const tTop = thread("t-25448");
+const tWork = thread("t-work");
+const tUnrelated = thread("t-25366");
+const tMid = thread("t-25356");
+const tBase = thread("t-25312");
+const activeThreads = [tTop, tWork, tUnrelated, tMid, tBase];
+
+const displayed = new Map([
+  [keyOf(tTop), top],
+  [keyOf(tUnrelated), unrelated],
+  [keyOf(tMid), mid],
+  [keyOf(tBase), base],
+]);
+
+describe("stackOpenPrListProjectRefs", () => {
+  it("selects only projects with at least two open-PR threads", () => {
+    const refs = stackOpenPrListProjectRefs({
+      activeThreads,
+      threadKeyOf: keyOf,
+      displayedOpenPrByThreadKey: displayed,
+    });
+    expect(refs).toEqual([{ environmentId: "env1", projectId: "p1" }]);
+
+    const single = stackOpenPrListProjectRefs({
+      activeThreads: [tTop, tWork],
+      threadKeyOf: keyOf,
+      displayedOpenPrByThreadKey: new Map([[keyOf(tTop), top]]),
+    });
+    expect(single).toEqual([]);
+  });
+});
+
+describe("planActiveThreadsWithStacks", () => {
+  const plan = (options?: {
+    openPrs?: readonly SidebarStackPullRequest[];
+    backed?: ReadonlySet<number>;
+    threads?: readonly TestThread[];
+    displayedPrs?: ReadonlyMap<string, SidebarStackPullRequest>;
+  }) =>
+    planActiveThreadsWithStacks({
+      activeThreads: options?.threads ?? activeThreads,
+      threadKeyOf: keyOf,
+      displayedOpenPrByThreadKey: options?.displayedPrs ?? displayed,
+      openPrsByProjectKey: new Map([[projectKey, options?.openPrs ?? []]]),
+      threadBackedPrNumbersByProjectKey: new Map(
+        options?.backed ? [[projectKey, options.backed]] : [],
+      ),
+    });
+
+  it("groups directly chained threads into one stack, top of stack first", () => {
+    // No open-PR list fetched: #25448's base (#25390) is unknown, so it stays
+    // a plain row and only the directly linked 25356→25312 pair groups,
+    // anchored at its most recent member.
+    const items = plan();
+    expect(items.map((item) => item.kind)).toEqual(["thread", "thread", "thread", "stack"]);
+    const stack = items[3];
+    if (stack?.kind !== "stack") throw new Error("expected stack");
+    expect(stack.group.anchor).toBe(tMid);
+    expect(stack.group.entries.map((entry) => entry.pr.number)).toEqual([25356, 25312]);
+  });
+
+  it("inserts ghosts from the open-PR list at their true position", () => {
+    const items = plan({ openPrs: [ghost, unrelated] });
+    const stack = items.find((item) => item.kind === "stack");
+    if (stack?.kind !== "stack") throw new Error("expected stack");
+    expect(stack.group.entries.map((entry) => entry.pr.number)).toEqual([
+      25448, 25390, 25356, 25312,
+    ]);
+    expect(stack.group.entries.map((entry) => entry.thread?.id ?? null)).toEqual([
+      "t-25448",
+      null,
+      "t-25356",
+      "t-25312",
+    ]);
+    // The unrelated open PR joins no chain and creates no ghost-only group.
+    expect(items.filter((item) => item.kind === "stack")).toHaveLength(1);
+  });
+
+  it("keeps non-member threads in their original order", () => {
+    const items = plan({ openPrs: [ghost] });
+    const threadIds = items.flatMap((item) => (item.kind === "thread" ? [item.thread.id] : []));
+    expect(threadIds).toEqual(["t-work", "t-25366"]);
+  });
+
+  it("omits PRs backed by threads outside the active section instead of ghosting them", () => {
+    const items = plan({ openPrs: [ghost], backed: new Set([25390]) });
+    const stack = items.find((item) => item.kind === "stack");
+    if (stack?.kind !== "stack") throw new Error("expected stack");
+    expect(stack.group.entries.map((entry) => entry.pr.number)).toEqual([25448, 25356, 25312]);
+  });
+
+  it("yields two groups for two independent chains", () => {
+    const otherTop = pr(30, "feat/x2", "feat/x1");
+    const otherBase = pr(29, "feat/x1", "main");
+    const tOtherTop = thread("t-30");
+    const tOtherBase = thread("t-29");
+    const items = plan({
+      threads: [...activeThreads, tOtherTop, tOtherBase],
+      displayedPrs: new Map([
+        ...displayed,
+        [keyOf(tOtherTop), otherTop],
+        [keyOf(tOtherBase), otherBase],
+      ]),
+    });
+    expect(items.filter((item) => item.kind === "stack")).toHaveLength(2);
+  });
+
+  it("requires at least two thread-backed PRs per group", () => {
+    const items = plan({
+      threads: [tTop, tWork],
+      displayedPrs: new Map([[keyOf(tTop), top]]),
+      openPrs: [ghost, mid, base],
+    });
+    expect(items.every((item) => item.kind === "thread")).toBe(true);
+  });
+
+  it("survives ref cycles without hanging or throwing", () => {
+    const cycleA = pr(1, "a", "b");
+    const cycleB = pr(2, "b", "a");
+    const tA = thread("t-1");
+    const tB = thread("t-2");
+    const items = plan({
+      threads: [tA, tB],
+      displayedPrs: new Map([
+        [keyOf(tA), cycleA],
+        [keyOf(tB), cycleB],
+      ]),
+    });
+    const stack = items.find((item) => item.kind === "stack");
+    if (stack?.kind !== "stack") throw new Error("expected stack");
+    expect(stack.group.entries).toHaveLength(2);
+  });
+
+  it("does not draw siblings of one base as a chain", () => {
+    // Two PRs based on feat/base: neither sits on the other, so the rail would
+    // be claiming an order the repository does not have.
+    const forkA = pr(41, "feat/a", "feat/base");
+    const forkB = pr(42, "feat/b", "feat/base");
+    const tForkA = thread("t-41");
+    const tForkB = thread("t-42");
+    const items = plan({
+      threads: [tForkA, tForkB, tBase],
+      displayedPrs: new Map([
+        [keyOf(tForkA), forkA],
+        [keyOf(tForkB), forkB],
+        [keyOf(tBase), base],
+      ]),
+    });
+    expect(items.every((item) => item.kind === "thread")).toBe(true);
+  });
+
+  it("still chains the linear part of a repository that forks elsewhere", () => {
+    // #25448 → #25390 → #25356 is linear; two PRs fork off #25312's branch, so
+    // the chain stops at #25356 rather than swallowing the fork.
+    const forkA = pr(41, "feat/a", "feat/base");
+    const forkB = pr(42, "feat/b", "feat/base");
+    const tForkA = thread("t-41");
+    const items = plan({
+      threads: [tTop, tMid, tForkA],
+      displayedPrs: new Map([
+        [keyOf(tTop), top],
+        [keyOf(tMid), mid],
+        [keyOf(tForkA), forkA],
+      ]),
+      openPrs: [ghost, base, forkB],
+    });
+    const stack = items.find((item) => item.kind === "stack");
+    if (stack?.kind !== "stack") throw new Error("expected stack");
+    expect(stack.group.entries.map((entry) => entry.pr.number)).toEqual([25448, 25390, 25356]);
+  });
+
+  it("does not group threads across projects", () => {
+    const tOther = thread("t-other", "p2");
+    const items = planActiveThreadsWithStacks({
+      activeThreads: [tTop, tOther],
+      threadKeyOf: keyOf,
+      displayedOpenPrByThreadKey: new Map([
+        [keyOf(tTop), top],
+        [keyOf(tOther), pr(99, "feat/tour-codes", "main")],
+      ]),
+      openPrsByProjectKey: new Map(),
+      threadBackedPrNumbersByProjectKey: new Map(),
+    });
+    expect(items.every((item) => item.kind === "thread")).toBe(true);
+  });
+});

--- a/apps/web/src/components/Sidebar.stacks.ts
+++ b/apps/web/src/components/Sidebar.stacks.ts
@@ -1,0 +1,254 @@
+import type { ThreadLinkedPullRequest } from "@t3tools/contracts";
+
+/**
+ * Pure derivation of pull-request stacks for the sidebar's active section.
+ *
+ * A stack is a chain of open PRs in one project where each PR's base ref is
+ * another's head ref (the GitButler / stacked-PR workflow). Threads whose
+ * displayed PRs chain render as one group; chain positions whose PR has no
+ * thread anywhere render as slim ghost entries inside the group. Everything
+ * here works on data the sidebar already holds — no requests, no effects.
+ */
+
+export interface SidebarStackPullRequest {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly headRef: string;
+  readonly baseRef: string;
+  /** Prebuilt link payload for "open a thread on this PR". Present on
+      open-list entries (ghost candidates); thread-backed PRs don't need it. */
+  readonly link?: ThreadLinkedPullRequest;
+}
+
+interface StackThreadShape {
+  readonly environmentId: string;
+  readonly projectId: string;
+  readonly id: string;
+}
+
+export interface SidebarStackEntry<T extends StackThreadShape> {
+  readonly pr: SidebarStackPullRequest;
+  /** null = ghost: the PR exists on the host but no visible thread drives it. */
+  readonly thread: T | null;
+}
+
+export interface SidebarStackGroupModel<T extends StackThreadShape> {
+  readonly key: string;
+  /** The group's most recent member thread; carries the scoped project ref
+      for actions (ghost click) without the module knowing branded types. */
+  readonly anchor: T;
+  /** Top of stack first, base last. */
+  readonly entries: readonly SidebarStackEntry<T>[];
+}
+
+export type SidebarActiveListItem<T extends StackThreadShape> =
+  | { readonly kind: "thread"; readonly thread: T }
+  | { readonly kind: "stack"; readonly group: SidebarStackGroupModel<T> };
+
+/** Unambiguous: a raw `env:project` join collides for ids that contain the
+    separator, which would let one project's threads suppress another's ghosts. */
+export function sidebarStackProjectKey(ref: {
+  readonly environmentId: string;
+  readonly projectId: string;
+}): string {
+  return JSON.stringify([ref.environmentId, ref.projectId]);
+}
+
+/** Projects whose active threads display ≥2 open PRs — the only ones worth an
+    open-PR list read for ghost discovery. Sorted for a stable query key. */
+export function stackOpenPrListProjectRefs<T extends StackThreadShape>(input: {
+  readonly activeThreads: readonly T[];
+  readonly threadKeyOf: (thread: T) => string;
+  readonly displayedOpenPrByThreadKey: ReadonlyMap<string, SidebarStackPullRequest>;
+}): Array<{ environmentId: T["environmentId"]; projectId: T["projectId"] }> {
+  const counts = new Map<string, { thread: T; count: number }>();
+  for (const thread of input.activeThreads) {
+    if (!input.displayedOpenPrByThreadKey.has(input.threadKeyOf(thread))) continue;
+    const projectKey = sidebarStackProjectKey(thread);
+    const existing = counts.get(projectKey);
+    if (existing) existing.count += 1;
+    else counts.set(projectKey, { thread, count: 1 });
+  }
+  return [...counts.entries()]
+    .filter(([, value]) => value.count >= 2)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, value]) => ({
+      environmentId: value.thread.environmentId,
+      projectId: value.thread.projectId,
+    }));
+}
+
+interface StackMember<T extends StackThreadShape> {
+  readonly pr: SidebarStackPullRequest;
+  readonly thread: T | null;
+  readonly threadKey: string | null;
+}
+
+export function planActiveThreadsWithStacks<T extends StackThreadShape>(input: {
+  readonly activeThreads: readonly T[];
+  readonly threadKeyOf: (thread: T) => string;
+  /** Each active thread's displayed pull request, open state only. */
+  readonly displayedOpenPrByThreadKey: ReadonlyMap<string, SidebarStackPullRequest>;
+  /** Open PRs per project key (ghost candidates), from the open-PR list. */
+  readonly openPrsByProjectKey: ReadonlyMap<string, readonly SidebarStackPullRequest[]>;
+  /** PR numbers displayed by ANY visible thread (pinned/snoozed/settled
+      included), per project key. Suppresses ghosts for PRs that already have
+      a thread outside the active section. */
+  readonly threadBackedPrNumbersByProjectKey: ReadonlyMap<string, ReadonlySet<number>>;
+}): Array<SidebarActiveListItem<T>> {
+  const nodesByProject = new Map<string, Array<{ thread: T; threadKey: string }>>();
+  for (const thread of input.activeThreads) {
+    const threadKey = input.threadKeyOf(thread);
+    if (!input.displayedOpenPrByThreadKey.has(threadKey)) continue;
+    const projectKey = sidebarStackProjectKey(thread);
+    const nodes = nodesByProject.get(projectKey);
+    if (nodes) nodes.push({ thread, threadKey });
+    else nodesByProject.set(projectKey, [{ thread, threadKey }]);
+  }
+
+  const groupByAnchorThreadKey = new Map<string, SidebarStackGroupModel<T>>();
+  const groupedThreadKeys = new Set<string>();
+
+  for (const [projectKey, nodes] of nodesByProject) {
+    if (nodes.length < 2) continue;
+    // Membership: active threads' PRs win over list entries with the same
+    // number, so a slightly stale list can never demote a thread to a ghost.
+    const members = new Map<number, StackMember<T>>();
+    for (const node of nodes) {
+      const pr = input.displayedOpenPrByThreadKey.get(node.threadKey);
+      if (pr === undefined || members.has(pr.number)) continue;
+      members.set(pr.number, { pr, thread: node.thread, threadKey: node.threadKey });
+    }
+    for (const pr of input.openPrsByProjectKey.get(projectKey) ?? []) {
+      if (members.has(pr.number)) continue;
+      members.set(pr.number, { pr, thread: null, threadKey: null });
+    }
+
+    // A sits on B when A.baseRef === B.headRef. Duplicate head refs keep the
+    // first claimant; a repo in that state has no honest chain to draw.
+    const numberByHeadRef = new Map<string, number>();
+    for (const member of members.values()) {
+      if (!numberByHeadRef.has(member.pr.headRef)) {
+        numberByHeadRef.set(member.pr.headRef, member.pr.number);
+      }
+    }
+    const baseOf = (number: number): number | undefined => {
+      const member = members.get(number);
+      if (member === undefined) return undefined;
+      const below = numberByHeadRef.get(member.pr.baseRef);
+      return below === number ? undefined : below;
+    };
+    // A rail is a line, and two PRs based on the same branch are not one:
+    // they are siblings, and drawing them one above the other would claim an
+    // order the repository does not have. Where a PR carries more than one PR
+    // on top of it, the fork is dropped rather than flattened.
+    const aboveCount = new Map<number, number>();
+    for (const number of members.keys()) {
+      const below = baseOf(number);
+      if (below === undefined) continue;
+      aboveCount.set(below, (aboveCount.get(below) ?? 0) + 1);
+    }
+    const belowOf = (number: number): number | undefined => {
+      const below = baseOf(number);
+      return below !== undefined && aboveCount.get(below) === 1 ? below : undefined;
+    };
+
+    // Connected components via union-find over PR numbers.
+    const parent = new Map<number, number>();
+    const find = (start: number): number => {
+      let n = start;
+      while ((parent.get(n) ?? n) !== n) n = parent.get(n) ?? n;
+      parent.set(start, n);
+      return n;
+    };
+    for (const number of members.keys()) parent.set(number, number);
+    for (const number of members.keys()) {
+      const below = belowOf(number);
+      if (below !== undefined) parent.set(find(number), find(below));
+    }
+    const componentsByRoot = new Map<number, number[]>();
+    for (const number of members.keys()) {
+      const root = find(number);
+      const component = componentsByRoot.get(root);
+      if (component) component.push(number);
+      else componentsByRoot.set(root, [number]);
+    }
+
+    for (const component of componentsByRoot.values()) {
+      const threadMembers = component
+        .map((number) => members.get(number))
+        .filter((member): member is StackMember<T> => member?.thread != null);
+      if (threadMembers.length < 2) continue;
+
+      // Depth from the base (0), walking baseRef links; cycles bottom out at 0.
+      const depthCache = new Map<number, number>();
+      const depthOf = (start: number): number => {
+        const cached = depthCache.get(start);
+        if (cached !== undefined) return cached;
+        const chain: number[] = [];
+        const seen = new Set<number>();
+        let current: number | undefined = start;
+        let base = -1;
+        while (current !== undefined) {
+          const known = depthCache.get(current);
+          if (known !== undefined) {
+            base = known;
+            break;
+          }
+          if (seen.has(current)) break;
+          seen.add(current);
+          chain.push(current);
+          current = belowOf(current);
+        }
+        for (let index = chain.length - 1; index >= 0; index -= 1) {
+          base += 1;
+          depthCache.set(chain[index] as number, base);
+        }
+        return depthCache.get(start) ?? 0;
+      };
+
+      const backedNumbers = input.threadBackedPrNumbersByProjectKey.get(projectKey);
+      const entries = component
+        .map((number) => members.get(number))
+        .filter((member): member is StackMember<T> => member !== undefined)
+        // A PR driven by a pinned/snoozed/settled thread is neither a card
+        // here nor a ghost: it renders in its own section and the rail
+        // simply skips it.
+        .filter((member) => member.thread !== null || backedNumbers?.has(member.pr.number) !== true)
+        .sort((left, right) => {
+          const depthDelta = depthOf(right.pr.number) - depthOf(left.pr.number);
+          return depthDelta !== 0 ? depthDelta : right.pr.number - left.pr.number;
+        })
+        .map((member) => ({ pr: member.pr, thread: member.thread }));
+
+      const componentNumbers = new Set(component);
+      const anchorNode = nodes.find((node) => {
+        const pr = input.displayedOpenPrByThreadKey.get(node.threadKey);
+        return pr !== undefined && componentNumbers.has(pr.number);
+      });
+      if (anchorNode === undefined) continue;
+      for (const member of threadMembers) {
+        if (member.threadKey !== null) groupedThreadKeys.add(member.threadKey);
+      }
+      groupByAnchorThreadKey.set(anchorNode.threadKey, {
+        key: `stack:${projectKey}:${Math.min(...component)}`,
+        anchor: anchorNode.thread,
+        entries,
+      });
+    }
+  }
+
+  const items: Array<SidebarActiveListItem<T>> = [];
+  for (const thread of input.activeThreads) {
+    const threadKey = input.threadKeyOf(thread);
+    const group = groupByAnchorThreadKey.get(threadKey);
+    if (group) {
+      items.push({ kind: "stack", group });
+      continue;
+    }
+    if (groupedThreadKeys.has(threadKey)) continue;
+    items.push({ kind: "thread", thread });
+  }
+  return items;
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import type { ScopedThreadRef, ThreadId, ThreadLinkedPullRequest } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
@@ -44,6 +44,7 @@ import {
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
+  LayersIcon,
   MessageSquareIcon,
   PinIcon,
   PlusIcon,
@@ -152,13 +153,24 @@ import {
   resolveDisplayedThreadPr,
   resolveDisplayedThreadPrProvider,
   setThreadChangeRequestSnapshot,
+  setThreadLinkedPullRequest,
   settledPrHoverColorClass,
   terminalStatusFromRunningIds,
   threadChangeRequestSnapshotsAtom,
+  threadLinkedPullRequestsAtom,
   type ThreadChangeRequestSnapshot,
+  type ThreadPr,
   type TerminalStatusIndicator,
   useLinkedThreadPullRequest,
 } from "./ThreadStatusIndicators";
+import {
+  planActiveThreadsWithStacks,
+  sidebarStackProjectKey,
+  stackOpenPrListProjectRefs,
+  type SidebarStackGroupModel,
+  type SidebarStackPullRequest,
+} from "./Sidebar.stacks";
+import { usePullRequestList } from "../state/pullRequests";
 import {
   resolveSnoozePresets,
   snoozeWakeDescription,
@@ -810,6 +822,14 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     linkedPullRequest: thread.linkedPullRequest,
     linkedPullRequestStatus,
   });
+  // The stack rail lives above the rows, so the resolved link is reported up
+  // rather than resolved a second time there.
+  useEffect(() => {
+    setThreadLinkedPullRequest(
+      threadKey,
+      thread.linkedPullRequest == null ? null : (linkedPullRequestStatus?.pr ?? null),
+    );
+  }, [linkedPullRequestStatus, thread.linkedPullRequest, threadKey]);
 
   // Same semantics as the legacy sidebar (never-visited counts as read):
   // switching sidebars must not light up every historical thread as unread.
@@ -1614,6 +1634,91 @@ function latestTurnDiff(
   return null;
 }
 
+const sidebarThreadKeyOf = (thread: EnvironmentThreadShell): string =>
+  scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+
+// Stack-group row heights, used to place rail ticks. The row <li>s
+// paint-contain themselves ([content-visibility:auto]), so a tick inside a
+// row could never reach out to the rail — the group draws all ticks from the
+// rail container instead, mirroring the fixed row heights.
+// Rem, because the rows are rem-sized and the interface font-size preference
+// rewrites the root font size at runtime — pixel offsets would drift off the
+// rail at 12px and bunch at 20px.
+const STACK_CARD_ROW_REM = 5.125; // h-[4.875rem] content + li py-0.5
+const STACK_CARD_TICK_REM = 2.5; // aligns with the card's title line
+const STACK_GHOST_ROW_REM = 2; // h-8 ghost row
+const STACK_ROW_GAP_PX = 1; // gap-px
+
+/**
+ * One pull-request stack in the active section: header, vertical rail at the
+ * row content inset, member thread cards top-of-stack first, and slim ghost
+ * rows for stack PRs no visible thread drives. Clicking a ghost opens a new
+ * draft thread that links the PR on promotion.
+ */
+function SidebarStackGroupItem(props: {
+  group: SidebarStackGroupModel<EnvironmentThreadShell>;
+  renderThreadRow: (thread: EnvironmentThreadShell) => ReactNode;
+  onGhostClick: (anchor: EnvironmentThreadShell, link: ThreadLinkedPullRequest) => void;
+}) {
+  const { group } = props;
+  const tickTops: string[] = [];
+  let rowTopRem = 0;
+  let rowTopPx = 0;
+  for (const entry of group.entries) {
+    const rowRem = entry.thread ? STACK_CARD_ROW_REM : STACK_GHOST_ROW_REM;
+    const tickRem = entry.thread ? STACK_CARD_TICK_REM : rowRem / 2;
+    tickTops.push(`calc(${rowTopRem + tickRem}rem + ${rowTopPx}px)`);
+    rowTopRem += rowRem;
+    rowTopPx += STACK_ROW_GAP_PX;
+  }
+  return (
+    <li className="list-none py-0.5" data-testid="sidebar-stack-group">
+      <div className="flex items-center gap-1.5 px-[var(--sidebar-row-content-inset)] pt-1 pb-0.5 font-medium text-[11px] text-secondary-label">
+        <LayersIcon aria-hidden className="size-3" />
+        <span>
+          Stack · {group.entries.length} {group.entries.length === 1 ? "PR" : "PRs"}
+        </span>
+      </div>
+      <div className="relative ml-[var(--sidebar-row-content-inset)]">
+        <div aria-hidden className="absolute top-2 bottom-2 left-0 w-px bg-sidebar-border/60" />
+        {group.entries.map((entry, index) => (
+          <div
+            key={`tick-${entry.pr.number}`}
+            aria-hidden
+            className="absolute left-0 h-px w-2 bg-sidebar-border/60"
+            style={{ top: tickTops[index] }}
+          />
+        ))}
+        <ul role="list" className="flex flex-col gap-px pl-2">
+          {group.entries.map((entry) =>
+            entry.thread ? (
+              props.renderThreadRow(entry.thread)
+            ) : (
+              <li key={`ghost-${entry.pr.number}`} className="list-none">
+                <button
+                  type="button"
+                  data-testid="sidebar-stack-ghost"
+                  aria-label={`Open a new thread on pull request #${entry.pr.number}`}
+                  onClick={() => {
+                    if (entry.pr.link) props.onGhostClick(group.anchor, entry.pr.link);
+                  }}
+                  className="flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-[var(--sidebar-row-content-inset)] text-left text-xs text-secondary-label/70 hover:bg-sidebar-row-hover"
+                >
+                  <span className="shrink-0 text-emerald-600/70 tabular-nums dark:text-emerald-300/70">
+                    #{entry.pr.number}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{entry.pr.title}</span>
+                  <span className="shrink-0 text-[10px] text-secondary-label/50">no thread</span>
+                </button>
+              </li>
+            ),
+          )}
+        </ul>
+      </div>
+    </li>
+  );
+}
+
 const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
   thread: SidebarThreadSummary;
   projectCwd: string | null;
@@ -1937,6 +2042,7 @@ export default function Sidebar() {
   const [snoozeWakeTick, bumpSnoozeWakeTick] = useState(0);
 
   const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
+  const linkedPullRequestByKey = useAtomValue(threadLinkedPullRequestsAtom);
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
@@ -2240,9 +2346,146 @@ export default function Sidebar() {
     return routeThread === undefined ? [] : [routeThread];
   }, [routeThreadKey, snoozedShelfExpanded, snoozedThreads]);
 
+  // ——— Pull-request stacks ———
+  // Each visible thread's displayed PR, resolved with the same priority the
+  // settle partition uses: a link outranks the branch snapshot, and an
+  // unresolved link yields nothing rather than falling back to HEAD-match.
+  const displayedPrByThreadKey = useMemo(() => {
+    const map = new Map<string, NonNullable<ThreadPr>>();
+    for (const thread of threads) {
+      const threadKey = sidebarThreadKeyOf(thread);
+      if (thread.linkedPullRequest != null) {
+        const linked = linkedPullRequestByKey.get(threadKey);
+        if (linked !== undefined) map.set(threadKey, linked);
+        continue;
+      }
+      const snapshot = changeRequestSnapshotByKey.get(threadKey);
+      if (snapshot != null && (thread.worktreePath === null || snapshot.branch === thread.branch)) {
+        map.set(threadKey, snapshot.pr);
+      }
+    }
+    return map;
+  }, [changeRequestSnapshotByKey, linkedPullRequestByKey, threads]);
+  const displayedOpenPrByThreadKey = useMemo(() => {
+    const map = new Map<string, SidebarStackPullRequest>();
+    for (const [threadKey, pr] of displayedPrByThreadKey) {
+      if (pr.state !== "open") continue;
+      map.set(threadKey, {
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        headRef: pr.headRef,
+        baseRef: pr.baseRef,
+      });
+    }
+    return map;
+  }, [displayedPrByThreadKey]);
+  // Ghost discovery costs one open-PR list read per project that can
+  // actually hold a stack, byte-identical to LinkPullRequestDialog's input so
+  // the sidebar, the dialog, and the pull requests page share one cache entry.
+  const stackListTargets = useMemo(
+    () =>
+      stackOpenPrListProjectRefs({
+        activeThreads,
+        threadKeyOf: sidebarThreadKeyOf,
+        displayedOpenPrByThreadKey,
+      })
+        // A ghost's only affordance is "open a thread on this PR", which needs
+        // the server to persist the link. Without that capability the row
+        // would promise a linked thread and hand back an ordinary one.
+        .filter(
+          (ref) =>
+            serverConfigs.get(ref.environmentId)?.environment.capabilities
+              .threadPullRequestLinking === true,
+        )
+        .map((ref) => ({
+          environmentId: ref.environmentId,
+          input: { state: "open" as const, projectId: ref.projectId, limit: 30 },
+        })),
+    [activeThreads, displayedOpenPrByThreadKey, serverConfigs],
+  );
+  const stackOpenPrList = usePullRequestList(stackListTargets);
+  const stackOpenPrsByProjectKey = useMemo(() => {
+    const map = new Map<string, SidebarStackPullRequest[]>();
+    for (const entry of stackOpenPrList.data?.entries ?? []) {
+      const projectKey = sidebarStackProjectKey({
+        environmentId: entry.environmentId,
+        projectId: entry.projectId,
+      });
+      const list = map.get(projectKey) ?? [];
+      list.push({
+        number: entry.number,
+        title: entry.title,
+        url: entry.url,
+        headRef: entry.headBranch,
+        baseRef: entry.baseBranch,
+        link: {
+          projectId: entry.projectId,
+          repository: entry.repository,
+          number: entry.number,
+          url: entry.url,
+        },
+      });
+      map.set(projectKey, list);
+    }
+    return map;
+  }, [stackOpenPrList.data?.entries]);
+  const threadBackedPrNumbersByProjectKey = useMemo(() => {
+    const map = new Map<string, Set<number>>();
+    for (const thread of threads) {
+      // Archived threads are gone from every section, so counting them would
+      // suppress a ghost the reader has no other way to reach. A link whose
+      // detail has not arrived yet still counts: the number is on the thread
+      // itself, and treating the row as threadless would offer a ghost that
+      // opens a duplicate thread for a PR that already has one.
+      if (thread.archivedAt !== null) continue;
+      const number =
+        thread.linkedPullRequest?.number ??
+        displayedPrByThreadKey.get(sidebarThreadKeyOf(thread))?.number;
+      if (number === undefined) continue;
+      const projectKey = sidebarStackProjectKey(thread);
+      const numbers = map.get(projectKey) ?? new Set<number>();
+      numbers.add(number);
+      map.set(projectKey, numbers);
+    }
+    return map;
+  }, [displayedPrByThreadKey, threads]);
+  const activeListItems = useMemo(
+    () =>
+      planActiveThreadsWithStacks({
+        activeThreads,
+        threadKeyOf: sidebarThreadKeyOf,
+        displayedOpenPrByThreadKey,
+        openPrsByProjectKey: stackOpenPrsByProjectKey,
+        threadBackedPrNumbersByProjectKey,
+      }),
+    [
+      activeThreads,
+      displayedOpenPrByThreadKey,
+      stackOpenPrsByProjectKey,
+      threadBackedPrNumbersByProjectKey,
+    ],
+  );
+  // Stack grouping hoists member threads to the group's anchor position, so the
+  // flat order behind shift-range-select, prev/next traversal and the ⌘1..9
+  // jump hints has to be read off the rendered plan, not off activeThreads.
+  const orderedActiveThreads = useMemo(
+    () =>
+      activeListItems.flatMap((item) =>
+        item.kind === "thread"
+          ? [item.thread]
+          : item.group.entries.flatMap((entry) => (entry.thread ? [entry.thread] : [])),
+      ),
+    [activeListItems],
+  );
   const orderedThreads = useMemo(
-    () => [...pinnedThreads, ...activeThreads, ...visibleSnoozedThreads, ...renderedSettledThreads],
-    [pinnedThreads, activeThreads, visibleSnoozedThreads, renderedSettledThreads],
+    () => [
+      ...pinnedThreads,
+      ...orderedActiveThreads,
+      ...visibleSnoozedThreads,
+      ...renderedSettledThreads,
+    ],
+    [pinnedThreads, orderedActiveThreads, visibleSnoozedThreads, renderedSettledThreads],
   );
   const orderedThreadKeys = useMemo(
     () =>
@@ -2276,6 +2519,22 @@ export default function Sidebar() {
   // a ref keeps it out of attemptSettle's dependency array.
   const handleNewThreadRef = useRef(newThreadContext.handleNewThread);
   handleNewThreadRef.current = newThreadContext.handleNewThread;
+
+  const handleStackGhostClick = useCallback(
+    (anchor: EnvironmentThreadShell, link: ThreadLinkedPullRequest) => {
+      void (async () => {
+        const opened = await handleNewThreadRef.current(
+          scopeProjectRef(anchor.environmentId, anchor.projectId),
+        );
+        if (!opened) return;
+        useComposerDraftStore.getState().setDraftThreadLinkedPullRequest(opened.draftId, link);
+        // Same as every other row: on mobile the sheet would otherwise stay
+        // open over the composer the tap just created.
+        if (isMobile) setOpenMobile(false);
+      })();
+    },
+    [isMobile, setOpenMobile],
+  );
   const settledThreadKeys = useMemo(
     () =>
       new Set(
@@ -3832,8 +4091,22 @@ export default function Sidebar() {
                       />,
                     );
                   }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
+                  // Active threads whose open PRs chain render as one stack
+                  // group at the position of their most recent member; every
+                  // other thread renders as today.
+                  for (const item of activeListItems) {
+                    if (item.kind === "thread") {
+                      items.push(renderThreadRow(item.thread, "active"));
+                      continue;
+                    }
+                    items.push(
+                      <SidebarStackGroupItem
+                        key={item.group.key}
+                        group={item.group}
+                        renderThreadRow={(thread) => renderThreadRow(thread, "active")}
+                        onGhostClick={handleStackGhostClick}
+                      />,
+                    );
                   }
                   // Snoozed shelf: between the inbox and Settled — out of the
                   // way, never gone. The header always renders while anything

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -179,6 +179,44 @@ export interface ThreadChangeRequestSnapshot {
   readonly linkedPullRequest?: ThreadLinkedPullRequest;
 }
 
+/**
+ * Each visible row publishes its resolved linked pull request here, so the
+ * sidebar's stack rail can read every row's PR without resolving them a
+ * second time above the list.
+ */
+export const threadLinkedPullRequestsAtom = Atom.make<ReadonlyMap<string, NonNullable<ThreadPr>>>(
+  new Map(),
+).pipe(Atom.keepAlive, Atom.withLabel("sidebar:thread-linked-pull-requests"));
+
+export function setThreadLinkedPullRequest(
+  threadKey: string,
+  pr: NonNullable<ThreadPr> | null,
+): void {
+  appAtomRegistry.modify(threadLinkedPullRequestsAtom, (current) => {
+    const existing = current.get(threadKey);
+    if (pr === null) {
+      if (existing === undefined) return [false, current];
+      const next = new Map(current);
+      next.delete(threadKey);
+      return [true, next];
+    }
+    if (
+      existing !== undefined &&
+      existing.number === pr.number &&
+      existing.state === pr.state &&
+      existing.title === pr.title &&
+      existing.url === pr.url &&
+      existing.baseRef === pr.baseRef &&
+      existing.headRef === pr.headRef
+    ) {
+      return [false, current];
+    }
+    const next = new Map(current);
+    next.set(threadKey, pr);
+    return [true, next];
+  });
+}
+
 export const threadChangeRequestSnapshotsAtom = Atom.make<
   ReadonlyMap<string, ThreadChangeRequestSnapshot>
 >(new Map()).pipe(Atom.keepAlive, Atom.withLabel("sidebar:thread-change-request-snapshots"));

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1,5 +1,8 @@
 import { scopedThreadKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
-import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
 import type {
   EnvironmentId,
   PullRequestAction,
@@ -8,6 +11,7 @@ import type {
   PullRequestRef,
   PullRequestState,
   ScopedThreadRef,
+  ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
 import {
   ArrowDownUpIcon,
@@ -26,6 +30,7 @@ import {
   GitPullRequestIcon,
   HammerIcon,
   LayersIcon,
+  Link2Icon,
   MessageCircleQuestionIcon,
   MessageSquareIcon,
   LinkIcon,
@@ -35,6 +40,7 @@ import {
   RefreshCwIcon,
   ServerIcon,
   TriangleAlertIcon,
+  UnlinkIcon,
 } from "lucide-react";
 import {
   lazy,
@@ -51,12 +57,13 @@ import {
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
 import { useCopyToClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { changeRequestRepositoryUrl } from "~/lib/openPullRequestLink";
+import { useThreadPullRequestLinkActions } from "~/hooks/useThreadPullRequestLink";
+import { changeRequestRepositoryUrl, matchesLinkedPullRequestUrl } from "~/lib/openPullRequestLink";
 import { usePreparePullRequestThreadAction } from "~/lib/sourceControlActions";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import type { ReviewCommentContext } from "~/reviewCommentContext";
-import { useProjects } from "~/state/entities";
+import { useProjects, useServerConfigs, useThreadShell } from "~/state/entities";
 import { useEnvironments } from "~/state/environments";
 import { useEnvironmentQuery } from "~/state/query";
 import { useLiveRefresh } from "~/hooks/useLiveRefresh";
@@ -109,6 +116,7 @@ import {
   handoffReviewComments,
   latestPullRequestReviewOutcomes,
   isStackedPullRequestBase,
+  isThreadLinkedToPullRequest,
   pullRequestActionMenuHasGroup,
   pullRequestActionNeedsHostRefresh,
   pullRequestComposerTarget,
@@ -708,6 +716,80 @@ export function PullRequestDetailPanel({
   // the work.
   const attachTarget = pullRequestComposerTarget(context, composerDraftTarget);
   const handoffLabels = pullRequestHandoffLabels(attachTarget !== null);
+
+  // Linking from the pull-request side needs a real thread to pin, and that is
+  // the open thread — not the handoff attach target. Gating on thread context
+  // would strand the reader: once they unlink, the thread stops matching this
+  // pull request by branch, the panel falls back to page context, and the way
+  // back would vanish with it.
+  const attachThreadRef =
+    composerDraftTarget !== undefined &&
+    composerDraftTarget !== null &&
+    typeof composerDraftTarget !== "string"
+      ? composerDraftTarget
+      : null;
+  const attachThread = useThreadShell(attachThreadRef);
+  const { linkPullRequest, unlinkPullRequest } = useThreadPullRequestLinkActions();
+  const threadLinkedPullRequest = attachThread?.linkedPullRequest ?? null;
+  const isLinkedToThisPullRequest = isThreadLinkedToPullRequest({
+    linkedPullRequest: threadLinkedPullRequest,
+    detail,
+    matchesUrl: (linked, targetUrl) =>
+      matchesLinkedPullRequestUrl(linked as ThreadLinkedPullRequest, targetUrl),
+  });
+  // Capabilities land after connect, so this read has to be reactive: an older
+  // server drops linkedPullRequest from thread.meta.update and still resolves,
+  // which would leave a success toast for a link that was never persisted.
+  const serverConfigs = useServerConfigs();
+  const supportsPullRequestLink =
+    attachThreadRef !== null &&
+    serverConfigs.get(attachThreadRef.environmentId)?.environment.capabilities
+      .threadPullRequestLinking === true;
+
+  // thread.meta.update is last-write-wins, so two of these in flight at once
+  // can land in the reverse order and leave the thread on the choice the
+  // reader made first. One at a time, and the item says so while it runs.
+  const [pullRequestLinkPending, setPullRequestLinkPending] = useState(false);
+
+  const linkPullRequestToThread = () => {
+    if (detail === null || attachThreadRef === null || pullRequestLinkPending) return;
+    const link: ThreadLinkedPullRequest = {
+      projectId: detail.projectId,
+      repository: reference.repository,
+      number: detail.number,
+      url: detail.url,
+    };
+    setPullRequestLinkPending(true);
+    void linkPullRequest(attachThreadRef, link).then((result) => {
+      setPullRequestLinkPending(false);
+      if (result._tag === "Failure") {
+        if (!isAtomCommandInterrupted(result)) {
+          toastManager.add({ type: "error", title: "Could not link the pull request" });
+        }
+        return;
+      }
+      toastManager.add({
+        type: "success",
+        title: "Linked to this thread",
+        description: `#${detail.number} now drives this thread's badge and settle-on-merge.`,
+      });
+    });
+  };
+
+  const unlinkPullRequestFromThread = () => {
+    if (attachThreadRef === null || pullRequestLinkPending) return;
+    setPullRequestLinkPending(true);
+    void unlinkPullRequest(attachThreadRef).then((result) => {
+      setPullRequestLinkPending(false);
+      if (result._tag === "Failure") {
+        if (!isAtomCommandInterrupted(result)) {
+          toastManager.add({ type: "error", title: "Could not unlink the pull request" });
+        }
+        return;
+      }
+      toastManager.add({ type: "success", title: "Unlinked from this thread" });
+    });
+  };
 
   const writeTaskToComposer = (target: ScopedThreadRef | DraftId, task: ThreadTask) => {
     const store = useComposerDraftStore.getState();
@@ -1350,6 +1432,25 @@ export function PullRequestDetailPanel({
                     <HammerIcon className="size-3.5" />
                     {handoff === "findings" ? "Preparing..." : handoffLabels.fixFindings}
                   </MenuItem>
+                  {/* Pinning from the pull-request side: where the panel sits beside a thread,
+                      that thread is one press away from following this pull request's state.
+                      Unlink takes the item's place once this is the linked one. */}
+                  {attachThreadRef !== null && detail !== null && supportsPullRequestLink ? (
+                    isLinkedToThisPullRequest ? (
+                      <MenuItem
+                        disabled={pullRequestLinkPending}
+                        onClick={unlinkPullRequestFromThread}
+                      >
+                        <UnlinkIcon className="size-3.5" />
+                        {pullRequestLinkPending ? "Unlinking..." : "Unlink PR from this thread"}
+                      </MenuItem>
+                    ) : (
+                      <MenuItem disabled={pullRequestLinkPending} onClick={linkPullRequestToThread}>
+                        <Link2Icon className="size-3.5" />
+                        {pullRequestLinkPending ? "Linking..." : "Link PR to this thread"}
+                      </MenuItem>
+                    )
+                  ) : null}
                   {pickableEnvironments.length > 0 ? (
                     <ActOnEnvironmentPicker
                       environments={pickableEnvironments}

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -18,6 +18,7 @@ import {
   handoffReviewComments,
   isPullRequestVerdictStale,
   isStackedPullRequestBase,
+  isThreadLinkedToPullRequest,
   isThreadOwnPullRequest,
   latestPullRequestReviewOutcomes,
   newestPullRequestCommitAt,
@@ -1245,5 +1246,58 @@ describe("which actions need the host read again after they run", () => {
     ] as const) {
       expect(pullRequestActionNeedsHostRefresh(action)).toBe(false);
     }
+  });
+});
+
+describe("isThreadLinkedToPullRequest", () => {
+  // The real matcher: host + repository + number, path-suffix tolerant.
+  const matchesUrl = (linked: { readonly url: string }, targetUrl: string) => {
+    const parse = (url: string) => /^(https:\/\/[^/]+\/[^/]+\/[^/]+)\/pull\/(\d+)/u.exec(url);
+    const left = parse(linked.url);
+    const right = parse(targetUrl);
+    return left !== null && right !== null && left[1] === right[1] && left[2] === right[2];
+  };
+  const detail = { number: 42, url: "https://github.com/acme/repo/pull/42" };
+
+  it("treats a link stored from a subpage as the same pull request", () => {
+    expect(
+      isThreadLinkedToPullRequest({
+        linkedPullRequest: { number: 42, url: "https://github.com/acme/repo/pull/42/files" },
+        detail,
+        matchesUrl,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not claim a different pull request in the same repository", () => {
+    expect(
+      isThreadLinkedToPullRequest({
+        linkedPullRequest: { number: 43, url: "https://github.com/acme/repo/pull/43" },
+        detail,
+        matchesUrl,
+      }),
+    ).toBe(false);
+  });
+
+  it("still recognises its own link on a host the matcher cannot parse", () => {
+    // This menu stores the detail URL verbatim, so exact equality is the way
+    // back for a self-hosted forge the change-request parser does not know.
+    const selfHosted = { number: 7, url: "https://git.internal/team/repo/changes/7" };
+    expect(
+      isThreadLinkedToPullRequest({
+        linkedPullRequest: selfHosted,
+        detail: selfHosted,
+        matchesUrl,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false while either side is missing", () => {
+    expect(isThreadLinkedToPullRequest({ linkedPullRequest: null, detail, matchesUrl })).toBe(
+      false,
+    );
+    expect(
+      isThreadLinkedToPullRequest({ linkedPullRequest: detail, detail: null, matchesUrl }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -937,3 +937,26 @@ const ACTION_NEEDS_HOST_REFRESH: Record<PullRequestAction, boolean> = {
 export function pullRequestActionNeedsHostRefresh(action: PullRequestAction): boolean {
   return ACTION_NEEDS_HOST_REFRESH[action];
 }
+
+/**
+ * Whether the thread beside this panel is already pinned to the pull request on
+ * screen — the decision behind offering Unlink rather than a second Link.
+ *
+ * The stored link keeps whatever URL it was created from, which for an
+ * agent-written href is often a subpage, so the shared change-request match is
+ * the primary test. The exact-URL fallback covers hosts that match cannot
+ * parse: this menu stores the detail URL verbatim, so without it an
+ * unrecognised host would link once and never offer the way back.
+ */
+export function isThreadLinkedToPullRequest(input: {
+  readonly linkedPullRequest: { readonly number: number; readonly url: string } | null;
+  readonly detail: { readonly number: number; readonly url: string } | null;
+  readonly matchesUrl: (linked: { readonly url: string }, targetUrl: string) => boolean;
+}): boolean {
+  const { linkedPullRequest, detail } = input;
+  if (linkedPullRequest === null || detail === null) return false;
+  return (
+    input.matchesUrl(linkedPullRequest, detail.url) ||
+    (linkedPullRequest.number === detail.number && linkedPullRequest.url === detail.url)
+  );
+}

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -12,6 +12,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   ThreadId,
+  ThreadLinkedPullRequest,
   type ModelSelection,
   type ProviderOptionSelection,
 } from "@t3tools/contracts";
@@ -1895,5 +1896,164 @@ describe("createDebouncedStorage", () => {
     vi.advanceTimersByTime(300);
     expect(base.setItem).toHaveBeenCalledTimes(1);
     expect(base.setItem).toHaveBeenCalledWith("key", "v2");
+  });
+});
+
+const decodeThreadLinkedPullRequest = Schema.decodeUnknownSync(ThreadLinkedPullRequest);
+
+describe("composerDraftStore pending pull-request link", () => {
+  const projectRef = scopeProjectRef(TEST_ENVIRONMENT_ID, ProjectId.make("project-link"));
+  const otherProjectRef = scopeProjectRef(TEST_ENVIRONMENT_ID, ProjectId.make("project-other"));
+  const draftId = DraftId.make("draft-link-1");
+  const link = decodeThreadLinkedPullRequest({
+    projectId: ProjectId.make("project-link"),
+    repository: "acme/repo",
+    number: 25390,
+    url: "https://github.com/acme/repo/pull/25390",
+  });
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("stores the pending link on an existing draft session", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    expect(
+      useComposerDraftStore.getState().getDraftSession(draftId)?.linkedPullRequest?.number,
+    ).toBe(25390);
+  });
+
+  it("ignores a link for a draft session that does not exist", () => {
+    const before = useComposerDraftStore.getState().draftThreadsByThreadKey;
+    useComposerDraftStore.getState().setDraftThreadLinkedPullRequest(draftId, link);
+    expect(useComposerDraftStore.getState().draftThreadsByThreadKey).toBe(before);
+  });
+
+  it("clears the pending link when the draft moves to another project", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    store.setLogicalProjectDraftThreadId(
+      scopedProjectKey(otherProjectRef),
+      otherProjectRef,
+      draftId,
+    );
+    expect(
+      useComposerDraftStore.getState().getDraftSession(draftId)?.linkedPullRequest ?? null,
+    ).toBeNull();
+  });
+
+  it("keeps the pending link across a same-project remap", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    store.setLogicalProjectDraftThreadId(scopedProjectKey(projectRef), projectRef, draftId);
+    expect(
+      useComposerDraftStore.getState().getDraftSession(draftId)?.linkedPullRequest?.number,
+    ).toBe(25390);
+  });
+
+  it("keeps the pending link when only the draft's branch changes", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    const session = useComposerDraftStore.getState().getDraftSession(draftId);
+    if (!session) throw new Error("expected a draft session");
+    useComposerDraftStore
+      .getState()
+      .setDraftThreadContext(scopeThreadRef(session.environmentId, session.threadId), {
+        branch: "feat/tour-codes",
+      });
+    expect(
+      useComposerDraftStore.getState().getDraftSession(draftId)?.linkedPullRequest?.number,
+    ).toBe(25390);
+  });
+
+  it("survives a reload before the first send", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (
+          state: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => Record<string, unknown>;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persisted = persistApi.getOptions().partialize(useComposerDraftStore.getState());
+    const merged = persistApi
+      .getOptions()
+      .merge(JSON.parse(JSON.stringify(persisted)), useComposerDraftStore.getInitialState());
+    expect(merged.draftThreadsByThreadKey[draftId]?.linkedPullRequest?.number).toBe(25390);
+  });
+
+  it("drops a half-written persisted link instead of promoting onto it", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (
+          state: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => Record<string, unknown>;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persisted = JSON.parse(
+      JSON.stringify(persistApi.getOptions().partialize(useComposerDraftStore.getState())),
+    ) as { draftThreadsByThreadKey: Record<string, Record<string, unknown>> };
+    const stored = persisted.draftThreadsByThreadKey[draftId];
+    if (!stored) throw new Error("expected a persisted draft thread");
+    stored.linkedPullRequest = { number: 25390 };
+    const merged = persistApi
+      .getOptions()
+      .merge(persisted, useComposerDraftStore.getInitialState());
+    expect(merged.draftThreadsByThreadKey[draftId]?.linkedPullRequest ?? null).toBeNull();
+  });
+
+  it("drops a persisted link that belongs to another project", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (
+          state: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => Record<string, unknown>;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persisted = JSON.parse(
+      JSON.stringify(persistApi.getOptions().partialize(useComposerDraftStore.getState())),
+    ) as { draftThreadsByThreadKey: Record<string, Record<string, unknown>> };
+    const stored = persisted.draftThreadsByThreadKey[draftId];
+    if (!stored) throw new Error("expected a persisted draft thread");
+    stored.linkedPullRequest = { ...link, projectId: "project-other" };
+    const merged = persistApi
+      .getOptions()
+      .merge(persisted, useComposerDraftStore.getInitialState());
+    expect(merged.draftThreadsByThreadKey[draftId]?.linkedPullRequest ?? null).toBeNull();
+  });
+
+  it("clearing sets the link back to null", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId);
+    store.setDraftThreadLinkedPullRequest(draftId, link);
+    store.setDraftThreadLinkedPullRequest(draftId, null);
+    expect(
+      useComposerDraftStore.getState().getDraftSession(draftId)?.linkedPullRequest ?? null,
+    ).toBeNull();
   });
 });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -16,6 +16,7 @@ import {
   type ScopedProjectRef,
   type ScopedThreadRef,
   ThreadId,
+  ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
 import {
   parseScopedProjectKey,
@@ -217,6 +218,7 @@ const PersistedDraftThreadState = Schema.Struct({
   worktreePath: Schema.NullOr(Schema.String),
   envMode: DraftThreadEnvModeSchema,
   startFromOrigin: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  linkedPullRequest: Schema.optionalKey(Schema.NullOr(ThreadLinkedPullRequest)),
   promotedTo: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({
@@ -321,6 +323,9 @@ export interface DraftSessionState {
   worktreePath: string | null;
   envMode: DraftThreadEnvMode;
   startFromOrigin: boolean;
+  /** Pull request to link once the draft promotes to a real thread. Set by
+      "open a thread on this PR" surfaces (e.g. a stack's ghost row). */
+  linkedPullRequest?: ThreadLinkedPullRequest | null;
   promotedTo?: ScopedThreadRef | null;
 }
 
@@ -417,6 +422,8 @@ interface ComposerDraftStoreState {
       interactionMode?: ProviderInteractionMode;
     },
   ) => void;
+  /** Sets or clears the pull request a draft will link on promotion. */
+  setDraftThreadLinkedPullRequest: (draftId: DraftId, link: ThreadLinkedPullRequest | null) => void;
   clearProjectDraftThreadId: (projectRef: ScopedProjectRef) => void;
   clearProjectDraftThreadById: (
     projectRef: ScopedProjectRef,
@@ -1414,6 +1421,9 @@ function createDraftThreadState(
     envMode:
       options?.envMode ?? (nextWorktreePath ? "worktree" : (existingThread?.envMode ?? "local")),
     startFromOrigin: nextStartFromOrigin,
+    // A project change invalidates the pending link the same way it does the
+    // branch: the PR belongs to the repository the draft is leaving.
+    linkedPullRequest: projectChanged ? null : (existingThread?.linkedPullRequest ?? null),
     promotedTo: null,
   };
 }
@@ -1446,6 +1456,8 @@ function draftThreadsEqual(left: DraftThreadState | undefined, right: DraftThrea
     left.worktreePath === right.worktreePath &&
     left.envMode === right.envMode &&
     left.startFromOrigin === right.startFromOrigin &&
+    (left.linkedPullRequest?.url ?? null) === (right.linkedPullRequest?.url ?? null) &&
+    (left.linkedPullRequest?.number ?? null) === (right.linkedPullRequest?.number ?? null) &&
     scopedThreadRefsEqual(left.promotedTo, right.promotedTo)
   );
 }
@@ -1542,6 +1554,34 @@ function normalizePersistedDraftThreads(
       const worktreePath = candidateDraftThread.worktreePath;
       const startFromOrigin = candidateDraftThread.startFromOrigin === true;
       const normalizedWorktreePath = typeof worktreePath === "string" ? worktreePath : null;
+      // Same hand-validation as promotedTo: persisted state is untrusted, and a
+      // half-written link would promote a thread onto the wrong pull request.
+      const linkedPullRequestCandidate = candidateDraftThread.linkedPullRequest;
+      const linkedPullRequestRecord =
+        linkedPullRequestCandidate && typeof linkedPullRequestCandidate === "object"
+          ? (linkedPullRequestCandidate as Record<string, unknown>)
+          : null;
+      const linkedPullRequest =
+        linkedPullRequestRecord &&
+        // A link whose project is not the draft's is stale storage, not intent:
+        // attaching it on promotion would pin the thread to another repository.
+        linkedPullRequestRecord.projectId === projectId &&
+        typeof linkedPullRequestRecord.projectId === "string" &&
+        linkedPullRequestRecord.projectId.length > 0 &&
+        typeof linkedPullRequestRecord.repository === "string" &&
+        linkedPullRequestRecord.repository.length > 0 &&
+        typeof linkedPullRequestRecord.number === "number" &&
+        Number.isInteger(linkedPullRequestRecord.number) &&
+        linkedPullRequestRecord.number > 0 &&
+        typeof linkedPullRequestRecord.url === "string" &&
+        linkedPullRequestRecord.url.length > 0
+          ? ({
+              projectId: linkedPullRequestRecord.projectId as ProjectId,
+              repository: linkedPullRequestRecord.repository,
+              number: linkedPullRequestRecord.number,
+              url: linkedPullRequestRecord.url,
+            } as ThreadLinkedPullRequest)
+          : null;
       const promotedToCandidate = candidateDraftThread.promotedTo;
       const promotedToRecord =
         promotedToCandidate && typeof promotedToCandidate === "object"
@@ -1589,6 +1629,7 @@ function normalizePersistedDraftThreads(
         worktreePath: normalizedWorktreePath,
         envMode: normalizeDraftThreadEnvMode(candidateDraftThread.envMode, normalizedWorktreePath),
         startFromOrigin,
+        linkedPullRequest,
         promotedTo,
       };
     }
@@ -2238,6 +2279,7 @@ function toHydratedDraftThreadState(
     worktreePath: persistedDraftThread.worktreePath,
     envMode: persistedDraftThread.envMode,
     startFromOrigin: persistedDraftThread.startFromOrigin,
+    linkedPullRequest: persistedDraftThread.linkedPullRequest ?? null,
     promotedTo: persistedDraftThread.promotedTo
       ? scopeThreadRef(
           persistedDraftThread.promotedTo.environmentId as EnvironmentId,
@@ -2415,6 +2457,26 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             options,
           );
         },
+        setDraftThreadLinkedPullRequest: (draftId, link) => {
+          set((state) => {
+            const existing = state.draftThreadsByThreadKey[draftId];
+            if (!existing) {
+              return state;
+            }
+            if (
+              (existing.linkedPullRequest?.url ?? null) === (link?.url ?? null) &&
+              (existing.linkedPullRequest?.number ?? null) === (link?.number ?? null)
+            ) {
+              return state;
+            }
+            return {
+              draftThreadsByThreadKey: {
+                ...state.draftThreadsByThreadKey,
+                [draftId]: { ...existing, linkedPullRequest: link },
+              },
+            };
+          });
+        },
         setDraftThreadContext: (threadRef, options) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
@@ -2473,6 +2535,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               envMode:
                 options.envMode ?? (nextWorktreePath ? "worktree" : (existing.envMode ?? "local")),
               startFromOrigin: nextStartFromOrigin,
+              // Same rule as createDraftThreadState: the pending link belongs to
+              // the repository the draft is leaving, so only a project change
+              // drops it. A branch or mode change must not.
+              linkedPullRequest: projectChanged ? null : (existing.linkedPullRequest ?? null),
               promotedTo: existing.promotedTo ?? null,
             };
             const isUnchanged =
@@ -2486,6 +2552,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               nextDraftThread.worktreePath === existing.worktreePath &&
               nextDraftThread.envMode === existing.envMode &&
               nextDraftThread.startFromOrigin === existing.startFromOrigin &&
+              (nextDraftThread.linkedPullRequest?.url ?? null) ===
+                (existing.linkedPullRequest?.url ?? null) &&
+              (nextDraftThread.linkedPullRequest?.number ?? null) ===
+                (existing.linkedPullRequest?.number ?? null) &&
               scopedThreadRefsEqual(nextDraftThread.promotedTo, existing.promotedTo);
             if (isUnchanged) {
               return state;

--- a/apps/web/src/hooks/useThreadPullRequestLink.ts
+++ b/apps/web/src/hooks/useThreadPullRequestLink.ts
@@ -1,0 +1,33 @@
+import type { ScopedThreadRef, ThreadLinkedPullRequest } from "@t3tools/contracts";
+import { useCallback } from "react";
+
+import { threadEnvironment } from "../state/threads";
+import { useAtomCommand } from "../state/use-atom-command";
+
+/**
+ * Link and unlink, both through `thread.meta.update`. These are the only
+ * callers allowed to send `linkedPullRequest`: the command is multi-field, so
+ * any other caller spreading thread state would silently unlink.
+ */
+export function useThreadPullRequestLinkActions() {
+  const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
+    reportFailure: false,
+  });
+  const linkPullRequest = useCallback(
+    (threadRef: ScopedThreadRef, link: ThreadLinkedPullRequest) =>
+      updateThreadMetadata({
+        environmentId: threadRef.environmentId,
+        input: { threadId: threadRef.threadId, linkedPullRequest: link },
+      }),
+    [updateThreadMetadata],
+  );
+  const unlinkPullRequest = useCallback(
+    (threadRef: ScopedThreadRef) =>
+      updateThreadMetadata({
+        environmentId: threadRef.environmentId,
+        input: { threadId: threadRef.threadId, linkedPullRequest: null },
+      }),
+    [updateThreadMetadata],
+  );
+  return { linkPullRequest, unlinkPullRequest };
+}

--- a/apps/web/src/routes/_chat.draft.$draftId.tsx
+++ b/apps/web/src/routes/_chat.draft.$draftId.tsx
@@ -1,5 +1,6 @@
+import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import ChatView from "../components/ChatView";
 import {
   resolveDraftPromotionNavigationTarget,
@@ -12,9 +13,11 @@ import {
   useComposerDraftStore,
 } from "../composerDraftStore";
 import { SidebarInset } from "../components/ui/sidebar";
+import { toastManager } from "../components/ui/toast";
 import { waitForDraftHeroTransition } from "../components/chat/draftHeroTransition";
 import { buildThreadRouteParams } from "../threadRoutes";
-import { useThread, useThreadRefs } from "../state/entities";
+import { useThreadPullRequestLinkActions } from "../hooks/useThreadPullRequestLink";
+import { useServerConfigs, useThread, useThreadRefs } from "../state/entities";
 
 function DraftChatThreadRouteView() {
   const navigate = useNavigate();
@@ -45,6 +48,49 @@ function DraftChatThreadRouteView() {
     }
     markPromotedDraftThreadByRef(inferredThreadRef);
   }, [draftSession?.promotedTo, inferredThreadRef]);
+
+  // A pending PR link (set by "open a thread on this PR" surfaces) applies once
+  // the pre-minted thread exists on the server. It fires before the route
+  // navigates away, and the in-flight key keeps a re-render from sending it
+  // twice. There is no in-app retry: the draft session is finalized the moment
+  // the thread route takes over, so a failure is reported to the reader
+  // instead, and the pull-request panel's own Link item is the way back.
+  const { linkPullRequest } = useThreadPullRequestLinkActions();
+  const pendingLinkedPullRequest = draftSession?.linkedPullRequest ?? null;
+  // Reactive, not a one-shot read: capabilities arrive after connect, and a
+  // read that misses them would skip the link with nothing left to re-run it
+  // before the thread route finalizes the draft.
+  const serverConfigs = useServerConfigs();
+  const linkAttemptKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!inferredThreadRef || !pendingLinkedPullRequest) return;
+    if (
+      serverConfigs.get(inferredThreadRef.environmentId)?.environment.capabilities
+        .threadPullRequestLinking !== true
+    ) {
+      return;
+    }
+    const attemptKey = `${inferredThreadRef.environmentId}:${inferredThreadRef.threadId}:${pendingLinkedPullRequest.number}`;
+    if (linkAttemptKeyRef.current === attemptKey) return;
+    linkAttemptKeyRef.current = attemptKey;
+    void (async () => {
+      const result = await linkPullRequest(inferredThreadRef, pendingLinkedPullRequest);
+      if (result._tag === "Failure") {
+        // Released so a draft still on screen can try again; an interrupted
+        // command is a navigation, not a failure worth a toast.
+        linkAttemptKeyRef.current = null;
+        if (!isAtomCommandInterrupted(result)) {
+          toastManager.add({
+            type: "error",
+            title: `Could not link #${pendingLinkedPullRequest.number} to this thread`,
+            description: "Link it from the pull request's menu.",
+          });
+        }
+        return;
+      }
+      useComposerDraftStore.getState().setDraftThreadLinkedPullRequest(draftId, null);
+    })();
+  }, [draftId, inferredThreadRef, linkPullRequest, pendingLinkedPullRequest, serverConfigs]);
 
   useEffect(() => {
     if (!canonicalThreadRef) {


### PR DESCRIPTION
Threads whose PRs form a GitHub stack — each PR based on the previous one's head branch, the normal stacked-branch workflow — render as unrelated sidebar rows in recency order. In a list of five threads there is no way to see which PR sits on which, which one is the base, or that a PR in the middle has no thread at all.

Threads whose displayed open PRs chain (one's `baseRef` equals another's `headRef`, same project) now collapse into one active-section group: a `Stack · N PRs` header, a vertical rail at the row content inset, member cards top-of-stack first and base last, and slim ghost rows for stack PRs that no visible thread drives — holding their true position, so the rail never lies about adjacency. Clicking a ghost opens a draft thread with the PR stored as a pending link on the draft session, applied once via `thread.meta.update` when the draft promotes to a real thread. Threads not in any stack render exactly as today, and a stack dissolves on its own as PRs merge or close.

Derivation is pure client logic over data the sidebar already lifts from its rows — no contracts change, no new RPC, no server work, no GitButler CLI integration. Ghost discovery reuses `LinkPullRequestDialog`'s open-PR list query with a byte-identical input, so the sidebar, the dialog, and the PR page share one atom-family entry and one 30s server cache, and it is fetched only for projects that already have a detected chain.

Why it is worth having: stacked PRs out of a single checkout are a common workflow — one project, several open PRs, each based on the previous. Merge order is the thing you need to see and the thing the sidebar hides. The ghost rows are the other half: a stack usually has a PR with no thread yet, and entering the stack there currently means creating a thread by hand and linking the PR manually.

Depends on #8488 (the PR-menu link entry point — `linkedPullRequest` link actions), which is the first commit on this branch. Merge that one first and this rebases to a single commit.

UI change note: this adds a new sidebar grouping; before/after screenshots available on request.

Model: Claude Opus 5 (1M context), harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread metadata (`linkedPullRequest`), draft promotion side effects, and sidebar navigation order; incorrect stack or ghost logic could mislead merge order or create duplicate threads, but behavior is largely client-side with capability gating and tests on the planner.
> 
> **Overview**
> **Stacked open PRs in the active sidebar** now collapse into a single group when threads in the same project display PRs that chain (`baseRef` → another PR's `headRef`). The UI shows a **Stack · N PRs** header, a vertical rail, full thread rows for members, and **ghost** rows for stack PRs with no active thread—clicking a ghost starts a new draft with a **pending** `linkedPullRequest` applied on promotion via `thread.meta.update`.
> 
> **New pure planner** (`planActiveThreadsWithStacks`, `stackOpenPrListProjectRefs`) handles ghosts from a shared open-PR list fetch (only projects with ≥2 open-PR active threads, gated on `threadPullRequestLinking`), fork/sibling/cycle edge cases, and suppression when a PR is already backed elsewhere. **Keyboard/range order** follows the rendered plan via `orderedActiveThreads`.
> 
> **Supporting changes:** rows publish resolved linked PRs through `threadLinkedPullRequestsAtom`; **Pull request detail** menu adds link/unlink to the open thread; `useThreadPullRequestLinkActions` centralizes metadata updates; composer draft store persists and validates pending links across reloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5730cfe3d590d5e0ec151c8963d64abcd3419fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group stacked PRs into a rail in the sidebar
> - Adds a `planActiveThreadsWithStacks` planner that groups directly chained open PRs into stack groups per project, using union-find for connected components and requiring at least two thread-backed PRs per group
> - Adds `SidebarStackGroupItem` component that renders grouped stacks with a vertical rail, tick marks, and clickable ghost rows for PRs not yet backed by a thread
> - Adds a shared `threadLinkedPullRequestsAtom` so thread rows publish their resolved linked PR once, avoiding duplicate resolution during stack planning
> - Adds pending PR link support to `composerDraftStore` and auto-applies the link when a draft thread is promoted to a server thread; also adds link/unlink menu items in `PullRequestDetailPanel`
> - Risk: `orderedActiveThreads` now reflects rendered plan order instead of raw active order; keyboard traversal and jump hints follow this new order, so any code relying on the original ordering may need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5730cfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->