### PR TITLE
fix(server): run worktree setup scripts as processes

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -14,6 +14,7 @@ import {
   type ComposerTrigger,
 } from "@t3tools/shared/composerTrigger";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
+import type { SetupScriptState } from "@t3tools/shared/projectScripts";
 import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
@@ -123,6 +124,8 @@ export interface ThreadComposerProps {
   readonly onExpandedChange?: (expanded: boolean) => void;
   /** Fires on editor focus/blur; hosts use it to vet stale keyboard state. */
   readonly onEditorFocusChange?: (focused: boolean) => void;
+  readonly setupScriptState?: SetupScriptState | null;
+  readonly onRerunSetupScript?: () => void;
 }
 
 /**
@@ -265,6 +268,50 @@ const ComposerConnectionStatusPill = memo(function ComposerConnectionStatusPill(
         >
           {props.status.label}
         </Text>
+      </Pressable>
+    </Animated.View>
+  );
+});
+
+const ComposerSetupScriptPill = memo(function ComposerSetupScriptPill(props: {
+  readonly state: SetupScriptState;
+  readonly onRerun?: () => void;
+}) {
+  const scriptLabel = props.state.scriptName?.trim() || "Setup script";
+  const isRunning = props.state.status === "running";
+  const label = isRunning
+    ? `${scriptLabel} is running`
+    : props.state.exitCode === null
+      ? `${scriptLabel} failed`
+      : `${scriptLabel} failed (exit ${props.state.exitCode})`;
+
+  return (
+    <Animated.View
+      className="absolute inset-x-0 bottom-full items-center pb-2"
+      entering={FadeInDown.duration(180)}
+      exiting={FadeOutDown.duration(140)}
+      pointerEvents="box-none"
+    >
+      <Pressable
+        accessibilityRole={isRunning || props.onRerun === undefined ? "text" : "button"}
+        disabled={isRunning || props.onRerun === undefined}
+        onPress={props.onRerun}
+        className="max-w-full flex-row items-center gap-2 rounded-full bg-white/90 px-3 py-2 shadow-sm active:opacity-70 dark:bg-neutral-900/90"
+      >
+        {isRunning ? (
+          <ActivityIndicator size="small" color="#8e8e93" />
+        ) : (
+          <View className="h-2 w-2 rounded-full bg-red-500" />
+        )}
+        <Text
+          className="max-w-[260px] text-sm font-t3-bold leading-snug text-foreground"
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+        {isRunning || props.onRerun === undefined ? null : (
+          <Text className="text-sm font-t3-bold text-foreground">Rerun setup</Text>
+        )}
       </Pressable>
     </Animated.View>
   );
@@ -751,6 +798,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           <ComposerConnectionStatusPill
             status={connectionStatus}
             onPress={props.onReconnectEnvironment}
+          />
+        ) : props.setupScriptState && props.setupScriptState.status !== "succeeded" ? (
+          <ComposerSetupScriptPill
+            state={props.setupScriptState}
+            onRerun={
+              props.setupScriptState.status === "failed" ? props.onRerunSetupScript : undefined
+            }
           />
         ) : null}
 

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -58,6 +58,7 @@ import type { StatusTone } from "../../components/StatusPill";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { CHAT_CONTENT_MAX_WIDTH, type LayoutVariant } from "../../lib/layout";
 import { IOS_NAV_BAR_HEIGHT } from "../../lib/layoutMetrics";
+import type { SetupScriptState } from "@t3tools/shared/projectScripts";
 import { scopedThreadKey } from "../../lib/scopedEntities";
 import type {
   PendingApproval,
@@ -88,6 +89,8 @@ export interface ThreadDetailScreenProps {
   readonly connectionError: string | null;
   readonly environmentLabel: string | null;
   readonly selectedThreadFeed: ReadonlyArray<ThreadFeedEntry>;
+  readonly setupScriptState?: SetupScriptState | null;
+  readonly onRerunSetupScript?: () => void;
   readonly activeWorkStartedAt: string | null;
   readonly activePendingApproval: PendingApproval | null;
   readonly respondingApprovalId: ApprovalRequestId | null;
@@ -767,6 +770,8 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 onUpdateInteractionMode={props.onUpdateThreadInteractionMode}
                 onExpandedChange={setComposerExpanded}
                 onEditorFocusChange={handleOwnedInputFocusChange}
+                setupScriptState={props.setupScriptState}
+                onRerunSetupScript={props.onRerunSetupScript}
               />
             </View>
           </View>

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -63,6 +63,7 @@ import { useSelectedThreadRequests } from "../../state/use-selected-thread-reque
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useThreadComposerState } from "../../state/use-thread-composer-state";
 import { threadEnvironment } from "../../state/threads";
+import { projectEnvironment } from "../../state/projects";
 import { projectThreadContentPresentation } from "./threadContentPresentation";
 import {
   useAdaptiveWorkspaceLayout,
@@ -214,6 +215,7 @@ function ThreadRouteContent(
   const gitActions = useSelectedThreadGitActions();
   const requests = useSelectedThreadRequests();
   const interruptThreadTurn = useAtomCommand(threadEnvironment.interruptTurn, "thread interrupt");
+  const runSetupScript = useAtomCommand(projectEnvironment.runSetupScript, "rerun setup script");
   const navigation = useNavigation();
   const params = props.route.params;
   const environmentIdRaw = firstRouteParam(params.environmentId);
@@ -773,6 +775,13 @@ function ThreadRouteContent(
           connectionError={routeConnectionError}
           environmentLabel={selectedEnvironmentConnection?.environmentLabel ?? null}
           selectedThreadFeed={composer.selectedThreadFeed}
+          setupScriptState={composer.setupScriptState}
+          onRerunSetupScript={() => {
+            void runSetupScript({
+              environmentId: selectedThread.environmentId,
+              input: { threadId: selectedThread.id },
+            });
+          }}
           activeWorkStartedAt={composer.activeWorkStartedAt}
           activePendingApproval={requests.activePendingApproval}
           respondingApprovalId={requests.respondingApprovalId}

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -337,6 +337,7 @@ function deriveWorkLogEntries(
     if (activity.kind === "task.updated" && !isTerminalBypassUpdate(activity)) continue;
     if (activity.kind === "tool.progress") continue;
     if (activity.kind === "context-window.updated") continue;
+    if (activity.kind.startsWith("setup-script.")) continue;
     if (activity.summary === "Checkpoint captured") continue;
     if (isNoContentRuntimeWarning(activity)) continue;
     if (isPlanBoundaryToolActivity(activity)) continue;

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -21,6 +21,7 @@ import {
 } from "@t3tools/client-runtime/state/threads";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
+import { setupScriptStateFromActivities } from "@t3tools/shared/projectScripts";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
 import {
@@ -123,6 +124,11 @@ export function useThreadComposerState() {
       ),
     });
   }, [feedbackSubmissionsByThreadKey, selectedThreadDetail, selectedThreadKey]);
+  const setupScriptState = useMemo(
+    () =>
+      selectedThreadDetail ? setupScriptStateFromActivities(selectedThreadDetail.activities) : null,
+    [selectedThreadDetail],
+  );
 
   const selectedDraft = selectedThreadKey ? composerDrafts[selectedThreadKey] : null;
   const draftMessage = selectedDraft?.text ?? "";
@@ -395,6 +401,7 @@ export function useThreadComposerState() {
 
   return {
     selectedThreadFeed,
+    setupScriptState,
     selectedThreadQueueCount,
     activeWorkStartedAt,
     draftMessage,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -81,6 +81,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.projectsSearchContents]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsWriteFile]: AuthOrchestrationOperateScope,
+  [WS_METHODS.projectsRunSetupScript]: AuthOrchestrationOperateScope,
   [WS_METHODS.shellOpenInEditor]: AuthOrchestrationOperateScope,
   [WS_METHODS.filesystemBrowse]: AuthOrchestrationReadScope,
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -4656,7 +4656,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
               new ProjectSetupScriptRunner.ProjectSetupScriptOperationError({
                 threadId: input.threadId,
                 worktreePath: input.worktreePath,
-                operation: "openTerminal",
+                operation: "spawn",
                 cause: new Error("terminal start failed"),
               }),
             ),

--- a/apps/server/src/project/ProjectSetupScriptProcess.ts
+++ b/apps/server/src/project/ProjectSetupScriptProcess.ts
@@ -1,0 +1,104 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+export interface ProjectSetupScriptSpawnInput {
+  readonly command: string;
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+}
+
+export interface ProjectSetupScriptProcessHandle {
+  readonly stdout: Stream.Stream<Uint8Array>;
+  readonly stderr: Stream.Stream<Uint8Array>;
+  readonly exitCode: Effect.Effect<number>;
+  readonly kill: Effect.Effect<void>;
+}
+
+export class ProjectSetupScriptSpawnError extends Schema.TaggedErrorClass<ProjectSetupScriptSpawnError>()(
+  "ProjectSetupScriptSpawnError",
+  {
+    command: Schema.String,
+    cwd: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to spawn project setup script '${this.command}' in '${this.cwd}'.`;
+  }
+}
+
+export class ProjectSetupScriptProcess extends Context.Service<
+  ProjectSetupScriptProcess,
+  {
+    readonly spawn: (
+      input: ProjectSetupScriptSpawnInput,
+    ) => Effect.Effect<ProjectSetupScriptProcessHandle, ProjectSetupScriptSpawnError, Scope.Scope>;
+  }
+>()("t3/project/ProjectSetupScriptProcess") {}
+
+export const make = Effect.gen(function* () {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const hostPlatform = yield* HostProcessPlatform;
+
+  const spawn: ProjectSetupScriptProcess["Service"]["spawn"] = Effect.fn(
+    "ProjectSetupScriptProcess.spawn",
+  )(function* (input) {
+    const child = yield* spawner
+      .spawn(
+        ChildProcess.make(input.command, [], {
+          cwd: input.cwd,
+          env: input.env,
+          extendEnv: true,
+          shell: true,
+          detached: hostPlatform !== "win32",
+        }),
+      )
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectSetupScriptSpawnError({
+              command: input.command,
+              cwd: input.cwd,
+              cause,
+            }),
+        ),
+      );
+
+    const killProcessGroup = (signal: NodeJS.Signals) =>
+      hostPlatform === "win32"
+        ? child.kill({ killSignal: signal }).pipe(Effect.asVoid)
+        : Effect.sync(() => {
+            try {
+              process.kill(-Number(child.pid), signal);
+            } catch {
+              // The shell or its children may already have exited.
+            }
+          });
+
+    const handle: ProjectSetupScriptProcessHandle = {
+      stdout: child.stdout.pipe(Stream.catchCause(() => Stream.empty)),
+      stderr: child.stderr.pipe(Stream.catchCause(() => Stream.empty)),
+      exitCode: child.exitCode.pipe(
+        Effect.map((code) => Number(code)),
+        Effect.orElseSucceed(() => 1),
+      ),
+      kill: killProcessGroup("SIGTERM").pipe(
+        Effect.andThen(Effect.sleep("1 second")),
+        Effect.andThen(killProcessGroup("SIGKILL")),
+        Effect.ignore,
+      ),
+    };
+    return handle;
+  });
+
+  return ProjectSetupScriptProcess.of({ spawn });
+});
+
+export const layer = Layer.effect(ProjectSetupScriptProcess, make);

--- a/apps/server/src/project/ProjectSetupScriptProcess.ts
+++ b/apps/server/src/project/ProjectSetupScriptProcess.ts
@@ -57,6 +57,7 @@ export const make = Effect.gen(function* () {
           env: input.env,
           extendEnv: true,
           shell: true,
+          stdin: "ignore",
           detached: hostPlatform !== "win32",
         }),
       )

--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -1,12 +1,23 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it, vi } from "@effect/vitest";
 import { type OrchestrationProject, ProjectId } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 
+import * as ServerConfig from "../config.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as TerminalManager from "../terminal/Manager.ts";
+import * as ProjectSetupScriptProcess from "./ProjectSetupScriptProcess.ts";
 import * as ProjectSetupScriptRunner from "./ProjectSetupScriptRunner.ts";
 
 const isProjectSetupScriptOperationError = Schema.is(
@@ -23,6 +34,14 @@ const makeProject = (scripts: OrchestrationProject["scripts"]): OrchestrationPro
   updatedAt: "2026-01-01T00:00:00.000Z",
   deletedAt: null,
 });
+
+const setupScript = {
+  id: "setup",
+  name: "Setup",
+  command: "bash .cursor/setup-worktree-unix.sh",
+  icon: "configure" as const,
+  runOnWorktreeCreate: true,
+};
 
 const makeProjectionSnapshotQueryLayer = (project: OrchestrationProject) =>
   Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
@@ -47,33 +66,74 @@ const makeProjectionSnapshotQueryLayer = (project: OrchestrationProject) =>
     searchThreads: () => Effect.succeed({ matches: [] }),
   });
 
+const unusedTerminalError = () => Effect.die(new Error("unused"));
+
 const makeTerminalManagerLayer = (
-  overrides: Pick<TerminalManager.TerminalManager["Service"], "open" | "write">,
+  overrides: Pick<TerminalManager.TerminalManager["Service"], "open" | "write" | "appendOutput">,
 ) =>
   Layer.succeed(TerminalManager.TerminalManager, {
     ...overrides,
-    attachStream: () => Effect.die(new Error("unused")),
+    attachStream: unusedTerminalError,
     resize: () => Effect.void,
     clear: () => Effect.void,
-    restart: () => Effect.die(new Error("unused")),
+    restart: unusedTerminalError,
     close: () => Effect.void,
     subscribe: () => Effect.succeed(() => undefined),
     subscribeMetadata: () => Effect.succeed(() => undefined),
   });
 
-const testLayer = (
-  project: OrchestrationProject,
-  terminal: Pick<TerminalManager.TerminalManager["Service"], "open" | "write">,
-) =>
+const makeHandle = (input: {
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly code?: number;
+  readonly exitCode?: Effect.Effect<number>;
+}): ProjectSetupScriptProcess.ProjectSetupScriptProcessHandle => ({
+  stdout: input.stdout === undefined ? Stream.empty : Stream.encodeText(Stream.make(input.stdout)),
+  stderr: input.stderr === undefined ? Stream.empty : Stream.encodeText(Stream.make(input.stderr)),
+  exitCode: input.exitCode ?? Effect.succeed(input.code ?? 0),
+  kill: Effect.void,
+});
+
+const testLayer = (input: {
+  readonly project: OrchestrationProject;
+  readonly terminal: Pick<
+    TerminalManager.TerminalManager["Service"],
+    "open" | "write" | "appendOutput"
+  >;
+  readonly process: ProjectSetupScriptProcess.ProjectSetupScriptProcess["Service"];
+}) =>
   ProjectSetupScriptRunner.layer.pipe(
-    Layer.provideMerge(makeProjectionSnapshotQueryLayer(project)),
-    Layer.provideMerge(makeTerminalManagerLayer(terminal)),
+    Layer.provide(
+      Layer.succeed(ProjectSetupScriptProcess.ProjectSetupScriptProcess, input.process),
+    ),
+    Layer.provideMerge(makeProjectionSnapshotQueryLayer(input.project)),
+    Layer.provideMerge(makeTerminalManagerLayer(input.terminal)),
+    Layer.provideMerge(
+      ServerConfig.layerTest(process.cwd(), { prefix: "t3-setup-script-runner-" }),
+    ),
+    Layer.provideMerge(NodeServices.layer),
   );
+
+const openSnapshot = {
+  threadId: "thread-1",
+  terminalId: "setup-setup",
+  cwd: "/repo/worktrees/a",
+  worktreePath: "/repo/worktrees/a",
+  status: "running" as const,
+  pid: 123,
+  history: "",
+  exitCode: null,
+  exitSignal: null,
+  label: "setup-setup",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
 
 describe("ProjectSetupScriptRunner", () => {
   it.effect("returns no-script when no setup script exists", () => {
+    const spawn = vi.fn(() => Effect.die("unexpected spawn"));
     const open = vi.fn(() => Effect.die("unexpected open"));
     const write = vi.fn(() => Effect.die("unexpected write"));
+    const appendOutput = vi.fn(() => Effect.die("unexpected append"));
     const project = makeProject([]);
 
     return Effect.gen(function* () {
@@ -85,89 +145,118 @@ describe("ProjectSetupScriptRunner", () => {
       });
 
       expect(result).toEqual({ status: "no-script" });
+      expect(spawn).not.toHaveBeenCalled();
       expect(open).not.toHaveBeenCalled();
       expect(write).not.toHaveBeenCalled();
-    }).pipe(Effect.provide(testLayer(project, { open, write })));
+      expect(appendOutput).not.toHaveBeenCalled();
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          project,
+          terminal: { open, write, appendOutput },
+          process: { spawn },
+        }),
+      ),
+    );
   });
 
-  it.effect(
-    "opens the deterministic setup terminal with worktree env and writes the command",
-    () => {
-      const open = vi.fn(() =>
-        Effect.succeed({
-          threadId: "thread-1",
-          terminalId: "setup-setup",
-          cwd: "/repo/worktrees/a",
-          worktreePath: "/repo/worktrees/a",
-          status: "running" as const,
-          pid: 123,
-          history: "",
-          exitCode: null,
-          exitSignal: null,
-          label: "setup-setup",
-          updatedAt: "2026-01-01T00:00:00.000Z",
+  it.effect("runs the setup command as a process and waits for success", () => {
+    const spawn = vi.fn((_input: ProjectSetupScriptProcess.ProjectSetupScriptSpawnInput) =>
+      Effect.succeed(makeHandle({ stdout: "installed\n", code: 0 })),
+    );
+    const open = vi.fn(() => Effect.succeed(openSnapshot));
+    const write = vi.fn(() => Effect.die("setup must not type into a PTY"));
+    const appendOutput = vi.fn(() => Effect.void);
+    const project = makeProject([setupScript]);
+
+    return Effect.gen(function* () {
+      const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+      const result = yield* runner.runForThread({
+        threadId: "thread-1",
+        projectCwd: "/repo/project",
+        worktreePath: "/repo/worktrees/a",
+      });
+
+      expect(result.status).toBe("succeeded");
+      if (result.status !== "succeeded") {
+        return;
+      }
+      expect(result.scriptId).toBe("setup");
+      expect(result.scriptName).toBe("Setup");
+      expect(result.terminalId).toBe("setup-setup");
+      expect(result.cwd).toBe("/repo/worktrees/a");
+      expect(result.exitCode).toBe(0);
+      expect(result.logPath.length).toBeGreaterThan(0);
+      expect(spawn).toHaveBeenCalledWith({
+        command: "bash .cursor/setup-worktree-unix.sh",
+        cwd: "/repo/worktrees/a",
+        env: expect.objectContaining({
+          T3CODE_PROJECT_ROOT: "/repo/project",
+          T3CODE_WORKTREE_PATH: "/repo/worktrees/a",
         }),
-      );
-      const write = vi.fn(() => Effect.void);
-      const project = makeProject([
-        {
-          id: "setup",
-          name: "Setup",
-          command: "bun install",
-          icon: "configure",
-          runOnWorktreeCreate: true,
-        },
-      ]);
+      });
+      expect(write).not.toHaveBeenCalled();
+      expect(appendOutput).toHaveBeenCalledWith({
+        threadId: "thread-1",
+        terminalId: "setup-setup",
+        data: "installed\n",
+      });
+      const fileSystem = yield* FileSystem.FileSystem;
+      expect(yield* fileSystem.readFileString(result.logPath)).toContain("installed");
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          project,
+          terminal: { open, write, appendOutput },
+          process: { spawn },
+        }),
+      ),
+    );
+  });
 
-      return Effect.gen(function* () {
-        const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
-        const result = yield* runner.runForThread({
-          threadId: "thread-1",
-          projectCwd: "/repo/project",
-          worktreePath: "/repo/worktrees/a",
-        });
+  it.effect("returns failed and logs when the process exits non-zero", () => {
+    const spawn = vi.fn(() =>
+      Effect.succeed(makeHandle({ stdout: "boom\n", stderr: "nope\n", code: 7 })),
+    );
+    const open = vi.fn(() => Effect.succeed(openSnapshot));
+    const project = makeProject([setupScript]);
 
-        expect(result).toEqual({
-          status: "started",
-          scriptId: "setup",
-          scriptName: "Setup",
-          terminalId: "setup-setup",
-          cwd: "/repo/worktrees/a",
-        });
-        expect(open).toHaveBeenCalledWith({
-          threadId: "thread-1",
-          terminalId: "setup-setup",
-          cwd: "/repo/worktrees/a",
-          worktreePath: "/repo/worktrees/a",
-          env: {
-            T3CODE_PROJECT_ROOT: "/repo/project",
-            T3CODE_WORKTREE_PATH: "/repo/worktrees/a",
-          },
-        });
-        expect(write).toHaveBeenCalledWith({
-          threadId: "thread-1",
-          terminalId: "setup-setup",
-          data: "bun install\r",
-        });
-      }).pipe(Effect.provide(testLayer(project, { open, write })));
-    },
-  );
+    return Effect.gen(function* () {
+      const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+      const result = yield* runner.runForThread({
+        threadId: "thread-1",
+        projectId: "project-1",
+        worktreePath: "/repo/worktrees/a",
+      });
 
-  it.effect("keeps terminal failures as the exact cause of a structured operation error", () => {
-    const rootCause = new Error("stat failed");
-    const terminalError = new TerminalManager.TerminalCwdStatError({
+      expect(result.status).toBe("failed");
+      if (result.status !== "failed") {
+        return;
+      }
+      expect(result.exitCode).toBe(7);
+      const fileSystem = yield* FileSystem.FileSystem;
+      const log = yield* fileSystem.readFileString(result.logPath);
+      expect(log).toContain("boom");
+      expect(log).toContain("nope");
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          project,
+          terminal: { open, write: () => Effect.void, appendOutput: () => Effect.void },
+          process: { spawn },
+        }),
+      ),
+    );
+  });
+
+  it.effect("keeps spawn failures as a structured operation error", () => {
+    const spawnCause = new ProjectSetupScriptProcess.ProjectSetupScriptSpawnError({
+      command: setupScript.command,
       cwd: "/repo/worktrees/a",
-      cause: rootCause,
+      cause: new Error("ENOENT"),
     });
-    const project = makeProject([
-      {
-        id: "setup",
-        name: "Setup",
-        command: "bun install",
-        icon: "configure",
-        runOnWorktreeCreate: true,
-      },
-    ]);
+    const spawn = vi.fn(() => Effect.fail(spawnCause));
+    const project = makeProject([setupScript]);
 
     return Effect.gen(function* () {
       const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
@@ -181,20 +270,183 @@ describe("ProjectSetupScriptRunner", () => {
 
       expect(isProjectSetupScriptOperationError(error)).toBe(true);
       if (isProjectSetupScriptOperationError(error)) {
-        expect(error.operation).toBe("openTerminal");
+        expect(error.operation).toBe("spawn");
         expect(error.threadId).toBe("thread-1");
-        expect(error.projectId).toBe("project-1");
         expect(error.worktreePath).toBe("/repo/worktrees/a");
-        expect(error.cause).toBe(terminalError);
-        expect(terminalError.cause).toBe(rootCause);
+        expect(error.cause).toBe(spawnCause);
       }
     }).pipe(
       Effect.provide(
-        testLayer(project, {
-          open: () => Effect.fail(terminalError),
-          write: () => Effect.die("unexpected write"),
+        testLayer({
+          project,
+          terminal: {
+            open: () => Effect.succeed(openSnapshot),
+            write: () => Effect.void,
+            appendOutput: () => Effect.void,
+          },
+          process: { spawn },
         }),
       ),
     );
+  });
+
+  it.effect("joins an in-flight run for the same worktree instead of spawning twice", () =>
+    Effect.gen(function* () {
+      const spawned = yield* Deferred.make<void>();
+      const gate = yield* Deferred.make<number>();
+      let spawnCount = 0;
+      const spawn = vi.fn(() =>
+        Effect.gen(function* () {
+          spawnCount += 1;
+          yield* Deferred.succeed(spawned, undefined);
+          const code = yield* Deferred.await(gate);
+          return makeHandle({ stdout: "once\n", code });
+        }),
+      );
+      const project = makeProject([setupScript]);
+
+      yield* Effect.gen(function* () {
+        const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+        const input = {
+          threadId: "thread-1",
+          projectId: "project-1",
+          worktreePath: "/repo/worktrees/a",
+        };
+        const first = yield* runner.runForThread(input).pipe(Effect.forkChild);
+        yield* Deferred.await(spawned);
+        const second = yield* runner.runForThread(input).pipe(Effect.forkChild);
+        yield* Deferred.succeed(gate, 0);
+        const [firstResult, secondResult] = yield* Effect.all([
+          Fiber.join(first),
+          Fiber.join(second),
+        ]);
+
+        expect(spawnCount).toBe(1);
+        expect(firstResult.status).toBe("succeeded");
+        expect(secondResult.status).toBe("succeeded");
+        expect(firstResult).toEqual(secondResult);
+      }).pipe(
+        Effect.provide(
+          testLayer({
+            project,
+            terminal: {
+              open: () => Effect.succeed(openSnapshot),
+              write: () => Effect.void,
+              appendOutput: () => Effect.void,
+            },
+            process: { spawn },
+          }),
+        ),
+      );
+    }),
+  );
+
+  it.effect("still runs the process when the optional terminal viewer fails to open", () => {
+    const spawn = vi.fn(() => Effect.succeed(makeHandle({ stdout: "ok\n", code: 0 })));
+    const project = makeProject([setupScript]);
+
+    return Effect.gen(function* () {
+      const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+      const result = yield* runner.runForThread({
+        threadId: "thread-1",
+        projectId: "project-1",
+        worktreePath: "/repo/worktrees/a",
+      });
+
+      expect(result.status).toBe("succeeded");
+      expect(spawn).toHaveBeenCalledTimes(1);
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          project,
+          terminal: {
+            open: () =>
+              Effect.fail(
+                new TerminalManager.TerminalCwdStatError({
+                  cwd: "/repo/worktrees/a",
+                  cause: new Error("stat failed"),
+                }),
+              ),
+            write: () => Effect.die("unexpected write"),
+            appendOutput: () => Effect.void,
+          },
+          process: { spawn },
+        }),
+      ),
+    );
+  });
+});
+
+describe("ProjectSetupScriptRunner worktree integration", () => {
+  it.effect("creates a worktree, runs a marker script, and reports succeeded", () => {
+    const liveLayer = ProjectSetupScriptRunner.layer.pipe(
+      Layer.provide(ProjectSetupScriptProcess.layer),
+      Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(
+        ServerConfig.layerTest(process.cwd(), { prefix: "t3-setup-script-integration-" }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const repoDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-setup-script-repo-",
+      });
+      const worktreeDir = `${repoDir}-worktree`;
+      NodeChildProcess.execFileSync("git", ["init", "--initial-branch=main"], { cwd: repoDir });
+      NodeChildProcess.execFileSync("git", ["config", "user.email", "test@example.com"], {
+        cwd: repoDir,
+      });
+      NodeChildProcess.execFileSync("git", ["config", "user.name", "Test User"], { cwd: repoDir });
+      yield* fileSystem.writeFileString(NodePath.join(repoDir, "README.md"), "hello\n");
+      NodeChildProcess.execFileSync("git", ["add", "README.md"], { cwd: repoDir });
+      NodeChildProcess.execFileSync("git", ["commit", "-m", "Initial commit"], { cwd: repoDir });
+      NodeChildProcess.execFileSync("git", ["worktree", "add", "--detach", worktreeDir, "HEAD"], {
+        cwd: repoDir,
+      });
+
+      const project = makeProject([
+        {
+          id: "setup",
+          name: "Setup",
+          command: "printf ready > .t3-setup-marker",
+          icon: "configure",
+          runOnWorktreeCreate: true,
+        },
+      ]);
+
+      const result = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner.pipe(
+        Effect.flatMap((runner) =>
+          runner.runForThread({
+            threadId: "thread-1",
+            projectId: "project-1",
+            worktreePath: worktreeDir,
+          }),
+        ),
+        Effect.provide(
+          liveLayer.pipe(
+            Layer.provideMerge(makeProjectionSnapshotQueryLayer(project)),
+            Layer.provideMerge(
+              makeTerminalManagerLayer({
+                open: () => Effect.succeed({ ...openSnapshot, cwd: worktreeDir }),
+                write: () => Effect.die("setup must not type into a PTY"),
+                appendOutput: () => Effect.void,
+              }),
+            ),
+          ),
+        ),
+      );
+
+      expect(result.status).toBe("succeeded");
+      if (result.status !== "succeeded") {
+        return;
+      }
+      expect(result.exitCode).toBe(0);
+      expect(yield* fileSystem.exists(NodePath.join(worktreeDir, ".t3-setup-marker"))).toBe(true);
+      expect(yield* fileSystem.exists(NodePath.join(repoDir, ".t3-setup-marker"))).toBe(false);
+      expect(yield* fileSystem.readFileString(NodePath.join(worktreeDir, ".t3-setup-marker"))).toBe(
+        "ready",
+      );
+    }).pipe(Effect.provide(NodeServices.layer));
   });
 });

--- a/apps/server/src/project/ProjectSetupScriptRunner.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.ts
@@ -1,29 +1,48 @@
 import { ProjectId } from "@t3tools/contracts";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import { projectScriptRuntimeEnv, setupProjectScript } from "@t3tools/shared/projectScripts";
 import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
 
+import * as ServerConfig from "../config.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as TerminalManager from "../terminal/Manager.ts";
+import * as ProjectSetupScriptProcess from "./ProjectSetupScriptProcess.ts";
+
+export const DEFAULT_SETUP_SCRIPT_TIMEOUT = Duration.minutes(10);
+export const MAX_SETUP_SCRIPT_LOG_BYTES = 1_048_576;
 
 export interface ProjectSetupScriptRunnerResultNoScript {
   readonly status: "no-script";
 }
 
-export interface ProjectSetupScriptRunnerResultStarted {
-  readonly status: "started";
+export interface ProjectSetupScriptRunnerResultCompleted {
+  readonly status: "succeeded" | "failed";
   readonly scriptId: string;
   readonly scriptName: string;
   readonly terminalId: string;
   readonly cwd: string;
+  readonly exitCode: number | null;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly logPath: string;
 }
 
 export type ProjectSetupScriptRunnerResult =
   | ProjectSetupScriptRunnerResultNoScript
-  | ProjectSetupScriptRunnerResultStarted;
+  | ProjectSetupScriptRunnerResultCompleted;
 
 export interface ProjectSetupScriptRunnerInput {
   readonly threadId: string;
@@ -31,6 +50,14 @@ export interface ProjectSetupScriptRunnerInput {
   readonly projectCwd?: string;
   readonly worktreePath: string;
   readonly preferredTerminalId?: string;
+  readonly onSpawn?: (info: {
+    readonly scriptId: string;
+    readonly scriptName: string;
+    readonly terminalId: string;
+    readonly cwd: string;
+    readonly logPath: string;
+    readonly startedAt: string;
+  }) => Effect.Effect<void, never, never>;
 }
 
 export class ProjectSetupScriptOperationError extends Schema.TaggedErrorClass<ProjectSetupScriptOperationError>()(
@@ -40,7 +67,7 @@ export class ProjectSetupScriptOperationError extends Schema.TaggedErrorClass<Pr
     projectId: Schema.optional(Schema.String),
     projectCwd: Schema.optional(Schema.String),
     worktreePath: Schema.String,
-    operation: Schema.Literals(["resolveProject", "openTerminal", "writeCommand"]),
+    operation: Schema.Literals(["resolveProject", "spawn", "writeLog"]),
     cause: Schema.Defect(),
   },
 ) {
@@ -69,6 +96,13 @@ export const ProjectSetupScriptRunnerError = Schema.Union([
 ]);
 export type ProjectSetupScriptRunnerError = typeof ProjectSetupScriptRunnerError.Type;
 
+type InFlight = Effect.Effect<ProjectSetupScriptRunnerResult, ProjectSetupScriptRunnerError, never>;
+
+type Claimed = {
+  readonly role: "join" | "start";
+  readonly wait: InFlight;
+};
+
 export class ProjectSetupScriptRunner extends Context.Service<
   ProjectSetupScriptRunner,
   {
@@ -78,12 +112,30 @@ export class ProjectSetupScriptRunner extends Context.Service<
   }
 >()("t3/project/ProjectSetupScriptRunner") {}
 
+const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+
+const toStringEnv = (env: NodeJS.ProcessEnv): Record<string, string> => {
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) {
+      next[key] = value;
+    }
+  }
+  return next;
+};
+
 export const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const terminalManager = yield* TerminalManager.TerminalManager;
+  const setupProcess = yield* ProjectSetupScriptProcess.ProjectSetupScriptProcess;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const serverConfig = yield* ServerConfig.ServerConfig;
+  const hostEnv = yield* HostProcessEnvironment;
+  const inFlight = yield* SynchronizedRef.make(new Map<string, InFlight>());
 
-  const runForThread: ProjectSetupScriptRunner["Service"]["runForThread"] = Effect.fn(
-    "ProjectSetupScriptRunner.runForThread",
+  const runExclusive: ProjectSetupScriptRunner["Service"]["runForThread"] = Effect.fn(
+    "ProjectSetupScriptRunner.runExclusive",
   )(function* (input) {
     const errorContext = {
       threadId: input.threadId,
@@ -133,10 +185,35 @@ export const make = Effect.gen(function* () {
 
     const terminalId = input.preferredTerminalId ?? `setup-${script.id}`;
     const cwd = input.worktreePath;
-    const env = projectScriptRuntimeEnv({
-      project: { cwd: project.workspaceRoot },
-      worktreePath: input.worktreePath,
-    });
+    const env = {
+      ...toStringEnv(hostEnv),
+      ...projectScriptRuntimeEnv({
+        project: { cwd: project.workspaceRoot },
+        worktreePath: input.worktreePath,
+      }),
+    };
+    const logDir = path.join(serverConfig.logsDir, "setup-scripts");
+    const logPath = path.join(logDir, `${input.threadId}_${script.id}.log`);
+    yield* fileSystem.makeDirectory(logDir, { recursive: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProjectSetupScriptOperationError({
+            ...errorContext,
+            operation: "writeLog",
+            cause,
+          }),
+      ),
+    );
+    yield* fileSystem.writeFileString(logPath, "").pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProjectSetupScriptOperationError({
+            ...errorContext,
+            operation: "writeLog",
+            cause,
+          }),
+      ),
+    );
 
     yield* terminalManager
       .open({
@@ -144,42 +221,222 @@ export const make = Effect.gen(function* () {
         terminalId,
         cwd,
         worktreePath: input.worktreePath,
-        env,
+        env: projectScriptRuntimeEnv({
+          project: { cwd: project.workspaceRoot },
+          worktreePath: input.worktreePath,
+        }),
       })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ProjectSetupScriptOperationError({
-              ...errorContext,
-              operation: "openTerminal",
-              cause,
-            }),
-        ),
-      );
-    yield* terminalManager
-      .write({
-        threadId: input.threadId,
-        terminalId,
-        data: `${script.command}\r`,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ProjectSetupScriptOperationError({
-              ...errorContext,
-              operation: "writeCommand",
-              cause,
-            }),
-        ),
-      );
+      .pipe(Effect.ignore);
 
-    return {
-      status: "started",
-      scriptId: script.id,
-      scriptName: script.name,
-      terminalId,
-      cwd,
-    } as const;
+    const startedAt = yield* nowIso;
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* setupProcess
+          .spawn({
+            command: script.command,
+            cwd,
+            env,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProjectSetupScriptOperationError({
+                  ...errorContext,
+                  operation: "spawn",
+                  cause,
+                }),
+            ),
+          );
+
+        if (input.onSpawn) {
+          yield* input.onSpawn({
+            scriptId: script.id,
+            scriptName: script.name,
+            terminalId,
+            cwd,
+            logPath,
+            startedAt,
+          });
+        }
+
+        const logBytes = yield* Ref.make(0);
+        const logTruncated = yield* Ref.make(false);
+        const persistChunk = (text: string) =>
+          Effect.gen(function* () {
+            if (text.length === 0) {
+              return;
+            }
+            const written = yield* Ref.get(logBytes);
+            if (written >= MAX_SETUP_SCRIPT_LOG_BYTES) {
+              const alreadyTruncated = yield* Ref.get(logTruncated);
+              if (!alreadyTruncated) {
+                yield* Ref.set(logTruncated, true);
+                yield* fileSystem.writeFileString(logPath, "\n[truncated]\n", { flag: "a" }).pipe(
+                  Effect.catch((cause) =>
+                    Effect.logWarning("failed to persist setup script log", {
+                      threadId: input.threadId,
+                      logPath,
+                      cause,
+                    }),
+                  ),
+                );
+              }
+              return;
+            }
+            const remaining = MAX_SETUP_SCRIPT_LOG_BYTES - written;
+            const slice = text.length > remaining ? text.slice(0, remaining) : text;
+            yield* Ref.set(logBytes, written + slice.length);
+            yield* fileSystem.writeFileString(logPath, slice, { flag: "a" }).pipe(
+              Effect.catch((cause) =>
+                Effect.logWarning("failed to persist setup script log", {
+                  threadId: input.threadId,
+                  logPath,
+                  cause,
+                }),
+              ),
+            );
+            if (slice.length < text.length) {
+              yield* Ref.set(logTruncated, true);
+              yield* fileSystem.writeFileString(logPath, "\n[truncated]\n", { flag: "a" }).pipe(
+                Effect.catch((cause) =>
+                  Effect.logWarning("failed to persist setup script log", {
+                    threadId: input.threadId,
+                    logPath,
+                    cause,
+                  }),
+                ),
+              );
+            }
+          });
+        const consume = (stream: Stream.Stream<Uint8Array>) => {
+          const decoder = new TextDecoder("utf-8");
+          return stream.pipe(
+            Stream.catchCause(() => Stream.empty),
+            Stream.runForEach((chunk) =>
+              Effect.gen(function* () {
+                const text = decoder.decode(chunk, { stream: true });
+                if (text.length === 0) {
+                  return;
+                }
+                yield* persistChunk(text);
+                yield* terminalManager
+                  .appendOutput({
+                    threadId: input.threadId,
+                    terminalId,
+                    data: text,
+                  })
+                  .pipe(Effect.ignore);
+              }),
+            ),
+            Effect.flatMap(() =>
+              Effect.gen(function* () {
+                const flushed = decoder.decode();
+                if (flushed.length === 0) {
+                  return;
+                }
+                yield* persistChunk(flushed);
+                yield* terminalManager
+                  .appendOutput({
+                    threadId: input.threadId,
+                    terminalId,
+                    data: flushed,
+                  })
+                  .pipe(Effect.ignore);
+              }),
+            ),
+          );
+        };
+
+        const timeoutMs = script.setupScriptTimeoutMs;
+        const timeout =
+          typeof timeoutMs === "number" ? Duration.millis(timeoutMs) : DEFAULT_SETUP_SCRIPT_TIMEOUT;
+        const waitForExit = Effect.all(
+          [consume(handle.stdout), consume(handle.stderr), handle.exitCode],
+          { concurrency: "unbounded" },
+        ).pipe(Effect.map(([, , exitCode]) => exitCode));
+
+        const timed = yield* waitForExit.pipe(Effect.timeoutOption(timeout));
+        const finishedAt = yield* nowIso;
+
+        const completed = (
+          status: "succeeded" | "failed",
+          exitCode: number | null,
+        ): ProjectSetupScriptRunnerResultCompleted => ({
+          status,
+          scriptId: script.id,
+          scriptName: script.name,
+          terminalId,
+          cwd,
+          exitCode,
+          startedAt,
+          finishedAt,
+          logPath,
+        });
+
+        if (Option.isNone(timed)) {
+          yield* handle.kill.pipe(Effect.ignore);
+          yield* Effect.logError("Project setup script timed out", {
+            threadId: input.threadId,
+            worktreePath: input.worktreePath,
+            command: script.command,
+            logPath,
+          });
+          return completed("failed", null);
+        }
+
+        const exitCode = timed.value;
+        if (exitCode !== 0) {
+          yield* Effect.logError("Project setup script exited with a non-zero status", {
+            threadId: input.threadId,
+            worktreePath: input.worktreePath,
+            command: script.command,
+            exitCode,
+            logPath,
+          });
+          return completed("failed", exitCode);
+        }
+
+        return completed("succeeded", exitCode);
+      }),
+    );
+  });
+
+  const runForThread: ProjectSetupScriptRunner["Service"]["runForThread"] = Effect.fn(
+    "ProjectSetupScriptRunner.runForThread",
+  )(function* (input) {
+    const waiter = yield* Deferred.make<
+      ProjectSetupScriptRunnerResult,
+      ProjectSetupScriptRunnerError
+    >();
+    const claimed = yield* SynchronizedRef.modify(
+      inFlight,
+      (current): readonly [Claimed, Map<string, InFlight>] => {
+        const existing = current.get(input.worktreePath);
+        if (existing !== undefined) {
+          return [{ role: "join", wait: existing }, current];
+        }
+        const wait = Deferred.await(waiter);
+        const next = new Map(current);
+        next.set(input.worktreePath, wait);
+        return [{ role: "start", wait }, next];
+      },
+    );
+
+    if (claimed.role === "join") {
+      return yield* claimed.wait;
+    }
+
+    const exit = yield* runExclusive(input).pipe(Effect.exit);
+    yield* Deferred.done(waiter, exit);
+    yield* SynchronizedRef.update(inFlight, (current) => {
+      const next = new Map(current);
+      next.delete(input.worktreePath);
+      return next;
+    });
+    if (Exit.isSuccess(exit)) {
+      return exit.value;
+    }
+    return yield* Effect.failCause(exit.cause);
   });
 
   return ProjectSetupScriptRunner.of({ runForThread });

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7866,16 +7866,32 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         );
         const runForThread = vi.fn(
           (
-            _: Parameters<
+            input: Parameters<
               ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"]["runForThread"]
             >[0],
           ) =>
-            Effect.succeed({
-              status: "started" as const,
-              scriptId: "setup",
-              scriptName: "Setup",
-              terminalId: "setup-setup",
-              cwd: "/tmp/bootstrap-worktree",
+            Effect.gen(function* () {
+              yield* (
+                input.onSpawn?.({
+                  scriptId: "setup",
+                  scriptName: "Setup",
+                  terminalId: "setup-setup",
+                  cwd: "/tmp/bootstrap-worktree",
+                  logPath: "/tmp/setup.log",
+                  startedAt: "2026-01-01T00:00:00.000Z",
+                }) ?? Effect.void
+              );
+              return {
+                status: "succeeded" as const,
+                scriptId: "setup",
+                scriptName: "Setup",
+                terminalId: "setup-setup",
+                cwd: "/tmp/bootstrap-worktree",
+                exitCode: 0,
+                startedAt: "2026-01-01T00:00:00.000Z",
+                finishedAt: "2026-01-01T00:00:01.000Z",
+                logPath: "/tmp/setup.log",
+              };
             }),
         );
 
@@ -7945,12 +7961,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           ),
         );
 
-        assert.equal(response.sequence, 5);
+        assert.equal(response.sequence, 6);
         assert.deepEqual(
           dispatchedCommands.map((command) => command.type),
           [
             "thread.create",
             "thread.meta.update",
+            "thread.activity.append",
             "thread.activity.append",
             "thread.activity.append",
             "thread.turn.start",
@@ -7978,12 +7995,11 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           "resolve-remote-commit",
           "create-worktree",
         ]);
-        assert.deepEqual(runForThread.mock.calls[0]?.[0], {
-          threadId: ThreadId.make("thread-bootstrap"),
-          projectId: defaultProjectId,
-          projectCwd: "/tmp/project",
-          worktreePath: "/tmp/bootstrap-worktree",
-        });
+        const setupCall = runForThread.mock.calls[0]?.[0];
+        assert.equal(setupCall?.threadId, ThreadId.make("thread-bootstrap"));
+        assert.equal(setupCall?.projectId, defaultProjectId);
+        assert.equal(setupCall?.projectCwd, "/tmp/project");
+        assert.equal(setupCall?.worktreePath, "/tmp/bootstrap-worktree");
         assert.deepEqual(refreshStatus.mock.calls[0]?.[0], "/tmp/bootstrap-worktree");
 
         const setupActivities = dispatchedCommands.filter(
@@ -7992,14 +8008,133 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         );
         assert.deepEqual(
           setupActivities.map((command) => command.activity.kind),
-          ["setup-script.requested", "setup-script.started"],
+          ["setup-script.requested", "setup-script.started", "setup-script.succeeded"],
         );
-        const finalCommand = dispatchedCommands[4];
+        const finalCommand = dispatchedCommands[5];
         assertTrue(finalCommand?.type === "thread.turn.start");
         if (finalCommand?.type === "thread.turn.start") {
           assert.equal(finalCommand.bootstrap, undefined);
         }
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("waits for the setup script to finish before dispatching the first turn start", () =>
+    Effect.gen(function* () {
+      const dispatchedCommands: Array<OrchestrationCommand> = [];
+      const setupStarted = yield* Deferred.make<void>();
+      const releaseSetup = yield* Deferred.make<void>();
+      const createWorktree = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+          Effect.succeed({
+            worktree: {
+              refName: "t3code/bootstrap-refName",
+              path: "/tmp/bootstrap-worktree",
+            },
+          }),
+      );
+      const runForThread = vi.fn(
+        (
+          input: Parameters<
+            ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"]["runForThread"]
+          >[0],
+        ) =>
+          Effect.gen(function* () {
+            yield* (
+              input.onSpawn?.({
+                scriptId: "setup",
+                scriptName: "Setup",
+                terminalId: "setup-setup",
+                cwd: "/tmp/bootstrap-worktree",
+                logPath: "/tmp/setup.log",
+                startedAt: "2026-01-01T00:00:00.000Z",
+              }) ?? Effect.void
+            );
+            yield* Deferred.succeed(setupStarted, undefined);
+            yield* Deferred.await(releaseSetup);
+            return {
+              status: "succeeded" as const,
+              scriptId: "setup",
+              scriptName: "Setup",
+              terminalId: "setup-setup",
+              cwd: "/tmp/bootstrap-worktree",
+              exitCode: 0,
+              startedAt: "2026-01-01T00:00:00.000Z",
+              finishedAt: "2026-01-01T00:00:01.000Z",
+              logPath: "/tmp/setup.log",
+            };
+          }),
+      );
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitVcsDriver: {
+            createWorktree,
+          },
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                dispatchedCommands.push(command);
+                return { sequence: dispatchedCommands.length };
+              }),
+            readEvents: () => Stream.empty,
+          },
+          projectSetupScriptRunner: {
+            runForThread,
+          },
+        },
+      });
+
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const rpcFiber = yield* Effect.forkChild(
+        Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+              type: "thread.turn.start",
+              commandId: CommandId.make("cmd-bootstrap-await-setup"),
+              threadId: ThreadId.make("thread-bootstrap-await-setup"),
+              message: {
+                messageId: MessageId.make("msg-bootstrap-await-setup"),
+                role: "user",
+                text: "hello",
+                attachments: [],
+              },
+              modelSelection: defaultModelSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              bootstrap: {
+                createThread: {
+                  projectId: defaultProjectId,
+                  title: "Bootstrap Thread",
+                  modelSelection: defaultModelSelection,
+                  runtimeMode: "full-access",
+                  interactionMode: "default",
+                  branch: "main",
+                  worktreePath: null,
+                  createdAt,
+                },
+                prepareWorktree: {
+                  projectCwd: "/tmp/project",
+                  baseBranch: "main",
+                  branch: "t3code/bootstrap-refName",
+                },
+                runSetupScript: true,
+              },
+              createdAt,
+            }),
+          ),
+        ),
+      );
+
+      yield* Deferred.await(setupStarted);
+      assert.equal(
+        dispatchedCommands.some((command) => command.type === "thread.turn.start"),
+        false,
+      );
+      yield* Deferred.succeed(releaseSetup, undefined);
+      yield* Fiber.join(rpcFiber);
+      assert.equal(dispatchedCommands.at(-1)?.type, "thread.turn.start");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
   it.effect(
@@ -8128,7 +8263,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             new ProjectSetupScriptRunner.ProjectSetupScriptOperationError({
               threadId: input.threadId,
               worktreePath: input.worktreePath,
-              operation: "openTerminal",
+              operation: "spawn",
               cause: { message: "pty unavailable" },
             }),
           ),
@@ -8225,16 +8360,32 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       );
       const runForThread = vi.fn(
         (
-          _: Parameters<
+          input: Parameters<
             ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"]["runForThread"]
           >[0],
         ) =>
-          Effect.succeed({
-            status: "started" as const,
-            scriptId: "setup",
-            scriptName: "Setup",
-            terminalId: "setup-setup",
-            cwd: "/tmp/bootstrap-worktree",
+          Effect.gen(function* () {
+            yield* (
+              input.onSpawn?.({
+                scriptId: "setup",
+                scriptName: "Setup",
+                terminalId: "setup-setup",
+                cwd: "/tmp/bootstrap-worktree",
+                logPath: "/tmp/setup.log",
+                startedAt: "2026-01-01T00:00:00.000Z",
+              }) ?? Effect.void
+            );
+            return {
+              status: "succeeded" as const,
+              scriptId: "setup",
+              scriptName: "Setup",
+              terminalId: "setup-setup",
+              cwd: "/tmp/bootstrap-worktree",
+              exitCode: 0,
+              startedAt: "2026-01-01T00:00:00.000Z",
+              finishedAt: "2026-01-01T00:00:01.000Z",
+              logPath: "/tmp/setup.log",
+            };
           }),
       );
       let setupActivityAppendAttempt = 0;
@@ -8314,10 +8465,16 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
 
-      assert.equal(response.sequence, 4);
+      assert.equal(response.sequence, 5);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
-        ["thread.create", "thread.meta.update", "thread.activity.append", "thread.turn.start"],
+        [
+          "thread.create",
+          "thread.meta.update",
+          "thread.activity.append",
+          "thread.activity.append",
+          "thread.turn.start",
+        ],
       );
       const setupActivities = dispatchedCommands.filter(
         (command): command is Extract<OrchestrationCommand, { type: "thread.activity.append" }> =>
@@ -8325,7 +8482,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       );
       assert.deepEqual(
         setupActivities.map((command) => command.activity.kind),
-        ["setup-script.requested"],
+        ["setup-script.requested", "setup-script.succeeded"],
       );
       assertTrue(
         setupActivities.every((command) => command.activity.kind !== "setup-script.failed"),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -82,6 +82,7 @@ import * as ReviewService from "./review/ReviewService.ts";
 import * as SourceControlProviderRegistry from "./sourceControl/SourceControlProviderRegistry.ts";
 import * as SourceControlRateLimit from "./sourceControl/SourceControlRateLimit.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
+import * as ProjectSetupScriptProcess from "./project/ProjectSetupScriptProcess.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
 import { ObservabilityLive } from "./observability/Layers/Observability.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
@@ -285,6 +286,7 @@ const SourceControlProviderRegistryLayerLive = SourceControlProviderRegistry.lay
 
 const GitManagerLayerLive = GitManager.layer.pipe(
   Layer.provideMerge(ProjectSetupScriptRunner.layer),
+  Layer.provideMerge(ProjectSetupScriptProcess.layer),
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
   Layer.provideMerge(TextGeneration.layer),

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -152,6 +152,18 @@ export class TerminalManager extends Context.Service<
     readonly write: (input: TerminalWriteInput) => Effect.Effect<void, TerminalError>;
 
     /**
+     * Append output to a terminal buffer without writing to the PTY.
+     *
+     * Used by setup-script execution so the terminal is a viewer, not the
+     * process that runs the command. Missing sessions are ignored.
+     */
+    readonly appendOutput: (input: {
+      readonly threadId: string;
+      readonly terminalId: string;
+      readonly data: string;
+    }) => Effect.Effect<void>;
+
+    /**
      * Resize the PTY backing a terminal session.
      */
     readonly resize: (input: TerminalResizeInput) => Effect.Effect<void, TerminalError>;
