### PR TITLE
fix(web): open provider settings on the Models tab

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -426,7 +426,7 @@ export function ProviderInstanceCard({
   onRunUpdate,
   isUpdating = false,
 }: ProviderInstanceCardProps) {
-  const [activeTab, setActiveTab] = useState<"models" | "configuration">("configuration");
+  const [activeTab, setActiveTab] = useState<"models" | "configuration">("models");
   const enabled = resolveProviderInstanceEnabled(instance);
   // A locally disabled provider stays neutral even if its last server status
   // is stale. Enabled providers use the server status when one is available.


### PR DESCRIPTION
Fixes #8521.

Since #8380 every provider opened its editor on the Configuration tab, so set-once plumbing (display name, accent color, env vars, binary path) was the first thing on the Providers page instead of the Models list users actually change.

`ProviderInstanceCard` now initialises `activeTab` to `"models"`. The existing `visibleTab` guard still forces Configuration for unknown drivers that have no Models tab, so nothing changes for custom fork instances.

## Screenshots

| Before (Configuration by default) | After (Models by default) |
| --- | --- |
| ![Providers page opening on the Configuration form](https://gist.githubusercontent.com/Gigioxx/b17cc6464a0e99cfb6b515152385848f/raw/providers-before-configuration-default.png) | ![Providers page opening on the Models list](https://gist.githubusercontent.com/Gigioxx/b17cc6464a0e99cfb6b515152385848f/raw/providers-after-models-default.png) |

## Checks

- `vp test run apps/web/src/components/settings/ProviderInstanceCard.test.ts apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx`
- `vp run typecheck` in `apps/web`
- Targeted lint
- Verified in Chrome at 1536 x 860: default selection and switching providers both land on Models; Configuration stays one click away
- Codex review of the diff: no findings

Made with Claude Fable 5 in the Claude Code harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default UI state change with no API, auth, or data-handling impact; unknown-driver fallback behavior is preserved.
> 
> **Overview**
> **Provider instance editor** now opens on the **Models** tab instead of **Configuration**, so the Providers page surfaces model visibility/favorites first rather than one-time plumbing (display name, env vars, binary path).
> 
> Only the initial `activeTab` state in `ProviderInstanceCard` changes from `"configuration"` to `"models"`. The existing `visibleTab` rule still pins **Configuration** when `driverOption` is missing (unknown/custom fork drivers with no Models tab), so that path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eab817ff4c943b1e3d3a0e23c6488af29fcddf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set default tab to `models` in `ProviderInstanceCard`
> Changes the initial `activeTab` state in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/8543/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) from `configuration` to `models`. The Models tab is now shown first when opening provider settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4eab817.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->