### PR TITLE
fix(server): preserve usage cache outside walked roots

### DIFF
--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -193,6 +193,20 @@ describe("pruneScanCache with an unwalked root", () => {
     expect(removed).toBe(0);
     expect(cache.size).toBe(1);
   });
+
+  it("keeps entries under a sibling path that only shares the walked root prefix", () => {
+    const cache = cacheWith([["/claude/projects-copy/a.jsonl", 5000, [record()]]]);
+
+    const removed = pruneScanCache(cache, {
+      livePaths: new Set(),
+      walkedRoots: ["/claude/projects"],
+      windowStartMs: 4000,
+      retentionCutoffMs: 1000,
+    });
+
+    expect(removed).toBe(0);
+    expect(cache.size).toBe(1);
+  });
 });
 
 describe("dedupeWithinFile", () => {

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -14,6 +14,9 @@
  *
  * @module usageScanCache
  */
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
 import type { UsageProviderKind } from "@t3tools/contracts";
 
 import type { UsageRecord } from "./usageTranscripts.ts";
@@ -229,7 +232,15 @@ export function pruneScanCache(cache: ScanCache, options: PruneOptions): number 
   let removed = 0;
   for (const [path, entry] of cache) {
     const agedOut = entry.mtimeMs < options.retentionCutoffMs;
-    const underWalkedRoot = options.walkedRoots.some((root) => path.startsWith(root));
+    const underWalkedRoot = options.walkedRoots.some((root) => {
+      const relative = NodePath.relative(root, path);
+      return (
+        relative === "" ||
+        (relative !== ".." &&
+          !relative.startsWith(`..${NodePath.sep}`) &&
+          !NodePath.isAbsolute(relative))
+      );
+    });
     const deleted =
       underWalkedRoot && entry.mtimeMs >= options.windowStartMs && !options.livePaths.has(path);
     if (agedOut || deleted) {


### PR DESCRIPTION
## Problem

`pruneScanCache` used a raw string prefix to decide whether a cached transcript belonged to a walked root. Scanning `/claude/projects` could therefore evict an entry such as `/claude/projects-copy/a.jsonl`, even though that file was never part of the scan. The next usage read then had to parse that transcript again.

## Fix

Use `node:path.relative` to distinguish the root and its real descendants from paths that only share the same prefix. Add a regression test that keeps an in-window cache entry under the prefix-matching sibling directory.

## Verification

- `./node_modules/.bin/vp test run apps/server/src/usage/usageScanCache.test.ts`
- `./node_modules/.bin/vp run --filter t3 typecheck`
- `./node_modules/.bin/vp lint --report-unused-disable-directives apps/server/src/usage/usageScanCache.ts apps/server/src/usage/usageScanCache.test.ts`
- `./node_modules/.bin/vp fmt --check apps/server/src/usage/usageScanCache.ts apps/server/src/usage/usageScanCache.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized pruning logic fix with a regression test; behavior change only affects edge-case path matching, not auth or data writes.
> 
> **Overview**
> **`pruneScanCache`** no longer treats cached file paths as “under a walked root” when they only share a string prefix. It uses **`node:path.relative`** so paths must be the root itself or a true descendant (e.g. `/claude/projects/...`), not siblings like `/claude/projects-copy/...`.
> 
> That fixes incorrect eviction of in-window cache entries that were never part of the scan but were previously classified as under `/claude/projects`. A regression test asserts those prefix-sibling paths are kept when their root was not walked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a6b13b62cdb4968acb5e8b397a81a21597e02d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `pruneScanCache` to use path-aware root matching
> The previous logic used a plain string-prefix check, so a cached path like `/claude/projects-copy/...` was wrongly treated as under the walked root `/claude/projects` and deleted. The fix uses `NodePath.relative` to compute the true relative path and only considers a path "under" a root if the result is empty or does not escape via `..`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a6b13b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Implemented with gpt-daybreak-blue-latest via the Codex harness in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage cache cleanup to distinguish genuine subdirectories from similarly named sibling paths.
  * Prevented valid cache entries from being incorrectly removed during pruning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->