### PR TITLE
fix(client-runtime): tolerate transient foreground probe timeouts

### DIFF
--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -994,10 +994,19 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("uses the full tolerance window for a stalled desktop foreground probe", () =>
+  it.effect("reconnects only after consecutive desktop foreground probe timeouts", () =>
     Effect.gen(function* () {
+      const firstProbeStarted = yield* Deferred.make<void>();
+      const secondProbeStarted = yield* Deferred.make<void>();
+      const probeCount = yield* Ref.make(0);
       const harness = yield* makeHarness({
-        probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
+        probe: () =>
+          Ref.updateAndGet(probeCount, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              Deferred.succeed(count === 1 ? firstProbeStarted : secondProbeStarted, undefined),
+            ),
+            Effect.andThen(Effect.never),
+          ),
       });
       const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
         initiallyDesired: true,
@@ -1005,15 +1014,71 @@ describe("EnvironmentSupervisor", () => {
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
       yield* harness.wake("application-active");
+      yield* Deferred.await(firstProbeStarted);
       yield* TestClock.adjust("14999 millis");
       expect(yield* Ref.get(harness.sessionCount)).toBe(1);
       yield* TestClock.adjust("1 milli");
+      yield* Effect.yieldNow;
+
+      expect((yield* SubscriptionRef.get(supervisor.state)).phase).toBe("connected");
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+
+      yield* harness.wake("application-active");
+      yield* Deferred.await(secondProbeStarted);
+      yield* TestClock.adjust("15 seconds");
       yield* awaitState(
         supervisor.state,
         (state) => state.phase === "connected" && state.generation === 2 && state.attempt === 1,
       );
 
       expect(yield* Ref.get(harness.sessionCount)).toBe(2);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(1);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("resets the desktop foreground probe timeout count after a successful probe", () =>
+    Effect.gen(function* () {
+      const firstProbeStarted = yield* Deferred.make<void>();
+      const secondProbeStarted = yield* Deferred.make<void>();
+      const thirdProbeStarted = yield* Deferred.make<void>();
+      const probeCount = yield* Ref.make(0);
+      const harness = yield* makeHarness({
+        probe: () =>
+          Ref.updateAndGet(probeCount, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              count === 1
+                ? Deferred.succeed(firstProbeStarted, undefined)
+                : count === 2
+                  ? Deferred.succeed(secondProbeStarted, undefined)
+                  : count === 3
+                    ? Deferred.succeed(thirdProbeStarted, undefined)
+                    : Effect.void,
+            ),
+            Effect.flatMap((count) => (count === 2 ? Effect.void : Effect.never)),
+          ),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active");
+      yield* Deferred.await(firstProbeStarted);
+      yield* TestClock.adjust("15 seconds");
+
+      yield* harness.wake("application-active");
+      yield* Deferred.await(secondProbeStarted);
+      yield* Effect.yieldNow;
+
+      yield* harness.wake("application-active");
+      yield* Deferred.await(thirdProbeStarted);
+      yield* TestClock.adjust("15 seconds");
+      yield* Effect.yieldNow;
+
+      expect((yield* SubscriptionRef.get(supervisor.state)).phase).toBe("connected");
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
     }).pipe(Effect.provide(TestClock.layer())),
   );
 

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -33,6 +33,7 @@ const RETRY_DELAYS_MS = [3_000, 4_000, 8_000, 16_000] as const;
 const CONNECTION_ESTABLISHMENT_TIMEOUT = "15 seconds";
 const CONNECTION_PROBE_TIMEOUT = "15 seconds";
 const MOBILE_CONNECTION_PROBE_TIMEOUT = "3 seconds";
+const FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT = 2;
 const BACKOFF_RESET_AFTER_MS = 30_000;
 
 interface SupervisorIntent {
@@ -396,6 +397,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
   const monitorConnectedLease = Effect.fnUntraced(function* (
     lease: ConnectionDriver.EnvironmentConnectionLease,
   ) {
+    let foregroundProbeTimeoutCount = 0;
     for (;;) {
       const next = yield* Queue.take(signals);
       switch (next._tag) {
@@ -419,19 +421,23 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             return true;
           }
           if (next.reason === "application-active" || next.reason === "application-active-probe") {
+            const tolerateProbeTimeout = next.reason === "application-active";
             const probe = yield* lease.session.probe.pipe(
+              Effect.as(true),
               Effect.timeoutOrElse({
                 duration:
                   next.reason === "application-active-probe"
                     ? MOBILE_CONNECTION_PROBE_TIMEOUT
                     : CONNECTION_PROBE_TIMEOUT,
                 orElse: () =>
-                  Effect.fail(
-                    new ConnectionTransientError({
-                      reason: "timeout",
-                      detail: `${target.label} did not respond to a connection health check.`,
-                    }),
-                  ),
+                  tolerateProbeTimeout
+                    ? Effect.succeed(false)
+                    : Effect.fail(
+                        new ConnectionTransientError({
+                          reason: "timeout",
+                          detail: `${target.label} did not respond to a connection health check.`,
+                        }),
+                      ),
               }),
               Effect.forkChild,
             );
@@ -448,7 +454,29 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
                 if (Exit.isFailure(probeEvent.exit)) {
                   yield* Ref.set(wakeProbeFailed, true);
                 }
-                yield* probeEvent.exit;
+                const responded = yield* probeEvent.exit;
+                if (responded) {
+                  foregroundProbeTimeoutCount = 0;
+                  break;
+                }
+                foregroundProbeTimeoutCount += 1;
+                if (foregroundProbeTimeoutCount >= FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT) {
+                  // Consecutive stalls mean the transport is dead; reconnect
+                  // immediately, same as a definite probe failure.
+                  yield* Ref.set(wakeProbeFailed, true);
+                  return yield* new ConnectionTransientError({
+                    reason: "timeout",
+                    detail: `${target.label} did not respond to a connection health check.`,
+                  });
+                }
+                yield* Effect.logWarning(
+                  "Foreground connection health check timed out; keeping the existing session.",
+                ).pipe(
+                  Effect.annotateLogs({
+                    "environment.id": target.environmentId,
+                    "environment.label": target.label,
+                  }),
+                );
                 break;
               }
               switch (probeEvent.signal._tag) {


### PR DESCRIPTION
## What Changed

The connection supervisor no longer replaces a live desktop or web session after a single foreground health probe timeout. It reconnects only after two consecutive timeouts, and a successful probe resets the count. When it does reconnect, it still skips the first backoff rung, the same as a definite probe failure. Definite probe failures and the mobile resume probe are unchanged.

## Why

Under temporary host load, one slow probe (15s) tore down an otherwise healthy WebSocket, showed "Failed to connect. Reconnecting..." and disabled the composer while the same host was still stalled.

Fixes #7231. Same approach as #5198, which no longer applies to `main`.

## Verification

- `vp test run packages/client-runtime/src/connection/supervisor.test.ts` (36 passed; covers single-timeout tolerance, reconnect on the second timeout, and reset after a successful probe)
- client-runtime typecheck, targeted lint and fmt

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Built with Claude Fable 5.1 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection recovery timing for desktop foreground probes (up to ~30s before reconnect on hung probes) in a core client-runtime path, though definite failures and mobile probes are unchanged.
> 
> **Overview**
> **Desktop/web foreground health checks** no longer tear down a live session on a single 15s probe timeout. `EnvironmentSupervisor` now requires **two consecutive** stalled `application-active` probes before treating the transport as dead and reconnecting (with the same immediate retry behavior as a definite probe failure). A probe that completes successfully **resets** the timeout counter, and the first timeout only emits a warning while keeping the existing session.
> 
> **Mobile `application-active-probe`** behavior is unchanged: timeouts still fail fast on the shorter 3s window. Tests were expanded to cover single-timeout tolerance, reconnect on the second timeout, and counter reset after a successful probe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ace61a6a1ca605e9bd5855fd0927903df3bae9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tolerate transient foreground probe timeouts in `EnvironmentSupervisor`
> Adds `FOREGROUND_PROBE_TIMEOUTS_BEFORE_RECONNECT` (set to 2) so the desktop foreground probe tolerates a single timeout before forcing a reconnect. A successful probe resets the timeout counter. Mobile explicit foreground probes (`application-active-probe`) still fail fast on timeout.
> - Risk: desktop reconnects now trigger only after 2 consecutive timeouts instead of 1, so a probe that permanently hangs takes up to 30s to recover; check `foregroundProbeTimeoutCount` logic in [supervisor.ts](https://github.com/pingdotgg/t3code/pull/8522/files#diff-9cea0e0ed5756232bad1eb5801220443f2c1a6cbabaedc22ad335b39a79c7de9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97442ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



