### PR TITLE
feat(mobile): show linked dev servers on mobile

### DIFF
--- a/apps/mobile/src/components/AppSymbol.tsx
+++ b/apps/mobile/src/components/AppSymbol.tsx
@@ -138,6 +138,7 @@ const ANDROID_ICON_BY_SF_SYMBOL: Partial<Record<SFSymbol, Icon>> = {
   "folder.badge.plus": IconFolderPlus,
   "folder.fill": IconFolder,
   gearshape: IconSettings,
+  globe: IconWorld,
   "info.circle": IconInfoCircle,
   laptopcomputer: IconDeviceLaptop,
   link: IconLink,

--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -14,6 +14,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeHeaderToolbar } from "../../native/StackHeader";
 import { useCallback, useMemo } from "react";
 import { Alert } from "react-native";
+import { devServerDescription, devServerLabel, type ResolvedDevServer } from "../../lib/devServers";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import {
   basename,
@@ -70,6 +71,7 @@ type ThreadGitHeaderActionItems = {
   readonly terminal: HeaderItem;
   readonly files: HeaderItem;
   readonly git: HeaderItem;
+  readonly devServers: HeaderItem | null;
 };
 type QuickActionIcon =
   | "arrow.down.circle"
@@ -99,6 +101,8 @@ type ThreadGitControlsProps = ThreadGitMenuProps & {
   readonly canOpenFiles: boolean;
   readonly projectScripts: ReadonlyArray<ProjectScript>;
   readonly terminalSessions: ReadonlyArray<TerminalMenuSession>;
+  readonly devServers: ReadonlyArray<ResolvedDevServer>;
+  readonly onOpenDevServer: (server: ResolvedDevServer) => Promise<void>;
   readonly showActionControls?: boolean;
   readonly showDirectFileControl?: boolean;
   readonly onOpenTerminal: (terminalId?: string | null) => void;
@@ -251,6 +255,29 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 
   return useMemo(
     () => ({
+      devServers:
+        props.devServers.length === 0
+          ? null
+          : {
+              accessibilityLabel: "Open dev server",
+              icon: { name: "globe", type: "sfSymbol" },
+              identifier: "thread-right-dev-servers",
+              label: "Dev servers",
+              menu: {
+                items: props.devServers.map((resolved) => ({
+                  description: devServerDescription(resolved),
+                  disabled: !resolved.reachable,
+                  icon: { name: "globe", type: "sfSymbol" as const },
+                  label: devServerLabel(resolved.server),
+                  onPress: () => void props.onOpenDevServer(resolved),
+                  type: "action" as const,
+                })),
+                title: "Dev servers",
+              },
+              sharesBackground: true,
+              type: "menu",
+              variant: "plain",
+            },
       terminal: {
         accessibilityLabel: "Open terminal",
         disabled: !props.canOpenTerminal,
@@ -380,7 +407,9 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
       model.runQuickAction,
       props.canOpenFiles,
       props.canOpenTerminal,
+      props.devServers,
       props.gitStatus,
+      props.onOpenDevServer,
       props.onOpenNewTerminal,
       props.onOpenTerminal,
       props.onRunProjectScript,
@@ -393,7 +422,13 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.git, actionItems.files, actionItems.terminal] as HeaderItems,
+    () =>
+      [
+        ...(actionItems.devServers ? [actionItems.devServers] : []),
+        actionItems.git,
+        actionItems.files,
+        actionItems.terminal,
+      ] as HeaderItems,
     [actionItems],
   );
 }
@@ -401,7 +436,13 @@ export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): Hea
 export function useThreadGitCenterHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
   return useMemo(
-    () => [actionItems.files, actionItems.git, actionItems.terminal] as HeaderItems,
+    () =>
+      [
+        ...(actionItems.devServers ? [actionItems.devServers] : []),
+        actionItems.files,
+        actionItems.git,
+        actionItems.terminal,
+      ] as HeaderItems,
     [actionItems],
   );
 }
@@ -423,6 +464,23 @@ export function ThreadGitControls(props: ThreadGitControlsProps) {
           onPress={props.auxiliaryPaneControl.onPress}
           separateBackground
         />
+      ) : null}
+      {showActionControls && props.devServers.length > 0 ? (
+        <NativeHeaderToolbar.Menu icon="globe" separateBackground>
+          {props.devServers.map((resolved) => (
+            <NativeHeaderToolbar.MenuAction
+              key={`${resolved.server.host}:${resolved.server.port}`}
+              icon="globe"
+              disabled={!resolved.reachable}
+              onPress={() => void props.onOpenDevServer(resolved)}
+              subtitle={devServerDescription(resolved)}
+            >
+              <NativeHeaderToolbar.Label>
+                {devServerLabel(resolved.server)}
+              </NativeHeaderToolbar.Label>
+            </NativeHeaderToolbar.MenuAction>
+          ))}
+        </NativeHeaderToolbar.Menu>
       ) : null}
       {showActionControls ? (
         <NativeHeaderToolbar.Menu

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -38,6 +38,8 @@ import {
   type AndroidHeaderAction,
 } from "../../components/AndroidScreenHeader";
 import { LoadingScreen } from "../../components/LoadingScreen";
+import { resolveDevServerUrl, type ResolvedDevServer } from "../../lib/devServers";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { scopedThreadKey } from "../../lib/scopedEntities";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { connectionTone } from "../connection/connectionTone";
@@ -47,6 +49,8 @@ import {
   useRemoteConnectionStatus,
   useRemoteEnvironmentRuntime,
 } from "../../state/use-remote-environment-registry";
+import { useThreadDevServers } from "../../state/preview";
+import { usePreparedConnection } from "../../state/session";
 import { useKnownTerminalSessions } from "../../state/use-terminal-session";
 import { useSelectedThreadDetailState } from "../../state/use-thread-detail";
 import { useThreadSelection } from "../../state/use-thread-selection";
@@ -625,6 +629,39 @@ function ThreadRouteContent(
       terminalMenuSessions,
     ],
   );
+  const linkedDevServers = useThreadDevServers({
+    environmentId: selectedThread?.environmentId ?? null,
+    threadId: selectedThread?.id ?? null,
+  });
+  const preparedConnection = usePreparedConnection(selectedThread?.environmentId ?? null);
+  const devServers = useMemo(() => {
+    const httpBaseUrl = Option.isSome(preparedConnection)
+      ? preparedConnection.value.httpBaseUrl
+      : null;
+    return linkedDevServers.map((server) => resolveDevServerUrl(httpBaseUrl, server));
+  }, [linkedDevServers, preparedConnection]);
+
+  // Header item factories are stabilized by source text, so a menu that was
+  // empty while discovery was still running cannot reapply itself. Version the
+  // native options on the resolved servers instead.
+  const devServersOptionsVersion = useMemo(
+    () => devServers.map((entry) => `${entry.url}:${entry.reachable}`),
+    [devServers],
+  );
+
+  const handleOpenDevServer = useCallback(async (resolved: ResolvedDevServer) => {
+    if (!resolved.reachable) {
+      Alert.alert(
+        "Dev server unreachable",
+        "This dev server cannot be reached from this device over the current connection.",
+      );
+      return;
+    }
+    if (!(await tryOpenExternalUrl(resolved.url, "dev-server"))) {
+      Alert.alert("Unable to open dev server", "The dev server URL could not be opened.");
+    }
+  }, []);
+
   const threadGitControlProps = {
     environmentId: environmentIdRaw ?? "",
     threadId: threadId ?? "",
@@ -650,6 +687,8 @@ function ThreadRouteContent(
         )
       : [],
     terminalSessions: terminalMenuSessions,
+    devServers,
+    onOpenDevServer: handleOpenDevServer,
     showDirectFileControl: layout.usesSplitView,
     onOpenTerminal: handleOpenTerminal,
     onOpenNewTerminal: handleOpenNewTerminal,
@@ -725,6 +764,16 @@ function ThreadRouteContent(
         onPress: () => handleOpenTerminal(null),
       });
     }
