### PR TITLE
fix(usage): canonical LiteLLM keys must win rate-table collisions

### DIFF
--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { cacheSavingsUsd, parseRateTable, priceUsage } from "./usagePricing.ts";
+
+/**
+ * Mirrors the shape of the live LiteLLM document that broke #8534: the
+ * canonical `claude-fable-5` entry carries Anthropic's cache rates, and a
+ * reseller entry thousands of lines later normalizes to the same name with no
+ * cache fields at all.
+ */
+const canonicalFable = {
+  input_cost_per_token: 1e-5,
+  output_cost_per_token: 5e-5,
+  cache_read_input_token_cost: 1e-6,
+  cache_creation_input_token_cost: 1.25e-5,
+};
+const resellerFable = {
+  input_cost_per_token: 1e-5,
+  output_cost_per_token: 5e-5,
+};
+
+describe("parseRateTable", () => {
+  it("keeps the canonical entry when a prefixed entry follows it (#8534)", () => {
+    const table = parseRateTable({
+      "claude-fable-5": canonicalFable,
+      "deepinfra/anthropic/claude-fable-5": resellerFable,
+    });
+    expect(table.get("claude-fable-5")?.cacheReadCostPerToken).toBe(1e-6);
+    expect(table.get("claude-fable-5")?.cacheCreationCostPerToken).toBe(1.25e-5);
+  });
+
+  it("keeps the canonical entry when a prefixed entry precedes it", () => {
+    const table = parseRateTable({
+      "deepinfra/anthropic/claude-fable-5": resellerFable,
+      "claude-fable-5": canonicalFable,
+    });
+    expect(table.get("claude-fable-5")?.cacheReadCostPerToken).toBe(1e-6);
+  });
+
+  it("keeps the canonical base rates against a prefixed entry that prices differently", () => {
+    const table = parseRateTable({
+      "gemini-2.5-pro": { input_cost_per_token: 1.25e-6, output_cost_per_token: 1e-5 },
+      "vercel_ai_gateway/gemini-2.5-pro": {
+        input_cost_per_token: 2.5e-6,
+        output_cost_per_token: 2e-5,
+        cache_read_input_token_cost: 2.5e-7,
+      },
+    });
+    expect(table.get("gemini-2.5-pro")?.inputCostPerToken).toBe(1.25e-6);
+  });
+
+  it("fills a name that only exists as a prefixed entry", () => {
+    const table = parseRateTable({
+      "vertex_ai/some-prefixed-only-model": {
+        input_cost_per_token: 3e-6,
+        output_cost_per_token: 9e-6,
+      },
+    });
+    expect(table.get("some-prefixed-only-model")?.inputCostPerToken).toBe(3e-6);
+  });
+
+  it("still prices cached input as plain input when the canonical entry has no cache rates", () => {
+    const table = parseRateTable({
+      "gpt-realtime-mini": { input_cost_per_token: 6e-7, output_cost_per_token: 2.4e-6 },
+    });
+    expect(table.get("gpt-realtime-mini")?.cacheReadCostPerToken).toBe(6e-7);
+  });
+
+  it("treats a dot-prefixed name as its own canonical entry, not a collision", () => {
+    const table = parseRateTable({
+      "claude-fable-5": canonicalFable,
+      "us.anthropic.claude-fable-5": {
+        input_cost_per_token: 1.1e-5,
+        output_cost_per_token: 5.5e-5,
+        cache_read_input_token_cost: 1.1e-6,
+      },
+    });
+    expect(table.get("claude-fable-5")?.inputCostPerToken).toBe(1e-5);
+    expect(table.get("us.anthropic.claude-fable-5")?.inputCostPerToken).toBe(1.1e-5);
+  });
+});
+
+describe("pricing with a colliding table", () => {
+  const table = parseRateTable({
+    "claude-fable-5": canonicalFable,
+    "deepinfra/anthropic/claude-fable-5": resellerFable,
+  });
+  const totals = {
+    uncachedInputTokens: 1_000,
+    cachedInputTokens: 1_000_000,
+    cacheCreationTokens: 10_000,
+    outputTokens: 2_000,
+    reasoningTokens: 0,
+  };
+
+  it("prices cache reads at the discounted rate", () => {
+    const priced = priceUsage(table, "claude-fable-5", totals, null);
+    expect(priced.costSource).toBe("modelPriced");
+    // 1000*1e-5 + 1_000_000*1e-6 + 10_000*1.25e-5 + 2000*5e-5 = 1.235
+    expect(priced.costUsd).toBeCloseTo(1.235, 10);
+  });
+
+  it("reports nonzero cache savings", () => {
+    // 1_000_000 * (1e-5 - 1e-6) = 9.0
+    expect(cacheSavingsUsd(table, "claude-fable-5", totals)).toBeCloseTo(9.0, 10);
+  });
+});

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -44,11 +44,19 @@ function finiteNumber(value: unknown): number | null {
  * Entries without both an input and an output rate are dropped: a half-priced
  * model would silently under-report cost, which is worse than reporting the
  * model as unpriced.
+ *
+ * Several LiteLLM keys can normalize to the same name: the document lists
+ * `claude-fable-5` and, thousands of lines later, reseller variants like
+ * `deepinfra/anthropic/claude-fable-5` that carry no cache rates and sometimes
+ * different base rates. A slash-free key is the canonical entry for the name
+ * transcripts actually record, so it always wins its slot; a prefix-stripped
+ * key only fills a slot no canonical entry claims.
  */
 export function parseRateTable(document: unknown): RateTable {
   const table = new Map<string, ModelRate>();
   if (typeof document !== "object" || document === null) return table;
 
+  const canonicalNames = new Set<string>();
   for (const [name, raw] of Object.entries(document as Record<string, unknown>)) {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as LiteLlmEntry;
@@ -56,7 +64,15 @@ export function parseRateTable(document: unknown): RateTable {
     const output = finiteNumber(entry.output_cost_per_token);
     if (input === null || output === null) continue;
 
-    table.set(normalizeModelName(name), {
+    const normalized = normalizeModelName(name);
+    const isCanonical = !name.includes("/");
+    if (isCanonical) {
+      canonicalNames.add(normalized);
+    } else if (canonicalNames.has(normalized)) {
+      continue;
+    }
+
+    table.set(normalized, {
       inputCostPerToken: input,
       outputCostPerToken: output,
       // Anthropic bills cache reads at a discount and cache writes at a


### PR DESCRIPTION
## What Changed

`parseRateTable` now gives a canonical (slash-free) LiteLLM key precedence over prefix-stripped keys that normalize to the same name. A prefix-stripped entry only fills a slot no canonical entry claims. Added `usagePricing.test.ts` (the file did not exist) covering both collision orders, differing base rates, prefixed-only models, the missing-cache-fields fallback, dotted Bedrock-style keys, and end-to-end cost + savings arithmetic in the exact #8534 shape.

## Why

The rate table is built last-entry-wins over normalized names. In today's LiteLLM document the canonical `claude-fable-5` / `claude-opus-5` / `claude-opus-4-8` / `claude-sonnet-5` entries are shadowed by `deepinfra/anthropic/*` reseller entries that carry no `cache_read_input_token_cost`, so the `?? input` fallback priced every cache read at full input rate and cache savings computed as zero. `gpt-5` / `gpt-5-mini` / `gpt-5-nano` lose the same way to `replicate/openai/*`.

The reporter's screenshot in #8534 confirms this to the cent: fable-5 averages $10.14/M (full input rate) on a bucket that is overwhelmingly cache reads, the six model costs sum exactly to the $62,540.18 headline, and the $9.45 cache savings is producible only by the two models whose canonical keys happen to serialize last. Full arithmetic in the issue comment.

Deliberately unchanged: the `?? input` fallback (correct for models that genuinely publish no cache pricing) and stripped-vs-stripped ordering for names with no canonical entry.

Note: beyond the cache column, this also corrects base rates for models whose canonical entries were shadowed by gateway variants with different prices (e.g. `gemini-2.5-pro` was priced at 2x from a `vercel_ai_gateway/*` entry). Every retarget moves toward the canonical price.

Fixes #8534

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (server-side pricing only; no UI change)
- [ ] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reported usage cost and cache-savings math for models affected by LiteLLM key collisions; no auth or payment flow changes, but billing visibility shifts toward canonical rates.
> 
> **Overview**
> Fixes **#8534**, where reseller/gateway LiteLLM keys (e.g. `deepinfra/anthropic/claude-fable-5`) that normalize to the same model name were overwriting canonical slash-free entries, stripping cache discount rates and sometimes doubling base input/output prices.
> 
> **`parseRateTable`** now treats keys without `/` as canonical: they always claim their normalized slot, and prefixed keys are skipped once a canonical name exists; prefixed-only models still populate the table when no canonical key is present.
> 
> Adds **`usagePricing.test.ts`** with collision ordering, gateway vs canonical base rates, cache fallbacks, dot-prefixed Bedrock-style keys, and end-to-end **`priceUsage`** / **`cacheSavingsUsd`** checks for the fable-5 scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b49df8ec4fba1d50d2e607d1bf00ecf4c77df47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseRateTable` to let canonical LiteLLM keys win rate-table collisions
> - `parseRateTable` now tracks canonical (slash-free) model names in a `Set` and skips prefixed entries (e.g. `deepinfra/anthropic/claude-fable-5`) when a canonical entry for the same normalized name already exists.
> - Cache read/creation costs default to the input cost when the rate entry omits them.
> - Adds tests in [usagePricing.test.ts](https://github.com/pingdotgg/t3code/pull/8548/files#diff-c1502a5efe3d9c16af5b5ee964d04000b33940f152e287b7c87985385964bc60) covering canonical-vs-prefixed collisions, cache-rate defaults, dot-prefixed names, and savings calculations.
> - Behavioral Change: prefixed entries that previously overwrote canonical rates for the same normalized name are now ignored; consumers relying on prefixed-override behavior will see the canonical rates instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b49df8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->