### PR TITLE
fix(chat): avoid stalled pending follow-ups

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1559,6 +1559,28 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         },
       });
 
+      yield* eventStore.append({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-tl-checkpoint"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-01-01T00:00:06.000Z",
+        commandId: CommandId.make("cmd-tl-checkpoint"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-tl-checkpoint"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId,
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-turn-lifecycle/turn/1"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("message-tl-interim"),
+          completedAt: "2026-01-01T00:00:06.000Z",
+        },
+      });
+
       yield* projectionPipeline.bootstrap;
 
       const runningRows = yield* sql<{

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1453,20 +1453,22 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           });
 
           if (Option.isSome(existingTurn)) {
+            const projectedState = turnStillRunning ? existingTurn.value.state : nextState;
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
               assistantMessageId: event.payload.assistantMessageId,
-              state: turnStillRunning ? existingTurn.value.state : nextState,
+              state: projectedState,
               checkpointTurnCount: event.payload.checkpointTurnCount,
               checkpointRef: event.payload.checkpointRef,
               checkpointStatus: event.payload.status,
               checkpointFiles: event.payload.files,
               startedAt: existingTurn.value.startedAt ?? event.payload.completedAt,
               requestedAt: existingTurn.value.requestedAt ?? event.payload.completedAt,
-              completedAt: event.payload.completedAt,
+              completedAt: projectedState === "running" ? null : event.payload.completedAt,
             });
             return;
           }
+          const projectedState = turnStillRunning ? "running" : nextState;
           yield* projectionTurnRepository.upsertByTurnId({
             turnId: event.payload.turnId,
             threadId: event.payload.threadId,
@@ -1474,10 +1476,10 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             sourceProposedPlanThreadId: null,
             sourceProposedPlanId: null,
             assistantMessageId: event.payload.assistantMessageId,
-            state: turnStillRunning ? "running" : nextState,
+            state: projectedState,
             requestedAt: event.payload.completedAt,
             startedAt: event.payload.completedAt,
-            completedAt: event.payload.completedAt,
+            completedAt: projectedState === "running" ? null : event.payload.completedAt,
             checkpointTurnCount: event.payload.checkpointTurnCount,
             checkpointRef: event.payload.checkpointRef,
             checkpointStatus: event.payload.status,

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -818,6 +818,54 @@ describe("deriveMessagesTimelineRows", () => {
     expect(finalRow?.kind === "message" && finalRow.showAssistantMeta).toBe(true);
   });
 
+  it("omits a blank pending follow-up while the active turn keeps running", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-active-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:20Z",
+          message: {
+            id: "assistant-active" as never,
+            role: "assistant",
+            text: "Still working",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:20Z",
+            updatedAt: "2026-01-01T00:00:22Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "blank-followup-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:01:00Z",
+          message: {
+            id: "blank-followup" as never,
+            role: "user",
+            text: "   ",
+            turnId: null,
+            createdAt: "2026-01-01T00:01:00Z",
+            updatedAt: "2026-01-01T00:01:00Z",
+            streaming: false,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+      runningTurnId: "turn-1" as never,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["assistant-active-entry", "working-indicator-row"]);
+  });
+
   it("does not fold the active in-progress turn", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -692,9 +692,9 @@ export function deriveMessagesTimelineRows(input: {
     }
   }
 
+  const latestUserMessageIndex = lastUserMessageIndex(input.timelineEntries);
   let activeTurnHeaderIndex = input.timelineEntries.length;
   if (input.isWorking) {
-    const latestUserMessageIndex = lastUserMessageIndex(input.timelineEntries);
     const firstOwnedAfterUser =
       unsettledTurnId === null
         ? -1
@@ -994,6 +994,16 @@ export function deriveMessagesTimelineRows(input: {
         createdAt: timelineEntry.createdAt,
         turnPlan: timelineEntry.turnPlan,
       });
+      continue;
+    }
+
+    if (
+      timelineEntry.message.role === "user" &&
+      input.isWorking &&
+      index === latestUserMessageIndex &&
+      timelineEntry.message.text.trim().length === 0 &&
+      (timelineEntry.message.attachments?.length ?? 0) === 0
+    ) {
       continue;
     }
 


### PR DESCRIPTION
## What Changed

Fork PR: https://github.com/pingdotgg/t3code/pull/8547

- Keep a turn's `completed_at` null while its projected state is still `running`, including after checkpoint events.
- Hide only the latest in-flight user row when it is blank and has no attachments. Text and attachment follow-ups remain visible.

## Why

Submitting a follow-up while a turn was already running could leave a blank pending row in the timeline, making healthy agent work look stalled. A checkpoint could also copy its completion timestamp onto the still-running turn.

The projection now derives `completed_at` from the projected terminal state. The timeline filters the empty in-flight placeholder instead of treating it as a visible message.

Focused checks passed on commit `d27f0ccc4c25c11def3c4cde7219b9c2540ded33`:

- `cd apps/server && ./node_modules/.bin/vp test run src/orchestration/Layers/ProjectionPipeline.test.ts` (23 passed)
- `cd apps/web && ./node_modules/.bin/vp test run --passWithNoTests --project unit src/components/chat/MessagesTimeline.logic.test.ts` (46 passed)
- `./node_modules/.bin/vp lint --report-unused-disable-directives apps/server/src/orchestration/Layers/ProjectionPipeline.ts apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts apps/web/src/components/chat/MessagesTimeline.logic.ts apps/web/src/components/chat/MessagesTimeline.logic.test.ts`
- `./node_modules/.bin/vp run --filter t3 typecheck`
- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- `git diff --check HEAD^ HEAD`

## UI Changes

This changes interaction-state rendering. No live runtime or video evidence has been captured yet.

- Before: Not yet captured. This PR is a draft while interaction media is prepared.
- After: Not yet captured. This PR is a draft while interaction media is prepared.
- Interaction video: Not yet captured. This PR is a draft while interaction media is prepared.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Prepared with GPT-5.6 Sol via Codex Desktop.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stalled pending follow-ups in chat by keeping running turns uncompleted and hiding blank user messages
> - In [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/8547/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4), upserts for `thread.turn-diff-completed` events now set `completedAt` to null when the turn is still running, instead of persisting the event's timestamp
> - In [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/8547/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe), `deriveMessagesTimelineRows` now skips the latest user message while a turn is running if it has only whitespace and no attachments
> - Tests added in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/8547/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) and [MessagesTimeline.logic.test.ts](https://github.com/pingdotgg/t3code/pull/8547/files#diff-e1bf628eaf9220069a00bdd08d5e22144ed7c8bb723b4cafa3ffb550083c2a72) to cover both paths
> - Behavioral Change: `projection_turns` rows for running turns no longer carry a `completed_at` value; blank pending user messages are excluded from the timeline during active turns
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d27f0cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->