### PR TITLE
feat(web): filter sidebar threads by environment

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -13,6 +13,7 @@ import {
   deleteSelectedThreadEntries,
   filterSidebarProjectScopeItems,
   getSidebarThreadIdsToPrewarm,
+  pruneDisabledEnvironmentIds,
   resolveAdjacentThreadId,
   reduceSidebarProjectScopeMenuState,
   getFallbackThreadIdAfterDelete,
@@ -45,6 +46,7 @@ import {
   sortScopedProjectsForSidebar,
   shouldCreateNewThreadInCurrentProject,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
+  toggleDisabledEnvironmentId,
   type SidebarListItem,
   type SidebarListMarker,
   type SidebarSection,
@@ -2469,6 +2471,119 @@ describe("sortLogicalProjectsForSidebar", () => {
         (project) => project.projectKey,
       ),
     ).toEqual(["logical-newer", "logical-older"]);
+  });
+});
+
+describe("toggleDisabledEnvironmentId", () => {
+  const envA = EnvironmentId.make("env-a");
+  const envB = EnvironmentId.make("env-b");
+  const all = [envA, envB];
+
+  it("disables an environment", () => {
+    const next = toggleDisabledEnvironmentId({
+      disabledIds: new Set(),
+      environmentId: envA,
+      enabled: false,
+      allEnvironmentIds: all,
+    });
+    expect([...next]).toEqual([envA]);
+  });
+
+  it("re-enables a disabled environment", () => {
+    const next = toggleDisabledEnvironmentId({
+      disabledIds: new Set([envA]),
+      environmentId: envA,
+      enabled: true,
+      allEnvironmentIds: all,
+    });
+    expect(next.size).toBe(0);
+  });
+
+  it("refuses to disable the last enabled environment", () => {
+    const current: ReadonlySet<EnvironmentId> = new Set([envA]);
+    const next = toggleDisabledEnvironmentId({
+      disabledIds: current,
+      environmentId: envB,
+      enabled: false,
+      allEnvironmentIds: all,
+    });
+    expect(next).toBe(current);
+  });
+
+  it("returns the same instance when disabling an already-disabled environment", () => {
+    const current: ReadonlySet<EnvironmentId> = new Set([envA]);
+    const next = toggleDisabledEnvironmentId({
+      disabledIds: current,
+      environmentId: envA,
+      enabled: false,
+      allEnvironmentIds: all,
+    });
+    expect(next).toBe(current);
+  });
+
+  it("returns the same instance when enabling an already-enabled environment", () => {
+    const current: ReadonlySet<EnvironmentId> = new Set([envB]);
+    const next = toggleDisabledEnvironmentId({
+      disabledIds: current,
+      environmentId: envA,
+      enabled: true,
+      allEnvironmentIds: all,
+    });
+    expect(next).toBe(current);
+  });
+});
+
+describe("pruneDisabledEnvironmentIds", () => {
+  const envA = EnvironmentId.make("env-a");
+  const envB = EnvironmentId.make("env-b");
+  const envC = EnvironmentId.make("env-c");
+
+  it("returns the same instance when nothing is disabled", () => {
+    const current: ReadonlySet<EnvironmentId> = new Set();
+    expect(
+      pruneDisabledEnvironmentIds({
+        disabledIds: current,
+        connectedEnvironmentIds: new Set([envA]),
+      }),
+    ).toBe(current);
+  });
+
+  it("drops disabled environments that left the catalog", () => {
+    const next = pruneDisabledEnvironmentIds({
+      disabledIds: new Set([envA, envC]),
+      connectedEnvironmentIds: new Set([envA, envB]),
+    });
+    expect([...next]).toEqual([envA]);
+  });
+
+  it("returns the same instance when every disabled environment is still connected", () => {
+    const current: ReadonlySet<EnvironmentId> = new Set([envA]);
+    expect(
+      pruneDisabledEnvironmentIds({
+        disabledIds: current,
+        connectedEnvironmentIds: new Set([envA, envB]),
+      }),
+    ).toBe(current);
+  });
+
+  it("returns all-enabled for the render where the last enabled environment disconnects", () => {
+    // envB (the only enabled environment) disconnected; keeping envA disabled
+    // would hide every thread while the filter button no longer renders.
+    const current = new Set<EnvironmentId>([envA]);
+    const next = pruneDisabledEnvironmentIds({
+      disabledIds: current,
+      connectedEnvironmentIds: new Set([envA]),
+    });
+    expect(next).not.toBe(current);
+    expect(next.size).toBe(0);
+  });
+
+  it("clears the filter when the catalog is empty", () => {
+    const next = pruneDisabledEnvironmentIds({
+      disabledIds: new Set([envA]),
+      connectedEnvironmentIds: new Set(),
+    });
+    expect(next.size).toBe(0);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -5,7 +5,7 @@ import {
   isAtomCommandInterrupted,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
-import type { ContextMenuItem } from "@t3tools/contracts";
+import type { ContextMenuItem, EnvironmentId } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import type { AsyncResult } from "effect/unstable/reactivity";
 import { planPinnedReorder } from "@t3tools/client-runtime/state/thread-sort";
@@ -1234,4 +1234,50 @@ export function sortScopedProjectsForSidebar<
       left.environmentId.localeCompare(right.environmentId) ||
       left.id.localeCompare(right.id),
   );
+}
+
+// --- Sidebar environment filter --------------------------------------------
+// The filter stores the DISABLED environments so a newly connected
+// environment is visible by default and "all enabled" is the empty set. Both
+// helpers return the input set instance when nothing changed so React state
+// setters can skip the update entirely.
+
+export function toggleDisabledEnvironmentId(input: {
+  disabledIds: ReadonlySet<EnvironmentId>;
+  environmentId: EnvironmentId;
+  enabled: boolean;
+  allEnvironmentIds: ReadonlyArray<EnvironmentId>;
+}): ReadonlySet<EnvironmentId> {
+  if (input.disabledIds.has(input.environmentId) !== input.enabled) {
+    // Already in the requested state (repeated or stale checkbox event):
+    // keep the instance so the caller's state update is a no-op.
+    return input.disabledIds;
+  }
+  const next = new Set(input.disabledIds);
+  if (input.enabled) {
+    next.delete(input.environmentId);
+    return next;
+  }
+  next.add(input.environmentId);
+  // Never allow disabling the last enabled environment: an empty thread list
+  // with no visible reason reads as data loss. (The menu also disables the
+  // last enabled item; this guards races and stale events.)
+  const someEnabled = input.allEnvironmentIds.some((id) => !next.has(id));
+  return someEnabled ? next : input.disabledIds;
+}
+
+export function pruneDisabledEnvironmentIds(input: {
+  disabledIds: ReadonlySet<EnvironmentId>;
+  connectedEnvironmentIds: ReadonlySet<EnvironmentId>;
+}): ReadonlySet<EnvironmentId> {
+  const { connectedEnvironmentIds, disabledIds } = input;
+  if (disabledIds.size === 0) return disabledIds;
+  const next = new Set([...disabledIds].filter((id) => connectedEnvironmentIds.has(id)));
+  // A catalog change can strand the filter with nothing enabled (the last
+  // enabled environment disconnected) — and on single-environment catalogs
+  // the filter button no longer renders, so nothing could undo it. Reset to
+  // all-enabled instead of hiding every thread.
+  const someEnabled = [...connectedEnvironmentIds].some((id) => !next.has(id));
+  if (!someEnabled) return new Set<EnvironmentId>();
+  return next.size === disabledIds.size ? disabledIds : next;
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2350,7 +2350,7 @@ export default function Sidebar() {
     [environmentLabelById],
   );
   // Derive the safe set during render so a catalog change can never paint a
-  // filtered-empty frame before the state synchronization effect runs.
+  // filtered-empty frame before the stored selection is updated.
   const disabledEnvironmentIds = useMemo(
     () =>
       pruneDisabledEnvironmentIds({
@@ -2747,7 +2747,7 @@ export default function Sidebar() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = `${[...disabledEnvironmentIds].sort().join(",")}\0${projectScopeKey ?? "all"}`;
+  const settledResetKey = JSON.stringify([[...disabledEnvironmentIds].sort(), projectScopeKey]);
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -4660,7 +4660,11 @@ export default function Sidebar() {
                               <SidebarMenuButton
                                 size="icon"
                                 type="button"
-                                aria-label="Filter threads by environment"
+                                aria-label={
+                                  isEnvironmentFilterActive
+                                    ? "Filter threads by environment (filter active)"
+                                    : "Filter threads by environment"
+                                }
                                 className="relative shrink-0 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                               />
                             }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -31,6 +31,7 @@ import {
 import {
   resolveEnvironmentMachineKind,
   type EnvironmentMachineKind,
+  type EnvironmentId,
   type ProjectIconOverride,
   type ScopedThreadRef,
   type ThreadId,
@@ -52,6 +53,7 @@ import {
   PinOffIcon,
   PlusIcon,
   SearchIcon,
+  ServerIcon,
   SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
@@ -159,6 +161,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   planSidebarThreadDrop,
+  pruneDisabledEnvironmentIds,
   reduceSidebarProjectScopeMenuState,
   resolveAdjacentThreadId,
   resolveSidebarDropTarget,
@@ -175,6 +178,7 @@ import {
   sortPinnedThreadsForSidebar,
   sortSettledThreadsForSidebar,
   sortThreadsForSidebar,
+  toggleDisabledEnvironmentId,
   useRetainedValue,
   useSidebarRowSubscriptionLease,
   useThreadJumpHintVisibility,
@@ -229,6 +233,7 @@ import {
   ComboboxTrigger,
   useComboboxFilter,
 } from "./ui/combobox";
+import { Menu, MenuCheckboxItem, MenuPopup, MenuTrigger } from "./ui/menu";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
@@ -802,6 +807,7 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
   projectByKey: ReadonlyMap<string, EnvironmentProject>;
   projectDisplayNameByKey: ReadonlyMap<string, string>;
   scopedProjectKeys: ReadonlySet<string> | null;
+  disabledEnvironmentIds: ReadonlySet<EnvironmentId>;
   routeDraftId: string | null;
   onNavigateToDraft: (draftId: DraftId) => void;
 }) {
@@ -847,6 +853,9 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
       ) {
         continue;
       }
+      if (props.disabledEnvironmentIds.has(session.environmentId)) {
+        continue;
+      }
       if (draftKey === props.routeDraftId) {
         // Open draft: render the frozen entry snapshot, or nothing for a
         // draft that has never been left. Gated on the LIVE session above so
@@ -868,6 +877,7 @@ const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
     draftThreadsByThreadKey,
     draftsByThreadKey,
     frozenActive,
+    props.disabledEnvironmentIds,
     props.routeDraftId,
     props.scopedProjectKeys,
   ]);
@@ -2327,6 +2337,53 @@ export default function Sidebar() {
   // fresh clock whenever it recomputes.
   const [snoozeWakeTick, bumpSnoozeWakeTick] = useState(0);
 
+  // Environment filter: a checklist of environments whose threads the list
+  // shows, composing with the project scope. Stored as the DISABLED set so a
+  // newly connected environment is visible by default and "select all" is the
+  // natural empty state. Hidden entirely on single-environment setups.
+  // Session-only; project scope remains persisted.
+  const [configuredDisabledEnvironmentIds, setConfiguredDisabledEnvironmentIds] = useState<
+    ReadonlySet<EnvironmentId>
+  >(() => new Set());
+  const connectedEnvironmentIds = useMemo(
+    () => new Set(environmentLabelById.keys()),
+    [environmentLabelById],
+  );
+  // Derive the safe set during render so a catalog change can never paint a
+  // filtered-empty frame before the state synchronization effect runs.
+  const disabledEnvironmentIds = useMemo(
+    () =>
+      pruneDisabledEnvironmentIds({
+        disabledIds: configuredDisabledEnvironmentIds,
+        connectedEnvironmentIds,
+      }),
+    [configuredDisabledEnvironmentIds, connectedEnvironmentIds],
+  );
+  const isEnvironmentFilterActive = disabledEnvironmentIds.size > 0;
+  // An environment that leaves the catalog must not keep filtering from
+  // beyond the grave: prune it so its threads reappear if it reconnects.
+  // Pruning returns the same instance when nothing changed, so this
+  // render-time adjustment settles after one pass.
+  if (disabledEnvironmentIds !== configuredDisabledEnvironmentIds) {
+    setConfiguredDisabledEnvironmentIds(disabledEnvironmentIds);
+  }
+  const handleToggleEnvironment = useCallback(
+    (environmentId: EnvironmentId, checked: boolean) => {
+      setConfiguredDisabledEnvironmentIds((current) =>
+        toggleDisabledEnvironmentId({
+          disabledIds: current,
+          environmentId,
+          enabled: checked,
+          allEnvironmentIds: environments.map((environment) => environment.environmentId),
+        }),
+      );
+    },
+    [environments],
+  );
+  const handleEnableAllEnvironments = useCallback(() => {
+    setConfiguredDisabledEnvironmentIds((current) => (current.size === 0 ? current : new Set()));
+  }, []);
+
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
   // The selection lives in the persisted UI store next to the other sidebar
@@ -2334,17 +2391,33 @@ export default function Sidebar() {
   // app restarts keep it.
   const projectScopeKey = useUiStateStore((store) => store.sidebarProjectScopeKey);
   const setProjectScopeKey = useUiStateStore((store) => store.setSidebarProjectScopeKey);
+  // The project menu only offers projects with a presence in an enabled
+  // environment; the full group list keeps driving everything else.
+  const menuProjectGroups = useMemo(
+    () =>
+      disabledEnvironmentIds.size === 0
+        ? projectGroups
+        : projectGroups.filter((group) =>
+            group.memberProjectRefs.some(
+              (projectRef) => !disabledEnvironmentIds.has(projectRef.environmentId),
+            ),
+          ),
+    [disabledEnvironmentIds, projectGroups],
+  );
   // {value, label} items let Base UI drive the combobox selection contract
   // while the popup search filters the same collection.
   const projectScopeItems = useMemo(
     () => [
       { value: "all", label: "All projects" },
-      ...projectGroups.map((project) => ({
+      ...menuProjectGroups.map((project) => ({
         value: project.projectKey,
+        // The logical label already represents every grouped clone and never
+        // needs a redundant environment suffix, even when only one
+        // environment is enabled.
         label: project.displayName,
       })),
     ],
-    [projectGroups],
+    [menuProjectGroups],
   );
   // Same-named projects on two machines are only told apart by where they
   // live, so rows on another machine carry its icon once the catalog spans
@@ -2413,6 +2486,19 @@ export default function Sidebar() {
       setProjectScopeKey(null);
     }
   }, [allProjectSnapshotsReady, projectScopeKey, scopedProjectGroup, setProjectScopeKey]);
+  // Disabling every environment the scoped project lives in would pin the
+  // list empty with no visible reason; widen back to all projects.
+  useEffect(() => {
+    if (
+      isEnvironmentFilterActive &&
+      scopedProjectGroup !== null &&
+      !scopedProjectGroup.memberProjectRefs.some(
+        (projectRef) => !disabledEnvironmentIds.has(projectRef.environmentId),
+      )
+    ) {
+      setProjectScopeKey(null);
+    }
+  }, [disabledEnvironmentIds, isEnvironmentFilterActive, scopedProjectGroup, setProjectScopeKey]);
   // Count-only subscription: the parent needs "are there draft rows" for the
   // empty state, while SidebarDraftBlock owns the per-keystroke content
   // subscription. Selecting a number keeps typing in a draft composer from
@@ -2435,6 +2521,9 @@ export default function Sidebar() {
       ) {
         continue;
       }
+      if (disabledEnvironmentIds.has(session.environmentId)) {
+        continue;
+      }
       count += 1;
     }
     return count;
@@ -2443,7 +2532,7 @@ export default function Sidebar() {
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
     clearSelection();
-  }, [clearSelection, projectScopeKey]);
+  }, [clearSelection, disabledEnvironmentIds, projectScopeKey]);
 
   const openProjectSettings = useCallback(
     (projectGroup: SidebarProjectSnapshot) => {
@@ -2510,6 +2599,7 @@ export default function Sidebar() {
     const visible = threads.filter(
       (thread) =>
         thread.archivedAt === null &&
+        !disabledEnvironmentIds.has(thread.environmentId) &&
         (scopedProjectKeys === null ||
           scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
     );
@@ -2597,7 +2687,15 @@ export default function Sidebar() {
       settledThreads: sortSettledThreadsForSidebar(settled),
       snoozeNow: preciseNow,
     };
-  }, [nowMinute, optimisticDrop, scopedProjectKeys, serverConfigs, snoozeWakeTick, threads]);
+  }, [
+    disabledEnvironmentIds,
+    nowMinute,
+    optimisticDrop,
+    scopedProjectKeys,
+    serverConfigs,
+    snoozeWakeTick,
+    threads,
+  ]);
 
   const threadSearchInputRef = useRef<HTMLInputElement>(null);
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
@@ -2649,7 +2747,7 @@ export default function Sidebar() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = projectScopeKey ?? "all";
+  const settledResetKey = `${[...disabledEnvironmentIds].sort().join(",")}\0${projectScopeKey ?? "all"}`;
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -4552,6 +4650,95 @@ export default function Sidebar() {
                     </ComboboxList>
                   </ComboboxPopup>
                 </Combobox>
+                {environments.length > 1 ? (
+                  <Menu>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <MenuTrigger
+                            render={
+                              <SidebarMenuButton
+                                size="icon"
+                                type="button"
+                                aria-label="Filter threads by environment"
+                                className="relative shrink-0 focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                              />
+                            }
+                          />
+                        }
+                      >
+                        <ServerIcon />
+                        {isEnvironmentFilterActive ? (
+                          <span
+                            aria-hidden
+                            data-testid="sidebar-environment-filter-active"
+                            className="absolute right-0.5 top-0.5 size-1.5 rounded-full bg-primary"
+                          />
+                        ) : null}
+                      </TooltipTrigger>
+                      <TooltipPopup>Environments</TooltipPopup>
+                    </Tooltip>
+                    <MenuPopup align="end" className="w-64 max-w-(--available-width)">
+                      <MenuCheckboxItem
+                        checked={!isEnvironmentFilterActive}
+                        // Checked means "already all enabled" — there is
+                        // nothing for a click to do, so the item is disabled
+                        // rather than a checkbox that snaps back.
+                        disabled={!isEnvironmentFilterActive}
+                        onCheckedChange={handleEnableAllEnvironments}
+                        className="font-medium"
+                      >
+                        All environments
+                      </MenuCheckboxItem>
+                      {environments.map((environment) => {
+                        const isEnabled = !disabledEnvironmentIds.has(environment.environmentId);
+                        const isLastEnabled =
+                          isEnabled && environments.length - disabledEnvironmentIds.size === 1;
+                        const item = (
+                          <MenuCheckboxItem
+                            key={environment.environmentId}
+                            checked={isEnabled}
+                            // The last enabled environment cannot be unchecked
+                            // (an empty list with no visible reason reads as
+                            // data loss); disabling the item communicates the
+                            // at-least-one constraint instead of a checkbox
+                            // that silently snaps back.
+                            disabled={isLastEnabled}
+                            onCheckedChange={(checked) =>
+                              handleToggleEnvironment(environment.environmentId, checked)
+                            }
+                            className={cn(
+                              "[&>span:last-child]:min-w-0",
+                              isEnabled
+                                ? "text-foreground"
+                                : "text-muted-foreground data-highlighted:text-accent-foreground/70",
+                              isLastEnabled &&
+                                "data-disabled:pointer-events-auto data-disabled:bg-accent/40 data-disabled:opacity-100",
+                            )}
+                          >
+                            <span className="flex min-w-0 flex-col">
+                              <span className="truncate">{environment.label}</span>
+                              {environment.displayUrl ? (
+                                <span className="truncate text-xs text-muted-foreground">
+                                  {environment.displayUrl}
+                                </span>
+                              ) : null}
+                            </span>
+                          </MenuCheckboxItem>
+                        );
+                        if (!isLastEnabled) return item;
+                        return (
+                          <Tooltip key={environment.environmentId}>
+                            <TooltipTrigger render={item} />
+                            <TooltipPopup side="top" className="max-w-80">
+                              At least one environment must remain selected
+                            </TooltipPopup>
+                          </Tooltip>
+                        );
+                      })}
+                    </MenuPopup>
+                  </Menu>
+                ) : null}
                 <Tooltip>
                   <TooltipTrigger
                     render={
@@ -4797,6 +4984,7 @@ export default function Sidebar() {
                           projectByKey={projectByKey}
                           projectDisplayNameByKey={projectDisplayNameByKey}
                           scopedProjectKeys={scopedProjectKeys}
+                          disabledEnvironmentIds={disabledEnvironmentIds}
                           routeDraftId={routeDraftIdForRows}
                           onNavigateToDraft={navigateToDraft}
                         />,
@@ -4944,6 +5132,8 @@ export default function Sidebar() {
                 </>
               ) : scopedProjectGroup ? (
                 `No threads in ${scopedProjectGroup.displayName} yet`
+              ) : isEnvironmentFilterActive ? (
+                "No threads in the enabled environments yet"
               ) : (
                 "No threads yet"
               )}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -20,6 +20,20 @@ on Windows and Linux to start a new thread and immediately open another draft. T
 next draft keeps the workspace mode and base branch you selected. With **New
 worktree**, each background submission creates its own worktree.
 
+## Filter the thread list
+
+On web and desktop, use the project picker above the thread list to focus on one
+project. Choose **All projects** in that picker to clear the project filter.
+
+When more than one environment is listed, open **Environments** beside the
+project picker and select the environments whose threads you want to see. At
+least one environment must stay selected. Choose **All environments** to clear
+this filter.
+
+The filters work together: the list shows threads from the selected project in
+the selected environments. Clear both filters to see threads across all projects
+and environments again.
+
 ## Pin and reorder threads
 
 Pin a thread from its menu to keep it above your active work.


### PR DESCRIPTION
With multiple environments, web and desktop mix every machine’s threads in the sidebar. This adds an **Environments** checklist beside the project picker to narrow the list and an **All environments** action to restore it.

The session-only selection applies to pinned, active, settled, snoozed, and draft rows, and combines with the persisted project filter. Project choices follow the enabled environments; hiding every environment for the selected project resets its scope. At least one environment stays enabled, newly added environments appear by default, and removed catalog entries are pruned during render. The user guide explains both filters and how to clear them, addressing Theo’s documentation carryover from #9241.

Rebased onto `b1e223e2b0` without conflicts. Upstream’s persisted project scope, machine badges, and current sidebar rendering are retained. Searches of upstream history and merged/open sidebar-filter PRs found no equivalent environment filter on main.

Verification:

- `vp test run apps/web/src/components/Sidebar.logic.test.ts`: **168 passed**.
- `vp exec tsc --noEmit -p apps/web/tsconfig.json`: **passed** after `vp i` restored missing dependencies; existing Effect suggestions remain.
- `vp lint apps/web/src/components/Sidebar.tsx apps/web/src/components/Sidebar.logic.ts apps/web/src/components/Sidebar.logic.test.ts`: **passed**, existing warnings remain.
- `vp fmt --check` on the four changed files and `git diff --check`: **passed**.

Existing real-client evidence compares base `e3b644c5af` with candidate `5a9505325`, captured at 1280×800 using two disposable servers paired through the normal UI. These are older recordings: the visible environment-menu structure is unchanged, so they still demonstrate filtering and restoring the list. This refresh adds an accessible active-filter label and uses an unambiguous pagination-reset key; neither changes the recorded appearance. They do not show newer upstream sidebar styling or machine badges. A fresh attached-preview pass on the final candidate paired two disposable local servers through the normal UI: filtering reduced two bootstrap rows to one, **All environments** restored both, and the accessible button name changed to include **(filter active)** and back.

Before — threads from both environments:

![Before: threads from both environments](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8530-before.gif)

After — filter to one environment, then restore all:

![After: filter to one environment, then restore all](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8530-after.gif)

[Full before recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8530-before-clean.mp4) · [Full after recording](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/8530-after-clean.mp4)

The GIFs were downloaded, decoded, and sample frames inspected during this refresh. Electron, relay/tunnel, and catalog removal were not exercised in a live client; focused tests cover catalog pruning and the last-enabled guard. Mobile uses a separate thread list. This change adds no provider, backend, or wire-contract behavior; global search and the command palette retain their existing scope.

Independent review: direct **Claude Fable 5, high**, read-only with tools disabled, exited **0**. Its accessible-label and pagination-key findings were fixed and the final diff reviewed again. The draft-count dependency concern was ruled out by inspecting the per-render store selector. Remaining evidence gap: the attached preview exposed the disabled menu row in the DOM but omitted the menu in captured pixels; disabled-row tooltip hover/video proof remains unverified. Existing before/after interaction media is retained; this gap prevents claiming complete tooltip verification.

Coordination trace: T3 thread f8f62d4f-e284-46ce-a13c-b973c02e21ee

Refresh and verification: GPT-6 Astra in Codex (T3 Code). Independent review: Claude Fable 5 high in Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Environments** sidebar filter for hiding threads, drafts, and project entries from selected environments.
  - Prevents all environments from being disabled at once and automatically updates filtering when environments disconnect.
  - Restores broader project scope when the selected project is unavailable in enabled environments.
  - Shows a dedicated empty state when filters hide all entries.

- **Documentation**
  - Documented combining project and environment filters in the thread sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->