### PR TITLE
fix(web): preserve provider options when switching models

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1662,6 +1662,34 @@ describe("composerDraftStore sticky composer settings", () => {
     expect(useComposerDraftStore.getState().stickyActiveProvider).toBe("codex");
   });
 
+  it("restores each provider's sticky options when switching providers", () => {
+    const store = useComposerDraftStore.getState();
+    const threadId = ThreadId.make("thread-sticky-provider-switch");
+    const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+
+    store.setStickyModelSelection(
+      modelSelection(CODEX_DRIVER, "gpt-5.4", { reasoningEffort: "high" }),
+    );
+    store.setStickyModelSelection(
+      modelSelection(CLAUDE_AGENT_DRIVER, "claude-opus-4-6", { effort: "max" }),
+    );
+
+    store.setModelSelection(threadRef, modelSelection(CLAUDE_AGENT_DRIVER, "claude-opus-4-6"));
+    store.setStickyModelSelection(modelSelection(CLAUDE_AGENT_DRIVER, "claude-opus-4-6"));
+    store.setModelSelection(threadRef, modelSelection(CODEX_DRIVER, "gpt-5.4"));
+    store.setStickyModelSelection(modelSelection(CODEX_DRIVER, "gpt-5.4"));
+
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.modelSelectionByProvider).toEqual({
+      codex: modelSelection(CODEX_DRIVER, "gpt-5.4", { reasoningEffort: "high" }),
+      claudeAgent: modelSelection(CLAUDE_AGENT_DRIVER, "claude-opus-4-6", { effort: "max" }),
+    });
+    expect(useComposerDraftStore.getState().stickyModelSelectionByProvider).toEqual({
+      codex: modelSelection(CODEX_DRIVER, "gpt-5.4", { reasoningEffort: "high" }),
+      claudeAgent: modelSelection(CLAUDE_AGENT_DRIVER, "claude-opus-4-6", { effort: "max" }),
+    });
+    expect(useComposerDraftStore.getState().stickyActiveProvider).toBe(CODEX_INSTANCE);
+  });
+
   it("normalizes empty sticky model options by dropping selection options", () => {
     const store = useComposerDraftStore.getState();
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -2605,9 +2605,17 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             if (!normalized) {
               return state;
             }
+            const nextSelection =
+              normalized.options !== undefined
+                ? normalized
+                : createModelSelection(
+                    normalized.instanceId,
+                    normalized.model,
+                    state.stickyModelSelectionByProvider[normalized.instanceId]?.options,
+                  );
             const nextMap: Partial<Record<ProviderInstanceId, ModelSelection>> = {
               ...state.stickyModelSelectionByProvider,
-              [normalized.instanceId]: normalized,
+              [normalized.instanceId]: nextSelection,
             };
             if (Equal.equals(state.stickyModelSelectionByProvider, nextMap)) {
               return state.stickyActiveProvider === normalized.instanceId
@@ -2727,7 +2735,9 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const base = existing ?? createEmptyThreadDraft();
             const nextMap = { ...base.modelSelectionByProvider };
             if (normalized) {
-              const current = nextMap[normalized.instanceId];
+              const current =
+                nextMap[normalized.instanceId] ??
+                state.stickyModelSelectionByProvider[normalized.instanceId];
               if (normalized.options !== undefined || opts?.replaceOptions) {
                 // Explicit options provided (or the caller passed a complete
                 // snapshot whose absent options mean "no options") → use the


### PR DESCRIPTION
## Problem

Switching providers replaced that provider’s sticky model selection with an option-less selection. Returning from Claude to Codex could therefore erase a saved reasoning effort such as High and fall back to the model default, Low.

## Fix

Preserve existing provider-specific options when updating a sticky model selection without explicit options. When a draft has no selection for the newly active provider, restore that provider’s sticky options instead.

Add regression coverage for switching between Codex and Claude while retaining both providers’ saved options.

## Verification

- `vp test run apps/web/src/composerDraftStore.test.ts` — 81 passed
- targeted formatting and lint checks
- `vp run --filter @t3tools/web typecheck`

## UI changes

No visual changes. Before this fix, Codex → Claude → Codex could change the saved reasoning effort from High to Low. After the fix, High is restored.

Built with gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized composer draft store logic with regression tests; no API or auth changes, only how per-provider model options are merged on switch.
> 
> **Overview**
> Fixes composer draft state so **provider-specific model options** (e.g. Codex reasoning effort, Claude effort) are not dropped when you switch providers or update a sticky selection without passing options again.
> 
> **`setStickyModelSelection`** now reuses the existing sticky entry’s options when the incoming selection has no `options` field, instead of overwriting with a bare provider+model pair.
> 
> **`setModelSelection`** uses the same fallback: if the thread draft has no selection for that provider yet, it pulls options from **`stickyModelSelectionByProvider`** before merging, so returning to Codex after Claude restores High instead of defaulting to Low.
> 
> Adds a regression test that alternates Codex and Claude and asserts both providers keep their saved options in the draft and sticky maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5840b4674bb90c3bc3b96c908ec85943ce4061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `composerDraftStore` to preserve provider options when switching models
> - `setStickyModelSelection` now reuses existing sticky options from `state.stickyModelSelectionByProvider[instanceId]` when an incoming selection has no options, instead of overwriting with an options-less entry
> - `setModelSelection` now falls back to the sticky selection for that provider when no per-thread selection exists, preserving options across provider switches
> - Adds a test in [composerDraftStore.test.ts](https://github.com/pingdotgg/t3code/pull/8560/files#diff-61714da43700c6105d471eadf7c6f4e80aee8189d14bed8e4362b66dded855e1) verifying sticky options are preserved when switching between `codex` and `claudeAgent` providers
> - Behavioral Change: calling `setStickyModelSelection` or `setModelSelection` without options now retains previously stored options rather than dropping them
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b5840b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->