### PR TITLE
fix(codex): scope custom model catalogs to the provider

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -271,6 +271,35 @@ validationLayer("CodexAdapterLive validation", (it) => {
       NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
     }),
   );
+  it.effect("rejects an undeclared provider-namespaced model before starting Codex", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId: asThreadId("thread-namespaced-model"),
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("codex"),
+            "z-ai/glm-5.3-flash",
+          ),
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.deepStrictEqual(
+        result.failure,
+        new ProviderAdapterValidationError({
+          provider: ProviderDriverKind.make("codex"),
+          operation: "startSession",
+          issue:
+            "Provider-namespaced model 'z-ai/glm-5.3-flash' is not configured on instance 'codex'.",
+        }),
+      );
+      NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
+    }),
+  );
   it.effect("maps codex model options before starting a session", () =>
     Effect.gen(function* () {
       validationRuntimeFactory.factory.mockClear();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -11,6 +11,7 @@ import {
   type CanonicalItemType,
   type CanonicalRequestType,
   type CodexSettings,
+  type ModelSelection,
   ProviderDriverKind,
   type ProviderEvent,
   ProviderInstanceId,
@@ -54,6 +55,7 @@ import {
 import { type CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import { isProviderNamespacedModelSlug } from "../providerSnapshot.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
@@ -1662,6 +1664,24 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
+  const customModelSlugs = new Set(codexConfig.customModels.map((model) => model.trim()));
+  const validateModelSelection = (
+    operation: "startSession" | "sendTurn",
+    selection: ModelSelection | undefined,
+  ): ProviderAdapterValidationError | undefined => {
+    if (
+      selection?.instanceId !== boundInstanceId ||
+      !isProviderNamespacedModelSlug(selection.model) ||
+      customModelSlugs.has(selection.model)
+    ) {
+      return undefined;
+    }
+    return new ProviderAdapterValidationError({
+      provider: PROVIDER,
+      operation,
+      issue: `Provider-namespaced model '${selection.model}' is not configured on instance '${boundInstanceId}'.`,
+    });
+  };
 
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
@@ -1672,6 +1692,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             operation: "startSession",
             issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
           });
+        }
+
+        const modelSelectionError = validateModelSelection("startSession", input.modelSelection);
+        if (modelSelectionError) {
+          return yield* modelSelectionError;
         }
 
         const existing = sessions.get(input.threadId);
@@ -1822,6 +1847,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   });
 
   const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
+    const modelSelectionError = validateModelSelection("sendTurn", input.modelSelection);
+    if (modelSelectionError) {
+      return yield* modelSelectionError;
+    }
+
     // Codex ingests images only. Anything else would be base64-encoded as an
     // image and rejected or misread; generic files reach the agent through the
     // path line ProviderService puts in the prompt.

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,11 @@
 import { assert, it } from "@effect/vitest";
+import type { ServerProviderModel } from "@t3tools/contracts";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  scopeCodexModelsToInstance,
+} from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -143,4 +148,46 @@ it("ignores custom models that shadow a preferred slug", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("requires provider-namespaced catalog models to be declared on the instance", () => {
+  const openAiModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    capabilities: null,
+  };
+  const openRouterModel: ServerProviderModel = {
+    slug: "z-ai/glm-5.3-flash",
+    name: "GLM-5.3-Flash",
+    isCustom: false,
+    capabilities: { optionDescriptors: [] },
+  };
+  const catalog = [openAiModel, openRouterModel];
+
+  assert.deepStrictEqual(
+    scopeCodexModelsToInstance(catalog, []).map((model) => model.slug),
+    ["gpt-5.6-sol"],
+  );
+  assert.deepStrictEqual(scopeCodexModelsToInstance(catalog, ["z-ai/glm-5.3-flash"]), [
+    openAiModel,
+    {
+      ...openRouterModel,
+      isCustom: true,
+    },
+  ]);
+});
+
+it("preserves first-party catalog metadata when a custom slug shadows it", () => {
+  const firstPartyModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    isLegacy: true,
+    capabilities: null,
+  };
+
+  assert.deepStrictEqual(scopeCodexModelsToInstance([firstPartyModel], [firstPartyModel.slug]), [
+    firstPartyModel,
+  ]);
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -30,6 +30,7 @@ import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts
 import {
   AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
+  isProviderNamespacedModelSlug,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
@@ -224,31 +225,48 @@ export function applyPreferredCodexDefaultModel(
   });
 }
 
