### PR TITLE
fix(server): render local images outside the worktree

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -72,7 +72,7 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it.effect("rejects workspace files outside the authorized root", () =>
+  it.effect("rejects external browser documents and relative path traversal", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -83,7 +83,9 @@ describe("AssetAccess", () => {
         prefix: "t3-asset-outside-",
       });
       const htmlPath = path.join(outside, "report.html");
+      const imagePath = path.join(outside, "preview.png");
       yield* fileSystem.writeFileString(htmlPath, "<p>outside</p>");
+      yield* fileSystem.writeFile(imagePath, new Uint8Array([137, 80, 78, 71]));
 
       const error = yield* issueAssetUrl({
         resource: {
@@ -103,6 +105,19 @@ describe("AssetAccess", () => {
         },
       });
       expect(error.cause).toBeInstanceOf(WorkspacePaths.WorkspacePathOutsideRootError);
+
+      const traversalError = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: path.relative(root, imagePath),
+        },
+        workspaceRoot: root,
+      }).pipe(Effect.flip);
+      expect(traversalError).toMatchObject({
+        _tag: "AssetWorkspacePathValidationError",
+      });
+      expect(traversalError.cause).toBeInstanceOf(WorkspacePaths.WorkspacePathOutsideRootError);
     }).pipe(Effect.provide(testLayer)),
   );
 
