### PR TITLE
fix(web): preserve theme when toggling advanced colors

### DIFF
--- a/apps/web/src/components/settings/ThemeEditorPanel.tsx
+++ b/apps/web/src/components/settings/ThemeEditorPanel.tsx
@@ -308,6 +308,7 @@ export function ThemeEditorPanel({
   const [simpleColorsDirtyByAppearance, setSimpleColorsDirtyByAppearance] = useState<
     Record<ThemeAppearance, boolean>
   >({ light: false, dark: false });
+  const [shouldRegenerateGuidedColors, setShouldRegenerateGuidedColors] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isMinimized, setIsMinimized] = useState(false);
   const [roleQuery, setRoleQuery] = useState("");
@@ -401,6 +402,10 @@ export function ThemeEditorPanel({
       // regenerate when the guided editor produced it.
       setIsAdvanced(sourceTheme !== null && sourceTheme.managed !== true);
       setSimpleColorsDirtyByAppearance({ light: false, dark: false });
+      // An unmanaged palette needs conversion when the user opts into the
+      // guided editor. Merely revealing Advanced for a managed/default draft
+      // must stay read-only until a color changes.
+      setShouldRegenerateGuidedColors(sourceTheme !== null && sourceTheme.managed !== true);
       setColorsByAppearance(nextColors);
       setSelectedRole(null);
       setUsageCount(null);
@@ -497,6 +502,7 @@ export function ThemeEditorPanel({
           [activeAppearance]: true,
         }));
       }
+      if (isAdvanced) setShouldRegenerateGuidedColors(true);
     },
     [activeAppearance, isAdvanced],
   );
@@ -735,6 +741,7 @@ export function ThemeEditorPanel({
       if (selectedRole && !THEME_EDITOR_SIMPLE_ROLES.includes(selectedRole)) {
         setSelectedRole(null);
       }
+      if (!shouldRegenerateGuidedColors) return;
 
       // Regenerate every appearance the theme will save, not just the visible
       // one, so the palettes shown after toggling match what gets saved.
@@ -754,8 +761,9 @@ export function ThemeEditorPanel({
         }
         return next;
       });
+      setShouldRegenerateGuidedColors(false);
     },
-    [activeAppearance, editingTheme, selectedRole],
+    [activeAppearance, editingTheme, selectedRole, shouldRegenerateGuidedColors],
   );
 
   const handleSubmit = () => {


### PR DESCRIPTION
Opening the theme editor on the default light theme and toggling Advanced on and off regenerated the guided palette even when no color changed. The live UI changed even though the switch should only reveal or hide controls.

Track whether the draft actually needs guided regeneration. Default and managed drafts now stay unchanged through a toggle-only round trip. Unmanaged palettes and real advanced color edits still regenerate when the user switches back to guided mode.

Fixes #8416

## Playwright proof

Playwright opened the editor through the command palette in the reported default-theme, light-mode setup, toggled Advanced on and off, then compared all 57 applied theme roles. The final switch state was off and all 57 values matched exactly, with 0 changed roles.

![Theme editor Advanced toggle leaves the palette unchanged](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/9692ec91-e827-4033-b8e7-7e227edf52a5/theme-editor-advanced-toggle-proof.gif)

## Verification

- `pnpm exec vp test run apps/web/src/themePalette.test.ts` (32 tests)
- `pnpm exec vp lint apps/web/src/components/settings/ThemeEditorPanel.tsx`
- `pnpm --filter @t3tools/web typecheck`
- Playwright: default light theme, 57 palette roles before and after Advanced on/off, exact match

Built with GPT-5.6-Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized theme editor state logic with no auth, persistence schema, or API changes; behavior is easier to reason about for toggle-only flows.
> 
> **Overview**
> Fixes unwanted palette changes when users only flip the **Advanced** switch in the theme editor (e.g. default light theme with no edits).
> 
> Adds **`shouldRegenerateGuidedColors`** so guided regeneration runs only when it is actually needed: opening an **unmanaged** theme (imports / hand-tuned palettes) that must be converted when returning to guided mode, or after a real **advanced** color edit. Managed/default drafts that only show or hide advanced controls no longer call **`getManagedEditorColors`** on the way back to guided mode, so the live preview and all role values stay identical through an on/off toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50342ad7364aa5a36db52229de5b31f20bdcde6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve guided palettes when toggling `isAdvanced` in `ThemeEditorPanel`
> Adds a `shouldRegenerateGuidedColors` flag that controls whether guided palettes are regenerated when the user exits advanced mode. The flag is set to true when the draft originates from an unmanaged theme or when any color change occurs in advanced mode. `handleAdvancedChange` now early-returns without regeneration when the flag is false, so toggling advanced mode off preserves the current palettes unless advanced edits were made.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a50342a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->