+    if (devServers.length > 0) {
+      // Android's in-flow header has no menus, so mirror the web sidebar
+      // globe: one tap opens the first reachable linked dev server.
+      const firstReachable = devServers.find((resolved) => resolved.reachable) ?? devServers[0]!;
+      actions.push({
+        accessibilityLabel: "Open dev server",
+        icon: "globe",
+        onPress: () => void handleOpenDevServer(firstReachable),
+      });
+    }
     actions.push({
       accessibilityLabel: "Open git controls",
       icon: "point.topleft.down.curvedto.point.bottomright.up",
@@ -739,7 +788,9 @@ function ThreadRouteContent(
     }
     return actions;
   }, [
+    devServers,
     fileInspector.supported,
+    handleOpenDevServer,
     handleOpenFilesInspector,
     handleOpenTerminal,
     handleOpenGitInspector,
@@ -898,7 +949,7 @@ function ThreadRouteContent(
     <>
       {activeInspectorRenderer ? <InspectorPaneRoleActivation /> : null}
       <NativeStackScreenOptions
-        optionsVersion={threadGitControlProps.projectScripts}
+        optionsVersion={[threadGitControlProps.projectScripts, devServersOptionsVersion]}
         options={{
           // Android draws its own in-flow header (AndroidScreenHeader below);
           // the native stack header stays iOS-only.

--- a/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
+++ b/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
@@ -1,0 +1,85 @@
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { memo, useCallback, useMemo } from "react";
+import { Alert, Pressable } from "react-native";
+import * as Option from "effect/Option";
+
+import { SymbolView } from "../../components/AppSymbol";
+import { devServerLabel, resolveDevServerUrl } from "../../lib/devServers";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
+import { useThreadDevServers } from "../../state/preview";
+import { usePreparedConnection } from "../../state/session";
+import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
+
+// Matches the web sidebar's emerald globe. Theme variables carry no accent
+// green, so the pair is inlined the way the row's PR label inlines its own.
+const GLOBE_TINT_BY_APPEARANCE = {
+  light: "#059669",
+  dark: "#34d399",
+} as const;
+
+/**
+ * The thread row's linked dev server glyph, mirroring the web sidebar globe.
+ * Renders nothing until one of the thread's terminals owns a listening
+ * server. Tapping opens the first reachable one.
+ */
+export const ThreadDevServerIndicator = memo(function ThreadDevServerIndicator(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+}) {
+  const { environmentId, threadId } = props;
+  const servers = useThreadDevServers({ environmentId, threadId });
+  const preparedConnection = usePreparedConnection(environmentId);
+  const { themeAppearance } = useAppearancePreferences();
+
+  const resolved = useMemo(() => {
+    const httpBaseUrl = Option.isSome(preparedConnection)
+      ? preparedConnection.value.httpBaseUrl
+      : null;
+    return servers.map((server) => resolveDevServerUrl(httpBaseUrl, server));
+  }, [preparedConnection, servers]);
+
+  const target = useMemo(
+    () => resolved.find((entry) => entry.reachable) ?? resolved[0] ?? null,
+    [resolved],
+  );
+
+  const handlePress = useCallback(async () => {
+    if (target === null) return;
+    if (!target.reachable) {
+      Alert.alert(
+        "Dev server unreachable",
+        "This dev server cannot be reached from this device over the current connection.",
+      );
+      return;
+    }
+    if (!(await tryOpenExternalUrl(target.url, "dev-server"))) {
+      Alert.alert("Unable to open dev server", "The dev server URL could not be opened.");
+    }
+  }, [target]);
+
+  if (target === null) {
+    return null;
+  }
+
+  const extraCount = resolved.length - 1;
+  return (
+    <Pressable
+      accessibilityLabel={
+        extraCount > 0
+          ? `Open ${devServerLabel(target.server)} (+${extraCount} more)`
+          : `Open ${devServerLabel(target.server)}`
+      }
+      accessibilityRole="button"
+      hitSlop={10}
+      onPress={() => void handlePress()}
+      style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+    >
+      <SymbolView
+        name="globe"
+        size={13}
+        tintColor={GLOBE_TINT_BY_APPEARANCE[themeAppearance === "dark" ? "dark" : "light"]}
+        type="monochrome"
+      />
+    </Pressable>
+  );
+});

--- a/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
+++ b/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
@@ -68,8 +68,8 @@ export const ThreadDevServerIndicator = memo(function ThreadDevServerIndicator(p
         !target.reachable
           ? `${devServerLabel(target.server)} is not reachable over this connection`
           : extraCount > 0
-          ? `Open ${devServerLabel(target.server)} (+${extraCount} more)`
-          : `Open ${devServerLabel(target.server)}`
+            ? `Open ${devServerLabel(target.server)} (+${extraCount} more)`
+            : `Open ${devServerLabel(target.server)}`
       }
       accessibilityRole="button"
       hitSlop={10}

--- a/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
+++ b/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
@@ -73,7 +73,10 @@ export const ThreadDevServerIndicator = memo(function ThreadDevServerIndicator(p
       }
       accessibilityRole="button"
       hitSlop={10}
-      onPress={() => void handlePress()}
+      onPress={(event) => {
+        event.stopPropagation();
+        void handlePress();
+      }}
       style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
     >
       <SymbolView

--- a/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
+++ b/apps/mobile/src/features/threads/thread-dev-server-indicator.tsx
@@ -65,7 +65,9 @@ export const ThreadDevServerIndicator = memo(function ThreadDevServerIndicator(p
   return (
     <Pressable
       accessibilityLabel={
-        extraCount > 0
+        !target.reachable
+          ? `${devServerLabel(target.server)} is not reachable over this connection`
+          : extraCount > 0
           ? `Open ${devServerLabel(target.server)} (+${extraCount} more)`
           : `Open ${devServerLabel(target.server)}`
       }

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -30,6 +30,8 @@ import { buildThreadTitleRegenerationMenuItems } from "./thread-title-regenerati
 import { QueuedMessageIcon } from "./queued-message-icon";
 import { resolveThreadStatus } from "./threadPresentation";
 import { ThreadSearchMatchExcerpt } from "./thread-search-match";
+import { ThreadDevServerIndicator } from "./thread-dev-server-indicator";
+import { useThreadDevServers } from "../../state/preview";
 
 /**
  * Shared presentation for the thread lists: the compact (phone) Home list and
@@ -487,6 +489,10 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   } = props;
   const status = resolveThreadStatus(thread);
   const pr = useThreadPr(thread);
+  const devServerCount = useThreadDevServers({
+    environmentId: thread.environmentId,
+    threadId: thread.id,
+  }).length;
   const timestamp = relativeTime(
     thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt,
   );
@@ -569,7 +575,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   ) : null;
 
   const subtitleRow =
-    subtitleParts.length > 0 || pr !== null ? (
+    subtitleParts.length > 0 || pr !== null || devServerCount > 0 ? (
       <View className="mt-px flex-row items-center gap-1.5">
         {subtitleParts.length > 0 ? (
           <>
@@ -598,6 +604,9 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
               {subtitleParts.join(" · ")}
             </Text>
           </>
+        ) : null}
+        {devServerCount > 0 ? (
+          <ThreadDevServerIndicator environmentId={thread.environmentId} threadId={thread.id} />
         ) : null}
         {pr !== null ? (
           <View className="flex-row items-center gap-0.5">

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -18,6 +18,7 @@ import { EnvironmentMachineSymbol } from "../../components/EnvironmentMachineSym
 import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { cn } from "../../lib/cn";
+import { ThreadDevServerIndicator } from "./thread-dev-server-indicator";
 import { relativeTime } from "../../lib/time";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
@@ -816,6 +817,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         ) : (
           <View className="flex-1" />
         )}
+        <ThreadDevServerIndicator environmentId={thread.environmentId} threadId={thread.id} />
         {pr ? (
           <Text
             accessibilityLabel={pr.accessibilityLabel}

--- a/apps/mobile/src/lib/devServers.test.ts
+++ b/apps/mobile/src/lib/devServers.test.ts
@@ -1,0 +1,72 @@
+import type { DiscoveredLocalServer } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { devServerDescription, devServerLabel, resolveDevServerUrl } from "./devServers";
+
+function server(overrides: Partial<DiscoveredLocalServer> = {}): DiscoveredLocalServer {
+  return {
+    host: "127.0.0.1",
+    port: 5173,
+    url: "http://localhost:5173/",
+    processName: "node",
+    pid: 4242,
+    terminal: null,
+    ...overrides,
+  } as DiscoveredLocalServer;
+}
+
+describe("resolveDevServerUrl", () => {
+  it("rewrites loopback URLs onto a LAN environment host", () => {
+    const resolved = resolveDevServerUrl("http://192.168.1.20:4600", server());
+    expect(resolved.url).toBe("http://192.168.1.20:5173/");
+    expect(resolved.reachable).toBe(true);
+  });
+
+  it("rewrites loopback URLs onto a tailnet environment host", () => {
+    const resolved = resolveDevServerUrl("https://laptop.tail1234.ts.net", server());
+    expect(resolved.url).toBe("http://laptop.tail1234.ts.net:5173/");
+    expect(resolved.reachable).toBe(true);
+  });
+
+  it("brackets IPv6 environment hosts", () => {
+    const resolved = resolveDevServerUrl("http://[fd7a:115c:a1e0::1]:4600", server());
+    expect(resolved.url).toBe("http://[fd7a:115c:a1e0::1]:5173/");
+    expect(resolved.reachable).toBe(true);
+  });
+
+  it("keeps loopback URLs when the environment itself is loopback", () => {
+    const resolved = resolveDevServerUrl("http://localhost:4600", server());
+    expect(resolved.url).toBe("http://localhost:5173/");
+    expect(resolved.reachable).toBe(true);
+  });
+
+  it("marks servers behind a public tunnel host unreachable", () => {
+    const resolved = resolveDevServerUrl("https://box.tunnel.t3.codes", server());
+    expect(resolved.reachable).toBe(false);
+  });
+
+  it("marks servers unreachable while the environment connection is unknown", () => {
+    expect(resolveDevServerUrl(null, server()).reachable).toBe(false);
+  });
+
+  it("passes non-loopback discovered URLs through untouched", () => {
+    const resolved = resolveDevServerUrl(
+      "https://box.tunnel.t3.codes",
+      server({ url: "http://192.168.1.30:8080/admin" }),
+    );
+    expect(resolved.url).toBe("http://192.168.1.30:8080/admin");
+    expect(resolved.reachable).toBe(true);
+  });
+});
+
+describe("dev server presentation", () => {
+  it("labels servers by port and describes them by process", () => {
+    expect(devServerLabel(server())).toBe("localhost:5173");
+    expect(devServerDescription({ server: server(), url: "http://x/", reachable: true })).toBe(
+      "node",
+    );
+    expect(devServerDescription({ server: server(), url: "http://x/", reachable: false })).toBe(
+      "Not reachable over this connection",
+    );
+  });
+});

--- a/apps/mobile/src/lib/devServers.ts
+++ b/apps/mobile/src/lib/devServers.ts
@@ -1,0 +1,64 @@
+import { isLocalLoopbackHost, isPrivateNetworkHost } from "@t3tools/shared/hostClassification";
+import type { DiscoveredLocalServer } from "@t3tools/contracts";
+import {
+  isLoopbackHost,
+  normalizePreviewUrl,
+} from "@t3tools/shared/preview";
+
+export interface ResolvedDevServer {
+  readonly server: DiscoveredLocalServer;
+  readonly url: string;
+  readonly reachable: boolean;
+}
+
+/**
+ * Rewrite a dev server's loopback URL onto the environment host so this
+ * device can reach it. The phone is never the machine the server scanned, so
+ * `localhost:PORT` only works after substituting the address the environment
+ * is connected through (LAN IP, tailnet name, …). Marked unreachable when the
+ * environment is only reachable through a public host such as a tunnel, which
+ * does not forward arbitrary dev ports.
+ */
+export function resolveDevServerUrl(
+  httpBaseUrl: string | null,
+  server: DiscoveredLocalServer,
+): ResolvedDevServer {
+  try {
+    const parsed = new URL(normalizePreviewUrl(server.url));
+    if (!isLoopbackHost(parsed.hostname)) {
+      return { server, url: parsed.href, reachable: true };
+    }
+    if (httpBaseUrl === null) {
+      return { server, url: parsed.href, reachable: false };
+    }
+    const environmentUrl = new URL(httpBaseUrl);
+    if (isLocalLoopbackHost(environmentUrl.hostname)) {
+      // The environment address is loopback from this device's point of view
+      // (e.g. a simulator whose localhost forwards to its host machine), so
+      // the discovered URL already resolves to the right place.
+      return { server, url: parsed.href, reachable: true };
+    }
+    if (!isPrivateNetworkHost(environmentUrl.hostname)) {
+      return { server, url: parsed.href, reachable: false };
+    }
+    const environmentHost = environmentUrl.hostname.replace(/^\[|\]$/g, "");
+    const resolvedHost = environmentHost.includes(":") ? `[${environmentHost}]` : environmentHost;
+    const rewritten = new URL(
+      `${parsed.protocol}//${resolvedHost}:${server.port}${parsed.pathname}${parsed.search}${parsed.hash}`,
+    );
+    return { server, url: rewritten.href, reachable: true };
+  } catch {
+    return { server, url: server.url, reachable: false };
+  }
+}
+
+export function devServerLabel(server: DiscoveredLocalServer): string {
+  return `localhost:${server.port}`;
+}
+
+export function devServerDescription(resolved: ResolvedDevServer): string {
+  if (!resolved.reachable) {
+    return "Not reachable over this connection";
+  }
+  return resolved.server.processName ?? "Linked dev server";
+}

--- a/apps/mobile/src/lib/devServers.ts
+++ b/apps/mobile/src/lib/devServers.ts
@@ -1,9 +1,6 @@
 import { isLocalLoopbackHost, isPrivateNetworkHost } from "@t3tools/shared/hostClassification";
 import type { DiscoveredLocalServer } from "@t3tools/contracts";
-import {
-  isLoopbackHost,
-  normalizePreviewUrl,
-} from "@t3tools/shared/preview";
+import { isLoopbackHost, normalizePreviewUrl } from "@t3tools/shared/preview";
 
 export interface ResolvedDevServer {
   readonly server: DiscoveredLocalServer;

--- a/apps/mobile/src/lib/openExternalUrl.ts
+++ b/apps/mobile/src/lib/openExternalUrl.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 import { Linking } from "react-native";
 
 const ExternalUrlTarget = Schema.Literals([
+  "dev-server",
   "file-preview",
   "markdown-link",
   "pull-request",

--- a/apps/mobile/src/state/preview.ts
+++ b/apps/mobile/src/state/preview.ts
@@ -1,0 +1,34 @@
+import { createPreviewEnvironmentAtoms } from "@t3tools/client-runtime/state/preview";
+import type { DiscoveredLocalServer, EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { useMemo } from "react";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+import { useEnvironmentQuery } from "./query";
+
+export const previewEnvironment = createPreviewEnvironmentAtoms(connectionAtomRuntime);
+
+const EMPTY_SERVERS: ReadonlyArray<DiscoveredLocalServer> = Object.freeze([]);
+
+/**
+ * Dev servers whose owning terminal belongs to the given thread. Subscribing
+ * retains the environment's port scanner, so only mounted thread screens
+ * should call this.
+ */
+export function useThreadDevServers(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly threadId: ThreadId | null;
+}): ReadonlyArray<DiscoveredLocalServer> {
+  const query = useEnvironmentQuery(
+    input.environmentId === null
+      ? null
+      : previewEnvironment.discoveredServers({ environmentId: input.environmentId, input: {} }),
+  );
+  const servers = query.data?.servers ?? EMPTY_SERVERS;
+  return useMemo(
+    () =>
+      input.threadId === null
+        ? EMPTY_SERVERS
+        : servers.filter((server) => server.terminal?.threadId === input.threadId),
+    [input.threadId, servers],
+  );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - [Import browser sessions](./user/browser-import.md)
 - [Usage and limits](./user/usage.md)
 - [Product usage data](./user/telemetry.md)
+- [Linked dev servers](./user/dev-servers.md)
 - [Remote access](./user/remote-access.md)
 - [Running in the background](./user/background-service.md)
 - [Updating T3 Code](./user/updating.md)

--- a/docs/user/dev-servers.md
+++ b/docs/user/dev-servers.md
@@ -1,0 +1,16 @@
+# Linked dev servers
+
+When a terminal in a thread starts a web dev server, T3 Code detects the listening port and links
+the server to that thread. Linked servers follow the thread wherever you work:
+
+- On web and desktop, a globe icon appears on the thread's row in the sidebar; click it to open
+  the server. The desktop in-app browser also lists every live local server, so you can open one
+  in a browser tab next to the conversation.
+- On mobile, a globe button appears in the thread header while the thread has a linked dev
+  server. On iOS it opens a menu listing each server by port and process; pick one to open it in
+  your browser. On Android it opens the first available server directly.
+
+Your phone is not the machine running the server, so T3 Code rewrites `localhost` addresses to
+the address you are connected to the environment through before opening them. This works when you
+reach the environment over your local network or a tailnet. A public tunnel does not forward dev
+server ports, so those servers are still listed but marked as not reachable from your device.

--- a/docs/user/dev-servers.md
+++ b/docs/user/dev-servers.md
@@ -8,7 +8,7 @@ the server to that thread. Linked servers follow the thread wherever you work:
   in a browser tab next to the conversation.
 - On mobile, a globe button appears in the thread header while the thread has a linked dev
   server. On iOS it opens a menu listing each server by port and process; pick one to open it in
-  your browser. On Android it opens the first available server directly.
+  your browser. On Android it opens the first reachable server directly.
 
 Your phone is not the machine running the server, so T3 Code rewrites `localhost` addresses to
 the address you are connected to the environment through before opening them. This works when you


### PR DESCRIPTION


https://github.com/user-attachments/assets/2f4403b7-0e15-4733-9567-6fa8fef6e488

Desktop surfaces a thread's linked dev servers with a globe on its sidebar row and lists them in the in-app browser, but mobile had no access to the discovery stream at all — there was no way to reach a running dev server from a phone.

Mobile now subscribes to the same `subscribeDiscoveredLocalServers` stream and filters to the servers owned by that thread's terminals. Thread rows carry the globe next to the pull request and provider glyphs, and the thread header gains one too: a menu of every server on iOS, and a direct open of the first reachable one on Android, whose in-flow header has no menus. Rows share a single discovery subscription per environment because the atom family keys on the environment, so the glyph costs no extra stream per row.

A phone is never the machine that scanned the port, so `localhost:PORT` is meaningless to it. Loopback URLs are rewritten onto the environment's connection host before opening, the same way the desktop browser resolves them, which covers LAN and tailnet environments. Servers reachable only through a public tunnel are listed but disabled with "Not reachable over this connection", since a tunnel does not forward arbitrary dev ports. The host classification helpers this needs (`isPrivateNetworkHost`, `isLocalLoopbackHost`, `normalizeHostname`, `isPublicFaviconHost`) moved from `apps/web` into `packages/shared` so both clients share one definition; web re-exports them, so no web caller changed.

No new dependencies, and no server or contract changes — this is a client-side consumer of an existing stream.

## Surfaces

- **Clients**: mobile (both thread list variants plus the thread header). Web and desktop are unchanged apart from the helper move.
- **Platforms**: iOS compact header, iOS split-view header, the iOS non-glass fallback toolbar, and the Android in-flow header, which gets a direct open because it cannot render menus. `globe` is mapped for Android icon rendering.
- **Connection modes**: local, LAN, and tailnet resolve and open; tunnel-only environments are shown as unreachable rather than opening a dead page.
- **Docs**: `docs/user/dev-servers.md` describes the behavior across desktop and mobile, indexed in `docs/README.md`.

## Verification

- `apps/mobile/src/lib/devServers.test.ts` covers the resolver: LAN, tailnet, and IPv6 rewrites, loopback passthrough, tunnel-unreachable, and unknown-connection cases.
- Existing `apps/web/src/browser/browserTargetResolver.test.ts` passes unchanged against the moved helpers.
- Typecheck clean for `apps/mobile`, `apps/web`, and `packages/shared`.
- Verified on a physical iPhone against a real environment: a `next-server` dev server started from a thread's terminal shows the globe on that thread's row and opens correctly.

Model: Claude Opus 5 (1M context). Harness: Claude Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how mobile builds and opens dev-server URLs over remote connections; shared host-classification moves affect web and mobile together, though behavior is intended to stay equivalent with existing web tests.
> 
> **Overview**
> **Mobile can surface and open thread-linked dev servers**, matching the web sidebar globe: thread list rows get a tappable indicator, and the thread screen adds a **Dev servers** header control (iOS menu per server; Android one-tap opens the first reachable server).
> 
> Discovery uses the existing preview **`discoveredServers`** stream via new **`useThreadDevServers`**, filtered to servers owned by that thread’s terminals. **`resolveDevServerUrl`** rewrites loopback URLs onto the environment connection host (LAN/tailnet) before **`tryOpenExternalUrl`**; tunnel-only or unknown connections stay listed but **unreachable**, with alerts when open is blocked.
> 
> Hostname helpers (**`isPrivateNetworkHost`**, **`isLocalLoopbackHost`**, **`normalizeHostname`**, **`isPublicFaviconHost`**) move from **`apps/web`** into **`packages/shared/preview`** (web re-exports). Adds **`globe`** Android icon mapping, unit tests for the resolver, and user docs in **`docs/user/dev-servers.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726b4b9b6be83335426c0113cd6a46534635ebec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add linked dev server indicators and menus to mobile thread UI
> - Adds a globe indicator to compact, sidebar, and V2 thread rows when linked dev servers exist via [ThreadDevServerIndicator](https://github.com/pingdotgg/t3code/pull/8562/files#diff-94e369da0b424388cf8c7971d932dc480dbf5355caa053067b26e8a5c1969a75)
> - Adds a linked-servers globe menu to thread headers in [ThreadGitControls](https://github.com/pingdotgg/t3code/pull/8562/files#diff-4a2090eaad8fbb455e06b0e8a1faf33c00ce11bcd9d773b5f982291849dfc9ba) and integrates it into [ThreadRouteScreen](https://github.com/pingdotgg/t3code/pull/8562/files#diff-6335d58d7c246073ba2e7cd1c773675c00c0019ceaecf67ff39734bed4dea283)
> - [resolveDevServerUrl](https://github.com/pingdotgg/t3code/pull/8562/files#diff-e0a3462b8cc2b6c36825dd904eca4234eda41e572c5f00b898322c6d7a4e0d8c) rewrites loopback discovery URLs to private environment hosts (LAN/tailnet/IPv6) and marks servers unreachable for missing or public-only connections
> - Adds the [useThreadDevServers](https://github.com/pingdotgg/t3code/pull/8562/files#diff-01c5a0139e4ff94f1e0800226668c2d193334d6a89f4704c3546609ed8df2e87) hook to query discovered servers owned by a specific thread
> - Behavioral Change: unreachable servers are disabled in the header menu and show an alert when opened directly on Android
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f105448.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added linked development server indicators to mobile thread lists.
  - Added a globe menu in thread headers for viewing and opening available development servers.
  - Automatically adapts local server links for reachable network connections and identifies unavailable servers.
  - Added Android support for globe icons and direct access to the first reachable server.

- **Documentation**
  - Added user documentation explaining linked development servers, platform behavior, and network reachability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->