### PR TITLE
feat(composer): drop non-image files as filesystem paths

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,7 +5,7 @@ import type {
   DesktopPreviewTabState,
 } from "@t3tools/contracts";
 import { exposeClerkBridge } from "@clerk/electron/preload";
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
 
@@ -39,6 +39,15 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     return result as ReturnType<DesktopBridge["getAppBranding"]>;
   },
   getClientPlatform: () => clientPlatform,
+  getPathForFile: (file: File) => {
+    // Throws for a File that never came from the OS (e.g. built by the page).
+    try {
+      const path = webUtils.getPathForFile(file);
+      return path.length > 0 ? path : null;
+    } catch {
+      return null;
+    }
+  },
   getSystemLocale: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_SYSTEM_LOCALE_CHANNEL);
     return typeof result === "string" ? result : null;

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -169,7 +169,9 @@ import {
   submitComposerDraft,
 } from "./composerSubmission";
 import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
-import { formatDroppedFilePaths } from "./droppedFilePaths";
+import { getPrimaryKnownEnvironment } from "~/environments/primary";
+
+import { droppedPathsResolveInEnvironment, formatDroppedFilePaths } from "./droppedFilePaths";
 
 function ComposerVideoThumbnail({ file }: { file: File }) {
   const setVideo = useCallback(
@@ -3165,6 +3167,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (!resolvePath) {
       reportFailure(
         "Attaching files by path needs the desktop app. Paste an image, or type the path.",
+      );
+      return false;
+    }
+    // The bridge reads a path on THIS machine. Inserting it into a thread whose
+    // agent runs elsewhere hands over a path that host cannot open — so gate on
+    // the thread's environment being the one this desktop app supervises,
+    // rather than on the bridge merely existing.
+    const primaryEnvironment = getPrimaryKnownEnvironment();
+    if (
+      !droppedPathsResolveInEnvironment({
+        primarySource: primaryEnvironment?.source,
+        primaryEnvironmentId: primaryEnvironment?.environmentId,
+        threadEnvironmentId: environmentId,
+      })
+    ) {
+      reportFailure(
+        "This thread runs on another machine, which cannot open a path from this one. Attach the file, or type a path that exists there.",
       );
       return false;
     }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -169,6 +169,7 @@ import {
   submitComposerDraft,
 } from "./composerSubmission";
 import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
+import { formatDroppedFilePaths } from "./droppedFilePaths";
 
 function ComposerVideoThumbnail({ file }: { file: File }) {
   const setVideo = useCallback(
@@ -3148,6 +3149,37 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     void addComposerAttachments(files);
   };
 
+  /**
+   * Insert dropped non-image files as filesystem paths. Only the desktop app
+   * can resolve a path from a dropped File, so in a browser tab this reports
+   * why nothing was inserted instead of silently swallowing the drop.
+   */
+  const insertDroppedFilePaths = (files: File[]) => {
+    const resolvePath = window.desktopBridge?.getPathForFile;
+    if (!resolvePath) {
+      setThreadError(
+        activeThreadId,
+        "Attaching files by path needs the desktop app. Paste an image, or type the path.",
+      );
+      return;
+    }
+    const paths = files
+      .map((file) => resolvePath(file))
+      .filter((path): path is string => path !== null);
+    const text = formatDroppedFilePaths(paths);
+    if (text.length === 0) {
+      setThreadError(activeThreadId, "Could not read the location of the dropped file(s).");
+      return;
+    }
+    if (!insertComposerTextAtEnd(text, { ensureLeadingBoundary: true })) {
+      toastManager.add({
+        type: "error",
+        title: "Unable to add to chat",
+        description: "The composer is busy; try again once it is ready.",
+      });
+    }
+  };
+
   const insertComposerTextAtEnd = (
     text: string,
     options?: { ensureLeadingBoundary?: boolean },
@@ -3271,7 +3303,29 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         composerEditorRef.current?.focusAt(cursor);
       },
       addDroppedFiles: (files: File[]) => {
-        void addComposerAttachments(files);
+        // The composer attaches what it can render inline — images and video.
+        // Everything else (audio, PDF, archives, …) is handed over as a path so
+        // the agent opens it from disk itself, instead of being rejected as "not
+        // a supported image type" or pushing a 40MB recording across the wire.
+        const attachable = files.filter(
+          (file) =>
+            file.type.startsWith("image/") ||
+            videoMimeType({ name: file.name, mimeType: file.type }) !== undefined,
+        );
+        const byPath = files.filter((file) => !attachable.includes(file));
+        if (attachable.length > 0) {
+          void addComposerAttachments(attachable);
+        }
+        if (byPath.length > 0) {
+          // Deliberately no focusComposer() on this path. `applyPromptReplacement`
+          // focuses on the next frame, once Lexical has reconciled; focusing
+          // synchronously here makes the not-yet-reconciled editor sync its stale
+          // empty state back over the text we just inserted, so the drop looks
+          // like it silently did nothing. Same footgun the file-tree mention drop
+          // documents in makeComposerMentionDragHandlers.
+          insertDroppedFilePaths(byPath);
+          return;
+        }
         focusComposer();
       },
       insertTextAtEnd: insertComposerTextAtEnd,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3150,34 +3150,41 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   };
 
   /**
-   * Insert dropped non-image files as filesystem paths. Only the desktop app
-   * can resolve a path from a dropped File, so in a browser tab this reports
-   * why nothing was inserted instead of silently swallowing the drop.
+   * Insert dropped non-image files as filesystem paths, reporting to a toast
+   * rather than the thread error banner: a mixed drop's images own that banner,
+   * and a path failure there would read as though the whole drop failed. Only
+   * the desktop app can resolve a path from a dropped File, so in a browser tab
+   * this says so instead of silently swallowing the drop. Returns whether text
+   * was actually inserted.
    */
-  const insertDroppedFilePaths = (files: File[]) => {
+  const insertDroppedFilePaths = (files: File[], hadImages: boolean): boolean => {
+    const reportFailure = (description: string) => {
+      toastManager.add({ type: "error", title: "Unable to add to chat", description });
+    };
     const resolvePath = window.desktopBridge?.getPathForFile;
     if (!resolvePath) {
-      setThreadError(
-        activeThreadId,
+      reportFailure(
         "Attaching files by path needs the desktop app. Paste an image, or type the path.",
       );
-      return;
+      return false;
     }
     const paths = files
       .map((file) => resolvePath(file))
       .filter((path): path is string => path !== null);
     const text = formatDroppedFilePaths(paths);
     if (text.length === 0) {
-      setThreadError(activeThreadId, "Could not read the location of the dropped file(s).");
-      return;
+      reportFailure("Could not read the location of the dropped file(s).");
+      return false;
     }
     if (!insertComposerTextAtEnd(text, { ensureLeadingBoundary: true })) {
-      toastManager.add({
-        type: "error",
-        title: "Unable to add to chat",
-        description: "The composer is busy; try again once it is ready.",
-      });
+      // This refusal comes from the same composer state that already rejected
+      // the images, so one drop never says it twice.
+      if (!hadImages) {
+        reportFailure("The composer is busy; try again once it is ready.");
+      }
+      return false;
     }
+    return true;
   };
 
   const insertComposerTextAtEnd = (
@@ -3316,17 +3323,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (attachable.length > 0) {
           void addComposerAttachments(attachable);
         }
-        if (byPath.length > 0) {
-          // Deliberately no focusComposer() on this path. `applyPromptReplacement`
-          // focuses on the next frame, once Lexical has reconciled; focusing
-          // synchronously here makes the not-yet-reconciled editor sync its stale
-          // empty state back over the text we just inserted, so the drop looks
-          // like it silently did nothing. Same footgun the file-tree mention drop
-          // documents in makeComposerMentionDragHandlers.
-          insertDroppedFilePaths(byPath);
-          return;
+        const insertedPath =
+          byPath.length > 0 && insertDroppedFilePaths(byPath, attachable.length > 0);
+        // Focus unless a path just landed. `applyPromptReplacement` focuses on the
+        // next frame, once Lexical has reconciled; focusing synchronously right
+        // after the insert makes the not-yet-reconciled editor sync its stale empty
+        // state back over the text, so the drop looks like it silently did nothing
+        // — the footgun makeComposerMentionDragHandlers documents for the mention
+        // drop. Nothing inserted means nothing to lose, so focus as before.
+        if (!insertedPath) {
+          focusComposer();
         }
-        focusComposer();
       },
       insertTextAtEnd: insertComposerTextAtEnd,
       openModelPicker: () => {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3177,9 +3177,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return false;
     }
     if (!insertComposerTextAtEnd(text, { ensureLeadingBoundary: true })) {
-      // This refusal comes from the same composer state that already rejected
-      // the images, so one drop never says it twice.
-      if (!hadImages) {
+      // Pending plan questions is the ONLY refusal `addComposerImages` shares
+      // with the insert, so that is the only case a mixed drop has already been
+      // told about. Staying silent for the others — connecting, approval,
+      // project selection — would attach the images and drop the paths without
+      // a word, which is the failure this whole branch exists to avoid.
+      const alreadyReported = hadImages && pendingUserInputs.length > 0;
+      if (!alreadyReported) {
         reportFailure("The composer is busy; try again once it is ready.");
       }
       return false;

--- a/apps/web/src/components/chat/droppedFilePaths.test.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { formatDroppedFilePaths, quoteDroppedFilePath } from "./droppedFilePaths";
+import {
+  droppedPathsResolveInEnvironment,
+  formatDroppedFilePaths,
+  quoteDroppedFilePath,
+} from "./droppedFilePaths";
 
 describe("quoteDroppedFilePath", () => {
   it("leaves a path without whitespace alone", () => {
@@ -37,5 +41,74 @@ describe("formatDroppedFilePaths", () => {
 
   it("returns an empty string when nothing resolved", () => {
     expect(formatDroppedFilePaths([])).toBe("");
+  });
+});
+
+describe("droppedPathsResolveInEnvironment", () => {
+  const LOCAL = "env-local";
+  const OTHER = "env-other";
+
+  it("accepts a thread running on the desktop-managed environment", () => {
+    expect(
+      droppedPathsResolveInEnvironment({
+        primarySource: "desktop-managed",
+        primaryEnvironmentId: LOCAL,
+        threadEnvironmentId: LOCAL,
+      }),
+    ).toBe(true);
+  });
+
+  it("refuses a thread on a different environment even when the bridge is present", () => {
+    // The desktop app supervises env-local, but this thread runs on another
+    // machine: its agent cannot open a path read from this filesystem.
+    expect(
+      droppedPathsResolveInEnvironment({
+        primarySource: "desktop-managed",
+        primaryEnvironmentId: LOCAL,
+        threadEnvironmentId: OTHER,
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["configured", "manual", "window-origin"])(
+    "refuses a %s connection, which always names a server elsewhere",
+    (source) => {
+      expect(
+        droppedPathsResolveInEnvironment({
+          primarySource: source,
+          primaryEnvironmentId: LOCAL,
+          threadEnvironmentId: LOCAL,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("refuses while either id is still unknown", () => {
+    // Bootstrapping is not evidence the thread runs here; guessing wrong
+    // inserts a path the agent silently cannot read.
+    expect(
+      droppedPathsResolveInEnvironment({
+        primarySource: "desktop-managed",
+        primaryEnvironmentId: undefined,
+        threadEnvironmentId: LOCAL,
+      }),
+    ).toBe(false);
+    expect(
+      droppedPathsResolveInEnvironment({
+        primarySource: "desktop-managed",
+        primaryEnvironmentId: LOCAL,
+        threadEnvironmentId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("refuses when there is no primary environment at all", () => {
+    expect(
+      droppedPathsResolveInEnvironment({
+        primarySource: undefined,
+        primaryEnvironmentId: undefined,
+        threadEnvironmentId: LOCAL,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/droppedFilePaths.test.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.test.ts
@@ -7,6 +7,14 @@ describe("quoteDroppedFilePath", () => {
     expect(quoteDroppedFilePath("/Users/me/notes.pdf")).toBe("/Users/me/notes.pdf");
   });
 
+  it("escapes a double quote inside a quoted path", () => {
+    expect(quoteDroppedFilePath('/tmp/a " b.pdf')).toBe('"/tmp/a \\" b.pdf"');
+  });
+
+  it("leaves a double quote alone when there is no whitespace to quote for", () => {
+    expect(quoteDroppedFilePath('/tmp/a"b.pdf')).toBe('/tmp/a"b.pdf');
+  });
+
   it("quotes a path containing spaces", () => {
     expect(quoteDroppedFilePath("/Users/me/Voice Memos/note 1.m4a")).toBe(
       '"/Users/me/Voice Memos/note 1.m4a"',
@@ -17,6 +25,10 @@ describe("quoteDroppedFilePath", () => {
 describe("formatDroppedFilePaths", () => {
   it("joins several paths with a space", () => {
     expect(formatDroppedFilePaths(["/a/one.opus", "/b/two.pdf"])).toBe("/a/one.opus /b/two.pdf");
+  });
+
+  it("preserves a trailing space in a filename instead of trimming it", () => {
+    expect(formatDroppedFilePaths(["/tmp/report "])).toBe('"/tmp/report "');
   });
 
   it("skips empty and whitespace-only entries", () => {

--- a/apps/web/src/components/chat/droppedFilePaths.test.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatDroppedFilePaths, quoteDroppedFilePath } from "./droppedFilePaths";
+
+describe("quoteDroppedFilePath", () => {
+  it("leaves a path without whitespace alone", () => {
+    expect(quoteDroppedFilePath("/Users/me/notes.pdf")).toBe("/Users/me/notes.pdf");
+  });
+
+  it("quotes a path containing spaces", () => {
+    expect(quoteDroppedFilePath("/Users/me/Voice Memos/note 1.m4a")).toBe(
+      '"/Users/me/Voice Memos/note 1.m4a"',
+    );
+  });
+});
+
+describe("formatDroppedFilePaths", () => {
+  it("joins several paths with a space", () => {
+    expect(formatDroppedFilePaths(["/a/one.opus", "/b/two.pdf"])).toBe("/a/one.opus /b/two.pdf");
+  });
+
+  it("skips empty and whitespace-only entries", () => {
+    expect(formatDroppedFilePaths(["", "   ", "/a/one.opus"])).toBe("/a/one.opus");
+  });
+
+  it("returns an empty string when nothing resolved", () => {
+    expect(formatDroppedFilePaths([])).toBe("");
+  });
+});

--- a/apps/web/src/components/chat/droppedFilePaths.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.ts
@@ -1,0 +1,31 @@
+/**
+ * Files dropped from the OS that aren't images are handed to the agent by
+ * *path*, not by content: it can open the file itself, so a 40MB recording or
+ * a PDF never has to cross the wire as an attachment. This mirrors dropping a
+ * file into a terminal, where the shell receives the path.
+ *
+ * Paths are only available in the desktop app (Electron's `webUtils`); in a
+ * browser tab the File object carries no filesystem path at all.
+ */
+
+/**
+ * Quote a path for the prompt when whitespace would make where it ends
+ * ambiguous. This is prompt text, not a shell command — the goal is a clear
+ * boundary for the reader, not shell-injection safety.
+ */
+export function quoteDroppedFilePath(path: string): string {
+  return /\s/.test(path) ? `"${path}"` : path;
+}
+
+/**
+ * The text inserted into the composer for a set of dropped paths. Empty and
+ * whitespace-only paths are dropped (a bridge that can't resolve a file
+ * returns null, which the caller filters, but be defensive about "" too).
+ */
+export function formatDroppedFilePaths(paths: ReadonlyArray<string>): string {
+  return paths
+    .map((path) => path.trim())
+    .filter((path) => path.length > 0)
+    .map(quoteDroppedFilePath)
+    .join(" ");
+}

--- a/apps/web/src/components/chat/droppedFilePaths.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.ts
@@ -14,18 +14,25 @@
  * boundary for the reader, not shell-injection safety.
  */
 export function quoteDroppedFilePath(path: string): string {
-  return /\s/.test(path) ? `"${path}"` : path;
+  if (!/\s/.test(path)) {
+    return path;
+  }
+  // A double quote is legal in a POSIX filename, so escape any before wrapping —
+  // otherwise the first inner quote reads as the closing delimiter.
+  return `"${path.replace(/"/g, '\\"')}"`;
 }
 
 /**
- * The text inserted into the composer for a set of dropped paths. Empty and
- * whitespace-only paths are dropped (a bridge that can't resolve a file
+ * The text inserted into the composer for a set of dropped paths. Entries that
+ * are empty or all whitespace are skipped (a bridge that can't resolve a file
  * returns null, which the caller filters, but be defensive about "" too).
+ * A path that survives is never altered: leading and trailing spaces are legal
+ * in a filename, so trimming one would point the agent at a file that does not
+ * exist. Quoting keeps such a path readable instead.
  */
 export function formatDroppedFilePaths(paths: ReadonlyArray<string>): string {
   return paths
-    .map((path) => path.trim())
-    .filter((path) => path.length > 0)
+    .filter((path) => path.trim().length > 0)
     .map(quoteDroppedFilePath)
     .join(" ");
 }

--- a/apps/web/src/components/chat/droppedFilePaths.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.ts
@@ -6,7 +6,44 @@
  *
  * Paths are only available in the desktop app (Electron's `webUtils`); in a
  * browser tab the File object carries no filesystem path at all.
+ *
+ * A path is also only *meaningful* where the agent can open it. The desktop
+ * bridge resolves a path on the machine the client runs on, so the path is
+ * valid only when the thread's environment is that same machine — see
+ * `droppedPathsResolveInEnvironment`.
  */
+
+/**
+ * Whether a filesystem path read from the local desktop bridge means anything
+ * to the environment a thread runs in.
+ *
+ * The bridge resolves the path on *this* machine. `desktop-managed` is the one
+ * environment the desktop app supervises here, so only a thread bound to that
+ * environment shares the filesystem the path names. Every other connection —
+ * a LAN or Tailscale host, a relay, a tunnel, another desktop acting as server
+ * — runs the agent on a different machine, where the path either does not
+ * exist or, worse, names a different file.
+ *
+ * Passing the ids explicitly keeps this pure: the caller reads the primary
+ * environment, this decides.
+ */
+export function droppedPathsResolveInEnvironment(input: {
+  readonly primarySource: string | undefined;
+  readonly primaryEnvironmentId: string | undefined;
+  readonly threadEnvironmentId: string | undefined;
+}): boolean {
+  if (input.primarySource !== "desktop-managed") {
+    return false;
+  }
+  // Both ids must be known. A missing id is not a match: bootstrapping is not
+  // evidence that the thread runs here, and guessing wrong inserts a path the
+  // agent silently cannot read.
+  return (
+    input.primaryEnvironmentId !== undefined &&
+    input.threadEnvironmentId !== undefined &&
+    input.primaryEnvironmentId === input.threadEnvironmentId
+  );
+}
 
 /**
  * Quote a path for the prompt when whitespace would make where it ends

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1091,6 +1091,13 @@ export interface DesktopBridge {
    * regardless of OS settings.
    */
   getSystemLocale?: () => string | null;
+  /**
+   * The filesystem path of a dropped/pasted `File`, which the renderer cannot
+   * read for itself (Electron removed `File.path` in v32). Returns null when
+   * the object has no path — e.g. a file synthesised in-page rather than
+   * dragged in from the OS.
+   */
+  getPathForFile?: (file: File) => string | null;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.


### PR DESCRIPTION
Reopening #7749, which was closed with this reason:

> This inserts local desktop paths for dropped files, but a selected remote environment often cannot read those paths. The implementation breaks the remote-ready contract even though its quoting tests are useful.

That was correct, and this fixes it. I could not reopen #7749 through the API (`reopenPullRequest` returns "Could not open the pull request", `PATCH state=open` returns 422), hence a fresh PR rather than ignoring the request to explain what was missed.

## What Changed

Dropping a non-image file (audio, PDF, video, …) on the composer inserts its filesystem path as text, so the agent opens the file itself instead of a 40MB attachment crossing the wire — the same gesture as dropping a file into a terminal. Images are unaffected and still attach.

The insert is gated on the thread's environment being the one this desktop app supervises:

```ts
export function droppedPathsResolveInEnvironment(input: {
  readonly primarySource: string | undefined;
  readonly primaryEnvironmentId: string | undefined;
  readonly threadEnvironmentId: string | undefined;
}): boolean {
  if (input.primarySource !== "desktop-managed") return false;
  return (
    input.primaryEnvironmentId !== undefined &&
    input.threadEnvironmentId !== undefined &&
    input.primaryEnvironmentId === input.threadEnvironmentId
  );
}
```

When it refuses, the composer says why rather than dropping the file on the floor:

> This thread runs on another machine, which cannot open a path from this one. Attach the file, or type a path that exists there.

## Why

The earlier version resolved a path through the local desktop bridge and inserted it regardless of where the thread ran. On a remote environment — a LAN or Tailscale host, a relay, a tunnel, another desktop acting as server — that path names a file on the wrong machine, so the agent either cannot find it or, worse, finds a different one. `packages/contracts/src/ipc.ts` already states the rule that broke:

> callers should resolve it by `environmentId` rather than reaching through the local desktop bridge

`desktop-managed` is the single environment this app supervises on this machine; every other `KnownEnvironmentSource` (`configured`, `manual`, `window-origin`) names a server somewhere else. A missing id on either side also refuses — bootstrapping is not evidence the thread runs here, and guessing wrong reproduces exactly the silent failure that got #7749 closed.

Two smaller decisions carried over from the earlier review:

- Failures report through a toast, not `setThreadError`. A mixed drop's images own that banner, and a path failure there reads as though the whole drop failed.
- A resolved path is never trimmed. Leading and trailing spaces are legal in a filename, so trimming one points the agent at a file that does not exist; quoting keeps it readable instead.

## UI Changes

No visual change. The only new surface is an error toast on a drop that cannot be honored, where the previous behavior was silence.

## Test plan

- `apps/web/src/components/chat/droppedFilePaths.test.ts` — 15 tests: quoting (whitespace, embedded quotes, paths that must not be trimmed), formatting, and the environment predicate (matching ids, mismatched ids, each non-desktop source, either id unknown).
- `pnpm --filter @t3tools/web typecheck` clean, targeted lint clean.
- Manually: dropped a PDF and an audio file on a local thread — paths inserted; images in the same drop still attached.

Rebased onto current `main`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — n/a, no visual change
- [x] I included a video for animation/interaction changes — n/a

---

Written with Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes drop handling and prompt content in a high-traffic composer path; environment gating limits wrong-machine paths but incorrect ID matching could still block or allow inserts incorrectly.
> 
> **Overview**
> **Dropping non-image files on the chat composer** (PDFs, audio, archives, etc.) now inserts their **local filesystem path** into the prompt instead of rejecting them or uploading large blobs—similar to dropping a file into a terminal. **Images and video still attach** as before; mixed drops handle both paths.
> 
> The **desktop preload** exposes `desktopBridge.getPathForFile` via Electron `webUtils` (replacing removed `File.path`), with the contract updated accordingly.
> 
> Path insertion runs **only when the thread’s `environmentId` matches the desktop-managed primary environment** on this machine (`droppedPathsResolveInEnvironment`). Browser tabs, remote/SSH/relay connections, mismatched environments, or unknown IDs get **explicit error toasts** instead of silent wrong-path inserts. Paths are **quoted** when they contain whitespace (without trimming legal trailing spaces).
> 
> **Composer focus** is skipped immediately after a successful path insert so Lexical reconciliation does not wipe the new text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52c963546fa1e562247a02441a1ba37bbefba41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Insert non-image dropped files as filesystem paths in `ChatComposer`
> - Adds `desktopBridge.getPathForFile(file)` to the preload bridge, using Electron's `webUtils` to resolve a filesystem path for OS-originated `File` objects (returns `null` otherwise)
> - Splits dropped files in `ChatComposer.addDroppedFiles`: images/videos attach as before; all other types are resolved to local paths and inserted as quoted text via the new `insertDroppedFilePaths` helper
> - Adds pure utilities in [droppedFilePaths.ts](https://github.com/pingdotgg/t3code/pull/8549/files#diff-3b1c46ba1728118957ed7272aefe0d2fcab6f06d955da9316f642c9a94ba1147): `droppedPathsResolveInEnvironment` (requires `primarySource === 'desktop-managed'` and matching environment ids), `quoteDroppedFilePath` (wraps paths with whitespace in double quotes), and `formatDroppedFilePaths` (filters empties and joins with spaces)
> - Surfaces failures via `toastManager` when the desktop bridge is absent, the thread environment does not match the local desktop-managed environment, no paths resolve, or the composer is busy
> - Behavioral Change: dropping a non-image file in a browser or in a thread whose environment differs from the local desktop-managed environment now shows an error toast instead of attaching or ignoring the file; focus after a drop is deferred when path text was inserted to avoid clobbering it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f52c963.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->