### PR TITLE
fix(web): preserve zero-based lists when copying markdown

### DIFF
--- a/apps/web/src/markdown-clipboard.test.ts
+++ b/apps/web/src/markdown-clipboard.test.ts
@@ -22,6 +22,7 @@ class FakeElement {
   constructor(
     readonly tagName: string,
     private readonly classNames: ReadonlyArray<string> = [],
+    private readonly attributes: Readonly<Record<string, string>> = {},
   ) {}
 
   get localName(): string {
@@ -32,17 +33,25 @@ class FakeElement {
     return this.childNodes.map((child) => child.textContent).join("");
   }
 
+  get children(): ReadonlyArray<FakeElement> {
+    return this.childNodes.filter((child): child is FakeElement => child instanceof FakeElement);
+  }
+
   append(...children: Array<FakeElement | FakeText>): this {
     this.childNodes.push(...children);
     return this;
   }
 
-  getAttribute(): string | null {
-    return null;
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
   }
 
-  hasAttribute(): boolean {
-    return false;
+  hasAttribute(name: string): boolean {
+    return name in this.attributes;
+  }
+
+  querySelector(): FakeElement | null {
+    return null;
   }
 }
 
@@ -91,5 +100,15 @@ describe("serializeRenderedMarkdownFragment", () => {
     const container = new FakeElement("DIV").append(code);
 
     expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("first line\nsecond line");
+  });
+
+  it("preserves an ordered list that starts at zero", () => {
+    const list = new FakeElement("OL", [], { start: "0" }).append(
+      new FakeElement("LI").append(new FakeText("first")),
+      new FakeElement("LI").append(new FakeText("second")),
+    );
+    const container = new FakeElement("DIV").append(list);
+
+    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("0. first\n1. second");
   });
 });

--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -138,7 +138,8 @@ function serializeListItem(item: Element, ordered: boolean, index: number): stri
 }
 
 function serializeList(list: Element, ordered: boolean): string {
-  const start = Number.parseInt(list.getAttribute("start") ?? "1", 10) || 1;
+  const parsedStart = Number.parseInt(list.getAttribute("start") ?? "1", 10);
+  const start = Number.isNaN(parsedStart) ? 1 : parsedStart;
   const items = [...list.children].filter((child) => child.tagName === "LI");
   if (items.length === 0) return "";
   return `${items.map((item, index) => serializeListItem(item, ordered, start + index)).join("\n")}\n\n`;


### PR DESCRIPTION
## Why

Rendered ordered lists can start at 0. The Markdown clipboard serializer used `Number.parseInt(...) || 1`, so copying a rendered `0., 1.` list produced `1., 2.` in the plain-text clipboard payload.

## What changed

The serializer now falls back to 1 only when it cannot parse the `start` attribute as an integer. A regression test covers `start="0"` and expects `0. first\n1. second`.

## UI changes

None. Rendering is unchanged, so screenshots and video do not apply.

## Verification

- `vp test run apps/web/src/markdown-clipboard.test.ts`
- `vp run --filter @t3tools/web typecheck`
- `vp lint --report-unused-disable-directives apps/web/src/markdown-clipboard.ts apps/web/src/markdown-clipboard.test.ts`
- `vp fmt --check apps/web/src/markdown-clipboard.ts apps/web/src/markdown-clipboard.test.ts`
- `git diff --check`

Built with gpt-daybreak-blue-latest and gpt-5.6-sol via the Codex harness in T3 Code.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not needed because rendering is unchanged
- [x] Video is not needed because there are no animation or interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `start="0"` ordered lists in `serializeList` markdown clipboard
> The `|| 1` fallback on the parsed `start` attribute coerced a valid `0` to `1`. Replaced it with explicit `NaN` handling via `Number.parseInt`, so only non-numeric starts default to `1`.
> - Extended the `FakeElement` test util to support an attributes map, `children` getter, and `querySelector` stub to enable the new test.
> - Added a test asserting an OL with `start="0"` serializes to `0. first\n1. second`.
> - Risk: non-numeric `start` values (e.g. `start="abc"`) still default to `1`, matching prior behavior — verify no callers rely on the old `|| 1` coercion for other falsy values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 979b715.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Clipboard serialization only; rendering is unchanged. Invalid `start` values still default to 1, same as before for non-numeric attributes.
> 
> **Overview**
> Fixes a bug where copying rendered markdown turned **zero-based ordered lists** into `1., 2., …` in the plain-text clipboard payload.
> 
> In `serializeList`, the old `parseInt(...) || 1` logic treated a valid **`start="0"`** as missing and defaulted to 1. Parsing now keeps **0** and only falls back to **1** when the attribute is not a number.
> 
> Tests extend the DOM **`FakeElement`** helper (attributes, `children`, `getAttribute`) and assert an `<ol start="0">` copies as `0. first` / `1. second`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979b715d55ab3f4e99d7ca8464140650d83a46aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ordered lists with a valid starting value of 0 now serialize correctly.
  * Invalid list start attributes continue to fall back to the default starting value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->