### PR TITLE
fix(shared): stop tracing individual command probes

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -2,10 +2,12 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as Tracer from "effect/Tracer";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   extractPathFromShellOutput,
+  CommandResolutionCache,
   CommandAvailability,
   type CommandAvailabilityChecker,
   isCommandAvailable,
@@ -373,6 +375,34 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
       }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
 
       expect(result._tag).toBe("Failure");
+    }),
+  );
+
+  it.effect("does not trace individual filesystem candidates", () =>
+    Effect.gen(function* () {
+      const spanNames: Array<string> = [];
+      const tracer = Tracer.make({
+        span: (options) => {
+          const span = new Tracer.NativeSpan(options);
+          spanNames.push(span.name);
+          return span;
+        },
+      });
+
+      const result = yield* resolveCommandPath("definitely-not-installed", {
+        env: { PATH: "C:\\first;C:\\second", PATHEXT: ".EXE;.CMD" },
+      }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(CommandResolutionCache, new Map()),
+        Effect.withTracer(tracer),
+        Effect.result,
+      );
+
+      expect(result._tag).toBe("Failure");
+      expect(spanNames).toEqual(
+        expect.arrayContaining(["shell.resolveCommandPath", "shell.resolveCommandPathForPlatform"]),
+      );
+      expect(spanNames).not.toContain("shell.isExecutableFile");
     }),
   );
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -497,8 +497,8 @@ function resolveCommandCandidates(
 }
 
 // Session bootstrap resolves the same commands over and over, each PATH scan
-// costing hundreds of 'shell.isExecutableFile' filesystem probes (tens of
-// thousands per connect). Memoize the scan outcome per
+// costing hundreds of filesystem probes (tens of thousands per connect).
+// Memoize the scan outcome per
 // (platform, PATH, PATHEXT, command) for a short window: repeat scans hit the
 // cache while any change to the search environment invalidates immediately.
 // Explicit-path resolution is never cached - callers probe paths they have
@@ -544,7 +544,7 @@ function cacheCommandResolution(
   });
 }
 
-const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
+const isExecutableFile = Effect.fnUntraced(function* (
   filePath: string,
   platform: NodeJS.Platform,
   windowsPathExtensions: ReadonlyArray<string>,


### PR DESCRIPTION
## What Changed

`isExecutableFile` in `packages/shared/src/shell.ts` is now `Effect.fnUntraced`, so each PATH and PATHEXT candidate check no longer emits a `shell.isExecutableFile` span. The `shell.resolveCommandPath` and `shell.resolveCommandPathForPlatform` spans stay. Command resolution and caching are unchanged. A test asserts the resolution spans are still emitted and the per-candidate span is not.

## Why

On Windows, command and editor discovery probes every PATH entry against every PATHEXT extension. Each probe opened its own span, producing thousands of near-empty spans on cold discovery and inflating server traces.

Related to #4210. Complements #5050.

## Verification

- `vp test run packages/shared/src/shell.test.ts` (31 passed)
- shared typecheck, targeted lint and fmt

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Built with Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to an internal probe helper; resolution and caching logic are unchanged.
> 
> **Overview**
> Windows command resolution was emitting a **`shell.isExecutableFile`** trace span for every PATH/PATHEXT candidate check, which could produce thousands of spans during session bootstrap and bloat server traces.
> 
> **`isExecutableFile`** is now defined with **`Effect.fnUntraced`** instead of a named traced **`Effect.fn`**, so per-candidate filesystem probes no longer create spans. Higher-level spans such as **`shell.resolveCommandPath`** and **`shell.resolveCommandPathForPlatform`** are unchanged, and command resolution plus caching behavior is the same.
> 
> A new test drives **`resolveCommandPath`** with a custom tracer and asserts those resolution spans appear while **`shell.isExecutableFile`** does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b92224442cc7463c0b198da06299623ef85276c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop tracing individual command probes in `isExecutableFile`
> Replaces the `Effect.fn("shell.isExecutableFile")` wrapper with `Effect.fnUntraced` in [shell.ts](https://github.com/pingdotgg/t3code/pull/8519/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce), so executability checks no longer create per-probe trace spans. Adds a test in [shell.test.ts](https://github.com/pingdotgg/t3code/pull/8519/files#diff-024b87c2c05ce19f7366c156ab261b505a48c5dcc47f564611041c74af49c9f4) confirming higher-level `shell.resolveCommandPath` spans still emit while `shell.isExecutableFile` does not. Comments around memoization are generalized from `shell.isExecutableFile` counts to "filesystem probes".
> - Risk: callers relying on `shell.isExecutableFile` span names in trace dashboards or alerting will no longer see them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c7e63a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



