### PR TITLE
fix(desktop): support stable Linux URL handler executable

### DIFF
--- a/apps/desktop/src/app/DesktopConfig.ts
+++ b/apps/desktop/src/app/DesktopConfig.ts
@@ -49,6 +49,7 @@ export const DesktopConfig = Config.all({
     Config.withDefault(10_000),
   ),
   appImagePath: trimmedString("APPIMAGE"),
+  linuxUrlHandlerExecutableOverride: trimmedString("T3CODE_LINUX_URL_HANDLER_EXECUTABLE"),
   disableAutoUpdate: optionalBoolean("T3CODE_DISABLE_AUTO_UPDATE"),
   mockUpdates: optionalBoolean("T3CODE_DESKTOP_MOCK_UPDATES"),
   mockUpdateServerPort: Config.port("T3CODE_DESKTOP_MOCK_UPDATE_SERVER_PORT").pipe(

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -47,6 +47,8 @@ describe("DesktopEnvironment", () => {
           T3CODE_DEV_REMOTE_T3_SERVER_ENTRY_PATH: " /remote/server.mjs ",
           T3CODE_OTLP_TRACES_URL: " http://127.0.0.1:4318/v1/traces ",
           T3CODE_OTLP_EXPORT_INTERVAL_MS: "2500",
+          APPIMAGE: "/opt/t3/T3-Code.AppImage",
+          T3CODE_LINUX_URL_HANDLER_EXECUTABLE: " /opt/t3/bin/t3code-nightly ",
         },
       );
 
@@ -79,6 +81,11 @@ describe("DesktopEnvironment", () => {
       assert.deepEqual(environment.commitHashOverride, Option.some("0123456789abcdef"));
       assert.deepEqual(environment.otlpTracesUrl, Option.some("http://127.0.0.1:4318/v1/traces"));
       assert.equal(environment.otlpExportIntervalMs, 2500);
+      assert.deepEqual(environment.appImagePath, Option.some("/opt/t3/T3-Code.AppImage"));
+      assert.deepEqual(
+        environment.linuxUrlHandlerExecutableOverride,
+        Option.some("/opt/t3/bin/t3code-nightly"),
+      );
     }),
   );
 

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -76,6 +76,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly linuxWmClass: string;
     readonly linuxApplicationsDir: string;
     readonly appImagePath: Option.Option<string>;
+    readonly linuxUrlHandlerExecutableOverride: Option.Option<string>;
     readonly userDataDirName: string;
     readonly legacyUserDataDirName: string;
     readonly defaultDesktopSettings: DesktopAppSettings.DesktopSettings;
@@ -230,6 +231,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",
     linuxApplicationsDir,
     appImagePath: config.appImagePath,
+    linuxUrlHandlerExecutableOverride: config.linuxUrlHandlerExecutableOverride,
     userDataDirName,
     legacyUserDataDirName,
     defaultDesktopSettings: DesktopAppSettings.resolveDefaultDesktopSettings(input.appVersion),

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -15,7 +15,21 @@ interface RecordedRegistration {
   readonly directories: string[];
   readonly files: Array<{ readonly path: string; readonly content: string }>;
   readonly commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }>;
+  readonly executableChecks: string[];
 }
