### PR TITLE
fix(release): preserve resource monitor executable modes

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,14 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "executableFiles": [
+      "dist/resource-monitor/darwin-arm64/t3-resource-monitor",
+      "dist/resource-monitor/darwin-x64/t3-resource-monitor",
+      "dist/resource-monitor/linux-arm64/t3-resource-monitor",
+      "dist/resource-monitor/linux-x64/t3-resource-monitor"
+    ]
+  },
   "scripts": {
     "dev": "node --watch src/bin.ts",
     "build:bundle": "vp pack && vp pack src/service-launcher.ts --out-dir dist --no-clean",

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -15,7 +15,6 @@ import {
   resolveWebAssetBrandForPackageVersion,
   resolveWebIconOverrides,
 } from "../../../scripts/lib/brand-assets.ts";
-import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
 import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
 import { fromYaml } from "@t3tools/shared/schemaYaml";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
@@ -28,22 +27,7 @@ import {
   ServerCliPublishIconSourceMissingError,
   ServerCliPublishIconTargetMissingError,
 } from "./cliErrors.ts";
-
-interface PackageJson {
-  name: string;
-  repository: {
-    type: string;
-    url: string;
-    directory: string;
-  };
-  bin: Record<string, string>;
-  type: string;
-  version: string;
-  engines: Record<string, string>;
-  files: string[];
-  dependencies: Record<string, string>;
-  overrides: Record<string, string>;
-}
+import { createServerCliPublishPackageJson } from "./cliManifest.ts";
 
 const PackageJsonPrettyJson = fromJsonStringPretty(Schema.Unknown);
 const encodePackageJson = Schema.encodeEffect(PackageJsonPrettyJson);
@@ -241,25 +225,12 @@ const publishCmd = Command.make(
           const workspaceConfig = yield* readWorkspaceConfig();
           const workspaceCatalog = workspaceConfig.catalog ?? {};
           const workspaceOverrides = workspaceConfig.overrides ?? {};
-          const pkg: PackageJson = {
-            name: serverPackageJson.name,
-            repository: serverPackageJson.repository,
-            bin: serverPackageJson.bin,
-            type: serverPackageJson.type,
+          const pkg = createServerCliPublishPackageJson({
+            source: serverPackageJson,
             version,
-            engines: serverPackageJson.engines,
-            files: serverPackageJson.files,
-            dependencies: resolveCatalogDependencies(
-              serverPackageJson.dependencies,
-              workspaceCatalog,
-              "apps/server",
-            ),
-            overrides: resolveCatalogDependencies(
-              workspaceOverrides,
-              workspaceCatalog,
-              "apps/server",
-            ),
-          };
+            workspaceCatalog,
+            workspaceOverrides,
+          });
 
           return {
             packageJsonString: yield* encodePackageJson(pkg),

--- a/apps/server/scripts/cliManifest.test.ts
+++ b/apps/server/scripts/cliManifest.test.ts
@@ -1,0 +1,126 @@
+import * as NodeProcess from "node:process";
+import * as NodeZlib from "node:zlib";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import serverPackageJson from "../package.json" with { type: "json" };
+import { createServerCliPublishPackageJson } from "./cliManifest.ts";
+
+const RESOURCE_MONITOR_EXECUTABLES = [
+  "dist/resource-monitor/darwin-arm64/t3-resource-monitor",
+  "dist/resource-monitor/darwin-x64/t3-resource-monitor",
+  "dist/resource-monitor/linux-arm64/t3-resource-monitor",
+  "dist/resource-monitor/linux-x64/t3-resource-monitor",
+];
+const encodeUnknownJson = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+
+function readTarField(header: Uint8Array, start: number, end: number): string {
+  const field = header.subarray(start, end);
+  const nullOffset = field.indexOf(0);
+  return field
+    .subarray(0, nullOffset === -1 ? field.length : nullOffset)
+    .toString()
+    .trim();
+}
+
+function readTarModes(tarball: Uint8Array): ReadonlyMap<string, number> {
+  const archive = NodeZlib.gunzipSync(tarball);
+  const modes = new Map<string, number>();
+
+  for (let offset = 0; offset + 512 <= archive.length; ) {
+    const header = archive.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = readTarField(header, 0, 100);
+    const modeText = readTarField(header, 100, 108);
+    const sizeText = readTarField(header, 124, 136);
+    const mode = Number.parseInt(modeText, 8);
+    const size = Number.parseInt(sizeText, 8);
+
+    modes.set(name, mode & 0o777);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+
+  return modes;
+}
+
+describe("CLI publish manifest", () => {
+  it("marks POSIX resource monitors as executable", () => {
+    assert.deepStrictEqual(
+      serverPackageJson.publishConfig.executableFiles,
+      RESOURCE_MONITOR_EXECUTABLES,
+    );
+  });
+
+  it("retains executable file metadata in the generated publish manifest", () => {
+    const manifest = createServerCliPublishPackageJson({
+      source: { ...serverPackageJson, dependencies: {} },
+      version: "1.2.3",
+      workspaceCatalog: {},
+      workspaceOverrides: {},
+    });
+
+    assert.deepStrictEqual(manifest.publishConfig.executableFiles, RESOURCE_MONITOR_EXECUTABLES);
+  });
+
+  it.effect("packs every POSIX resource monitor with executable mode", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fixtureDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-resource-monitor-pack-",
+      });
+      const outputDir = path.join(fixtureDir, "packed");
+
+      yield* fileSystem.makeDirectory(outputDir);
+      yield* fileSystem.writeFileString(
+        path.join(fixtureDir, "package.json"),
+        encodeUnknownJson({
+          name: "t3-resource-monitor-pack-fixture",
+          version: "1.0.0",
+          packageManager: "pnpm@11.10.0",
+          files: ["dist"],
+          publishConfig: serverPackageJson.publishConfig,
+        }),
+      );
+
+      for (const executable of RESOURCE_MONITOR_EXECUTABLES) {
+        const executablePath = path.join(fixtureDir, executable);
+        yield* fileSystem.makeDirectory(path.dirname(executablePath), { recursive: true });
+        yield* fileSystem.writeFileString(executablePath, "fixture\n");
+        yield* fileSystem.chmod(executablePath, 0o644);
+      }
+
+      const vpExecutable = path.resolve(
+        import.meta.dirname,
+        "../../../node_modules/vite-plus/bin/vp",
+      );
+      const child = yield* spawner.spawn(
+        ChildProcess.make(
+          NodeProcess.execPath,
+          [vpExecutable, "pm", "pack", "--pack-destination", outputDir],
+          {
+            cwd: fixtureDir,
+            stdout: "inherit",
+            stderr: "inherit",
+          },
+        ),
+      );
+      assert.equal(yield* child.exitCode, 0);
+
+      const [tarballName] = yield* fileSystem.readDirectory(outputDir);
+      assert.ok(tarballName);
+      const modes = readTarModes(yield* fileSystem.readFile(path.join(outputDir, tarballName)));
+      for (const executable of RESOURCE_MONITOR_EXECUTABLES) {
+        assert.equal(modes.get(`package/${executable}`), 0o755, executable);
+      }
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/scripts/cliManifest.ts
+++ b/apps/server/scripts/cliManifest.ts
@@ -1,0 +1,50 @@
+import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
+
+export interface ServerCliPublishPackageJson {
+  readonly name: string;
+  readonly repository: {
+    readonly type: string;
+    readonly url: string;
+    readonly directory: string;
+  };
+  readonly bin: Readonly<Record<string, string>>;
+  readonly type: string;
+  readonly version: string;
+  readonly engines: Readonly<Record<string, string>>;
+  readonly files: ReadonlyArray<string>;
+  readonly dependencies: Readonly<Record<string, string>>;
+  readonly overrides: Readonly<Record<string, string>>;
+  readonly publishConfig: {
+    readonly executableFiles: ReadonlyArray<string>;
+  };
+}
+
+type ServerCliPackageSource = Omit<ServerCliPublishPackageJson, "version" | "overrides">;
+
+export function createServerCliPublishPackageJson(input: {
+  readonly source: ServerCliPackageSource;
+  readonly version: string;
+  readonly workspaceCatalog: Record<string, string>;
+  readonly workspaceOverrides: Record<string, string>;
+}): ServerCliPublishPackageJson {
+  return {
+    name: input.source.name,
+    repository: input.source.repository,
+    bin: input.source.bin,
+    type: input.source.type,
+    version: input.version,
+    engines: input.source.engines,
+    files: input.source.files,
+    dependencies: resolveCatalogDependencies(
+      input.source.dependencies,
+      input.workspaceCatalog,
+      "apps/server",
+    ),
+    overrides: resolveCatalogDependencies(
+      input.workspaceOverrides,
+      input.workspaceCatalog,
+      "apps/server",
+    ),
+    publishConfig: input.source.publishConfig,
+  };
+}


### PR DESCRIPTION
## Summary

- preserve executable modes for every supported POSIX resource-monitor sidecar during pnpm packaging
- cover the shipped macOS and Linux binaries plus non-shipped `linux-arm64` parity
- add a packaging regression test that runs real `pnpm pack` and verifies tar modes remain `0755`

## Root cause

Fleet inspection found the `.1195` and `.1209` npm-installed resource-monitor sidecars at mode `0644`, while the AppImage copy remained `0755`. The release package's `publishConfig.executableFiles` did not list these sidecars, so pnpm did not preserve executable mode in the npm tarball.

## Verification

- 3 focused release packaging tests, including real `pnpm pack`/tar assertions for `0755`
- release tooling typecheck
- lint
- format check
- diff check
- independent Tier 2 review: PASS WITH RISKS; exact-candidate closure OK

This PR does not publish a release or deploy anything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release packaging and publish-manifest wiring only; no runtime auth, data, or service behavior changes.
> 
> **Overview**
> Fixes npm-installed **resource-monitor** sidecars shipping as non-executable (`0644`) by declaring all four POSIX `t3-resource-monitor` paths under **`publishConfig.executableFiles`** in `apps/server/package.json`, so pnpm preserves **`0755`** in the published tarball.
> 
> Publish flow now builds the temporary manifest via **`createServerCliPublishPackageJson`** in `cliManifest.ts`, which copies **`publishConfig`** from the source package (along with catalog-resolved deps/overrides) instead of assembling publish JSON inline in `cli.ts`.
> 
> Adds **`cliManifest.test.ts`** to lock the executable list, assert the generated publish manifest keeps it, and run a real **`vp pm pack`** regression that inspects tar entry modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd77f6411a530cdca3ed0afac310667acfe1c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve executable file modes for resource monitor binaries in publish manifest
> - Adds `publishConfig.executableFiles` to [package.json](https://github.com/pingdotgg/t3code/pull/8558/files#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2) listing four POSIX `t3-resource-monitor` binaries for darwin-arm64/x64 and linux-arm64/x64
> - Introduces `createServerCliPublishPackageJson` in [cliManifest.ts](https://github.com/pingdotgg/t3code/pull/8558/files#diff-21022fdd0f2917e6165c71fe90d723af07f6dce91e891d4e0afe5dfaf10fab14) to build the publish manifest while copying `publishConfig` from the source package
> - Replaces inline manifest construction in [cli.ts](https://github.com/pingdotgg/t3code/pull/8558/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) with the new factory so `executableFiles` survives into the packed tarball
> - Adds tests in [cliManifest.test.ts](https://github.com/pingdotgg/t3code/pull/8558/files#diff-33fbe6ffc8fdec443ce1a75756dcb74a9459b60e1c86e20878814a3c23115c45) verifying the manifest retains `executableFiles` and that `vite-plus pm pack` produces mode `0755` for those files
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfd77f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->