### PR TITLE
fix(composer): scope skill discovery to workspace

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -226,6 +226,7 @@ export function NewTaskDraftScreen(props: {
         ? selectedProject?.workspaceRoot
         : (flow.selectedWorktreePath ?? selectedProject?.workspaceRoot)) || null,
     selectedProviderStatus: flow.selectedProviderStatus,
+    skills: flow.selectedProviderSkills,
     hasThread: false,
     enabled: isComposerFocused && !isIncomingShareTransferPending,
     onChangeDraftMessage: flow.setPrompt,

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -7,6 +7,7 @@ import type {
   ProviderInteractionMode,
   RuntimeMode,
   ServerConfig as T3ServerConfig,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import { updateExplicitSkillInvocationsForTextEdit } from "@t3tools/shared/explicitSkillInvocations";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
@@ -83,6 +84,7 @@ export interface ThreadComposerProps {
   readonly threadSyncPhase?: "loading" | "syncing" | null;
   readonly selectedThread: OrchestrationThreadShell;
   readonly serverConfig: T3ServerConfig | null;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly queueCount: number;
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
@@ -353,6 +355,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     environmentId: props.environmentId,
     projectCwd: props.projectCwd,
     selectedProviderStatus,
+    skills: props.skills,
     hasThread: true,
     onChangeDraftMessage: handleDraftMessageChange,
     onUpdateInteractionMode: props.onUpdateInteractionMode,
@@ -564,7 +567,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               ref={inputRef}
               multiline
               value={props.draftMessage}
-              skills={selectedProviderStatus?.skills ?? []}
+              skills={props.skills}
               selection={composerMenu.selection}
               onChangeText={handleDraftMessageChange}
               onSelectionChange={composerMenu.onSelectionChange}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -1,5 +1,6 @@
 import type {
   EnvironmentId,
+  ExplicitSkillInvocation,
   MessageId,
   ModelSelection,
   OrchestrationThreadShell,
@@ -7,6 +8,7 @@ import type {
   RuntimeMode,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
+import { updateExplicitSkillInvocationsForTextEdit } from "@t3tools/shared/explicitSkillInvocations";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
@@ -65,6 +67,7 @@ export const COMPOSER_EXPANDED_CHROME = 156;
 
 export interface ThreadComposerProps {
   readonly draftMessage: string;
+  readonly draftSkillInvocations: ReadonlyArray<ExplicitSkillInvocation>;
   readonly draftAttachments: ReadonlyArray<DraftComposerImageAttachment>;
   readonly placeholder: string;
   readonly contentMaxWidth?: number;
@@ -84,7 +87,10 @@ export interface ThreadComposerProps {
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
   readonly editorRef?: RefObject<ComposerEditorHandle | null>;
-  readonly onChangeDraftMessage: (value: string) => void;
+  readonly onChangeDraftMessage: (
+    value: string,
+    skillInvocations: ReadonlyArray<ExplicitSkillInvocation>,
+  ) => void;
   readonly onPickDraftImages: () => Promise<void>;
   readonly onNativePasteImages: (uris: ReadonlyArray<string>) => Promise<void>;
   readonly onRemoveDraftImage: (imageId: string) => void;
@@ -245,7 +251,19 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const settingsRoutePresentedRef = useRef(false);
   const wasExpandedBeforePreviewRef = useRef(false);
   const inFlightThreadIdsRef = useRef(new Set<string>());
+  const skillInvocationsRef = useRef<ExplicitSkillInvocation[]>([...props.draftSkillInvocations]);
+  const previousDraftMessageRef = useRef(props.draftMessage);
   const { onExpandedChange } = props;
+
+  useEffect(() => {
+    previousDraftMessageRef.current = props.draftMessage;
+    skillInvocationsRef.current = [...props.draftSkillInvocations];
+  }, [
+    props.draftMessage,
+    props.draftSkillInvocations,
+    props.environmentId,
+    props.selectedThread.id,
+  ]);
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
@@ -309,13 +327,34 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     );
   }, [props.serverConfig, props.selectedThread.modelSelection.instanceId]);
 
+  const { onChangeDraftMessage } = props;
+  // Keeps the draft's `$skill` ranges aligned with the text they point at, and
+  // records the range when the command menu inserts a skill.
+  const handleDraftMessageChange = useCallback(
+    (nextMessage: string, addedInvocation?: ExplicitSkillInvocation) => {
+      const previousMessage = previousDraftMessageRef.current;
+      skillInvocationsRef.current = updateExplicitSkillInvocationsForTextEdit({
+        previousText: previousMessage,
+        nextText: nextMessage,
+        invocations: skillInvocationsRef.current,
+      });
+      if (addedInvocation) {
+        skillInvocationsRef.current.push(addedInvocation);
+        skillInvocationsRef.current.sort((left, right) => left.start - right.start);
+      }
+      previousDraftMessageRef.current = nextMessage;
+      onChangeDraftMessage(nextMessage, skillInvocationsRef.current);
+    },
+    [onChangeDraftMessage],
+  );
+
   const composerMenu = useComposerCommandMenu({
     draftMessage: props.draftMessage,
     environmentId: props.environmentId,
     projectCwd: props.projectCwd,
     selectedProviderStatus,
     hasThread: true,
-    onChangeDraftMessage: props.onChangeDraftMessage,
+    onChangeDraftMessage: handleDraftMessageChange,
     onUpdateInteractionMode: props.onUpdateInteractionMode,
   });
   const { onSendMessage } = props;
@@ -329,6 +368,8 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       if (messageId === null) {
         return;
       }
+      skillInvocationsRef.current = [];
+      previousDraftMessageRef.current = "";
       // Sending a prompt starts agent work: arm the lock-screen card while the
       // app is foregrounded and the activity token can be registered. Armed
       // after the send so its preference read and native Activity start don't
@@ -525,7 +566,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               value={props.draftMessage}
               skills={selectedProviderStatus?.skills ?? []}
               selection={composerMenu.selection}
-              onChangeText={props.onChangeDraftMessage}
+              onChangeText={handleDraftMessageChange}
               onSelectionChange={composerMenu.onSelectionChange}
               onPasteImages={(uris) => void props.onNativePasteImages(uris)}
               placeholder={props.placeholder}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -6,6 +6,7 @@ import { HeaderHeightContext } from "@react-navigation/elements";
 import type {
   ApprovalRequestId,
   EnvironmentId,
+  ExplicitSkillInvocation,
   MessageId,
   ModelSelection,
   OrchestrationThreadShell,
@@ -96,6 +97,7 @@ export interface ThreadDetailScreenProps {
   readonly activePendingUserInputAnswers: Record<string, string | ReadonlyArray<string>> | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
   readonly draftMessage: string;
+  readonly draftSkillInvocations: ReadonlyArray<ExplicitSkillInvocation>;
   readonly draftAttachments: ReadonlyArray<DraftComposerImageAttachment>;
   readonly connectionStateLabel: EnvironmentConnectionPhase;
   /** Message sync status for the selected thread (drives the composer status pill). */
@@ -111,7 +113,10 @@ export interface ThreadDetailScreenProps {
   readonly usesAutomaticContentInsets?: boolean;
   readonly onHeaderMaterialVisibilityChange?: (visible: boolean) => void;
   readonly onOpenConnectionEditor: () => void;
-  readonly onChangeDraftMessage: (value: string) => void;
+  readonly onChangeDraftMessage: (
+    value: string,
+    skillInvocations: ReadonlyArray<ExplicitSkillInvocation>,
+  ) => void;
   readonly onPickDraftImages: () => Promise<void>;
   readonly onNativePasteImages: (uris: ReadonlyArray<string>) => Promise<void>;
   readonly onRemoveDraftImage: (imageId: string) => void;
@@ -742,6 +747,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
               <ThreadComposer
                 editorRef={composerEditorRef}
                 draftMessage={props.draftMessage}
+                draftSkillInvocations={props.draftSkillInvocations}
                 draftAttachments={props.draftAttachments}
                 placeholder="Ask the repo agent, or run a command…"
                 contentMaxWidth={contentMaxWidth}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -60,6 +60,7 @@ import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { CHAT_CONTENT_MAX_WIDTH, type LayoutVariant } from "../../lib/layout";
 import { IOS_NAV_BAR_HEIGHT } from "../../lib/layoutMetrics";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { useProviderSkills } from "../../state/providerSkills";
 import type {
   PendingApproval,
   PendingUserInput,
@@ -452,12 +453,20 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
-  const selectedProviderSkills = useMemo(
+  const selectedProviderSnapshot = useMemo(
     () =>
-      props.serverConfig?.providers.find((provider) => provider.instanceId === selectedInstanceId)
-        ?.skills ?? [],
+      props.serverConfig?.providers.find(
+        (provider) => provider.instanceId === selectedInstanceId,
+      ) ?? null,
     [props.serverConfig, selectedInstanceId],
   );
+  const selectedProviderSkills = useProviderSkills({
+    environmentId: props.environmentId,
+    instanceId: selectedInstanceId,
+    projectId: props.selectedThread.projectId,
+    threadId: props.selectedThread.id,
+    fallback: selectedProviderSnapshot?.skills ?? [],
+  });
 
   useLayoutEffect(() => {
     selectedThreadKeyRef.current = selectedThreadKey;
@@ -757,6 +766,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 threadSyncPhase={threadSyncPhase}
                 selectedThread={props.selectedThread}
                 serverConfig={props.serverConfig}
+                skills={selectedProviderSkills}
                 queueCount={props.selectedThreadQueueCount}
                 environmentId={props.environmentId}
                 projectCwd={props.projectWorkspaceRoot}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -781,6 +781,7 @@ function ThreadRouteContent(
           activePendingUserInputAnswers={requests.activePendingUserInputAnswers}
           respondingUserInputId={requests.respondingUserInputId}
           draftMessage={composer.draftMessage}
+          draftSkillInvocations={composer.draftSkillInvocations}
           draftAttachments={composer.draftAttachments}
           connectionStateLabel={routeConnectionState}
           threadSyncStatus={selectedThreadDetailState.status}

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -8,6 +8,7 @@ import type {
   ProviderOptionSelection,
   RuntimeMode,
   ServerProvider,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import {
   CommandId,
@@ -40,6 +41,7 @@ import { scopedProjectKey } from "../../lib/scopedEntities";
 import { appAtomRegistry } from "../../state/atom-registry";
 import { projectEnvironment } from "../../state/projects";
 import { useEnvironmentQuery } from "../../state/query";
+import { useProviderSkills } from "../../state/providerSkills";
 import {
   appendComposerDraftAttachments,
   clearComposerDraft,
@@ -157,6 +159,9 @@ type NewTaskFlowContextValue = {
   readonly selectedModel: ModelSelection | null;
   readonly selectedModelOption: ModelOption | null;
   readonly selectedProviderStatus: ServerProvider | null;
+  // Skills for the selected workspace, which can differ from the snapshot's
+  // environment-wide list.
+  readonly selectedProviderSkills: ReadonlyArray<ServerProviderSkill>;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly filteredBranches: ReadonlyArray<VcsRef>;
   readonly reset: () => void;
@@ -466,6 +471,12 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       ) ?? null,
     [selectedEnvironmentServerConfig, selectedModel?.instanceId],
   );
+  const selectedProviderSkills = useProviderSkills({
+    environmentId: selectedProject?.environmentId ?? selectedEnvironmentId,
+    instanceId: selectedModel?.instanceId ?? null,
+    projectId: selectedProject?.id ?? null,
+    fallback: selectedProviderStatus?.skills ?? [],
+  });
   const setSelectedModelKey = useCallback(
     // Options ride along in the same write: a follow-up setSelectedModelOptions
     // call would rebuild the selection from the stale pre-switch model.
@@ -1045,6 +1056,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedModel,
       selectedModelOption,
       selectedProviderStatus,
+      selectedProviderSkills,
       providerGroups,
       filteredBranches,
       reset,
@@ -1107,6 +1119,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedModelOption,
       selectedProjectDraftKey,
       selectedProviderStatus,
+      selectedProviderSkills,
       setSelectedModelOptions,
       selectedProject,
       selectedProjectKey,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentId, ProviderInteractionMode, ServerProvider } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ExplicitSkillInvocation,
+  ProviderInteractionMode,
+  ServerProvider,
+} from "@t3tools/contracts";
 import {
   detectComposerTrigger,
   replaceTextRange,
@@ -33,7 +38,12 @@ export function useComposerCommandMenu({
   readonly selectedProviderStatus: ServerProvider | null;
   readonly hasThread: boolean;
   readonly enabled?: boolean;
-  readonly onChangeDraftMessage: (value: string) => void;
+  // Inserting a skill reports the range it occupies so callers that track
+  // explicit invocations can record it with the same edit.
+  readonly onChangeDraftMessage: (
+    value: string,
+    addedSkillInvocation?: ExplicitSkillInvocation,
+  ) => void;
   readonly onUpdateInteractionMode?: (mode: ProviderInteractionMode) => void;
 }) {
   const [selection, setSelection] = useState(() => ({
@@ -267,7 +277,16 @@ export function useComposerCommandMenu({
         replacement,
       );
       setSelection({ start: result.cursor, end: result.cursor });
-      onChangeDraftMessage(result.text);
+      onChangeDraftMessage(
+        result.text,
+        item.type === "skill"
+          ? {
+              name: item.skill.name,
+              start: trigger.rangeStart,
+              end: trigger.rangeStart + item.skill.name.length + 1,
+            }
+          : undefined,
+      );
     },
     [draftMessage, onChangeDraftMessage, onUpdateInteractionMode, trigger],
   );

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -3,6 +3,7 @@ import type {
   ExplicitSkillInvocation,
   ProviderInteractionMode,
   ServerProvider,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import {
   detectComposerTrigger,
@@ -27,6 +28,7 @@ export function useComposerCommandMenu({
   environmentId,
   projectCwd,
   selectedProviderStatus,
+  skills,
   hasThread,
   enabled = true,
   onChangeDraftMessage,
@@ -36,6 +38,9 @@ export function useComposerCommandMenu({
   readonly environmentId: EnvironmentId | null;
   readonly projectCwd: string | null;
   readonly selectedProviderStatus: ServerProvider | null;
+  // Scoped to the composer's workspace, so it can differ from the provider
+  // snapshot's environment-wide list.
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly hasThread: boolean;
   readonly enabled?: boolean;
   // Inserting a skill reports the range it occupies so callers that track
@@ -131,7 +136,7 @@ export function useComposerCommandMenu({
         });
       }
 
-      const skillItems = (selectedProviderStatus?.skills ?? [])
+      const skillItems = skills
         .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
           id: `skill:${skill.name}`,
@@ -145,7 +150,7 @@ export function useComposerCommandMenu({
     }
 
     if (trigger.kind === "skill") {
-      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((skill) => skill.enabled);
+      const enabledSkills = skills.filter((skill) => skill.enabled);
       const normalizedQuery = normalizeSearchQuery(trigger.query, {
         trimLeadingPattern: /^\$+/,
       });
@@ -242,7 +247,14 @@ export function useComposerCommandMenu({
     }
 
     return [];
-  }, [hasThread, onUpdateInteractionMode, pathSearch.entries, selectedProviderStatus, trigger]);
+  }, [
+    hasThread,
+    onUpdateInteractionMode,
+    pathSearch.entries,
+    selectedProviderStatus,
+    skills,
+    trigger,
+  ]);
 
   const onSelect = useCallback(
     (item: ComposerCommandItem) => {

--- a/apps/mobile/src/state/providerSkills.ts
+++ b/apps/mobile/src/state/providerSkills.ts
@@ -1,0 +1,32 @@
+import type {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ServerProviderSkill,
+  ThreadId,
+} from "@t3tools/contracts";
+
+import { serverEnvironment } from "./server";
+import { useEnvironmentQuery } from "./query";
+
+export function useProviderSkills(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly projectId: ProjectId | null;
+  readonly threadId?: ThreadId | null;
+  readonly fallback: ReadonlyArray<ServerProviderSkill>;
+}): ReadonlyArray<ServerProviderSkill> {
+  const query = useEnvironmentQuery(
+    input.environmentId && input.projectId && input.instanceId
+      ? serverEnvironment.providerSkills({
+          environmentId: input.environmentId,
+          input: {
+            instanceId: input.instanceId,
+            projectId: input.projectId,
+            ...(input.threadId ? { threadId: input.threadId } : {}),
+          },
+        })
+      : null,
+  );
+  return query.data?.skills ?? input.fallback;
+}

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -3,6 +3,7 @@ import type { EnvironmentShellStatus } from "@t3tools/client-runtime/state/shell
 import {
   CommandId,
   EnvironmentId,
+  ExplicitSkillInvocation,
   IsoDateTime,
   MessageId,
   ModelSelection,
@@ -21,7 +22,7 @@ import { DraftComposerImageAttachmentSchema } from "../lib/composer-image-schema
 import type { DraftComposerImageAttachment } from "../lib/composerImages";
 import { scopedThreadKey } from "../lib/scopedEntities";
 
-const THREAD_OUTBOX_SCHEMA_VERSION = 3;
+const THREAD_OUTBOX_SCHEMA_VERSION = 4;
 const THREAD_OUTBOX_MAX_RETRY_DELAY_MS = 16_000;
 
 const QueuedThreadCreationSchema = Schema.Struct({
@@ -37,12 +38,13 @@ const QueuedThreadCreationSchema = Schema.Struct({
 });
 
 export const QueuedThreadMessageSchema = Schema.Struct({
-  schemaVersion: Schema.Literals([1, 2, THREAD_OUTBOX_SCHEMA_VERSION]),
+  schemaVersion: Schema.Literals([1, 2, 3, THREAD_OUTBOX_SCHEMA_VERSION]),
   environmentId: EnvironmentId,
   threadId: ThreadId,
   messageId: MessageId,
   commandId: CommandId,
   text: Schema.String,
+  skillInvocations: Schema.optional(Schema.Array(ExplicitSkillInvocation)),
   attachments: Schema.Array(DraftComposerImageAttachmentSchema),
   modelSelection: Schema.optional(ModelSelection),
   runtimeMode: Schema.optional(RuntimeMode),
@@ -72,6 +74,7 @@ export interface QueuedThreadMessage {
   readonly messageId: MessageId;
   readonly commandId: CommandId;
   readonly text: string;
+  readonly skillInvocations?: ReadonlyArray<typeof ExplicitSkillInvocation.Type>;
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
   readonly modelSelection?: ModelSelectionType;
   readonly runtimeMode?: RuntimeModeType;

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -92,6 +92,7 @@ describe("thread outbox", () => {
       },
       runtimeMode: "approval-required",
       interactionMode: "plan",
+      skillInvocations: [{ name: "review", start: 0, end: 7 }],
     } satisfies QueuedThreadMessage;
 
     expect(decodeQueuedThreadMessage(encodeQueuedThreadMessage(selectedMessage))).toEqual(

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -383,6 +383,38 @@ describe("mobile composer drafts", () => {
     });
   });
 
+  it("persists explicit skill ranges and clears them with sent content", () => {
+    const draftKey = "environment-1:thread-1";
+    const draft = decodePersistedComposerDrafts({
+      schemaVersion: 1,
+      drafts: {
+        [draftKey]: {
+          text: "$review this",
+          skillInvocations: [{ name: "review", start: 0, end: 7 }],
+          attachments: [],
+        },
+      },
+    })[draftKey];
+
+    expect(draft?.skillInvocations).toEqual([{ name: "review", start: 0, end: 7 }]);
+    expect(clearComposerDraftContentState({ [draftKey]: draft! }, draftKey)).toEqual({});
+  });
+
+  it("restores skill ranges when a failed send merges into matching text", () => {
+    const draftKey = "environment-1:thread-1";
+    const merged = mergeComposerDraftContentState(
+      { [draftKey]: { text: "$review this", attachments: [] } },
+      draftKey,
+      {
+        text: "$review this",
+        skillInvocations: [{ name: "review", start: 0, end: 7 }],
+        attachments: [],
+      },
+    );
+
+    expect(merged[draftKey]?.skillInvocations).toEqual([{ name: "review", start: 0, end: 7 }]);
+  });
+
   it("clears sent content without clearing the selected model or workspace", () => {
     const draftKey = "environment-1:thread-1";
     const draft: ComposerDraft = {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -1,10 +1,12 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   ModelSelection as ModelSelectionSchema,
+  ExplicitSkillInvocation as ExplicitSkillInvocationSchema,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   ProviderInteractionMode as ProviderInteractionModeSchema,
   RuntimeMode as RuntimeModeSchema,
   type EnvironmentId,
+  type ExplicitSkillInvocation,
   type ModelSelection,
   type ProviderInteractionMode,
   type RuntimeMode,
@@ -40,6 +42,7 @@ export class ComposerDraftPersistenceError extends Schema.TaggedErrorClass<Compo
 
 export interface ComposerDraft {
   readonly text: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
   readonly importedShareIds?: ReadonlyArray<string>;
   readonly modelSelection?: ModelSelection;
@@ -50,6 +53,7 @@ export interface ComposerDraft {
 
 export interface ComposerDraftContent {
   readonly text: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
   readonly sourceShareId?: string;
 }
@@ -75,6 +79,7 @@ const ComposerDraftWorkspaceSelectionSchema = Schema.Struct({
 
 const ComposerDraftSchema = Schema.Struct({
   text: Schema.String,
+  skillInvocations: Schema.optional(Schema.Array(ExplicitSkillInvocationSchema)),
   attachments: Schema.Array(DraftComposerImageAttachmentSchema),
   importedShareIds: Schema.optional(Schema.Array(Schema.String)),
   modelSelection: Schema.optional(ModelSelectionSchema),
@@ -361,11 +366,18 @@ export function setStickyComposerModelSelection(modelSelection: ModelSelection):
   schedulePersistComposerState();
 }
 
-export function setComposerDraftText(draftKey: string, value: string): void {
+export function setComposerDraftText(
+  draftKey: string,
+  value: string,
+  skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>,
+): void {
   updateComposerDrafts((current) => {
+    const existing = normalizeDraft(current[draftKey]);
+    const { skillInvocations: _skillInvocations, ...draftWithoutSkills } = existing;
     const draft = {
-      ...normalizeDraft(current[draftKey]),
+      ...(skillInvocations === undefined ? existing : draftWithoutSkills),
       text: value,
+      ...(skillInvocations && skillInvocations.length > 0 ? { skillInvocations } : {}),
     };
     if (isEmptyDraft(draft)) {
       const next = { ...current };
@@ -487,6 +499,7 @@ export function clearComposerDraftContentState(
   const {
     importedShareIds: _importedShareIds,
     modelSelection,
+    skillInvocations: _skillInvocations,
     workspaceSelection,
     ...retained
   } = existing;
@@ -550,6 +563,7 @@ export function copyComposerDraftContentState(
     [targetDraftKey]: {
       ...target,
       text: source.text,
+      ...(source.skillInvocations ? { skillInvocations: source.skillInvocations } : {}),
       attachments: source.attachments,
       ...(source.importedShareIds ? { importedShareIds: source.importedShareIds } : {}),
     },
@@ -584,6 +598,13 @@ function mergeComposerDraftText(existing: string, incoming: string): string {
   return `${existing}\n\n${incoming}`;
 }
 
+function mergedTextOffset(existing: string, incoming: string): number | null {
+  if (incoming.length === 0) return null;
+  if (existing.length === 0 || existing === incoming) return 0;
+  if (existing.endsWith(`\n\n${incoming}`)) return existing.length - incoming.length;
+  return existing.length + 2;
+}
+
 export function mergeComposerDraftContentState(
   current: Record<string, ComposerDraft>,
   draftKey: string,
@@ -606,13 +627,35 @@ export function mergeComposerDraftContentState(
     PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   );
   const text = mergeComposerDraftText(existing.text, content.text);
+  const incomingTextOffset = mergedTextOffset(existing.text, content.text);
+  const skillInvocations = [...(existing.skillInvocations ?? [])];
+  if (incomingTextOffset !== null) {
+    for (const invocation of content.skillInvocations ?? []) {
+      const shifted = {
+        ...invocation,
+        start: invocation.start + incomingTextOffset,
+        end: invocation.end + incomingTextOffset,
+      };
+      if (
+        !skillInvocations.some(
+          (existingInvocation) =>
+            existingInvocation.name === shifted.name &&
+            existingInvocation.start === shifted.start &&
+            existingInvocation.end === shifted.end,
+        )
+      ) {
+        skillInvocations.push(shifted);
+      }
+    }
+  }
   const importedShareIds = content.sourceShareId
     ? [...(existing.importedShareIds ?? []), content.sourceShareId]
     : existing.importedShareIds;
   if (
     text === existing.text &&
     attachments.length === existing.attachments.length &&
-    importedShareIds === existing.importedShareIds
+    importedShareIds === existing.importedShareIds &&
+    skillInvocations.length === (existing.skillInvocations?.length ?? 0)
   ) {
     return current;
   }
@@ -621,6 +664,7 @@ export function mergeComposerDraftContentState(
     [draftKey]: {
       ...existing,
       text,
+      ...(skillInvocations.length > 0 ? { skillInvocations } : {}),
       attachments,
       ...(importedShareIds ? { importedShareIds } : {}),
     },

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -5,6 +5,7 @@ import * as Cause from "effect/Cause";
 
 import {
   CommandId,
+  type ExplicitSkillInvocation,
   MessageId,
   type EnvironmentId,
   type ModelSelection,
@@ -21,6 +22,7 @@ import {
 } from "@t3tools/client-runtime/state/threads";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
+import { remapExplicitSkillInvocations } from "@t3tools/shared/explicitSkillInvocations";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
 import {
@@ -81,6 +83,7 @@ export function useThreadDraftForThread(input: {
 
   return {
     draftMessage: draft.text,
+    draftSkillInvocations: draft.skillInvocations ?? [],
     draftAttachments: draft.attachments,
   };
 }
@@ -126,6 +129,7 @@ export function useThreadComposerState() {
 
   const selectedDraft = selectedThreadKey ? composerDrafts[selectedThreadKey] : null;
   const draftMessage = selectedDraft?.text ?? "";
+  const draftSkillInvocations = selectedDraft?.skillInvocations ?? [];
   const draftAttachments = selectedDraft?.attachments ?? [];
   const selectedThreadQueueCount = selectedThreadQueuedMessages.length;
   const selectedThread = selectedThreadDetail ?? selectedThreadShell;
@@ -167,6 +171,11 @@ export function useThreadComposerState() {
     const draft = getComposerDraftSnapshot(threadKey);
     const thread = selectedThreadDetail ?? selectedThreadShell;
     const text = draft.text.trim();
+    const sentSkillInvocations = remapExplicitSkillInvocations({
+      sourceText: draft.text,
+      outgoingText: text,
+      invocations: draft.skillInvocations ?? [],
+    });
     const attachments = draft.attachments;
     if (text.length === 0 && attachments.length === 0) {
       return null;
@@ -249,6 +258,7 @@ export function useThreadComposerState() {
       messageId,
       commandId: CommandId.make(metadata.commandId),
       text,
+      ...(sentSkillInvocations.length > 0 ? { skillInvocations: sentSkillInvocations } : {}),
       attachments,
       modelSelection: draft.modelSelection ?? thread.modelSelection,
       runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
@@ -261,7 +271,11 @@ export function useThreadComposerState() {
       // append: the merge path slots existing attachments first and truncates
       // at the send limit, which would silently drop this message's images if
       // the user attached new ones while the write was in flight.
-      void mergeComposerDraftContent(threadKey, { text, attachments: [] });
+      void mergeComposerDraftContent(threadKey, {
+        text,
+        skillInvocations: sentSkillInvocations,
+        attachments: [],
+      });
       appendComposerDraftAttachments(threadKey, attachments);
       setPendingConnectionError(
         error instanceof Error ? error.message : "Failed to save the queued message.",
@@ -276,13 +290,13 @@ export function useThreadComposerState() {
   ]);
 
   const onChangeDraftMessage = useCallback(
-    (value: string) => {
+    (value: string, skillInvocations: ReadonlyArray<ExplicitSkillInvocation>) => {
       if (!selectedThreadShell) {
         return;
       }
 
       const threadKey = scopedThreadKey(selectedThreadShell.environmentId, selectedThreadShell.id);
-      setComposerDraftText(threadKey, value);
+      setComposerDraftText(threadKey, value, skillInvocations);
     },
     [selectedThreadShell],
   );
@@ -398,6 +412,7 @@ export function useThreadComposerState() {
     selectedThreadQueueCount,
     activeWorkStartedAt,
     draftMessage,
+    draftSkillInvocations,
     draftAttachments,
     modelSelection,
     runtimeMode,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -227,6 +227,9 @@ export function useThreadOutboxDrain(): void {
             role: "user",
             text: queuedMessage.text,
             attachments: toUploadChatImageAttachments(queuedMessage.attachments),
+            ...(queuedMessage.skillInvocations !== undefined
+              ? { skillInvocations: queuedMessage.skillInvocations }
+              : {}),
           },
           modelSelection: settings.modelSelection,
           runtimeMode: settings.runtimeMode,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
+  [WS_METHODS.providerListSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -540,8 +540,9 @@ describe("ProviderCommandReactor", () => {
         message: {
           messageId: asMessageId("user-message-1"),
           role: "user",
-          text: "hello reactor",
+          text: "  hello $reactor  ",
           attachments: [],
+          skillInvocations: [{ name: "reactor", start: 8, end: 16 }],
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
@@ -566,6 +567,10 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      input: "hello $reactor",
+      skillInvocations: [{ name: "reactor", start: 6, end: 14 }],
+    });
   });
 
   effectIt.effect("projects starting before a slow provider session finishes", () =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -9,10 +9,12 @@ import {
   type OrchestrationSession,
   ThreadId,
   type ProviderSession,
+  type ProviderSendTurnInput,
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { remapExplicitSkillInvocations } from "@t3tools/shared/explicitSkillInvocations";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -775,6 +777,7 @@ const make = Effect.gen(function* () {
     readonly threadId: ThreadId;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
+    readonly skillInvocations?: ProviderSendTurnInput["skillInvocations"];
     readonly modelSelection?: ModelSelection;
     readonly interactionMode?: "default" | "plan";
     readonly createdAt: string;
@@ -794,6 +797,13 @@ const make = Effect.gen(function* () {
     }
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
     const normalizedAttachments = input.attachments ?? [];
+    const skillInvocations = normalizedInput
+      ? remapExplicitSkillInvocations({
+          sourceText: input.messageText,
+          outgoingText: normalizedInput,
+          invocations: input.skillInvocations ?? [],
+        })
+      : [];
     const activeSession = yield* providerService
       .listSessions()
       .pipe(
@@ -826,6 +836,7 @@ const make = Effect.gen(function* () {
       threadId: input.threadId,
       ...(normalizedInput ? { input: normalizedInput } : {}),
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
+      ...(skillInvocations !== undefined ? { skillInvocations } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
     };
@@ -1206,6 +1217,9 @@ const make = Effect.gen(function* () {
       threadId: event.payload.threadId,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+      ...(event.payload.skillInvocations !== undefined
+        ? { skillInvocations: event.payload.skillInvocations }
+        : {}),
       ...(event.payload.modelSelection !== undefined
         ? { modelSelection: event.payload.modelSelection }
         : {}),

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -307,8 +307,9 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
           message: {
             messageId: asMessageId("message-user-1"),
             role: "user",
-            text: "hello",
+            text: "hello $review",
             attachments: [],
+            skillInvocations: [{ name: "review", start: 6, end: 13 }],
           },
           modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
             { id: "reasoningEffort", value: "high" },
@@ -334,12 +335,14 @@ it.layer(NodeServices.layer)("decider project scripts", (it) => {
       expect(turnStartEvent.payload).toMatchObject({
         threadId: ThreadId.make("thread-1"),
         messageId: asMessageId("message-user-1"),
+        skillInvocations: [{ name: "review", start: 6, end: 13 }],
         modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
           { id: "reasoningEffort", value: "high" },
           { id: "fastMode", value: true },
         ]),
         runtimeMode: "approval-required",
       });
+      expect(events[0]?.payload).not.toHaveProperty("skillInvocations");
     }),
   );
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -988,6 +988,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           messageId: command.message.messageId,
+          ...(command.message.skillInvocations !== undefined
+            ? { skillInvocations: command.message.skillInvocations }
+            : {}),
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -55,7 +55,9 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
+import { makeProviderSkillsCache } from "../providerSkillsCache.ts";
 import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -153,6 +155,13 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       };
       const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
       const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
+      const skillsCache = yield* makeProviderSkillsCache((workspaceCwd) =>
+        discoverClaudeSkills(effectiveConfig, workspaceCwd, processEnv).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+          Effect.option,
+        ),
+      );
 
       // Per-instance capabilities cache: keyed on binary + resolved HOME so
       // account-specific probes never share auth metadata across instances.
@@ -233,6 +242,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        listSkillsForCwd: (workspaceCwd) => Cache.get(skillsCache, workspaceCwd),
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -1,10 +1,42 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { assert, it } from "@effect/vitest";
+import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { discoverClaudeSkills } from "./ClaudeSkills.ts";
+import { discoverClaudeSkills, prepareClaudeSkillContents } from "./ClaudeSkills.ts";
+
+describe("prepareClaudeSkillContents", () => {
+  it("expands full and positional arguments", () => {
+    assert.deepEqual(
+      prepareClaudeSkillContents(
+        ["---", "name: migrate", "---", "", "Move $0 from $1. Full: $ARGUMENTS"].join("\n"),
+        'Button "old folder"',
+      ),
+      {
+        kind: "prepared",
+        contents: 'Move Button from old folder. Full: Button "old folder"',
+      },
+    );
+  });
+
+  it("appends arguments when the body has no placeholder", () => {
+    assert.deepEqual(prepareClaudeSkillContents("# Review", "this change"), {
+      kind: "prepared",
+      contents: "# Review\n\nARGUMENTS: this change",
+    });
+  });
+
+  it("rejects runtime fields the fallback cannot preserve", () => {
+    assert.deepEqual(
+      prepareClaudeSkillContents(
+        ["---", "name: review", "context: fork", "allowed-tools: Read", "---", "Review"].join("\n"),
+        "this change",
+      ),
+      { kind: "unsupported", fields: ["allowed-tools", "context"] },
+    );
+  });
+});
 
 const writeSkill = Effect.fn(function* (
   skillsDir: string,
@@ -63,6 +95,29 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
           description: "Deploy the app.",
         },
       ]);
+    }),
+  );
+
+  it.effect("hides skills disabled for user invocation", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "model-only",
+        [
+          "---",
+          "name: model-only",
+          "description: Not available in the composer.",
+          "user-invocable: false",
+          "---",
+        ].join("\n"),
+      );
+
+      assert.deepEqual(yield* discoverClaudeSkills({ homePath: configDir }), []);
     }),
   );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -17,7 +17,9 @@ import type { ClaudeSettings, ServerProviderSkill } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
-import { parse as parseYamlDocument } from "yaml";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
 
 import { expandHomePath } from "../../pathExpansion.ts";
 
@@ -25,10 +27,38 @@ type ClaudeSkillScope = "user" | "project";
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
+const ClaudeSkillFrontmatter = fromYaml(
+  Schema.Struct({
+    name: Schema.optional(Schema.String),
+    description: Schema.optional(Schema.String),
+    "user-invocable": Schema.optional(Schema.Boolean),
+  }),
+);
+const decodeClaudeSkillFrontmatter = Schema.decodeUnknownOption(ClaudeSkillFrontmatter);
+const decodeClaudeSkillFrontmatterRecord = Schema.decodeUnknownOption(
+  fromYaml(Schema.Record(Schema.String, Schema.Unknown)),
+);
+
+const UNSUPPORTED_FALLBACK_FIELDS = [
+  "allowed-tools",
+  "disallowed-tools",
+  "model",
+  "context",
+  "agent",
+  "background",
+  "hooks",
+  "arguments",
+] as const;
+
 type SkillFrontmatter =
   | { readonly kind: "missing" }
   | { readonly kind: "malformed" }
-  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
+  | {
+      readonly kind: "parsed";
+      readonly name?: string;
+      readonly description?: string;
+      readonly userInvocable: boolean;
+    };
 
 function parseSkillFrontmatter(contents: string): SkillFrontmatter {
   const match = FRONTMATTER_PATTERN.exec(contents);
@@ -36,23 +66,94 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
     return { kind: "missing" };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = parseYamlDocument(match[1] ?? "");
-  } catch {
-    return { kind: "malformed" };
-  }
-  if (typeof parsed !== "object" || parsed === null) {
+  const parsed = Option.getOrUndefined(decodeClaudeSkillFrontmatter(match[1] ?? ""));
+  if (!parsed) {
     return { kind: "malformed" };
   }
 
-  const record = parsed as Record<string, unknown>;
-  const name = typeof record.name === "string" ? record.name.trim() : "";
-  const description = typeof record.description === "string" ? record.description.trim() : "";
+  const name = parsed.name?.trim() ?? "";
+  const description = parsed.description?.trim() ?? "";
   return {
     kind: "parsed",
+    userInvocable: parsed["user-invocable"] !== false,
     ...(name ? { name } : {}),
     ...(description ? { description } : {}),
+  };
+}
+
+function splitClaudeSkillArguments(value: string): ReadonlyArray<string> {
+  const arguments_: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+    } else if (character === "\\" && quote !== "'") {
+      escaped = true;
+    } else if (quote) {
+      if (character === quote) quote = null;
+      else current += character;
+    } else if (character === "'" || character === '"') {
+      quote = character;
+    } else if (/\s/.test(character)) {
+      if (current.length > 0) {
+        arguments_.push(current);
+        current = "";
+      }
+    } else {
+      current += character;
+    }
+  }
+  if (escaped) current += "\\";
+  if (current.length > 0) arguments_.push(current);
+  return arguments_;
+}
+
+export type PreparedClaudeSkillContents =
+  | { readonly kind: "prepared"; readonly contents: string }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "unsupported"; readonly fields: ReadonlyArray<string> };
+
+/**
+ * Prepares a Claude skill for providers that cannot ask Claude Code to invoke
+ * it natively. Argument placeholders are expanded; runtime-only frontmatter
+ * is rejected so the fallback never silently weakens a skill's contract.
+ */
+export function prepareClaudeSkillContents(
+  contents: string,
+  argumentsText: string,
+): PreparedClaudeSkillContents {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  const body = match ? contents.slice(match[0].length).trimStart() : contents;
+  if (match) {
+    const frontmatter = Option.getOrUndefined(decodeClaudeSkillFrontmatterRecord(match[1] ?? ""));
+    if (!frontmatter) return { kind: "malformed" };
+    const fields = UNSUPPORTED_FALLBACK_FIELDS.filter((field) => frontmatter[field] !== undefined);
+    if (fields.length > 0) return { kind: "unsupported", fields };
+  }
+
+  const positionalArguments = splitClaudeSkillArguments(argumentsText);
+  let substituted = false;
+  const prepared = body.replace(
+    /(\\*)\$(?:ARGUMENTS(?:\[(\d+)\])?|(\d+))/g,
+    (token, backslashes: string, indexed: string | undefined, shorthand: string | undefined) => {
+      const placeholder = token.slice(backslashes.length);
+      if (backslashes.length === 1) return placeholder;
+      substituted = true;
+      const index = indexed ?? shorthand;
+      const replacement =
+        index === undefined ? argumentsText : (positionalArguments[Number(index)] ?? placeholder);
+      return `${backslashes}${replacement}`;
+    },
+  );
+  return {
+    kind: "prepared",
+    contents:
+      !substituted && argumentsText.length > 0
+        ? `${prepared.trimEnd()}\n\nARGUMENTS: ${argumentsText}`
+        : prepared,
   };
 }
 
@@ -131,6 +232,9 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       // either — skip it rather than surfacing a broken entry under its
       // directory name.
       if (frontmatter.kind === "malformed") {
+        continue;
+      }
+      if (frontmatter.kind === "parsed" && !frontmatter.userInvocable) {
         continue;
       }
 

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -22,6 +22,7 @@
  * @module provider/Drivers/CodexDriver
  */
 import { CodexSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -36,12 +37,18 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
-import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
+import {
+  checkCodexProviderStatus,
+  discoverCodexSkills,
+  makePendingCodexProvider,
+} from "../Layers/CodexProvider.ts";
+import { resolveCodexLaunchArgs } from "../Layers/codexLaunchArgs.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import * as ModelManifest from "../ModelManifest.ts";
 import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { makeProviderSkillsCache } from "../providerSkillsCache.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
@@ -164,6 +171,19 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       });
       const textGeneration = yield* makeCodexTextGeneration(effectiveConfig, processEnv);
+      const skillsCache = yield* makeProviderSkillsCache((cwd) =>
+        discoverCodexSkills({
+          binaryPath: effectiveConfig.binaryPath,
+          launchArgs: resolveCodexLaunchArgs(effectiveConfig.launchArgs, processEnv),
+          cwd,
+          environment: processEnv,
+          ...(effectiveConfig.homePath ? { homePath: effectiveConfig.homePath } : {}),
+        }).pipe(
+          Effect.scoped,
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Effect.option,
+        ),
+      );
 
       // Build a managed snapshot whose settings never change — mutations come
       // in as instance rebuilds from the registry rather than in-place
@@ -225,6 +245,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        listSkillsForCwd: (cwd) => Cache.get(skillsCache, cwd),
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -12,6 +12,7 @@
  * @module provider/Drivers/CursorDriver
  */
 import { CursorSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -39,6 +40,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { makeProviderSkillsCache } from "../providerSkillsCache.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   makeProviderMaintenanceCapabilities,
@@ -50,6 +52,7 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
+import { discoverCursorSkills } from "./CursorSkills.ts";
 const decodeCursorSettings = Schema.decodeSync(CursorSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("cursor");
@@ -132,6 +135,13 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         instanceId,
       });
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
+      const skillsCache = yield* makeProviderSkillsCache((workspaceCwd) =>
+        discoverCursorSkills(workspaceCwd, processEnv).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+          Effect.option,
+        ),
+      );
 
       const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
@@ -182,6 +192,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        listSkillsForCwd: (workspaceCwd) => Cache.get(skillsCache, workspaceCwd),
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -105,6 +105,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
+      const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -132,7 +133,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
       });
       const textGeneration = yield* makeCursorTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = checkCursorProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/CursorSkills.test.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.test.ts
@@ -1,0 +1,90 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverCursorSkills } from "./CursorSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  relativeDirectory: string,
+  contents: string,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDirectory = path.join(skillsDir, relativeDirectory);
+  yield* fileSystem.makeDirectory(skillDirectory, { recursive: true });
+  yield* fileSystem.writeFileString(path.join(skillDirectory, "SKILL.md"), contents);
+});
+
+const skill = (name: string, description = `Use ${name}.`) =>
+  ["---", `name: ${name}`, `description: ${description}`, "---", "", `# ${name}`].join("\n");
+
+it.layer(NodeServices.layer)("discoverCursorSkills", (it) => {
+  it.effect("discovers every documented direct user and project root", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const home = path.join(tempDir, "home");
+      const workspace = path.join(tempDir, "workspace");
+      const rootNames = [".agents", ".cursor", ".claude", ".codex"] as const;
+
+      for (const rootName of rootNames) {
+        yield* writeSkill(
+          path.join(home, rootName, "skills"),
+          `user-${rootName.slice(1)}`,
+          skill(`user-${rootName.slice(1)}`),
+        );
+        yield* writeSkill(
+          path.join(workspace, rootName, "skills"),
+          `project-${rootName.slice(1)}`,
+          skill(`project-${rootName.slice(1)}`),
+        );
+      }
+
+      const skills = yield* discoverCursorSkills(workspace, { HOME: home });
+
+      assert.deepEqual(
+        skills.map((entry) => [entry.name, entry.scope]),
+        [
+          ["project-agents", "project"],
+          ["project-claude", "project"],
+          ["project-codex", "project"],
+          ["project-cursor", "project"],
+          ["user-agents", "user"],
+          ["user-claude", "user"],
+          ["user-codex", "user"],
+          ["user-cursor", "user"],
+        ],
+      );
+    }),
+  );
+
+  it.effect("discovers nested skills and rejects invalid entries", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cursor-skills-" });
+      const workspace = path.join(tempDir, "workspace");
+      const skillsDirectory = path.join(workspace, ".cursor", "skills");
+
+      yield* writeSkill(skillsDirectory, "shipping/deploy", skill("deploy"));
+      yield* writeSkill(skillsDirectory, "wrong-folder", skill("another-name"));
+      yield* writeSkill(
+        skillsDirectory,
+        "no-description",
+        ["---", "name: no-description", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverCursorSkills(workspace, { HOME: path.join(tempDir, "home") });
+
+      assert.deepEqual(
+        skills.map((entry) => entry.name),
+        ["deploy"],
+      );
+      assert.equal(skills[0]?.path, path.join(skillsDirectory, "shipping", "deploy", "SKILL.md"));
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,0 +1,121 @@
+/**
+ * CursorSkills — filesystem discovery for the Cursor `$` picker.
+ *
+ * Cursor Agent discovers skills from its own, Agent Skills, Claude, and Codex
+ * directories. T3 reads the same on-disk skills because Cursor ACP does not
+ * expose a skill catalogue.
+ *
+ * @module provider/Drivers/CursorSkills
+ */
+import * as NodeOS from "node:os";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
+
+type CursorSkillScope = "user" | "project";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const SKILL_NAME_PATTERN = /^[a-z0-9-]+$/;
+
+const CursorSkillFrontmatter = fromYaml(
+  Schema.Struct({
+    name: Schema.String,
+    description: Schema.String,
+  }),
+);
+const decodeCursorSkillFrontmatter = Schema.decodeUnknownOption(CursorSkillFrontmatter);
+
+type SkillFrontmatter =
+  | { readonly kind: "malformed" }
+  | { readonly kind: "parsed"; readonly name: string; readonly description: string };
+
+function parseSkillFrontmatter(contents: string): SkillFrontmatter {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) {
+    return { kind: "malformed" };
+  }
+
+  const parsed = Option.getOrUndefined(decodeCursorSkillFrontmatter(match[1] ?? ""));
+  if (!parsed) {
+    return { kind: "malformed" };
+  }
+
+  const name = parsed.name.trim();
+  const description = parsed.description.trim();
+  if (!SKILL_NAME_PATTERN.test(name) || !description) {
+    return { kind: "malformed" };
+  }
+
+  return { kind: "parsed", name, description };
+}
+
+function isSkillFile(entry: string): boolean {
+  return entry === "SKILL.md" || entry.replaceAll("\\", "/").endsWith("/SKILL.md");
+}
+
+/**
+ * List skills from Cursor's documented user and project roots. The scan is
+ * best-effort so unreadable or malformed entries never affect provider state.
+ */
+export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* (
+  cwd?: string,
+  environment?: NodeJS.ProcessEnv,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const homePath = environment?.HOME?.trim() || NodeOS.homedir();
+  const roots: ReadonlyArray<{ directory: string; scope: CursorSkillScope }> = [
+    { directory: path.join(homePath, ".agents", "skills"), scope: "user" },
+    { directory: path.join(homePath, ".cursor", "skills"), scope: "user" },
+    { directory: path.join(homePath, ".claude", "skills"), scope: "user" },
+    { directory: path.join(homePath, ".codex", "skills"), scope: "user" },
+    ...(cwd
+      ? [
+          { directory: path.join(cwd, ".agents", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".cursor", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".claude", "skills"), scope: "project" as const },
+          { directory: path.join(cwd, ".codex", "skills"), scope: "project" as const },
+        ]
+      : []),
+  ];
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory, { recursive: true })
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].filter(isSkillFile).sort()) {
+      const skillPath = path.join(root.directory, entry);
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+      if (frontmatter.name !== path.basename(path.dirname(skillPath))) {
+        continue;
+      }
+
+      skillsByName.set(frontmatter.name, {
+        name: frontmatter.name,
+        description: frontmatter.description,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});

--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -1,4 +1,5 @@
 import { GrokSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -26,6 +27,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { makeProviderSkillsCache } from "../providerSkillsCache.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   makeManualOnlyProviderMaintenanceCapabilities,
@@ -37,6 +39,7 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
+import { discoverGrokSkills } from "./GrokSkills.ts";
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("grok");
@@ -113,6 +116,12 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         instanceId,
       });
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
+      const skillsCache = yield* makeProviderSkillsCache((workspaceCwd) =>
+        discoverGrokSkills(effectiveConfig, processEnv, workspaceCwd).pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Effect.option,
+        ),
+      );
 
       const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
@@ -157,6 +166,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
+        listSkillsForCwd: (workspaceCwd) => Cache.get(skillsCache, workspaceCwd),
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -13,6 +13,7 @@
  * @module provider/Drivers/OpenCodeDriver
  */
 import { OpenCodeSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -29,6 +30,7 @@ import { ProviderDriverError } from "../Errors.ts";
 import { makeOpenCodeAdapter } from "../Layers/OpenCodeAdapter.ts";
 import {
   checkOpenCodeProviderStatus,
+  discoverOpenCodeSkills,
   makePendingOpenCodeProvider,
 } from "../Layers/OpenCodeProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
@@ -41,6 +43,7 @@ import {
   type ProviderInstance,
 } from "../ProviderDriver.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { makeProviderSkillsCache } from "../providerSkillsCache.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
@@ -150,6 +153,13 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
           : {}),
         environment: processEnv,
       });
+      const skillsCache = yield* makeProviderSkillsCache((workspaceCwd) =>
+        discoverOpenCodeSkills(effectiveConfig, workspaceCwd).pipe(
+          Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
+          Effect.provideService(OpenCodeRuntime, openCodeRuntime),
+          Effect.option,
+        ),
+      );
       const textGeneration = yield* makeOpenCodeTextGeneration(effectiveConfig).pipe(
         Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
       );
@@ -204,6 +214,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         accentColor,
         enabled,
         snapshot,
+        listSkillsForCwd: (workspaceCwd) => Cache.get(skillsCache, workspaceCwd),
         adapter,
         textGeneration,
       } satisfies ProviderInstance;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -782,6 +782,60 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("explicitly injects a selected skill document into Claude prompts", () => {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-skills-"));
+    const configDir = NodePath.join(baseDir, "claude-home");
+    const skillsDir = NodePath.join(configDir, "skills", "wayfinder");
+    NodeFS.mkdirSync(skillsDir, { recursive: true });
+    NodeFS.writeFileSync(
+      NodePath.join(skillsDir, "SKILL.md"),
+      [
+        "---",
+        "name: wayfinder",
+        "description: Plan and document the work.",
+        "disable-model-invocation: true",
+        "---",
+        "",
+        "# Wayfinder",
+        "Map the work before implementation.",
+      ].join("\n"),
+    );
+    const harness = makeHarness({
+      baseDir,
+      cwd: NodePath.join(baseDir, "workspace"),
+      claudeConfig: { homePath: configDir },
+    });
+
+    return Effect.gen(function* () {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(baseDir, { recursive: true, force: true })),
+      );
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "Use $wayfinder to plan this change.",
+        skillInvocations: [{ name: "wayfinder", start: 4, end: 14 }],
+        attachments: [],
+      });
+
+      const promptText = yield* Effect.promise(() =>
+        readFirstPromptText(harness.getLastCreateQueryInput()),
+      );
+      assert.include(promptText ?? "", "Map the work before implementation.");
+      assert.include(promptText ?? "", "[T3 explicitly invoked skill: wayfinder]");
+      assert.notInclude(promptText ?? "", "$wayfinder");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("embeds image attachments in Claude user messages", () => {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-attachments-"));
     const harness = makeHarness({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -35,6 +35,7 @@ import {
   type ProviderRuntimeTurnStatus,
   type ProviderSendTurnInput,
   type ProviderSession,
+  type ServerProviderSkill,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   type RuntimeContentStreamKind,
@@ -79,6 +80,7 @@ import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import { discoverClaudeSkills, prepareClaudeSkillContents } from "../Drivers/ClaudeSkills.ts";
 import {
   getClaudeModelCapabilities,
   isClaudeUltracodeEffort,
@@ -96,6 +98,11 @@ import {
   type ProviderAdapterError,
 } from "../Errors.ts";
 import { type ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
+import {
+  replaceExplicitSkillInvocations,
+  renderProviderSkillPrompt,
+  loadInvokedSkills,
+} from "../skillInvocations.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const decodeUnknownJsonStringExit = Schema.decodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
@@ -273,6 +280,7 @@ function rememberPendingTaskModel(
 
 interface ClaudeSessionContext {
   session: ProviderSession;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly promptQueue: Queue.Queue<PromptQueueItem>;
   readonly query: ClaudeQueryRuntime;
   streamFiber: Fiber.Fiber<void, Error> | undefined;
@@ -1716,6 +1724,76 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
   const sessions = new Map<ThreadId, ClaudeSessionContext>();
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+
+  const discoverSkills = (cwd?: string) =>
+    discoverClaudeSkills(claudeSettings, cwd, claudeEnvironment).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+    );
+
+  const prepareSkillPrompt = (input: ProviderSendTurnInput, context: ClaudeSessionContext) =>
+    Effect.gen(function* () {
+      const prompt = input.input?.trim();
+      const invocations = input.skillInvocations ?? [];
+      if (!prompt || invocations.length === 0) {
+        return undefined;
+      }
+
+      const resolved = yield* loadInvokedSkills({
+        provider: PROVIDER,
+        providerLabel: "Claude",
+        prompt,
+        invocations,
+        skills: context.skills,
+        readFile: (skillPath) =>
+          fileSystem.readFileString(skillPath).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "turn/start",
+                  detail: `Failed to read Claude skill '${skillPath}'.`,
+                  cause,
+                }),
+            ),
+          ),
+      });
+      const argumentsText = replaceExplicitSkillInvocations(
+        prompt,
+        resolved.invocations,
+        () => "",
+      ).trim();
+      const documents = resolved.documents.map((document) => ({
+        ...document,
+        prepared: prepareClaudeSkillContents(document.contents, argumentsText),
+      }));
+      const malformed = documents.find((document) => document.prepared.kind === "malformed");
+      if (malformed) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "sendTurn",
+          issue: `Claude skill '$${malformed.name}' has malformed frontmatter.`,
+        });
+      }
+      const unsupported = documents.find((document) => document.prepared.kind === "unsupported");
+      if (unsupported?.prepared.kind === "unsupported") {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "sendTurn",
+          issue: `Claude skill '$${unsupported.name}' requires native runtime fields unsupported by T3's explicit fallback: ${unsupported.prepared.fields.join(", ")}.`,
+        });
+      }
+      return renderProviderSkillPrompt(
+        prompt,
+        documents.map((document) => ({
+          name: document.name,
+          path: document.path,
+          contents:
+            document.prepared.kind === "prepared" ? document.prepared.contents : document.contents,
+        })),
+        resolved.invocations,
+      );
+    });
 
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
   const randomUUIDv4 = crypto.randomUUIDv4.pipe(
@@ -3735,7 +3813,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     // Same reason as the approvals above: a request nobody can answer any more
     // must not stay open, or the thread can never be settled.
-    for (const pending of [...context.pendingUserInputs.values()]) {
+    for (const pending of context.pendingUserInputs.values()) {
       yield* pending.cancel;
     }
 
@@ -3826,6 +3904,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       const startedAt = yield* nowIso;
+      const skills = yield* discoverSkills(input.cwd);
       const resumeState = readClaudeResumeState(input.resumeCursor);
       const threadId = input.threadId;
       const existingResumeSessionId = resumeState?.resume;
@@ -4391,6 +4470,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const context: ClaudeSessionContext = {
         session,
+        skills,
         promptQueue,
         query: queryRuntime,
         streamFiber: undefined,
@@ -4499,6 +4579,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
         ? input.modelSelection
         : undefined;
+    const skillPrompt = yield* prepareSkillPrompt(input, context);
 
     // A sendTurn while a real turn is running is a steer: the message is
     // queued into the live SDK agent loop and the work continues as the same
@@ -4585,11 +4666,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
     }
 
-    const message = yield* buildUserMessageEffect(input, {
-      fileSystem,
-      attachmentsDir: serverConfig.attachmentsDir,
-      boundInstanceId,
-    });
+    const message = yield* buildUserMessageEffect(
+      skillPrompt === undefined ? input : { ...input, input: skillPrompt },
+      {
+        fileSystem,
+        attachmentsDir: serverConfig.attachmentsDir,
+        boundInstanceId,
+      },
+    );
 
     yield* Queue.offer(context.promptQueue, {
       type: "message",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -57,6 +57,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
+  CodexSessionRuntimeUnknownSkillError,
   describeMcpElicitation,
   makeCodexSessionRuntime,
   type CodexSessionRuntimeError,
@@ -70,6 +71,7 @@ const isCodexAppServerTransportError = Schema.is(CodexErrors.CodexAppServerTrans
 const isCodexSessionRuntimeThreadIdMissingError = Schema.is(
   CodexSessionRuntimeThreadIdMissingError,
 );
+const isCodexSessionRuntimeUnknownSkillError = Schema.is(CodexSessionRuntimeUnknownSkillError);
 const isCodexResumeCursorSchema = Schema.is(CodexResumeCursorSchema);
 
 const PROVIDER = ProviderDriverKind.make("codex");
@@ -113,6 +115,15 @@ function mapCodexRuntimeError(
     return new ProviderAdapterSessionNotFoundError({
       provider: PROVIDER,
       threadId,
+      cause: error,
+    });
+  }
+
+  if (isCodexSessionRuntimeUnknownSkillError(error)) {
+    return new ProviderAdapterValidationError({
+      provider: PROVIDER,
+      operation: "sendTurn",
+      issue: `Unknown Codex skill${error.names.length === 1 ? "" : "s"}: ${error.names.map((name) => `$${name}`).join(", ")}.`,
       cause: error,
     });
   }
@@ -1843,6 +1854,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     return yield* session.runtime
       .sendTurn({
         ...(input.input !== undefined ? { input: input.input } : {}),
+        ...(input.skillInvocations !== undefined
+          ? { skillInvocations: input.skillInvocations }
+          : {}),
         ...(input.modelSelection?.instanceId === boundInstanceId
           ? { model: input.modelSelection.model }
           : {}),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -318,12 +318,11 @@ export function buildCodexInitializeParams(): CodexSchema.V1InitializeParams {
   };
 }
 
-const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
+const connectCodexAppServer = Effect.fn("connectCodexAppServer")(function* (input: {
   readonly binaryPath: string;
   readonly homePath?: string;
   readonly launchArgs?: string;
   readonly cwd: string;
-  readonly customModels?: ReadonlyArray<string>;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
@@ -379,6 +378,31 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     },
   });
   yield* client.notify("initialized", undefined);
+
+  return { client, initialize };
+});
+
+export const discoverCodexSkills = Effect.fn("discoverCodexSkills")(function* (input: {
+  readonly binaryPath: string;
+  readonly homePath?: string;
+  readonly launchArgs?: string;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}) {
+  const { client } = yield* connectCodexAppServer(input);
+  const response = yield* client.request("skills/list", { cwds: [input.cwd] });
+  return parseCodexSkillsListResponse(response, input.cwd);
+});
+
+const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
+  readonly binaryPath: string;
+  readonly homePath?: string;
+  readonly launchArgs?: string;
+  readonly cwd: string;
+  readonly customModels?: ReadonlyArray<string>;
+  readonly environment?: NodeJS.ProcessEnv;
+}) {
+  const { client, initialize } = yield* connectCodexAppServer(input);
 
   // Extract the version string after the first '/' in userAgent, up to the next space or the end
   const versionMatch = initialize.userAgent.match(/\/([^\s]+)/);

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -251,7 +251,7 @@ function appendCustomCodexModels(
   return customEntries.length === 0 ? models : [...models, ...customEntries];
 }
 
-function parseCodexSkillsListResponse(
+export function parseCodexSkillsListResponse(
   response: CodexSchema.V2SkillsListResponse,
   cwd: string,
 ): ReadonlyArray<ServerProviderSkill> {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -17,6 +17,7 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  CodexSessionRuntimeUnknownSkillError,
   describeMcpElicitation,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
@@ -25,6 +26,8 @@ import {
   toMcpElicitationResponse,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+const isCodexAppServerProtocolParseError = Schema.is(CodexErrors.CodexAppServerProtocolParseError);
+const isCodexSessionRuntimeUnknownSkillError = Schema.is(CodexSessionRuntimeUnknownSkillError);
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {
@@ -81,6 +84,10 @@ describe("buildTurnStartParams", () => {
         ],
       }).pipe(Effect.flip),
     );
+    if (!isCodexAppServerProtocolParseError(error)) {
+      NodeAssert.fail("expected CodexAppServerProtocolParseError");
+      return;
+    }
     const { cause, ...directDiagnostics } = error;
 
     NodeAssert.equal(error.operation, "decode-request-payload");
@@ -221,6 +228,85 @@ describe("buildTurnStartParams", () => {
           },
         ],
       });
+    }),
+  );
+
+  it.effect("attaches explicit $skill tokens as Codex skill user input", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "$grill-with-docs explain why this skill is not in the list",
+        skillInvocations: [{ name: "grill-with-docs", start: 0, end: 16 }],
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params.input, [
+        {
+          type: "text",
+          text: "[T3 explicitly invoked skill: grill-with-docs] explain why this skill is not in the list",
+        },
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("fails instead of sending an unknown $skill token", () =>
+    Effect.gen(function* () {
+      const error = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "$missing-skill do this",
+        skillInvocations: [{ name: "missing-skill", start: 0, end: 14 }],
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      }).pipe(Effect.flip);
+
+      if (!isCodexSessionRuntimeUnknownSkillError(error)) {
+        NodeAssert.fail("expected CodexSessionRuntimeUnknownSkillError");
+        return;
+      }
+      NodeAssert.deepStrictEqual(error.names, ["missing-skill"]);
+      NodeAssert.equal(error.message, "Unknown Codex skill $missing-skill.");
+    }),
+  );
+
+  it.effect("leaves a message without $skill tokens unchanged", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Review this change",
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params.input, [
+        {
+          type: "text",
+          text: "Review this change",
+        },
+      ]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -9,6 +9,7 @@ import {
   type ProviderApprovalOption,
   type ProviderEvent,
   type ProviderInteractionMode,
+  type ExplicitSkillInvocation,
   type ProviderRequestKind,
   type ProviderSession,
   type ProviderTurnStartResult,
@@ -17,8 +18,8 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -36,7 +37,9 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
-import { buildCodexInitializeParams } from "./CodexProvider.ts";
+import { buildCodexInitializeParams, parseCodexSkillsListResponse } from "./CodexProvider.ts";
+import { bindCodexSkillInvocations } from "./codexSkillInvocations.ts";
+import { replaceExplicitSkillInvocations } from "../skillInvocations.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
@@ -170,6 +173,7 @@ export interface CodexSessionRuntimeOptions {
 
 export interface CodexSessionRuntimeSendTurnInput {
   readonly input?: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments?: ReadonlyArray<{
     readonly type: "image";
     readonly url: string;
@@ -221,7 +225,8 @@ export type CodexSessionRuntimeError =
   | CodexSessionRuntimePendingApprovalNotFoundError
   | CodexSessionRuntimePendingUserInputNotFoundError
   | CodexSessionRuntimeInvalidUserInputAnswersError
-  | CodexSessionRuntimeThreadIdMissingError;
+  | CodexSessionRuntimeThreadIdMissingError
+  | CodexSessionRuntimeUnknownSkillError;
 
 export class CodexSessionRuntimePendingApprovalNotFoundError extends Schema.TaggedErrorClass<CodexSessionRuntimePendingApprovalNotFoundError>()(
   "CodexSessionRuntimePendingApprovalNotFoundError",
@@ -264,6 +269,21 @@ export class CodexSessionRuntimeThreadIdMissingError extends Schema.TaggedErrorC
 ) {
   override get message(): string {
     return `Codex session is missing a provider thread id for ${this.threadId}`;
+  }
+}
+
+export class CodexSessionRuntimeUnknownSkillError extends Schema.TaggedErrorClass<CodexSessionRuntimeUnknownSkillError>()(
+  "CodexSessionRuntimeUnknownSkillError",
+  {
+    names: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    const listed = this.names.map((name) => `$${name}`).join(", ");
+    if (this.names.length === 1) {
+      return `Unknown Codex skill ${listed}.`;
+    }
+    return `Unknown Codex skills ${listed}.`;
   }
 }
 
@@ -593,9 +613,15 @@ export function buildTurnStartParams(input: {
   readonly threadId: string;
   readonly runtimeMode: RuntimeMode;
   readonly prompt?: string;
+  readonly skillInvocations?: ReadonlyArray<ExplicitSkillInvocation>;
   readonly attachments?: ReadonlyArray<{
     readonly type: "image";
     readonly url: string;
+  }>;
+  readonly availableSkills?: ReadonlyArray<{
+    readonly name: string;
+    readonly path: string;
+    readonly enabled: boolean;
   }>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;
@@ -605,14 +631,33 @@ export function buildTurnStartParams(input: {
   readonly browserToolsAvailable?: boolean;
 }): Effect.Effect<
   CodexTurnStartParamsWithCollaborationMode,
-  CodexErrors.CodexAppServerProtocolParseError
+  CodexErrors.CodexAppServerProtocolParseError | CodexSessionRuntimeUnknownSkillError
 > {
+  const boundSkills = bindCodexSkillInvocations(
+    input.prompt ?? "",
+    input.skillInvocations ?? [],
+    input.availableSkills ?? [],
+  );
+  if (!boundSkills.ok) {
+    return Effect.fail(new CodexSessionRuntimeUnknownSkillError({ names: boundSkills.names }));
+  }
+
   const turnInput: Array<EffectCodexSchema.V2TurnStartParams__UserInput> = [];
-  if (input.prompt) {
+  const prompt = input.prompt
+    ? replaceExplicitSkillInvocations(
+        input.prompt,
+        input.skillInvocations ?? [],
+        (name) => `[T3 explicitly invoked skill: ${name}]`,
+      )
+    : undefined;
+  if (prompt) {
     turnInput.push({
       type: "text",
-      text: input.prompt,
+      text: prompt,
     });
+  }
+  for (const skill of boundSkills.inputs) {
+    turnInput.push(skill);
   }
   for (const attachment of input.attachments ?? []) {
     turnInput.push(attachment);
@@ -2308,11 +2353,21 @@ export const makeCodexSessionRuntime = (
           const normalizedModel = normalizeCodexModelSlug(
             input.model ?? (yield* Ref.get(sessionRef)).model,
           );
+          const skillInvocations = input.skillInvocations ?? [];
+          let availableSkills: ReturnType<typeof parseCodexSkillsListResponse> = [];
+          if (skillInvocations.length > 0) {
+            const session = yield* Ref.get(sessionRef);
+            const cwd = session.cwd ?? options.cwd;
+            const skillsResponse = yield* client.request("skills/list", { cwds: [cwd] });
+            availableSkills = parseCodexSkillsListResponse(skillsResponse, cwd);
+          }
           const params = yield* buildTurnStartParams({
             threadId: providerThreadId,
             runtimeMode: options.runtimeMode,
             ...(input.input ? { prompt: input.input } : {}),
+            ...(skillInvocations.length > 0 ? { skillInvocations } : {}),
             ...(input.attachments ? { attachments: input.attachments } : {}),
+            ...(skillInvocations.length > 0 ? { availableSkills } : {}),
             ...(normalizedModel ? { model: normalizedModel } : {}),
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
             ...(input.effort ? { effort: input.effort } : {}),

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -168,6 +168,77 @@ const cursorAdapterTestLayer = it.layer(
 );
 
 cursorAdapterTestLayer("CursorAdapterLive", (it) => {
+  it.effect("injects selected Cursor skill documents", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-skill-invocation");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-acp-skill-")),
+      );
+      const workspace = NodePath.join(tempDir, "workspace");
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const skillPath = NodePath.join(workspace, ".cursor", "skills", "deploy", "SKILL.md");
+      const reviewSkillPath = NodePath.join(workspace, ".cursor", "skills", "review", "SKILL.md");
+      yield* Effect.promise(async () => {
+        await NodeFSP.mkdir(NodePath.dirname(skillPath), { recursive: true });
+        await NodeFSP.mkdir(NodePath.dirname(reviewSkillPath), { recursive: true });
+        await NodeFSP.writeFile(
+          skillPath,
+          ["---", "name: deploy", "description: Deploy the service.", "---", "", "# Deploy"].join(
+            "\n",
+          ),
+          "utf8",
+        );
+        await NodeFSP.writeFile(
+          reviewSkillPath,
+          ["---", "name: review", "description: Review the service.", "---", "", "# Review"].join(
+            "\n",
+          ),
+          "utf8",
+        );
+        await NodeFSP.writeFile(requestLogPath, "", "utf8");
+      });
+      const wrapperPath = yield* Effect.promise(() =>
+        makeProbeWrapper(requestLogPath, NodePath.join(tempDir, "argv.txt")),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: workspace,
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("cursor"), model: "default" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "First use $deploy, then $review to ship the release.",
+        skillInvocations: [
+          { name: "deploy", start: 10, end: 17 },
+          { name: "review", start: 24, end: 31 },
+        ],
+        attachments: [],
+      });
+
+      const requests = yield* waitForJsonLogMatch(
+        requestLogPath,
+        (entry) => entry.method === "session/prompt",
+      );
+      const promptRequest = requests.find((entry) => entry.method === "session/prompt");
+      const prompt = (promptRequest?.params as { prompt?: Array<{ text?: string }> } | undefined)
+        ?.prompt?.[0]?.text;
+      assert.include(prompt ?? "", "# Deploy");
+      assert.include(prompt ?? "", "# Review");
+      assert.include(prompt ?? "", "[T3 explicitly invoked skill: deploy]");
+      assert.include(prompt ?? "", "[T3 explicitly invoked skill: review]");
+      assert.notInclude(prompt ?? "", "$deploy");
+      assert.notInclude(prompt ?? "", "$review");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -7,6 +7,7 @@
 import {
   ApprovalRequestId,
   type CursorSettings,
+  type ServerProviderSkill,
   type ProviderOptionSelection,
   EventId,
   type ProviderApprovalDecision,
@@ -43,6 +44,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import { discoverCursorSkills } from "../Drivers/CursorSkills.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
@@ -75,6 +77,7 @@ import {
   extractTodosAsPlan,
 } from "../acp/CursorAcpExtension.ts";
 import { type CursorAdapterShape } from "../Services/CursorAdapter.ts";
+import { renderProviderSkillPrompt, loadInvokedSkills } from "../skillInvocations.ts";
 import { resolveCursorAcpBaseModelId } from "./CursorProvider.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
@@ -133,6 +136,8 @@ interface CursorSessionContext {
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
   activeTurnId: TurnId | undefined;
+  /** Skills discovered for the session cwd, refreshed lazily before a `$` turn. */
+  skills: ReadonlyArray<ServerProviderSkill>;
   /** Number of sendTurn prompts currently in flight or being prepared.
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
@@ -336,6 +341,12 @@ export function makeCursorAdapter(
     const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
 
+    const discoverSkills = (cwd?: string) =>
+      discoverCursorSkills(cwd, options?.environment).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
       Effect.mapError(
@@ -530,6 +541,7 @@ export function makeCursorAdapter(
           const effectiveCursorSettings = options?.resolveSettings
             ? yield* options.resolveSettings
             : cursorSettings;
+          const skills = yield* discoverSkills(cwd);
 
           const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
           const acp = yield* makeCursorAcpRuntime({
@@ -778,6 +790,7 @@ export function makeCursorAdapter(
             turns: [],
             lastPlanFingerprint: undefined,
             activeTurnId: undefined,
+            skills,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -916,6 +929,34 @@ export function makeCursorAdapter(
     const sendTurn: CursorAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
+        const promptText = input.input?.trim();
+        let preparedPromptText = promptText;
+        if (promptText && input.skillInvocations && input.skillInvocations.length > 0) {
+          const resolved = yield* loadInvokedSkills({
+            provider: PROVIDER,
+            providerLabel: "Cursor",
+            prompt: promptText,
+            invocations: input.skillInvocations,
+            skills: ctx.skills,
+            readFile: (skillPath) =>
+              fileSystem.readFileString(skillPath).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new ProviderAdapterRequestError({
+                      provider: PROVIDER,
+                      method: "session/prompt",
+                      detail: `Failed to read Cursor skill '${skillPath}'.`,
+                      cause,
+                    }),
+                ),
+              ),
+          });
+          preparedPromptText = renderProviderSkillPrompt(
+            promptText,
+            resolved.documents,
+            resolved.invocations,
+          );
+        }
         // A sendTurn while a prompt is in flight is a steer: the agent folds
         // the new prompt into the ongoing work, so the active turn id is
         // reused instead of opening a new turn.
@@ -967,8 +1008,11 @@ export function makeCursorAdapter(
           }
 
           const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          if (input.input?.trim()) {
-            promptParts.push({ type: "text", text: input.input.trim() });
+          if (preparedPromptText) {
+            promptParts.push({
+              type: "text",
+              text: preparedPromptText,
+            });
           }
           if (input.attachments && input.attachments.length > 0) {
             for (const attachment of input.attachments) {

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -87,7 +87,9 @@ exec ${mockAgentCommand} "$@"
   return wrapperPath;
 });
 
-const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")(function* () {
+const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")(function* (
+  version = "2026.04.09-f2b0fcd",
+) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const mockAgentPath = yield* resolveMockAgentPath();
@@ -99,7 +101,7 @@ const makeMockAgentWithAboutWrapper = Effect.fn("makeMockAgentWithAboutWrapper")
   const mockAgentCommand = ["node", mockAgentPath].map((arg) => JSON.stringify(arg)).join(" ");
   const script = `#!/bin/sh
 if [ "$1" = "about" ]; then
-  printf 'CLI Version         2026.04.09-f2b0fcd\\n'
+  printf 'CLI Version         ${version}\\n'
   printf 'User Email          cursor@example.com\\n'
   exit 0
 fi
@@ -323,6 +325,37 @@ describe("getCursorFallbackModels", () => {
 });
 
 describe("buildCursorProviderSnapshot", () => {
+  it("publishes discovered skills for the shared composer picker", () => {
+    expect(
+      buildCursorProviderSnapshot({
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        cursorSettings: baseCursorSettings,
+        parsed: {
+          version: "2026.04.09-f2b0fcd",
+          status: "ready",
+          auth: { status: "authenticated" },
+        },
+        skills: [
+          {
+            name: "deploy",
+            description: "Deploy the service.",
+            path: "/workspace/.cursor/skills/deploy/SKILL.md",
+            enabled: true,
+            scope: "project",
+          },
+        ],
+      }).skills,
+    ).toEqual([
+      {
+        name: "deploy",
+        description: "Deploy the service.",
+        path: "/workspace/.cursor/skills/deploy/SKILL.md",
+        enabled: true,
+        scope: "project",
+      },
+    ]);
+  });
+
   it("downgrades ready status to warning when ACP model discovery times out", () => {
     expect(
       buildCursorProviderSnapshot({
@@ -471,6 +504,43 @@ describe("checkCursorProviderStatus", () => {
       "claude-opus-4-6",
     ]);
     await expect(runNode(waitForFileContent(requestLogPath))).resolves.toContain("initialize");
+  });
+
+  it("keeps discovered skills when the parameterized model picker is unavailable", async () => {
+    const fixture = await runNode(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fileSystem.makeTempDirectory({
+          directory: NodeOS.tmpdir(),
+          prefix: "cursor-provider-skills-",
+        });
+        const workspace = path.join(tempDir, "workspace");
+        const skillPath = path.join(workspace, ".cursor", "skills", "deploy", "SKILL.md");
+        yield* fileSystem.makeDirectory(path.dirname(skillPath), { recursive: true });
+        yield* fileSystem.writeFileString(
+          skillPath,
+          ["---", "name: deploy", "description: Deploy the service.", "---"].join("\n"),
+        );
+        return { workspace, home: path.join(tempDir, "home") };
+      }),
+    );
+    const wrapperPath = await runNode(makeMockAgentWithAboutWrapper("2026.04.07-f2b0fcd"));
+
+    const provider = await runNode(
+      checkCursorProviderStatus(
+        {
+          enabled: true,
+          binaryPath: wrapperPath,
+          apiEndpoint: "",
+          customModels: [],
+        },
+        { HOME: fixture.home },
+        fixture.workspace,
+      ),
+    );
+
+    expect(provider.skills.map((skill) => skill.name)).toEqual(["deploy"]);
   });
 });
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -7,6 +7,7 @@ import type {
   ServerProviderAuth,
   ServerProviderModel,
   ServerProviderState,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
@@ -30,6 +31,7 @@ import {
 } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
+import { discoverCursorSkills } from "../Drivers/CursorSkills.ts";
 import {
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
@@ -627,6 +629,7 @@ export function buildCursorProviderSnapshot(input: {
   readonly cursorSettings: CursorSettings;
   readonly parsed: CursorAboutResult;
   readonly discoveredModels?: ReadonlyArray<ServerProviderModel>;
+  readonly skills?: ReadonlyArray<ServerProviderSkill>;
   readonly discoveryWarning?: string;
 }): ServerProviderDraft {
   const message = joinProviderMessages(input.parsed.message, input.discoveryWarning);
@@ -639,6 +642,7 @@ export function buildCursorProviderSnapshot(input: {
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
     ),
+    skills: input.skills ?? [],
     probe: {
       installed: true,
       version: input.parsed.version,
@@ -987,6 +991,7 @@ const runCursorAboutCommand = (cursorSettings: CursorSettings, environment?: Nod
 export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(function* (
   cursorSettings: CursorSettings,
   environment?: NodeJS.ProcessEnv,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -1056,6 +1061,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
   }
 
   const parsed = parseCursorAboutOutput(aboutProbe.success.value);
+  const skills = yield* discoverCursorSkills(cwd, environment);
   const cursorCliConfigChannel = yield* readCursorCliConfigChannel();
   const parameterizedModelPickerUnsupportedMessage =
     getCursorParameterizedModelPickerUnsupportedMessage({
@@ -1068,6 +1074,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       enabled: cursorSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version: parsed.version,
@@ -1109,6 +1116,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
       Option.filter(discoveredModels, (models) => models.length > 0),
       () => [] as const,
     ),
+    skills,
     ...(discoveryWarning ? { discoveryWarning } : {}),
   });
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -38,15 +38,22 @@ const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
 const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
 const mockAgentCommand = process.execPath;
+const encodeInspectJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
 
-async function makeMockGrokWrapper(extraEnv?: Record<string, string>) {
+async function makeMockGrokWrapper(extraEnv?: Record<string, string>, inspectJson?: string) {
   const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-mock-"));
   const wrapperPath = NodePath.join(dir, "fake-grok.sh");
   const envExports = Object.entries(extraEnv ?? {})
     .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
     .join("\n");
+  const inspectBranch = `export T3_GROK_INSPECT_JSON=${JSON.stringify(inspectJson ?? '{"skills":[]}')}
+if [ "$1" = "inspect" ] && [ "$2" = "--json" ]; then
+  printf '%s\\n' "$T3_GROK_INSPECT_JSON"
+  exit 0
+fi`;
   const script = `#!/bin/sh
 ${envExports}
+${inspectBranch}
 exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
 `;
   await NodeFSP.writeFile(wrapperPath, script, "utf8");
@@ -273,6 +280,61 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       if (delta?.type === "content.delta") {
         assert.equal(delta.payload.delta, "hello from mock");
       }
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("injects explicitly selected skills into Grok ACP prompts", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-skill-invocation");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-skill-")),
+      );
+      const workspace = NodePath.join(tempDir, "workspace");
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const skillPath = NodePath.join(workspace, ".agents", "skills", "review", "SKILL.md");
+      const inspectJson = yield* encodeInspectJson({
+        skills: [
+          {
+            name: "review",
+            description: "Review the change.",
+            source: { type: "project", path: skillPath },
+            userInvocable: true,
+          },
+        ],
+      });
+      yield* Effect.promise(async () => {
+        await NodeFSP.mkdir(NodePath.dirname(skillPath), { recursive: true });
+        await NodeFSP.writeFile(
+          skillPath,
+          "---\nname: review\ndescription: Review the change.\n---\n\n# Review checklist",
+          "utf8",
+        );
+        await NodeFSP.writeFile(requestLogPath, "", "utf8");
+      });
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_REQUEST_LOG_PATH: requestLogPath }, inspectJson),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: workspace,
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Use $review to inspect this change.",
+        skillInvocations: [{ name: "review", start: 4, end: 11 }],
+        attachments: [],
+      });
+
+      const requests = yield* waitForFileContent(requestLogPath, 40, "# Review checklist");
+      assert.include(requests, "# Review checklist");
+      assert.notInclude(requests, "$review");
 
       yield* adapter.stopSession(threadId);
     }),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -5,6 +5,7 @@ import {
   type ProviderApprovalDecision,
   type ProviderRuntimeEvent,
   type ProviderSession,
+  type ServerProviderSkill,
   type ProviderUserInputAnswers,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -59,6 +60,7 @@ import {
 } from "../acp/AcpCoreRuntimeEvents.ts";
 import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import { discoverGrokSkills } from "../Drivers/GrokSkills.ts";
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
@@ -80,6 +82,7 @@ import {
 } from "../acp/XAiAcpExtension.ts";
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { renderProviderSkillPrompt, loadInvokedSkills } from "../skillInvocations.ts";
 
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
@@ -131,6 +134,7 @@ interface GrokSessionContext {
   readonly threadId: ThreadId;
   readonly acpSessionId: string;
   session: ProviderSession;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
   readonly scope: Scope.Closeable;
   readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
   notificationFiber: Fiber.Fiber<void, never> | undefined;
@@ -370,6 +374,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
         : DEFAULT_GROK_ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS;
     const activeToolInactivityTimeoutNanos =
       BigInt(activeToolInactivityTimeoutMs) * NANOS_PER_MILLI;
+    const discoverSkills = (cwd?: string) =>
+      discoverGrokSkills(grokSettings, options?.environment ?? hostEnvironment, cwd).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+      );
 
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
@@ -955,6 +963,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           }
 
           const cwd = path.resolve(input.cwd.trim());
+          const skills = yield* discoverSkills(cwd);
           const grokModelSelection =
             input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
           const existing = sessions.get(input.threadId);
@@ -1266,6 +1275,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             threadId: input.threadId,
             acpSessionId: started.sessionId,
             session,
+            skills,
             scope: sessionScope,
             acp,
             notificationFiber: undefined,
@@ -1504,6 +1514,33 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               );
 
               const text = input.input?.trim();
+              let promptText = text;
+              if (text && input.skillInvocations && input.skillInvocations.length > 0) {
+                const resolved = yield* loadInvokedSkills({
+                  provider: PROVIDER,
+                  providerLabel: "Grok",
+                  prompt: text,
+                  invocations: input.skillInvocations,
+                  skills: ctx.skills,
+                  readFile: (skillPath) =>
+                    fileSystem.readFileString(skillPath).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ProviderAdapterRequestError({
+                            provider: PROVIDER,
+                            method: "session/prompt",
+                            detail: `Failed to read Grok skill '${skillPath}'.`,
+                            cause,
+                          }),
+                      ),
+                    ),
+                });
+                promptText = renderProviderSkillPrompt(
+                  text,
+                  resolved.documents,
+                  resolved.invocations,
+                );
+              }
               // Grok ingests images only. Generic files reach the agent
               // through the path line ProviderService puts in the prompt.
               const imagePromptParts = yield* Effect.forEach(
@@ -1540,7 +1577,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   }),
               );
               const promptParts: Array<EffectAcpSchema.ContentBlock> = [
-                ...(text ? [{ type: "text" as const, text }] : []),
+                ...(promptText ? [{ type: "text" as const, text: promptText }] : []),
                 ...imagePromptParts,
               ];
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -74,6 +74,8 @@ const runtimeMock = {
     messageCalls: [] as Array<{ sessionID: string; messageID: string }>,
     messageFailures: 0,
     promptCalls: [] as Array<unknown>,
+    skillCalls: [] as Array<{ directory?: string }>,
+    skills: [] as Array<{ name: string; location: string; content: string }>,
     promptAsyncError: null as Error | null,
     promptAsyncImplementation: null as (() => Promise<void>) | null,
     autoPromptEcho: true,
@@ -121,6 +123,8 @@ const runtimeMock = {
     this.state.messageCalls.length = 0;
     this.state.messageFailures = 0;
     this.state.promptCalls.length = 0;
+    this.state.skillCalls.length = 0;
+    this.state.skills = [];
     this.state.promptAsyncError = null;
     this.state.promptAsyncImplementation = null;
     this.state.autoPromptEcho = true;
@@ -329,6 +333,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             targetIndex >= 0
               ? runtimeMock.state.messages.slice(0, targetIndex + 1)
               : runtimeMock.state.messages;
+        },
+      },
+      app: {
+        skills: async (input?: { directory?: string }) => {
+          runtimeMock.state.skillCalls.push(input?.directory ? { directory: input.directory } : {});
+          return { data: runtimeMock.state.skills };
         },
       },
       event: {
@@ -926,6 +936,45 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         schemaVersion: 1,
         sessionId: "ses_persisted",
       });
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("injects explicitly selected skills into OpenCode prompts", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-skill");
+      runtimeMock.state.skills = [
+        {
+          name: "review",
+          location: "/workspace/.agents/skills/review/SKILL.md",
+          content: "---\nname: review\n---\n\n# Review checklist",
+        },
+      ];
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        cwd: "/workspace",
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Use $review to inspect this change.",
+        skillInvocations: [{ name: "review", start: 4, end: 11 }],
+        modelSelection: createModelSelection(ProviderInstanceId.make("opencode"), "openai/gpt-5"),
+      });
+
+      const prompt = runtimeMock.state.promptCalls.at(-1) as {
+        parts?: Array<{ type?: string; text?: string }>;
+      };
+      const promptText = prompt.parts?.find((part) => part.type === "text")?.text ?? "";
+      NodeAssert.equal(runtimeMock.state.skillCalls.length, 1);
+      NodeAssert.equal(runtimeMock.state.skillCalls[0]?.directory, "/workspace");
+      NodeAssert.equal(promptText.includes("# Review checklist"), true);
+      NodeAssert.equal(promptText.includes("[T3 explicitly invoked skill: review]"), true);
+      NodeAssert.equal(promptText.includes("$review"), false);
 
       yield* adapter.stopSession(threadId);
     }),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1,5 +1,6 @@
 import {
   EventId,
+  type ProviderSendTurnInput,
   type OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -55,6 +56,7 @@ import {
   toOpenCodeQuestionAnswers,
   type OpenCodeServerConnection,
 } from "../opencodeRuntime.ts";
+import { renderProviderSkillPrompt, loadInvokedSkills } from "../skillInvocations.ts";
 import * as Option from "effect/Option";
 
 const PROVIDER = ProviderDriverKind.make("opencode");
@@ -318,8 +320,15 @@ function isOpenCodeDefaultTitle(title: string): boolean {
   return OPENCODE_DEFAULT_TITLE_PATTERN.test(title);
 }
 
+interface OpenCodeSkillSnapshot {
+  readonly name: string;
+  readonly location: string;
+  readonly content: string;
+}
+
 interface OpenCodeSessionContext {
   session: ProviderSession;
+  readonly skills: ReadonlyArray<OpenCodeSkillSnapshot>;
   readonly client: OpencodeClient;
   readonly server: OpenCodeServerConnection;
   readonly directory: string;
@@ -820,6 +829,31 @@ export function makeOpenCodeAdapter(
       }
       return current;
     });
+    const prepareSkillPrompt = (
+      context: OpenCodeSessionContext,
+      text: string | undefined,
+      invocations: ProviderSendTurnInput["skillInvocations"],
+    ) =>
+      Effect.gen(function* () {
+        if (!text || !invocations || invocations.length === 0) {
+          return text;
+        }
+
+        const skillsByPath = new Map(context.skills.map((skill) => [skill.location, skill]));
+        const resolved = yield* loadInvokedSkills({
+          provider: PROVIDER,
+          providerLabel: "OpenCode",
+          prompt: text,
+          invocations,
+          skills: context.skills.map((skill) => ({
+            name: skill.name,
+            path: skill.location,
+            enabled: true,
+          })),
+          readFile: (skillPath) => Effect.succeed(skillsByPath.get(skillPath)?.content ?? ""),
+        });
+        return renderProviderSkillPrompt(text, resolved.documents, resolved.invocations);
+      });
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
       Effect.mapError(
         (cause) =>
@@ -2435,6 +2469,10 @@ export function makeOpenCodeAdapter(
         });
 
         const createdAt = yield* nowIso;
+        const skillResponse = yield* runOpenCodeSdk("app.skills", () =>
+          started.client.app.skills({ directory }),
+        ).pipe(Effect.mapError(toRequestError));
+        const skills = (skillResponse.data ?? []) satisfies ReadonlyArray<OpenCodeSkillSnapshot>;
         const session: ProviderSession = {
           provider: PROVIDER,
           providerInstanceId: boundInstanceId,
@@ -2456,6 +2494,7 @@ export function makeOpenCodeAdapter(
 
         const context: OpenCodeSessionContext = {
           session,
+          skills,
           client: started.client,
           server: started.server,
           directory,
@@ -2586,6 +2625,7 @@ export function makeOpenCodeAdapter(
           issue: "OpenCode turns require text input or at least one attachment.",
         });
       }
+      const promptText = yield* prepareSkillPrompt(context, text, input.skillInvocations);
 
       return yield* context.promptSemaphore.withPermit(
         Effect.gen(function* () {
@@ -2692,7 +2732,10 @@ export function makeOpenCodeAdapter(
                 model: parsedModel,
                 ...(context.activeAgent ? { agent: context.activeAgent } : {}),
                 ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-                parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+                parts: [
+                  ...(promptText ? [{ type: "text" as const, text: promptText }] : []),
+                  ...fileParts,
+                ],
               },
               { signal },
             ),

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -281,6 +281,55 @@ function flattenOpenCodeSkills(input: OpenCodeInventory): ReadonlyArray<ServerPr
   return skills.toSorted((left, right) => left.name.localeCompare(right.name));
 }
 
+/**
+ * Loads the inventory a single workspace sees. A local server is borrowed from
+ * the instance's shared owner; an externally configured one is connected to for
+ * the call. Both the status probe and workspace skill discovery go through here
+ * so they never disagree about which server answered.
+ */
+const loadOpenCodeInventoryForCwd = Effect.fn("loadOpenCodeInventoryForCwd")(function* (
+  openCodeSettings: OpenCodeSettings,
+  cwd: string,
+) {
+  const openCodeRuntime = yield* OpenCodeRuntime;
+  const serverOwner = yield* OpenCodeServerOwner.OpenCodeServerOwner;
+  const loadInventory = (server: {
+    readonly url: string;
+    readonly serverPassword?: string;
+    readonly version: string;
+  }) =>
+    openCodeRuntime
+      .loadOpenCodeInventory(
+        openCodeRuntime.createOpenCodeSdkClient({
+          baseUrl: server.url,
+          directory: cwd,
+          ...(server.serverPassword !== undefined ? { serverPassword: server.serverPassword } : {}),
+        }),
+      )
+      .pipe(Effect.map((inventory) => ({ inventory, version: server.version })));
+
+  return yield* openCodeSettings.serverUrl.trim().length === 0
+    ? serverOwner.withServer(loadInventory)
+    : openCodeRuntime
+        .connectToOpenCodeServer({
+          binaryPath: openCodeSettings.binaryPath,
+          directory: cwd,
+          serverUrl: openCodeSettings.serverUrl,
+          ...(openCodeSettings.serverPassword
+            ? { serverPassword: openCodeSettings.serverPassword }
+            : {}),
+        })
+        .pipe(Effect.flatMap(loadInventory), Effect.scoped);
+});
+
+export const discoverOpenCodeSkills = Effect.fn("discoverOpenCodeSkills")(function* (
+  openCodeSettings: OpenCodeSettings,
+  cwd: string,
+) {
+  const { inventory } = yield* loadOpenCodeInventoryForCwd(openCodeSettings, cwd);
+  return flattenOpenCodeSkills(inventory);
+});
+
 export const makePendingOpenCodeProvider = (
   openCodeSettings: OpenCodeSettings,
 ): Effect.Effect<ServerProviderDraft> =>
@@ -431,34 +480,8 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     }
   }
 
-  const loadInventory = (server: {
-    readonly url: string;
-    readonly serverPassword?: string;
-    readonly version: string;
-  }) =>
-    openCodeRuntime
-      .loadOpenCodeInventory(
-        openCodeRuntime.createOpenCodeSdkClient({
-          baseUrl: server.url,
-          directory: cwd,
-          ...(server.serverPassword !== undefined ? { serverPassword: server.serverPassword } : {}),
-        }),
-      )
-      .pipe(Effect.map((inventory) => ({ inventory, version: server.version })));
-  const inventoryEffect = isExternalServer
-    ? openCodeRuntime
-        .connectToOpenCodeServer({
-          binaryPath: openCodeSettings.binaryPath,
-          directory: cwd,
-          serverUrl: openCodeSettings.serverUrl,
-          ...(openCodeSettings.serverPassword
-            ? { serverPassword: openCodeSettings.serverPassword }
-            : {}),
-        })
-        .pipe(Effect.flatMap(loadInventory), Effect.scoped)
-    : serverOwner.withServer(loadInventory);
   const inventoryExit = yield* Effect.exit(
-    inventoryEffect.pipe(
+    loadOpenCodeInventoryForCwd(openCodeSettings, cwd).pipe(
       Effect.mapError(
         (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
       ),

--- a/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { bindCodexSkillInvocations } from "./codexSkillInvocations.ts";
+
+const grillWithDocs = {
+  name: "grill-with-docs",
+  path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+  enabled: true,
+};
+
+describe("bindCodexSkillInvocations", () => {
+  it("attaches a selected skill as structured Codex input", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "Use $grill-with-docs please",
+        [{ name: "grill-with-docs", start: 4, end: 20 }],
+        [grillWithDocs],
+      ),
+    ).toEqual({
+      ok: true,
+      inputs: [{ type: "skill", name: "grill-with-docs", path: grillWithDocs.path }],
+    });
+  });
+
+  it("allows explicitly selected Codex skills disabled for model invocation", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "$grill-with-docs go",
+        [{ name: "grill-with-docs", start: 0, end: 16 }],
+        [{ ...grillWithDocs, enabled: false }],
+      ),
+    ).toEqual({
+      ok: true,
+      inputs: [{ type: "skill", name: "grill-with-docs", path: grillWithDocs.path }],
+    });
+  });
+
+  it("does not infer invocations from ordinary dollar text", () => {
+    expect(bindCodexSkillInvocations("check $HOME/.config", [], [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
+  });
+
+  it("rejects unknown and stale invocation metadata", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "$missing-skill do this",
+        [{ name: "missing-skill", start: 0, end: 14 }],
+        [grillWithDocs],
+      ),
+    ).toEqual({ ok: false, names: ["missing-skill"] });
+    expect(
+      bindCodexSkillInvocations(
+        "$grill-with-docs go",
+        [{ name: "grill-with-docs", start: 1, end: 17 }],
+        [grillWithDocs],
+      ),
+    ).toEqual({ ok: false, names: ["grill-with-docs"] });
+  });
+
+  it("deduplicates selected skills by path", () => {
+    expect(
+      bindCodexSkillInvocations(
+        "$grill-with-docs then $grill-with-docs",
+        [
+          { name: "grill-with-docs", start: 0, end: 16 },
+          { name: "grill-with-docs", start: 22, end: 38 },
+        ],
+        [grillWithDocs],
+      ),
+    ).toEqual({
+      ok: true,
+      inputs: [{ type: "skill", name: "grill-with-docs", path: grillWithDocs.path }],
+    });
+  });
+});

--- a/apps/server/src/provider/Layers/codexSkillInvocations.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.ts
@@ -1,0 +1,40 @@
+import type { ExplicitSkillInvocation, ServerProviderSkill } from "@t3tools/contracts";
+import { resolveProviderSkillInvocations } from "../skillInvocations.ts";
+
+export type CodexSkillUserInput = {
+  readonly type: "skill";
+  readonly name: string;
+  readonly path: string;
+};
+
+export type BindCodexSkillInvocationsResult =
+  | { readonly ok: true; readonly inputs: ReadonlyArray<CodexSkillUserInput> }
+  | { readonly ok: false; readonly names: readonly string[] };
+
+export function bindCodexSkillInvocations(
+  prompt: string,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "path" | "enabled">>,
+): BindCodexSkillInvocationsResult {
+  if (invocations.length === 0) {
+    return { ok: true, inputs: [] };
+  }
+
+  // Codex reports skills disabled for model invocation as disabled. Users can
+  // still invoke those skills explicitly.
+  const resolution = resolveProviderSkillInvocations(prompt, invocations, skills, {
+    allowDisabled: true,
+  });
+  const failedNames = [...new Set([...resolution.invalidNames, ...resolution.unknownNames])];
+  if (failedNames.length > 0) {
+    return { ok: false, names: failedNames };
+  }
+  return {
+    ok: true,
+    inputs: resolution.references.map((skill) => ({
+      type: "skill",
+      name: skill.name,
+      path: skill.path,
+    })),
+  };
+}

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,8 +25,10 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
+import type * as Option from "effect/Option";
 import type * as Schema from "effect/Schema";
 import type * as Scope from "effect/Scope";
 
@@ -69,6 +71,9 @@ export interface ProviderInstance {
   readonly accentColor?: string | undefined;
   readonly enabled: boolean;
   readonly snapshot: ServerProviderShape;
+  readonly listSkillsForCwd?: (
+    cwd: string,
+  ) => Effect.Effect<Option.Option<ReadonlyArray<ServerProviderSkill>>>;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
 }

--- a/apps/server/src/provider/providerSkills.test.ts
+++ b/apps/server/src/provider/providerSkills.test.ts
@@ -1,18 +1,30 @@
 import {
   ProjectId,
+  ProviderDriverKind,
   ProviderInstanceId,
   ThreadId,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+  type ServerProvider,
   type ServerProviderSkill,
 } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
 
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import type { ProviderInstance } from "./ProviderDriver.ts";
+import * as ProviderInstanceRegistry from "./Services/ProviderInstanceRegistry.ts";
+import { makeManualOnlyProviderMaintenanceCapabilities } from "./providerMaintenance.ts";
 import { queryProviderSkills } from "./providerSkills.ts";
 
 const instanceId = ProviderInstanceId.make("claude-work");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
+const driverKind = ProviderDriverKind.make("claudeAgent");
+const now = "2026-08-28T00:00:00.000Z";
 
 const fallbackSkill: ServerProviderSkill = {
   name: "global-skill",
@@ -28,48 +40,119 @@ const workspaceSkill: ServerProviderSkill = {
   scope: "project",
 };
 
-function makeDependencies(input: {
+const project = {
+  id: projectId,
+  title: "T3 Code",
+  workspaceRoot: "/projects/t3code",
+  repositoryIdentity: null,
+  defaultModelSelection: null,
+  scripts: [],
+  createdAt: now,
+  updatedAt: now,
+} satisfies OrchestrationProjectShell;
+
+function makeThread(input: {
+  readonly projectId: ProjectId;
+  readonly worktreePath: string | null;
+}): OrchestrationThreadShell {
+  return {
+    id: threadId,
+    projectId: input.projectId,
+    title: "Test thread",
+    modelSelection: { instanceId, model: "claude-sonnet" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: input.worktreePath,
+    latestTurn: null,
+    createdAt: now,
+    updatedAt: now,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+  };
+}
+
+function makeLayer(input: {
   readonly loadSkills: (
     cwd: string,
   ) => Effect.Effect<Option.Option<ReadonlyArray<ServerProviderSkill>>>;
   readonly threadProjectId?: ProjectId;
   readonly worktreePath?: string | null;
 }) {
-  return {
-    getProvider: () =>
-      Effect.succeed({
-        fallbackSkills: [fallbackSkill],
-        listSkillsForCwd: input.loadSkills,
+  const snapshot = {
+    instanceId,
+    driver: driverKind,
+    status: "ready",
+    enabled: true,
+    installed: true,
+    auth: { status: "authenticated" },
+    checkedAt: now,
+    version: "1.0.0",
+    models: [],
+    slashCommands: [],
+    skills: [fallbackSkill],
+  } satisfies ServerProvider;
+  const instance = {
+    instanceId,
+    driverKind,
+    continuationIdentity: {
+      driverKind,
+      continuationKey: `${driverKind}:instance:${instanceId}`,
+    },
+    displayName: undefined,
+    enabled: true,
+    snapshot: {
+      maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+        provider: driverKind,
+        packageName: null,
       }),
-    getProject: () =>
-      Effect.succeed(
-        Option.some({
-          id: projectId,
-          workspaceRoot: "/projects/t3code",
-        }),
-      ),
-    getThread: () =>
-      Effect.succeed(
-        Option.some({
-          projectId: input.threadProjectId ?? projectId,
-          worktreePath:
-            input.worktreePath === undefined ? "/worktrees/feature" : input.worktreePath,
-        }),
-      ),
-  };
+      getSnapshot: Effect.succeed(snapshot),
+      refresh: Effect.succeed(snapshot),
+      streamChanges: Stream.empty,
+    },
+    listSkillsForCwd: input.loadSkills,
+    adapter: {} as ProviderInstance["adapter"],
+    textGeneration: {} as ProviderInstance["textGeneration"],
+  } satisfies ProviderInstance;
+
+  return Layer.merge(
+    Layer.mock(ProviderInstanceRegistry.ProviderInstanceRegistry)({
+      getInstance: () => Effect.succeed(instance),
+    }),
+    Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+      getProjectShellById: () => Effect.succeed(Option.some(project)),
+      getThreadShellById: () =>
+        Effect.succeed(
+          Option.some(
+            makeThread({
+              projectId: input.threadProjectId ?? projectId,
+              worktreePath:
+                input.worktreePath === undefined ? "/worktrees/feature" : input.worktreePath,
+            }),
+          ),
+        ),
+    }),
+  );
 }
 
 it.effect("discovers skills from the thread worktree", () =>
   Effect.gen(function* () {
     let discoveredCwd: string | undefined;
-    const result = yield* queryProviderSkills(
-      { instanceId, projectId, threadId },
-      makeDependencies({
-        loadSkills: (cwd) => {
-          discoveredCwd = cwd;
-          return Effect.succeed(Option.some([workspaceSkill]));
-        },
-      }),
+    const result = yield* queryProviderSkills({ instanceId, projectId, threadId }).pipe(
+      Effect.provide(
+        makeLayer({
+          loadSkills: (cwd) => {
+            discoveredCwd = cwd;
+            return Effect.succeed(Option.some([workspaceSkill]));
+          },
+        }),
+      ),
     );
 
     assert.strictEqual(discoveredCwd, "/worktrees/feature");
@@ -80,15 +163,16 @@ it.effect("discovers skills from the thread worktree", () =>
 it.effect("uses the project root when the supplied thread belongs to another project", () =>
   Effect.gen(function* () {
     let discoveredCwd: string | undefined;
-    const result = yield* queryProviderSkills(
-      { instanceId, projectId, threadId },
-      makeDependencies({
-        threadProjectId: ProjectId.make("project-2"),
-        loadSkills: (cwd) => {
-          discoveredCwd = cwd;
-          return Effect.succeed(Option.some([]));
-        },
-      }),
+    const result = yield* queryProviderSkills({ instanceId, projectId, threadId }).pipe(
+      Effect.provide(
+        makeLayer({
+          threadProjectId: ProjectId.make("project-2"),
+          loadSkills: (cwd) => {
+            discoveredCwd = cwd;
+            return Effect.succeed(Option.some([]));
+          },
+        }),
+      ),
     );
 
     assert.strictEqual(discoveredCwd, "/projects/t3code");
@@ -98,11 +182,12 @@ it.effect("uses the project root when the supplied thread belongs to another pro
 
 it.effect("preserves the provider snapshot when scoped discovery fails", () =>
   Effect.gen(function* () {
-    const result = yield* queryProviderSkills(
-      { instanceId, projectId, threadId },
-      makeDependencies({
-        loadSkills: () => Effect.succeed(Option.none()),
-      }),
+    const result = yield* queryProviderSkills({ instanceId, projectId, threadId }).pipe(
+      Effect.provide(
+        makeLayer({
+          loadSkills: () => Effect.succeed(Option.none()),
+        }),
+      ),
     );
 
     assert.deepStrictEqual(result, {

--- a/apps/server/src/provider/providerSkills.test.ts
+++ b/apps/server/src/provider/providerSkills.test.ts
@@ -1,0 +1,113 @@
+import {
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type ServerProviderSkill,
+} from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { queryProviderSkills } from "./providerSkills.ts";
+
+const instanceId = ProviderInstanceId.make("claude-work");
+const projectId = ProjectId.make("project-1");
+const threadId = ThreadId.make("thread-1");
+
+const fallbackSkill: ServerProviderSkill = {
+  name: "global-skill",
+  path: "/home/ishan/.claude/skills/global-skill/SKILL.md",
+  enabled: true,
+  scope: "user",
+};
+
+const workspaceSkill: ServerProviderSkill = {
+  name: "workspace-skill",
+  path: "/worktrees/feature/.claude/skills/workspace-skill/SKILL.md",
+  enabled: true,
+  scope: "project",
+};
+
+function makeDependencies(input: {
+  readonly loadSkills: (
+    cwd: string,
+  ) => Effect.Effect<Option.Option<ReadonlyArray<ServerProviderSkill>>>;
+  readonly threadProjectId?: ProjectId;
+  readonly worktreePath?: string | null;
+}) {
+  return {
+    getProvider: () =>
+      Effect.succeed({
+        fallbackSkills: [fallbackSkill],
+        listSkillsForCwd: input.loadSkills,
+      }),
+    getProject: () =>
+      Effect.succeed(
+        Option.some({
+          id: projectId,
+          workspaceRoot: "/projects/t3code",
+        }),
+      ),
+    getThread: () =>
+      Effect.succeed(
+        Option.some({
+          projectId: input.threadProjectId ?? projectId,
+          worktreePath:
+            input.worktreePath === undefined ? "/worktrees/feature" : input.worktreePath,
+        }),
+      ),
+  };
+}
+
+it.effect("discovers skills from the thread worktree", () =>
+  Effect.gen(function* () {
+    let discoveredCwd: string | undefined;
+    const result = yield* queryProviderSkills(
+      { instanceId, projectId, threadId },
+      makeDependencies({
+        loadSkills: (cwd) => {
+          discoveredCwd = cwd;
+          return Effect.succeed(Option.some([workspaceSkill]));
+        },
+      }),
+    );
+
+    assert.strictEqual(discoveredCwd, "/worktrees/feature");
+    assert.deepStrictEqual(result, { source: "workspace", skills: [workspaceSkill] });
+  }),
+);
+
+it.effect("uses the project root when the supplied thread belongs to another project", () =>
+  Effect.gen(function* () {
+    let discoveredCwd: string | undefined;
+    const result = yield* queryProviderSkills(
+      { instanceId, projectId, threadId },
+      makeDependencies({
+        threadProjectId: ProjectId.make("project-2"),
+        loadSkills: (cwd) => {
+          discoveredCwd = cwd;
+          return Effect.succeed(Option.some([]));
+        },
+      }),
+    );
+
+    assert.strictEqual(discoveredCwd, "/projects/t3code");
+    assert.deepStrictEqual(result, { source: "workspace", skills: [] });
+  }),
+);
+
+it.effect("preserves the provider snapshot when scoped discovery fails", () =>
+  Effect.gen(function* () {
+    const result = yield* queryProviderSkills(
+      { instanceId, projectId, threadId },
+      makeDependencies({
+        loadSkills: () => Effect.succeed(Option.none()),
+      }),
+    );
+
+    assert.deepStrictEqual(result, {
+      source: "providerSnapshot",
+      skills: [fallbackSkill],
+    });
+  }),
+);

--- a/apps/server/src/provider/providerSkills.ts
+++ b/apps/server/src/provider/providerSkills.ts
@@ -1,0 +1,79 @@
+import type {
+  ProjectId,
+  ProviderInstanceId,
+  ProviderSkillsListInput,
+  ProviderSkillsListResult,
+  ServerProviderSkill,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+interface ProviderSkillsProject {
+  readonly id: ProjectId;
+  readonly workspaceRoot: string;
+}
+
+interface ProviderSkillsThread {
+  readonly projectId: ProjectId;
+  readonly worktreePath: string | null;
+}
+
+interface ProviderSkillsSource {
+  readonly fallbackSkills: ReadonlyArray<ServerProviderSkill>;
+  readonly listSkillsForCwd?: (
+    cwd: string,
+  ) => Effect.Effect<Option.Option<ReadonlyArray<ServerProviderSkill>>>;
+}
+
+export interface ProviderSkillsQueryDependencies {
+  readonly getProvider: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ProviderSkillsSource | undefined>;
+  readonly getProject: (
+    projectId: ProjectId,
+  ) => Effect.Effect<Option.Option<ProviderSkillsProject>>;
+  readonly getThread: (threadId: ThreadId) => Effect.Effect<Option.Option<ProviderSkillsThread>>;
+}
+
+const providerSnapshotResult = (
+  skills: ReadonlyArray<ServerProviderSkill>,
+): ProviderSkillsListResult => ({
+  source: "providerSnapshot",
+  skills,
+});
+
+export const queryProviderSkills = Effect.fn("queryProviderSkills")(function* (
+  input: ProviderSkillsListInput,
+  dependencies: ProviderSkillsQueryDependencies,
+): Effect.fn.Return<ProviderSkillsListResult> {
+  const provider = yield* dependencies.getProvider(input.instanceId);
+  if (!provider) {
+    return providerSnapshotResult([]);
+  }
+  if (!provider.listSkillsForCwd) {
+    return providerSnapshotResult(provider.fallbackSkills);
+  }
+
+  const project = yield* dependencies.getProject(input.projectId);
+  if (Option.isNone(project)) {
+    return providerSnapshotResult(provider.fallbackSkills);
+  }
+
+  let cwd = project.value.workspaceRoot;
+  if (input.threadId) {
+    const thread = yield* dependencies.getThread(input.threadId);
+    if (Option.isSome(thread) && thread.value.projectId === input.projectId) {
+      cwd = thread.value.worktreePath ?? cwd;
+    }
+  }
+
+  const skills = yield* provider.listSkillsForCwd(cwd);
+  if (Option.isNone(skills)) {
+    return providerSnapshotResult(provider.fallbackSkills);
+  }
+  return {
+    source: "workspace",
+    skills: skills.value,
+  };
+});

--- a/apps/server/src/provider/providerSkills.ts
+++ b/apps/server/src/provider/providerSkills.ts
@@ -1,40 +1,13 @@
 import type {
-  ProjectId,
-  ProviderInstanceId,
   ProviderSkillsListInput,
   ProviderSkillsListResult,
   ServerProviderSkill,
-  ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
-interface ProviderSkillsProject {
-  readonly id: ProjectId;
-  readonly workspaceRoot: string;
-}
-
-interface ProviderSkillsThread {
-  readonly projectId: ProjectId;
-  readonly worktreePath: string | null;
-}
-
-interface ProviderSkillsSource {
-  readonly fallbackSkills: ReadonlyArray<ServerProviderSkill>;
-  readonly listSkillsForCwd?: (
-    cwd: string,
-  ) => Effect.Effect<Option.Option<ReadonlyArray<ServerProviderSkill>>>;
-}
-
-export interface ProviderSkillsQueryDependencies {
-  readonly getProvider: (
-    instanceId: ProviderInstanceId,
-  ) => Effect.Effect<ProviderSkillsSource | undefined>;
-  readonly getProject: (
-    projectId: ProjectId,
-  ) => Effect.Effect<Option.Option<ProviderSkillsProject>>;
-  readonly getThread: (threadId: ThreadId) => Effect.Effect<Option.Option<ProviderSkillsThread>>;
-}
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ProviderInstanceRegistry from "./Services/ProviderInstanceRegistry.ts";
 
 const providerSnapshotResult = (
   skills: ReadonlyArray<ServerProviderSkill>,
@@ -45,32 +18,43 @@ const providerSnapshotResult = (
 
 export const queryProviderSkills = Effect.fn("queryProviderSkills")(function* (
   input: ProviderSkillsListInput,
-  dependencies: ProviderSkillsQueryDependencies,
-): Effect.fn.Return<ProviderSkillsListResult> {
-  const provider = yield* dependencies.getProvider(input.instanceId);
-  if (!provider) {
+): Effect.fn.Return<
+  ProviderSkillsListResult,
+  never,
+  | ProjectionSnapshotQuery.ProjectionSnapshotQuery
+  | ProviderInstanceRegistry.ProviderInstanceRegistry
+> {
+  const providerRegistry = yield* ProviderInstanceRegistry.ProviderInstanceRegistry;
+  const snapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+  const instance = yield* providerRegistry.getInstance(input.instanceId);
+  if (!instance) {
     return providerSnapshotResult([]);
   }
-  if (!provider.listSkillsForCwd) {
-    return providerSnapshotResult(provider.fallbackSkills);
+  const fallbackSkills = (yield* instance.snapshot.getSnapshot).skills;
+  if (!instance.listSkillsForCwd) {
+    return providerSnapshotResult(fallbackSkills);
   }
 
-  const project = yield* dependencies.getProject(input.projectId);
+  const project = yield* snapshotQuery
+    .getProjectShellById(input.projectId)
+    .pipe(Effect.orElseSucceed(() => Option.none()));
   if (Option.isNone(project)) {
-    return providerSnapshotResult(provider.fallbackSkills);
+    return providerSnapshotResult(fallbackSkills);
   }
 
   let cwd = project.value.workspaceRoot;
   if (input.threadId) {
-    const thread = yield* dependencies.getThread(input.threadId);
+    const thread = yield* snapshotQuery
+      .getThreadShellById(input.threadId)
+      .pipe(Effect.orElseSucceed(() => Option.none()));
     if (Option.isSome(thread) && thread.value.projectId === input.projectId) {
       cwd = thread.value.worktreePath ?? cwd;
     }
   }
 
-  const skills = yield* provider.listSkillsForCwd(cwd);
+  const skills = yield* instance.listSkillsForCwd(cwd);
   if (Option.isNone(skills)) {
-    return providerSnapshotResult(provider.fallbackSkills);
+    return providerSnapshotResult(fallbackSkills);
   }
   return {
     source: "workspace",

--- a/apps/server/src/provider/providerSkillsCache.ts
+++ b/apps/server/src/provider/providerSkillsCache.ts
@@ -1,0 +1,14 @@
+import * as Cache from "effect/Cache";
+import * as Duration from "effect/Duration";
+import type * as Effect from "effect/Effect";
+
+const PROVIDER_SKILLS_CACHE_CAPACITY = 16;
+const PROVIDER_SKILLS_CACHE_TTL = Duration.seconds(5);
+
+export function makeProviderSkillsCache<A>(lookup: (cwd: string) => Effect.Effect<A>) {
+  return Cache.make({
+    capacity: PROVIDER_SKILLS_CACHE_CAPACITY,
+    timeToLive: PROVIDER_SKILLS_CACHE_TTL,
+    lookup,
+  });
+}

--- a/apps/server/src/provider/skillInvocations.test.ts
+++ b/apps/server/src/provider/skillInvocations.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderProviderSkillPrompt, resolveProviderSkillInvocations } from "./skillInvocations.ts";
+
+const reviewSkill = {
+  name: "review",
+  path: "/workspace/.agents/skills/review/SKILL.md",
+  enabled: true,
+};
+
+describe("resolveProviderSkillInvocations", () => {
+  it("resolves only explicit composer selections", () => {
+    const prompt = "Use $review, then inspect $HOME/.config.";
+    const invocation = { name: "review", start: 4, end: 11 };
+
+    expect(resolveProviderSkillInvocations(prompt, [invocation], [reviewSkill])).toEqual({
+      references: [reviewSkill],
+      invocations: [invocation],
+      unknownNames: [],
+      invalidNames: [],
+    });
+  });
+
+  it("reports unknown, disabled, and invalid explicit invocations", () => {
+    expect(
+      resolveProviderSkillInvocations(
+        "$missing $review",
+        [
+          { name: "missing", start: 0, end: 8 },
+          { name: "review", start: 10, end: 17 },
+        ],
+        [{ ...reviewSkill, enabled: false }],
+      ),
+    ).toEqual({
+      references: [],
+      invocations: [],
+      unknownNames: ["missing"],
+      invalidNames: ["review"],
+    });
+  });
+});
+
+describe("renderProviderSkillPrompt", () => {
+  it("replaces selected ranges and includes the skill location and document", () => {
+    const rendered = renderProviderSkillPrompt(
+      "Use $review to inspect $HOME.",
+      [
+        {
+          ...reviewSkill,
+          contents: "---\nname: review\n---\n\n# Review checklist",
+        },
+      ],
+      [{ name: "review", start: 4, end: 11 }],
+    );
+
+    expect(rendered).toContain(
+      "file: /workspace/.agents/skills/review/SKILL.md\n---\nname: review\n---\n\n# Review checklist",
+    );
+    expect(rendered).toContain("Use [T3 explicitly invoked skill: review] to inspect $HOME.");
+  });
+});

--- a/apps/server/src/provider/skillInvocations.ts
+++ b/apps/server/src/provider/skillInvocations.ts
@@ -1,0 +1,182 @@
+import type {
+  ExplicitSkillInvocation,
+  ProviderDriverKind,
+  ServerProviderSkill,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import { ProviderAdapterValidationError } from "./Errors.ts";
+
+export type ProviderSkillReference = Pick<ServerProviderSkill, "name" | "path" | "enabled">;
+
+export interface ProviderSkillDocument {
+  readonly name: string;
+  readonly path: string;
+  readonly contents: string;
+}
+
+export interface ProviderSkillInvocationResolution {
+  readonly references: ReadonlyArray<ProviderSkillReference>;
+  readonly invocations: ReadonlyArray<ExplicitSkillInvocation>;
+  readonly unknownNames: ReadonlyArray<string>;
+  readonly invalidNames: ReadonlyArray<string>;
+}
+
+export function replaceExplicitSkillInvocations(
+  prompt: string,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+  replace: (name: string) => string,
+): string {
+  let result = prompt;
+  for (const invocation of invocations.toReversed()) {
+    result = `${result.slice(0, invocation.start)}${replace(invocation.name)}${result.slice(invocation.end)}`;
+  }
+  return result;
+}
+
+export function loadProviderSkillDocuments<E>(
+  references: ReadonlyArray<ProviderSkillReference>,
+  readFile: (path: string) => Effect.Effect<string, E>,
+): Effect.Effect<ReadonlyArray<ProviderSkillDocument>, E> {
+  return Effect.forEach(references, (reference) =>
+    readFile(reference.path).pipe(
+      Effect.map(
+        (contents): ProviderSkillDocument => ({
+          name: reference.name,
+          path: reference.path,
+          contents,
+        }),
+      ),
+    ),
+  );
+}
+
+export function findProviderSkill(
+  name: string,
+  skills: ReadonlyArray<ProviderSkillReference>,
+  options?: { readonly allowDisabled?: boolean },
+): ProviderSkillReference | undefined {
+  const candidates = options?.allowDisabled ? skills : skills.filter((skill) => skill.enabled);
+  const exact = candidates.find((skill) => skill.name === name);
+  if (exact) {
+    return exact;
+  }
+
+  const lowerName = name.toLowerCase();
+  return candidates.find((skill) => skill.name.toLowerCase() === lowerName);
+}
+
+export function resolveProviderSkillInvocations(
+  prompt: string,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+  skills: ReadonlyArray<ProviderSkillReference>,
+  options?: { readonly allowDisabled?: boolean },
+): ProviderSkillInvocationResolution {
+  const references: ProviderSkillReference[] = [];
+  const validInvocations: ExplicitSkillInvocation[] = [];
+  const unknownNames: string[] = [];
+  const invalidNames: string[] = [];
+  const seenPaths = new Set<string>();
+  let previousEnd = 0;
+
+  for (const invocation of invocations) {
+    const expectedToken = `$${invocation.name}`;
+    const validRange =
+      invocation.start >= previousEnd &&
+      invocation.end > invocation.start &&
+      prompt.slice(invocation.start, invocation.end) === expectedToken;
+    if (!validRange) {
+      if (!invalidNames.includes(invocation.name)) {
+        invalidNames.push(invocation.name);
+      }
+      continue;
+    }
+    previousEnd = invocation.end;
+
+    const skill = findProviderSkill(invocation.name, skills, options);
+    if (!skill) {
+      if (!unknownNames.includes(invocation.name)) {
+        unknownNames.push(invocation.name);
+      }
+      continue;
+    }
+    validInvocations.push(invocation);
+    if (!seenPaths.has(skill.path)) {
+      seenPaths.add(skill.path);
+      references.push(skill);
+    }
+  }
+
+  return { references, invocations: validInvocations, unknownNames, invalidNames };
+}
+
+export function loadInvokedSkills<E>(input: {
+  readonly provider: ProviderDriverKind;
+  readonly providerLabel: string;
+  readonly prompt: string;
+  readonly invocations: ReadonlyArray<ExplicitSkillInvocation>;
+  readonly skills: ReadonlyArray<ProviderSkillReference>;
+  readonly readFile: (path: string) => Effect.Effect<string, E>;
+}): Effect.Effect<
+  {
+    readonly documents: ReadonlyArray<ProviderSkillDocument>;
+    readonly invocations: ReadonlyArray<ExplicitSkillInvocation>;
+  },
+  E | ProviderAdapterValidationError
+> {
+  const resolution = resolveProviderSkillInvocations(input.prompt, input.invocations, input.skills);
+  if (resolution.invalidNames.length > 0) {
+    return Effect.fail(
+      new ProviderAdapterValidationError({
+        provider: input.provider,
+        operation: "sendTurn",
+        issue: `Invalid explicit ${input.providerLabel} skill invocation metadata for: ${resolution.invalidNames.map((name) => `$${name}`).join(", ")}.`,
+      }),
+    );
+  }
+  if (resolution.unknownNames.length > 0) {
+    return Effect.fail(
+      new ProviderAdapterValidationError({
+        provider: input.provider,
+        operation: "sendTurn",
+        issue: `Unknown ${input.providerLabel} skill${resolution.unknownNames.length === 1 ? "" : "s"}: ${resolution.unknownNames.map((name) => `$${name}`).join(", ")}.`,
+      }),
+    );
+  }
+  return loadProviderSkillDocuments(resolution.references, input.readFile).pipe(
+    Effect.map((documents) => ({ documents, invocations: resolution.invocations })),
+  );
+}
+
+/**
+ * Makes a provider-neutral skill document part of the turn without leaving a
+ * `$skill` token for the provider to reinterpret as a model-invoked tool.
+ */
+export function renderProviderSkillPrompt(
+  prompt: string,
+  documents: ReadonlyArray<ProviderSkillDocument>,
+  invocations: ReadonlyArray<ExplicitSkillInvocation>,
+): string {
+  if (documents.length === 0) {
+    return prompt;
+  }
+
+  const documentsByName = new Map<string, ProviderSkillDocument>();
+  for (const document of documents) {
+    documentsByName.set(document.name, document);
+    documentsByName.set(document.name.toLowerCase(), document);
+  }
+
+  const promptWithoutTokens = replaceExplicitSkillInvocations(prompt, invocations, (name) => {
+    const document = documentsByName.get(name) ?? documentsByName.get(name.toLowerCase());
+    return document ? `[T3 explicitly invoked skill: ${document.name}]` : `$${name}`;
+  });
+  const skillContext = documents
+    .map(
+      (document) =>
+        `<t3-explicit-skill>\nname: ${document.name}\nfile: ${document.path}\n${document.contents.trim()}\n</t3-explicit-skill>`,
+    )
+    .join("\n\n");
+
+  return `The user explicitly invoked the skills below. Follow their instructions. Resolve relative file references from the parent directory of each skill file.\n\n${skillContext}\n\n${promptWithoutTokens}`;
+}

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -122,6 +122,7 @@ import { ThreadDeletionReactor } from "./orchestration/Services/ThreadDeletionRe
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as ProviderInstanceRegistry from "./provider/Services/ProviderInstanceRegistry.ts";
 import * as ProviderService from "./provider/Services/ProviderService.ts";
 import { ProviderAdapterRequestError } from "./provider/Errors.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
@@ -398,6 +399,9 @@ const buildAppUnderTest = (options?: {
     keybindings?: Partial<Keybindings.Keybindings["Service"]>;
     environmentTheme?: Partial<EnvironmentTheme.EnvironmentThemeService["Service"]>;
     providerRegistry?: Partial<ProviderRegistry.ProviderRegistry["Service"]>;
+    providerInstanceRegistry?: Partial<
+      ProviderInstanceRegistry.ProviderInstanceRegistry["Service"]
+    >;
     providerService?: Partial<ProviderService.ProviderService["Service"]>;
     serverSettings?: Partial<ServerSettings.ServerSettingsService["Service"]>;
     externalLauncher?: Partial<ExternalLauncher.ExternalLauncher["Service"]>;
@@ -661,6 +665,14 @@ const buildAppUnderTest = (options?: {
             setProviderMaintenanceActionState: () => Effect.succeed([]),
             streamChanges: Stream.empty,
             ...options?.layers?.providerRegistry,
+          }),
+          Layer.mock(ProviderInstanceRegistry.ProviderInstanceRegistry)({
+            getInstance: () => Effect.succeed(undefined),
+            listInstances: Effect.succeed([]),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.empty,
+            subscribeChanges: Effect.die("Provider instance changes are not stubbed in this test"),
+            ...options?.layers?.providerInstanceRegistry,
           }),
           Layer.mock(ProviderService.ProviderService)({
             uploadFeedback: () => Effect.die("Provider feedback is not stubbed in this test"),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -93,8 +93,10 @@ import {
   observeRpcStreamEffect as instrumentRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as ProviderInstanceRegistry from "./provider/Services/ProviderInstanceRegistry.ts";
 import * as ProviderService from "./provider/Services/ProviderService.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
+import { queryProviderSkills } from "./provider/providerSkills.ts";
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
@@ -504,6 +506,7 @@ const makeWsRpcLayer = (
       const previewManager = yield* PreviewManager.PreviewManager;
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
+      const providerInstanceRegistry = yield* ProviderInstanceRegistry.ProviderInstanceRegistry;
       const providerService = yield* ProviderService.ProviderService;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
@@ -1633,6 +1636,33 @@ const makeWsRpcLayer = (
               : providerRegistry.refresh()
             ).pipe(Effect.map((providers) => ({ providers }))),
             { "rpc.aggregate": "server" },
+          ),
+        [WS_METHODS.providerListSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.providerListSkills,
+            queryProviderSkills(input, {
+              getProvider: (instanceId) =>
+                Effect.gen(function* () {
+                  const instance = yield* providerInstanceRegistry.getInstance(instanceId);
+                  if (!instance) return undefined;
+                  const snapshot = yield* instance.snapshot.getSnapshot;
+                  return {
+                    fallbackSkills: snapshot.skills,
+                    ...(instance.listSkillsForCwd
+                      ? { listSkillsForCwd: instance.listSkillsForCwd }
+                      : {}),
+                  };
+                }),
+              getProject: (projectId) =>
+                projectionSnapshotQuery
+                  .getProjectShellById(projectId)
+                  .pipe(Effect.orElseSucceed(() => Option.none())),
+              getThread: (threadId) =>
+                projectionSnapshotQuery
+                  .getThreadShellById(threadId)
+                  .pipe(Effect.orElseSucceed(() => Option.none())),
+            }),
+            { "rpc.aggregate": "provider" },
           ),
         [WS_METHODS.providerUploadFeedback]: (input) =>
           observeRpcEffect(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1640,28 +1640,16 @@ const makeWsRpcLayer = (
         [WS_METHODS.providerListSkills]: (input) =>
           observeRpcEffect(
             WS_METHODS.providerListSkills,
-            queryProviderSkills(input, {
-              getProvider: (instanceId) =>
-                Effect.gen(function* () {
-                  const instance = yield* providerInstanceRegistry.getInstance(instanceId);
-                  if (!instance) return undefined;
-                  const snapshot = yield* instance.snapshot.getSnapshot;
-                  return {
-                    fallbackSkills: snapshot.skills,
-                    ...(instance.listSkillsForCwd
-                      ? { listSkillsForCwd: instance.listSkillsForCwd }
-                      : {}),
-                  };
-                }),
-              getProject: (projectId) =>
-                projectionSnapshotQuery
-                  .getProjectShellById(projectId)
-                  .pipe(Effect.orElseSucceed(() => Option.none())),
-              getThread: (threadId) =>
-                projectionSnapshotQuery
-                  .getThreadShellById(threadId)
-                  .pipe(Effect.orElseSucceed(() => Option.none())),
-            }),
+            queryProviderSkills(input).pipe(
+              Effect.provideService(
+                ProviderInstanceRegistry.ProviderInstanceRegistry,
+                providerInstanceRegistry,
+              ),
+              Effect.provideService(
+                ProjectionSnapshotQuery.ProjectionSnapshotQuery,
+                projectionSnapshotQuery,
+              ),
+            ),
             { "rpc.aggregate": "provider" },
           ),
         [WS_METHODS.providerUploadFeedback]: (input) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -138,6 +138,7 @@ import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import { remapExplicitSkillInvocations } from "@t3tools/shared/explicitSkillInvocations";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import {
@@ -242,7 +243,7 @@ import {
   type DraftId,
 } from "../composerDraftStore";
 import {
-  appendTerminalContextsToPrompt,
+  appendTerminalContextsToPromptWithRanges,
   formatTerminalContextLabel,
   type TerminalContextDraft,
   type TerminalContextSelection,
@@ -569,6 +570,7 @@ function formatOutgoingPrompt(params: {
   const promptEffort = resolvePromptInjectedEffort(caps, params.effort);
   return applyClaudePromptEffortPrefix(params.text, promptEffort);
 }
+
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
 
@@ -5494,6 +5496,7 @@ function ChatViewContent(props: ChatViewProps) {
       selectedProviderModels: ctxSelectedProviderModels,
       selectedPromptEffort: ctxSelectedPromptEffort,
       selectedModelSelection: ctxSelectedModelSelection,
+      skillInvocations: composerSkillInvocations,
     } = sendCtx;
     const annotationImageAlreadyAttached =
       directAnnotation?.image !== undefined &&
@@ -5527,7 +5530,7 @@ function ChatViewContent(props: ChatViewProps) {
             },
           ]
         : sendContextPreviewAnnotations;
-    const promptForSend = promptRef.current;
+    const promptForSend = sendCtx.prompt;
     const {
       trimmedPrompt: trimmed,
       sendableTerminalContexts: sendableComposerTerminalContexts,
@@ -5736,8 +5739,13 @@ function ChatViewContent(props: ChatViewProps) {
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
     const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const terminalContextPrompt = appendTerminalContextsToPromptWithRanges(
+      promptForSend,
+      composerTerminalContextsSnapshot,
+      composerSkillInvocations,
+    );
     const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      terminalContextPrompt.prompt,
       composerElementContextsSnapshot,
     );
     const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
@@ -5754,6 +5762,11 @@ function ChatViewContent(props: ChatViewProps) {
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
       text: messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
+    });
+    const outgoingSkillInvocations = remapExplicitSkillInvocations({
+      sourceText: messageTextForSend,
+      outgoingText: outgoingMessageText,
+      invocations: terminalContextPrompt.ranges,
     });
     if (composerRef.current?.validateProviderInput(outgoingMessageText) === false) {
       return;
@@ -6059,6 +6072,9 @@ function ChatViewContent(props: ChatViewProps) {
             role: "user",
             text: outgoingMessageText,
             attachments: turnAttachmentsResult.value,
+            ...(outgoingSkillInvocations.length > 0
+              ? { skillInvocations: outgoingSkillInvocations }
+              : {}),
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: title,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -260,6 +260,7 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
+import { useProviderSkills } from "../state/providerSkills";
 import {
   environmentServerConfigsAtom,
   primaryServerAvailableEditorsAtom,
@@ -2891,6 +2892,13 @@ function ChatViewContent(props: ChatViewProps) {
     const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
+  const activeProviderSkills = useProviderSkills({
+    environmentId,
+    instanceId: activeProviderInstanceId ?? defaultInstanceIdForDriver(selectedProvider),
+    projectId: activeProject?.id ?? null,
+    ...(activeThread ? { threadId: activeThread.id } : {}),
+    fallback: activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS,
+  });
   const [resumeCompactionPermanentlyDismissed, setResumeCompactionPermanentlyDismissed] =
     useLocalStorage(
       `t3code:resume-compaction-dismissed:${environmentId}:${activeProviderInstanceId ?? "claudeAgent"}`,
@@ -7148,7 +7156,7 @@ function ChatViewContent(props: ChatViewProps) {
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
                 workspaceRoot={activeWorkspaceRoot}
-                skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
+                skills={activeProviderSkills}
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 contentInsetEndAdjustment={composerOverlayHeight}
@@ -7241,6 +7249,7 @@ function ChatViewContent(props: ChatViewProps) {
                             composerRef={composerRef}
                             composerDraftTarget={composerDraftTarget}
                             environmentId={environmentId}
+                            projectId={activeProject?.id ?? null}
                             attachmentUploadsCapabilityKnown={attachmentUploadsCapabilityKnown}
                             supportsAttachmentUploads={supportsAttachmentUploads}
                             maxFileAttachmentBytes={maxFileAttachmentBytes}

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -5,7 +5,7 @@ import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
-import { type ServerProviderSkill } from "@t3tools/contracts";
+import { type ExplicitSkillInvocation, type ServerProviderSkill } from "@t3tools/contracts";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import {
   $applyNodeReplacement,
@@ -230,17 +230,19 @@ type ComposerSkillMetadata = {
   description: string | null;
 };
 
-function skillMetadataByName(
+function enabledSkillMetadataByName(
   skills: ReadonlyArray<ServerProviderSkill>,
 ): ReadonlyMap<string, ComposerSkillMetadata> {
   return new Map(
-    skills.map((skill) => [
-      skill.name,
-      {
-        label: formatProviderSkillDisplayName(skill),
-        description: resolveSkillDescription(skill),
-      },
-    ]),
+    skills
+      .filter((skill) => skill.enabled)
+      .map((skill) => [
+        skill.name,
+        {
+          label: formatProviderSkillDisplayName(skill),
+          description: resolveSkillDescription(skill),
+        },
+      ]),
   );
 }
 
@@ -865,6 +867,23 @@ function collectTerminalContextIds(node: LexicalNode): string[] {
   return [];
 }
 
+function collectExplicitSkillInvocations(
+  node: LexicalNode,
+  skillMetadata: ReadonlyMap<string, ComposerSkillMetadata>,
+): ExplicitSkillInvocation[] {
+  if (node instanceof ComposerSkillNode) {
+    if (!skillMetadata.has(node.__skillName)) return [];
+    const start = getExpandedAbsoluteOffsetForPoint(node, 0);
+    return [{ name: node.__skillName, start, end: start + node.getTextContentSize() }];
+  }
+  if ($isElementNode(node)) {
+    return node
+      .getChildren()
+      .flatMap((child) => collectExplicitSkillInvocations(child, skillMetadata));
+  }
+  return [];
+}
+
 export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
@@ -874,6 +893,7 @@ export interface ComposerPromptEditorHandle {
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   };
 }
 
@@ -1266,7 +1286,7 @@ function ComposerSurroundSelectionPlugin(props: {
 }) {
   const [editor] = useLexicalComposerContext();
   const terminalContextsRef = useRef(props.terminalContexts);
-  const skillMetadataRef = useRef(skillMetadataByName(props.skills));
+  const skillMetadataRef = useRef(enabledSkillMetadataByName(props.skills));
   const pendingSurroundSelectionRef = useRef<{
     value: string;
     expandedStart: number;
@@ -1283,7 +1303,7 @@ function ComposerSurroundSelectionPlugin(props: {
   }, [props.terminalContexts]);
 
   useEffect(() => {
-    skillMetadataRef.current = skillMetadataByName(props.skills);
+    skillMetadataRef.current = enabledSkillMetadataByName(props.skills);
   }, [props.skills]);
 
   const applySurroundInsertion = useEffectEvent((inputData: string): boolean => {
@@ -1547,12 +1567,13 @@ function ComposerPromptEditorInner({
   const terminalContextsSignatureRef = useRef(terminalContextsSignature);
   const skillsSignature = skillSignature(skills);
   const skillsSignatureRef = useRef(skillsSignature);
-  const skillMetadataRef = useRef(skillMetadataByName(skills));
+  const skillMetadataRef = useRef(enabledSkillMetadataByName(skills));
   const snapshotRef = useRef({
     value,
     cursor: initialCursor,
     expandedCursor: expandCollapsedComposerCursor(value, initialCursor),
     terminalContextIds: terminalContexts.map((context) => context.id),
+    skillInvocations: [] as ExplicitSkillInvocation[],
   });
   const isApplyingControlledUpdateRef = useRef(false);
   const terminalContextActions = useMemo(
@@ -1565,7 +1586,7 @@ function ComposerPromptEditorInner({
   }, [onChange]);
 
   useLayoutEffect(() => {
-    skillMetadataRef.current = skillMetadataByName(skills);
+    skillMetadataRef.current = enabledSkillMetadataByName(skills);
   }, [skills]);
 
   useEffect(() => {
@@ -1591,6 +1612,7 @@ function ComposerPromptEditorInner({
       cursor: normalizedCursor,
       expandedCursor: expandCollapsedComposerCursor(value, normalizedCursor),
       terminalContextIds: terminalContexts.map((context) => context.id),
+      skillInvocations: [],
     };
     terminalContextsSignatureRef.current = terminalContextsSignature;
     skillsSignatureRef.current = skillsSignature;
@@ -1631,6 +1653,7 @@ function ComposerPromptEditorInner({
         cursor: boundedCursor,
         expandedCursor: expandCollapsedComposerCursor(snapshotRef.current.value, boundedCursor),
         terminalContextIds: snapshotRef.current.terminalContextIds,
+        skillInvocations: snapshotRef.current.skillInvocations,
       };
       onChangeRef.current(
         snapshotRef.current.value,
@@ -1648,6 +1671,7 @@ function ComposerPromptEditorInner({
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   } => {
     let snapshot = snapshotRef.current;
     editor.getEditorState().read(() => {
@@ -1666,11 +1690,16 @@ function ComposerPromptEditorInner({
         $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
       );
       const terminalContextIds = collectTerminalContextIds($getRoot());
+      const skillInvocations = collectExplicitSkillInvocations(
+        $getRoot(),
+        skillMetadataRef.current,
+      );
       snapshot = {
         value: nextValue,
         cursor: nextCursor,
         expandedCursor: nextExpandedCursor,
         terminalContextIds,
+        skillInvocations,
       };
     });
     snapshotRef.current = snapshot;
@@ -1714,13 +1743,26 @@ function ComposerPromptEditorInner({
         $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
       );
       const terminalContextIds = collectTerminalContextIds($getRoot());
+      const skillInvocations = collectExplicitSkillInvocations(
+        $getRoot(),
+        skillMetadataRef.current,
+      );
       const previousSnapshot = snapshotRef.current;
       if (
         previousSnapshot.value === nextValue &&
         previousSnapshot.cursor === nextCursor &&
         previousSnapshot.expandedCursor === nextExpandedCursor &&
         previousSnapshot.terminalContextIds.length === terminalContextIds.length &&
-        previousSnapshot.terminalContextIds.every((id, index) => id === terminalContextIds[index])
+        previousSnapshot.terminalContextIds.every(
+          (id, index) => id === terminalContextIds[index],
+        ) &&
+        previousSnapshot.skillInvocations.length === skillInvocations.length &&
+        previousSnapshot.skillInvocations.every(
+          (invocation, index) =>
+            invocation.name === skillInvocations[index]?.name &&
+            invocation.start === skillInvocations[index]?.start &&
+            invocation.end === skillInvocations[index]?.end,
+        )
       ) {
         return;
       }
@@ -1732,6 +1774,7 @@ function ComposerPromptEditorInner({
         cursor: nextCursor,
         expandedCursor: nextExpandedCursor,
         terminalContextIds,
+        skillInvocations,
       };
       const cursorAdjacentToMention =
         isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "left") ||
@@ -1803,7 +1846,7 @@ export function ComposerPromptEditor({
 }: ComposerPromptEditorProps) {
   const initialValueRef = useRef(value);
   const initialTerminalContextsRef = useRef(terminalContexts);
-  const initialSkillMetadataRef = useRef(skillMetadataByName(skills));
+  const initialSkillMetadataRef = useRef(enabledSkillMetadataByName(skills));
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "t3tools-composer-editor",

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1,6 +1,7 @@
 import type {
   ApprovalRequestId,
   EnvironmentId,
+  ExplicitSkillInvocation,
   ModelSelection,
   PreviewAnnotationPayload,
   ProviderApprovalDecision,
@@ -536,6 +537,7 @@ export interface ChatComposerHandle {
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   };
   /** Reset composer cursor/trigger/highlight after external prompt mutations (e.g. onSend). */
   resetCursorState: (options?: {
@@ -561,6 +563,7 @@ export interface ChatComposerHandle {
     selectedProvider: ProviderDriverKind;
     selectedModel: string;
     selectedProviderModels: ReadonlyArray<ServerProvider["models"][number]>;
+    skillInvocations: ExplicitSkillInvocation[];
   };
   /** Validate the fully composed text immediately before a provider turn starts. */
   validateProviderInput: (providerInput: string) => boolean;
@@ -1912,6 +1915,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cursor: number;
     expandedCursor: number;
     terminalContextIds: string[];
+    skillInvocations: ExplicitSkillInvocation[];
   } => {
     const editorSnapshot = composerEditorRef.current?.readSnapshot();
     if (editorSnapshot) {
@@ -1922,6 +1926,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       cursor: composerCursor,
       expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
       terminalContextIds: composerTerminalContexts.map((context) => context.id),
+      skillInvocations: [],
     };
   }, [composerCursor, composerTerminalContexts, promptRef]);
 
@@ -3286,22 +3291,28 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           composerEditorRef.current?.focusAt(nextCollapsedCursor);
         });
       },
-      getSendContext: () => ({
-        prompt: promptRef.current,
-        images: composerImagesRef.current,
-        files: composerFilesRef.current,
-        terminalContexts: composerTerminalContextsRef.current,
-        elementContexts: composerElementContextsRef.current,
-        previewAnnotations: composerPreviewAnnotations,
-        reviewComments: composerReviewComments,
-        selectedPromptEffort,
-        selectedModelOptionsForDispatch,
-        selectedModelSelection,
-        providerAvailable: !noProviderAvailable,
-        selectedProvider,
-        selectedModel,
-        selectedProviderModels,
-      }),
+      getSendContext: () => {
+        const snapshot = isComposerApprovalState
+          ? undefined
+          : composerEditorRef.current?.readSnapshot();
+        return {
+          prompt: snapshot?.value ?? promptRef.current,
+          images: composerImagesRef.current,
+          files: composerFilesRef.current,
+          terminalContexts: composerTerminalContextsRef.current,
+          elementContexts: composerElementContextsRef.current,
+          previewAnnotations: composerPreviewAnnotations,
+          reviewComments: composerReviewComments,
+          selectedPromptEffort,
+          selectedModelOptionsForDispatch,
+          selectedModelSelection,
+          providerAvailable: !noProviderAvailable,
+          selectedProvider,
+          selectedModel,
+          selectedProviderModels,
+          skillInvocations: snapshot?.skillInvocations ?? [],
+        };
+      },
       validateProviderInput: (providerInput: string) => {
         const validationMessage = getComposerSubmissionValidationMessage({
           prompt: promptRef.current,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -16,6 +16,7 @@ import type {
 import {
   ProviderDriverKind,
   ProviderInstanceId,
+  type ProjectId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
@@ -115,6 +116,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { useProviderSkills } from "../../state/providerSkills";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -576,6 +578,7 @@ export interface ChatComposerHandle {
 export interface ChatComposerProps {
   composerDraftTarget: ScopedThreadRef | DraftId;
   environmentId: EnvironmentId;
+  projectId: ProjectId | null;
   attachmentUploadsCapabilityKnown: boolean;
   supportsAttachmentUploads: boolean;
   maxFileAttachmentBytes: number | null;
@@ -696,6 +699,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const {
     composerDraftTarget,
     environmentId,
+    projectId,
     attachmentUploadsCapabilityKnown,
     supportsAttachmentUploads,
     maxFileAttachmentBytes,
@@ -1058,6 +1062,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => selectedProviderEntry?.snapshot ?? null,
     [selectedProviderEntry],
   );
+  const selectedProviderSkills = useProviderSkills({
+    environmentId,
+    instanceId: selectedInstanceId,
+    projectId,
+    threadId: activeThreadId,
+    fallback: selectedProviderStatus?.skills ?? [],
+  });
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],
     [selectedProviderEntry],
@@ -1286,7 +1297,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           : []),
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
       const slashMenuSkills = getProviderSkillsForSlashMenu(
-        selectedProviderStatus?.skills ?? [],
+        selectedProviderSkills,
         settings.showSkillsInSlashMenu,
       );
       const providerSlashCommandItems = getProviderSlashCommandsForSlashMenu(
@@ -1320,25 +1331,24 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(selectedProviderSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
   }, [
     composerTrigger,
     planModeUiEnabled,
     selectedProvider,
+    selectedProviderSkills,
     selectedProviderStatus,
     settings.showSkillsInSlashMenu,
     workspaceEntries.entries,
@@ -3902,7 +3912,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       ? composerTerminalContexts
                       : []
                   }
-                  skills={selectedProviderStatus?.skills ?? []}
+                  skills={selectedProviderSkills}
                   {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                   onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                   onChange={onPromptChange}

--- a/apps/web/src/lib/terminalContext.test.ts
+++ b/apps/web/src/lib/terminalContext.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   appendTerminalContextsToPrompt,
+  appendTerminalContextsToPromptWithRanges,
   buildTerminalContextPreviewTitle,
   buildTerminalContextBlock,
   countInlineTerminalContextPlaceholders,
@@ -207,5 +208,21 @@ describe("terminalContext", () => {
         [makeContext()],
       ),
     ).toBe("Investigate @terminal-1:12-13 carefully");
+  });
+
+  it("remaps prompt ranges after trimming and materializing terminal labels", () => {
+    const prompt = `  ${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} then $review  `;
+    const start = prompt.indexOf("$review");
+    const result = appendTerminalContextsToPromptWithRanges(
+      prompt,
+      [makeContext()],
+      [{ name: "review", start, end: start + "$review".length }],
+    );
+    const mappedStart = result.prompt.indexOf("$review");
+
+    expect(result.ranges).toEqual([
+      { name: "review", start: mappedStart, end: mappedStart + "$review".length },
+    ]);
+    expect(result.prompt.slice(result.ranges[0]!.start, result.ranges[0]!.end)).toBe("$review");
   });
 });

--- a/apps/web/src/lib/terminalContext.ts
+++ b/apps/web/src/lib/terminalContext.ts
@@ -189,10 +189,43 @@ export function materializeInlineTerminalContextPrompt(
     lineEnd: number;
   }>,
 ): string {
+  return materializeInlineTerminalContextPromptWithRanges(prompt, contexts, []).prompt;
+}
+
+interface PromptRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+function materializeInlineTerminalContextPromptWithRanges<T extends PromptRange>(
+  prompt: string,
+  contexts: ReadonlyArray<{
+    terminalLabel: string;
+    lineStart: number;
+    lineEnd: number;
+  }>,
+  ranges: ReadonlyArray<T>,
+): { prompt: string; ranges: T[] } {
+  const validRanges = ranges.filter(
+    (range) =>
+      Number.isInteger(range.start) &&
+      Number.isInteger(range.end) &&
+      range.start >= 0 &&
+      range.end >= range.start &&
+      range.end <= prompt.length,
+  );
+  const boundaries = new Set(validRanges.flatMap((range) => [range.start, range.end]));
+  const outputOffsets = new Map<number, number>();
   let nextContextIndex = 0;
   let result = "";
 
-  for (const char of prompt) {
+  for (let index = 0; index <= prompt.length; index += 1) {
+    if (boundaries.has(index)) {
+      outputOffsets.set(index, result.length);
+    }
+    if (index === prompt.length) break;
+
+    const char = prompt[index]!;
     if (char !== INLINE_TERMINAL_CONTEXT_PLACEHOLDER) {
       result += char;
       continue;
@@ -205,19 +238,44 @@ export function materializeInlineTerminalContextPrompt(
     result += formatInlineTerminalContextLabel(context);
   }
 
-  return result;
+  return {
+    prompt: result,
+    ranges: validRanges.map((range) => ({
+      ...range,
+      start: outputOffsets.get(range.start)!,
+      end: outputOffsets.get(range.end)!,
+    })),
+  };
+}
+
+export function appendTerminalContextsToPromptWithRanges<T extends PromptRange>(
+  prompt: string,
+  contexts: ReadonlyArray<TerminalContextSelection>,
+  ranges: ReadonlyArray<T>,
+): { prompt: string; ranges: T[] } {
+  const materialized = materializeInlineTerminalContextPromptWithRanges(prompt, contexts, ranges);
+  const leadingTrim = materialized.prompt.length - materialized.prompt.trimStart().length;
+  const trimmedPrompt = materialized.prompt.trim();
+  const trimmedRanges = materialized.ranges.flatMap((range) => {
+    const start = range.start - leadingTrim;
+    const end = range.end - leadingTrim;
+    return start < 0 || end > trimmedPrompt.length ? [] : [{ ...range, start, end }];
+  });
+  const contextBlock = buildTerminalContextBlock(contexts);
+  if (contextBlock.length === 0) {
+    return { prompt: trimmedPrompt, ranges: trimmedRanges };
+  }
+  return {
+    prompt: trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock,
+    ranges: trimmedRanges,
+  };
 }
 
 export function appendTerminalContextsToPrompt(
   prompt: string,
   contexts: ReadonlyArray<TerminalContextSelection>,
 ): string {
-  const trimmedPrompt = materializeInlineTerminalContextPrompt(prompt, contexts).trim();
-  const contextBlock = buildTerminalContextBlock(contexts);
-  if (contextBlock.length === 0) {
-    return trimmedPrompt;
-  }
-  return trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock;
+  return appendTerminalContextsToPromptWithRanges(prompt, contexts, []).prompt;
 }
 
 export function extractTrailingTerminalContexts(prompt: string): ExtractedTerminalContexts {

--- a/apps/web/src/state/providerSkills.ts
+++ b/apps/web/src/state/providerSkills.ts
@@ -1,0 +1,32 @@
+import type {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ServerProviderSkill,
+  ThreadId,
+} from "@t3tools/contracts";
+
+import { serverEnvironment } from "./server";
+import { useEnvironmentQuery } from "./query";
+
+export function useProviderSkills(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly projectId: ProjectId | null;
+  readonly threadId?: ThreadId | null;
+  readonly fallback: ReadonlyArray<ServerProviderSkill>;
+}): ReadonlyArray<ServerProviderSkill> {
+  const query = useEnvironmentQuery(
+    input.environmentId && input.projectId && input.instanceId
+      ? serverEnvironment.providerSkills({
+          environmentId: input.environmentId,
+          input: {
+            instanceId: input.instanceId,
+            projectId: input.projectId,
+            ...(input.threadId ? { threadId: input.threadId } : {}),
+          },
+        })
+      : null,
+  );
+  return query.data?.skills ?? input.fallback;
+}

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -42,11 +42,22 @@ use the skills and commands from the selected environment and provider.
 
 By default, the `/` menu includes skills. To keep this menu command-only, turn off **Show skills in
 slash menu** in **Settings → General**. Skill results use the `/skill:Skill Name` label and add the
-same `$name` skill token to your message. The original skill name remains searchable. If the provider
-also reports that skill as a native slash command, T3 Code hides the duplicate native entry and keeps
-the `/skill:Skill Name` label.
+same `$name` skill chip to your message. When you send the message, T3 passes the selected skill
+explicitly to the provider. Typing ordinary dollar-prefixed text does not invoke a skill. If the
+provider also reports that skill as a native slash command, T3 Code hides the duplicate native entry
+and keeps the `/skill:Skill Name` label.
 
 On desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows and Linux from a new thread to
 start it in the background. T3 Code opens another new thread and shows an **Open** action for the
 thread that started. The new thread keeps the selected workspace mode and base branch. If **New
 worktree** is selected, each background thread creates its own worktree.
+
+## Cursor skills
+
+When a thread uses Cursor, type `$` in the composer to search the skills T3 Code found. Choose a
+skill to add it to your message. T3 Code passes the selected skill's instructions to Cursor
+explicitly, including when several skills are selected in one message.
+
+T3 Code finds skills stored in your project or user skill folders. Cursor-managed built-in,
+marketplace, and plugin skills are not shown because Cursor does not make that list available to
+T3 Code.

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -791,6 +791,11 @@ export function createServerEnvironmentAtoms<R, E>(
         key: ({ environmentId }) => environmentId,
       },
     }),
+    providerSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:provider:skills",
+      tag: WS_METHODS.providerListSkills,
+      staleTimeMs: 5_000,
+    }),
     updateProvider: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:update-provider",
       tag: WS_METHODS.serverUpdateProvider,

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -911,6 +911,18 @@ it.effect("decodes thread.turn-start-requested source proposed plan metadata whe
   }),
 );
 
+it.effect("decodes explicit skill invocation metadata when present", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadTurnStartRequestedPayload({
+      threadId: "thread-2",
+      messageId: "msg-2",
+      skillInvocations: [{ name: "review", start: 4, end: 11 }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.deepStrictEqual(parsed.skillInvocations, [{ name: "review", start: 4, end: 11 }]);
+  }),
+);
+
 it.effect("decodes thread.turn-start-requested title seed when present", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadTurnStartRequestedPayload({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -246,6 +246,22 @@ export type ChatAttachment = typeof ChatAttachment.Type;
 const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
+/** A skill chip the user explicitly selected in the composer. Offsets refer to the sent text. */
+export const ExplicitSkillInvocation = Schema.Struct({
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  start: NonNegativeInt,
+  end: NonNegativeInt,
+}).check(
+  Schema.makeFilter(
+    (input: { readonly start: number; readonly end: number }) =>
+      input.end > input.start || "Skill invocation end must be greater than start.",
+  ),
+);
+export type ExplicitSkillInvocation = typeof ExplicitSkillInvocation.Type;
+export const ExplicitSkillInvocations = Schema.Array(ExplicitSkillInvocation).check(
+  Schema.isMaxLength(256),
+);
+
 export const ProjectScriptIcon = Schema.Literals([
   "play",
   "test",
@@ -900,6 +916,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(ChatAttachment),
+    skillInvocations: Schema.optional(ExplicitSkillInvocations),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -921,6 +938,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
     role: Schema.Literal("user"),
     text: Schema.String,
     attachments: Schema.Array(Schema.Union([UploadChatAttachment, ChatAttachment])),
+    skillInvocations: Schema.optional(ExplicitSkillInvocations),
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
@@ -1317,6 +1335,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
 export const ThreadTurnStartRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
+  skillInvocations: Schema.optional(ExplicitSkillInvocations),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -121,6 +121,16 @@ describe("ProviderSessionStartInput", () => {
 });
 
 describe("ProviderSendTurnInput", () => {
+  it("accepts explicit skill invocation ranges", () => {
+    const parsed = decodeProviderSendTurnInput({
+      threadId: "thread-1",
+      input: "Use $review",
+      skillInvocations: [{ name: "review", start: 4, end: 11 }],
+    });
+
+    expect(parsed.skillInvocations).toEqual([{ name: "review", start: 4, end: 11 }]);
+  });
+
   it("accepts codex modelSelection", () => {
     const parsed = decodeProviderSendTurnInput({
       threadId: "thread-1",

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -10,6 +10,7 @@ import {
 } from "./baseSchemas.ts";
 import {
   ChatAttachment,
+  ExplicitSkillInvocations,
   ModelSelection,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
@@ -73,6 +74,7 @@ export const ProviderSendTurnInput = Schema.Struct({
   attachments: Schema.optional(
     Schema.Array(ChatAttachment).check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_ATTACHMENTS)),
   ),
+  skillInvocations: Schema.optional(ExplicitSkillInvocations),
   modelSelection: Schema.optional(ModelSelection),
   interactionMode: Schema.optional(ProviderInteractionMode),
 });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -167,6 +167,8 @@ import {
 import {
   ServerConfigStreamEvent,
   ServerConfig,
+  ProviderSkillsListInput,
+  ProviderSkillsListResult,
   ServerProviderUpdateError,
   ServerProviderUpdateInput,
   ServerLifecycleStreamEvent,
@@ -227,6 +229,7 @@ export const WS_METHODS = {
   attachmentsDelete: "attachments.delete",
 
   // Provider methods
+  providerListSkills: "provider.listSkills",
   providerUploadFeedback: "provider.uploadFeedback",
 
   // VCS methods
@@ -368,6 +371,12 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
     instanceId: Schema.optional(ProviderInstanceId),
   }),
   success: ServerProviderUpdatedPayload,
+  error: EnvironmentAuthorizationError,
+});
+
+export const WsProviderListSkillsRpc = Rpc.make(WS_METHODS.providerListSkills, {
+  payload: ProviderSkillsListInput,
+  success: ProviderSkillsListResult,
   error: EnvironmentAuthorizationError,
 });
 
@@ -1030,6 +1039,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
+  WsProviderListSkillsRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
   WsServerUpdateServerWithProgressRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -96,6 +96,19 @@ export const ServerProviderSkill = Schema.Struct({
 });
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 
+export const ProviderSkillsListInput = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  projectId: ProjectId,
+  threadId: Schema.optional(ThreadId),
+});
+export type ProviderSkillsListInput = typeof ProviderSkillsListInput.Type;
+
+export const ProviderSkillsListResult = Schema.Struct({
+  source: Schema.Literals(["workspace", "providerSnapshot"]),
+  skills: Schema.Array(ServerProviderSkill),
+});
+export type ProviderSkillsListResult = typeof ProviderSkillsListResult.Type;
+
 /**
  * Availability of a configured provider instance from the runtime's POV.
  *

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -175,6 +175,10 @@
       "types": "./src/composerInlineTokens.ts",
       "import": "./src/composerInlineTokens.ts"
     },
+    "./explicitSkillInvocations": {
+      "types": "./src/explicitSkillInvocations.ts",
+      "import": "./src/explicitSkillInvocations.ts"
+    },
     "./terminalLabels": {
       "types": "./src/terminalLabels.ts",
       "import": "./src/terminalLabels.ts"

--- a/packages/shared/src/explicitSkillInvocations.test.ts
+++ b/packages/shared/src/explicitSkillInvocations.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  remapExplicitSkillInvocations,
+  updateExplicitSkillInvocationsForTextEdit,
+} from "./explicitSkillInvocations.ts";
+
+describe("explicit skill invocation ranges", () => {
+  it("remaps ranges through trimming and an outgoing prefix", () => {
+    expect(
+      remapExplicitSkillInvocations({
+        sourceText: "  $review this  ",
+        outgoingText: "Think carefully.\n\n$review this",
+        invocations: [{ name: "review", start: 2, end: 9 }],
+      }),
+    ).toEqual([{ name: "review", start: 18, end: 25 }]);
+  });
+
+  it("drops stale ranges instead of invoking matching names elsewhere", () => {
+    expect(
+      remapExplicitSkillInvocations({
+        sourceText: "$review this",
+        outgoingText: "$review this",
+        invocations: [{ name: "review", start: 1, end: 8 }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("moves untouched ranges and drops edited tokens", () => {
+    const moved = updateExplicitSkillInvocationsForTextEdit({
+      previousText: "$review then $test",
+      nextText: "please $review then $test",
+      invocations: [
+        { name: "review", start: 0, end: 7 },
+        { name: "test", start: 13, end: 18 },
+      ],
+    });
+    expect(moved).toEqual([
+      { name: "review", start: 7, end: 14 },
+      { name: "test", start: 20, end: 25 },
+    ]);
+    expect(
+      updateExplicitSkillInvocationsForTextEdit({
+        previousText: "please $review then $test",
+        nextText: "please $review then $best",
+        invocations: moved,
+      }),
+    ).toEqual([{ name: "review", start: 7, end: 14 }]);
+  });
+});

--- a/packages/shared/src/explicitSkillInvocations.ts
+++ b/packages/shared/src/explicitSkillInvocations.ts
@@ -1,0 +1,71 @@
+export interface ExplicitSkillInvocationRange {
+  readonly name: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+export function remapExplicitSkillInvocations<T extends ExplicitSkillInvocationRange>(input: {
+  readonly sourceText: string;
+  readonly outgoingText: string;
+  readonly invocations: ReadonlyArray<T>;
+}): T[] {
+  if (input.invocations.length === 0) return [];
+
+  const trimmedSource = input.sourceText.trim();
+  const leadingTrim = input.sourceText.length - input.sourceText.trimStart().length;
+  const prefixLength = input.outgoingText.length - trimmedSource.length;
+  if (!input.outgoingText.endsWith(trimmedSource) || prefixLength < 0) return [];
+
+  return input.invocations.flatMap((invocation) => {
+    if (input.sourceText.slice(invocation.start, invocation.end) !== `$${invocation.name}`) {
+      return [];
+    }
+    const start = invocation.start - leadingTrim + prefixLength;
+    const end = invocation.end - leadingTrim + prefixLength;
+    return start < prefixLength || end > input.outgoingText.length
+      ? []
+      : [{ ...invocation, start, end }];
+  });
+}
+
+export function updateExplicitSkillInvocationsForTextEdit<
+  T extends ExplicitSkillInvocationRange,
+>(input: {
+  readonly previousText: string;
+  readonly nextText: string;
+  readonly invocations: ReadonlyArray<T>;
+}): T[] {
+  let prefixLength = 0;
+  while (
+    prefixLength < input.previousText.length &&
+    prefixLength < input.nextText.length &&
+    input.previousText[prefixLength] === input.nextText[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < input.previousText.length - prefixLength &&
+    suffixLength < input.nextText.length - prefixLength &&
+    input.previousText[input.previousText.length - 1 - suffixLength] ===
+      input.nextText[input.nextText.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1;
+  }
+
+  const previousChangeEnd = input.previousText.length - suffixLength;
+  const delta = input.nextText.length - input.previousText.length;
+  return input.invocations.flatMap((invocation) => {
+    const candidate =
+      invocation.end <= prefixLength
+        ? invocation
+        : invocation.start >= previousChangeEnd
+          ? { ...invocation, start: invocation.start + delta, end: invocation.end + delta }
+          : null;
+    return candidate &&
+      input.nextText.slice(candidate.start, candidate.end) === `$${candidate.name}`
+      ? [candidate]
+      : [];
+  });
+}


### PR DESCRIPTION
> [!WARNING]
> Depends on #8336. This branch is one commit on top of its current head. Keep this PR in draft until #8336 merges. Once #8336 lands, this PR contains only the workspace picker fix.

The skill picker currently reads each provider health snapshot, which discovers from the server process cwd. Project and worktree skills are therefore missing in desktop, remote, and multi-project sessions.

This adds a provider.listSkills request keyed by provider instance, project, and optional thread. The server resolves thread.worktreePath ?? project.workspaceRoot, then calls the provider discovery path for Codex, Claude, Cursor, Grok, and OpenCode. Web and mobile use that catalog for the picker, editor chips, and message skill links. A five-second per-instance cache avoids repeated probes, and discovery failures keep the old snapshot fallback.

Tests: focused provider and contract tests, server/web/mobile typechecks, targeted lint.

Built with gpt-5.6-sol in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope skill discovery to workspace and pass explicit skill invocations
> - Adds `provider.listSkills` RPC and `useProviderSkills` hooks for mobile and web to fetch workspace-scoped skills, falling back to provider snapshot.
> - Introduces `ExplicitSkillInvocation` contract and carries it through outbox, decider, and reactor to preserve skill token ranges in outgoing messages.
> - Provider adapters for Claude, Codex, Cursor, Grok, and OpenCode now discover skills for the session cwd and embed invoked skill documents into the prompt text, removing raw `$skill` tokens.
> - Composer components track skill token ranges during text edits and remap them for sends.
> - Behavioral Change: `ThreadComposerProps` on mobile and `ChatComposer` on web now require `skills` and `draftSkillInvocations` props; `onChangeDraftMessage` accepts a second `skillInvocations` argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2c0e76. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->