+
+const normalizeAbsolutePath = (value: string): string => {
+  const segments: string[] = [];
+  for (const segment of value.split("/")) {
+    if (segment.length === 0 || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return `/${segments.join("/")}`;
+};
 
 const makeEnvironment = (overrides: Record<string, unknown> = {}) =>
   DesktopEnvironment.DesktopEnvironment.of({
@@ -26,7 +40,12 @@ const makeEnvironment = (overrides: Record<string, unknown> = {}) =>
     linuxWmClass: "t3code",
     linuxApplicationsDir: "/home/alice/.local/share/applications",
     appImagePath: Option.some("/home/alice/Applications/T3-Code.AppImage"),
-    path: { join: (...parts: ReadonlyArray<string>) => parts.join("/") },
+    linuxUrlHandlerExecutableOverride: Option.none(),
+    path: {
+      join: (...parts: ReadonlyArray<string>) => parts.join("/"),
+      isAbsolute: (value: string) => value.startsWith("/"),
+      normalize: normalizeAbsolutePath,
+    },
     ...overrides,
   } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]);
 
@@ -51,6 +70,10 @@ const makeHandlerLayer = (
     readonly environment?: Record<string, unknown>;
     readonly xdgMimeExitCode?: number;
     readonly writeError?: PlatformError.PlatformError;
+    readonly executableOverrideMode?: number;
+    readonly executableOverrideType?: FileSystem.File.Type;
+    readonly executableOverrideStatError?: PlatformError.PlatformError;
+    readonly executableOverrideExitCode?: number;
   } = {},
 ) =>
   DesktopLinuxUrlHandler.layer.pipe(
@@ -68,6 +91,29 @@ const makeHandlerLayer = (
               : Effect.sync(() => {
                   recorded.files.push({ path, content });
                 }),
+          stat: (path) =>
+            Effect.sync(() => recorded.executableChecks.push(path)).pipe(
+              Effect.flatMap(() =>
+                input.executableOverrideStatError
+                  ? Effect.fail(input.executableOverrideStatError)
+                  : Effect.succeed({
+                      type: input.executableOverrideType ?? "File",
+                      mtime: Option.none(),
+                      atime: Option.none(),
+                      birthtime: Option.none(),
+                      dev: 0,
+                      ino: Option.none(),
+                      mode: input.executableOverrideMode ?? 0o755,
+                      nlink: Option.none(),
+                      uid: Option.none(),
+                      gid: Option.none(),
+                      rdev: Option.none(),
+                      size: FileSystem.Size(0),
+                      blksize: Option.none(),
+                      blocks: Option.none(),
+                    } satisfies FileSystem.File.Info),
+              ),
+            ),
         }),
         Layer.succeed(
           ChildProcessSpawner.ChildProcessSpawner,
@@ -80,7 +126,13 @@ const makeHandlerLayer = (
               command: childProcess.command,
               args: childProcess.args,
             });
-            return Effect.succeed(mockProcess(input.xdgMimeExitCode ?? 0));
+            return Effect.succeed(
+              mockProcess(
+                childProcess.command === "test"
+                  ? (input.executableOverrideExitCode ?? 0)
+                  : (input.xdgMimeExitCode ?? 0),
+              ),
+            );
           }),
         ),
       ),
