### PR TITLE
fix(server): do not HTTP-probe unknown local listeners

### DIFF
--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -84,11 +84,13 @@ const TestPortDiscoveryLive = PortScanner.layer.pipe(
   ),
 );
 
-const LSOF_TEST_PORT = 43_123;
+const LSOF_TEST_PORT = 5173;
+const FOREIGN_LISTENER_PORT = 63_261;
 
 const makeLsofScannerLayer = (input: {
   readonly pid: () => number;
   readonly fetch: typeof globalThis.fetch;
+  readonly port?: number;
 }) =>
   PortScanner.layer.pipe(
     Layer.provide(
@@ -96,7 +98,7 @@ const makeLsofScannerLayer = (input: {
         Layer.succeed(ProcessRunner.ProcessRunner, {
           run: () =>
             Effect.succeed({
-              stdout: `p${input.pid()}\ncnode\nn*:${LSOF_TEST_PORT}\n`,
+              stdout: `p${input.pid()}\ncnode\nn*:${input.port ?? LSOF_TEST_PORT}\n`,
               stderr: "",
               code: null,
               timedOut: false,
@@ -242,6 +244,54 @@ effectIt.layer(TestPortDiscoveryLive)("PortDiscovery integration (TCP probe fall
       expect(received).toContain(port);
     }),
   );
+});
+
+effectIt.effect(
+  "does not HTTP-probe a discovered listener that is not a curated port or a T3 terminal",
+  () => {
+    const requests: string[] = [];
+    const fetchFn = ((input: Parameters<typeof globalThis.fetch>[0]) => {
+      requests.push(String(input));
+      return Promise.resolve(new Response("hello", { headers: { "content-type": "text/html" } }));
+    }) as typeof globalThis.fetch;
+    const layer = makeLsofScannerLayer({
+      pid: () => 9999,
+      port: FOREIGN_LISTENER_PORT,
+      fetch: fetchFn,
+    });
+
+    return Effect.gen(function* () {
+      const scanner = yield* PortScanner.PortDiscovery;
+      expect(yield* scanner.scan()).toEqual([]);
+      expect(requests).toEqual([]);
+    }).pipe(Effect.provide(layer));
+  },
+);
+
+effectIt.effect("HTTP-probes a high-numbered listener owned by a registered T3 terminal", () => {
+  const requests: string[] = [];
+  const fetchFn = ((input: Parameters<typeof globalThis.fetch>[0]) => {
+    requests.push(String(input));
+    return Promise.resolve(new Response("hello", { headers: { "content-type": "text/html" } }));
+  }) as typeof globalThis.fetch;
+  const layer = makeLsofScannerLayer({
+    pid: () => 9999,
+    port: FOREIGN_LISTENER_PORT,
+    fetch: fetchFn,
+  });
+
+  return Effect.gen(function* () {
+    const scanner = yield* PortScanner.PortDiscovery;
+    yield* scanner.registerTerminalProcesses({
+      threadId: "thread-preview",
+      terminalId: "term-1",
+      processIds: [9999],
+    });
+    const servers = yield* scanner.scan();
+    expect(servers).toHaveLength(1);
+    expect(servers[0]?.port).toBe(FOREIGN_LISTENER_PORT);
+    expect(requests[0]).toBe(`http://localhost:${FOREIGN_LISTENER_PORT}/`);
+  }).pipe(Effect.provide(layer));
 });
 
 effectIt.effect("revalidates a successful HTML probe after its cache entry expires", () => {

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -9,7 +9,10 @@
  * the shared Net service.
  *
  * Listening ports are published only after a bounded HTTP(S) probe finds a
- * successful HTML document or a redirect to one.
+ * successful HTML document or a redirect to one. Discovered listeners are
+ * probed only when they sit on a curated dev port, belong to a registered T3
+ * terminal, or were named in a configured Preview URL. Other sockets are left
+ * alone so binary RPC listeners are not sent HTTP.
  * Positive and negative results are cached briefly by candidate URL and listener identity,
  * limiting repeated requests without leaving stale classifications around.
  *
@@ -69,6 +72,9 @@ export class PortDiscovery extends Context.Service<
 export const COMMON_DEV_PORTS: ReadonlyArray<number> = Object.freeze([
   3000, 3001, 3333, 4173, 4200, 4321, 5000, 5173, 5174, 5175, 5500, 8000, 8080, 8081, 8888, 9000,
 ]);
+
+const isEligibleDiscoveredWebProbe = (server: DiscoveredLocalServer): boolean =>
+  COMMON_DEV_PORTS.includes(server.port) || server.terminal !== null;
 
 const POLL_INTERVAL = Duration.seconds(3);
 const LSOF_TIMEOUT_MS = 5_000;
@@ -379,6 +385,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     }
 
     for (const server of servers) {
+      if (!isEligibleDiscoveredWebProbe(server)) continue;
       groups.push({
         server,
         urls: [`http://${server.host}:${server.port}`, `https://${server.host}:${server.port}`],


### PR DESCRIPTION
## What Changed

`PortDiscovery` still HTTP-probes listeners so Preview can hide MySQL and Redis. It no longer GETs every local TCP socket.

A discovered listener is probed only when it is a curated dev port, a registered T3 terminal PID, or a configured Preview URL.

## Why

[#6021](https://github.com/pingdotgg/t3code/pull/6021) added HTML probes to classify servers. The classification is correct, but the probe itself writes HTTP onto unrelated binary listeners. #8407 reproduces that against thinkorswim's JxBrowser RPC socket: `lsof` finds a random high port, T3 sends `GET /` over HTTP then HTTPS, and the other app crashes during login.

Configured Preview URLs and ordinary Vite/webpack ports still get probed.

Closes #8407

## Blast Radius

Preview port discovery on macOS and Linux `lsof`, and the Windows listener scan. Non-HTTP services on curated ports are still probed, then excluded, same as today. Random system listeners are left untouched.

## Verification

Failing-then-passing regression in `apps/server/src/preview/PortScanner.test.ts`.

- Before the fix, a listener on port 63261 was returned after an HTTP GET.
- After the fix, that file is 21/21 passing. The same listener is probed when its PID is registered as a T3 terminal.
- `vp lint` on the two changed files: 0 errors.
- `vp run --filter t3 typecheck`: no errors in the changed file.

No UI chrome changed, so no screenshots.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI change (screenshots not applicable)
- [x] No motion change (video not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview port-scan behavior on macOS/Linux and Windows fallback paths; misclassification could hide a dev server on a non-curated port, but configured URLs and terminal PIDs still get probed.
> 
> **Overview**
> Preview port discovery no longer sends HTTP(S) GET probes to every TCP listener `lsof` finds on macOS/Linux. **Discovered** sockets are probed only when they sit on a **curated dev port** (e.g. Vite/webpack) or belong to a **registered T3 terminal** PID; configured Preview URLs are still probed as before.
> 
> This avoids writing HTTP onto unrelated binary/RPC listeners (e.g. random high ports from other apps) while keeping normal dev-server and terminal-owned port discovery. Tests cover a high port with no probe until `registerTerminalProcesses` maps the PID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abaad2bf9eede942ef42fc189250099a0af32a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip HTTP probing for unknown local listeners in `PortDiscovery.scan`
> Discovered listeners are now only HTTP-probed when on a curated dev port, owned by a registered T3 terminal, or named in a configured Preview URL. Adds `isEligibleDiscoveredWebProbe` in [PortScanner.ts](https://github.com/pingdotgg/t3code/pull/8561/files#diff-0f6b3292e660acf982893ba130c26e1ffa8f91ff09032cce9b07d55074e296f4) to gate probe URL construction and avoid sending HTTP to binary RPC listeners.
> - Tests in [PortScanner.test.ts](https://github.com/pingdotgg/t3code/pull/8561/files#diff-98bc68e3fec0e5eecd2296d96c5534119745d09603b318b5c1f35045a7325af9) verify the no-probe path for foreign listeners and the probe path for terminal-owned high-numbered ports
> - Behavioral Change: non-eligible discovered listeners are no longer probed and will not appear in `PortDiscovery.scan()` results
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abaad2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->