### PR TITLE
fix(server): roll back failed service installs

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -223,6 +223,22 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
     }),
   );
 
+  it.effect("rolls back a fresh install when activation fails", () =>
+    Effect.gen(function* () {
+      const { service, commands, control } = yield* makeHarness();
+      control.failCommand = "loginctl enable-linger";
+
+      expect((yield* service.install.pipe(Effect.flip))._tag).toBe("BootServiceCommandError");
+      expect((yield* service.status).installed).toBe(false);
+      expect(commands.filter((command) => command.startsWith("systemctl "))).toEqual([
+        "systemctl --user daemon-reload",
+        "systemctl --user enable t3code.service",
+        "systemctl --user disable --now t3code.service",
+        "systemctl --user daemon-reload",
+      ]);
+    }),
+  );
+
   it.effect("restarts an installed service when repair fails", () =>
     Effect.gen(function* () {
       const { service, commands, control } = yield* makeHarness();

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -666,7 +666,15 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       yield* runSteps(manager.activate);
     }).pipe(
       Effect.tapError(() =>
-        installed ? runSteps(manager.restart).pipe(Effect.ignore) : Effect.void,
+        installed
+          ? runSteps(manager.restart).pipe(Effect.ignore)
+          : manager.kind === "systemd"
+            ? Effect.gen(function* () {
+                yield* runSteps(manager.deactivate).pipe(Effect.ignore);
+                yield* fs.remove(unitPath).pipe(Effect.ignore);
+                yield* runSteps(manager.finalize).pipe(Effect.ignore);
+              })
+            : Effect.void,
       ),
     );
     return plan;


### PR DESCRIPTION
## Problem

A fresh systemd service install could fail during activation after writing and enabling the unit. The leftover unit made `t3 service status` report a current install, so retries short-circuited while the service remained inactive.

## Fix

Roll back failed fresh systemd activations through the existing service-manager cleanup steps: disable the unit, remove its file, and reload systemd. Existing-install repair recovery and documented launchd behavior stay unchanged.

## Verification

- `vp test run apps/server/src/cloud/bootService.test.ts` (21 tests)
- `vp run --filter t3 typecheck`
- changed-file `vp lint`
- changed-file `vp fmt --check`
- `git diff --check`
- Codex review: no findings

Fixes #8476

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches boot-service install failure recovery on Linux; incorrect rollback could leave systemd in a bad state, but changes are scoped to fresh installs and mirror existing uninstall steps.
> 
> **Overview**
> **Failed fresh systemd installs** no longer leave a half-enabled unit on disk. When `install` errors during activation and the service was not already present, the error handler now runs the same **deactivate → remove unit file → finalize** path as uninstall, instead of doing nothing.
> 
> **Repair behavior is unchanged**: if activation fails on an **existing** install, the flow still attempts **restart** only. **launchd** fresh-install failures still do not roll back (documented behavior).
> 
> A new test simulates activation failing at `loginctl enable-linger` and asserts `installed` is false and the expected `systemctl` rollback sequence runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b168f578ec81e1b8be8cf3347f5558582588970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Roll back failed systemd service installs in `bootService`
> When a fresh `systemd` install fails during activation, the error handler in the `install` effect now runs the full rollback sequence: deactivate steps, remove the unit file at `unitPath`, and finalize steps. All rollback steps ignore their own errors. Previously the handler did nothing for uninstalled services. Adds a test verifying the expected `systemctl` command sequence on rollback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b168f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->