### PR TITLE
fix(server): strip OSC/ANSI escapes from OpenCode CLI inventory output

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -8,6 +8,9 @@ import {
   parseSkillsCliOutput,
 } from "./opencodeRuntime.ts";
 
+// The terminal title the OpenCode CLI writes before its first line of stdout.
+const OSC_TITLE = "\u001b]0;OpenCode | t3code\u0007";
+
 describe("parseModelsCliOutput", () => {
   it("parses a single model from a single provider", () => {
     const stdout = [
@@ -154,6 +157,21 @@ describe("parseModelsCliOutput", () => {
     NodeAssert.equal(model.id, "qwen/qwen3-coder");
     NodeAssert.equal(model.providerID, "openrouter");
   });
+
+  it("keeps the first model when the CLI prefixes output with a terminal title sequence", () => {
+    // The prefixed slug line stops matching SLUG_LINE_RE, so the model is dropped.
+    const stdout = [
+      `${OSC_TITLE}opencode/big-pickle`,
+      JSON.stringify({ id: "big-pickle", providerID: "opencode", name: "Big Pickle" }),
+      "opencode/claude-fable-5",
+      JSON.stringify({ id: "claude-fable-5", providerID: "opencode", name: "Fable 5" }),
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    const provider = result.providers.get("opencode")!;
+    NodeAssert.ok(provider);
+    NodeAssert.deepEqual(Object.keys(provider.models).sort(), ["big-pickle", "claude-fable-5"]);
+  });
 });
 
 describe("parseAgentListCliOutput", () => {
@@ -255,6 +273,34 @@ describe("parseAgentListCliOutput", () => {
     NodeAssert.equal(result[0]!.hidden, true);
     NodeAssert.equal(result[1]!.hidden, false);
   });
+
+  it("strips an ST-terminated OSC sequence and ANSI color from agent headers", () => {
+    const stdout = [
+      "\u001b]0;OpenCode | t3code\u001b\\\u001b[36mbuild\u001b[0m (primary)",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.equal(result.length, 1);
+    NodeAssert.equal(result[0]!.name, "build");
+    NodeAssert.equal(result[0]!.mode, "primary");
+  });
+
+  it("keeps the first agent name clean when the CLI prefixes a terminal title sequence", () => {
+    // The escape sequence lands in the agent name, which OpenCode then rejects.
+    const stdout = [
+      `${OSC_TITLE}build (primary)`,
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+      "plan (primary)",
+      "  " + JSON.stringify([{ permission: "edit", action: "ask", pattern: "*.md" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.deepEqual(
+      result.map((agent) => agent.name),
+      ["build", "plan"],
+    );
+  });
 });
 
 describe("parseSkillsCliOutput", () => {
@@ -281,5 +327,17 @@ describe("parseSkillsCliOutput", () => {
 
   it("degrades malformed output to an empty skill list", () => {
     NodeAssert.deepEqual(parseSkillsCliOutput("not json"), []);
+  });
+
+  it("decodes skills when the CLI prefixes output with a terminal title sequence", () => {
+    const stdout =
+      OSC_TITLE +
+      JSON.stringify([
+        { name: "review-pr", description: "Review a pull request.", location: null },
+      ]);
+
+    NodeAssert.deepEqual(parseSkillsCliOutput(stdout), [
+      { name: "review-pr", description: "Review a pull request.", location: null },
+    ]);
   });
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -196,6 +196,18 @@ function parseServerUrlFromOutput(output: string): string | null {
   return null;
 }
 
+// The OpenCode CLI writes an OSC title sequence to stdout before its first line
+// of output, even when piped, which corrupts every parser below.
+// eslint-disable-next-line no-control-regex
+const OSC_SEQUENCE = /\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)/g;
+// Payload class excludes both terminators, so an unterminated prefix stays literal.
+// eslint-disable-next-line no-control-regex
+const CSI_SEQUENCE = /\u001b\[[0-9:;?<=>]*[ -/]*[@-~]/g;
+
+function stripTerminalEscapes(text: string): string {
+  return text.replace(OSC_SEQUENCE, "").replace(CSI_SEQUENCE, "");
+}
+
 const SLUG_LINE_RE = /^(\S+\/\S+)\s*$/;
 const AGENT_HEADER_RE = /^(.+)\s+\((\S+)\)\s*$/;
 
@@ -216,7 +228,7 @@ export function parseModelsCliOutput(stdout: string): {
     string,
     { id: string; name: string; models: { [key: string]: Model } }
   >();
-  const lines = stdout.split("\n");
+  const lines = stripTerminalEscapes(stdout).split("\n");
   let currentSlug: string | null = null;
   const jsonLines: Array<string> = [];
 
@@ -269,7 +281,7 @@ export function parseModelsCliOutput(stdout: string): {
 /** @internal */
 export function parseAgentListCliOutput(stdout: string): ReadonlyArray<Agent> {
   const agents: Array<Agent> = [];
-  const lines = stdout.split("\n");
+  const lines = stripTerminalEscapes(stdout).split("\n");
   let currentHeader: { name: string; mode: string } | null = null;
   const blockLines: Array<string> = [];
 
@@ -311,7 +323,7 @@ export function parseAgentListCliOutput(stdout: string): ReadonlyArray<Agent> {
 
 /** @internal */
 export function parseSkillsCliOutput(stdout: string): ReadonlyArray<OpenCodeSkill> {
-  const result = decodeOpenCodeSkillsCliOutputExit(stdout);
+  const result = decodeOpenCodeSkillsCliOutputExit(stripTerminalEscapes(stdout));
   return Exit.isSuccess(result) ? result.value : [];
 }
 


### PR DESCRIPTION
Fixes #7754

## What Changed

`opencodeRuntime.ts` strips terminal escape sequences from OpenCode CLI stdout before parsing it, at the entry of the three parsers that consume `runOpenCodeCommand` output — `parseModelsCliOutput`, `parseAgentListCliOutput`, `parseSkillsCliOutput` — plus regression tests. One file; no behaviour change when the output is already clean.

`parseServerUrlFromOutput` is left alone: `opencode serve` does not emit the sequence.

## Why

The OpenCode CLI writes an OSC title sequence to stdout before its first line, even when stdout is a pipe. On 1.18.23:

```
$ opencode agent list | cat -v
^[]0;OpenCode | t3code-pr^Gbuild (primary)

$ opencode models --verbose | cat -v
^[]0;OpenCode | t3code-pr^Gopencode/big-pickle
```

`loadInventoryFromCli` captures that verbatim, so the bytes are glued onto the first line of each command, and each parser breaks differently:

**Agents.** `AGENT_HEADER_RE` captures the escape as part of the agent *name*. The polluted value is stored in the inventory, persisted into the thread's model selection, and sent back as `agent` in `session.promptAsync`. OpenCode rejects it — from the provider event log of a failing turn:

```
Agent not found: "]0;OpenCode | t3code-prbuild". Available agents: build, explore, general, minion/commit, plan
```

The UI never shows that. It shows the wrapper — `UnknownError` at `SessionPrompt.createUserMessage` → `SessionHttpApi.promptAsync` — so every turn fails with nothing actionable.

**Models.** The polluted slug no longer matches `SLUG_LINE_RE` (the title contains spaces), so the first model of the first provider is silently dropped from the picker.

**Skills.** The JSON no longer starts at byte 0, decoding fails, and the list degrades to `[]`.

Parser entry is the smallest layer that fixes all three: it is the one point where captured CLI text becomes structured data.

### Verification

Dev build on WSL2, opencode 1.18.23, same environment on `main` (850e458) and this branch:

| | `main` | patched |
|---|---|---|
| agent chip | `Medium · ]0;OpenCode \| t3code-pr build` | `Build` |
| sending a turn | `UnknownError` at `createUserMessage` | completes |
| `opencode/big-pickle` | missing from picker | listed |

`vp test …/opencodeRuntime.cliParsers.test.ts` — 20 passed (4 new). `typecheck`, `lint`, `fmt --check` clean.

### Scope

A thread that already stored a polluted agent keeps it until re-picked — this fixes the source, it does not migrate rows. Deliberate, to keep it to one file.

### Related

#7754 is canonical (#7716 closed as its duplicate). #7755, #7988, #8302, #8391 fix the same bug with wider scope. This is the minimum version — close it in favour of one of those if you prefer.

## UI Changes

Same steps either side: open the model picker, search for `Big Pickle` (the first entry of `opencode models --verbose`), pick an OpenCode model, send one message.

**Before** — `Big Pickle` is missing from the picker, the agent chip reads `Medium · ]0;OpenCode | t3code-pr build`, and the turn fails with `UnknownError`:

![before](https://raw.githubusercontent.com/rehanhaider/t3code/pr-assets/.pr-assets/05-before-repro.gif)

**After** — `Big Pickle` is listed and selectable, the chip reads `Build`, and the turn completes:

![after](https://raw.githubusercontent.com/rehanhaider/t3code/pr-assets/.pr-assets/06-after-repro.gif)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip OSC/ANSI escapes from OpenCode CLI output before parsing
> Adds `stripTerminalEscapes` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/8496/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) which removes OSC window-title sequences and CSI ANSI control codes from raw stdout. The three CLI parsers — `parseModelsCliOutput`, `parseAgentListCliOutput`, and `parseSkillsCliOutput` — now run their line-splitting and JSON decoding on the cleaned text instead of raw stdout. Tests in [opencodeRuntime.cliParsers.test.ts](https://github.com/pingdotgg/t3code/pull/8496/files#diff-89a1591aef6b6557b8380e6b6169a55f61d0231dd60973e337aa2af824bde0f9) cover prefixed terminal-title sequences and embedded ANSI color codes.
> - Risk: any CLI output that legitimately contains ESC characters outside of OSC/CSI patterns is not affected; only those two regex classes are stripped, so other control sequences could still disrupt parsing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83e5ddb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->