### PR TITLE
fix(web): render nested markdown images correctly

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -24,12 +24,16 @@ import {
   squashAtomCommandFailure,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
-import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
+import {
+  classifyMarkdownImageSource,
+  markdownImageSourceFragment,
+} from "@t3tools/client-runtime/markdown-images";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import React, {
   Children,
   Suspense,
+  type CSSProperties,
   type ClipboardEvent as ReactClipboardEvent,
   type MouseEvent as ReactMouseEvent,
   isValidElement,
@@ -90,6 +94,7 @@ import {
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   extractMarkdownLinkHrefs,
+  isWindowsDrivePathHref,
   normalizeMarkdownLinkDestination,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
@@ -149,6 +154,7 @@ interface ChatMarkdownProps {
   lineBreaks?: boolean;
   /** Parse sanitized raw HTML instead of displaying its source text. */
   parseRawHtml?: boolean;
+  imageBaseDir?: string | undefined;
 }
 
 export function canUseMarkdownFileShellActions(
@@ -237,28 +243,25 @@ export function orderedListGutterStyle(
   return { "--list-gutter": `${markerWidth + 1}ch` };
 }
 
-type MarkdownHtmlAstNode = {
+type MarkdownImageHastNode = {
   type?: string;
   tagName?: string;
   properties?: Record<string, unknown>;
-  children?: MarkdownHtmlAstNode[];
+  children?: MarkdownImageHastNode[];
 };
 
-/** Preserve Windows drive paths through the protocol allowlist in rehype-sanitize. */
-function rehypeNormalizeWindowsImageSrc() {
-  return (tree: MarkdownHtmlAstNode) => {
-    const visit = (node: MarkdownHtmlAstNode) => {
+/** Carries raw Windows drive paths through the sanitizer to the image renderer. */
+function rehypePreserveWindowsImageSrc() {
+  return (tree: MarkdownImageHastNode) => {
+    const visit = (node: MarkdownImageHastNode) => {
       const src = node.properties?.src;
       if (
         node.type === "element" &&
         node.tagName === "img" &&
         typeof src === "string" &&
-        WINDOWS_DRIVE_PATH_REGEX.test(src)
+        isWindowsDrivePathHref(src)
       ) {
-        node.properties = {
-          ...node.properties,
-          src: `file:///${src.replaceAll("\\", "/")}`,
-        };
+        node.properties = { ...node.properties, dataLocalSrc: src };
       }
       node.children?.forEach(visit);
     };
@@ -274,6 +277,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
     blockquote: [...(defaultSchema.attributes?.blockquote ?? []), "dataAlert"],
+    img: [...(defaultSchema.attributes?.img ?? []), "dataLocalSrc"],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -301,7 +305,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
   rehypeRaw,
-  rehypeNormalizeWindowsImageSrc,
+  rehypePreserveWindowsImageSrc,
   [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
 ] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
@@ -1045,21 +1049,60 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
   );
 });
 
-const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME =
-  "h-auto w-auto max-h-[30rem] max-w-[min(100%,30rem)] object-contain";
-
-// block! outranks the unlayered `.chat-markdown img { display: inline-block }`
-// rule, keeping workspace images on the same block layout as their placeholder.
-const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
-  CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
-  "my-1 block! rounded-lg border border-border/40",
+const CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME = "max-h-[30rem] max-w-[min(100%,30rem)]";
+const CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME = "align-bottom";
+const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
+  "h-auto w-auto object-contain",
+  CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
 );
 
-function ChatMarkdownImageFallback(props: { readonly alt: string }) {
+function authoredImageSizeStyle(
+  width: string | number | undefined,
+  height: string | number | undefined,
+): CSSProperties | undefined {
+  const parsedWidth = Number(width);
+  const parsedHeight = Number(height);
+  const hasWidth = Number.isFinite(parsedWidth) && parsedWidth > 0;
+  const hasHeight = Number.isFinite(parsedHeight) && parsedHeight > 0;
+  if (hasWidth && hasHeight) {
+    return {
+      width: parsedWidth,
+      height: "auto",
+      aspectRatio: `${parsedWidth} / ${parsedHeight}`,
+      maxWidth: `min(100%, 30rem, ${(30 * parsedWidth) / parsedHeight}rem)`,
+    };
+  }
+  if (hasWidth) return { maxWidth: `min(100%, 30rem, ${parsedWidth}px)` };
+  if (hasHeight) return { maxHeight: `min(30rem, ${parsedHeight}px)` };
+  return undefined;
+}
+
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = cn(
+  "inline-block!",
+  CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME,
+);
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
+  CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
+  CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
+  "rounded-lg border border-border/40",
+);
+
+function ChatMarkdownImageFallback(props: {
+  readonly alt: string;
+  readonly copyMarkdown?: string | undefined;
+}) {
   return (
-    <span className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
-      <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
-      {props.alt.length > 0 ? `Image unavailable · ${props.alt}` : "Image unavailable"}
+    <span
+      data-markdown-copy={props.copyMarkdown}
+      className={cn(
+        CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
+        "rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground",
+      )}
+    >
+      <span className="inline-flex items-center gap-1.5">
+        <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
+        {props.alt.length > 0 ? `Image unavailable · ${props.alt}` : "Image unavailable"}
+      </span>
     </span>
   );
 }
@@ -1069,6 +1112,9 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   readonly threadRef: ScopedThreadRef;
   readonly path: string;
   readonly alt: string;
+  readonly copyMarkdown: string;
+  readonly srcFragment: string;
+  readonly style?: CSSProperties | undefined;
 }) {
   const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
     _tag: "workspace-file",
@@ -1078,24 +1124,32 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
 
   if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
-    return <ChatMarkdownImageFallback alt={props.alt} />;
+    return <ChatMarkdownImageFallback alt={props.alt} copyMarkdown={props.copyMarkdown} />;
   }
   if (assetUrl._tag !== "Success") {
     return (
       <span
+        data-markdown-copy={props.copyMarkdown}
         role="status"
         aria-label="Loading image"
-        className="my-1 block aspect-video w-full max-w-[30rem] rounded-lg bg-muted/60"
+        className={cn(
+          CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
+          "aspect-video w-64 max-w-full rounded-lg bg-muted/60",
+          CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
+        )}
+        style={props.style}
       />
     );
   }
   return (
     <img
-      src={assetUrl.url}
+      src={assetUrl.url + props.srcFragment}
       alt={props.alt}
+      data-markdown-copy={props.copyMarkdown}
       loading="lazy"
       draggable={false}
       className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
+      style={props.style}
       onError={() => setFailedUrl(assetUrl.url)}
     />
   );
@@ -1636,6 +1690,7 @@ function ChatMarkdown({
   className,
   lineBreaks = false,
   parseRawHtml = true,
+  imageBaseDir,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -1729,6 +1784,7 @@ function ChatMarkdown({
     return buildFileLinkParentSuffixByPath(filePaths);
   }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
+    if (isWindowsDrivePathHref(href)) return href;
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
   // Re-emit highlighted content as markdown so copying out of the rendered
@@ -2146,10 +2202,16 @@ function ChatMarkdown({
           </code>
         );
       },
-      img({ node: _node, title: _title, src, alt, ...props }) {
-        const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
+      img({ node, title: _title, src, alt, ...props }) {
+        const localSrc = node?.properties?.dataLocalSrc;
+        const authoredSrc = typeof localSrc === "string" ? localSrc : src;
+        const srcString =
+          typeof authoredSrc === "string" ? normalizeMarkdownLinkDestination(authoredSrc) : "";
+        const classifiedSrc =
+          typeof localSrc === "string" ? srcString.replaceAll("\\", "/") : srcString;
         const altText = alt ?? "";
-        const imageSource = classifyMarkdownImageSource(srcString, cwd);
+        const authoredSizeStyle = authoredImageSizeStyle(props.width, props.height);
+        const imageSource = classifyMarkdownImageSource(classifiedSrc, imageBaseDir ?? cwd);
         if (imageSource._tag === "Direct") {
           return (
             <img
@@ -2158,6 +2220,7 @@ function ChatMarkdown({
               alt={altText}
               loading="lazy"
               className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
+              style={authoredSizeStyle}
             />
           );
         }
@@ -2167,10 +2230,15 @@ function ChatMarkdown({
               threadRef={threadRef}
               path={imageSource.path}
               alt={altText}
+              copyMarkdown={`![${altText}](${srcString})`}
+              srcFragment={markdownImageSourceFragment(classifiedSrc)}
+              style={authoredSizeStyle}
             />
           );
         }
-        return <ChatMarkdownImageFallback alt={altText} />;
+        return (
+          <ChatMarkdownImageFallback alt={altText} copyMarkdown={`![${altText}](${srcString})`} />
+        );
       },
       table({ node: _node, ...props }) {
         return <MarkdownTable {...props} />;
@@ -2213,6 +2281,7 @@ function ChatMarkdown({
     diffThemeName,
     fileLinkParentSuffixByPath,
     inlineCodeFileLinkMetaByText,
+    imageBaseDir,
     isStreaming,
     markdownFileLinkMetaByHref,
     onTaskListChange,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1057,8 +1057,10 @@ const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
 );
 
 function markdownImageCopy(alt: string, src: string, title: string | undefined): string {
-  const titleSuffix = title === undefined ? "" : ` "${title.replaceAll('"', '\\"')}"`;
-  return `![${alt}](${src}${titleSuffix})`;
+  const escapedAlt = alt.replaceAll("\\", "\\\\").replaceAll("[", "\\[").replaceAll("]", "\\]");
+  const titleSuffix =
+    title === undefined ? "" : ` "${title.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+  return `![${escapedAlt}](${src}${titleSuffix})`;
 }
 
 function authoredImageSizeStyle(

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1050,7 +1050,6 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
 });
 
 const CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME = "max-h-[30rem] max-w-[min(100%,30rem)]";
-const CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME = "align-bottom";
 const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
   "h-auto w-auto object-contain",
   CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
@@ -1084,10 +1083,7 @@ function authoredImageSizeStyle(
   return undefined;
 }
 
-const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = cn(
-  "inline-block!",
-  CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME,
-);
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = "inline-block!";
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
   CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -250,18 +250,18 @@ type MarkdownImageHastNode = {
   children?: MarkdownImageHastNode[];
 };
 
-/** Carries raw Windows drive paths through the sanitizer to the image renderer. */
-function rehypePreserveWindowsImageSrc() {
+/** Carries authored image source metadata through the sanitizer to the image renderer. */
+function rehypePreserveImageSourceMeta() {
   return (tree: MarkdownImageHastNode) => {
     const visit = (node: MarkdownImageHastNode) => {
       const src = node.properties?.src;
-      if (
-        node.type === "element" &&
-        node.tagName === "img" &&
-        typeof src === "string" &&
-        isWindowsDrivePathHref(src)
-      ) {
-        node.properties = { ...node.properties, dataLocalSrc: src };
+      const title = node.properties?.title;
+      if (node.type === "element" && node.tagName === "img") {
+        node.properties = {
+          ...node.properties,
+          ...(typeof src === "string" && isWindowsDrivePathHref(src) ? { dataLocalSrc: src } : {}),
+          ...(typeof title === "string" ? { dataMarkdownTitle: title } : {}),
+        };
       }
       node.children?.forEach(visit);
     };
@@ -277,7 +277,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
     blockquote: [...(defaultSchema.attributes?.blockquote ?? []), "dataAlert"],
-    img: [...(defaultSchema.attributes?.img ?? []), "dataLocalSrc"],
+    img: [...(defaultSchema.attributes?.img ?? []), "dataLocalSrc", "dataMarkdownTitle"],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -305,7 +305,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
   rehypeRaw,
-  rehypePreserveWindowsImageSrc,
+  rehypePreserveImageSourceMeta,
   [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
 ] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
@@ -1055,6 +1055,11 @@ const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
   "h-auto w-auto object-contain",
   CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
 );
+
+function markdownImageCopy(alt: string, src: string, title: string | undefined): string {
+  const titleSuffix = title === undefined ? "" : ` "${title.replaceAll('"', '\\"')}"`;
+  return `![${alt}](${src}${titleSuffix})`;
+}
 
 function authoredImageSizeStyle(
   width: string | number | undefined,
@@ -2202,14 +2207,17 @@ function ChatMarkdown({
           </code>
         );
       },
-      img({ node, title: _title, src, alt, ...props }) {
+      img({ node, title, src, alt, ...props }) {
         const localSrc = node?.properties?.dataLocalSrc;
+        const markdownTitle = node?.properties?.dataMarkdownTitle;
         const authoredSrc = typeof localSrc === "string" ? localSrc : src;
+        const authoredTitle = typeof markdownTitle === "string" ? markdownTitle : title;
         const srcString =
           typeof authoredSrc === "string" ? normalizeMarkdownLinkDestination(authoredSrc) : "";
         const classifiedSrc =
           typeof localSrc === "string" ? srcString.replaceAll("\\", "/") : srcString;
         const altText = alt ?? "";
+        const copyMarkdown = markdownImageCopy(altText, srcString, authoredTitle);
         const authoredSizeStyle = authoredImageSizeStyle(props.width, props.height);
         const imageSource = classifyMarkdownImageSource(classifiedSrc, imageBaseDir ?? cwd);
         if (imageSource._tag === "Direct") {
@@ -2230,15 +2238,13 @@ function ChatMarkdown({
               threadRef={threadRef}
               path={imageSource.path}
               alt={altText}
-              copyMarkdown={`![${altText}](${srcString})`}
+              copyMarkdown={copyMarkdown}
               srcFragment={markdownImageSourceFragment(classifiedSrc)}
               style={authoredSizeStyle}
             />
           );
         }
-        return (
-          <ChatMarkdownImageFallback alt={altText} copyMarkdown={`![${altText}](${srcString})`} />
-        );
+        return <ChatMarkdownImageFallback alt={altText} copyMarkdown={copyMarkdown} />;
       },
       table({ node: _node, ...props }) {
         return <MarkdownTable {...props} />;

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -2,8 +2,6 @@ import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { serializeRenderedMarkdownFragment } from "../markdown-clipboard";
-
 const testState = vi.hoisted(() => ({
   resources: [] as Array<unknown>,
   assetState: "success" as "success" | "loading" | "failure",
@@ -51,14 +49,9 @@ const threadRef = {
   threadId: ThreadId.make("thread-windows"),
 };
 
-function render(markdown: string, parseRawHtml = true): string {
+function render(markdown: string): string {
   return renderToStaticMarkup(
-    <ChatMarkdown
-      cwd={"C:\\Users\\shawn\\project"}
-      threadRef={threadRef}
-      text={markdown}
-      parseRawHtml={parseRawHtml}
-    />,
+    <ChatMarkdown cwd={"C:\\Users\\shawn\\project"} threadRef={threadRef} text={markdown} />,
   );
 }
 
@@ -77,27 +70,10 @@ function renderFilePreview(cwd: string, relativePath: string): string {
   );
 }
 
-const TEXT_NODE = 3;
-const ELEMENT_NODE = 1;
-
 function copiedMarkdownFrom(html: string): string {
   const copy = /data-markdown-copy="([^"]*)"/.exec(html)?.[1]?.replaceAll("&quot;", '"');
   expect(copy).toBeDefined();
-  const element = {
-    nodeType: ELEMENT_NODE,
-    childNodes: [],
-    getAttribute: (name: string) => (name === "data-markdown-copy" ? copy : null),
-    hasAttribute: (name: string) => name === "data-markdown-copy",
-  };
-  const container = {
-    childNodes: [element],
-  };
-  vi.stubGlobal("Node", { TEXT_NODE, ELEMENT_NODE });
-  try {
-    return serializeRenderedMarkdownFragment(container as unknown as Node);
-  } finally {
-    vi.unstubAllGlobals();
-  }
+  return copy ?? "";
 }
 
 function firstInlineStyle(html: string): Record<string, string> {
@@ -124,6 +100,7 @@ describe("ChatMarkdown workspace images", () => {
       "docs\\README.md",
       "C:\\Users\\shawn\\project\\docs\\images\\diagram.png",
     ],
+    ["/workspace/project", "README.md", "/workspace/project/images/diagram.png"],
   ])("resolves images beside a nested file in %s", (cwd, relativePath, expectedPath) => {
     renderFilePreview(cwd, relativePath);
 
@@ -180,14 +157,6 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("https://signed.test/workspace-image.svg");
   });
 
-  it("keeps raw workspace images inline for authored paragraph alignment", () => {
-    const html = render('<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>');
-    const className = /<img[^>]*class="([^"]*)"/.exec(html)?.[1];
-
-    expect(className?.split(" ")).toContain("inline-block!");
-    expect(className?.split(" ")).not.toContain("block!");
-  });
-
   it("keeps a tall image placeholder and loaded image at the same proportional bounds", () => {
     const markdown = '<img src=".t3/workspace-image.svg" alt="sized" width="96" height="128">';
     const loadedStyle = firstInlineStyle(render(markdown));
@@ -209,15 +178,12 @@ describe("ChatMarkdown workspace images", () => {
   ])("treats a lone authored %s as a cap", (axis, constraint, expectedValue) => {
     const markdown = `<img src=".t3/workspace-image.svg" alt="sized" ${axis}="300">`;
     const loadedStyle = firstInlineStyle(render(markdown));
-    testState.assetState = "loading";
-    const loadingStyle = firstInlineStyle(render(markdown));
 
     expect(loadedStyle).not.toHaveProperty(axis);
     expect(loadedStyle).toHaveProperty(constraint, expectedValue);
-    expect(loadingStyle).toEqual(loadedStyle);
   });
 
-  it("keeps direct images baseline-aligned and workspace images bottom-aligned", () => {
+  it("keeps direct images baseline-aligned, workspace images bottom-aligned, and centered raw images inline", () => {
     const html = render(
       "![remote](https://example.com/badge.svg) ![workspace](.t3/workspace-image.svg)",
     );
@@ -228,29 +194,31 @@ describe("ChatMarkdown workspace images", () => {
     expect(classNames).toHaveLength(2);
     expect(classNames[0]).not.toContain("align-bottom");
     expect(classNames[1]).toContain("align-bottom");
-    for (const classes of classNames) {
-      expect(classes).not.toContain("my-1");
-    }
+
+    const centeredHtml = render(
+      '<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>',
+    );
+    const centeredClassName = /<img[^>]*class="([^"]*)"/.exec(centeredHtml)?.[1];
+
+    expect(centeredClassName?.split(" ")).toContain("inline-block!");
   });
 
   it("retains an authored SVG fragment on the signed URL", () => {
     const html = render("![logo](icons.svg#logo)");
 
-    expect(testState.resources).toEqual([
-      {
-        _tag: "workspace-file",
-        threadId: threadRef.threadId,
-        path: "C:\\Users\\shawn\\project\\icons.svg",
-      },
-    ]);
     expect(html).toContain('src="https://signed.test/workspace-image.svg#logo"');
   });
 
-  it.each(["success", "loading", "failure"] as const)(
-    "copies the authored workspace source while the asset is %s",
-    (assetState) => {
-      testState.assetState = assetState;
+  it.each(["success", "loading", "failure", "no-thread"] as const)(
+    "copies the authored workspace source (%s)",
+    (scenario) => {
+      if (scenario === "no-thread") {
+        const html = renderWithoutThread("![diagram](images/diagram.png)");
+        expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png)");
+        return;
+      }
 
+      testState.assetState = scenario;
       const html = render("![diagram](images/diagram.png#preview)");
 
       expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png#preview)");
@@ -263,20 +231,8 @@ describe("ChatMarkdown workspace images", () => {
     expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My Title")');
   });
 
-  it("copies the authored workspace source when no thread can sign it", () => {
-    const html = renderWithoutThread("![diagram](images/diagram.png)");
-
-    expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png)");
-  });
-
-  it("copies an authored title when no thread can sign the image", () => {
-    const html = renderWithoutThread('![logo](images/logo.svg "My Title")');
-
-    expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My Title")');
-  });
-
   it("escapes double quotes in an authored image title", () => {
-    const html = render(`![logo](images/logo.svg 'My "Title"')`, false);
+    const html = render(`![logo](images/logo.svg 'My "Title"')`);
 
     expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My \\"Title\\"")');
   });
@@ -312,7 +268,6 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain('aria-label="Loading image"');
     expect(html).not.toContain("animate-pulse");
     expect(className?.split(" ")).toContain("w-64");
-    expect(className?.split(" ")).not.toContain("w-full");
   });
 
   it("never passes a workspace source to a raw image when thread context is unavailable", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -281,6 +281,28 @@ describe("ChatMarkdown workspace images", () => {
     expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My \\"Title\\"")');
   });
 
+  it("escapes a closing bracket in authored image alt text", () => {
+    const markdown = String.raw`![build\] badge](badge.svg)`;
+
+    expect(copiedMarkdownFrom(render(markdown))).toBe(markdown);
+  });
+
+  it("escapes a literal backslash in authored image alt text", () => {
+    const markdown = String.raw`![folder\\name](badge.svg)`;
+
+    expect(copiedMarkdownFrom(render(markdown))).toBe(markdown);
+  });
+
+  it("escapes a literal backslash before a quote in an authored image title", () => {
+    const html = render(
+      String.raw`<img src="images/logo.svg" alt="logo" title="Path \&quot;Title\&quot;">`,
+    );
+
+    expect(copiedMarkdownFrom(html)).toBe(
+      String.raw`![logo](images/logo.svg "Path \\\"Title\\\"")`,
+    );
+  });
+
   it("uses a static bounded-width placeholder while a signed asset URL loads", () => {
     testState.assetState = "loading";
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -51,9 +51,14 @@ const threadRef = {
   threadId: ThreadId.make("thread-windows"),
 };
 
-function render(markdown: string): string {
+function render(markdown: string, parseRawHtml = true): string {
   return renderToStaticMarkup(
-    <ChatMarkdown cwd={"C:\\Users\\shawn\\project"} threadRef={threadRef} text={markdown} />,
+    <ChatMarkdown
+      cwd={"C:\\Users\\shawn\\project"}
+      threadRef={threadRef}
+      text={markdown}
+      parseRawHtml={parseRawHtml}
+    />,
   );
 }
 
@@ -76,7 +81,7 @@ const TEXT_NODE = 3;
 const ELEMENT_NODE = 1;
 
 function copiedMarkdownFrom(html: string): string {
-  const copy = /data-markdown-copy="([^"]*)"/.exec(html)?.[1];
+  const copy = /data-markdown-copy="([^"]*)"/.exec(html)?.[1]?.replaceAll("&quot;", '"');
   expect(copy).toBeDefined();
   const element = {
     nodeType: ELEMENT_NODE,
@@ -252,10 +257,28 @@ describe("ChatMarkdown workspace images", () => {
     },
   );
 
+  it("copies an authored title with a workspace image", () => {
+    const html = render('![logo](images/logo.svg "My Title")');
+
+    expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My Title")');
+  });
+
   it("copies the authored workspace source when no thread can sign it", () => {
     const html = renderWithoutThread("![diagram](images/diagram.png)");
 
     expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png)");
+  });
+
+  it("copies an authored title when no thread can sign the image", () => {
+    const html = renderWithoutThread('![logo](images/logo.svg "My Title")');
+
+    expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My Title")');
+  });
+
+  it("escapes double quotes in an authored image title", () => {
+    const html = render(`![logo](images/logo.svg 'My "Title"')`, false);
+
+    expect(copiedMarkdownFrom(html)).toBe('![logo](images/logo.svg "My \\"Title\\"")');
   });
 
   it("uses a static bounded-width placeholder while a signed asset URL loads", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -183,7 +183,7 @@ describe("ChatMarkdown workspace images", () => {
     expect(loadedStyle).toHaveProperty(constraint, expectedValue);
   });
 
-  it("keeps direct images baseline-aligned, workspace images bottom-aligned, and centered raw images inline", () => {
+  it("keeps all images baseline-aligned and workspace images inline", () => {
     const html = render(
       "![remote](https://example.com/badge.svg) ![workspace](.t3/workspace-image.svg)",
     );
@@ -192,8 +192,7 @@ describe("ChatMarkdown workspace images", () => {
     );
 
     expect(classNames).toHaveLength(2);
-    expect(classNames[0]).not.toContain("align-bottom");
-    expect(classNames[1]).toContain("align-bottom");
+    expect(classNames[1]).toContain("inline-block!");
 
     const centeredHtml = render(
       '<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>',

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -2,18 +2,20 @@ import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { serializeRenderedMarkdownFragment } from "../markdown-clipboard";
+
 const testState = vi.hoisted(() => ({
   resources: [] as Array<unknown>,
-  assetState: "success" as "success" | "loading",
+  assetState: "success" as "success" | "loading" | "failure",
 }));
 
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
 vi.mock("../assets/assetUrls", () => ({
   useAssetUrlState: (_environmentId: unknown, resource: unknown) => {
     testState.resources.push(resource);
-    return testState.assetState === "loading"
-      ? { _tag: "Loading" }
-      : { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
+    if (testState.assetState === "loading") return { _tag: "Loading" };
+    if (testState.assetState === "failure") return { _tag: "Failure" };
+    return { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
   },
 }));
 vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -42,6 +44,7 @@ vi.mock("~/lib/openPullRequestLink", () => ({
 }));
 
 import ChatMarkdown from "./ChatMarkdown";
+import { FileMarkdownPreview } from "./files/FileMarkdownPreview";
 
 const threadRef = {
   environmentId: EnvironmentId.make("env-windows"),
@@ -58,10 +61,74 @@ function renderWithoutThread(markdown: string): string {
   return renderToStaticMarkup(<ChatMarkdown cwd={"C:\\Users\\shawn\\project"} text={markdown} />);
 }
 
+function renderFilePreview(cwd: string, relativePath: string): string {
+  return renderToStaticMarkup(
+    <FileMarkdownPreview
+      cwd={cwd}
+      relativePath={relativePath}
+      text="![diagram](images/diagram.png)"
+      threadRef={threadRef}
+    />,
+  );
+}
+
+const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+function copiedMarkdownFrom(html: string): string {
+  const copy = /data-markdown-copy="([^"]*)"/.exec(html)?.[1];
+  expect(copy).toBeDefined();
+  const element = {
+    nodeType: ELEMENT_NODE,
+    childNodes: [],
+    getAttribute: (name: string) => (name === "data-markdown-copy" ? copy : null),
+    hasAttribute: (name: string) => name === "data-markdown-copy",
+  };
+  const container = {
+    childNodes: [element],
+  };
+  vi.stubGlobal("Node", { TEXT_NODE, ELEMENT_NODE });
+  try {
+    return serializeRenderedMarkdownFragment(container as unknown as Node);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}
+
+function firstInlineStyle(html: string): Record<string, string> {
+  const style = /style="([^"]+)"/.exec(html)?.[1];
+  expect(style).toBeDefined();
+  return Object.fromEntries(
+    (style ?? "").split(";").map((declaration) => {
+      const separator = declaration.indexOf(":");
+      return [declaration.slice(0, separator), declaration.slice(separator + 1)];
+    }),
+  );
+}
+
 describe("ChatMarkdown workspace images", () => {
   beforeEach(() => {
     testState.resources = [];
     testState.assetState = "success";
+  });
+
+  it.each([
+    ["/workspace/project", "docs/README.md", "/workspace/project/docs/images/diagram.png"],
+    [
+      "C:\\Users\\shawn\\project",
+      "docs\\README.md",
+      "C:\\Users\\shawn\\project\\docs\\images\\diagram.png",
+    ],
+  ])("resolves images beside a nested file in %s", (cwd, relativePath, expectedPath) => {
+    renderFilePreview(cwd, relativePath);
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: expectedPath,
+      },
+    ]);
   });
 
   it("loads every Windows workspace path form through a signed asset URL", () => {
@@ -108,13 +175,99 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("https://signed.test/workspace-image.svg");
   });
 
-  it("uses a static placeholder while a signed asset URL loads", () => {
+  it("keeps raw workspace images inline for authored paragraph alignment", () => {
+    const html = render('<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>');
+    const className = /<img[^>]*class="([^"]*)"/.exec(html)?.[1];
+
+    expect(className?.split(" ")).toContain("inline-block!");
+    expect(className?.split(" ")).not.toContain("block!");
+  });
+
+  it("keeps a tall image placeholder and loaded image at the same proportional bounds", () => {
+    const markdown = '<img src=".t3/workspace-image.svg" alt="sized" width="96" height="128">';
+    const loadedStyle = firstInlineStyle(render(markdown));
+    testState.assetState = "loading";
+    const loadingStyle = firstInlineStyle(render(markdown));
+
+    expect(loadedStyle).toMatchObject({
+      width: "96px",
+      height: "auto",
+      "aspect-ratio": "96 / 128",
+      "max-width": "min(100%, 30rem, 22.5rem)",
+    });
+    expect(loadingStyle).toEqual(loadedStyle);
+  });
+
+  it.each([
+    ["width", "max-width", "min(100%, 30rem, 300px)"],
+    ["height", "max-height", "min(30rem, 300px)"],
+  ])("treats a lone authored %s as a cap", (axis, constraint, expectedValue) => {
+    const markdown = `<img src=".t3/workspace-image.svg" alt="sized" ${axis}="300">`;
+    const loadedStyle = firstInlineStyle(render(markdown));
+    testState.assetState = "loading";
+    const loadingStyle = firstInlineStyle(render(markdown));
+
+    expect(loadedStyle).not.toHaveProperty(axis);
+    expect(loadedStyle).toHaveProperty(constraint, expectedValue);
+    expect(loadingStyle).toEqual(loadedStyle);
+  });
+
+  it("keeps direct images baseline-aligned and workspace images bottom-aligned", () => {
+    const html = render(
+      "![remote](https://example.com/badge.svg) ![workspace](.t3/workspace-image.svg)",
+    );
+    const classNames = Array.from(html.matchAll(/<img[^>]*class="([^"]*)"/g), (match) =>
+      match[1]?.split(" "),
+    );
+
+    expect(classNames).toHaveLength(2);
+    expect(classNames[0]).not.toContain("align-bottom");
+    expect(classNames[1]).toContain("align-bottom");
+    for (const classes of classNames) {
+      expect(classes).not.toContain("my-1");
+    }
+  });
+
+  it("retains an authored SVG fragment on the signed URL", () => {
+    const html = render("![logo](icons.svg#logo)");
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: "C:\\Users\\shawn\\project\\icons.svg",
+      },
+    ]);
+    expect(html).toContain('src="https://signed.test/workspace-image.svg#logo"');
+  });
+
+  it.each(["success", "loading", "failure"] as const)(
+    "copies the authored workspace source while the asset is %s",
+    (assetState) => {
+      testState.assetState = assetState;
+
+      const html = render("![diagram](images/diagram.png#preview)");
+
+      expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png#preview)");
+    },
+  );
+
+  it("copies the authored workspace source when no thread can sign it", () => {
+    const html = renderWithoutThread("![diagram](images/diagram.png)");
+
+    expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png)");
+  });
+
+  it("uses a static bounded-width placeholder while a signed asset URL loads", () => {
     testState.assetState = "loading";
 
     const html = render("![loading](.t3/workspace-image.svg)");
+    const className = /<span[^>]*aria-label="Loading image"[^>]*class="([^"]*)"/.exec(html)?.[1];
 
     expect(html).toContain('aria-label="Loading image"');
     expect(html).not.toContain("animate-pulse");
+    expect(className?.split(" ")).toContain("w-64");
+    expect(className?.split(" ")).not.toContain("w-full");
   });
 
   it("never passes a workspace source to a raw image when thread context is unavailable", () => {

--- a/apps/web/src/components/files/FileMarkdownPreview.tsx
+++ b/apps/web/src/components/files/FileMarkdownPreview.tsx
@@ -1,0 +1,34 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import ChatMarkdown from "~/components/ChatMarkdown";
+import { resolvePathLinkTarget } from "~/terminal-links";
+
+export function FileMarkdownPreview(props: {
+  readonly cwd: string;
+  readonly relativePath: string;
+  readonly text: string;
+  readonly threadRef: ScopedThreadRef;
+  readonly onTaskListChange?:
+    | ((input: { readonly markerOffset: number; readonly checked: boolean }) => void)
+    | undefined;
+}) {
+  const lastSeparator = Math.max(
+    props.relativePath.lastIndexOf("/"),
+    props.relativePath.lastIndexOf("\\"),
+  );
+  const imageBaseDir =
+    lastSeparator >= 0
+      ? resolvePathLinkTarget(props.relativePath.slice(0, lastSeparator), props.cwd)
+      : props.cwd;
+
+  return (
+    <ChatMarkdown
+      text={props.text}
+      cwd={props.cwd}
+      imageBaseDir={imageBaseDir}
+      threadRef={props.threadRef}
+      className="mx-auto max-w-4xl px-6 py-5"
+      onTaskListChange={props.onTaskListChange}
+    />
+  );
+}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -18,7 +18,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { isBrowserPreviewFile, openFileInPreview } from "~/browser/openFileInPreview";
 import { useAssetUrlState } from "~/assets/assetUrls";
-import ChatMarkdown from "~/components/ChatMarkdown";
 import { OpenInPicker } from "~/components/chat/OpenInPicker";
 import { useRemoteOpenState } from "~/remoteOpen";
 import { useClientSettings } from "~/hooks/useSettings";
@@ -42,6 +41,7 @@ import { useAtomCommand } from "~/state/use-atom-command";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
 import FileBrowserPanel from "./FileBrowserPanel";
+import { FileMarkdownPreview } from "./FileMarkdownPreview";
 import {
   type FileCommentAnnotationEntry,
   type FileCommentAnnotationGroup,
@@ -727,11 +727,11 @@ function RenderedMarkdownSurface({
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <ChatMarkdown
+      <FileMarkdownPreview
         text={contents}
         cwd={cwd}
+        relativePath={relativePath}
         threadRef={threadRef}
-        className="mx-auto max-w-4xl px-6 py-5"
         onTaskListChange={({ markerOffset, checked }) => {
           const currentContents =
             getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 
 import {
   extractMarkdownLinkHrefs,
+  isWindowsDrivePathHref,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
@@ -12,6 +13,20 @@ import {
   shouldOpenMarkdownFileLinkInBrowserByDefault,
   shouldOpenMarkdownFileLinkInEditor,
 } from "./markdown-links";
+
+describe("isWindowsDrivePathHref", () => {
+  it("recognizes plain drive paths", () => {
+    expect(isWindowsDrivePathHref("C:\\repo\\image.png")).toBe(true);
+  });
+
+  it("recognizes percent-encoded drive paths", () => {
+    expect(isWindowsDrivePathHref("C:%5Crepo%5Cimage.png")).toBe(true);
+  });
+
+  it("rejects https URLs", () => {
+    expect(isWindowsDrivePathHref("https://example.com/image.png")).toBe(false);
+  });
+});
 
 function renderMarkdownLinkHref(markdown: string): string | undefined {
   let renderedHref: string | undefined;

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -15,16 +15,12 @@ import {
 } from "./markdown-links";
 
 describe("isWindowsDrivePathHref", () => {
-  it("recognizes plain drive paths", () => {
-    expect(isWindowsDrivePathHref("C:\\repo\\image.png")).toBe(true);
-  });
-
-  it("recognizes percent-encoded drive paths", () => {
-    expect(isWindowsDrivePathHref("C:%5Crepo%5Cimage.png")).toBe(true);
-  });
-
-  it("rejects https URLs", () => {
-    expect(isWindowsDrivePathHref("https://example.com/image.png")).toBe(false);
+  it.each([
+    ["C:\\repo\\image.png", true],
+    ["C:%5Crepo%5Cimage.png", true],
+    ["https://example.com/image.png", false],
+  ])("classifies %s as %s", (href, expected) => {
+    expect(isWindowsDrivePathHref(href)).toBe(expected);
   });
 });
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -84,6 +84,10 @@ function safeDecode(value: string): string {
   }
 }
 
+export function isWindowsDrivePathHref(href: string): boolean {
+  return WINDOWS_DRIVE_PATH_PATTERN.test(safeDecode(href));
+}
+
 function unwrapMarkdownLinkDestination(value: string): string {
   return value.startsWith("<") && value.endsWith(">") ? value.slice(1, -1) : value;
 }

--- a/packages/client-runtime/src/markdownImages.test.ts
+++ b/packages/client-runtime/src/markdownImages.test.ts
@@ -62,11 +62,10 @@ describe("classifyMarkdownImageSource", () => {
 });
 
 describe("markdownImageSourceFragment", () => {
-  it("returns only the fragment from an angle-bracketed source with a query", () => {
-    expect(markdownImageSourceFragment("<icons.svg?version=2#logo>")).toBe("#logo");
-  });
-
-  it("ignores a query when the source has no fragment", () => {
-    expect(markdownImageSourceFragment("icons.svg?version=2")).toBe("");
+  it.each([
+    ["<icons.svg?version=2#logo>", "#logo"],
+    ["icons.svg?version=2", ""],
+  ])("extracts %s as %s", (source, fragment) => {
+    expect(markdownImageSourceFragment(source)).toBe(fragment);
   });
 });

--- a/packages/client-runtime/src/markdownImages.test.ts
+++ b/packages/client-runtime/src/markdownImages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { classifyMarkdownImageSource } from "./markdownImages.js";
+import { classifyMarkdownImageSource, markdownImageSourceFragment } from "./markdownImages.js";
 
 describe("classifyMarkdownImageSource", () => {
   it.each([
@@ -58,5 +58,15 @@ describe("classifyMarkdownImageSource", () => {
     "file://%",
   ])("blocks unsupported or unresolved source %s", (source) => {
     expect(classifyMarkdownImageSource(source)).toEqual({ _tag: "Blocked" });
+  });
+});
+
+describe("markdownImageSourceFragment", () => {
+  it("returns only the fragment from an angle-bracketed source with a query", () => {
+    expect(markdownImageSourceFragment("<icons.svg?version=2#logo>")).toBe("#logo");
+  });
+
+  it("ignores a query when the source has no fragment", () => {
+    expect(markdownImageSourceFragment("icons.svg?version=2")).toBe("");
   });
 });

--- a/packages/client-runtime/src/markdownImages.ts
+++ b/packages/client-runtime/src/markdownImages.ts
@@ -20,6 +20,12 @@ function normalizeSource(value: string): string {
   return trimmed.startsWith("<") && trimmed.endsWith(">") ? trimmed.slice(1, -1) : trimmed;
 }
 
+export function markdownImageSourceFragment(source: string): string {
+  const normalizedSource = normalizeSource(source);
+  const hashIndex = normalizedSource.indexOf("#");
+  return hashIndex >= 0 ? normalizedSource.slice(hashIndex) : "";
+}
+
 function normalizeWindowsDrivePath(value: string): string {
   return /^\/[A-Za-z]:[\\/]/.test(value) ? value.slice(1) : value;
 }


### PR DESCRIPTION
## Problem

#6433 added image rendering to chat markdown, but file previews still resolve relative image paths from the project root. Images work by coincidence in a root `README.md`, while nested files such as `docs/README.md` look for assets in the wrong directory.

The web renderer has a few related problems:

- image dimensions and alignment are not preserved reliably. High-density review buttons can render at their source size instead of their requested display size, covering the case described in #8314.
- Windows drive paths can be stripped before image resolution.
- SVG fragments such as `icon.svg#logo` disappear when T3 replaces the source with a signed asset URL.
- Copying a workspace image can capture the temporary signed URL instead of its original markdown.

## Fix

File previews now resolve relative images from the directory containing the markdown document.

The web markdown renderer now:

- preserves Windows image paths through sanitization
- retains SVG fragments on signed asset URLs
- copies the authored markdown in loading, success, and failure states
- honors authored width and height while keeping images proportional and bounded
- follows authored alignment and keeps inline images on the text baseline

This PR is web-only. 

## UI changes

These pics come from #7857. Web is unchanged by the branch split.

### Nested README before

The renderer searches from the project root and cannot find the image.

<img width="554" height="240" alt="Nested README before" src="https://github.com/user-attachments/assets/c9a56c1b-ba84-4795-9f86-3b9b8cd9fcf6" />

### Root README before

The image loads, but its size is ignored.

<img width="538" height="641" alt="Root README before" src="https://github.com/user-attachments/assets/b1eb1491-5963-4f6e-971e-84c7b3aaadfb" />

### File preview after

The nested image resolves and renders at the correct size.

<img width="535" height="327" alt="File preview after" src="https://github.com/user-attachments/assets/58c25fee-225e-4021-ba36-a53554088680" />

### Pull request viewer Before
<img width="1052" height="543" alt="PR viewer before" src="https://github.com/user-attachments/assets/2212122a-2300-4099-9af1-b3d2994b2c96" /> 

### Pull request viewer after
<img width="731" height="259" alt="PR viewer after" src="https://github.com/user-attachments/assets/016f95a1-c580-426f-9c23-634563bb0d08" /> |

## Verification

- `vp test run apps/web/src/components/ChatMarkdown.workspace-images.test.tsx apps/web/src/markdown-links.test.ts packages/client-runtime/src/markdownImages.test.ts`, 102 tests passed
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/client-runtime typecheck`
- Targeted lint and formatting checks for all changed files
- `git diff --check`

Changes prepared by GPT-5.6 Sol through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nested markdown image rendering in `ChatMarkdown`
> - Replaces `rehypeNormalizeWindowsImageSrc` with `rehypePreserveImageSourceMeta`, which carries authored `src` and `title` through sanitization via `dataLocalSrc` and `dataMarkdownTitle` attributes on `<img>` nodes
> - Reworks the image renderer in `ChatMarkdown` to preserve authored src/title, respect Windows drive paths, apply authored width/height within chat bounds, append URL fragments to signed asset URLs, and reproduce authored markdown on copy
> - Adds `FileMarkdownPreview` wrapper so images in file previews resolve against the markdown file's directory, not just `cwd`
> - Adds `markdownImageSourceFragment` util to extract and preserve URL fragments; adds `isWindowsDrivePathHref` guard in `markdownUrlTransform` to stop rewriting Windows drive paths to `file://`
> - Risk: `ChatMarkdownWorkspaceImage` now compares `failedUrl` against `assetUrl.url` instead of the raw src; if a signed URL changes between request and failure, the error UI may not trigger correctly. Reviewers should check the error branch in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/8501/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71a9b67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved markdown image rendering for local and Windows drive-path images.
  * Added support for resolving images relative to the current file’s location.
  * Preserved authored image sizing, alignment, SVG fragments, and copyable markdown.
  * Added dedicated markdown previews for file content.

* **Bug Fixes**
  * Fixed local image links being incorrectly rewritten as `file:///` URLs.
  * Improved image placeholders and fallback behavior across loading, failure, and missing-file states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->