@@ -2487,6 +2499,50 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     );
   };
 
+  const appendOutputLocked: TerminalManager["Service"]["appendOutput"] = Effect.fn(
+    "terminal.appendOutput",
+  )(function* (input) {
+    if (input.data.length === 0) {
+      return;
+    }
+    const session = yield* getSession(input.threadId, input.terminalId);
+    if (Option.isNone(session)) {
+      return;
+    }
+    const liveSession = session.value;
+    const sanitized = sanitizeTerminalHistoryChunk(
+      liveSession.pendingHistoryControlSequence,
+      input.data,
+    );
+    let history: string | null = null;
+    let eventStamp = { updatedAt: liveSession.updatedAt, sequence: liveSession.eventSequence };
+    yield* modifyManagerState((state) => {
+      liveSession.pendingHistoryControlSequence = sanitized.pendingControlSequence;
+      if (sanitized.visibleText.length > 0) {
+        liveSession.history = capHistory(
+          `${liveSession.history}${sanitized.visibleText}`,
+          historyLineLimit,
+        );
+        history = liveSession.history;
+      }
+      eventStamp = advanceEventSequence(liveSession);
+      return [undefined, state] as const;
+    });
+    if (history !== null) {
+      yield* queuePersist(input.threadId, input.terminalId, history);
+    }
+    yield* publishEvent({
+      type: "output",
+      threadId: input.threadId,
+      terminalId: input.terminalId,
+      sequence: eventStamp.sequence,
+      data: input.data,
+    });
+  });
+
+  const appendOutput: TerminalManager["Service"]["appendOutput"] = (input) =>
+    withThreadLock(input.threadId, appendOutputLocked(input));
+
   const write: TerminalManager["Service"]["write"] = Effect.fn("terminal.write")(function* (input) {
     const terminalId = input.terminalId;
     const session = yield* requireSession(input.threadId, terminalId);
@@ -2657,6 +2713,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     open,
     attachStream,
     write,
+    appendOutput,
     resize,
     clear,
     restart,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -48,6 +48,7 @@ import {
   ProjectSearchContentsError,
   ProjectSearchEntriesError,
   ProjectWriteFileError,
+  ProjectRunSetupScriptError,
   ProviderUploadFeedbackError,
   RelayClientInstallFailedError,
   type RelayClientInstallProgressEvent,
@@ -68,6 +69,7 @@ import {
   WsRpcGroup,
 } from "@t3tools/contracts";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import { setupProjectScript } from "@t3tools/shared/projectScripts";
 import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
@@ -633,7 +635,11 @@ const makeWsRpcLayer = (
 
       const appendSetupScriptActivity = (input: {
         readonly threadId: ThreadId;
-        readonly kind: "setup-script.requested" | "setup-script.started" | "setup-script.failed";
+        readonly kind:
+          | "setup-script.requested"
+          | "setup-script.started"
+          | "setup-script.succeeded"
+          | "setup-script.failed";
         readonly summary: string;
         readonly createdAt: string;
         readonly payload: Record<string, unknown>;
@@ -943,6 +949,7 @@ const makeWsRpcLayer = (
             readonly scriptId: string;
             readonly scriptName: string;
             readonly terminalId: string;
+            readonly logPath?: string;
           }) =>
             Effect.gen(function* () {
               const startedAt = yield* nowIso;
@@ -951,6 +958,9 @@ const makeWsRpcLayer = (
                 scriptName: input.scriptName,
                 terminalId: input.terminalId,
                 worktreePath: input.worktreePath,
+                ...(input.logPath === undefined ? {} : { logPath: input.logPath }),
+                status: "running" as const,
+                startedAt,
               };
               yield* Effect.all([
                 appendSetupScriptActivity({
@@ -986,6 +996,44 @@ const makeWsRpcLayer = (
               );
             });
 
+          const recordSetupScriptFinished = (input: {
+            readonly worktreePath: string;
+            readonly result: Extract<
+              ProjectSetupScriptRunner.ProjectSetupScriptRunnerResult,
+              { status: "succeeded" | "failed" }
+            >;
+          }) => {
+            const payload = {
+              scriptId: input.result.scriptId,
+              scriptName: input.result.scriptName,
+              terminalId: input.result.terminalId,
+              worktreePath: input.worktreePath,
+              exitCode: input.result.exitCode,
+              startedAt: input.result.startedAt,
+              finishedAt: input.result.finishedAt,
+              logPath: input.result.logPath,
+              status: input.result.status,
+            };
+            if (input.result.status === "succeeded") {
+              return appendSetupScriptActivity({
+                threadId: command.threadId,
+                kind: "setup-script.succeeded",
+                summary: "Setup script succeeded",
+                createdAt: input.result.finishedAt,
+                payload,
+                tone: "info",
+              }).pipe(Effect.ignoreCause({ log: false }));
+            }
+            return appendSetupScriptActivity({
+              threadId: command.threadId,
+              kind: "setup-script.failed",
+              summary: "Setup script failed",
+              createdAt: input.result.finishedAt,
+              payload,
+              tone: "error",
+            }).pipe(Effect.ignoreCause({ log: false }));
+          };
+
           const runSetupProgram = () =>
             Effect.gen(function* () {
               if (!bootstrap?.runSetupScript || !targetWorktreePath) {
@@ -993,12 +1041,21 @@ const makeWsRpcLayer = (
               }
               const worktreePath = targetWorktreePath;
               const requestedAt = yield* nowIso;
-              yield* projectSetupScriptRunner
+              const run = projectSetupScriptRunner
                 .runForThread({
                   threadId: command.threadId,
                   ...(targetProjectId ? { projectId: targetProjectId } : {}),
                   ...(targetProjectCwd ? { projectCwd: targetProjectCwd } : {}),
                   worktreePath,
+                  onSpawn: (info) =>
+                    recordSetupScriptStarted({
+                      requestedAt,
+                      worktreePath,
+                      scriptId: info.scriptId,
+                      scriptName: info.scriptName,
+                      terminalId: info.terminalId,
+                      logPath: info.logPath,
+                    }),
                 })
                 .pipe(
                   Effect.matchEffect({
@@ -1009,19 +1066,40 @@ const makeWsRpcLayer = (
                         worktreePath,
                       }),
                     onSuccess: (setupResult) => {
-                      if (setupResult.status !== "started") {
+                      if (setupResult.status === "no-script") {
                         return Effect.void;
                       }
-                      return recordSetupScriptStarted({
-                        requestedAt,
+                      return recordSetupScriptFinished({
                         worktreePath,
-                        scriptId: setupResult.scriptId,
-                        scriptName: setupResult.scriptName,
-                        terminalId: setupResult.terminalId,
+                        result: setupResult,
                       });
                     },
                   }),
                 );
+              let shouldAwait = true;
+              const project =
+                targetProjectId !== undefined
+                  ? yield* projectionSnapshotQuery.getProjectShellById(targetProjectId).pipe(
+                      Effect.map(Option.getOrUndefined),
+                      Effect.orElseSucceed(() => undefined),
+                    )
+                  : targetProjectCwd !== undefined
+                    ? yield* projectionSnapshotQuery
+                        .getActiveProjectByWorkspaceRoot(targetProjectCwd)
+                        .pipe(
+                          Effect.map(Option.getOrUndefined),
+                          Effect.orElseSucceed(() => undefined),
+                        )
+                    : undefined;
+              const script = project ? setupProjectScript(project.scripts) : null;
+              if (script) {
+                shouldAwait = script.awaitSetupScript !== false;
+              }
+              if (shouldAwait) {
+                yield* run;
+                return;
+              }
+              yield* Effect.forkDetach(run);
             });
 
           const bootstrapProgram = Effect.gen(function* () {
@@ -2010,6 +2088,115 @@ const makeWsRpcLayer = (
                   }),
               ),
             ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.projectsRunSetupScript]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.projectsRunSetupScript,
+            Effect.gen(function* () {
+              const thread = yield* projectionSnapshotQuery
+                .getThreadShellById(ThreadId.make(input.threadId))
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ProjectRunSetupScriptError({
+                        threadId: input.threadId,
+                        operation: "resolveThread",
+                        cause,
+                      }),
+                  ),
+                );
+              const resolved = Option.getOrUndefined(thread);
+              if (!resolved?.worktreePath) {
+                return yield* new ProjectRunSetupScriptError({
+                  threadId: input.threadId,
+                  operation: "missingWorktree",
+                });
+              }
+              const worktreePath = resolved.worktreePath;
+              const requestedAt = yield* nowIso;
+              return yield* projectSetupScriptRunner
+                .runForThread({
+                  threadId: input.threadId,
+                  projectId: resolved.projectId,
+                  worktreePath,
+                  onSpawn: (info) =>
+                    Effect.all([
+                      appendSetupScriptActivity({
+                        threadId: ThreadId.make(input.threadId),
+                        kind: "setup-script.requested",
+                        summary: "Starting setup script",
+                        createdAt: requestedAt,
+                        payload: {
+                          scriptId: info.scriptId,
+                          scriptName: info.scriptName,
+                          terminalId: info.terminalId,
+                          worktreePath,
+                          logPath: info.logPath,
+                          status: "running",
+                          startedAt: info.startedAt,
+                        },
+                        tone: "info",
+                      }),
+                      appendSetupScriptActivity({
+                        threadId: ThreadId.make(input.threadId),
+                        kind: "setup-script.started",
+                        summary: "Setup script started",
+                        createdAt: info.startedAt,
+                        payload: {
+                          scriptId: info.scriptId,
+                          scriptName: info.scriptName,
+                          terminalId: info.terminalId,
+                          worktreePath,
+                          logPath: info.logPath,
+                          status: "running",
+                          startedAt: info.startedAt,
+                        },
+                        tone: "info",
+                      }),
+                    ]).pipe(Effect.asVoid, Effect.ignoreCause({ log: false })),
+                })
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ProjectRunSetupScriptError({
+                        threadId: input.threadId,
+                        operation: "runSetupScript",
+                        worktreePath,
+                        cause,
+                      }),
+                  ),
+                  Effect.tap((result) => {
+                    if (result.status === "no-script") {
+                      return Effect.void;
+                    }
+                    return appendSetupScriptActivity({
+                      threadId: ThreadId.make(input.threadId),
+                      kind:
+                        result.status === "succeeded"
+                          ? "setup-script.succeeded"
+                          : "setup-script.failed",
+                      summary:
+                        result.status === "succeeded"
+                          ? "Setup script succeeded"
+                          : "Setup script failed",
+                      createdAt: result.finishedAt,
+                      payload: {
+                        scriptId: result.scriptId,
+                        scriptName: result.scriptName,
+                        terminalId: result.terminalId,
+                        worktreePath,
+                        exitCode: result.exitCode,
+                        startedAt: result.startedAt,
+                        finishedAt: result.finishedAt,
+                        logPath: result.logPath,
+                        status: result.status,
+                      },
+                      tone: result.status === "succeeded" ? "info" : "error",
+                    }).pipe(Effect.ignoreCause({ log: false }));
+                  }),
+                );
+            }),
             { "rpc.aggregate": "workspace" },
           ),
         [WS_METHODS.shellOpenInEditor]: (input) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -51,7 +51,11 @@ import {
   resolvePromptInjectedEffort,
 } from "@t3tools/shared/model";
 import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
-import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
+import {
+  projectScriptCwd,
+  projectScriptRuntimeEnv,
+  setupScriptStateFromActivities,
+} from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
 import {
   getTerminalLabel,
@@ -183,6 +187,7 @@ import {
   GitBranchIcon,
   Minimize2Icon,
   PaperclipIcon,
+  WrenchIcon,
   WifiOffIcon,
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
@@ -1280,6 +1285,9 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
+  const runSetupScript = useAtomCommand(projectEnvironment.runSetupScript, {
+    reportFailure: false,
+  });
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
     reportFailure: false,
   });
@@ -4811,6 +4819,33 @@ function ChatViewContent(props: ChatViewProps) {
     isUnsnoozing,
     isUnsettling,
   ]);
+  const [rerunningSetupThreadId, setRerunningSetupThreadId] = useState<string | null>(null);
+  const isRerunningSetup = rerunningSetupThreadId !== null && rerunningSetupThreadId === activeThreadId;
+  const handleRerunSetupScript = useCallback(async () => {
+    if (!activeThreadId) {
+      return;
+    }
+    const threadId = activeThreadId;
+    setRerunningSetupThreadId(threadId);
+    try {
+      const result = await runSetupScript({
+        environmentId,
+        input: { threadId },
+      });
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to rerun setup",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    } finally {
+      setRerunningSetupThreadId((current) => (current === threadId ? null : current));
+    }
+  }, [activeThreadId, environmentId, runSetupScript]);
   // Session-scoped dismissals, one key per (thread, snapshot). A set rather
   // than a single slot so dismissing the banner on one thread does not
   // resurface it on another thread dismissed earlier.
@@ -4912,6 +4947,42 @@ function ChatViewContent(props: ChatViewProps) {
     resumeCompactionPermanentlyDismissed,
     selectedProvider,
   ]);
+  const setupScriptBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
+    const setupScript = setupScriptStateFromActivities(threadActivities);
+    if (!setupScript || setupScript.status === "succeeded" || !activeThreadId) {
+      return null;
+    }
+    const scriptLabel = setupScript.scriptName?.trim() || "Setup script";
+    if (setupScript.status === "running") {
+      return {
+        id: `setup-script-running:${activeThreadId}`,
+        variant: "info",
+        icon: <WrenchIcon />,
+        title: `${scriptLabel} is running`,
+        description: "The first agent turn waits until this finishes.",
+      };
+    }
+    return {
+      id: `setup-script-failed:${activeThreadId}:${setupScript.finishedAt ?? "failed"}`,
+      variant: "error",
+      icon: <WrenchIcon />,
+      title: `${scriptLabel} failed`,
+      description:
+        setupScript.exitCode === null
+          ? "The setup script did not finish successfully."
+          : `Exited with code ${setupScript.exitCode}.`,
+      actions: (
+        <Button
+          size="xs"
+          variant="outline"
+          disabled={isRerunningSetup}
+          onClick={() => void handleRerunSetupScript()}
+        >
+          {isRerunningSetup ? "Rerunning..." : "Rerun setup"}
+        </Button>
+      ),
+    };
+  }, [activeThreadId, handleRerunSetupScript, isRerunningSetup, threadActivities]);
   const handleRestoreThreadBranch = useCallback(() => {
     if (gitStatusQuery.data?.hasWorkingTreeChanges) {
       setBranchRestoreConfirmOpen(true);
@@ -4930,9 +5001,11 @@ function ChatViewContent(props: ChatViewProps) {
       resumeCompactionBannerItem === null ? [] : [resumeCompactionBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
+    const setupScriptItems = setupScriptBannerItem === null ? [] : [setupScriptBannerItem];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
         ...urgentSystemItems,
+        ...setupScriptItems,
         ...backgroundLivenessItems,
         ...calmSystemItems,
         ...resumeCompactionItems,
@@ -4942,6 +5015,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return [
       ...urgentSystemItems,
+      ...setupScriptItems,
       ...backgroundLivenessItems,
       ...calmSystemItems,
       ...resumeCompactionItems,
@@ -4995,6 +5069,7 @@ function ChatViewContent(props: ChatViewProps) {
     localCheckoutBranchMismatch,
     parkedThreadBannerItem,
     resumeCompactionBannerItem,
+    setupScriptBannerItem,
     showBranchMismatchBanner,
     systemComposerBannerItems,
     wokeThreadBannerItem,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -54,6 +54,7 @@ import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
 import {
   projectScriptCwd,
   projectScriptRuntimeEnv,
+  setupProjectScript,
   setupScriptStateFromActivities,
 } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
@@ -4820,7 +4821,8 @@ function ChatViewContent(props: ChatViewProps) {
     isUnsettling,
   ]);
   const [rerunningSetupThreadId, setRerunningSetupThreadId] = useState<string | null>(null);
-  const isRerunningSetup = rerunningSetupThreadId !== null && rerunningSetupThreadId === activeThreadId;
+  const isRerunningSetup =
+    rerunningSetupThreadId !== null && rerunningSetupThreadId === activeThreadId;
   const handleRerunSetupScript = useCallback(async () => {
     if (!activeThreadId) {
       return;
@@ -4954,12 +4956,16 @@ function ChatViewContent(props: ChatViewProps) {
     }
     const scriptLabel = setupScript.scriptName?.trim() || "Setup script";
     if (setupScript.status === "running") {
+      const awaitsSetup =
+        setupProjectScript(activeProject?.scripts ?? [])?.awaitSetupScript !== false;
       return {
         id: `setup-script-running:${activeThreadId}`,
         variant: "info",
         icon: <WrenchIcon />,
         title: `${scriptLabel} is running`,
-        description: "The first agent turn waits until this finishes.",
+        description: awaitsSetup
+          ? "The first agent turn waits until this finishes."
+          : "Setup is still running in the background.",
       };
     }
     return {
@@ -4982,7 +4988,13 @@ function ChatViewContent(props: ChatViewProps) {
         </Button>
       ),
     };
-  }, [activeThreadId, handleRerunSetupScript, isRerunningSetup, threadActivities]);
+  }, [
+    activeProject?.scripts,
+    activeThreadId,
+    handleRerunSetupScript,
+    isRerunningSetup,
+    threadActivities,
+  ]);
   const handleRestoreThreadBranch = useCallback(() => {
     if (gitStatusQuery.data?.hasWorkingTreeChanges) {
       setBranchRestoreConfirmOpen(true);
@@ -5001,12 +5013,18 @@ function ChatViewContent(props: ChatViewProps) {
       resumeCompactionBannerItem === null ? [] : [resumeCompactionBannerItem];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
-    const setupScriptItems = setupScriptBannerItem === null ? [] : [setupScriptBannerItem];
+    const setupScriptFailedItems =
+      setupScriptBannerItem?.variant === "error" ? [setupScriptBannerItem] : [];
+    const setupScriptRunningItems =
+      setupScriptBannerItem !== null && setupScriptBannerItem.variant !== "error"
+        ? [setupScriptBannerItem]
+        : [];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
         ...urgentSystemItems,
-        ...setupScriptItems,
+        ...setupScriptFailedItems,
         ...backgroundLivenessItems,
+        ...setupScriptRunningItems,
         ...calmSystemItems,
         ...resumeCompactionItems,
         ...wokeThreadItems,
@@ -5015,8 +5033,9 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return [
       ...urgentSystemItems,
-      ...setupScriptItems,
+      ...setupScriptFailedItems,
       ...backgroundLivenessItems,
+      ...setupScriptRunningItems,
       ...calmSystemItems,
       ...resumeCompactionItems,
       ...wokeThreadItems,

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -113,6 +113,12 @@ export default function ProjectScriptsControl({
       command: fileScript.command,
       icon: fileScript.icon ?? "play",
       runOnWorktreeCreate: fileScript.runOnWorktreeCreate ?? false,
+      ...(fileScript.awaitSetupScript === undefined
+        ? {}
+        : { awaitSetupScript: fileScript.awaitSetupScript }),
+      ...(fileScript.setupScriptTimeoutMs === undefined
+        ? {}
+        : { setupScriptTimeoutMs: fileScript.setupScriptTimeoutMs }),
       keybinding: null,
       previewUrl: fileScript.previewUrl ?? null,
       autoOpenPreview: fileScript.previewUrl ? (fileScript.autoOpenPreview ?? false) : false,

--- a/apps/web/src/components/projectScriptEditor.tsx
+++ b/apps/web/src/components/projectScriptEditor.tsx
@@ -83,6 +83,8 @@ export interface NewProjectScriptInput {
   previewUrl: string | null;
   /** When true, automatically open the preview panel pointed at `previewUrl`. */
   autoOpenPreview: boolean;
+  awaitSetupScript?: boolean;
+  setupScriptTimeoutMs?: number;
 }
 
 export type ProjectScriptActionResult = AtomCommandResult<void, unknown>;
@@ -119,6 +121,10 @@ export function editorRequestForScript(
       keybinding: keybindingValueForCommand(keybindings, commandForProjectScript(script.id)),
       previewUrl: script.previewUrl ?? null,
       autoOpenPreview: script.autoOpenPreview ?? false,
+      ...(script.awaitSetupScript === undefined ? {} : { awaitSetupScript: script.awaitSetupScript }),
+      ...(script.setupScriptTimeoutMs === undefined
+        ? {}
+        : { setupScriptTimeoutMs: script.setupScriptTimeoutMs }),
     },
   };
 }
@@ -222,6 +228,12 @@ export function ProjectScriptEditorDialog({
         keybinding: keybindingRule?.key ?? null,
         previewUrl: trimmedPreviewUrl.length > 0 ? trimmedPreviewUrl : null,
         autoOpenPreview: trimmedPreviewUrl.length > 0 ? autoOpenPreview : false,
+        ...(request.initial.awaitSetupScript === undefined
+          ? {}
+          : { awaitSetupScript: request.initial.awaitSetupScript }),
+        ...(request.initial.setupScriptTimeoutMs === undefined
+          ? {}
+          : { setupScriptTimeoutMs: request.initial.setupScriptTimeoutMs }),
       } satisfies NewProjectScriptInput;
     } catch (error) {
       setValidationError(error instanceof Error ? error.message : "Failed to save action.");

--- a/apps/web/src/components/projectScriptEditor.tsx
+++ b/apps/web/src/components/projectScriptEditor.tsx
@@ -121,7 +121,9 @@ export function editorRequestForScript(
       keybinding: keybindingValueForCommand(keybindings, commandForProjectScript(script.id)),
       previewUrl: script.previewUrl ?? null,
       autoOpenPreview: script.autoOpenPreview ?? false,
-      ...(script.awaitSetupScript === undefined ? {} : { awaitSetupScript: script.awaitSetupScript }),
+      ...(script.awaitSetupScript === undefined
+        ? {}
+        : { awaitSetupScript: script.awaitSetupScript }),
       ...(script.setupScriptTimeoutMs === undefined
         ? {}
         : { setupScriptTimeoutMs: script.setupScriptTimeoutMs }),

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -643,6 +643,12 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
         keybinding: null,
         previewUrl: fileScript.previewUrl ?? null,
         autoOpenPreview: fileScript.previewUrl ? (fileScript.autoOpenPreview ?? false) : false,
+        ...(fileScript.awaitSetupScript === undefined
+          ? {}
+          : { awaitSetupScript: fileScript.awaitSetupScript }),
+        ...(fileScript.setupScriptTimeoutMs === undefined
+          ? {}
+          : { setupScriptTimeoutMs: fileScript.setupScriptTimeoutMs }),
       };
       const result = await submitScript(null, payload);
       if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {

--- a/apps/web/src/projectScripts.test.ts
+++ b/apps/web/src/projectScripts.test.ts
@@ -3,6 +3,7 @@ import {
   projectScriptCwd,
   projectScriptRuntimeEnv,
   setupProjectScript,
+  setupScriptStateFromActivities,
 } from "@t3tools/shared/projectScripts";
 
 import {
@@ -128,5 +129,25 @@ describe("projectScripts helpers", () => {
         worktreePath: null,
       }),
     ).toBe("/repo");
+  });
+
+  it("resolves setup script status from thread activities", () => {
+    expect(
+      setupScriptStateFromActivities([
+        { kind: "setup-script.started", payload: { scriptName: "Setup" } },
+        {
+          kind: "setup-script.failed",
+          payload: { scriptName: "Setup", exitCode: 1, logPath: "/tmp/setup.log" },
+        },
+      ]),
+    ).toEqual({
+      status: "failed",
+      exitCode: 1,
+      startedAt: null,
+      finishedAt: null,
+      logPath: "/tmp/setup.log",
+      scriptName: "Setup",
+      terminalId: null,
+    });
   });
 });

--- a/apps/web/src/projectScripts.ts
+++ b/apps/web/src/projectScripts.ts
@@ -14,6 +14,8 @@ export interface ProjectScriptInput {
   readonly runOnWorktreeCreate: ProjectScript["runOnWorktreeCreate"];
   readonly previewUrl: Exclude<ProjectScript["previewUrl"], undefined> | null;
   readonly autoOpenPreview: boolean;
+  readonly awaitSetupScript?: ProjectScript["awaitSetupScript"];
+  readonly setupScriptTimeoutMs?: ProjectScript["setupScriptTimeoutMs"];
 }
 
 export function buildProjectScript(id: string, input: ProjectScriptInput): ProjectScript {
@@ -29,6 +31,10 @@ export function buildProjectScript(id: string, input: ProjectScriptInput): Proje
           previewUrl: input.previewUrl,
           autoOpenPreview: input.autoOpenPreview,
         }),
+    ...(input.awaitSetupScript === undefined ? {} : { awaitSetupScript: input.awaitSetupScript }),
+    ...(input.setupScriptTimeoutMs === undefined
+      ? {}
+      : { setupScriptTimeoutMs: input.setupScriptTimeoutMs }),
   };
 }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -880,6 +880,7 @@ export function deriveWorkLogEntries(
     if (activity.kind === "task.updated") continue;
     if (activity.kind === "tool.progress") continue;
     if (activity.kind === "context-window.updated") continue;
+    if (activity.kind.startsWith("setup-script.")) continue;
     if (activity.summary === "Checkpoint captured") continue;
     if (isNoContentRuntimeWarning(activity)) continue;
     if (isPlanBoundaryToolActivity(activity)) continue;

--- a/docs/user/project-scripts.md
+++ b/docs/user/project-scripts.md
@@ -1,0 +1,13 @@
+# Project scripts
+
+Project scripts are shell commands you attach to a project. You can run them from the scripts menu, and one of them can prepare a new thread worktree automatically.
+
+## Worktree setup
+
+Mark a script to run when a thread worktree is created. T3 Code starts that command as its own process in the new worktree (not by typing into a terminal), waits for it to finish, then starts the first agent turn.
+
+If setup fails, the thread shows an error and a **Rerun setup** action. The first turn still proceeds after a failed setup so you can inspect or recover; rerun setup before sending more work if the worktree is incomplete.
+
+You can opt out of waiting so the first turn starts immediately while setup continues. In `t3.json`, set `awaitSetupScript` to `false` on that script. A timeout (ten minutes by default, or `setupScriptTimeoutMs`) fails the setup run loudly instead of hanging forever.
+
+Setup is also idempotent: if the same worktree is asked to run setup twice at once, the second request joins the run already in progress.

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -102,5 +102,14 @@ export function createProjectEnvironmentAtoms<R, E>(
           JSON.stringify([environmentId, input.cwd, input.relativePath]),
       },
     }),
+    runSetupScript: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:projects:run-setup-script",
+      tag: WS_METHODS.projectsRunSetupScript,
+      scheduler: projectScheduler,
+      concurrency: {
+        mode: "singleFlight",
+        key: ({ environmentId, input }) => JSON.stringify([environmentId, input.threadId]),
+      },
+    }),
   };
 }

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -273,6 +273,16 @@ export const ProjectScript = Schema.Struct({
    * the moment this script starts. Ignored without `previewUrl` or on web.
    */
   autoOpenPreview: Schema.optional(Schema.Boolean),
+  /**
+   * When false, the first agent turn may start while the worktree setup
+   * script is still running. Defaults to true: the turn waits for the script.
+   */
+  awaitSetupScript: Schema.optional(Schema.Boolean),
+  /**
+   * Milliseconds to wait for a `runOnWorktreeCreate` script before failing.
+   * Defaults to ten minutes.
+   */
+  setupScriptTimeoutMs: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
 });
 export type ProjectScript = typeof ProjectScript.Type;
 

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -298,3 +298,42 @@ export class ProjectWriteFileError extends Schema.TaggedErrorClass<ProjectWriteF
     } as any);
   }
 }