-function appendCustomCodexModels(
+/**
+ * Codex stores one model catalog cache per home, even when that home is used
+ * with multiple model providers. A provider-namespaced slug from that cache is
+ * therefore not evidence that the current instance can run it. Require an
+ * explicit custom-model declaration on this instance before exposing it.
+ */
+export function scopeCodexModelsToInstance(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
 ): ReadonlyArray<ServerProviderModel> {
-  if (customModels.length === 0) {
-    return models;
+  const customSlugs = new Set(customModels.map((model) => model.trim()).filter(Boolean));
+  const scopedModels: ServerProviderModel[] = [];
+  const seen = new Set<string>();
+
+  for (const model of models) {
+    if (isProviderNamespacedModelSlug(model.slug)) {
+      if (customSlugs.has(model.slug)) {
+        const { isLegacy: _isLegacy, ...rest } = model;
+        scopedModels.push({ ...rest, isCustom: true });
+        seen.add(model.slug);
+      }
+      continue;
+    }
+
+    scopedModels.push(model);
+    seen.add(model.slug);
   }
 
-  const seen = new Set(models.map((model) => model.slug));
   const fallbackCapabilities = models.find((model) => model.capabilities)?.capabilities ?? null;
-  const customEntries: ServerProviderModel[] = [];
-  for (const rawModel of customModels) {
-    const slug = rawModel.trim();
-    if (!slug || seen.has(slug)) {
+  for (const slug of customSlugs) {
+    if (seen.has(slug)) {
       continue;
     }
     seen.add(slug);
-    customEntries.push({
+    scopedModels.push({
       slug,
       name: slug,
       isCustom: true,
       capabilities: fallbackCapabilities,
     });
   }
-  return customEntries.length === 0 ? models : [...models, ...customEntries];
+  return scopedModels;
 }
 
 function parseCodexSkillsListResponse(
@@ -389,7 +407,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     return {
       account: accountResponse,
       version,
-      models: appendCustomCodexModels([], input.customModels ?? []),
+      models: scopeCodexModelsToInstance([], input.customModels ?? []),
       skills: [],
     } satisfies CodexAppServerProviderSnapshot;
   }
@@ -408,7 +426,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     account: accountResponse,
     version,
     models: applyPreferredCodexDefaultModel(
-      appendCustomCodexModels(models, input.customModels ?? []),
+      scopeCodexModelsToInstance(models, input.customModels ?? []),
     ),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
   } satisfies CodexAppServerProviderSnapshot;

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -603,6 +603,43 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ]);
       });
 
+      it("drops a removed provider-namespaced Codex custom model", () => {
+        const firstPartyModel = {
+          slug: "gpt-5.6-sol",
+          name: "GPT-5.6-Sol",
+          isCustom: false,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const removedCustomModel = {
+          slug: "z-ai/glm-5.3-flash",
+          name: "GLM-5.3-Flash",
+          isCustom: true,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-08-28T00:00:00.000Z",
+          version: "1.0.0",
+          models: [firstPartyModel, removedCustomModel],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-08-28T00:01:00.000Z",
+          models: [],
+        } satisfies ServerProvider;
+
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
+          firstPartyModel,
+        ]);
+      });
+
       it("drops stale OpenCode models missing from a successful refresh", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("opencode"),

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -53,6 +53,7 @@ import {
 } from "../providerStatusCache.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import { isProviderNamespacedModelSlug } from "../providerSnapshot.ts";
 import type { ProviderSnapshotSource } from "../builtInProviderCatalog.ts";
 
 const loadProviders = (
@@ -101,9 +102,14 @@ const mergeProviderModels = (
   nextModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const shouldRetainMissingModels = shouldRetainMissingProviderModels(provider);
+  const retainablePreviousModels = previousModels.filter(
+    (model) =>
+      provider.driver !== ProviderDriverKind.make("codex") ||
+      !isProviderNamespacedModelSlug(model.slug),
+  );
 
   if (shouldRetainMissingModels && nextModels.length === 0 && previousModels.length > 0) {
-    return previousModels;
+    return retainablePreviousModels;
   }
 
   const previousBySlug = new Map(previousModels.map((model) => [model.slug, model] as const));
@@ -119,7 +125,7 @@ const mergeProviderModels = (
   });
   const nextSlugs = new Set(nextModels.map((model) => model.slug));
   return shouldRetainMissingModels
-    ? [...mergedModels, ...previousModels.filter((model) => !nextSlugs.has(model.slug))]
+    ? [...mergedModels, ...retainablePreviousModels.filter((model) => !nextSlugs.has(model.slug))]
     : mergedModels;
 };
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -67,6 +67,10 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+export function isProviderNamespacedModelSlug(slug: string): boolean {
+  return slug.includes("/");
+}
+
 export function isCommandMissingCause(error: unknown): boolean {
   if (isProviderCommandNotFoundError(error)) return true;
   return error instanceof PlatformError.PlatformError && error.reason._tag === "NotFound";

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -205,6 +205,33 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
     );
   });
 
