### PR TITLE
fix(server): treat Bitbucket permissions 404 as a removed endpoint

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -894,6 +894,25 @@ layer("BitbucketPullRequestApi.layer", (it) => {
       }),
   );
 
+  it.effect(
+    "reads a removed permissions endpoint that answers 404 as granted rather than failing the merge",
+    () =>
+      Effect.gen(function* () {
+        mockedRequest.mockReturnValue(
+          Effect.fail(
+            new BitbucketApi.BitbucketResponseError({
+              operation: "request",
+              status: 404,
+              responseBodyLength: 0,
+            }),
+          ),
+        );
+        const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+        assert.isTrue(yield* api.getRepositoryPermission({ repository: "acme/web" }));
+      }),
+  );
+
   it.effect("still fails the permission read on a failure that is not the removed endpoint", () =>
     Effect.gen(function* () {
       mockedRequest.mockReturnValue(

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -111,11 +111,12 @@ export type BitbucketPullRequestApiError =
 /**
  * `/user/permissions/repositories` answering CHANGE-2770's removal notice rather than a
  * permission — Bitbucket sends this for every account now, not only ones it would have refused.
+ * Cloud answers 404. The original CHANGE-2770 notice was 410.
  */
 function isRepositoryPermissionRemovedError(
   error: BitbucketPullRequestApiError,
 ): error is BitbucketApi.BitbucketResponseError {
-  return error._tag === "BitbucketResponseError" && error.status === 410;
+  return error._tag === "BitbucketResponseError" && (error.status === 410 || error.status === 404);
 }
 
 /**
@@ -578,12 +579,13 @@ export const make = Effect.gen(function* () {
     // may do, so this endpoint is the one request Bitbucket makes unavoidable. It is asked
     // alongside the reads the detail was already making, so it costs no round trip of its own.
     //
-    // Bitbucket permanently removed this endpoint (CHANGE-2770): every account now gets HTTP 410
-    // in place of an answer, whatever it may do. That is the deprecated-endpoint signal, not a
-    // permission being refused, so it is read the same way an unreachable read already is
-    // elsewhere — as a permission that could not be learned, which grants rather than blocks, and
-    // leaves the actual merge or write to say why if the account may not do it. Any other failure
-    // (a bad token, a network fault, an unreadable body) still fails as it did before.
+    // Bitbucket permanently removed this endpoint (CHANGE-2770): every account now gets HTTP 404
+    // (or 410, from the original removal notice) in place of an answer, whatever it may do. That
+    // is the deprecated-endpoint signal, not a permission being refused, so it is read the same
+    // way an unreachable read already is elsewhere — as a permission that could not be learned,
+    // which grants rather than blocks, and leaves the actual merge or write to say why if the
+    // account may not do it. Any other failure (a bad token, a network fault, an unreadable body)
+    // still fails as it did before.
     getRepositoryPermission: (input) =>
       withRepository(input.repository, () =>
         readPage({


### PR DESCRIPTION
## What Changed

`isRepositoryPermissionRemovedError` now treats HTTP 404 the same as HTTP 410 on `GET /user/permissions/repositories`. Merge no longer dies in the permission gate when Bitbucket Cloud answers 404 for the removed endpoint.

401 and other real failures still fail.

## Why

[#6525](https://github.com/pingdotgg/t3code/pull/6525) already treats CHANGE-2770's 410 as "endpoint gone, do not block, let the merge call decide." Cloud now returns 404 for the same URL. The catch never fires, so merge fails with `Bitbucket returned HTTP 404`.

Closes #8328

## Blast Radius

Bitbucket permission reads only. GitHub and GitLab are untouched. A 404 on this one retired endpoint is treated as unknown permission, same as 410 already was. A bad token still fails.

## Verification

Failing-then-passing regression in `apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts`.

- Before the fix, the new 404 case failed with `Bitbucket returned HTTP 404.`
- After the fix, that file is 44/44 passing. The existing 410 and 401 cases still pass.
- `vp lint` on the two changed files: 0 errors.
- `vp run --filter t3 typecheck`: no errors in the changed file.

No UI chrome changed, so no screenshots.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI change (screenshots not applicable)
- [x] No motion change (video not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Bitbucket repository permission reads; only widens the “removed endpoint” catch to 404, matching existing 410 semantics without relaxing real auth failures.
> 
> **Overview**
> Bitbucket Cloud now returns **HTTP 404** (not only **410**) for the retired `GET /user/permissions/repositories` endpoint. **`isRepositoryPermissionRemovedError`** treats **404** like **410**, so **`getRepositoryPermission`** still resolves to granted when the endpoint is gone instead of surfacing `Bitbucket returned HTTP 404` and blocking merge.
> 
> Comments document the Cloud vs original CHANGE-2770 behavior. A regression test asserts a **404** on that URL yields `true`; **401** and other failures are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8662e6feaf2a606db9894572a0afdb9955ca6f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat Bitbucket permissions endpoint 404 as removed in `isRepositoryPermissionRemovedError`
> Bitbucket Cloud now returns 404 (in addition to the original 410) for the removed repository-permissions endpoint. `isRepositoryPermissionRemovedError` in [BitbucketPullRequestApi.ts](https://github.com/pingdotgg/t3code/pull/8557/files#diff-b8db316b58d8493059f93e4d1bec9cbf008091ccb14abcf8a88defe4de2fc842) is broadened to classify both statuses as the removed-endpoint signal, so `getRepositoryPermission` still resolves `true` instead of failing the merge.
> - Risk: any unrelated 404 from this Bitbucket endpoint will now be silently treated as "permission granted" rather than surfacing as an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8662e6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->