### PR TITLE
fix(web): open GitHub pull requests in browser when loading fails

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -51,7 +51,7 @@ import {
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
 import { useCopyToClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { changeRequestRepositoryUrl, pullRequestBrowserUrl } from "~/lib/openPullRequestLink";
+import { changeRequestRepositoryUrl, gitHubPullRequestBrowserUrl } from "~/lib/openPullRequestLink";
 import { usePreparePullRequestThreadAction } from "~/lib/sourceControlActions";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
@@ -590,14 +590,11 @@ export function PullRequestDetailPanel({
   const newThread = useNewThreadHandler();
   const { environments } = useEnvironments();
   const projects = useProjects();
-  const unavailableBrowserLink = useMemo(() => {
+  const unavailableGitHubUrl = useMemo(() => {
     const identity = projects.find(
       (project) => project.id === reference.projectId && project.environmentId === environmentId,
     )?.repositoryIdentity;
-    const href = pullRequestBrowserUrl(identity, reference.repository, reference.number);
-    return href && identity?.provider
-      ? { href, label: openOnHostLabel(identity.provider) }
-      : undefined;
+    return gitHubPullRequestBrowserUrl(identity, reference.repository, reference.number);
   }, [environmentId, projects, reference.number, reference.projectId, reference.repository]);
   // Beside a thread there is nothing to pick: the hand-offs land in that thread's composer, and
   // the thread is already on one server's copy of the branch.
@@ -1918,7 +1915,7 @@ export function PullRequestDetailPanel({
           <PullRequestsUnavailableState
             error={detailQuery.error}
             onRetry={refreshDetail}
-            {...(unavailableBrowserLink ? { browserLink: unavailableBrowserLink } : {})}
+            {...(unavailableGitHubUrl ? { gitHubUrl: unavailableGitHubUrl } : {})}
           />
         ) : detail ? (
           <>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -51,7 +51,7 @@ import {
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
 import { useCopyToClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { changeRequestRepositoryUrl } from "~/lib/openPullRequestLink";
+import { changeRequestRepositoryUrl, pullRequestBrowserUrl } from "~/lib/openPullRequestLink";
 import { usePreparePullRequestThreadAction } from "~/lib/sourceControlActions";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
@@ -590,6 +590,15 @@ export function PullRequestDetailPanel({
   const newThread = useNewThreadHandler();
   const { environments } = useEnvironments();
   const projects = useProjects();
+  const unavailableBrowserLink = useMemo(() => {
+    const identity = projects.find(
+      (project) => project.id === reference.projectId && project.environmentId === environmentId,
+    )?.repositoryIdentity;
+    const href = pullRequestBrowserUrl(identity, reference.repository, reference.number);
+    return href && identity?.provider
+      ? { href, label: openOnHostLabel(identity.provider) }
+      : undefined;
+  }, [environmentId, projects, reference.number, reference.projectId, reference.repository]);
   // Beside a thread there is nothing to pick: the hand-offs land in that thread's composer, and
   // the thread is already on one server's copy of the branch.
   const pickableEnvironments = useMemo(
@@ -1906,7 +1915,11 @@ export function PullRequestDetailPanel({
         }}
       >
         {detailQuery.error && !detail ? (
-          <PullRequestsUnavailableState error={detailQuery.error} onRetry={refreshDetail} />
+          <PullRequestsUnavailableState
+            error={detailQuery.error}
+            onRetry={refreshDetail}
+            {...(unavailableBrowserLink ? { browserLink: unavailableBrowserLink } : {})}
+          />
         ) : detail ? (
           <>
             {mountedTabs.has("summary") ? (

--- a/apps/web/src/components/pullRequest/PullRequestsUnavailableState.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestsUnavailableState.test.tsx
@@ -30,10 +30,7 @@ describe("PullRequestsUnavailableState", () => {
       <PullRequestsUnavailableState
         error="GitHub did not answer."
         onRetry={() => {}}
-        browserLink={{
-          href: "https://github.com/pingdotgg/t3code/pull/42",
-          label: "Open on GitHub",
-        }}
+        gitHubUrl="https://github.com/pingdotgg/t3code/pull/42"
       />,
     );
 
@@ -48,15 +45,21 @@ describe("PullRequestsUnavailableState", () => {
     const html = renderToStaticMarkup(
       <PullRequestsUnavailableState
         error="This server cannot read the pull request."
-        browserLink={{
-          href: "https://gitlab.example.test/group/repo/-/merge_requests/9",
-          label: "Open on GitLab",
-        }}
+        gitHubUrl="https://github.com/pingdotgg/t3code/pull/9"
       />,
     );
 
-    expect(html).toContain("Open on GitLab");
+    expect(html).toContain("Open on GitHub");
     expect(html).not.toContain("Retry");
+  });
+
+  it("can offer a retry without offering GitHub", () => {
+    const html = renderToStaticMarkup(
+      <PullRequestsUnavailableState error="The host did not answer." onRetry={() => {}} />,
+    );
+
+    expect(html).toContain("Retry");
+    expect(html).not.toContain("Open on GitHub");
   });
 
   it("renders no action content without a retry or browser target", () => {

--- a/apps/web/src/components/pullRequest/PullRequestsUnavailableState.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestsUnavailableState.test.tsx
@@ -1,4 +1,5 @@
 import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
 import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
@@ -25,8 +26,45 @@ describe("PullRequestsUnavailableState", () => {
   });
 
   it("retains the retry for transient load failures", () => {
-    expect(
-      textOf(PullRequestsUnavailableState({ error: "GitHub did not answer.", onRetry: () => {} })),
-    ).toContain("Retry");
+    const html = renderToStaticMarkup(
+      <PullRequestsUnavailableState
+        error="GitHub did not answer."
+        onRetry={() => {}}
+        browserLink={{
+          href: "https://github.com/pingdotgg/t3code/pull/42",
+          label: "Open on GitHub",
+        }}
+      />,
+    );
+
+    expect(html).toContain("Retry");
+    expect(html).toContain("Open on GitHub");
+    expect(html).toContain('href="https://github.com/pingdotgg/t3code/pull/42"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("can offer the browser without offering a retry", () => {
+    const html = renderToStaticMarkup(
+      <PullRequestsUnavailableState
+        error="This server cannot read the pull request."
+        browserLink={{
+          href: "https://gitlab.example.test/group/repo/-/merge_requests/9",
+          label: "Open on GitLab",
+        }}
+      />,
+    );
+
+    expect(html).toContain("Open on GitLab");
+    expect(html).not.toContain("Retry");
+  });
+
+  it("renders no action content without a retry or browser target", () => {
+    const html = renderToStaticMarkup(
+      <PullRequestsUnavailableState error="This project has no known remote." />,
+    );
+
+    expect(html).not.toContain('data-slot="empty-content"');
+    expect(html).not.toContain("href=");
   });
 });

--- a/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
@@ -14,15 +14,12 @@ export function PullRequestsUnavailableState({
   title = "Could not load pull requests",
   error,
   onRetry,
-  browserLink,
+  gitHubUrl,
 }: {
   title?: string;
   error: string;
   onRetry?: () => void;
-  browserLink?: {
-    readonly href: string;
-    readonly label: string;
-  };
+  gitHubUrl?: string;
 }) {
   return (
     <Empty className="px-4 py-16 md:px-4">
@@ -35,7 +32,7 @@ export function PullRequestsUnavailableState({
             shows its message rather than trying to infer one from the failure text. */}
         <EmptyDescription>{error}</EmptyDescription>
       </EmptyHeader>
-      {onRetry || browserLink ? (
+      {onRetry || gitHubUrl ? (
         <EmptyContent className="flex-row flex-wrap justify-center gap-2">
           {onRetry ? (
             <Button size="sm" variant="outline" onClick={onRetry}>
@@ -43,14 +40,14 @@ export function PullRequestsUnavailableState({
               Retry
             </Button>
           ) : null}
-          {browserLink ? (
+          {gitHubUrl ? (
             <Button
               size="sm"
               variant="outline"
-              render={<a href={browserLink.href} target="_blank" rel="noopener noreferrer" />}
+              render={<a href={gitHubUrl} target="_blank" rel="noopener noreferrer" />}
             >
               <ExternalLinkIcon aria-hidden className="size-3.5" />
-              {browserLink.label}
+              Open on GitHub
             </Button>
           ) : null}
         </EmptyContent>

--- a/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
@@ -1,4 +1,4 @@
-import { GitPullRequestIcon, RefreshCwIcon } from "lucide-react";
+import { ExternalLinkIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react";
 
 import { Button } from "../ui/button";
 import {
@@ -14,10 +14,15 @@ export function PullRequestsUnavailableState({
   title = "Could not load pull requests",
   error,
   onRetry,
+  browserLink,
 }: {
   title?: string;
   error: string;
   onRetry?: () => void;
+  browserLink?: {
+    readonly href: string;
+    readonly label: string;
+  };
 }) {
   return (
     <Empty className="px-4 py-16 md:px-4">
@@ -30,12 +35,24 @@ export function PullRequestsUnavailableState({
             shows its message rather than trying to infer one from the failure text. */}
         <EmptyDescription>{error}</EmptyDescription>
       </EmptyHeader>
-      {onRetry ? (
-        <EmptyContent>
-          <Button size="sm" variant="outline" onClick={onRetry}>
-            <RefreshCwIcon className="size-3.5" />
-            Retry
-          </Button>
+      {onRetry || browserLink ? (
+        <EmptyContent className="flex-row flex-wrap justify-center gap-2">
+          {onRetry ? (
+            <Button size="sm" variant="outline" onClick={onRetry}>
+              <RefreshCwIcon className="size-3.5" />
+              Retry
+            </Button>
+          ) : null}
+          {browserLink ? (
+            <Button
+              size="sm"
+              variant="outline"
+              render={<a href={browserLink.href} target="_blank" rel="noopener noreferrer" />}
+            >
+              <ExternalLinkIcon aria-hidden className="size-3.5" />
+              {browserLink.label}
+            </Button>
+          ) : null}
         </EmptyContent>
       ) : null}
     </Empty>

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -6,10 +6,133 @@ import {
   matchesLinkedPullRequestUrl,
   openPullRequestLink,
   parseChangeRequestUrl,
+  pullRequestBrowserUrl,
   PullRequestLinkOpenError,
   shouldOpenPullRequestExternally,
 } from "./openPullRequestLink";
-import { ProjectId } from "@t3tools/contracts";
+import { ProjectId, type RepositoryIdentity } from "@t3tools/contracts";
+
+function repositoryIdentity(
+  provider: string,
+  canonicalKey: string,
+  remoteUrl: string,
+): RepositoryIdentity {
+  return {
+    canonicalKey,
+    provider,
+    locator: { source: "git-remote", remoteName: "origin", remoteUrl },
+  };
+}
+
+describe("pullRequestBrowserUrl", () => {
+  it("uses the requested GitHub repository instead of the project's default repository", () => {
+    const identity = repositoryIdentity(
+      "github",
+      "github.com/acme/default",
+      "https://github.com/acme/default.git",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "acme/other", 42)).toBe(
+      "https://github.com/acme/other/pull/42",
+    );
+  });
+
+  it("preserves a custom GitHub HTTP origin without its credentials", () => {
+    const identity = repositoryIdentity(
+      "github",
+      "github.acme.test/team/default",
+      "http://token@github.acme.test:8443/team/default.git",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "platform/api", 7)).toBe(
+      "http://github.acme.test:8443/platform/api/pull/7",
+    );
+  });
+
+  it("preserves a nested GitLab repository path from an SSH remote", () => {
+    const identity = repositoryIdentity(
+      "gitlab",
+      "gitlab.acme.test/group/default",
+      "git@gitlab.acme.test:group/default.git",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "team/platform/api", 9)).toBe(
+      "https://gitlab.acme.test/team/platform/api/-/merge_requests/9",
+    );
+  });
+
+  it("builds a Bitbucket pull request URL", () => {
+    const identity = repositoryIdentity(
+      "bitbucket",
+      "bitbucket.org/workspace/default",
+      "git://bitbucket.org/workspace/default.git",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "workspace/repository", 5)).toBe(
+      "https://bitbucket.org/workspace/repository/pull-requests/5",
+    );
+  });
+
+  it("uses Azure DevOps remote context with the requested repository name", () => {
+    const identity = repositoryIdentity(
+      "azure-devops",
+      "dev.azure.com/acme/platform/_git/default",
+      "https://user:token@dev.azure.com/acme/platform/_git/default.git",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "checkout", 17)).toBe(
+      "https://dev.azure.com/acme/platform/_git/checkout/pullrequest/17",
+    );
+  });
+
+  it("converts an Azure DevOps SSH remote to its browser URL", () => {
+    const identity = repositoryIdentity(
+      "azure-devops",
+      "ssh.dev.azure.com/v3/acme/platform/default",
+      "git@ssh.dev.azure.com:v3/acme/platform/default",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "checkout", 17)).toBe(
+      "https://dev.azure.com/acme/platform/_git/checkout/pullrequest/17",
+    );
+    expect(pullRequestBrowserUrl(identity, "v3/acme/payments/checkout", 18)).toBe(
+      "https://dev.azure.com/acme/payments/_git/checkout/pullrequest/18",
+    );
+    expect(pullRequestBrowserUrl(identity, "acme/payments/_git/checkout", 19)).toBe(
+      "https://dev.azure.com/acme/payments/_git/checkout/pullrequest/19",
+    );
+  });
+
+  it("keeps a full Azure DevOps repository path from a linked pull request", () => {
+    const identity = repositoryIdentity(
+      "azure-devops",
+      "dev.azure.com/acme/platform/_git/default",
+      "https://dev.azure.com/acme/platform/_git/default.git",
+    );
+
+    expect(pullRequestBrowserUrl(identity, "acme/payments/_git/checkout", 17)).toBe(
+      "https://dev.azure.com/acme/payments/_git/checkout/pullrequest/17",
+    );
+  });
+
+  it("returns null without a supported repository identity", () => {
+    const unknown = repositoryIdentity(
+      "unknown",
+      "code.example.test/acme/repository",
+      "https://code.example.test/acme/repository.git",
+    );
+
+    expect(pullRequestBrowserUrl(null, "acme/repository", 1)).toBeNull();
+    expect(pullRequestBrowserUrl(unknown, "acme/repository", 1)).toBeNull();
+    expect(
+      pullRequestBrowserUrl(
+        repositoryIdentity("github", "bad host/acme/repository", "not a remote"),
+        "acme/repository",
+        1,
+      ),
+    ).toBeNull();
+  });
+});
 
 describe("changeRequestRepositoryUrl", () => {
   it("preserves repository path casing", () => {

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   changeRequestRepositoryUrl,
   findProjectForChangeRequest,
+  gitHubPullRequestBrowserUrl,
   matchesLinkedPullRequestUrl,
   openPullRequestLink,
   parseChangeRequestUrl,
-  pullRequestBrowserUrl,
   PullRequestLinkOpenError,
   shouldOpenPullRequestExternally,
 } from "./openPullRequestLink";
@@ -24,7 +24,7 @@ function repositoryIdentity(
   };
 }
 
-describe("pullRequestBrowserUrl", () => {
+describe("gitHubPullRequestBrowserUrl", () => {
   it("uses the requested GitHub repository instead of the project's default repository", () => {
     const identity = repositoryIdentity(
       "github",
@@ -32,7 +32,7 @@ describe("pullRequestBrowserUrl", () => {
       "https://github.com/acme/default.git",
     );
 
-    expect(pullRequestBrowserUrl(identity, "acme/other", 42)).toBe(
+    expect(gitHubPullRequestBrowserUrl(identity, "acme/other", 42)).toBe(
       "https://github.com/acme/other/pull/42",
     );
   });
@@ -44,94 +44,72 @@ describe("pullRequestBrowserUrl", () => {
       "http://token@github.acme.test:8443/team/default.git",
     );
 
-    expect(pullRequestBrowserUrl(identity, "platform/api", 7)).toBe(
+    expect(gitHubPullRequestBrowserUrl(identity, "platform/api", 7)).toBe(
       "http://github.acme.test:8443/platform/api/pull/7",
     );
   });
 
-  it("preserves a nested GitLab repository path from an SSH remote", () => {
-    const identity = repositoryIdentity(
-      "gitlab",
-      "gitlab.acme.test/group/default",
-      "git@gitlab.acme.test:group/default.git",
-    );
+  it.each([
+    {
+      name: "SSH",
+      remoteUrl: "git@github.acme.test:team/default.git",
+    },
+    {
+      name: "git protocol",
+      remoteUrl: "git://github.acme.test/team/default.git",
+    },
+  ])("uses the normalized host for a $name remote", ({ remoteUrl }) => {
+    const identity = repositoryIdentity("github", "github.acme.test/team/default", remoteUrl);
 
-    expect(pullRequestBrowserUrl(identity, "team/platform/api", 9)).toBe(
-      "https://gitlab.acme.test/team/platform/api/-/merge_requests/9",
+    expect(gitHubPullRequestBrowserUrl(identity, "platform/api", 9)).toBe(
+      "https://github.acme.test/platform/api/pull/9",
     );
   });
 
-  it("builds a Bitbucket pull request URL", () => {
-    const identity = repositoryIdentity(
-      "bitbucket",
-      "bitbucket.org/workspace/default",
-      "git://bitbucket.org/workspace/default.git",
-    );
-
-    expect(pullRequestBrowserUrl(identity, "workspace/repository", 5)).toBe(
-      "https://bitbucket.org/workspace/repository/pull-requests/5",
-    );
-  });
-
-  it("uses Azure DevOps remote context with the requested repository name", () => {
-    const identity = repositoryIdentity(
-      "azure-devops",
-      "dev.azure.com/acme/platform/_git/default",
-      "https://user:token@dev.azure.com/acme/platform/_git/default.git",
-    );
-
-    expect(pullRequestBrowserUrl(identity, "checkout", 17)).toBe(
-      "https://dev.azure.com/acme/platform/_git/checkout/pullrequest/17",
-    );
-  });
-
-  it("converts an Azure DevOps SSH remote to its browser URL", () => {
-    const identity = repositoryIdentity(
-      "azure-devops",
-      "ssh.dev.azure.com/v3/acme/platform/default",
-      "git@ssh.dev.azure.com:v3/acme/platform/default",
-    );
-
-    expect(pullRequestBrowserUrl(identity, "checkout", 17)).toBe(
-      "https://dev.azure.com/acme/platform/_git/checkout/pullrequest/17",
-    );
-    expect(pullRequestBrowserUrl(identity, "v3/acme/payments/checkout", 18)).toBe(
-      "https://dev.azure.com/acme/payments/_git/checkout/pullrequest/18",
-    );
-    expect(pullRequestBrowserUrl(identity, "acme/payments/_git/checkout", 19)).toBe(
-      "https://dev.azure.com/acme/payments/_git/checkout/pullrequest/19",
-    );
-  });
-
-  it("keeps a full Azure DevOps repository path from a linked pull request", () => {
-    const identity = repositoryIdentity(
-      "azure-devops",
-      "dev.azure.com/acme/platform/_git/default",
-      "https://dev.azure.com/acme/platform/_git/default.git",
-    );
-
-    expect(pullRequestBrowserUrl(identity, "acme/payments/_git/checkout", 17)).toBe(
-      "https://dev.azure.com/acme/payments/_git/checkout/pullrequest/17",
-    );
-  });
-
-  it("returns null without a supported repository identity", () => {
-    const unknown = repositoryIdentity(
-      "unknown",
-      "code.example.test/acme/repository",
-      "https://code.example.test/acme/repository.git",
-    );
-
-    expect(pullRequestBrowserUrl(null, "acme/repository", 1)).toBeNull();
-    expect(pullRequestBrowserUrl(unknown, "acme/repository", 1)).toBeNull();
+  it("returns null for missing or invalid GitHub data", () => {
+    expect(gitHubPullRequestBrowserUrl(null, "acme/repository", 1)).toBeNull();
     expect(
-      pullRequestBrowserUrl(
+      gitHubPullRequestBrowserUrl(
+        repositoryIdentity("github", "github.com/acme/repository", "https://github.com/a/b"),
+        "acme",
+        1,
+      ),
+    ).toBeNull();
+    expect(
+      gitHubPullRequestBrowserUrl(
+        repositoryIdentity("github", "github.com/acme/repository", "https://github.com/a/b"),
+        "../repository",
+        1,
+      ),
+    ).toBeNull();
+    expect(
+      gitHubPullRequestBrowserUrl(
+        repositoryIdentity("github", "github.com/acme/repository", "https://github.com/a/b"),
+        "acme/repository",
+        0,
+      ),
+    ).toBeNull();
+    expect(
+      gitHubPullRequestBrowserUrl(
         repositoryIdentity("github", "bad host/acme/repository", "not a remote"),
         "acme/repository",
         1,
       ),
     ).toBeNull();
   });
+
+  it.each(["gitlab", "bitbucket", "azure-devops", "unknown"])(
+    "does not build a fallback for %s",
+    (provider) => {
+      expect(
+        gitHubPullRequestBrowserUrl(
+          repositoryIdentity(provider, "github.com/acme/repository", "https://github.com/a/b"),
+          "acme/repository",
+          1,
+        ),
+      ).toBeNull();
+    },
+  );
 });
 
 describe("changeRequestRepositoryUrl", () => {

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -1,6 +1,7 @@
 import type {
   EnvironmentId,
   LocalApi,
+  RepositoryIdentity,
   ScopedThreadRef,
   ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
@@ -50,6 +51,132 @@ export async function openPullRequestLink(
     await shell.openExternal(targetUrl);
   } catch (cause) {
     throw PullRequestLinkOpenError.fromCause(targetUrl, cause);
+  }
+}
+
+interface RemoteLocation {
+  readonly origin: string;
+  readonly path: readonly string[];
+}
+
+function remoteLocationOf(identity: RepositoryIdentity): RemoteLocation | null {
+  try {
+    const url = new URL(identity.locator.remoteUrl.trim());
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return {
+        origin: url.origin,
+        path: url.pathname.split("/").filter(Boolean),
+      };
+    }
+  } catch {
+    // SSH remotes commonly use SCP syntax, so use their normalized identity below.
+  }
+
+  const [hostname, ...path] = identity.canonicalKey.split("/");
+  if (!hostname || path.length === 0) return null;
+  try {
+    return { origin: new URL(`https://${hostname}`).origin, path };
+  } catch {
+    return null;
+  }
+}
+
+function repositoryPathOf(repository: string): readonly string[] | null {
+  const path = repository.split("/");
+  return path.length > 0 &&
+    path.every((segment) => segment.length > 0 && segment !== "." && segment !== "..")
+    ? path
+    : null;
+}
+
+function azureDevOpsRepositoryPath(
+  remote: RemoteLocation,
+  repository: readonly string[],
+): { readonly origin: string; readonly path: readonly string[] } | null {
+  const [format, organization, project, ...repositoryName] = repository;
+  if (format === "v3" && organization && project && repositoryName.length > 0) {
+    return {
+      origin: "https://dev.azure.com",
+      path: [organization, project, "_git", ...repositoryName],
+    };
+  }
+
+  const referenceGitMarker = repository.indexOf("_git");
+  if (referenceGitMarker > 0 && referenceGitMarker < repository.length - 1) {
+    const remoteGitMarker = remote.path.indexOf("_git");
+    const organization =
+      remote.path[0] === "v3" ? remote.path[1] : remoteGitMarker === 2 ? remote.path[0] : undefined;
+    return {
+      origin: remote.path[0] === "v3" ? "https://dev.azure.com" : remote.origin,
+      path: referenceGitMarker === 1 && organization ? [organization, ...repository] : repository,
+    };
+  }
+
+  const remoteGitMarker = remote.path.indexOf("_git");
+  if (repository.length === 1 && remoteGitMarker > 0) {
+    return {
+      origin: remote.origin,
+      path: [...remote.path.slice(0, remoteGitMarker + 1), ...repository],
+    };
+  }
+
+  if (repository.length === 1 && remote.path[0] === "v3" && remote.path.length >= 4) {
+    const organization = remote.path[1];
+    const project = remote.path[2];
+    if (organization && project) {
+      return {
+        origin: "https://dev.azure.com",
+        path: [organization, project, "_git", ...repository],
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Builds the host URL available even when the pull request API cannot be read. */
+export function pullRequestBrowserUrl(
+  identity: RepositoryIdentity | null | undefined,
+  repository: string,
+  number: number,
+): string | null {
+  if (!identity || !Number.isSafeInteger(number) || number < 1) return null;
+  const remote = remoteLocationOf(identity);
+  const repositoryPath = repositoryPathOf(repository);
+  if (!remote || !repositoryPath) return null;
+
+  let origin = remote.origin;
+  let path: readonly string[];
+  switch (identity.provider) {
+    case "github":
+      if (repositoryPath.length < 2) return null;
+      path = [...repositoryPath, "pull", String(number)];
+      break;
+    case "gitlab":
+      if (repositoryPath.length < 2) return null;
+      path = [...repositoryPath, "-", "merge_requests", String(number)];
+      break;
+    case "bitbucket":
+      if (repositoryPath.length < 2) return null;
+      path = [...repositoryPath, "pull-requests", String(number)];
+      break;
+    case "azure-devops": {
+      const azureRepository = azureDevOpsRepositoryPath(remote, repositoryPath);
+      if (!azureRepository) return null;
+      origin = azureRepository.origin;
+      path = [...azureRepository.path, "pullrequest", String(number)];
+      break;
+    }
+    default:
+      return null;
+  }
+
+  try {
+    const url = new URL(origin);
+    url.pathname = `/${path.join("/")}`;
+    return url.toString();
+  } catch {
+    return null;
   }
 }
 

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -54,126 +54,36 @@ export async function openPullRequestLink(
   }
 }
 
-interface RemoteLocation {
-  readonly origin: string;
-  readonly path: readonly string[];
-}
-
-function remoteLocationOf(identity: RepositoryIdentity): RemoteLocation | null {
-  try {
-    const url = new URL(identity.locator.remoteUrl.trim());
-    if (url.protocol === "http:" || url.protocol === "https:") {
-      return {
-        origin: url.origin,
-        path: url.pathname.split("/").filter(Boolean),
-      };
-    }
-  } catch {
-    // SSH remotes commonly use SCP syntax, so use their normalized identity below.
-  }
-
-  const [hostname, ...path] = identity.canonicalKey.split("/");
-  if (!hostname || path.length === 0) return null;
-  try {
-    return { origin: new URL(`https://${hostname}`).origin, path };
-  } catch {
-    return null;
-  }
-}
-
-function repositoryPathOf(repository: string): readonly string[] | null {
-  const path = repository.split("/");
-  return path.length > 0 &&
-    path.every((segment) => segment.length > 0 && segment !== "." && segment !== "..")
-    ? path
-    : null;
-}
-
-function azureDevOpsRepositoryPath(
-  remote: RemoteLocation,
-  repository: readonly string[],
-): { readonly origin: string; readonly path: readonly string[] } | null {
-  const [format, organization, project, ...repositoryName] = repository;
-  if (format === "v3" && organization && project && repositoryName.length > 0) {
-    return {
-      origin: "https://dev.azure.com",
-      path: [organization, project, "_git", ...repositoryName],
-    };
-  }
-
-  const referenceGitMarker = repository.indexOf("_git");
-  if (referenceGitMarker > 0 && referenceGitMarker < repository.length - 1) {
-    const remoteGitMarker = remote.path.indexOf("_git");
-    const organization =
-      remote.path[0] === "v3" ? remote.path[1] : remoteGitMarker === 2 ? remote.path[0] : undefined;
-    return {
-      origin: remote.path[0] === "v3" ? "https://dev.azure.com" : remote.origin,
-      path: referenceGitMarker === 1 && organization ? [organization, ...repository] : repository,
-    };
-  }
-
-  const remoteGitMarker = remote.path.indexOf("_git");
-  if (repository.length === 1 && remoteGitMarker > 0) {
-    return {
-      origin: remote.origin,
-      path: [...remote.path.slice(0, remoteGitMarker + 1), ...repository],
-    };
-  }
-
-  if (repository.length === 1 && remote.path[0] === "v3" && remote.path.length >= 4) {
-    const organization = remote.path[1];
-    const project = remote.path[2];
-    if (organization && project) {
-      return {
-        origin: "https://dev.azure.com",
-        path: [organization, project, "_git", ...repository],
-      };
-    }
-  }
-
-  return null;
-}
-
-/** Builds the host URL available even when the pull request API cannot be read. */
-export function pullRequestBrowserUrl(
+/** Builds a GitHub URL that remains available when the pull request API cannot be read. */
+export function gitHubPullRequestBrowserUrl(
   identity: RepositoryIdentity | null | undefined,
   repository: string,
   number: number,
 ): string | null {
-  if (!identity || !Number.isSafeInteger(number) || number < 1) return null;
-  const remote = remoteLocationOf(identity);
-  const repositoryPath = repositoryPathOf(repository);
-  if (!remote || !repositoryPath) return null;
-
-  let origin = remote.origin;
-  let path: readonly string[];
-  switch (identity.provider) {
-    case "github":
-      if (repositoryPath.length < 2) return null;
-      path = [...repositoryPath, "pull", String(number)];
-      break;
-    case "gitlab":
-      if (repositoryPath.length < 2) return null;
-      path = [...repositoryPath, "-", "merge_requests", String(number)];
-      break;
-    case "bitbucket":
-      if (repositoryPath.length < 2) return null;
-      path = [...repositoryPath, "pull-requests", String(number)];
-      break;
-    case "azure-devops": {
-      const azureRepository = azureDevOpsRepositoryPath(remote, repositoryPath);
-      if (!azureRepository) return null;
-      origin = azureRepository.origin;
-      path = [...azureRepository.path, "pullrequest", String(number)];
-      break;
-    }
-    default:
-      return null;
+  if (identity?.provider !== "github" || !Number.isSafeInteger(number) || number < 1) return null;
+  const repositoryPath = repository.split("/");
+  if (
+    repositoryPath.length !== 2 ||
+    repositoryPath.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    return null;
   }
 
+  let origin: string | null = null;
   try {
-    const url = new URL(origin);
-    url.pathname = `/${path.join("/")}`;
+    const remoteUrl = new URL(identity.locator.remoteUrl.trim());
+    if (remoteUrl.protocol === "http:" || remoteUrl.protocol === "https:") {
+      origin = remoteUrl.origin;
+    }
+  } catch {
+    // SCP-style remotes are read from their normalized identity below.
+  }
+  const hostname = identity.canonicalKey.split("/")[0];
+  if (origin === null && !hostname) return null;
+
+  try {
+    const url = new URL(origin ?? `https://${hostname}`);
+    url.pathname = `/${repositoryPath.join("/")}/pull/${number}`;
     return url.toString();
   } catch {
     return null;

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -42,8 +42,8 @@ T3 Code works with the platforms your team already uses:
 - While working in a thread, open linked reviews in the same compact right-panel tabs without
   leaving the conversation
 - Open the review directly in your browser with one click
-- If T3 Code cannot load a review, including when the host rate limits requests, open it in your
-  browser from the error view
+- If T3 Code cannot load a GitHub pull request, including when GitHub rate limits requests, use
+  **Open on GitHub** in the error view
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
 

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -42,6 +42,8 @@ T3 Code works with the platforms your team already uses:
 - While working in a thread, open linked reviews in the same compact right-panel tabs without
   leaving the conversation
 - Open the review directly in your browser with one click
+- If T3 Code cannot load a review, including when the host rate limits requests, open it in your
+  browser from the error view
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
 


### PR DESCRIPTION
GitHub API errors can leave a failed pull request view with only Retry, even though the pull request is still available on GitHub.

The error view now includes an Open on GitHub link built from the saved project host and pull request reference, with no extra API request. The shared detail panel covers pull request pages and thread tabs in web and desktop. Error states for GitLab, Bitbucket, Azure DevOps, and unknown providers are unchanged.

## Screenshots

Before

![Before: the failed pull request view only shows Retry](https://files.tslop.org/2026/08/pr-error-before-full-7be6bdfa.png)

After

![After: the failed pull request view shows Retry and Open on GitHub](https://files.tslop.org/2026/08/pr-error-after-full-8b199c7a.png)

## Checks

- Focused unit tests
- Web typecheck
- Targeted lint and format
- Real browser verification with a local GitHub rate-limit fixture

Made with GPT-5.6 Sol using Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI fallback with validated URL construction and standard external-link attributes; no API or auth changes.
> 
> **Overview**
> When pull request detail fails to load (e.g. GitHub API errors or rate limits), users are no longer stuck with only **Retry**. The error empty state can show **Open on GitHub** next to retry when a safe browser URL can be derived locally.
> 
> A new `gitHubPullRequestBrowserUrl` helper builds that link from the project’s GitHub `repositoryIdentity` and the open PR reference—using the PR’s `owner/repo` (not the default remote path), honoring GitHub Enterprise HTTP origins without credentials, and falling back to the canonical host for SSH/git remotes. Non-GitHub providers and invalid input yield no link, so other hosts’ error UX is unchanged.
> 
> `PullRequestDetailPanel` wires this into `PullRequestsUnavailableState` on detail load failure. Tests cover URL construction edge cases and the retry/GitHub/action-row combinations; user docs mention **Open on GitHub** in the error view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3462252b7038fe014d69d4154b05a793df22e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Open on GitHub' fallback action to `PullRequestDetailPanel` error state
> - Adds `gitHubPullRequestBrowserUrl` util in [openPullRequestLink.ts](https://github.com/pingdotgg/t3code/pull/8507/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) to build a GitHub PR browser URL from a repository identity, PR number, and repo name; returns `null` for invalid inputs or non-GitHub providers
> - `PullRequestDetailPanel` derives `unavailableGitHubUrl` via `useMemo` from the project's `repositoryIdentity`, and passes it as `gitHubUrl` to `PullRequestsUnavailableState` when `detailQuery.error` is set
> - `PullRequestsUnavailableState` renders an outline "Open on GitHub" button (opens in a new tab with `rel="noopener noreferrer"`) when `gitHubUrl` is provided, alongside the existing optional Retry button
> - Behavioral Change: the error view can now show the new button; `EmptyContent` renders when either `onRetry` or `gitHubUrl` is present
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e346225.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->