### PR TITLE
fix(web): name providers in multi-provider update toasts

### DIFF
--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -292,6 +292,27 @@ describe("provider update launch notification logic", () => {
     });
   });
 
+  it("names providers in the one-click toast when multiple updates are available", () => {
+    const view = getProviderUpdateInitialToastView({
+      updateProviders: [
+        updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" }),
+        updateCandidate({ driver: driver("opencode"), latestVersion: "1.2.0" }),
+      ],
+      oneClickProviders: [
+        updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" }),
+        updateCandidate({ driver: driver("opencode"), latestVersion: "1.2.0" }),
+      ],
+    });
+
+    expect(view).toMatchObject({
+      phase: "initial",
+      type: "warning",
+      title: "Updates Available: 2 providers",
+      description:
+        "Updates available for Codex and OpenCode. Install now or review provider settings.",
+    });
+  });
+
   it("describes settings-only updates without one-click support", () => {
     const view = getProviderUpdateInitialToastView({
       updateProviders: [

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -228,7 +228,7 @@ export function getProviderUpdateInitialToastView(input: {
     description:
       input.oneClickProviders.length > 0
         ? hasMultipleUpdates
-          ? `Updates available for ${formatProviderList(input.oneClickProviders)}. Install now or review provider settings.`
+          ? `Updates available for ${formatProviderList(input.updateProviders)}. Install now or review provider settings.`
           : "Install the update now or review provider settings."
         : `${formatProviderList(input.updateProviders)} can be updated from provider settings.`,
   };

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -220,13 +220,16 @@ export function getProviderUpdateInitialToastView(input: {
   readonly updateProviders: ReadonlyArray<ProviderUpdateCandidate>;
   readonly oneClickProviders: ReadonlyArray<ProviderUpdateCandidate>;
 }): ProviderUpdateToastView {
+  const hasMultipleUpdates = input.updateProviders.length > 1;
   return {
     phase: "initial",
     type: "warning",
     title: getProviderUpdateInitialToastTitle(input.updateProviders),
     description:
       input.oneClickProviders.length > 0
-        ? "Install the update now or review provider settings."
+        ? hasMultipleUpdates
+          ? `Updates available for ${formatProviderList(input.updateProviders)}. Install now or review provider settings.`
+          : "Install the update now or review provider settings."
         : `${formatProviderList(input.updateProviders)} can be updated from provider settings.`,
   };
 }

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -228,7 +228,7 @@ export function getProviderUpdateInitialToastView(input: {
     description:
       input.oneClickProviders.length > 0
         ? hasMultipleUpdates
-          ? `Updates available for ${formatProviderList(input.updateProviders)}. Install now or review provider settings.`
+          ? `Updates available for ${formatProviderList(input.oneClickProviders)}. Install now or review provider settings.`
           : "Install the update now or review provider settings."
         : `${formatProviderList(input.updateProviders)} can be updated from provider settings.`,
   };


### PR DESCRIPTION
> Supersedes #8463 (closed automatically by bot cleanup as an unselected copy change). Re-submitting with clearer context on the UX safety rationale and UI consistency gap.

## What Changed

- Updated one-click provider update toasts to list outdated provider names when multiple updates are available (`Updates available for Codex and OpenCode. Install now or review provider settings.`).
- Preserved the existing concise single-provider description (`Install the update now or review provider settings.`) when the title already names the provider (`Update Available: Claude v2.1.248`).

## Why

1. **User Confidence & Flow Safety**: When users have active threads running (e.g. an active `OpenCode` session), seeing a generic `"Updates Available: 2 providers"` toast forces them to open Settings to verify whether their running provider will be interrupted by the update. Explicitly naming the target providers in the toast gives users immediate confidence to click "Update" without interrupting work.
2. **UI Consistency**: Manual-only update toasts *already* list the providers (`"Codex and OpenCode can be updated from provider settings."`). This change brings the common one-click toast into parity with the existing manual-only pattern.

## UI Summary

| Case | Title | Description |
| :--- | :--- | :--- |
| **Single Update** | `Update Available: Claude v2.1.248` | `Install the update now or review provider settings.` |
| **Multiple Updates** | `Updates Available: 2 providers` | `Updates available for Codex and OpenCode. Install now or review provider settings.` |

## Screenshots

### Before (Multiple Updates)
![Before](https://github.com/user-attachments/assets/f12a81b8-538f-4967-9983-3dfa676ecdef)

### After (Multiple Updates)
![After](https://github.com/user-attachments/assets/5df96454-6d61-4fb9-b340-accaf780de6e)

## Checklist

- [x] This PR is small and focused (+5, -1 lines in logic)
- [x] I explained what changed and why
- [x] Includes unit test covering multi-provider toast resolution

---
*Built with Antigravity.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in pure toast view logic with a new unit test; no auth, data, or update execution paths touched.
> 
> **Overview**
> **Multi-provider one-click update toasts** now spell out which providers are outdated instead of only showing a generic install line.
> 
> When more than one update is available and one-click install is supported, `getProviderUpdateInitialToastView` sets the description to something like *Updates available for Codex and OpenCode. Install now or review provider settings.*, using the same `formatProviderList` helper as settings-only toasts. **Single-update** toasts are unchanged—the title still carries the provider/version and the description stays *Install the update now or review provider settings.*
> 
> A unit test asserts the multi-provider title (*Updates Available: 2 providers*) and named description for Codex and OpenCode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b247ee5b2309d109b13a9d27222491d4d2e2f1c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-provider update toast to name providers in description
> When multiple provider updates are available and one-click updates are supported, the initial toast description now lists provider names (e.g., 'Updates available for Codex and OpenCode. Install now or review provider settings.'). Single-update and no-one-click cases keep the previous generic description.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b247ee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->