@@ -100,6 +152,7 @@ const emptyRecording = (): RecordedRegistration => ({
   directories: [],
   files: [],
   commands: [],
+  executableChecks: [],
 });
 
 describe("DesktopLinuxUrlHandler", () => {
@@ -122,6 +175,29 @@ describe("DesktopLinuxUrlHandler", () => {
     assert.include(entry, "NoDisplay=true");
     assert.notInclude(entry, "StartupWMClass=");
     assert.include(entry, "MimeType=x-scheme-handler/t3code;");
+  });
+
+  it("renders a validated explicit launcher as an unquoted Exec token", () => {
+    const execTarget = "/home/alice/bin/t3code-nightly";
+    assert.isTrue(DesktopLinuxUrlHandler.isSafeUnquotedDesktopEntryExecTarget(execTarget));
+
+    const entry = DesktopLinuxUrlHandler.renderUrlHandlerDesktopEntry({
+      displayName: "T3 Code (Nightly)",
+      execTarget,
+      unquotedExecTarget: true,
+      scheme: "t3code",
+    });
+
+    assert.include(entry, `Exec=${execTarget} %U`);
+    assert.notInclude(entry, `Exec="${execTarget}" %U`);
+
+    const unsafeEntry = DesktopLinuxUrlHandler.renderUrlHandlerDesktopEntry({
+      displayName: "T3 Code (Nightly)",
+      execTarget: "/home/alice/bin/t3 code",
+      unquotedExecTarget: true,
+      scheme: "t3code",
+    });
+    assert.include(unsafeEntry, 'Exec="/home/alice/bin/t3 code" %U');
   });
 
   it("carries structured context on registration errors", () => {
@@ -187,6 +263,88 @@ describe("DesktopLinuxUrlHandler", () => {
         recorded.files[0]?.content,
         `Exec=${DesktopLinuxUrlHandler.escapeDesktopEntryExecArgument(process.execPath)} %U`,
       );
+    });
+  });
+
+  it.effect("keeps an explicit executable stable across registrations", () => {
+    const first = emptyRecording();
+    const restarted = emptyRecording();
+    const executableOverride = Option.some("/home/alice/bin/../bin/t3code-nightly");
+
+    return Effect.gen(function* () {
+      yield* runRegister(first, {
+        environment: { linuxUrlHandlerExecutableOverride: executableOverride },
+      });
+      yield* runRegister(restarted, {
+        environment: {
+          appImagePath: Option.some("/home/alice/Applications/T3-Code-New.AppImage"),
+          linuxUrlHandlerExecutableOverride: executableOverride,
+        },
+      });
+
+      for (const recorded of [first, restarted]) {
+        assert.deepEqual(recorded.executableChecks, ["/home/alice/bin/t3code-nightly"]);
+        assert.include(recorded.files[0]?.content, "Exec=/home/alice/bin/t3code-nightly %U");
+        assert.deepEqual(recorded.commands, [
+          { command: "test", args: ["-x", "/home/alice/bin/t3code-nightly"] },
+          {
+            command: "xdg-mime",
+            args: ["default", "t3code-url-handler.desktop", "x-scheme-handler/t3code"],
+          },
+        ]);
+      }
+    });
+  });
+
+  it.effect("falls back when the executable override is invalid", () => {
+    const relative = emptyRecording();
+    const unsafe = emptyRecording();
+    const notExecutable = emptyRecording();
+    const missing = emptyRecording();
+
+    return Effect.gen(function* () {
+      yield* runRegister(relative, {
+        environment: {
+          linuxUrlHandlerExecutableOverride: Option.some("bin/t3code-nightly"),
+        },
+      });
+      yield* runRegister(notExecutable, {
+        environment: {
+          linuxUrlHandlerExecutableOverride: Option.some("/home/alice/bin/t3code-nightly"),
+        },
+        // A raw mode-bit check would accept this group-only executable, even
+        // when the current user cannot execute it. The effective-user probe
+        // is authoritative.
+        executableOverrideMode: 0o010,
+        executableOverrideExitCode: 1,
+      });
+      yield* runRegister(unsafe, {
+        environment: {
+          linuxUrlHandlerExecutableOverride: Option.some("/home/alice/bin/t3 code"),
+        },
+      });
+      yield* runRegister(missing, {
+        environment: {
+          linuxUrlHandlerExecutableOverride: Option.some("/home/alice/bin/missing"),
+        },
+        executableOverrideStatError: PlatformError.systemError({
+          _tag: "NotFound",
+          module: "FileSystem",
+          method: "stat",
+          pathOrDescriptor: "/home/alice/bin/missing",
+        }),
+      });
+
+      assert.deepEqual(relative.executableChecks, []);
+      assert.deepEqual(unsafe.executableChecks, []);
+      assert.deepEqual(notExecutable.executableChecks, ["/home/alice/bin/t3code-nightly"]);
+      assert.deepEqual(missing.executableChecks, ["/home/alice/bin/missing"]);
+      for (const recorded of [relative, unsafe, notExecutable, missing]) {
+        assert.include(
+          recorded.files[0]?.content,
+          'Exec="/home/alice/Applications/T3-Code.AppImage" %U',
+        );
+      }
     });
   });
 

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -65,18 +65,30 @@ export function escapeDesktopEntryExecArgument(value: string): string {
   return escapeDesktopEntryString(`"${quoted}"`);
 }
 
+// xdg-utils' generic resolver reads the first Exec token without applying the
+// desktop-entry quoting rules. Restrict explicit launcher overrides to a small
+// portable character set so they can be emitted as one unquoted token.
+export function isSafeUnquotedDesktopEntryExecTarget(value: string): boolean {
+  return /^\/[A-Za-z0-9._+/-]+$/.test(value);
+}
+
 // The AppImage integration entry owns the window identity and icon. This
 // hidden URL-only entry must not compete with it for StartupWMClass matching.
 export function renderUrlHandlerDesktopEntry(input: {
   readonly displayName: string;
   readonly execTarget: string;
+  readonly unquotedExecTarget?: boolean;
   readonly scheme: string;
 }): string {
+  const renderedExecTarget =
+    input.unquotedExecTarget && isSafeUnquotedDesktopEntryExecTarget(input.execTarget)
+      ? input.execTarget
+      : escapeDesktopEntryExecArgument(input.execTarget);
   return [
     "[Desktop Entry]",
     "Type=Application",
     `Name=${escapeDesktopEntryString(input.displayName)}`,
-    `Exec=${escapeDesktopEntryExecArgument(input.execTarget)} %U`,
+    `Exec=${renderedExecTarget} %U`,
     "Terminal=false",
     "NoDisplay=true",
     "StartupNotify=false",
@@ -103,16 +115,88 @@ export const make = Effect.gen(function* () {
     URL_HANDLER_DESKTOP_ENTRY_NAME,
   );
 
+  const defaultExecTarget = {
+    path: Option.getOrElse(environment.appImagePath, () => process.execPath),
+    unquoted: false,
+  } as const;
+
+  const resolveExecTarget = Effect.gen(function* () {
+    const override = Option.getOrUndefined(environment.linuxUrlHandlerExecutableOverride);
+    if (override === undefined) {
+      return defaultExecTarget;
+    }
+
+    if (!environment.path.isAbsolute(override)) {
+      yield* logWarning("ignoring invalid URL handler executable override", {
+        scheme,
+        reason: "path-not-absolute",
+      });
+      return defaultExecTarget;
+    }
+    if (override.includes("\0")) {
+      yield* logWarning("ignoring invalid URL handler executable override", {
+        scheme,
+        reason: "path-contains-null",
+      });
+      return defaultExecTarget;
+    }
+
+    const normalizedOverride = environment.path.normalize(override);
+    if (!isSafeUnquotedDesktopEntryExecTarget(normalizedOverride)) {
+      yield* logWarning("ignoring invalid URL handler executable override", {
+        scheme,
+        reason: "path-not-safe-unquoted",
+      });
+      return defaultExecTarget;
+    }
+
+    const executableInfo = yield* fileSystem.stat(normalizedOverride).pipe(
+      Effect.map(Option.some),
+      Effect.orElseSucceed(() => Option.none()),
+    );
+    if (Option.isNone(executableInfo) || executableInfo.value.type !== "File") {
+      yield* logWarning("ignoring invalid URL handler executable override", {
+        scheme,
+        reason: "path-not-file",
+      });
+      return defaultExecTarget;
+    }
+
+    const executableProbe = ChildProcess.make("test", ["-x", normalizedOverride], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    const executableProbeExitCode = yield* spawner.exitCode(executableProbe).pipe(
+      Effect.map(Number),
+      Effect.orElseSucceed(() => 1),
+    );
+    if (executableProbeExitCode !== 0) {
+      yield* logWarning("ignoring invalid URL handler executable override", {
+        scheme,
+        reason: "path-not-executable",
+      });
+      return defaultExecTarget;
+    }
+
+    return { path: normalizedOverride, unquoted: true } as const;
+  });
+
   const writeDesktopEntry = Effect.gen(function* () {
     // Inside the mounted AppImage, process.execPath points at a transient
     // /tmp/.mount_* path — the handler must launch the AppImage itself.
-    const execTarget = Option.getOrElse(environment.appImagePath, () => process.execPath);
+    // A fleet launcher may opt into a stable executable without changing
+    // APPIMAGE, which electron-updater still needs to identify the artifact.
+    // Every launch route must carry the override or the next registration will
+    // intentionally rewrite this entry back to the APPIMAGE/process fallback.
+    const execTarget = yield* resolveExecTarget;
     yield* fileSystem.makeDirectory(environment.linuxApplicationsDir, { recursive: true });
     yield* fileSystem.writeFileString(
       desktopEntryPath,
       renderUrlHandlerDesktopEntry({
         displayName: environment.displayName,
-        execTarget,
+        execTarget: execTarget.path,
+        unquotedExecTarget: execTarget.unquoted,
         scheme,
       }),
     );

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.xdg.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.xdg.test.ts
@@ -1,0 +1,136 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import * as DesktopLinuxUrlHandler from "./DesktopLinuxUrlHandler.ts";
+
+const RUN_XDG_RESOLVER_TEST = process.env.T3CODE_RUN_LINUX_URL_HANDLER_RESOLVER_TEST === "1";
+
+describe.runIf(RUN_XDG_RESOLVER_TEST)("DesktopLinuxUrlHandler xdg resolver", () => {
+  it.effect("remains selected by xdg-mime and GIO after registration and restart", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const liveSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-linux-url-handler-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const xdgConfigHome = path.join(root, "config");
+      const xdgDataHome = path.join(root, "data");
+      const applicationsDir = path.join(xdgDataHome, "applications");
+      const launcherPath = path.join(root, "bin", "t3code-nightly");
+      yield* fileSystem.makeDirectory(homeDirectory, { recursive: true });
+      yield* fileSystem.makeDirectory(path.dirname(launcherPath), { recursive: true });
+      yield* fileSystem.makeDirectory(applicationsDir, { recursive: true });
+      yield* fileSystem.writeFileString(launcherPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      yield* fileSystem.chmod(launcherPath, 0o755);
+
+      const sandboxEnv = {
+        HOME: homeDirectory,
+        XDG_CONFIG_HOME: xdgConfigHome,
+        XDG_DATA_HOME: xdgDataHome,
+        XDG_DATA_DIRS: "/usr/local/share:/usr/share",
+        XDG_CURRENT_DESKTOP: "",
+        DESKTOP_SESSION: "",
+        DE: "",
+        LC_ALL: "C",
+      };
+      const sandboxSpawner = ChildProcessSpawner.make((command) => {
+        if (command._tag !== "StandardCommand") {
+          return liveSpawner.spawn(command);
+        }
+        return liveSpawner.spawn(
+          ChildProcess.make(command.command, command.args, {
+            ...command.options,
+            env: { ...command.options.env, ...sandboxEnv },
+            extendEnv: true,
+          }),
+        );
+      });
+
+      const runSandboxCommand = Effect.fn("desktop.linuxUrlHandler.test.runCommand")(function* (
+        command: string,
+        args: ReadonlyArray<string>,
+      ) {
+        const handle = yield* liveSpawner.spawn(
+          ChildProcess.make(command, args, {
+            env: sandboxEnv,
+            extendEnv: true,
+          }),
+        );
+        const output = yield* handle.all.pipe(Stream.decodeText(), Stream.mkString);
+        const exitCode = Number(yield* handle.exitCode);
+        return { exitCode, output };
+      });
+
+      const makeEnvironment = (appImagePath: string) =>
+        DesktopEnvironment.DesktopEnvironment.of({
+          platform: "linux",
+          isPackaged: true,
+          isDevelopment: false,
+          displayName: "T3 Code (Nightly)",
+          linuxWmClass: "t3code",
+          linuxApplicationsDir: applicationsDir,
+          appImagePath: Option.some(appImagePath),
+          linuxUrlHandlerExecutableOverride: Option.some(launcherPath),
+          path,
+        } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]);
+
+      const register = (appImagePath: string) =>
+        DesktopLinuxUrlHandler.make.pipe(
+          Effect.provideService(
+            DesktopEnvironment.DesktopEnvironment,
+            makeEnvironment(appImagePath),
+          ),
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, sandboxSpawner),
+          Effect.flatMap((handler) => handler.register),
+        );
+
+      const verifyResolvers = Effect.gen(function* () {
+        const desktopEntryPath = path.join(
+          applicationsDir,
+          DesktopLinuxUrlHandler.URL_HANDLER_DESKTOP_ENTRY_NAME,
+        );
+        const desktopEntry = yield* fileSystem.readFileString(desktopEntryPath);
+        assert.include(desktopEntry, `Exec=${launcherPath} %U`);
+        assert.notInclude(desktopEntry, `Exec="${launcherPath}" %U`);
+
+        const validation = yield* runSandboxCommand("desktop-file-validate", [desktopEntryPath]);
+        assert.equal(validation.exitCode, 0, validation.output);
+        const databaseUpdate = yield* runSandboxCommand("update-desktop-database", [
+          applicationsDir,
+        ]);
+        assert.equal(databaseUpdate.exitCode, 0, databaseUpdate.output);
+
+        const xdgQuery = yield* runSandboxCommand("xdg-mime", [
+          "query",
+          "default",
+          "x-scheme-handler/t3code",
+        ]);
+        assert.equal(xdgQuery.exitCode, 0, xdgQuery.output);
+        assert.equal(xdgQuery.output.trim(), DesktopLinuxUrlHandler.URL_HANDLER_DESKTOP_ENTRY_NAME);
+
+        const gioQuery = yield* runSandboxCommand("gio", ["mime", "x-scheme-handler/t3code"]);
+        assert.equal(gioQuery.exitCode, 0, gioQuery.output);
+        const defaultApplication = gioQuery.output
+          .split("\n")
+          .find((line) => line.startsWith("Default application"));
+        assert.include(defaultApplication, DesktopLinuxUrlHandler.URL_HANDLER_DESKTOP_ENTRY_NAME);
+      });
+
+      yield* register(path.join(root, "T3-Code.AppImage"));
+      yield* verifyResolvers;
+      yield* register(path.join(root, "T3-Code-New.AppImage"));
+      yield* verifyResolvers;
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});


### PR DESCRIPTION
## What Changed

- add `T3CODE_LINUX_URL_HANDLER_EXECUTABLE` as an explicit Linux-only URL-handler launcher override
- validate the override as an absolute, executable file whose normalized path is safe as one unquoted desktop-entry `Exec` token
- keep `APPIMAGE` unchanged so electron-updater still identifies the installed artifact
- preserve `%U` forwarding and the existing quoted fallback for `APPIMAGE` / `process.execPath`

## Why

On Yoga, the generic `xdg-utils` resolver read the first token of a quoted desktop-entry `Exec` value without applying desktop-entry quoting. A callback entry that pointed directly at the AppImage therefore failed even though the target existed.

This lets packaged Linux installations register a stable wrapper path without overloading `APPIMAGE`. The override is accepted only when it is absolute, normalizes to the deliberately narrow safe character set, names a regular file, and passes an `X_OK` probe. Invalid overrides fall back to the current behavior with a reason-coded warning.

The override is an every-launch invariant: if a later launch omits it, registration intentionally returns to the normal AppImage/process fallback.

## Verification

- 15 focused unit/config tests
- real `xdg-mime` / GIO registration and restart test
- lint and formatting checks
- desktop typecheck
- diff check

Reviewed candidate: `e2d214d1cdb7a56848d44cdd0bcee6837af59421`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

No UI is changed, so screenshots or interaction video do not apply. This candidate has not been activated on a live installation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linux-only, best-effort URL handler registration with strict validation and fallback; no auth or data-path changes.
> 
> **Overview**
> Adds **`T3CODE_LINUX_URL_HANDLER_EXECUTABLE`** so packaged Linux builds can register a **stable wrapper** for `t3code://` handling without changing **`APPIMAGE`** (still used for electron-updater).
> 
> **`DesktopLinuxUrlHandler`** now picks the desktop entry `Exec` via **`resolveExecTarget`**: when the override is set, it must be an absolute path that normalizes to a **safe unquoted** token, refer to a regular file, and pass **`test -x`**; valid overrides are written as `Exec=/path/to/launcher %U` so **xdg-utils** resolves the first token correctly. Invalid or missing overrides log reason-coded warnings and keep the existing **quoted AppImage / `process.execPath`** fallback. The override must be present on every launch or registration reverts to that fallback.
> 
> Tests cover env wiring, unquoted vs quoted rendering, stability across AppImage path changes, fallback cases, and an opt-in **`T3CODE_RUN_LINUX_URL_HANDLER_RESOLVER_TEST=1`** integration check against **xdg-mime** and **GIO**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d214d1cdb7a56848d44cdd0bcee6837af59421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `linuxUrlHandlerExecutableOverride` to Linux URL handler registration
> - Adds `linuxUrlHandlerExecutableOverride` to `DesktopConfig`, sourced from `T3CODE_LINUX_URL_HANDLER_EXECUTABLE` via `trimmedString`, and propagates it through the `DesktopEnvironment` service.
> - `DesktopLinuxUrlHandler.make` now validates the override path (absolute, no NULs, safe for unquoted `Exec`, exists via `fileSystem.stat`, executable via `test -x`) and renders it as an unquoted `Exec` token in the desktop entry.
> - When the override is missing or invalid, registration logs a structured warning and falls back to `APPIMAGE` or `process.execPath` with quoting, as before.
> - Behavioral Change: when an override is provided, registration now performs a filesystem `stat` and spawns `test -x`; invalid overrides fall back rather than fail. Reviewers should check the validation logic in [DesktopLinuxUrlHandler.ts](https://github.com/pingdotgg/t3code/pull/8553/files#diff-504ebe51e9dfd4ae2551fe7de89cc99cac2fc37ae741fb4a2ccace15c8b81187) and the new `Option.Option<string>` field in [DesktopEnvironment.ts](https://github.com/pingdotgg/t3code/pull/8553/files#diff-c5eb157ffd36e7b8e67ed02141144a70cf475a58fa222a4465107c2d9600e194).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2d214d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->