### PR TITLE
feat(web): redesign provider editor and models list

### DIFF
--- a/apps/web/src/components/settings/ProviderAccentColorPicker.tsx
+++ b/apps/web/src/components/settings/ProviderAccentColorPicker.tsx
@@ -228,8 +228,17 @@ export function ProviderAccentColorPicker(props: {
   readonly onCommit: (value: string) => void;
   readonly description?: string;
   readonly commitDelayMs?: number;
+  /** `inline` renders only the swatch row, for callers that supply their own label. */
+  readonly layout?: "stacked" | "inline";
 }) {
-  const { commitDelayMs = 0, description, displayName, onCommit, value } = props;
+  const {
+    commitDelayMs = 0,
+    description,
+    displayName,
+    layout = "stacked",
+    onCommit,
+    value,
+  } = props;
   const [optimisticValue, setOptimisticValue] = useState(() => value ?? "");
   const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingCommitRef = useRef<string | null>(null);
@@ -295,40 +304,48 @@ export function ProviderAccentColorPicker(props: {
       : "";
   const customSelected = Boolean(normalized && selectedValue === "");
 
+  const swatchRow = (
+    <div className="flex min-w-0 flex-wrap items-center gap-2">
+      <ProviderCustomColorPicker
+        displayName={displayName}
+        value={normalized}
+        selected={customSelected}
+        onCommit={commitAccentColor}
+      />
+      <ColorSelector
+        key={selectedValue}
+        colors={[...PROVIDER_ACCENT_SWATCHES]}
+        defaultValue={selectedValue}
+        size="lg"
+        onColorSelect={commitAccentColor}
+        className="flex-wrap gap-1.5"
+      />
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        className={cn(
+          "size-7 shrink-0 text-muted-foreground transition-opacity",
+          normalized ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={() => commitAccentColor("")}
+        aria-label={`Clear accent color for ${displayName}`}
+        aria-hidden={!normalized}
+        tabIndex={normalized ? 0 : -1}
+      >
+        <XIcon className="size-3.5" aria-hidden />
+      </Button>
+    </div>
+  );
+
+  if (layout === "inline") {
+    return swatchRow;
+  }
+
   return (
     <div className="grid gap-2">
       <span className="text-xs font-medium text-foreground">Accent color</span>
-      <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <ProviderCustomColorPicker
-          displayName={displayName}
-          value={normalized}
-          selected={customSelected}
-          onCommit={commitAccentColor}
-        />
-        <ColorSelector
-          key={selectedValue}
-          colors={[...PROVIDER_ACCENT_SWATCHES]}
-          defaultValue={selectedValue}
-          size="lg"
-          onColorSelect={commitAccentColor}
-          className="flex-wrap gap-1.5"
-        />
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className={cn(
-            "size-7 shrink-0 text-muted-foreground transition-opacity",
-            normalized ? "opacity-100" : "pointer-events-none opacity-0",
-          )}
-          onClick={() => commitAccentColor("")}
-          aria-label={`Clear accent color for ${displayName}`}
-          aria-hidden={!normalized}
-          tabIndex={normalized ? 0 : -1}
-        >
-          <XIcon className="size-3.5" aria-hidden />
-        </Button>
-      </div>
+      {swatchRow}
       {description ? <span className="text-xs text-muted-foreground">{description}</span> : null}
     </div>
   );

--- a/apps/web/src/components/settings/ProviderAccentColorPicker.tsx
+++ b/apps/web/src/components/settings/ProviderAccentColorPicker.tsx
@@ -305,7 +305,11 @@ export function ProviderAccentColorPicker(props: {
   const customSelected = Boolean(normalized && selectedValue === "");
 
   const swatchRow = (
-    <div className="flex min-w-0 flex-wrap items-center gap-2">
+    <div
+      role="group"
+      aria-label="Accent color"
+      className="flex min-w-0 flex-wrap items-center gap-2"
+    >
       <ProviderCustomColorPicker
         displayName={displayName}
         value={normalized}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -53,9 +53,12 @@ import {
 
 const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
-/** Label-left field grid shared by the identity and runtime groups. */
+/** Label-left field grid for the Configuration tab: one row per field. */
 const PROVIDER_FIELD_GRID_CLASS_NAME =
-  "grid gap-x-4 gap-y-3 sm:grid-cols-[9rem_minmax(0,1fr)] sm:items-start";
+  "grid gap-x-4 gap-y-2.5 sm:grid-cols-[8rem_minmax(0,1fr)] sm:items-start";
+/** Full-width divider row that names the group of fields below it. */
+const PROVIDER_FIELD_GROUP_LABEL_CLASS_NAME =
+  "col-span-full mt-1 border-t border-border/60 pt-2.5 text-[11px] text-muted-foreground";
 
 let environmentVariableDraftId = 0;
 const nextEnvironmentVariableDraftId = () => `provider-env-${environmentVariableDraftId++}`;
@@ -479,6 +482,9 @@ export function ProviderInstanceCard({
     liveModels: liveProvider?.models,
     customModels,
   });
+  const hiddenModelCount = modelsForDisplay.filter(
+    (model) => !model.isCustom && hiddenModels.includes(model.slug),
+  ).length;
 
   const updateDisplayName = (value: string) => {
     const trimmed = value.trim();
@@ -818,10 +824,14 @@ export function ProviderInstanceCard({
           <button
             type="button"
             aria-pressed={visibleTab === "models"}
-            className={providerSettingsTabClassName(visibleTab === "models")}
+            className={cn(providerSettingsTabClassName(visibleTab === "models"), "gap-1.5")}
             onClick={() => setActiveTab("models")}
           >
             Models
+            <span className="font-normal text-muted-foreground/70">
+              {modelsForDisplay.length}
+              {hiddenModelCount > 0 ? ` · ${hiddenModelCount} hidden` : ""}
+            </span>
           </button>
         ) : null}
       </div>
@@ -836,7 +846,7 @@ export function ProviderInstanceCard({
           <div
             inert={readOnly}
             aria-disabled={readOnly || undefined}
-            className={cn("space-y-5 px-4 py-5", readOnly && "opacity-50 select-none")}
+            className={cn("px-4 py-4", readOnly && "opacity-50 select-none")}
           >
             <div className={PROVIDER_FIELD_GRID_CLASS_NAME}>
               <label
@@ -862,9 +872,7 @@ export function ProviderInstanceCard({
                   commitDelayMs={120}
                 />
               </div>
-            </div>
-
-            <div className={cn(PROVIDER_FIELD_GRID_CLASS_NAME, "border-t border-border/60 pt-5")}>
+              <div className={PROVIDER_FIELD_GROUP_LABEL_CLASS_NAME}>Runtime</div>
               {driverOption ? (
                 <ProviderSettingsForm
                   definition={driverOption}
@@ -884,11 +892,13 @@ export function ProviderInstanceCard({
                   </p>
                 </>
               )}
-              <span className="pt-1.5 text-xs font-medium text-foreground">Environment</span>
-              <ProviderEnvironmentSection
-                environment={instance.environment ?? []}
-                onChange={updateEnvironment}
-              />
+              <div className={PROVIDER_FIELD_GROUP_LABEL_CLASS_NAME}>Environment</div>
+              <div className="col-span-full">
+                <ProviderEnvironmentSection
+                  environment={instance.environment ?? []}
+                  onChange={updateEnvironment}
+                />
+              </div>
             </div>
           </div>
         </ScrollArea>

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -255,7 +255,8 @@ function ProviderEnvironmentSection(props: {
       {rows.map((variable, index) => (
         <div key={variable.id} className="flex min-w-0 items-center gap-1.5">
           <DraftInput
-            className="w-44 shrink-0 font-mono text-xs"
+            size="compact"
+            className="w-44 shrink-0 font-mono"
             value={variable.name}
             onCommit={(name) => updateVariable(variable.id, { name: name.trim() })}
             placeholder="VARIABLE_NAME"
@@ -266,7 +267,8 @@ function ProviderEnvironmentSection(props: {
             =
           </span>
           <DraftInput
-            className="min-w-0 flex-1 font-mono text-xs"
+            size="compact"
+            className="min-w-0 flex-1 font-mono"
             value={variable.valueRedacted ? "" : variable.value}
             onCommit={(value) => updateVariable(variable.id, { value })}
             type={variable.sensitive ? "password" : undefined}
@@ -284,7 +286,10 @@ function ProviderEnvironmentSection(props: {
                   type="button"
                   size="icon-micro"
                   variant="ghost-muted"
-                  className={cn(variable.sensitive && "text-foreground")}
+                  className={cn(
+                    "[--control-icon-color:currentColor]",
+                    variable.sensitive && "text-foreground",
+                  )}
                   onClick={() => {
                     const sensitive = !variable.sensitive;
                     updateVariable(variable.id, {
@@ -313,7 +318,7 @@ function ProviderEnvironmentSection(props: {
             type="button"
             size="icon-micro"
             variant="ghost-muted"
-            className="hover:text-destructive"
+            className="[--control-icon-color:currentColor] hover:text-destructive"
             onClick={() => removeVariable(variable.id)}
             aria-label={`Remove environment variable ${variable.name || index + 1}`}
           >
@@ -789,7 +794,7 @@ export function ProviderInstanceCard({
               type="button"
               size="xs"
               variant="ghost"
-              className="text-muted-foreground hover:text-destructive"
+              className="[--control-icon-color:currentColor] text-muted-foreground hover:text-destructive"
               onClick={onDelete}
               aria-label={`Delete provider instance ${instanceId}`}
             >

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -5,6 +5,8 @@ import {
   CopyIcon,
   DownloadIcon,
   LoaderIcon,
+  LockIcon,
+  LockOpenIcon,
   PlusIcon,
   Trash2Icon,
   XIcon,
@@ -28,12 +30,10 @@ import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Checkbox } from "../ui/checkbox";
 import { DraftInput } from "../ui/draft-input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { ScrollArea } from "../ui/scroll-area";
 import { Switch } from "../ui/switch";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import type { DriverOption } from "./providerDriverMeta";
@@ -52,6 +52,10 @@ import {
 } from "./providerStatus";
 
 const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/** Label-left field grid shared by the identity and runtime groups. */
+const PROVIDER_FIELD_GRID_CLASS_NAME =
+  "grid gap-x-4 gap-y-3 sm:grid-cols-[9rem_minmax(0,1fr)] sm:items-start";
 
 let environmentVariableDraftId = 0;
 const nextEnvironmentVariableDraftId = () => `provider-env-${environmentVariableDraftId++}`;
@@ -235,118 +239,105 @@ function ProviderEnvironmentSection(props: {
     publishRows(nextRows);
   };
 
+  const addVariable = () =>
+    setRows([
+      ...rows,
+      {
+        id: nextEnvironmentVariableDraftId(),
+        name: "",
+        value: "",
+        sensitive: true,
+      },
+    ]);
+
   return (
-    <div className="grid gap-2">
-      <div className="flex items-center justify-between gap-3">
-        <span className="text-xs font-medium text-foreground">Environment variables</span>
+    <div className="min-w-0 space-y-1.5">
+      {rows.map((variable, index) => (
+        <div key={variable.id} className="flex min-w-0 items-center gap-1.5">
+          <DraftInput
+            className="w-44 shrink-0 font-mono text-xs"
+            value={variable.name}
+            onCommit={(name) => updateVariable(variable.id, { name: name.trim() })}
+            placeholder="VARIABLE_NAME"
+            spellCheck={false}
+            aria-label={`Environment variable name ${index + 1}`}
+          />
+          <span className="text-muted-foreground" aria-hidden>
+            =
+          </span>
+          <DraftInput
+            className="min-w-0 flex-1 font-mono text-xs"
+            value={variable.valueRedacted ? "" : variable.value}
+            onCommit={(value) => updateVariable(variable.id, { value })}
+            type={variable.sensitive ? "password" : undefined}
+            autoComplete="off"
+            placeholder={
+              variable.valueRedacted ? "Stored secret, enter a new value to replace" : "value"
+            }
+            spellCheck={false}
+            aria-label={`Environment variable value ${index + 1}`}
+          />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-micro"
+                  variant="ghost-muted"
+                  className={cn(variable.sensitive && "text-foreground")}
+                  onClick={() => {
+                    const sensitive = !variable.sensitive;
+                    updateVariable(variable.id, {
+                      sensitive,
+                      ...(sensitive && variable.valueRedacted === undefined
+                        ? {}
+                        : { valueRedacted: sensitive ? variable.valueRedacted : false }),
+                    });
+                  }}
+                  aria-pressed={variable.sensitive}
+                  aria-label={`Mark environment variable ${variable.name || index + 1} as sensitive`}
+                >
+                  {variable.sensitive ? (
+                    <LockIcon className="size-3" />
+                  ) : (
+                    <LockOpenIcon className="size-3" />
+                  )}
+                </Button>
+              }
+            />
+            <TooltipPopup side="top">
+              {variable.sensitive ? "Sensitive, stored separately" : "Plain text"}
+            </TooltipPopup>
+          </Tooltip>
+          <Button
+            type="button"
+            size="icon-micro"
+            variant="ghost-muted"
+            className="hover:text-destructive"
+            onClick={() => removeVariable(variable.id)}
+            aria-label={`Remove environment variable ${variable.name || index + 1}`}
+          >
+            <XIcon className="size-3" />
+          </Button>
+        </div>
+      ))}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
         <Button
           type="button"
-          size="sm"
-          variant="outline"
-          className="h-7 gap-1.5 px-2 text-xs"
-          onClick={() =>
-            setRows([
-              ...rows,
-              {
-                id: nextEnvironmentVariableDraftId(),
-                name: "",
-                value: "",
-                sensitive: true,
-              },
-            ])
-          }
+          size="xs"
+          variant="ghost-muted"
+          className="-ml-2"
+          onClick={addVariable}
         >
           <PlusIcon className="size-3" />
-          Add
+          Add variable
         </Button>
+        <span className="text-xs text-muted-foreground">
+          {rows.length === 0
+            ? "API keys, base URLs, or other per-instance CLI settings."
+            : "Sensitive values are stored separately and never returned to the app."}
+        </span>
       </div>
-      {rows.length === 0 ? (
-        <p className="text-xs text-muted-foreground">
-          Add variables to pass API keys, base URLs, or other per-instance CLI settings.
-        </p>
-      ) : (
-        <div className="overflow-hidden rounded-md border border-border/70">
-          <Table>
-            <TableHeader className="bg-muted/25 text-[11px] text-muted-foreground">
-              <TableRow className="hover:bg-transparent">
-                <TableHead>Variable</TableHead>
-                <TableHead>Value</TableHead>
-                <TableHead className="w-20">Sensitive</TableHead>
-                <TableHead className="w-12 text-right">
-                  <span className="sr-only">Options</span>
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((variable, index) => (
-                <TableRow
-                  key={variable.id}
-                  className="border-border/60 odd:bg-muted/20 even:bg-background/20"
-                >
-                  <TableCell>
-                    <DraftInput
-                      value={variable.name}
-                      onCommit={(name) => updateVariable(variable.id, { name: name.trim() })}
-                      placeholder="VARIABLE_NAME"
-                      spellCheck={false}
-                      aria-label={`Environment variable name ${index + 1}`}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <DraftInput
-                      value={variable.valueRedacted ? "" : variable.value}
-                      onCommit={(value) => updateVariable(variable.id, { value })}
-                      type={variable.sensitive ? "password" : undefined}
-                      autoComplete="off"
-                      placeholder={
-                        variable.valueRedacted
-                          ? "Stored secret - enter a new value to replace"
-                          : "Value"
-                      }
-                      spellCheck={false}
-                      aria-label={`Environment variable value ${index + 1}`}
-                    />
-                  </TableCell>
-                  <TableCell className="w-20">
-                    <div className="flex h-8 items-center justify-center">
-                      <Checkbox
-                        checked={variable.sensitive}
-                        onCheckedChange={(checked) => {
-                          const sensitive = Boolean(checked);
-                          updateVariable(variable.id, {
-                            sensitive,
-                            ...(sensitive && variable.valueRedacted === undefined
-                              ? {}
-                              : { valueRedacted: sensitive ? variable.valueRedacted : false }),
-                          });
-                        }}
-                        aria-label={`Mark environment variable ${variable.name || index + 1} as sensitive`}
-                      />
-                    </div>
-                  </TableCell>
-                  <TableCell className="w-12">
-                    <div className="flex justify-end">
-                      <Button
-                        type="button"
-                        size="icon-sm"
-                        variant="ghost"
-                        className="size-8 text-muted-foreground hover:text-destructive"
-                        onClick={() => removeVariable(variable.id)}
-                        aria-label={`Remove environment variable ${variable.name || index + 1}`}
-                      >
-                        <XIcon className="size-3.5" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-      <span className="text-xs text-muted-foreground">
-        Sensitive values are stored separately and are not returned to the app after saving.
-      </span>
     </div>
   );
 }
@@ -362,7 +353,7 @@ interface ProviderInstanceCardProps {
   readonly readOnly?: boolean | undefined;
   readonly onUpdate: (nextInstance: ProviderInstanceConfig) => void;
   /**
-   * Pass `undefined` to hide the delete button entirely. Built-in default
+   * Pass `undefined` to hide the delete footer entirely. Built-in default
    * instance slots use `undefined` — they can't be deleted without losing
    * the slot, and their "reset to defaults" affordance lives on an outer
    * reset button instead. Explicit `| undefined` in the type accommodates
@@ -581,35 +572,9 @@ export function ProviderInstanceCard({
     </>
   );
 
-  const titleTailNode = (
-    <>
-      {headerAction ? (
-        <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-          {headerAction}
-        </span>
-      ) : null}
-      {onDelete ? (
-        <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  size="icon-micro"
-                  variant="ghost"
-                  className="text-muted-foreground hover:text-destructive"
-                  onClick={onDelete}
-                  aria-label={`Delete provider instance ${instanceId}`}
-                >
-                  <Trash2Icon className="size-3" />
-                </Button>
-              }
-            />
-            <TooltipPopup side="top">Delete instance</TooltipPopup>
-          </Tooltip>
-        </span>
-      ) : null}
-    </>
-  );
+  const titleTailNode = headerAction ? (
+    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">{headerAction}</span>
+  ) : null;
 
   const versionCodeNode = versionLabel ? (
     <code className="text-xs text-muted-foreground">{versionLabel}</code>
@@ -820,6 +785,25 @@ export function ProviderInstanceCard({
             </p>
           ) : null}
         </div>
+        {onDelete ? (
+          <span
+            inert={readOnly}
+            aria-disabled={readOnly || undefined}
+            className={cn("shrink-0", readOnly && "opacity-50")}
+          >
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              className="text-muted-foreground hover:text-destructive"
+              onClick={onDelete}
+              aria-label={`Delete provider instance ${instanceId}`}
+            >
+              <Trash2Icon className="size-3" />
+              Delete instance
+            </Button>
+          </span>
+        ) : null}
       </div>
 
       <div className="flex h-11 shrink-0 border-b border-border/70 px-1">
@@ -855,60 +839,58 @@ export function ProviderInstanceCard({
             aria-disabled={readOnly || undefined}
             className={cn("space-y-5 px-4 py-5", readOnly && "opacity-50 select-none")}
           >
-            <div>
-              <label htmlFor={`provider-instance-${instanceId}-display-name`} className="block">
-                <span className="text-xs font-medium text-foreground">Display name</span>
+            <div className={PROVIDER_FIELD_GRID_CLASS_NAME}>
+              <label
+                htmlFor={`provider-instance-${instanceId}-display-name`}
+                className="pt-1.5 text-xs font-medium text-foreground"
+              >
+                Display name
+              </label>
+              <div className="flex min-w-0 flex-wrap items-center gap-3">
                 <DraftInput
                   id={`provider-instance-${instanceId}-display-name`}
-                  className="mt-1.5"
+                  className="w-44"
                   value={instance.displayName ?? ""}
                   onCommit={updateDisplayName}
                   placeholder={driverOption?.label ?? "Instance label"}
                   spellCheck={false}
                 />
-                <span className="mt-1 block text-xs text-muted-foreground">
-                  Optional label shown in the provider list.
-                </span>
-              </label>
+                <ProviderAccentColorPicker
+                  layout="inline"
+                  displayName={displayName}
+                  value={accentColor}
+                  onCommit={updateAccentColor}
+                  commitDelayMs={120}
+                />
+              </div>
             </div>
 
-            <div>
-              <ProviderAccentColorPicker
-                displayName={displayName}
-                value={accentColor}
-                onCommit={updateAccentColor}
-                commitDelayMs={120}
-                description="Used to distinguish this instance in picker rails and model lists."
-              />
-            </div>
-
-            <div>
+            <div className={cn(PROVIDER_FIELD_GRID_CLASS_NAME, "border-t border-border/60 pt-5")}>
+              {driverOption ? (
+                <ProviderSettingsForm
+                  definition={driverOption}
+                  value={instance.config}
+                  idPrefix={`provider-instance-${instanceId}`}
+                  variant="grid"
+                  onChange={updateConfig}
+                />
+              ) : (
+                <>
+                  <span className="pt-1.5 text-xs font-medium text-foreground">Driver</span>
+                  <p className="text-xs text-muted-foreground">
+                    This instance uses a driver (
+                    <code className="text-foreground">{String(instance.driver)}</code>) that is not
+                    shipped with the current build. Configuration values are preserved but cannot be
+                    edited from this surface.
+                  </p>
+                </>
+              )}
+              <span className="pt-1.5 text-xs font-medium text-foreground">Environment</span>
               <ProviderEnvironmentSection
                 environment={instance.environment ?? []}
                 onChange={updateEnvironment}
               />
             </div>
-
-            {driverOption ? (
-              <ProviderSettingsForm
-                definition={driverOption}
-                value={instance.config}
-                idPrefix={`provider-instance-${instanceId}`}
-                variant="card"
-                onChange={updateConfig}
-              />
-            ) : null}
-
-            {driverOption === undefined ? (
-              <div>
-                <p className="text-xs text-muted-foreground">
-                  This instance uses a driver (
-                  <code className="text-foreground">{String(instance.driver)}</code>) that is not
-                  shipped with the current build. Configuration values are preserved but cannot be
-                  edited from this surface.
-                </p>
-              </div>
-            ) : null}
           </div>
         </ScrollArea>
         {driverOption !== undefined ? (

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -263,7 +263,7 @@ function ProviderEnvironmentSection(props: {
             spellCheck={false}
             aria-label={`Environment variable name ${index + 1}`}
           />
-          <span className="text-muted-foreground" aria-hidden>
+          <span className="text-xs text-muted-foreground" aria-hidden>
             =
           </span>
           <DraftInput
@@ -598,7 +598,7 @@ export function ProviderInstanceCard({
         className={cn(
           // Sidebar-style selection with a fixed row height so the list stays
           // even; the status line clamps to two lines instead of growing.
-          "group flex h-19 items-start gap-3 rounded-md px-3 py-2 transition-colors",
+          "group flex min-h-19 items-start gap-3 rounded-md px-3 py-2 transition-colors",
           // Foreground-alpha tint so the fill reads the same in light and dark themes.
           selected ? "bg-foreground/8" : "hover:bg-foreground/4",
         )}
@@ -676,7 +676,7 @@ export function ProviderInstanceCard({
                         size="icon-xs"
                         variant="ghost"
                         className={cn(
-                          "size-5 rounded-sm p-0",
+                          "size-5 rounded-sm p-0 [--control-icon-color:currentColor]",
                           versionAdvisory.emphasis === "strong"
                             ? "text-warning hover:text-warning"
                             : "text-muted-foreground hover:text-foreground",

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -321,14 +321,8 @@ function ProviderEnvironmentSection(props: {
           </Button>
         </div>
       ))}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-        <Button
-          type="button"
-          size="xs"
-          variant="ghost-muted"
-          className="-ml-2"
-          onClick={addVariable}
-        >
+      <div className="flex min-h-[1.875rem] flex-wrap items-center gap-x-3 gap-y-1">
+        <Button type="button" size="xs" variant="ghost-muted" onClick={addVariable}>
           <PlusIcon className="size-3" />
           Add variable
         </Button>

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -796,7 +796,7 @@ export function ProviderInstanceCard({
               variant="ghost"
               className="[--control-icon-color:currentColor] text-muted-foreground hover:text-destructive"
               onClick={onDelete}
-              aria-label={`Delete provider instance ${instanceId}`}
+              aria-label={`Delete instance ${instanceId}`}
             >
               <Trash2Icon className="size-3" />
               Delete instance

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ServerProviderModel } from "@t3tools/contracts";
+
+import { groupModelsForDisplay } from "./ProviderModelsSection";
+
+function model(slug: string, isCustom = false): ServerProviderModel {
+  return { slug, name: slug, isCustom, capabilities: null };
+}
+
+describe("groupModelsForDisplay", () => {
+  it("lists favorites first, then visible models in user order, then hidden ones", () => {
+    const models = [model("a"), model("b"), model("c"), model("d"), model("custom", true)];
+
+    const display = groupModelsForDisplay(models, {
+      favoriteModels: new Set(["c"]),
+      hiddenModels: new Set(["a", "custom"]),
+      modelOrder: ["d", "b"],
+    });
+
+    // A custom model is never hidden, even if its slug is in the hidden set.
+    expect(display.map((entry) => entry.slug)).toEqual(["c", "d", "b", "custom", "a"]);
+  });
+});

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -416,7 +416,7 @@ export function ProviderModelsSection({
         key={`${instanceId}:${model.slug}`}
         data-model-slug={model.slug}
         className={cn(
-          "grid h-7 grid-cols-[1.5rem_minmax(0,1fr)_auto_3rem_auto] items-center gap-2 rounded-md px-2 transition-colors hover:bg-muted/30",
+          "grid h-7 grid-cols-[1.5rem_minmax(0,1fr)_auto_4rem_auto] items-center gap-2 rounded-md px-2 transition-colors hover:bg-muted/30",
           isHidden && "opacity-50",
         )}
       >

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -434,14 +434,15 @@ export function ProviderModelsSection({
             </code>
           ) : null}
         </span>
-        {/* The capability column sizes to its content, so it yields to the name on phone widths. */}
-        {capLabels.length > 0 ? (
-          <span className="hidden text-[11px] text-muted-foreground/70 sm:block">
-            {capLabels.join(" · ")}
-          </span>
-        ) : (
-          <span />
-        )}
+        {/*
+          Always a grid item so the columns line up across rows; the text
+          itself drops out on phone widths where it would starve the name.
+        */}
+        <span className="text-[11px] text-muted-foreground/70">
+          {capLabels.length > 0 ? (
+            <span className="hidden sm:inline">{capLabels.join(" · ")}</span>
+          ) : null}
+        </span>
         {rowActions(model, { isHidden, canMoveUp, canMoveDown })}
         {pickerSwitch(model, isHidden)}
       </div>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  EyeIcon,
-  EyeOffIcon,
-  PlusIcon,
-  StarIcon,
-  XIcon,
-} from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, PlusIcon, StarIcon, XIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
   ProviderDriverKind,
@@ -22,6 +14,7 @@ import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 /**
@@ -35,6 +28,42 @@ const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, strin
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };
+
+/** Above this many models the list gets a filter input. */
+const FILTER_THRESHOLD = 8;
+
+/**
+ * Short capability words shown after a model's slug. Claude and Cursor report
+ * fast mode as a boolean `fastMode` option; Codex reports it as a
+ * `serviceTier` select whose fast tier is labelled "Fast" (catalog id
+ * `priority`, or `fast` from the speed-tier fallback), matching the composer.
+ */
+function describeModelCapabilities(model: ServerProviderModel): string[] {
+  const descriptors = model.capabilities?.optionDescriptors ?? [];
+  const labels: string[] = [];
+  const hasFastMode = descriptors.some(
+    (descriptor) =>
+      descriptor.id === "fastMode" ||
+      (descriptor.id === "serviceTier" &&
+        descriptor.type === "select" &&
+        descriptor.options.some((option) => option.id === "fast" || option.label === "Fast")),
+  );
+  if (hasFastMode) labels.push("Fast mode");
+  if (descriptors.some((descriptor) => descriptor.id === "thinking")) labels.push("Thinking");
+  if (
+    descriptors.some(
+      (descriptor) =>
+        descriptor.type === "select" &&
+        (descriptor.id === "reasoningEffort" ||
+          descriptor.id === "effort" ||
+          descriptor.id === "reasoning" ||
+          descriptor.id === "variant"),
+    )
+  ) {
+    labels.push("Reasoning");
+  }
+  return labels;
+}
 
 /**
  * Display order for the models list: favorites first (in user order), then
@@ -127,6 +156,8 @@ export function ProviderModelsSection({
   onModelOrderChange,
 }: ProviderModelsSectionProps) {
   const [input, setInput] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [filter, setFilter] = useState("");
   const [error, setError] = useState<string | null>(null);
   const hiddenModelSet = useMemo(() => new Set(hiddenModels), [hiddenModels]);
   const favoriteModelSet = useMemo(() => new Set(favoriteModels), [favoriteModels]);
@@ -143,6 +174,16 @@ export function ProviderModelsSection({
   const hiddenCount = displayModels.filter(
     (model) => !model.isCustom && hiddenModelSet.has(model.slug),
   ).length;
+  const showFilter = models.length > FILTER_THRESHOLD;
+  const normalizedFilter = filter.trim().toLowerCase();
+  const isFiltering = showFilter && normalizedFilter.length > 0;
+  const visibleModels = isFiltering
+    ? displayModels.filter(
+        (model) =>
+          model.name.toLowerCase().includes(normalizedFilter) ||
+          model.slug.toLowerCase().includes(normalizedFilter),
+      )
+    : displayModels;
 
   const handleAdd = () => {
     const normalized = normalizeCustomModelSlug(input);
@@ -166,6 +207,13 @@ export function ProviderModelsSection({
     onChange([...customModels, normalized]);
     setInput("");
     setError(null);
+    setIsAdding(false);
+  };
+
+  const cancelAdd = () => {
+    setInput("");
+    setError(null);
+    setIsAdding(false);
   };
 
   const handleRemove = (slug: string) => {
@@ -175,12 +223,11 @@ export function ProviderModelsSection({
     setError(null);
   };
 
-  const handleToggleHidden = (slug: string) => {
-    if (hiddenModelSet.has(slug)) {
-      onHiddenModelsChange(hiddenModels.filter((model) => model !== slug));
-      return;
-    }
-    onHiddenModelsChange([...hiddenModels, slug]);
+  const setHidden = (slug: string, hidden: boolean) => {
+    if (hidden === hiddenModelSet.has(slug)) return;
+    onHiddenModelsChange(
+      hidden ? [...hiddenModels, slug] : hiddenModels.filter((model) => model !== slug),
+    );
   };
 
   const handleToggleFavorite = (slug: string) => {
@@ -209,30 +256,19 @@ export function ProviderModelsSection({
     onModelOrderChange(next);
   };
 
-  const renderRow = (model: (typeof displayModels)[number], index: number) => {
-    const descriptors = model.capabilities?.optionDescriptors ?? [];
-    const capLabels: string[] = [];
-    if (descriptors.some((descriptor) => descriptor.id === "fastMode")) capLabels.push("Fast mode");
-    if (descriptors.some((descriptor) => descriptor.id === "thinking")) capLabels.push("Thinking");
-    if (
-      descriptors.some(
-        (descriptor) =>
-          descriptor.type === "select" &&
-          (descriptor.id === "reasoningEffort" ||
-            descriptor.id === "effort" ||
-            descriptor.id === "reasoning" ||
-            descriptor.id === "variant"),
-      )
-    ) {
-      capLabels.push("Reasoning");
-    }
+  const renderRow = (model: (typeof displayModels)[number]) => {
+    const capLabels = describeModelCapabilities(model);
     const group = groupOf(model);
     const isHidden = group === "hidden";
     const isFavorite = group === "favorite";
+    const index = displayModels.indexOf(model);
     const previousModel = displayModels[index - 1];
     const nextModel = displayModels[index + 1];
-    const canMoveUp = previousModel !== undefined && groupOf(previousModel) === group;
-    const canMoveDown = nextModel !== undefined && groupOf(nextModel) === group;
+    // Reordering a filtered view would be ambiguous, so arrows only show on
+    // the full list.
+    const canMoveUp =
+      !isFiltering && previousModel !== undefined && groupOf(previousModel) === group;
+    const canMoveDown = !isFiltering && nextModel !== undefined && groupOf(nextModel) === group;
 
     return (
       <div
@@ -285,7 +321,7 @@ export function ProviderModelsSection({
           ) : null}
         </span>
         <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-          {!isHidden ? (
+          {!isHidden && !isFiltering ? (
             <>
               <Tooltip>
                 <TooltipTrigger
@@ -321,25 +357,7 @@ export function ProviderModelsSection({
               </Tooltip>
             </>
           ) : null}
-          {!model.isCustom ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    size="icon-micro"
-                    variant="ghost-muted"
-                    onClick={() => handleToggleHidden(model.slug)}
-                    aria-label={`${isHidden ? "Show" : "Hide"} ${model.name}`}
-                  />
-                }
-              >
-                {isHidden ? <EyeIcon className="size-3" /> : <EyeOffIcon className="size-3" />}
-              </TooltipTrigger>
-              <TooltipPopup side="top">
-                {isHidden ? "Show in picker" : "Hide from picker"}
-              </TooltipPopup>
-            </Tooltip>
-          ) : (
+          {model.isCustom ? (
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -355,62 +373,126 @@ export function ProviderModelsSection({
               </TooltipTrigger>
               <TooltipPopup side="top">Remove custom model</TooltipPopup>
             </Tooltip>
-          )}
+          ) : null}
         </span>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Switch
+                className="[--thumb-size:--spacing(3.5)] sm:[--thumb-size:--spacing(3.5)]"
+                checked={!isHidden}
+                disabled={model.isCustom}
+                onCheckedChange={(checked) => setHidden(model.slug, !checked)}
+                aria-label={`Show ${model.name} in the model picker`}
+              />
+            }
+          />
+          <TooltipPopup side="top">
+            {model.isCustom
+              ? "Custom models are always shown in the picker"
+              : isHidden
+                ? "Hidden from picker"
+                : "Shown in picker"}
+          </TooltipPopup>
+        </Tooltip>
       </div>
     );
   };
 
-  const groupLabel = (label: string) => (
-    <div className="px-2 pt-3 pb-1 text-[11px] text-muted-foreground first:pt-0">{label}</div>
+  const groupLabel = (label: string, isFirst: boolean) => (
+    <div className={cn("px-2 pb-1.5 text-[11px] text-muted-foreground", isFirst ? "pt-1" : "pt-5")}>
+      {label}
+    </div>
   );
 
   return (
     <div className="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
-      <div className="text-xs text-muted-foreground">
-        {models.length} model{models.length === 1 ? "" : "s"} available
-        {favoriteCount > 0 ? ` · ${favoriteCount} favorite${favoriteCount === 1 ? "" : "s"}` : ""}
-        {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {showFilter ? (
+          <Input
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder="Filter models"
+            className="h-8 w-56 text-xs"
+            spellCheck={false}
+            aria-label="Filter models"
+          />
+        ) : null}
+        <span className="text-xs text-muted-foreground">
+          {models.length} model{models.length === 1 ? "" : "s"}
+          {favoriteCount > 0 ? ` · ${favoriteCount} favorite${favoriteCount === 1 ? "" : "s"}` : ""}
+          {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
+        </span>
       </div>
       <div className="mt-2 -mx-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
-        {displayModels.map((model, index) => {
+        {visibleModels.length === 0 ? (
+          <p className="px-2 py-2 text-xs text-muted-foreground">No models match.</p>
+        ) : null}
+        {visibleModels.map((model, index) => {
           const group = groupOf(model);
-          const previous = displayModels[index - 1];
+          const previous = visibleModels[index - 1];
           const startsGroup = previous === undefined || groupOf(previous) !== group;
           return (
             <div key={`${instanceId}:${model.slug}:group`}>
               {startsGroup && favoriteCount > 0 && group === "favorite"
-                ? groupLabel("Favorites")
+                ? groupLabel("Favorites", index === 0)
                 : null}
-              {startsGroup && favoriteCount > 0 && group === "visible" ? groupLabel("All") : null}
-              {startsGroup && group === "hidden" ? groupLabel("Hidden from picker") : null}
-              {renderRow(model, index)}
+              {startsGroup && favoriteCount > 0 && group === "visible"
+                ? groupLabel("All", index === 0)
+                : null}
+              {startsGroup && group === "hidden"
+                ? groupLabel("Hidden from picker", index === 0)
+                : null}
+              {renderRow(model)}
             </div>
           );
         })}
       </div>
 
-      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-        <Input
-          id={`provider-instance-${instanceId}-custom-model`}
-          value={input}
-          onChange={(event) => {
-            setInput(event.target.value);
-            if (error) setError(null);
-          }}
-          onKeyDown={(event) => {
-            if (event.key !== "Enter") return;
-            event.preventDefault();
-            handleAdd();
-          }}
-          placeholder={driverKind ? CUSTOM_MODEL_PLACEHOLDER_BY_KIND[driverKind] : "model-slug"}
-          spellCheck={false}
-        />
-        <Button className="shrink-0" variant="outline" onClick={handleAdd}>
-          <PlusIcon className="size-3.5" />
-          Add
+      {isAdding ? (
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          <Input
+            id={`provider-instance-${instanceId}-custom-model`}
+            autoFocus
+            value={input}
+            onChange={(event) => {
+              setInput(event.target.value);
+              if (error) setError(null);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                cancelAdd();
+                return;
+              }
+              if (event.key !== "Enter") return;
+              event.preventDefault();
+              handleAdd();
+            }}
+            placeholder={driverKind ? CUSTOM_MODEL_PLACEHOLDER_BY_KIND[driverKind] : "model-slug"}
+            spellCheck={false}
+          />
+          <div className="flex shrink-0 gap-2">
+            <Button variant="outline" onClick={handleAdd}>
+              Add
+            </Button>
+            <Button variant="ghost" onClick={cancelAdd}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost-muted"
+          className="mt-2 -ml-2"
+          onClick={() => setIsAdding(true)}
+        >
+          <PlusIcon className="size-3" />
+          Add custom model
         </Button>
-      </div>
+      )}
 
       {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
     </div>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -428,7 +428,7 @@ export function ProviderModelsSection({
           {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
         </span>
       </div>
-      <div className="mt-2 -mx-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+      <div className="mt-2 -mx-2 max-h-64 overflow-y-auto lg:max-h-none lg:min-h-0 lg:flex-1">
         {visibleModels.length === 0 ? (
           <p className="px-2 py-2 text-xs text-muted-foreground">
             {isFiltering ? "No models match." : "No models reported for this provider yet."}

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -256,7 +256,128 @@ export function ProviderModelsSection({
     onModelOrderChange(next);
   };
 
-  const renderRow = (model: (typeof displayModels)[number]) => {
+  type DisplayModel = (typeof displayModels)[number];
+
+  const starButton = (model: DisplayModel, isFavorite: boolean) => (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            size="icon-micro"
+            variant="ghost"
+            className={cn(
+              "[--control-icon-color:currentColor]",
+              isFavorite
+                ? "text-yellow-500 hover:text-yellow-600"
+                : "text-muted-foreground/40 hover:text-muted-foreground",
+            )}
+            onClick={() => handleToggleFavorite(model.slug)}
+            aria-label={`${isFavorite ? "Remove" : "Add"} ${model.name} ${
+              isFavorite ? "from" : "to"
+            } favorites`}
+          />
+        }
+      >
+        <StarIcon className={cn("size-3", isFavorite && "fill-current")} />
+      </TooltipTrigger>
+      <TooltipPopup side="top">
+        {isFavorite ? "Remove from favorites" : "Add to favorites"}
+      </TooltipPopup>
+    </Tooltip>
+  );
+
+  // Reorder and remove stay in the row at all times (dimmed when unavailable)
+  // so ordering is discoverable without hovering.
+  const rowActions = (
+    model: DisplayModel,
+    options: {
+      readonly isHidden: boolean;
+      readonly canMoveUp: boolean;
+      readonly canMoveDown: boolean;
+    },
+  ) => (
+    <span className="flex shrink-0 items-center justify-end gap-0.5">
+      {!options.isHidden && !isFiltering ? (
+        <>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="icon-micro"
+                  variant="ghost-muted"
+                  disabled={!options.canMoveUp}
+                  onClick={() => handleMove(model.slug, -1)}
+                  aria-label={`Move ${model.name} up`}
+                />
+              }
+            >
+              <ArrowUpIcon className="size-3" />
+            </TooltipTrigger>
+            <TooltipPopup side="top">Move up</TooltipPopup>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="icon-micro"
+                  variant="ghost-muted"
+                  disabled={!options.canMoveDown}
+                  onClick={() => handleMove(model.slug, 1)}
+                  aria-label={`Move ${model.name} down`}
+                />
+              }
+            >
+              <ArrowDownIcon className="size-3" />
+            </TooltipTrigger>
+            <TooltipPopup side="top">Move down</TooltipPopup>
+          </Tooltip>
+        </>
+      ) : null}
+      {model.isCustom ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                size="icon-micro"
+                variant="ghost-muted"
+                aria-label={`Remove ${model.slug}`}
+                onClick={() => handleRemove(model.slug)}
+              />
+            }
+          >
+            <XIcon className="size-3" />
+          </TooltipTrigger>
+          <TooltipPopup side="top">Remove custom model</TooltipPopup>
+        </Tooltip>
+      ) : null}
+    </span>
+  );
+
+  const pickerTooltip = (model: DisplayModel, isHidden: boolean) =>
+    model.isCustom
+      ? "Custom models are always shown in the picker"
+      : isHidden
+        ? "Hidden from picker"
+        : "Shown in picker";
+
+  // The trigger is a wrapper span: a disabled switch gets no pointer events,
+  // so it could not open the tooltip itself.
+  const pickerSwitch = (model: DisplayModel, isHidden: boolean) => (
+    <Tooltip>
+      <TooltipTrigger render={<span className="flex shrink-0 items-center" />}>
+        <Switch
+          className="sm:[--thumb-size:--spacing(3.5)]"
+          checked={!isHidden}
+          disabled={model.isCustom}
+          onCheckedChange={(checked) => setHidden(model.slug, !checked)}
+          aria-label={`Show ${model.name} in the model picker`}
+        />
+      </TooltipTrigger>
+      <TooltipPopup side="top">{pickerTooltip(model, isHidden)}</TooltipPopup>
+    </Tooltip>
+  );
+
+  const renderRow = (model: DisplayModel) => {
     const capLabels = describeModelCapabilities(model);
     const group = groupOf(model);
     // Hidden is read from the preference itself: a favorited model can still be
@@ -271,132 +392,34 @@ export function ProviderModelsSection({
     const canMoveUp =
       !isFiltering && previousModel !== undefined && groupOf(previousModel) === group;
     const canMoveDown = !isFiltering && nextModel !== undefined && groupOf(nextModel) === group;
+    const nameClassName = cn("text-xs", isHidden ? "text-muted-foreground" : "text-foreground/90");
 
     return (
       <div
         key={`${instanceId}:${model.slug}`}
         className={cn(
-          "group flex min-h-8 items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-muted/30",
+          "grid h-7 grid-cols-[1.5rem_minmax(0,1fr)_auto_3rem_auto] items-center gap-2 rounded-md px-2 transition-colors hover:bg-muted/30",
           isHidden && "opacity-50",
         )}
       >
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                size="icon-micro"
-                variant="ghost"
-                className={cn(
-                  "[--control-icon-color:currentColor]",
-                  isFavorite
-                    ? "text-yellow-500 hover:text-yellow-600"
-                    : "text-muted-foreground/40 hover:text-muted-foreground",
-                )}
-                onClick={() => handleToggleFavorite(model.slug)}
-                aria-label={`${isFavorite ? "Remove" : "Add"} ${model.name} ${
-                  isFavorite ? "from" : "to"
-                } favorites`}
-              />
-            }
-          >
-            <StarIcon className={cn("size-3", isFavorite && "fill-current")} />
-          </TooltipTrigger>
-          <TooltipPopup side="top">
-            {isFavorite ? "Remove from favorites" : "Add to favorites"}
-          </TooltipPopup>
-        </Tooltip>
-        <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
-          <span
-            className={cn("text-xs", isHidden ? "text-muted-foreground" : "text-foreground/90")}
-          >
-            {model.name}
-          </span>
-          {model.name !== model.slug ? (
+        {starButton(model, isFavorite)}
+        <span className="flex min-w-0 items-baseline gap-2">
+          <span className={cn(nameClassName, "truncate")}>{model.name}</span>
+          {model.isCustom ? (
+            <span className="text-[11px] text-muted-foreground/70">custom</span>
+          ) : model.name !== model.slug ? (
             <code className="truncate font-mono text-[11px] text-muted-foreground/70">
               {model.slug}
             </code>
           ) : null}
-          {model.isCustom ? (
-            <span className="text-[11px] text-muted-foreground/70">custom</span>
-          ) : null}
-          {capLabels.length > 0 ? (
-            <span className="text-[11px] text-muted-foreground/70">{capLabels.join(" · ")}</span>
-          ) : null}
         </span>
-        <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity pointer-coarse:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100">
-          {!isHidden && !isFiltering ? (
-            <>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      size="icon-micro"
-                      variant="ghost-muted"
-                      disabled={!canMoveUp}
-                      onClick={() => handleMove(model.slug, -1)}
-                      aria-label={`Move ${model.name} up`}
-                    />
-                  }
-                >
-                  <ArrowUpIcon className="size-3" />
-                </TooltipTrigger>
-                <TooltipPopup side="top">Move up</TooltipPopup>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      size="icon-micro"
-                      variant="ghost-muted"
-                      disabled={!canMoveDown}
-                      onClick={() => handleMove(model.slug, 1)}
-                      aria-label={`Move ${model.name} down`}
-                    />
-                  }
-                >
-                  <ArrowDownIcon className="size-3" />
-                </TooltipTrigger>
-                <TooltipPopup side="top">Move down</TooltipPopup>
-              </Tooltip>
-            </>
-          ) : null}
-          {model.isCustom ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    size="icon-micro"
-                    variant="ghost-muted"
-                    aria-label={`Remove ${model.slug}`}
-                    onClick={() => handleRemove(model.slug)}
-                  />
-                }
-              >
-                <XIcon className="size-3" />
-              </TooltipTrigger>
-              <TooltipPopup side="top">Remove custom model</TooltipPopup>
-            </Tooltip>
-          ) : null}
-        </span>
-        {/* The trigger is a wrapper span: a disabled switch gets no pointer events, so it could not open the tooltip itself. */}
-        <Tooltip>
-          <TooltipTrigger render={<span className="flex shrink-0 items-center" />}>
-            <Switch
-              className="sm:[--thumb-size:--spacing(3.5)]"
-              checked={!isHidden}
-              disabled={model.isCustom}
-              onCheckedChange={(checked) => setHidden(model.slug, !checked)}
-              aria-label={`Show ${model.name} in the model picker`}
-            />
-          </TooltipTrigger>
-          <TooltipPopup side="top">
-            {model.isCustom
-              ? "Custom models are always shown in the picker"
-              : isHidden
-                ? "Hidden from picker"
-                : "Shown in picker"}
-          </TooltipPopup>
-        </Tooltip>
+        {capLabels.length > 0 ? (
+          <span className="text-[11px] text-muted-foreground/70">{capLabels.join(" · ")}</span>
+        ) : (
+          <span />
+        )}
+        {rowActions(model, { isHidden, canMoveUp, canMoveDown })}
+        {pickerSwitch(model, isHidden)}
       </div>
     );
   };

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -220,7 +220,10 @@ export function ProviderModelsSection({
       return;
     }
 
+    // Clear the filter so the new row renders even when it does not match,
+    // which is also what lets the pending scroll target resolve and clear.
     scrollToSlugRef.current = normalized;
+    setFilter("");
     onChange([...customModels, normalized]);
     setInput("");
     setError(null);

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowDownIcon, ArrowUpIcon, PlusIcon, StarIcon, XIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ProviderDriverKind,
   type ProviderInstanceId,
@@ -159,6 +159,9 @@ export function ProviderModelsSection({
   const [isAdding, setIsAdding] = useState(false);
   const [filter, setFilter] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  // Slug of a just-added custom model, scrolled into view once its row exists.
+  const scrollToSlugRef = useRef<string | null>(null);
   const hiddenModelSet = useMemo(() => new Set(hiddenModels), [hiddenModels]);
   const favoriteModelSet = useMemo(() => new Set(favoriteModels), [favoriteModels]);
   const displayModels = useMemo(
@@ -185,6 +188,19 @@ export function ProviderModelsSection({
       )
     : displayModels;
 
+  // The parent commits the new custom model and hands back an updated
+  // `models` list, so the row can only be scrolled to after that render.
+  useEffect(() => {
+    const slug = scrollToSlugRef.current;
+    if (slug === null) return;
+    const row = listRef.current?.querySelector<HTMLElement>(
+      `[data-model-slug="${CSS.escape(slug)}"]`,
+    );
+    if (!row) return;
+    scrollToSlugRef.current = null;
+    row.scrollIntoView({ block: "nearest" });
+  }, [displayModels]);
+
   const handleAdd = () => {
     const normalized = normalizeCustomModelSlug(input);
     if (!normalized) {
@@ -204,6 +220,7 @@ export function ProviderModelsSection({
       return;
     }
 
+    scrollToSlugRef.current = normalized;
     onChange([...customModels, normalized]);
     setInput("");
     setError(null);
@@ -397,6 +414,7 @@ export function ProviderModelsSection({
     return (
       <div
         key={`${instanceId}:${model.slug}`}
+        data-model-slug={model.slug}
         className={cn(
           "grid h-7 grid-cols-[1.5rem_minmax(0,1fr)_auto_3rem_auto] items-center gap-2 rounded-md px-2 transition-colors hover:bg-muted/30",
           isHidden && "opacity-50",
@@ -450,7 +468,10 @@ export function ProviderModelsSection({
           {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
         </span>
       </div>
-      <div className="mt-2 -mx-2 max-h-64 overflow-y-auto lg:max-h-none lg:min-h-0 lg:flex-1">
+      <div
+        ref={listRef}
+        className="mt-2 -mx-2 max-h-64 overflow-y-auto lg:max-h-none lg:min-h-0 lg:flex-1"
+      >
         {visibleModels.length === 0 ? (
           <p className="px-2 py-2 text-xs text-muted-foreground">
             {isFiltering ? "No models match." : "No models reported for this provider yet."}

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -378,18 +378,17 @@ export function ProviderModelsSection({
             </Tooltip>
           ) : null}
         </span>
+        {/* The trigger is a wrapper span: a disabled switch gets no pointer events, so it could not open the tooltip itself. */}
         <Tooltip>
-          <TooltipTrigger
-            render={
-              <Switch
-                className="sm:[--thumb-size:--spacing(3.5)]"
-                checked={!isHidden}
-                disabled={model.isCustom}
-                onCheckedChange={(checked) => setHidden(model.slug, !checked)}
-                aria-label={`Show ${model.name} in the model picker`}
-              />
-            }
-          />
+          <TooltipTrigger render={<span className="flex shrink-0 items-center" />}>
+            <Switch
+              className="sm:[--thumb-size:--spacing(3.5)]"
+              checked={!isHidden}
+              disabled={model.isCustom}
+              onCheckedChange={(checked) => setHidden(model.slug, !checked)}
+              aria-label={`Show ${model.name} in the model picker`}
+            />
+          </TooltipTrigger>
           <TooltipPopup side="top">
             {model.isCustom
               ? "Custom models are always shown in the picker"

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -434,8 +434,11 @@ export function ProviderModelsSection({
             </code>
           ) : null}
         </span>
+        {/* The capability column sizes to its content, so it yields to the name on phone widths. */}
         {capLabels.length > 0 ? (
-          <span className="text-[11px] text-muted-foreground/70">{capLabels.join(" · ")}</span>
+          <span className="hidden text-[11px] text-muted-foreground/70 sm:block">
+            {capLabels.join(" · ")}
+          </span>
         ) : (
           <span />
         )}

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -5,12 +5,11 @@ import {
   ArrowUpIcon,
   EyeIcon,
   EyeOffIcon,
-  InfoIcon,
   PlusIcon,
   StarIcon,
   XIcon,
 } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   ProviderDriverKind,
   type ProviderInstanceId,
@@ -23,7 +22,6 @@ import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
-import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 /**
@@ -37,6 +35,36 @@ const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, strin
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };
+
+/**
+ * Display order for the models list: favorites first (in user order), then
+ * visible models, then hidden ones. Hidden models sink so the list reads
+ * top-down as "what the picker shows"; moves only swap rows within the same
+ * group, and the resulting display order is what gets persisted as
+ * `modelOrder`.
+ */
+export function groupModelsForDisplay<
+  T extends { readonly slug: string; readonly isCustom: boolean },
+>(
+  models: ReadonlyArray<T>,
+  options: {
+    readonly favoriteModels: ReadonlySet<string>;
+    readonly hiddenModels: ReadonlySet<string>;
+    readonly modelOrder: ReadonlyArray<string>;
+  },
+): T[] {
+  const ordered = sortModelsForProviderInstance(models, {
+    favoriteModels: options.favoriteModels,
+    groupFavorites: true,
+    modelOrder: options.modelOrder,
+  });
+  const isHidden = (model: T) => !model.isCustom && options.hiddenModels.has(model.slug);
+  return [
+    ...ordered.filter((model) => options.favoriteModels.has(model.slug)),
+    ...ordered.filter((model) => !options.favoriteModels.has(model.slug) && !isHidden(model)),
+    ...ordered.filter((model) => !options.favoriteModels.has(model.slug) && isHidden(model)),
+  ];
+}
 
 interface ProviderModelsSectionProps {
   /** Identifier used to namespace input ids within the DOM. */
@@ -100,16 +128,21 @@ export function ProviderModelsSection({
 }: ProviderModelsSectionProps) {
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const listRef = useRef<HTMLDivElement | null>(null);
   const hiddenModelSet = useMemo(() => new Set(hiddenModels), [hiddenModels]);
   const favoriteModelSet = useMemo(() => new Set(favoriteModels), [favoriteModels]);
-  const orderedModels = useMemo(() => {
-    return sortModelsForProviderInstance(models, {
-      favoriteModels: favoriteModelSet,
-      groupFavorites: true,
-      modelOrder,
-    });
-  }, [favoriteModelSet, modelOrder, models]);
+  const displayModels = useMemo(
+    () =>
+      groupModelsForDisplay(models, {
+        favoriteModels: favoriteModelSet,
+        hiddenModels: hiddenModelSet,
+        modelOrder,
+      }),
+    [favoriteModelSet, hiddenModelSet, modelOrder, models],
+  );
+  const favoriteCount = displayModels.filter((model) => favoriteModelSet.has(model.slug)).length;
+  const hiddenCount = displayModels.filter(
+    (model) => !model.isCustom && hiddenModelSet.has(model.slug),
+  ).length;
 
   const handleAdd = () => {
     const normalized = normalizeCustomModelSlug(input);
@@ -133,21 +166,6 @@ export function ProviderModelsSection({
     onChange([...customModels, normalized]);
     setInput("");
     setError(null);
-
-    // Scroll the new row into view once the DOM reflects the commit.
-    // `MutationObserver` handles the one-frame gap between `onChange` and
-    // the `models` prop update; the `requestAnimationFrame` covers the
-    // common case where the parent updates synchronously.
-    const el = listRef.current;
-    if (!el) return;
-    const scrollToEnd = () => el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-    requestAnimationFrame(scrollToEnd);
-    const observer = new MutationObserver(() => {
-      scrollToEnd();
-      observer.disconnect();
-    });
-    observer.observe(el, { childList: true, subtree: true });
-    setTimeout(() => observer.disconnect(), 2_000);
   };
 
   const handleRemove = (slug: string) => {
@@ -173,211 +191,200 @@ export function ProviderModelsSection({
     onFavoriteModelsChange([...favoriteModels, slug]);
   };
 
+  // Rows only trade places with a neighbour in the same group (favorites,
+  // visible, hidden), and the display order is persisted as the new order.
+  const groupOf = (model: (typeof displayModels)[number]) =>
+    favoriteModelSet.has(model.slug)
+      ? "favorite"
+      : !model.isCustom && hiddenModelSet.has(model.slug)
+        ? "hidden"
+        : "visible";
   const handleMove = (slug: string, direction: -1 | 1) => {
-    const slugs = orderedModels.map((model) => model.slug);
-    const index = slugs.indexOf(slug);
+    const index = displayModels.findIndex((model) => model.slug === slug);
     const nextIndex = index + direction;
-    if (index < 0 || nextIndex < 0 || nextIndex >= slugs.length) {
-      return;
-    }
-    const next = [...slugs];
+    if (index < 0 || nextIndex < 0 || nextIndex >= displayModels.length) return;
+    if (groupOf(displayModels[index]!) !== groupOf(displayModels[nextIndex]!)) return;
+    const next = displayModels.map((model) => model.slug);
     [next[index], next[nextIndex]] = [next[nextIndex]!, next[index]!];
     onModelOrderChange(next);
   };
 
+  const renderRow = (model: (typeof displayModels)[number], index: number) => {
+    const descriptors = model.capabilities?.optionDescriptors ?? [];
+    const capLabels: string[] = [];
+    if (descriptors.some((descriptor) => descriptor.id === "fastMode")) capLabels.push("Fast mode");
+    if (descriptors.some((descriptor) => descriptor.id === "thinking")) capLabels.push("Thinking");
+    if (
+      descriptors.some(
+        (descriptor) =>
+          descriptor.type === "select" &&
+          (descriptor.id === "reasoningEffort" ||
+            descriptor.id === "effort" ||
+            descriptor.id === "reasoning" ||
+            descriptor.id === "variant"),
+      )
+    ) {
+      capLabels.push("Reasoning");
+    }
+    const group = groupOf(model);
+    const isHidden = group === "hidden";
+    const isFavorite = group === "favorite";
+    const previousModel = displayModels[index - 1];
+    const nextModel = displayModels[index + 1];
+    const canMoveUp = previousModel !== undefined && groupOf(previousModel) === group;
+    const canMoveDown = nextModel !== undefined && groupOf(nextModel) === group;
+
+    return (
+      <div
+        key={`${instanceId}:${model.slug}`}
+        className={cn(
+          "group flex min-h-8 items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-muted/30",
+          isHidden && "opacity-50",
+        )}
+      >
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                size="icon-micro"
+                variant="ghost"
+                className={cn(
+                  isFavorite
+                    ? "text-yellow-500 hover:text-yellow-600"
+                    : "text-muted-foreground/40 hover:text-muted-foreground",
+                )}
+                onClick={() => handleToggleFavorite(model.slug)}
+                aria-label={`${isFavorite ? "Remove" : "Add"} ${model.name} ${
+                  isFavorite ? "from" : "to"
+                } favorites`}
+              />
+            }
+          >
+            <StarIcon className={cn("size-3", isFavorite && "fill-current")} />
+          </TooltipTrigger>
+          <TooltipPopup side="top">
+            {isFavorite ? "Remove from favorites" : "Add to favorites"}
+          </TooltipPopup>
+        </Tooltip>
+        <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
+          <span
+            className={cn("text-xs", isHidden ? "text-muted-foreground" : "text-foreground/90")}
+          >
+            {model.name}
+          </span>
+          {model.name !== model.slug ? (
+            <code className="truncate font-mono text-[11px] text-muted-foreground/70">
+              {model.slug}
+            </code>
+          ) : null}
+          {model.isCustom ? (
+            <span className="text-[11px] text-muted-foreground/70">custom</span>
+          ) : null}
+          {capLabels.length > 0 ? (
+            <span className="text-[11px] text-muted-foreground/70">{capLabels.join(" · ")}</span>
+          ) : null}
+        </span>
+        <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+          {!isHidden ? (
+            <>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      size="icon-micro"
+                      variant="ghost-muted"
+                      disabled={!canMoveUp}
+                      onClick={() => handleMove(model.slug, -1)}
+                      aria-label={`Move ${model.name} up`}
+                    />
+                  }
+                >
+                  <ArrowUpIcon className="size-3" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">Move up</TooltipPopup>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      size="icon-micro"
+                      variant="ghost-muted"
+                      disabled={!canMoveDown}
+                      onClick={() => handleMove(model.slug, 1)}
+                      aria-label={`Move ${model.name} down`}
+                    />
+                  }
+                >
+                  <ArrowDownIcon className="size-3" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">Move down</TooltipPopup>
+              </Tooltip>
+            </>
+          ) : null}
+          {!model.isCustom ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-micro"
+                    variant="ghost-muted"
+                    onClick={() => handleToggleHidden(model.slug)}
+                    aria-label={`${isHidden ? "Show" : "Hide"} ${model.name}`}
+                  />
+                }
+              >
+                {isHidden ? <EyeIcon className="size-3" /> : <EyeOffIcon className="size-3" />}
+              </TooltipTrigger>
+              <TooltipPopup side="top">
+                {isHidden ? "Show in picker" : "Hide from picker"}
+              </TooltipPopup>
+            </Tooltip>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-micro"
+                    variant="ghost-muted"
+                    aria-label={`Remove ${model.slug}`}
+                    onClick={() => handleRemove(model.slug)}
+                  />
+                }
+              >
+                <XIcon className="size-3" />
+              </TooltipTrigger>
+              <TooltipPopup side="top">Remove custom model</TooltipPopup>
+            </Tooltip>
+          )}
+        </span>
+      </div>
+    );
+  };
+
+  const groupLabel = (label: string) => (
+    <div className="px-2 pt-3 pb-1 text-[11px] text-muted-foreground first:pt-0">{label}</div>
+  );
+
   return (
     <div className="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
-      <div className="text-xs font-medium text-foreground">Models</div>
-      <div className="mt-1 text-xs text-muted-foreground">
-        {models.length} model{models.length === 1 ? "" : "s"} available.
+      <div className="text-xs text-muted-foreground">
+        {models.length} model{models.length === 1 ? "" : "s"} available
+        {favoriteCount > 0 ? ` · ${favoriteCount} favorite${favoriteCount === 1 ? "" : "s"}` : ""}
+        {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
       </div>
-      <div
-        ref={listRef}
-        className="mt-2 max-h-40 overflow-y-auto pb-1 lg:min-h-0 lg:max-h-none lg:flex-1"
-      >
-        {orderedModels.map((model, index) => {
-          const caps = model.capabilities;
-          const capLabels: string[] = [];
-          const isHidden = !model.isCustom && hiddenModelSet.has(model.slug);
-          const isFavorite = favoriteModelSet.has(model.slug);
-          const previousModel = orderedModels[index - 1];
-          const nextModel = orderedModels[index + 1];
-          const canMoveUp =
-            previousModel !== undefined && favoriteModelSet.has(previousModel.slug) === isFavorite;
-          const canMoveDown =
-            nextModel !== undefined && favoriteModelSet.has(nextModel.slug) === isFavorite;
-          const descriptors = caps?.optionDescriptors ?? [];
-          if (descriptors.some((descriptor) => descriptor.id === "fastMode")) {
-            capLabels.push("Fast mode");
-          }
-          if (descriptors.some((descriptor) => descriptor.id === "thinking")) {
-            capLabels.push("Thinking");
-          }
-          if (
-            descriptors.some(
-              (descriptor) =>
-                descriptor.type === "select" &&
-                (descriptor.id === "reasoningEffort" ||
-                  descriptor.id === "effort" ||
-                  descriptor.id === "reasoning" ||
-                  descriptor.id === "variant"),
-            )
-          ) {
-            capLabels.push("Reasoning");
-          }
-          const hasDetails = capLabels.length > 0 || model.name !== model.slug;
-
+      <div className="mt-2 -mx-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+        {displayModels.map((model, index) => {
+          const group = groupOf(model);
+          const previous = displayModels[index - 1];
+          const startsGroup = previous === undefined || groupOf(previous) !== group;
           return (
-            <div
-              key={`${instanceId}:${model.slug}`}
-              className={cn(
-                "grid min-h-7 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 py-1",
-                isHidden && "text-muted-foreground",
-              )}
-            >
-              <div className="flex min-w-0 items-center gap-1">
-                <span
-                  className={cn(
-                    "min-w-0 truncate text-xs",
-                    isHidden ? "text-muted-foreground line-through" : "text-foreground/90",
-                  )}
-                >
-                  {model.name}
-                </span>
-                {hasDetails ? (
-                  <Popover>
-                    <PopoverTrigger
-                      openOnHover
-                      delay={250}
-                      closeDelay={100}
-                      render={
-                        <Button
-                          size="icon-micro"
-                          variant="ghost"
-                          className="text-muted-foreground/60 hover:text-muted-foreground"
-                          aria-label={`Details for ${model.name}`}
-                        />
-                      }
-                    >
-                      <InfoIcon className="size-3" />
-                    </PopoverTrigger>
-                    <PopoverPopup side="top" tooltipStyle className="max-w-56">
-                      <div className="space-y-1">
-                        <code className="block text-[11px] text-foreground">{model.slug}</code>
-                        {capLabels.length > 0 ? (
-                          <div className="flex flex-wrap gap-x-2 gap-y-0.5">
-                            {capLabels.map((label) => (
-                              <span key={label} className="text-[10px] text-muted-foreground">
-                                {label}
-                              </span>
-                            ))}
-                          </div>
-                        ) : null}
-                      </div>
-                    </PopoverPopup>
-                  </Popover>
-                ) : null}
-                {isHidden ? (
-                  <span className="text-[10px] text-muted-foreground">hidden</span>
-                ) : null}
-                {model.isCustom ? (
-                  <span className="text-[10px] text-muted-foreground">custom</span>
-                ) : null}
-              </div>
-              <div className="flex shrink-0 items-center gap-0.5">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="icon-micro"
-                        variant="ghost-muted"
-                        className={cn(isFavorite && "text-yellow-500 hover:text-yellow-600")}
-                        onClick={() => handleToggleFavorite(model.slug)}
-                        aria-label={`${isFavorite ? "Remove" : "Add"} ${model.name} ${
-                          isFavorite ? "from" : "to"
-                        } favorites`}
-                      />
-                    }
-                  >
-                    <StarIcon className={cn("size-3", isFavorite && "fill-current")} />
-                  </TooltipTrigger>
-                  <TooltipPopup side="top">
-                    {isFavorite ? "Remove from favorites" : "Add to favorites"}
-                  </TooltipPopup>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="icon-micro"
-                        variant="ghost-muted"
-                        disabled={!canMoveUp}
-                        onClick={() => handleMove(model.slug, -1)}
-                        aria-label={`Move ${model.name} up`}
-                      />
-                    }
-                  >
-                    <ArrowUpIcon className="size-3" />
-                  </TooltipTrigger>
-                  <TooltipPopup side="top">Move up</TooltipPopup>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="icon-micro"
-                        variant="ghost-muted"
-                        disabled={!canMoveDown}
-                        onClick={() => handleMove(model.slug, 1)}
-                        aria-label={`Move ${model.name} down`}
-                      />
-                    }
-                  >
-                    <ArrowDownIcon className="size-3" />
-                  </TooltipTrigger>
-                  <TooltipPopup side="top">Move down</TooltipPopup>
-                </Tooltip>
-                {!model.isCustom ? (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <Button
-                          size="icon-micro"
-                          variant="ghost-muted"
-                          onClick={() => handleToggleHidden(model.slug)}
-                          aria-label={`${isHidden ? "Show" : "Hide"} ${model.name}`}
-                        />
-                      }
-                    >
-                      {isHidden ? (
-                        <EyeIcon className="size-3" />
-                      ) : (
-                        <EyeOffIcon className="size-3" />
-                      )}
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">
-                      {isHidden ? "Show in picker" : "Hide from picker"}
-                    </TooltipPopup>
-                  </Tooltip>
-                ) : null}
-                {model.isCustom ? (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <Button
-                          size="icon-micro"
-                          variant="ghost-muted"
-                          aria-label={`Remove ${model.slug}`}
-                          onClick={() => handleRemove(model.slug)}
-                        />
-                      }
-                    >
-                      <XIcon className="size-3" />
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">Remove custom model</TooltipPopup>
-                  </Tooltip>
-                ) : null}
-              </div>
+            <div key={`${instanceId}:${model.slug}:group`}>
+              {startsGroup && favoriteCount > 0 && group === "favorite"
+                ? groupLabel("Favorites")
+                : null}
+              {startsGroup && favoriteCount > 0 && group === "visible" ? groupLabel("All") : null}
+              {startsGroup && group === "hidden" ? groupLabel("Hidden from picker") : null}
+              {renderRow(model, index)}
             </div>
           );
         })}

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -323,7 +323,7 @@ export function ProviderModelsSection({
             <span className="text-[11px] text-muted-foreground/70">{capLabels.join(" · ")}</span>
           ) : null}
         </span>
-        <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+        <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity pointer-coarse:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100">
           {!isHidden && !isFiltering ? (
             <>
               <Tooltip>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -259,7 +259,9 @@ export function ProviderModelsSection({
   const renderRow = (model: (typeof displayModels)[number]) => {
     const capLabels = describeModelCapabilities(model);
     const group = groupOf(model);
-    const isHidden = group === "hidden";
+    // Hidden is read from the preference itself: a favorited model can still be
+    // hidden, and its switch must say so even though it sits in the favorites group.
+    const isHidden = !model.isCustom && hiddenModelSet.has(model.slug);
     const isFavorite = group === "favorite";
     const index = displayModels.indexOf(model);
     const previousModel = displayModels[index - 1];
@@ -285,6 +287,7 @@ export function ProviderModelsSection({
                 size="icon-micro"
                 variant="ghost"
                 className={cn(
+                  "[--control-icon-color:currentColor]",
                   isFavorite
                     ? "text-yellow-500 hover:text-yellow-600"
                     : "text-muted-foreground/40 hover:text-muted-foreground",
@@ -379,7 +382,7 @@ export function ProviderModelsSection({
           <TooltipTrigger
             render={
               <Switch
-                className="[--thumb-size:--spacing(3.5)] sm:[--thumb-size:--spacing(3.5)]"
+                className="sm:[--thumb-size:--spacing(3.5)]"
                 checked={!isHidden}
                 disabled={model.isCustom}
                 onCheckedChange={(checked) => setHidden(model.slug, !checked)}
@@ -413,7 +416,8 @@ export function ProviderModelsSection({
             value={filter}
             onChange={(event) => setFilter(event.target.value)}
             placeholder="Filter models"
-            className="h-8 w-56 text-xs"
+            size="compact"
+            className="w-56"
             spellCheck={false}
             aria-label="Filter models"
           />
@@ -426,7 +430,9 @@ export function ProviderModelsSection({
       </div>
       <div className="mt-2 -mx-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
         {visibleModels.length === 0 ? (
-          <p className="px-2 py-2 text-xs text-muted-foreground">No models match.</p>
+          <p className="px-2 py-2 text-xs text-muted-foreground">
+            {isFiltering ? "No models match." : "No models reported for this provider yet."}
+          </p>
         ) : null}
         {visibleModels.map((model, index) => {
           const group = groupOf(model);

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -205,7 +205,9 @@ function ProviderSettingsFieldRow({
 
   if (variant === "grid") {
     // Label cell, then a control cell where the description sits beside a
-    // fixed-width control and wraps under it when the pane is narrow.
+    // fixed-width control and wraps under it when the pane is narrow. The
+    // description is outside the label, so the control points at it instead.
+    const descriptionId = field.description ? `${inputId}-description` : undefined;
     return (
       <>
         {field.control === "switch" ? (
@@ -224,11 +226,13 @@ function ProviderSettingsFieldRow({
                   onChange(nextProviderConfigWithFieldValue(value, field, Boolean(checked)))
                 }
                 aria-label={field.label}
+                aria-describedby={descriptionId}
               />
             </span>
           ) : field.control === "textarea" ? (
             <Textarea
               id={inputId}
+              aria-describedby={descriptionId}
               className="w-full max-w-sm"
               value={readProviderConfigString(value, field.key)}
               onChange={(event) =>
@@ -240,6 +244,7 @@ function ProviderSettingsFieldRow({
           ) : (
             <DraftInput
               id={inputId}
+              aria-describedby={descriptionId}
               className="w-56"
               type={field.control === "password" ? "password" : undefined}
               autoComplete={field.control === "password" ? "off" : undefined}
@@ -250,7 +255,7 @@ function ProviderSettingsFieldRow({
             />
           )}
           {field.description ? (
-            <span className="text-[11px] leading-snug text-muted-foreground">
+            <span id={descriptionId} className="text-[11px] leading-snug text-muted-foreground">
               {field.description}
             </span>
           ) : null}

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -161,7 +161,8 @@ interface ProviderSettingsFormProps {
   /**
    * `card` stacks label over control, `dialog` is the compact wizard layout,
    * `grid` emits a label cell and a control cell per field for a parent
-   * two-column grid (label column left, control right).
+   * two-column grid (label column left, control right), with the description
+   * beside a fixed-width control so each field stays on one line.
    */
   readonly variant: "card" | "dialog" | "grid";
   readonly onChange: (nextConfig: Record<string, unknown> | undefined) => void;
@@ -203,17 +204,20 @@ function ProviderSettingsFieldRow({
   ) : null;
 
   if (variant === "grid") {
-    const gridLabel = (
-      <label htmlFor={inputId} className="pt-1.5 text-xs font-medium text-foreground">
-        {field.label}
-      </label>
-    );
-    if (field.control === "switch") {
-      return (
-        <>
+    // Label cell, then a control cell where the description sits beside a
+    // fixed-width control and wraps under it when the pane is narrow.
+    return (
+      <>
+        {field.control === "switch" ? (
           <span className="pt-1.5 text-xs font-medium text-foreground">{field.label}</span>
-          <div className="min-w-0">
-            <div className="flex h-8 items-center">
+        ) : (
+          <label htmlFor={inputId} className="pt-1.5 text-xs font-medium text-foreground">
+            {field.label}
+          </label>
+        )}
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+          {field.control === "switch" ? (
+            <span className="flex h-8 items-center">
               <Switch
                 checked={readProviderConfigBoolean(value, field.key, field.defaultBooleanValue)}
                 onCheckedChange={(checked) =>
@@ -221,19 +225,11 @@ function ProviderSettingsFieldRow({
                 }
                 aria-label={field.label}
               />
-            </div>
-            {description}
-          </div>
-        </>
-      );
-    }
-    if (field.control === "textarea") {
-      return (
-        <>
-          {gridLabel}
-          <div className="min-w-0">
+            </span>
+          ) : field.control === "textarea" ? (
             <Textarea
               id={inputId}
+              className="w-full max-w-sm"
               value={readProviderConfigString(value, field.key)}
               onChange={(event) =>
                 onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
@@ -241,26 +237,23 @@ function ProviderSettingsFieldRow({
               placeholder={field.placeholder}
               spellCheck={false}
             />
-            {description}
-          </div>
-        </>
-      );
-    }
-    return (
-      <>
-        {gridLabel}
-        <div className="min-w-0">
-          <DraftInput
-            id={inputId}
-            className="max-w-md"
-            type={field.control === "password" ? "password" : undefined}
-            autoComplete={field.control === "password" ? "off" : undefined}
-            value={readProviderConfigString(value, field.key)}
-            onCommit={(next) => onChange(nextProviderConfigWithFieldValue(value, field, next))}
-            placeholder={field.placeholder}
-            spellCheck={false}
-          />
-          {description}
+          ) : (
+            <DraftInput
+              id={inputId}
+              className="w-56"
+              type={field.control === "password" ? "password" : undefined}
+              autoComplete={field.control === "password" ? "off" : undefined}
+              value={readProviderConfigString(value, field.key)}
+              onCommit={(next) => onChange(nextProviderConfigWithFieldValue(value, field, next))}
+              placeholder={field.placeholder}
+              spellCheck={false}
+            />
+          )}
+          {field.description ? (
+            <span className="text-[11px] leading-snug text-muted-foreground">
+              {field.description}
+            </span>
+          ) : null}
         </div>
       </>
     );

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -158,7 +158,12 @@ interface ProviderSettingsFormProps {
   readonly definition: ProviderClientDefinition;
   readonly value: unknown;
   readonly idPrefix: string;
-  readonly variant: "card" | "dialog";
+  /**
+   * `card` stacks label over control, `dialog` is the compact wizard layout,
+   * `grid` emits a label cell and a control cell per field for a parent
+   * two-column grid (label column left, control right).
+   */
+  readonly variant: "card" | "dialog" | "grid";
   readonly onChange: (nextConfig: Record<string, unknown> | undefined) => void;
 }
 
@@ -189,13 +194,77 @@ function ProviderSettingsFieldRow({
 }: ProviderSettingsFieldRowProps) {
   const inputId = `${idPrefix}-${field.key}`;
   const descriptionClassName =
-    variant === "card"
-      ? "mt-1 block text-xs text-muted-foreground"
-      : "text-[11px] text-muted-foreground";
+    variant === "dialog"
+      ? "text-[11px] text-muted-foreground"
+      : "mt-1 block text-xs text-muted-foreground";
   const label = <span className="text-xs font-medium text-foreground">{field.label}</span>;
   const description = field.description ? (
     <span className={descriptionClassName}>{field.description}</span>
   ) : null;
+
+  if (variant === "grid") {
+    const gridLabel = (
+      <label htmlFor={inputId} className="pt-1.5 text-xs font-medium text-foreground">
+        {field.label}
+      </label>
+    );
+    if (field.control === "switch") {
+      return (
+        <>
+          <span className="pt-1.5 text-xs font-medium text-foreground">{field.label}</span>
+          <div className="min-w-0">
+            <div className="flex h-8 items-center">
+              <Switch
+                checked={readProviderConfigBoolean(value, field.key, field.defaultBooleanValue)}
+                onCheckedChange={(checked) =>
+                  onChange(nextProviderConfigWithFieldValue(value, field, Boolean(checked)))
+                }
+                aria-label={field.label}
+              />
+            </div>
+            {description}
+          </div>
+        </>
+      );
+    }
+    if (field.control === "textarea") {
+      return (
+        <>
+          {gridLabel}
+          <div className="min-w-0">
+            <Textarea
+              id={inputId}
+              value={readProviderConfigString(value, field.key)}
+              onChange={(event) =>
+                onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
+              }
+              placeholder={field.placeholder}
+              spellCheck={false}
+            />
+            {description}
+          </div>
+        </>
+      );
+    }
+    return (
+      <>
+        {gridLabel}
+        <div className="min-w-0">
+          <DraftInput
+            id={inputId}
+            className="max-w-md"
+            type={field.control === "password" ? "password" : undefined}
+            autoComplete={field.control === "password" ? "off" : undefined}
+            value={readProviderConfigString(value, field.key)}
+            onCommit={(next) => onChange(nextProviderConfigWithFieldValue(value, field, next))}
+            placeholder={field.placeholder}
+            spellCheck={false}
+          />
+          {description}
+        </div>
+      </>
+    );
+  }
 
   if (field.control === "switch") {
     return (

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -141,6 +141,21 @@ function renderPanel(options?: {
   }) as ReactElement<Record<string, unknown>>;
 }
 
+function isRefreshButton(element: ReactElement<Record<string, unknown>>): boolean {
+  const children = element.props.children;
+  return (
+    Array.isArray(children) &&
+    children.some(
+      (child) =>
+        typeof child === "object" &&
+        child !== null &&
+        (child as ReactElement<Record<string, unknown>>).props?.className === "sr-only" &&
+        (child as ReactElement<Record<string, unknown>>).props?.children ===
+          "Refresh provider status",
+    )
+  );
+}
+
 function isAddProviderButton(element: ReactElement<Record<string, unknown>>): boolean {
   return element.props["aria-label"] === "Add provider";
 }
@@ -184,10 +199,7 @@ describe("EnvironmentProviderSettings routing", () => {
   it("routes refresh and provider update commands to the selected environment", async () => {
     atoms.providers = [provider()];
     const panel = renderPanel();
-    const refreshButton = visitElements(
-      panel,
-      (element) => element.props["aria-label"] === "Refresh provider status",
-    );
+    const refreshButton = visitElements(panel, isRefreshButton);
     expect(refreshButton).not.toBeNull();
     (refreshButton?.props.onClick as (() => void) | undefined)?.();
     await flushPromises();
@@ -243,9 +255,7 @@ describe("EnvironmentProviderSettings routing", () => {
     const notice = visitElements(panel, (element) => element.props.title === "Limited permissions");
     expect(notice).not.toBeNull();
 
-    expect(
-      visitElements(panel, (element) => element.props["aria-label"] === "Refresh provider status"),
-    ).toBeNull();
+    expect(visitElements(panel, isRefreshButton)).toBeNull();
     expect(visitElements(panel, isAddProviderButton)).toBeNull();
   });
 
@@ -256,9 +266,7 @@ describe("EnvironmentProviderSettings routing", () => {
     expect(
       visitElements(panel, (element) => element.props.title === "Limited permissions"),
     ).toBeNull();
-    expect(
-      visitElements(panel, (element) => element.props["aria-label"] === "Refresh provider status"),
-    ).not.toBeNull();
+    expect(visitElements(panel, isRefreshButton)).not.toBeNull();
     expect(visitElements(panel, isAddProviderButton)).not.toBeNull();
   });
 

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -873,13 +873,13 @@ export function EnvironmentProviderSettings({
                         variant="ghost-muted"
                         disabled={isRefreshingProviders}
                         onClick={() => void refreshProviders()}
-                        aria-label="Refresh provider status"
                       >
                         {isRefreshingProviders ? (
                           <LoaderIcon className="animate-spin" />
                         ) : (
                           <RefreshCwIcon />
                         )}
+                        <span className="sr-only">Refresh provider status</span>
                         <span className="hidden min-w-0 truncate sm:inline">
                           <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
                         </span>

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -135,11 +135,11 @@ function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }
   }
 
   if (lastCheckedRelative.status === "invalid") {
-    return <span className="text-[11px] text-muted-foreground/50">Checked unavailable</span>;
+    return <span>Checked unavailable</span>;
   }
 
   return (
-    <span className="text-[11px] text-muted-foreground/60">
+    <span>
       {lastCheckedRelative.suffix ? (
         <>
           Checked <span className="font-mono tabular-nums">{lastCheckedRelative.value}</span>{" "}
@@ -858,33 +858,31 @@ export function EnvironmentProviderSettings({
       <SettingsSection
         {...searchableSetting("providers")}
         headerAction={
-          <div className="flex min-w-0 items-center gap-1.5">
-            {/*
-              The 11px size must sit on this flex item, not just the span
-              inside: the item's line box is struck from its own font size,
-              and an inherited 16px strut hangs the smaller text below the
-              vertical center of the row.
-            */}
-            <span className="hidden min-w-0 truncate text-[11px] sm:inline">
-              <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
-            </span>
-            {!readOnly ? (
+          <div className="flex min-w-0 items-center gap-2">
+            {readOnly ? (
+              <span className="hidden min-w-0 truncate text-xs text-muted-foreground sm:inline">
+                <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
+              </span>
+            ) : (
               <>
                 <Tooltip>
                   <TooltipTrigger
                     render={
                       <Button
-                        size="icon-micro"
+                        size="compact"
                         variant="ghost-muted"
                         disabled={isRefreshingProviders}
                         onClick={() => void refreshProviders()}
                         aria-label="Refresh provider status"
                       >
                         {isRefreshingProviders ? (
-                          <LoaderIcon className="size-3 animate-spin" />
+                          <LoaderIcon className="animate-spin" />
                         ) : (
-                          <RefreshCwIcon className="size-3" />
+                          <RefreshCwIcon />
                         )}
+                        <span className="hidden min-w-0 truncate sm:inline">
+                          <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
+                        </span>
                       </Button>
                     }
                   />
@@ -906,7 +904,7 @@ export function EnvironmentProviderSettings({
                   <TooltipPopup side="top">Add provider</TooltipPopup>
                 </Tooltip>
               </>
-            ) : null}
+            )}
           </div>
         }
       >

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -860,7 +860,7 @@ export function EnvironmentProviderSettings({
         headerAction={
           <div className="flex min-w-0 items-center gap-2">
             {readOnly ? (
-              <span className="hidden min-w-0 truncate text-xs text-muted-foreground sm:inline">
+              <span className="min-w-0 truncate text-xs text-muted-foreground">
                 <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
               </span>
             ) : (
@@ -946,27 +946,24 @@ export function EnvironmentProviderSettings({
               Advanced
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <div
-                inert={readOnly}
-                aria-disabled={readOnly || undefined}
-                className={readOnly ? "opacity-50 select-none" : undefined}
-              >
-                <SettingsRow
-                  id={searchableSetting("provider-health-check-interval").id}
-                  title={
-                    <span className="inline-flex items-center gap-1.5">
-                      {searchableSetting("provider-health-check-interval").title}
-                      <PolicyTooltip>
-                        This interval is configured here, then the shared Background activity policy
-                        decides whether provider probes may run when the timer fires. Custom
-                        intervals appear as Advanced in General settings.
-                      </PolicyTooltip>
-                    </span>
-                  }
-                  description="Refresh availability, versions, auth state, and models in the background. 0 seconds turns background checks off."
-                  resetAction={
-                    providerHealthRefreshIntervalSeconds !==
-                    defaultProviderHealthRefreshIntervalSeconds ? (
+              {/* Only the write controls go inert; the title and its policy tooltip stay readable. */}
+              <SettingsRow
+                id={searchableSetting("provider-health-check-interval").id}
+                title={
+                  <span className="inline-flex items-center gap-1.5">
+                    {searchableSetting("provider-health-check-interval").title}
+                    <PolicyTooltip>
+                      This interval is configured here, then the shared Background activity policy
+                      decides whether provider probes may run when the timer fires. Custom intervals
+                      appear as Advanced in General settings.
+                    </PolicyTooltip>
+                  </span>
+                }
+                description="Refresh availability, versions, auth state, and models in the background. 0 seconds turns background checks off."
+                resetAction={
+                  providerHealthRefreshIntervalSeconds !==
+                  defaultProviderHealthRefreshIntervalSeconds ? (
+                    <span inert={readOnly} className={readOnly ? "opacity-50" : undefined}>
                       <SettingResetButton
                         label="provider health check interval"
                         onClick={() =>
@@ -979,41 +976,48 @@ export function EnvironmentProviderSettings({
                           )
                         }
                       />
-                    ) : null
-                  }
-                  control={
-                    <div className="flex shrink-0 items-center gap-2">
-                      <NumberField
-                        value={providerHealthRefreshIntervalSeconds}
-                        min={0}
-                        step={PROVIDER_HEALTH_INTERVAL_STEP_SECONDS}
-                        size="sm"
-                        className="w-32"
-                        onValueChange={(value) =>
-                          updateSettings(
-                            backgroundActivityOverrideSettings(
-                              settings.backgroundActivity,
-                              resolvedBackgroundActivity,
-                              {
-                                providerHealthRefreshInterval: Duration.seconds(
-                                  normalizeIntervalSeconds(value),
-                                ),
-                              },
-                            ),
-                          )
-                        }
-                      >
-                        <NumberFieldGroup>
-                          <NumberFieldDecrement aria-label="Decrease provider health check interval" />
-                          <NumberFieldInput aria-label="Provider health check interval in seconds" />
-                          <NumberFieldIncrement aria-label="Increase provider health check interval" />
-                        </NumberFieldGroup>
-                      </NumberField>
-                      <span className="text-xs text-muted-foreground">seconds</span>
-                    </div>
-                  }
-                />
-              </div>
+                    </span>
+                  ) : null
+                }
+                control={
+                  <div
+                    inert={readOnly}
+                    aria-disabled={readOnly || undefined}
+                    className={cn(
+                      "flex shrink-0 items-center gap-2",
+                      readOnly && "opacity-50 select-none",
+                    )}
+                  >
+                    <NumberField
+                      value={providerHealthRefreshIntervalSeconds}
+                      min={0}
+                      step={PROVIDER_HEALTH_INTERVAL_STEP_SECONDS}
+                      size="sm"
+                      className="w-32"
+                      onValueChange={(value) =>
+                        updateSettings(
+                          backgroundActivityOverrideSettings(
+                            settings.backgroundActivity,
+                            resolvedBackgroundActivity,
+                            {
+                              providerHealthRefreshInterval: Duration.seconds(
+                                normalizeIntervalSeconds(value),
+                              ),
+                            },
+                          ),
+                        )
+                      }
+                    >
+                      <NumberFieldGroup>
+                        <NumberFieldDecrement aria-label="Decrease provider health check interval" />
+                        <NumberFieldInput aria-label="Provider health check interval in seconds" />
+                        <NumberFieldIncrement aria-label="Increase provider health check interval" />
+                      </NumberFieldGroup>
+                    </NumberField>
+                    <span className="text-xs text-muted-foreground">seconds</span>
+                  </div>
+                }
+              />
             </CollapsibleContent>
           </Collapsible>
         </div>


### PR DESCRIPTION
The provider editor was a long stack of full-width label-over-input fields, a four-column table for usually zero to two environment variables, and a Models tab capped at 160px with four always-visible icon buttons per row. Codex models also never showed "Fast mode" because the label only matched the boolean `fastMode` descriptor, not Codex's `serviceTier` select.

What changes:

- Configuration tab regrouped into a label-left grid (new `grid` variant of `ProviderSettingsForm`; the Add wizard's `dialog` variant is untouched): display name and accent swatches on one line, then Runtime and Environment groups under small divider labels. Each driver field is one line, with its description beside a fixed-width input. Environment variables are compact `NAME = value` rows with a lock toggle for sensitive values. Delete instance moves to the editor header.
- Models tab: no height cap, rows are a fixed-column grid (star, name and slug, capabilities, reorder and remove, picker switch) so capabilities line up and the reorder arrows stay in the row instead of appearing on hover. Picker visibility is a per-row switch (custom models show a disabled checked switch since they are always offered), favorites are grouped first with hidden models sunk to the bottom, a filter input appears above eight models, and "Add custom model" is a ghost button that expands into the input. The Models tab label shows the model count and how many are hidden.
- Capability labels count a Codex `serviceTier` select with a "Fast" tier as Fast mode, matching the composer's logic.
- Section header: "Checked Xs ago" and refresh are one compact ghost button next to Add provider.

## Before

Configuration tab:

![Provider editor before, Configuration](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/d1704652-77ab-49f0-91fc-f2f8a90b978c/provider-editor-before-configuration.png)

Models tab:

![Provider editor before, Models](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/e9d8bc0e-de49-434d-8627-ab9cb0857367/provider-editor-before-models.png)

## After

Screenshots predate the last commit, which made each driver field one line, aligned the model columns, and added the model count to the tab.

Configuration tab:

![Provider editor after, Configuration](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/d307e141-6945-460f-a229-10e233116fe4/provider-editor-after-configuration.png)

Models tab:

![Provider editor after, Models](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/ede352e8-bd15-445f-a33d-ce3ae0fdfdcd/provider-editor-after-models.png)

## Checks

- `vp test run` on the four provider settings test files (21 tests), including a new `groupModelsForDisplay` test
- `vp run --filter @t3tools/web typecheck`
- Focused lint and format on the changed files

Built with Claude Fable 5.1 in the Claude Code harness via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Model list ordering and hidden-model grouping change persisted `modelOrder` semantics and what users see for edge cases (e.g. custom slugs in hidden prefs); otherwise UI-only settings changes with new test coverage for grouping.
> 
> **Overview**
> Redesigns the provider instance **Configuration** and **Models** tabs plus related settings chrome.
> 
> The **Configuration** tab moves to a label-left two-column grid: display name shares a row with an **inline** accent swatch row (`ProviderAccentColorPicker` `layout="inline"`), driver fields use a new **`grid`** variant on `ProviderSettingsForm` (description beside fixed-width controls), and **Runtime** / **Environment** sections get divider labels. Environment variables drop the bordered table for compact `NAME = value` rows with lock/unlock for sensitivity and inline remove. **Delete instance** moves from the list header icon to a text button in the editor header.
> 
> The **Models** tab removes the short height cap and info popovers in favor of a fixed-column row layout: inline capability tags (including **Fast mode** for Codex `serviceTier` selects), always-visible reorder/remove actions, and a **picker visibility switch** instead of eye icons. Lists are ordered via new **`groupModelsForDisplay`** (favorites, then visible, then hidden built-ins; custom models never treated as hidden). Reorder only swaps neighbors within the same group; filtering appears when there are more than eight models; add-custom-model is collapsible with cancel/Escape and scroll-to-new-row. The Models tab label shows total and hidden counts.
> 
> **Providers** section header combines refresh and “Checked … ago” into one compact button (sr-only label for tests); read-only mode shows last-checked text and keeps Advanced health-interval labels readable while controls stay inert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fb0bbf91f8d32c1278406426e22dc4ca9e1f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline layout option to `ProviderAccentColorPicker`
> Extracts the custom picker, preset swatches, and clear action into a reusable swatch row. The new optional `stacked`/`inline` layout prop defaults to `stacked`, which keeps the label and description. `inline` mode renders only the swatch row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6fb0bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



