### PR TITLE
fix(git): support nested project workspaces

### DIFF
--- a/apps/server/src/git/Utils.ts
+++ b/apps/server/src/git/Utils.ts
@@ -1,7 +1,0 @@
-// @effect-diagnostics nodeBuiltinImport:off
-import * as NodeFS from "node:fs";
-import * as NodePath from "node:path";
-
-export function isGitRepository(cwd: string): boolean {
-  return NodeFS.existsSync(NodePath.join(cwd, ".git"));
-}

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -286,13 +286,21 @@ describe("CheckpointReactor", () => {
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderDriverKind;
     readonly gitStatusRefreshCalls?: Array<string>;
+    readonly nestedWorkspace?: boolean;
   }) {
     const cwd = createGitRepository();
     tempDirs.push(cwd);
+    const workspaceCwd = options?.nestedWorkspace ? NodePath.join(cwd, "frontend") : cwd;
+    if (options?.nestedWorkspace) {
+      NodeFS.mkdirSync(workspaceCwd);
+      NodeFS.writeFileSync(NodePath.join(workspaceCwd, "README.md"), "v1\n", "utf8");
+      runGit(cwd, ["add", "."]);
+      runGit(cwd, ["commit", "-m", "Add frontend workspace"]);
+    }
     const provider = createProviderServiceHarness(
-      cwd,
+      workspaceCwd,
       options?.hasSession ?? true,
-      options?.providerSessionCwd ?? cwd,
+      options?.providerSessionCwd ?? workspaceCwd,
       options?.providerName ?? ProviderDriverKind.make("codex"),
     );
     const orchestrationLayer = OrchestrationEngineLive.pipe(
@@ -372,7 +380,7 @@ describe("CheckpointReactor", () => {
         commandId: CommandId.make("cmd-project-create"),
         projectId: asProjectId("project-1"),
         title: "Test Project",
-        workspaceRoot: options?.projectWorkspaceRoot ?? cwd,
+        workspaceRoot: options?.projectWorkspaceRoot ?? workspaceCwd,
         defaultModelSelection: {
           instanceId: ProviderInstanceId.make("codex"),
           model: "gpt-5-codex",
@@ -395,7 +403,12 @@ describe("CheckpointReactor", () => {
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "approval-required",
           branch: options?.threadBranch ?? null,
-          worktreePath: options?.threadWorktreePath ?? cwd,
+          worktreePath:
+            options?.threadWorktreePath !== undefined
+              ? options.threadWorktreePath
+              : options?.nestedWorkspace
+                ? null
+                : cwd,
           createdAt,
         })
         .pipe(
@@ -450,9 +463,53 @@ describe("CheckpointReactor", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
       cwd,
+      workspaceCwd,
       drain,
     };
   }
+
+  it("captures checkpoints when the project cwd is nested below the Git root", async () => {
+    const harness = await createHarness({
+      nestedWorkspace: true,
+      seedFilesystemCheckpoints: false,
+    });
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-nested-workspace"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-nested-workspace"),
+    });
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
+    );
+
+    NodeFS.writeFileSync(NodePath.join(harness.workspaceCwd, "README.md"), "v2\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-nested-workspace"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      turnId: asTurnId("turn-nested-workspace"),
+      payload: { state: "completed" },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.checkpoints.some((checkpoint) => checkpoint.checkpointTurnCount === 1),
+    );
+    expect(thread.checkpoints).toHaveLength(1);
+    expect(
+      gitShowFileAtRef(
+        harness.cwd,
+        checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
+        "frontend/README.md",
+      ),
+    ).toBe("v2\n");
+  });
 
   it("captures pre-turn baseline on turn.started and post-turn checkpoint on turn.completed", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -35,7 +35,6 @@ import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts"
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import type { OrchestrationDispatchError } from "../Errors.ts";
-import { isGitRepository } from "../../git/Utils.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
 
@@ -88,6 +87,7 @@ const make = Effect.gen(function* () {
   const receiptBus = yield* RuntimeReceiptBus;
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
+  const isGitWorkspace = (cwd: string) => checkpointStore.isGitRepository(cwd);
 
   const appendRevertFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -177,8 +177,6 @@ const make = Effect.gen(function* () {
     return project ? [project] : [];
   });
 
-  const isGitWorkspace = (cwd: string) => isGitRepository(cwd);
-
   // Resolves the workspace CWD for checkpoint operations, preferring the
   // active provider session CWD and falling back to the thread/project config.
   // Returns undefined when no CWD can be determined or the workspace is not
@@ -188,7 +186,7 @@ const make = Effect.gen(function* () {
     readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
     readonly projects: ReadonlyArray<{ readonly id: ProjectId; readonly workspaceRoot: string }>;
     readonly preferSessionRuntime: boolean;
-  }): Effect.fn.Return<string | undefined> {
+  }): Effect.fn.Return<string | undefined, CheckpointStoreError> {
     const fromSession = yield* resolveSessionRuntimeForThread(input.threadId);
     const fromThread = resolveThreadWorkspaceCwd({
       thread: input.thread,
@@ -209,7 +207,7 @@ const make = Effect.gen(function* () {
     if (!cwd) {
       return undefined;
     }
-    if (!isGitWorkspace(cwd)) {
+    if (!(yield* isGitWorkspace(cwd))) {
       return undefined;
     }
     return cwd;
@@ -713,7 +711,7 @@ const make = Effect.gen(function* () {
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
-    if (!isGitWorkspace(sessionRuntime.value.cwd)) {
+    if (!(yield* isGitWorkspace(sessionRuntime.value.cwd))) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,
         turnCount: event.payload.turnCount,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -48,6 +48,7 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQu
 import * as ThreadBackgroundLiveness from "../ThreadBackgroundLiveness.ts";
 import * as ThreadPlanProgress from "../ThreadPlanProgress.ts";
 import { ProviderRuntimeIngestionLive } from "./ProviderRuntimeIngestion.ts";
+import * as CheckpointStore from "../../checkpointing/CheckpointStore.ts";
 import { DEFAULT_THREAD_TITLE } from "../threadTitles.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
@@ -251,6 +252,11 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(ThreadPlanProgress.layer),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
+      Layer.provideMerge(
+        Layer.mock(CheckpointStore.CheckpointStore)({
+          isGitRepository: () => Effect.succeed(true),
+        }),
+      ),
       Layer.provideMerge(makeTestServerSettingsLayer(options?.serverSettings)),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
       Layer.provideMerge(NodeServices.layer),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -32,7 +32,7 @@ import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
-import { isGitRepository } from "../../git/Utils.ts";
+import * as CheckpointStore from "../../checkpointing/CheckpointStore.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ThreadBackgroundLivenessService } from "../ThreadBackgroundLiveness.ts";
 import { ThreadPlanProgressService } from "../ThreadPlanProgress.ts";
@@ -896,6 +896,7 @@ const make = Effect.gen(function* () {
   const providerService = yield* ProviderService;
   const projectionTurnRepository = yield* ProjectionTurnRepository;
   const serverSettingsService = yield* ServerSettingsService;
+  const checkpointStore = yield* CheckpointStore.CheckpointStore;
   const providerCommandId = (event: ProviderRuntimeEvent, tag: string) =>
     crypto.randomUUIDv4.pipe(
       Effect.map((uuid) => CommandId.make(`provider:${event.eventId}:${tag}:${uuid}`)),
@@ -1932,7 +1933,12 @@ const make = Effect.gen(function* () {
           : undefined;
         const workspaceCwd =
           checkpointContext?.worktreePath ?? checkpointContext?.workspaceRoot ?? undefined;
-        if (turnId && checkpointContext && workspaceCwd && isGitRepository(workspaceCwd)) {
+        if (
+          turnId &&
+          checkpointContext &&
+          workspaceCwd &&
+          (yield* checkpointStore.isGitRepository(workspaceCwd))
+        ) {
           // Skip if a checkpoint already exists for this turn. A real
           // (non-placeholder) capture from CheckpointReactor should not
           // be clobbered, and dispatching a duplicate placeholder for the

--- a/apps/server/src/review/ReviewService.test.ts
+++ b/apps/server/src/review/ReviewService.test.ts
@@ -1,20 +1,39 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 
+import { ProjectId, type OrchestrationProject } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as ReviewService from "./ReviewService.ts";
 
 function makeLayer(input: {
   readonly workspaceRoot: string;
   readonly baseDir: string;
   readonly detectCalls?: Array<{ readonly cwd: string }>;
+  readonly registeredWorkspaceRoots?: ReadonlySet<string>;
 }) {
+  const makeProject = (workspaceRoot: string): OrchestrationProject => ({
+    id: ProjectId.make(`project:${workspaceRoot}`),
+    title: "Review project",
+    workspaceRoot,
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    deletedAt: null,
+  });
+
   return ReviewService.layer.pipe(
     Layer.provide(
       Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
@@ -28,12 +47,100 @@ function makeLayer(input: {
       }),
     ),
     Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
+    Layer.provide(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getActiveProjectByWorkspaceRoot: (workspaceRoot) =>
+          Effect.succeed(
+            input.registeredWorkspaceRoots?.has(workspaceRoot)
+              ? Option.some(makeProject(workspaceRoot))
+              : Option.none(),
+          ),
+      }),
+    ),
     Layer.provide(ServerConfig.layerTest(input.workspaceRoot, input.baseDir)),
     Layer.provideMerge(NodeServices.layer),
   );
 }
 
+function makeLiveLayer(workspaceRoot: string, baseDir: string) {
+  const serverConfigLayer = ServerConfig.layerTest(workspaceRoot, baseDir);
+  const vcsProcessLayer = VcsProcess.layer.pipe(Layer.provide(NodeServices.layer));
+  const vcsRegistryLayer = VcsDriverRegistry.layer.pipe(
+    Layer.provide(vcsProcessLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
+
+  return ReviewService.layer.pipe(
+    Layer.provideMerge(GitVcsDriver.layer),
+    Layer.provideMerge(vcsRegistryLayer),
+    Layer.provideMerge(vcsProcessLayer),
+    Layer.provideMerge(serverConfigLayer),
+    Layer.provide(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getActiveProjectByWorkspaceRoot: () => Effect.succeed(Option.none()),
+      }),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+
 describe("ReviewService", () => {
+  it.effect("returns working-tree and branch diffs from a nested project cwd", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const repositoryRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-repo-" });
+      const projectRoot = NodePath.join(repositoryRoot, "frontend");
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      yield* fs.makeDirectory(projectRoot);
+
+      const result = yield* Effect.gen(function* () {
+        const git = yield* GitVcsDriver.GitVcsDriver;
+        const runGit = (cwd: string, args: ReadonlyArray<string>) =>
+          git.execute({
+            operation: "ReviewService.test.git",
+            cwd,
+            args,
+            timeoutMs: 10_000,
+          });
+
+        yield* git.initRepo({ cwd: repositoryRoot });
+        yield* runGit(repositoryRoot, ["config", "user.email", "test@test.com"]);
+        yield* runGit(repositoryRoot, ["config", "user.name", "Test"]);
+        yield* runGit(repositoryRoot, ["branch", "-M", "main"]);
+        yield* fs.writeFileString(
+          NodePath.join(projectRoot, "tracked.ts"),
+          "export const v = 1;\n",
+        );
+        yield* runGit(repositoryRoot, ["add", "."]);
+        yield* runGit(repositoryRoot, ["commit", "-m", "initial commit"]);
+        yield* runGit(repositoryRoot, ["checkout", "-b", "feature/nested-review"]);
+        yield* fs.writeFileString(NodePath.join(projectRoot, "committed.ts"), "export {};\n");
+        yield* runGit(repositoryRoot, ["add", "."]);
+        yield* runGit(repositoryRoot, ["commit", "-m", "feature commit"]);
+        yield* fs.writeFileString(
+          NodePath.join(projectRoot, "tracked.ts"),
+          "export const v = 2;\n",
+        );
+        yield* fs.writeFileString(
+          NodePath.join(projectRoot, "untracked.ts"),
+          "export const u = 1;\n",
+        );
+
+        const review = yield* ReviewService.ReviewService;
+        return yield* review.getDiffPreview({ cwd: projectRoot });
+      }).pipe(Effect.provide(makeLiveLayer(projectRoot, baseDir)));
+
+      const workingTree = result.sources.find((source) => source.kind === "working-tree");
+      const branchRange = result.sources.find((source) => source.kind === "branch-range");
+      assert.ok(workingTree);
+      assert.match(workingTree.diff, /frontend\/tracked\.ts/);
+      assert.match(workingTree.diff, /frontend\/untracked\.ts/);
+      assert.ok(branchRange);
+      assert.strictEqual(branchRange.baseRef, "main");
+      assert.match(branchRange.diff, /frontend\/committed\.ts/);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("rejects diff preview cwd outside the configured workspace roots", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -51,9 +158,37 @@ describe("ReviewService", () => {
       assert.strictEqual(error.operation, "ReviewService.getDiffPreview");
       assert.match(
         "detail" in error ? error.detail : "",
-        /must stay within the configured workspace root/,
+        /must be a registered project or stay within a configured workspace root/,
       );
       assert.deepStrictEqual(detectCalls, []);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("allows an active project outside the server process root", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const workspaceRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-workspace-" });
+      const projectRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-project-" });
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      const detectCalls: Array<{ readonly cwd: string }> = [];
+
+      const result = yield* Effect.gen(function* () {
+        const review = yield* ReviewService.ReviewService;
+        return yield* review.getDiffPreview({ cwd: projectRoot });
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            workspaceRoot,
+            baseDir,
+            detectCalls,
+            registeredWorkspaceRoots: new Set([projectRoot]),
+          }),
+        ),
+      );
+
+      assert.strictEqual(result.cwd, projectRoot);
+      assert.deepStrictEqual(result.sources, []);
+      assert.deepStrictEqual(detectCalls, [{ cwd: projectRoot }]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -84,7 +219,7 @@ describe("ReviewService", () => {
       assert.strictEqual(error.operation, "ReviewService.getDiffFileContents");
       assert.match(
         "detail" in error ? error.detail : "",
-        /must stay within the configured workspace root/,
+        /must be a registered project or stay within a configured workspace root/,
       );
       assert.deepStrictEqual(detectCalls, []);
     }).pipe(Effect.provide(NodeServices.layer)),

--- a/apps/server/src/review/ReviewService.ts
+++ b/apps/server/src/review/ReviewService.ts
@@ -3,6 +3,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
 import {
@@ -16,6 +17,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 
@@ -35,6 +37,7 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const git = yield* GitVcsDriver.GitVcsDriver;
 
@@ -76,13 +79,30 @@ export const make = Effect.gen(function* () {
       return;
     }
 
+    const registeredProject = yield* projectionSnapshotQuery
+      .getActiveProjectByWorkspaceRoot(cwd)
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new VcsRepositoryDetectionError({
+              operation,
+              cwd,
+              detail: "Failed to verify the requested review workspace.",
+              cause,
+            }),
+        ),
+      );
+    if (Option.isSome(registeredProject)) {
+      return;
+    }
+
     return yield* new VcsRepositoryDetectionError({
       operation,
       cwd,
       detail:
         operation === "ReviewService.getDiffPreview"
-          ? "Review diff preview cwd must stay within the configured workspace root."
-          : "Review diff file contents cwd must stay within the configured workspace root.",
+          ? "Review diff preview cwd must be a registered project or stay within a configured workspace root."
+          : "Review diff file contents cwd must be a registered project or stay within a configured workspace root.",
     });
   });
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -15,6 +15,7 @@ import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, type ReviewDiffFileContentsInput } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { ServerConfig } from "../config.ts";
 import { makeGitVcsDriverCore, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
@@ -781,6 +782,49 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         });
 
         assert.deepStrictEqual(paths, ["complete.txt", "final.txt"]);
+      }),
+    );
+
+    it.effect("scopes untracked diffs to a symlinked nested workspace", () =>
+      Effect.gen(function* () {
+        const repositoryRoot = yield* makeTmpDir();
+        yield* initRepoWithCommit(repositoryRoot);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        const linksRoot = yield* makeTmpDir("git-vcs-driver-links-");
+        const linkedRepositoryRoot = pathService.join(linksRoot, "repository");
+        yield* fileSystem.symlink(repositoryRoot, linkedRepositoryRoot);
+        const workspaceRoot = pathService.join(linkedRepositoryRoot, "workspace");
+        yield* writeTextFile(repositoryRoot, "workspace/inside.ts", "export {};\n");
+        yield* writeTextFile(repositoryRoot, "outside.ts", "export {};\n");
+
+        const result = yield* driver.getReviewDiffPreview({ cwd: workspaceRoot });
+
+        const workingTree = result.sources.find((source) => source.kind === "working-tree");
+        assert.ok(workingTree);
+        assert.include(workingTree.diff, "workspace/inside.ts");
+        assert.notInclude(workingTree.diff, "outside.ts");
+      }),
+    );
+
+    it.effect("does not interpret nested workspace names as Git pathspec magic", () =>
+      Effect.gen(function* () {
+        if ((yield* HostProcessPlatform) === "win32") return;
+        const repositoryRoot = yield* makeTmpDir();
+        yield* initRepoWithCommit(repositoryRoot);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const pathService = yield* Path.Path;
+        const workspaceRoot = pathService.join(repositoryRoot, ":(glob)**");
+        yield* writeTextFile(repositoryRoot, ":(glob)**/inside.ts", "export {};\n");
+        yield* writeTextFile(repositoryRoot, "outside.ts", "export {};\n");
+
+        const result = yield* driver.getReviewDiffPreview({ cwd: workspaceRoot });
+
+        const workingTree = result.sources.find((source) => source.kind === "working-tree");
+        assert.ok(workingTree);
+        assert.include(workingTree.diff, ":(glob)**/inside.ts");
+        assert.notInclude(workingTree.diff, "outside.ts");
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2174,10 +2174,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   });
 
   const readUntrackedReviewDiffs = Effect.fn("readUntrackedReviewDiffs")(function* (cwd: string) {
+    const repositoryPaths = yield* resolveRepositoryPaths(cwd);
+    const repositoryRoot = repositoryPaths?.worktreeRoot ?? cwd;
     const untrackedResult = yield* executeGit(
       "GitVcsDriver.readUntrackedReviewDiffs.list",
       cwd,
-      ["ls-files", "--others", "--exclude-standard", "-z"],
+      ["ls-files", "--others", "--exclude-standard", "--full-name", "-z"],
       {
         maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
         appendTruncationMarker: true,
@@ -2193,7 +2195,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       (relativePath) =>
         executeGit(
           "GitVcsDriver.readUntrackedReviewDiffs.diff",
-          cwd,
+          repositoryRoot,
           [
             "diff",
             "--no-index",

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -244,7 +244,7 @@ export default function DiffPanel({
     },
     { enabled: isGitRepo && selectedTurn !== undefined },
   );
-  const primaryBranchDiffPreview = useEnvironmentQuery(
+  const branchDiffPreview = useEnvironmentQuery(
     selectedTurnId === null && activeThread && activeCwd
       ? reviewEnvironment.diffPreview({
           environmentId: activeThread.environmentId,
@@ -256,26 +256,6 @@ export default function DiffPanel({
         })
       : null,
   );
-  const shouldRetryBranchDiffAtEnvironmentCwd =
-    selectedTurnId === null &&
-    primaryBranchDiffPreview.error?.includes("configured workspace root") === true &&
-    serverConfig?.cwd !== undefined &&
-    serverConfig.cwd !== activeCwd;
-  const fallbackBranchDiffPreview = useEnvironmentQuery(
-    shouldRetryBranchDiffAtEnvironmentCwd && activeThread && serverConfig
-      ? reviewEnvironment.diffPreview({
-          environmentId: activeThread.environmentId,
-          input: {
-            cwd: serverConfig.cwd,
-            ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
-            ignoreWhitespace: diffIgnoreWhitespace,
-          },
-        })
-      : null,
-  );
-  const branchDiffPreview = shouldRetryBranchDiffAtEnvironmentCwd
-    ? fallbackBranchDiffPreview
-    : primaryBranchDiffPreview;
   const refreshBranchDiffPreview = branchDiffPreview.refresh;
   const canRefreshGitDiff =
     isGitRepo && selectedTurnId === null && activeThread != null && activeCwd != null;


### PR DESCRIPTION
Projects rooted below a Git repository currently fail several Git-backed flows because repository detection requires a `.git` entry in the exact project directory. Review requests can then be rejected, checkpoints can be skipped, and the web diff panel can mask the failure by retrying against the server workspace.

Use repository-aware detection for checkpoint flows and authorize exact active project roots for reviews. Discover untracked files from the requested workspace with root-relative output for patch generation, preserving scope across nested, symlinked, and pathspec-like directory names. Remove the web fallback so review errors remain visible and scoped to the requested project.

---

*The text has been composed and the bugfix has been implemented by GPT-5.6-Sol Xhigh in Codex, with manual revision and testing from me.*