+
+export const ProjectRunSetupScriptInput = Schema.Struct({
+  threadId: TrimmedNonEmptyString,
+});
+export type ProjectRunSetupScriptInput = typeof ProjectRunSetupScriptInput.Type;
+
+export const ProjectRunSetupScriptResult = Schema.Union([
+  Schema.Struct({
+    status: Schema.Literal("no-script"),
+  }),
+  Schema.Struct({
+    status: Schema.Literals(["succeeded", "failed"]),
+    scriptId: TrimmedNonEmptyString,
+    scriptName: TrimmedNonEmptyString,
+    terminalId: TrimmedNonEmptyString,
+    cwd: TrimmedNonEmptyString,
+    exitCode: Schema.NullOr(Schema.Int),
+    startedAt: TrimmedNonEmptyString,
+    finishedAt: TrimmedNonEmptyString,
+    logPath: TrimmedNonEmptyString,
+  }),
+]);
+export type ProjectRunSetupScriptResult = typeof ProjectRunSetupScriptResult.Type;
+
+export class ProjectRunSetupScriptError extends Schema.TaggedErrorClass<ProjectRunSetupScriptError>()(
+  "ProjectRunSetupScriptError",
+  {
+    threadId: TrimmedNonEmptyString,
+    operation: Schema.Literals(["resolveThread", "missingWorktree", "runSetupScript"]),
+    worktreePath: Schema.optional(TrimmedNonEmptyString),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return this.operation === "missingWorktree"
+      ? `Thread '${this.threadId}' has no worktree to run a setup script in.`
+      : `Setup script operation '${this.operation}' failed for thread '${this.threadId}'.`;
+  }
+}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -127,6 +127,9 @@ import {
   ProjectWriteFileError,
   ProjectWriteFileInput,
   ProjectWriteFileResult,
+  ProjectRunSetupScriptError,
+  ProjectRunSetupScriptInput,
+  ProjectRunSetupScriptResult,
 } from "./project.ts";
 import {
   TerminalAttachInput,
@@ -216,6 +219,7 @@ export const WS_METHODS = {
   projectsSearchContents: "projects.searchContents",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsRunSetupScript: "projects.runSetupScript",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -666,6 +670,12 @@ export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
   error: Schema.Union([ProjectWriteFileError, EnvironmentAuthorizationError]),
 });
 