@@ -181,6 +196,162 @@ describe("AssetAccess", () => {
       });
       expect(yield* resolveAsset(token, "other.png")).toBeNull();
       expect(yield* resolveAsset(token, "../icon.png")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("issues exact capabilities for absolute images outside the workspace", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-image-root-",
+      });
+      const outside = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-image-",
+      });
+      const imagePath = path.join(outside, "preview.png");
+      const siblingPath = path.join(outside, "sibling.png");
+      yield* fileSystem.writeFile(imagePath, new Uint8Array([137, 80, 78, 71]));
+      yield* fileSystem.writeFile(siblingPath, new Uint8Array([137, 80, 78, 71]));
+      const canonicalImagePath = yield* fileSystem.realPath(imagePath);
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: imagePath,
+        },
+        workspaceRoot: root,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "preview.png")).toEqual({
+        kind: "file",
+        path: canonicalImagePath,
+      });
+      expect(yield* resolveAsset(token, "sibling.png")).toBeNull();
+      expect(yield* resolveAsset(token, "../preview.png")).toBeNull();
+      expect(yield* resolveAsset(`${token}tampered`, "preview.png")).toBeNull();
+
+      yield* TestClock.adjust("1 hour");
+      expect(yield* resolveAsset(token, "preview.png")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects an absolute image symlink whose target is not an image", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-symlink-root-",
+      });
+      const outside = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-symlink-",
+      });
+      const textPath = path.join(outside, "secret.txt");
+      const imageLink = path.join(outside, "preview.png");
+      yield* fileSystem.writeFileString(textPath, "not an image");
+      yield* fileSystem.symlink(textPath, imageLink);
+
+      const error = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: imageLink,
+        },
+        workspaceRoot: root,
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(AssetPreviewTypeValidationError);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("pins an external image capability to its canonical path", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-pin-root-",
+      });
+      const outside = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-pin-",
+      });
+      const imagePath = path.join(outside, "preview.png");
+      const replacementPath = path.join(outside, "replacement.png");
+      yield* fileSystem.writeFile(imagePath, new Uint8Array([137, 80, 78, 71]));
+      yield* fileSystem.writeFile(replacementPath, new Uint8Array([71, 78, 80, 137]));
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: imagePath,
+        },
+        workspaceRoot: root,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      yield* fileSystem.remove(imagePath);
+      yield* fileSystem.symlink(replacementPath, imagePath);
+
+      expect(yield* resolveAsset(token, "preview.png")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("preserves typed failures for external absolute images", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-failure-root-",
+      });
+      const outside = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-external-failure-",
+      });
+      const missingPath = path.join(outside, "missing.png");
+      const directoryPath = path.join(outside, "directory.png");
+      yield* fileSystem.makeDirectory(directoryPath);
+
+      for (const resourcePath of [missingPath, directoryPath]) {
+        const error = yield* issueAssetUrl({
+          resource: {
+            _tag: "workspace-file",
+            threadId: ThreadId.make("thread-1"),
+            path: resourcePath,
+          },
+          workspaceRoot: root,
+        }).pipe(Effect.flip);
+        expect(error).toMatchObject({
+          _tag: "AssetWorkspaceAssetNotFoundError",
+        });
+      }
+
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "realPath",
+        pathOrDescriptor: missingPath,
+      });
+      const failingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        realPath: () => Effect.fail(cause),
+      });
+      const inspectionError = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: missingPath,
+        },
+        workspaceRoot: root,
+      }).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem), Effect.flip);
+      expect(inspectionError).toMatchObject({
+        _tag: "AssetWorkspaceAssetInspectionError",
+        cause,
+      });
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -77,6 +77,12 @@ const AssetClaimsSchema = Schema.Union([
   }),
   Schema.Struct({
     version: Schema.Literal(1),
+    kind: Schema.Literal("image-file-exact"),
+    filePath: Schema.String,
+    expiresAt: Schema.Number,
+  }),
+  Schema.Struct({
+    version: Schema.Literal(1),
     kind: Schema.Literal("attachment"),
     attachmentId: Schema.String,
     /** Decided at mint time. Absent tokens (from before this field) serve
@@ -215,6 +221,38 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         return yield* new AssetWorkspaceContextNotFoundError({
           resource: input.resource,
         });
+      }
+      if (
+        path.isAbsolute(input.resource.path) &&
+        isWorkspaceImagePreviewPath(input.resource.path)
+      ) {
+        const canonicalFile = yield* resolveCanonicalFile(input.resource.path).pipe(
+          Effect.mapError(
+            (cause) =>
+              new AssetWorkspaceAssetInspectionError({
+                resource: input.resource,
+                cause,
+              }),
+          ),
+        );
+        if (!canonicalFile) {
+          return yield* new AssetWorkspaceAssetNotFoundError({
+            resource: input.resource,
+          });
+        }
+        if (!isWorkspaceImagePreviewPath(canonicalFile)) {
+          return yield* new AssetPreviewTypeValidationError({
+            resource: input.resource,
+          });
+        }
+        claims = {
+          version: 1,
+          kind: "image-file-exact",
+          filePath: canonicalFile,
+          expiresAt,
+        };
+        fileName = path.basename(canonicalFile);
+        break;
       }
       const workspaceRoot = yield* workspacePaths.normalizeWorkspaceRoot(input.workspaceRoot).pipe(
         Effect.mapError(
@@ -521,6 +559,21 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   const decodedPath = decodeRelativePath(relativePath);
   if (decodedPath === null) return null;
   const path = yield* Path.Path;
+  if (claims.kind === "image-file-exact") {
+    if (decodedPath !== path.basename(claims.filePath)) return null;
+    const imagePath = yield* resolveCanonicalFile(claims.filePath).pipe(
+      Effect.tapError((cause) =>
+        Effect.logError("Failed to resolve canonical asset path.", {
+          filePath: claims.filePath,
+          cause,
+        }),
+      ),
+      Effect.orElseSucceed(() => null),
+    );
+    return imagePath === claims.filePath
+      ? ({ kind: "file", path: imagePath } satisfies ResolvedAsset)
+      : null;
+  }
   if (claims.kind === "workspace-file-exact") {
     if (decodedPath !== path.basename(claims.relativePath)) return null;
     const exactWorkspaceFile = yield* resolveCanonicalWorkspaceFileForRequest({

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -28,6 +28,10 @@ managed relay connectivity:
 The desktop bootstrap credential and command-line administrative bootstrap
 credentials additionally grant `access:read access:write relay:write`.
 
+Asset previews use short-lived signed URLs. An absolute image path can name a file
+outside the project root. The server resolves that path and signs only the canonical
+file. The signed URL does not grant access to its directory or sibling files.
+
 ## Authentication Flows
 
 ### Browser Session

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -180,6 +180,11 @@ see [Keeping T3 Code in Sync](./updating.md).
 On a Linux host, you can keep the server running after logout and manage it independently of the
 connection method. See [Running T3 Code in the Background](./background-service.md).
 
+## Local Image Paths
+
+Local image paths in agent messages refer to files on the server machine. Images in temporary or
+artifact directories can render on remote clients while those files remain available.
+
 ## How Pairing Works
 
 The remote device does not need a long-lived secret up front.


### PR DESCRIPTION
Absolute local image paths from agent Markdown were rejected when screenshots lived in temporary or artifact directories outside the project worktree. Existing files then showed "Image unavailable."

This change resolves each absolute image path to its canonical file and signs an exact-file asset URL. The token cannot read sibling files or traverse directories. Directory-scoped HTML previews still require files inside the project worktree.

## Tests

- `vp test run apps/server/src/assets/AssetAccess.test.ts apps/server/src/http.test.ts` (30 passed)
- `vp run --filter t3 typecheck`
- Focused lint and format checks
- Chrome reproduced both unavailable images, then rendered both 1920 x 873 images through the existing server asset route

## Before

![Local images shown as unavailable](https://files.tslop.org/2026/08/before-fe5670ad.png)

## After

![Local images rendered](https://files.tslop.org/2026/08/after-07bc3ead.png)

Model: GPT-5.6 Sol. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands server file read access beyond the worktree for images only; mitigated by exact-file tokens, canonical-path checks, and unchanged directory-scoped HTML rules.
> 
> **Overview**
> **Absolute local image paths** (e.g. screenshots in temp or artifact dirs) can now be served through signed asset URLs instead of failing workspace validation and showing “Image unavailable.”
> 
> `issueAssetUrl` adds an early path for **absolute** `workspace-file` resources that pass `isWorkspaceImagePreviewPath`: it resolves the **canonical** file, mints a new **`image-file-exact`** claim (pinned `filePath`), and `resolveAsset` only serves that basename when the live canonical path still matches the claim. Siblings, `..` traversal, tampered tokens, expiry, and symlink swaps to non-images or other files are rejected. **Non-image** absolute paths and **HTML** outside the project root still use the existing workspace rules.
> 
> Tests cover external images, traversal, symlinks, typed errors, and canonical pinning. Docs note exact-file signing for out-of-root images in internals auth and remote-access user guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a93d0cba1659310f3925ceebf10d511f397c8ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render local images outside the worktree via canonical-path signed URLs
> - Adds a new `image-file-exact` claim variant to `AssetClaimsSchema` in [AssetAccess.ts](https://github.com/pingdotgg/t3code/pull/8523/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) so asset tokens can bind to a single absolute image file by its canonical path.
> - `issueAssetUrl` now resolves absolute image paths to their canonical file with `resolveCanonicalFile`, returning typed errors (`AssetWorkspaceAssetNotFoundError`, `AssetPreviewTypeValidationError`, `AssetWorkspaceAssetInspectionError`) for missing, non-image, or unresolvable targets.
> - `resolveAsset` serves `image-file-exact` tokens only when the requested relative path matches the basename and the file still resolves to the same canonical path, preventing sibling or traversal access.
> - Documents the new asset preview signed URL behavior in [environment-auth.md](https://github.com/pingdotgg/t3code/pull/8523/files#diff-7f19e5e5409c468ba8360c07615568dd83e41240a7db91a70a0f2db1fcc0a2a3) and [remote-access.md](https://github.com/pingdotgg/t3code/pull/8523/files#diff-e6cd63b1b8b5df551539c3cbb1790b40f70baa2a5ed146d56f1c7044d7adcb8a).
> - Behavioral Change: absolute image paths outside the workspace root are no longer treated as workspace-relative capabilities; they now produce exact-file tokens that fail if the file moves or is replaced by a symlink to a different target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a93d0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->