### PR TITLE
fix(server): include symlink directories in project browse

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -658,6 +658,34 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
+    it.effect("includes directory symlinks and excludes file and dangling ones", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-symlink-" });
+        const target = yield* makeTempDir({ prefix: "t3code-workspace-browse-symlink-target-" });
+        yield* writeTextFile(cwd, "src/index.ts", "export {};\n");
+        yield* writeTextFile(cwd, "notes.txt", "ignore me");
+        yield* fileSystem.symlink(target, path.join(cwd, "Projects"));
+        yield* fileSystem.symlink(path.join(cwd, "notes.txt"), path.join(cwd, "notes-link"));
+        yield* fileSystem.symlink(path.join(cwd, "missing"), path.join(cwd, "broken"));
+
+        const listed = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+        });
+        const prefixed = yield* workspaceEntries.browse({
+          partialPath: path.join(cwd, "Pro"),
+        });
+
+        expect(listed.entries.map((entry) => entry.name)).toEqual(["Projects", "src"]);
+        expect(prefixed).toEqual({
+          parentPath: cwd,
+          entries: [{ name: "Projects", fullPath: path.join(cwd, "Projects") }],
+        });
+      }),
+    );
+
     it.effect("shows dot directories in directory mode and hidden-prefix mode", () =>
       Effect.gen(function* () {
         const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
 import * as NodeFSP from "node:fs/promises";
 import * as NodeOS from "node:os";
 
@@ -138,6 +139,17 @@ const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(fu
   return path.resolve(expandHomePath(input.cwd, path), input.partialPath);
 });
 
+const isBrowsableDirectory = (dirent: NodeFS.Dirent, parentPath: string, path: Path.Path) => {
+  if (dirent.isDirectory()) return Effect.succeed(true);
+  if (!dirent.isSymbolicLink()) return Effect.succeed(false);
+  return Effect.promise(() =>
+    NodeFSP.stat(path.join(parentPath, dirent.name)).then(
+      (stats) => stats.isDirectory(),
+      () => false,
+    ),
+  );
+};
+
 export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
@@ -219,15 +231,18 @@ export const make = Effect.gen(function* () {
       const entries: Array<{ readonly name: string; readonly fullPath: string }> = [];
       for (const dirent of dirents) {
         if (
-          dirent.isDirectory() &&
-          dirent.name.toLowerCase().startsWith(lowerPrefix) &&
-          (showHidden || !dirent.name.startsWith("."))
+          !dirent.name.toLowerCase().startsWith(lowerPrefix) ||
+          (!showHidden && dirent.name.startsWith("."))
         ) {
-          entries.push({
-            name: dirent.name,
-            fullPath: path.join(parentPath, dirent.name),
-          });
+          continue;
         }
+        if (!(yield* isBrowsableDirectory(dirent, parentPath, path))) {
+          continue;
+        }
+        entries.push({
+          name: dirent.name,
+          fullPath: path.join(parentPath, dirent.name),
+        });
       }
 
       return {


### PR DESCRIPTION
## What Changed

`WorkspaceEntries.browse` now treats a symlink to a directory as a folder. Add Project and path autocomplete both use this listing, so a `~/Projects` link to another drive shows up.

File symlinks and dangling links stay omitted. That matches the old file-exclusion rule.

## Why

`readdir(..., { withFileTypes: true })` fills each `Dirent` from lstat. For a symlink, `isDirectory()` is false even when the target is a folder, so the browser dropped those names with no error.

The report in #8408 is a home directory whose `Projects` entry is a symlink to `/work/projects`. The picker showed neither, so the only way in was typing the resolved path.

Following the link with `stat` is the smallest change that restores directory semantics. Treating every symlink as a folder would also list files, which this RPC is not for.

Closes #8408

## Blast Radius

Server-side `filesystem.browse` only. Web, desktop, and mobile all consume that RPC for Add Project and path autocomplete.

The extra `stat` runs only for name-matched symlink dirents, not for every entry in the directory.

A broken or file symlink still does not appear.

## Verification

Failing-then-passing regression in `apps/server/src/workspace/WorkspaceEntries.test.ts`.

- Before the fix, `vp test run apps/server/src/workspace/WorkspaceEntries.test.ts` failed with `expected [ 'src' ] to deeply equal [ 'Projects', 'src' ]`.
- After the fix, that file is 31/31 passing.
- `vp lint` on the two changed files: 0 errors.
- `vp run --filter t3 typecheck`: no errors in the changed file.

No UI chrome changed, so no screenshots.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI change (screenshots not applicable)
- [x] No motion change (video not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to server browse listing with extra stat only on name-matched symlinks; behavior for normal directories and non-symlink entries is unchanged.
> 
> **Overview**
> **`WorkspaceEntries.browse`** (backing **`filesystem.browse`**) now lists **directory symlinks** in Add Project and path autocomplete, fixing cases like a `~/Projects` link to another drive that never appeared because `readdir` + `withFileTypes` only sees the link, not the target folder.
> 
> A new **`isBrowsableDirectory`** check keeps real directories as before and, for symlinks only, follows with **`stat`** to include folder targets. **File symlinks** and **broken links** still stay out of results; prefix and hidden-dot filtering are unchanged.
> 
> A regression test covers directory vs file vs dangling symlinks and prefix matching on a symlink name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542f312a832e3ea598503eb2b05fbfa169272756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include directory symlinks in `WorkspaceEntries.browse` results
> Adds an `isBrowsableDirectory` helper that returns true for real directories and for symlinks whose `stat` target is a directory. Dangling symlinks and file symlinks resolve to false via `stat` failure. The browse handler in [WorkspaceEntries.ts](https://github.com/pingdotgg/t3code/pull/8539/files#diff-26feb5e4175dd3c4b97bf023c259c336abef121574cd5665d06d3e4dbf1b15b8) now uses this helper instead of a plain `isDirectory` check, so directory symlinks appear in listings while still respecting prefix and hidden-name filtering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 542f312.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
