### PR TITLE
fix(web): copy terminal selection with Ctrl+Insert

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -556,6 +556,20 @@ describe("isTerminalCopyShortcut", () => {
     expect(isTerminalCopyShortcut(event({ key: "C", metaKey: true }), "MacIntel")).toBe(true);
     expect(isTerminalCopyShortcut(event({ key: "j", metaKey: true }), "MacIntel")).toBe(false);
   });
+
+  it("supports the conventional Ctrl+Insert copy shortcut", () => {
+    expect(isTerminalCopyShortcut(event({ key: "Insert", ctrlKey: true }), "Linux x86_64")).toBe(
+      true,
+    );
+    expect(isTerminalCopyShortcut(event({ key: "Insert" }), "Linux x86_64")).toBe(false);
+    expect(
+      isTerminalCopyShortcut(
+        event({ key: "Insert", ctrlKey: true, shiftKey: true }),
+        "Linux x86_64",
+      ),
+    ).toBe(false);
+    expect(isTerminalCopyShortcut(event({ key: "Insert", ctrlKey: true }), "MacIntel")).toBe(false);
+  });
 });
 
 describe("applyTerminalCopyEvent", () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -321,7 +321,11 @@ export function isTerminalCopyShortcut(
   event: Pick<KeyboardEvent, "ctrlKey" | "key" | "metaKey" | "shiftKey">,
   platform = navigator.platform,
 ) {
-  if (event.key.toLowerCase() !== "c") return false;
+  const key = event.key.toLowerCase();
+  if (key === "insert" && !isMacPlatform(platform)) {
+    return event.ctrlKey && !event.shiftKey && !event.metaKey;
+  }
+  if (key !== "c") return false;
   return isMacPlatform(platform) ? event.metaKey : event.ctrlKey;
 }
 
@@ -1027,12 +1031,12 @@ export class GhosttyTerminalSurface {
       // A plain Ctrl+C/Cmd+C fires the browser's native copy event, caught in
       // onCopyEvent; not preventing the default keeps that path alive. WebKit
       // omits the keyboard copy event without a DOM selection, so race the
-      // clipboard write against it the same way paste races its read. The
-      // Shift variant has no native event (Chrome binds Ctrl+Shift+C to
+      // clipboard write against it the same way paste races its read. Ctrl+Shift+C
+      // and Ctrl+Insert have no native copy event (Chrome binds the former to
       // inspect), so synthesize one with execCommand("copy").
       const selection = this.getSelection();
       this.primeCopy(selection);
-      if (event.shiftKey) {
+      if (event.shiftKey || event.key.toLowerCase() === "insert") {
         event.preventDefault();
         document.execCommand("copy");
       } else {


### PR DESCRIPTION
## What Changed

`isTerminalCopyShortcut` now treats `Ctrl+Insert` as copy on non-mac platforms, matching the existing `Shift+Insert` paste branch. The keydown handler copies with `execCommand("copy")` the same way it does for `Ctrl+Shift+C`, so the chord does not go to the PTY and is not treated as SIGINT.

## Why

Tiling WMs such as Omarchy map universal copy on a terminal window to `Ctrl+Insert`. Paste already worked because #5982 added `Shift+Insert`. Copy still required `key === "c"`, so the selection never reached the clipboard.

`Ctrl+Insert` is also the usual GTK/VTE copy chord.

Closes #8525

## Blast Radius

Web and desktop share `GhosttyTerminalSurface`. Mobile does not use this helper.

`Ctrl+C` and `Ctrl+Shift+C` are unchanged. macOS still ignores Insert for this shortcut.

## Verification

Failing-then-passing regression in `apps/web/src/terminal/ghostty/surface.test.ts`.

- Before the fix, `vp test run apps/web/src/terminal/ghostty/surface.test.ts` failed with `expected false to be true` on `Ctrl+Insert`.
- After the fix, that file is 44/44 passing.
- `vp lint` on the two changed files: 0 errors.
- `vp run --filter @t3tools/web typecheck`: clean.

No UI chrome changed, so no screenshots.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI change (screenshots not applicable)
- [x] No motion change (video not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped keyboard shortcut and clipboard copy path in the Ghostty terminal surface; existing Ctrl+C and macOS behavior stay unchanged.
> 
> **Overview**
> **Non-mac** Ghostty terminal copy now treats **Ctrl+Insert** like other copy chords when text is selected, alongside existing **Ctrl+C** / **Cmd+C** behavior.
> 
> `isTerminalCopyShortcut` adds an **Insert** branch (Ctrl, no Shift/Meta) on non-mac platforms, mirroring how **Shift+Insert** is handled for paste. The surface keydown path runs **`execCommand("copy")`** for Insert as well as **Ctrl+Shift+C**, because the browser does not fire a native copy event for those chords—so the selection is primed and copied without sending the key to the PTY or triggering SIGINT semantics tied to plain **Ctrl+C**.
> 
> Regression tests cover Linux acceptance and macOS rejection of **Ctrl+Insert**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b54bb6c899677d47075ce376b60ecb71356d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Ctrl+Insert` copy shortcut to terminal on non-mac platforms
> - Extends `isTerminalCopyShortcut` in [surface.ts](https://github.com/pingdotgg/t3code/pull/8541/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) to return true for the `Insert` key on non-mac platforms when `Ctrl` is pressed and neither `Shift` nor `Meta` are held.
> - Updates the `keydown` handler so `Ctrl+Insert` triggers the synthesized copy path (`document.execCommand('copy')`) and calls `preventDefault`, matching the existing `Ctrl+Shift+C` behavior.
> - Risk: macOS ignores `Ctrl+Insert`, and `Shift+Insert` / `Meta+Insert` are not treated as copy on any platform.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f0b9ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the conventional Ctrl+Insert shortcut to copy terminal content on non-macOS platforms.
  * The shortcut works alongside existing copy shortcuts, providing an alternative way to copy selected terminal text.

* **Bug Fixes**
  * Ensured Ctrl+Insert triggers clipboard copying correctly while preserving platform-specific shortcut behavior, including the expected behavior on macOS and for related Insert key combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->