+  it("does not hydrate undeclared provider-namespaced Codex models", () => {
+    const namespacedModel = {
+      slug: "z-ai/glm-5.3-flash",
+      name: "GLM-5.3-Flash",
+      isCustom: false,
+      capabilities: emptyCapabilities,
+    } as const;
+    const cachedCodex = makeProvider(CODEX_DRIVER, { models: [namespacedModel] });
+    const fallbackCodex = makeProvider(CODEX_DRIVER);
+
+    assert.deepStrictEqual(
+      hydrateCachedProvider({ cachedProvider: cachedCodex, fallbackProvider: fallbackCodex })
+        .models,
+      [],
+    );
+
+    const declaredModel = { ...namespacedModel, isCustom: true } as const;
+    const declaredFallback = makeProvider(CODEX_DRIVER, { models: [declaredModel] });
+    assert.deepStrictEqual(
+      hydrateCachedProvider({
+        cachedProvider: cachedCodex,
+        fallbackProvider: declaredFallback,
+      }).models,
+      [declaredModel],
+    );
+  });
+
   it("rejects cached snapshots that are not correlated to the fallback instance", () => {
     const fallbackCodex = makeProvider(CODEX_DRIVER, {
       models: [

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -11,17 +11,26 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import { writeFileStringAtomically } from "../atomicWrite.ts";
+import { isProviderNamespacedModelSlug } from "./providerSnapshot.ts";
 
 const decodeProviderStatusCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(ServerProviderSchema),
 );
 
 const mergeProviderModels = (
+  driver: ProviderDriverKind,
   fallbackModels: ReadonlyArray<ServerProvider["models"][number]>,
   cachedModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const fallbackSlugs = new Set(fallbackModels.map((model) => model.slug));
-  return [...fallbackModels, ...cachedModels.filter((model) => !fallbackSlugs.has(model.slug))];
+  return [
+    ...fallbackModels,
+    ...cachedModels.filter(
+      (model) =>
+        !fallbackSlugs.has(model.slug) &&
+        (driver !== "codex" || !isProviderNamespacedModelSlug(model.slug)),
+    ),
+  ];
 };
 
 export const orderProviderSnapshots = (
@@ -59,7 +68,11 @@ export const hydrateCachedProvider = (input: {
   const { message: _fallbackMessage, ...fallbackWithoutMessage } = input.fallbackProvider;
   const hydratedProvider: ServerProvider = {
     ...fallbackWithoutMessage,
-    models: mergeProviderModels(input.fallbackProvider.models, input.cachedProvider.models),
+    models: mergeProviderModels(
+      input.fallbackProvider.driver,
+      input.fallbackProvider.models,
+      input.cachedProvider.models,
+    ),
     installed: input.cachedProvider.installed,
     version: input.cachedProvider.version,
     status: input.cachedProvider.status,


### PR DESCRIPTION
## What Changed

- Scope Codex model catalogs to each provider instance. Slash-qualified provider namespaces no longer leak from a shared Codex home catalog into an instance that did not declare them.
- Treat `customModels` as the explicit per-instance allowlist for provider-namespaced models. A declared model remains selectable, is marked custom, and keeps catalog capabilities when they are available.
- Apply the same rule when hydrating cached provider status, reject an undeclared provider-namespaced selection before Codex starts a session or sends a turn, and evict removed provider-namespaced models from live merged snapshots without discarding missing first-party inventory.

Focused validation passed:

- `vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts apps/server/src/provider/Layers/CodexProvider.test.ts apps/server/src/provider/providerStatusCache.test.ts apps/server/src/provider/Layers/ProviderRegistry.test.ts` (`4` files, `92` tests)
- `vp lint --report-unused-disable-directives` on all `9` changed files
- `vp fmt --check` on all `9` changed files
- `vp run --filter t3 typecheck`
- `git show --format= --check HEAD`

No packaged desktop, web, or mobile runtime evidence has been collected yet.

The two medium bot findings on the first revision are covered by regressions that preserve unqualified first-party metadata and remove an undeclared provider-namespaced model from a live merged snapshot. The corrected two-commit tree `fa3322d42baef71cb7649f02113f3f349117ed30` was squashed onto the original base without changing that tree.

Exact-candidate review: Tier 2 `PASS WITH RISKS` with two low-severity residual risks; reviewer `claude:bf3d4a410980f0fb7ff5f5d6964069bf`; promotion closure `OK`.

Final full commit: `74e8c2139870807894acaccc5f11b882ae145e1c`

PR URL: https://github.com/pingdotgg/t3code/pull/8544

<!-- buzz-delivery
BUZZ_REPO_OWNER=4a34c131ec5cb5dd9a200bac619bbd103c0793e068fad278d1de59203d05b97d
BUZZ_REPO_ID=glm-codex-workforce
BUZZ_ISSUE_ID=1a6389b42b5ad4cc0ce1611383b7f9f33922eb7bf79eb911ba129e1b49191d00
BUZZ_PR_ID=af80c0f02d0bfeb0a11812c755aec4150e3c2529d35b4a2d8964759031a11899
EXTERNAL_PR=pingdotgg/t3code#8544
BASE_SHA=4c51b4c9b6a85d96a22e0df41d5cfd2d8fc9901d
HEAD_SHA=74e8c2139870807894acaccc5f11b882ae145e1c
-->

## Why

Codex keeps one model catalog cache per home, even when that home is shared by instances that use different model providers. A model discovered through one provider could therefore appear under another instance and remain selectable there. The incompatible instance would pass that foreign model slug to its own provider and fail only when the turn reached the provider.

Provider ownership is represented generically by the model namespace and each instance's existing `customModels` configuration. This avoids hard-coding one provider or model. Unqualified catalog models keep their current behavior, while slash-qualified models require an explicit declaration on the active instance.

## UI Changes

This PR does not change UI code. No screenshots have been collected yet.

Requested media: none; this change has no UI or interaction surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because this PR has no UI changes
- [x] Video is not applicable because this PR has no animation or interaction changes

Model/harness: GPT-5.6 Sol via Codex CLI. Implementation used high reasoning; PR drafting used medium reasoning.