+export const WsProjectsRunSetupScriptRpc = Rpc.make(WS_METHODS.projectsRunSetupScript, {
+  payload: ProjectRunSetupScriptInput,
+  success: ProjectRunSetupScriptResult,
+  error: Schema.Union([ProjectRunSetupScriptError, EnvironmentAuthorizationError]),
+});
+
 export const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
   payload: LaunchEditorInput,
   error: Schema.Union([ExternalLauncherError, EnvironmentAuthorizationError]),
@@ -1066,6 +1076,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
+  WsProjectsRunSetupScriptRpc,
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
   WsAssetsCreateUrlRpc,

--- a/packages/contracts/src/t3ProjectFile.ts
+++ b/packages/contracts/src/t3ProjectFile.ts
@@ -29,7 +29,8 @@ export const T3ProjectFileScript = Schema.Struct({
     description: "Display name for the script, shown in the T3 Code scripts menu.",
   }),
   command: trimmedNonEmpty({
-    description: "Shell command executed in a T3 Code terminal at the project root.",
+    description:
+      "Shell command to run. Scripts with runOnWorktreeCreate execute as a process in the new worktree; other scripts run in a T3 Code terminal at the project root.",
   }),
   icon: Schema.optionalKey(
     ProjectScriptIcon.annotate({
@@ -39,7 +40,19 @@ export const T3ProjectFileScript = Schema.Struct({
   runOnWorktreeCreate: Schema.optionalKey(
     Schema.Boolean.annotate({
       description:
-        "When true, the script runs automatically after a worktree is created for a new thread.",
+        "When true, the script runs automatically as a process in the new worktree after it is created for a thread. The first agent turn waits until it finishes unless awaitSetupScript is false.",
+    }),
+  ),
+  awaitSetupScript: Schema.optionalKey(
+    Schema.Boolean.annotate({
+      description:
+        "When true (the default), T3 Code waits for this worktree setup script to finish before starting the first agent turn. Set false to start the turn immediately.",
+    }),
+  ),
+  setupScriptTimeoutMs: Schema.optionalKey(
+    Schema.Int.check(Schema.isGreaterThan(0)).annotate({
+      description:
+        "Milliseconds to wait for this worktree setup script before failing it. Defaults to 600000 (10 minutes).",
     }),
   ),
   previewUrl: Schema.optionalKey(

--- a/packages/shared/src/projectScripts.ts
+++ b/packages/shared/src/projectScripts.ts
@@ -35,3 +35,84 @@ export function projectScriptRuntimeEnv(
 export function setupProjectScript(scripts: readonly ProjectScript[]): ProjectScript | null {
   return scripts.find((script) => script.runOnWorktreeCreate) ?? null;
 }
+
+export type SetupScriptStatus = "running" | "succeeded" | "failed";
+
+export interface SetupScriptState {
+  readonly status: SetupScriptStatus;
+  readonly exitCode: number | null;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly logPath: string | null;
+  readonly scriptName: string | null;
+  readonly terminalId: string | null;
+}
+
+const SETUP_SCRIPT_ACTIVITY_KIND = {
+  requested: "setup-script.requested",
+  started: "setup-script.started",
+  succeeded: "setup-script.succeeded",
+  failed: "setup-script.failed",
+} as const;
+
+export function isSetupScriptActivityKind(kind: string): boolean {
+  return kind.startsWith("setup-script.");
+}
+
+export function setupScriptStateFromActivities(
+  activities: ReadonlyArray<{
+    readonly kind: string;
+    readonly payload: unknown;
+  }>,
+): SetupScriptState | null {
+  let state: SetupScriptState | null = null;
+  for (const activity of activities) {
+    if (!isSetupScriptActivityKind(activity.kind)) {
+      continue;
+    }
+    const payload =
+      activity.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : {};
+    const exitCode = typeof payload.exitCode === "number" ? payload.exitCode : null;
+    const startedAt = typeof payload.startedAt === "string" ? payload.startedAt : null;
+    const finishedAt = typeof payload.finishedAt === "string" ? payload.finishedAt : null;
+    const logPath = typeof payload.logPath === "string" ? payload.logPath : null;
+    const scriptName = typeof payload.scriptName === "string" ? payload.scriptName : null;
+    const terminalId = typeof payload.terminalId === "string" ? payload.terminalId : null;
+    if (activity.kind === SETUP_SCRIPT_ACTIVITY_KIND.succeeded) {
+      state = {
+        status: "succeeded",
+        exitCode,
+        startedAt,
+        finishedAt,
+        logPath,
+        scriptName,
+        terminalId,
+      };
+      continue;
+    }
+    if (activity.kind === SETUP_SCRIPT_ACTIVITY_KIND.failed) {
+      state = {
+        status: "failed",
+        exitCode,
+        startedAt,
+        finishedAt,
+        logPath,
+        scriptName,
+        terminalId,
+      };
+      continue;
+    }
+    state = {
+      status: "running",
+      exitCode: null,
+      startedAt,
+      finishedAt: null,
+      logPath,
+      scriptName,
+      terminalId,
+    };
+  }
+  return state;
+}

--- a/packages/shared/src/t3ProjectFile.test.ts
+++ b/packages/shared/src/t3ProjectFile.test.ts
@@ -45,11 +45,13 @@ describe("buildT3ProjectFileJsonSchema", () => {
     expect(script?.required).toEqual(["name", "command"]);
     expect(Object.keys(script?.properties ?? {}).sort()).toEqual([
       "autoOpenPreview",
+      "awaitSetupScript",
       "command",
       "icon",
       "name",
       "previewUrl",
       "runOnWorktreeCreate",
+      "setupScriptTimeoutMs",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Worktree `runOnWorktreeCreate` scripts were typed into a PTY and returned `started` immediately, so shell startup could drop the command and setup never ran.
- Spawn the script as a process in the worktree, stream output into the setup terminal and a log file, persist `running` / `succeeded` / `failed` on the thread, and wait for it before the first agent turn (opt-out via `awaitSetupScript`).
- Surface failures with a **Rerun setup** action on web and mobile; concurrent runs for the same worktree join the in-flight process.

## Test plan
- [ ] Create a thread worktree whose `t3.json` has `runOnWorktreeCreate` (e.g. copy a marker file). Confirm the marker exists and the first agent turn starts only after setup finishes.
- [ ] Fail the setup command and confirm the thread shows an error plus **Rerun setup**, which re-runs the same script.
- [ ] Optional: set `awaitSetupScript: false` and confirm the first turn can start while setup is still running.


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run worktree setup scripts as OS processes
> - Setup scripts execute as real OS processes via a new `ProjectSetupScriptProcess` service in [ProjectSetupScriptProcess.ts](https://github.com/pingdotgg/t3code/pull/8550/files#diff-c489e75dd7bd3c0552e1d96ad58ed1984457ea8d62cd7d01daffe51357ad64e6), replacing PTY commands
> - [ProjectSetupScriptRunner.ts](https://github.com/pingdotgg/t3code/pull/8550/files#diff-7ca99e864eafb76644d30338cec8869844b8c2d62113b7e4b348f829dd12bcf2) runs scripts with a default 10-minute timeout, logs output to a file capped at 1 MiB, and de-duplicates concurrent runs for the same worktree
> - Adds a `projects.runSetupScript` RPC method and UI banners in web and mobile to display setup status and trigger reruns
> - Risk: `ProjectSetupScriptRunnerResult` returns a completed `succeeded`/`failed` status instead of `started`, and `ProjectSetupScriptOperationError` operation labels changed from `openTerminal` to `spawn`; consumers in [server.ts](https://github.com/pingdotgg/t3code/pull/8550/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) and [ws.ts](https://github.com/pingdotgg/t3code/pull/8550/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) are updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd3e80b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->