### PR TITLE
fix(server): time out pull-request lookup during VCS refresh

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -5,8 +5,10 @@ import * as NodeChildProcess from "node:child_process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
@@ -14,6 +16,7 @@ import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as References from "effect/References";
 import * as Scope from "effect/Scope";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { expect } from "vite-plus/test";
 import type {
@@ -62,6 +65,9 @@ interface FakeGhScenario {
   failWith?: GitHubCli.GitHubCliError;
   /** Let this many gh calls succeed before failWith kicks in (default 0 = fail immediately). */
   failAfterCalls?: number;
+  hangPrList?: boolean;
+  prListStarted?: Deferred.Deferred<void>;
+  onPrListInterrupt?: () => void;
 }
 
 function fakeGhOutput(stdout: string): VcsProcess.VcsProcessOutput {
@@ -368,6 +374,15 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
     }
 
     if (args[0] === "pr" && args[1] === "list") {
+      if (scenario.hangPrList) {
+        const started = scenario.prListStarted
+          ? Deferred.succeed(scenario.prListStarted, undefined)
+          : Effect.void;
+        return started.pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() => Effect.sync(() => scenario.onPrListInterrupt?.())),
+        );
+      }
       const headSelectorIndex = args.findIndex((value) => value === "--head");
       const headSelector =
         headSelectorIndex >= 0 && headSelectorIndex < args.length - 1
@@ -1566,6 +1581,62 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       expect(status.refName).toBe("feature/status-no-gh");
       expect(status.pr).toBeNull();
     }),
+  );
+
+  it.effect("status interrupts a hanging gh PR lookup at the enrichment deadline", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/status-hanging-gh"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/status-hanging-gh"]);
+
+      let prListInterrupted = false;
+      const prListStarted = yield* Deferred.make<void>();
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          hangPrList: true,
+          prListStarted,
+          onPrListInterrupt: () => {
+            prListInterrupted = true;
+          },
+        },
+      });
+      const logs: Array<{ message: string; annotations: Record<string, unknown> }> = [];
+      const logger = Logger.make<unknown, void>(({ fiber, message }) => {
+        logs.push({
+          message: String(message),
+          annotations: { ...fiber.getRef(References.CurrentLogAnnotations) },
+        });
+      });
+
+      const statusFiber = yield* manager
+        .status({ cwd: repoDir })
+        .pipe(
+          Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
+          Effect.forkChild,
+        );
+      yield* Deferred.await(prListStarted);
+      yield* TestClock.adjust(Duration.millis(4_999));
+      expect(statusFiber.pollUnsafe()).toBeUndefined();
+
+      yield* TestClock.adjust(Duration.millis(1));
+      const status = yield* Fiber.join(statusFiber);
+
+      expect(status.refName).toBe("feature/status-hanging-gh");
+      expect(status.hasUpstream).toBe(true);
+      expect(status.pr).toBeNull();
+      expect(prListInterrupted).toBe(true);
+      expect(
+        logs.find((entry) => entry.message.includes("PR lookup failed"))?.annotations,
+      ).toMatchObject({
+        operation: "lookupStatusPr",
+        branch: "feature/status-hanging-gh",
+        errorTag: "TimeoutError",
+        timeoutMs: 5_000,
+      });
+    }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("status logs actionable provider detail without exposing the upstream cause", () =>

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1,5 +1,6 @@
 import * as Arr from "effect/Array";
 import * as Cache from "effect/Cache";
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
@@ -116,6 +117,7 @@ const PR_LOOKUP_CACHE_TTL = Duration.minutes(2);
 const PR_LOOKUP_FAILURE_BASE_TTL = Duration.seconds(20);
 const PR_LOOKUP_FAILURE_MAX_TTL = Duration.minutes(15);
 const PR_LOOKUP_CACHE_CAPACITY = 2_048;
+const STATUS_PR_LOOKUP_TIMEOUT = Duration.seconds(5);
 const isSourceControlProviderError = Schema.is(SourceControlProviderError);
 
 /**
@@ -974,7 +976,9 @@ export const make = Effect.gen(function* () {
         if (details.upstreamRef === null && (yield* isUnpublishedBranch(cwd, headContext))) {
           return { latest: null, headContext };
         }
-        const latest = yield* findLatestPrForHeadContext(cwd, headContext);
+        const latest = yield* findLatestPrForHeadContext(cwd, headContext).pipe(
+          Effect.timeout(STATUS_PR_LOOKUP_TIMEOUT),
+        );
         return { latest, headContext };
       });
     },
@@ -1090,6 +1094,9 @@ export const make = Effect.gen(function* () {
               typeof error === "object" && error !== null && "_tag" in error
                 ? String(error._tag)
                 : typeof error,
+            ...(Cause.isTimeoutError(error)
+              ? { timeoutMs: Duration.toMillis(STATUS_PR_LOOKUP_TIMEOUT) }
+              : {}),
             ...(isSourceControlProviderError(error)
               ? {
                   provider: error.provider,


### PR DESCRIPTION
## What Changed

- Bound GitHub PR enrichment during VCS status reads to five seconds.
- Interrupt a hanging PR lookup at the deadline and use the existing failure path. Local branch and upstream status still return, while PR metadata falls back to the last known value or `null`.
- Add a structured timeout diagnostic with the operation, branch, error tag, and `timeoutMs: 5000`. The warning does not include the underlying provider cause.

Focused source tests passed:

- `status includes PR metadata when branch already has an open PR`
- `backs off repeated PR lookup failures past the healthy refresh cadence`
- `status is resilient to gh lookup failures and returns pr null`
- `status interrupts a hanging gh PR lookup at the enrichment deadline`
- `status logs actionable provider detail without exposing the upstream cause`
- `status keeps the last known PR when a later lookup fails`
- `refreshes the cached snapshot after explicit invalidation`

The six focused `GitManager` tests passed, with 81 unrelated tests skipped. The focused `VcsStatusBroadcaster` refresh test passed, with 12 unrelated tests skipped.

No packaged desktop, web, or mobile runtime evidence has been collected yet.

Final full commit: `be9a32dd7deca4e7fff81234d39f568761862d47`

PR URL: `https://github.com/pingdotgg/t3code/pull/8545`

## Why

PR enrichment currently waits for the GitHub CLI without a deadline. If the CLI stalls while reading credentials from a locked desktop keyring, the full VCS refresh can remain pending even though local Git status is already available.

A five-second deadline keeps this optional provider lookup from holding the status request indefinitely. Successful lookups are unchanged. A timeout degrades only PR metadata and preserves the local status users need.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model/harness: GPT-5.6 Sol via Codex CLI. Implementation used high reasoning; PR drafting used medium reasoning.
