### PR TITLE
fix(server): show symlinked directories in folder browser

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -658,6 +658,31 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
+    it.effect("includes symlinked directories and excludes other symlinks", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-symlink-" });
+        yield* writeTextFile(cwd, "real-dir/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "real-file.txt", "ignore me");
+        yield* fileSystem.symlink(path.join(cwd, "real-dir"), path.join(cwd, "linked-dir"));
+        yield* fileSystem.symlink(path.join(cwd, "real-file.txt"), path.join(cwd, "linked-file"));
+        yield* fileSystem.symlink(path.join(cwd, "missing-target"), path.join(cwd, "broken-link"));
+        yield* fileSystem.symlink(path.join(cwd, "cycle-b"), path.join(cwd, "cycle-a"));
+        yield* fileSystem.symlink(path.join(cwd, "cycle-a"), path.join(cwd, "cycle-b"));
+
+        const result = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+        });
+
+        expect(result.entries).toEqual([
+          { name: "linked-dir", fullPath: path.join(cwd, "linked-dir") },
+          { name: "real-dir", fullPath: path.join(cwd, "real-dir") },
+        ]);
+      }),
+    );
+
     it.effect("shows dot directories in directory mode and hidden-prefix mode", () =>
       Effect.gen(function* () {
         const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -219,13 +219,26 @@ export const make = Effect.gen(function* () {
       const entries: Array<{ readonly name: string; readonly fullPath: string }> = [];
       for (const dirent of dirents) {
         if (
-          dirent.isDirectory() &&
-          dirent.name.toLowerCase().startsWith(lowerPrefix) &&
-          (showHidden || !dirent.name.startsWith("."))
+          !dirent.name.toLowerCase().startsWith(lowerPrefix) ||
+          (!showHidden && dirent.name.startsWith("."))
         ) {
+          continue;
+        }
+
+        const fullPath = path.join(parentPath, dirent.name);
+        const isDirectory =
+          dirent.isDirectory() ||
+          (dirent.isSymbolicLink() &&
+            (yield* Effect.promise(() =>
+              NodeFSP.stat(fullPath).then(
+                (stats) => stats.isDirectory(),
+                () => false,
+              ),
+            )));
+        if (isDirectory) {
           entries.push({
             name: dirent.name,
-            fullPath: path.join(parentPath, dirent.name),
+            fullPath,
           });
         }
       }


### PR DESCRIPTION
## Problem

The Add Project folder browser and path autocomplete silently omit symlinks to directories because `readdir` returns symlink dirents with `lstat` semantics.

## Fix

Treat matching symlinks as directories only when `stat` confirms their target is a directory. The browse result keeps the symlink path the user selected, while file, broken, and cyclic symlinks remain excluded.

No client or contract changes are required because every affected surface uses the shared `filesystem.browse` RPC.

Closes #8408

## Verification

- `vp test run apps/server/src/workspace/WorkspaceEntries.test.ts` (31 passed)
- `vp run --filter t3 typecheck`
- `vp lint apps/server/src/workspace/WorkspaceEntries.ts apps/server/src/workspace/WorkspaceEntries.test.ts --report-unused-disable-directives`
- `vp fmt apps/server/src/workspace/WorkspaceEntries.ts apps/server/src/workspace/WorkspaceEntries.test.ts --check`
- Codex review of the two-file diff found no issues

## Screenshots

Not applicable. This is a server-only filesystem classification change covered at the shared browse service boundary.

Generated with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-only browse filtering with defensive `stat` failures treated as non-directories; no API or client contract changes.
> 
> **Overview**
> **Fixes folder browse omitting directory symlinks** by classifying entries with `readdir` + `withFileTypes` using a follow-up `stat` when a dirent is a symlink, so only targets that resolve to directories are listed (paths stay the symlink name).
> 
> **Symlinks to files, broken links, and cyclic links stay hidden**; prefix and dot-directory filtering is unchanged but refactored to early-`continue` before the directory check.
> 
> A new **`browse` integration test** covers `linked-dir` vs file, broken, and cyclic symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35545ca0988c3ee092e9766c398e43334cd4dd20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show symlinked directories in `WorkspaceEntries.browse` results
> - Reworks directory entry filtering in [WorkspaceEntries.ts](https://github.com/pingdotgg/t3code/pull/8497/files#diff-26feb5e4175dd3c4b97bf023c259c336abef121574cd5665d06d3e4dbf1b15b8) to resolve symlink targets with `NodeFSP.stat` before inclusion.
> - Symlinks pointing to directories now appear in the folder browser, while symlinks to files, broken links, and cyclic links are excluded.
> - Behavioral Change: entries failing `NodeFSP.stat` (e.g., broken or cyclic symlinks) are silently skipped instead of being included or throwing errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35545ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->