### PR TITLE
perf(terminal): stream output and history

### DIFF
--- a/apps/mobile/modules/t3-terminal/android/src/main/cpp/t3_terminal_jni.cpp
+++ b/apps/mobile/modules/t3-terminal/android/src/main/cpp/t3_terminal_jni.cpp
@@ -12,7 +12,10 @@ namespace {
 
 constexpr uint32_t kSnapshotMagic = 0x54563354;  // "T3VT" in little endian.
 constexpr uint16_t kSnapshotVersion = 1;
-constexpr size_t kMaxScrollbackRows = 10000;
+// libghostty-vt applies max_scrollback to internal cell storage even though
+// older headers describe it as a line count. Text expands once cells carry
+// terminal state, so leave enough room for the client's 4 MB replay.
+constexpr size_t kMaxScrollbackBytes = 64 * 1024 * 1024;
 
 enum CellFlag : uint16_t {
   kBold = 1 << 0,
@@ -205,7 +208,7 @@ Java_expo_modules_t3terminal_GhosttyBridge_nativeCreate(
   GhosttyTerminalOptions options = {
       .cols = static_cast<uint16_t>(std::clamp(cols, 1, 65535)),
       .rows = static_cast<uint16_t>(std::clamp(rows, 1, 65535)),
-      .max_scrollback = kMaxScrollbackRows,
+      .max_scrollback = kMaxScrollbackBytes,
   };
   if (ghostty_terminal_new(nullptr, &session->terminal, options) != GHOSTTY_SUCCESS ||
       ghostty_render_state_new(nullptr, &session->render_state) != GHOSTTY_SUCCESS ||

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
@@ -11,6 +11,7 @@ class T3TerminalModule : Module() {
     // logs so a stale native binary is distinguishable from a broken key pipeline.
     Constants(
       "hardwareKeyRevision" to 2,
+      "streamingRevision" to 1,
     )
 
     View(T3TerminalView::class) {
@@ -55,6 +56,14 @@ class T3TerminalModule : Module() {
       }
 
       Events("onInput", "onResize")
+
+      AsyncFunction("write") { view: T3TerminalView, data: String ->
+        view.writeRemoteData(data)
+      }
+
+      AsyncFunction("reset") { view: T3TerminalView, data: String ->
+        view.resetRemoteData(data)
+      }
 
       OnViewDestroys { view: T3TerminalView ->
         view.cleanup()

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
@@ -11,7 +11,7 @@ class T3TerminalModule : Module() {
     // logs so a stale native binary is distinguishable from a broken key pipeline.
     Constants(
       "hardwareKeyRevision" to 2,
-      "streamingRevision" to 1,
+      "streamingRevision" to 2,
     )
 
     View(T3TerminalView::class) {
@@ -59,6 +59,10 @@ class T3TerminalModule : Module() {
 
       AsyncFunction("write") { view: T3TerminalView, data: String ->
         view.writeRemoteData(data)
+      }
+
+      AsyncFunction("writeReplay") { view: T3TerminalView, data: String ->
+        view.writeReplayRemoteData(data)
       }
 
       AsyncFunction("reset") { view: T3TerminalView, data: String ->

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -25,6 +25,8 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   private val onResize by EventDispatcher()
   private var terminalHandle = 0L
   private var fedBuffer = ""
+  private var bufferedOutput = ""
+  private var pendingRemoteData = ""
   private var cols = 0
   private var rows = 0
   private var clearingInput = false
@@ -44,15 +46,20 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       recreateTerminal()
     }
 
-  var initialBuffer: String = ""
+  var initialBuffer: String
+    get() = bufferedOutput
     set(value) {
-      if (field == value) return
-      field = value
+      if (bufferedOutput == value) return
+      bufferedOutput = value
       feedPendingBuffer()
     }
 
   fun writeRemoteData(data: String) {
-    if (terminalHandle == 0L || data.isEmpty()) return
+    if (data.isEmpty()) return
+    if (terminalHandle == 0L) {
+      pendingRemoteData += data
+      return
+    }
     emitResponse(GhosttyBridge.nativeFeed(terminalHandle, data.toByteArray(Charsets.UTF_8)))
     if (terminalCanvas.hasActiveSelection()) {
       GhosttyBridge.nativeClearSelection(terminalHandle)
@@ -63,7 +70,9 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
 
   fun resetRemoteData(data: String) {
     destroyTerminal()
-    initialBuffer = data
+    bufferedOutput = data
+    pendingRemoteData = ""
+    if (data.isEmpty()) terminalCanvas.clearFrame()
     createTerminal()
     feedPendingBuffer()
   }
@@ -364,7 +373,9 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     }
     val suffix = initialBuffer.substring(fedBuffer.length)
     if (suffix.isNotEmpty()) {
-      emitResponse(GhosttyBridge.nativeFeed(terminalHandle, suffix.toByteArray(Charsets.UTF_8)))
+      // Retained history is renderer input, not live PTY output. Discard any
+      // terminal query replies it generates instead of forwarding them to the shell.
+      GhosttyBridge.nativeFeed(terminalHandle, suffix.toByteArray(Charsets.UTF_8))
       // New output invalidates an active selection (matches the web drawer);
       // otherwise the copy toolbar drifts out of sync with the grid.
       if (terminalCanvas.hasActiveSelection()) {
@@ -373,6 +384,11 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       }
     }
     fedBuffer = initialBuffer
+    if (pendingRemoteData.isNotEmpty()) {
+      val pending = pendingRemoteData
+      pendingRemoteData = ""
+      emitResponse(GhosttyBridge.nativeFeed(terminalHandle, pending.toByteArray(Charsets.UTF_8)))
+    }
     renderSnapshot()
   }
 

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -34,6 +34,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   private var mutedForegroundColorValue = Color.parseColor("#959DA5")
   private var cursorColorValue = Color.parseColor("#009FFF")
   private var paletteColors = IntArray(0)
+  private var renderSnapshotScheduled = false
 
   var terminalKey: String = ""
     set(value) {
@@ -49,6 +50,23 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       field = value
       feedPendingBuffer()
     }
+
+  fun writeRemoteData(data: String) {
+    if (terminalHandle == 0L || data.isEmpty()) return
+    emitResponse(GhosttyBridge.nativeFeed(terminalHandle, data.toByteArray(Charsets.UTF_8)))
+    if (terminalCanvas.hasActiveSelection()) {
+      GhosttyBridge.nativeClearSelection(terminalHandle)
+      terminalCanvas.resetSelectionState()
+    }
+    scheduleRenderSnapshot()
+  }
+
+  fun resetRemoteData(data: String) {
+    destroyTerminal()
+    initialBuffer = data
+    createTerminal()
+    feedPendingBuffer()
+  }
 
   var fontSize: Float = 10f
     set(value) {
@@ -363,6 +381,15 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     TerminalFrame.decode(
       GhosttyBridge.nativeSnapshot(terminalHandle)
     )?.let(terminalCanvas::setFrame)
+  }
+
+  private fun scheduleRenderSnapshot() {
+    if (renderSnapshotScheduled) return
+    renderSnapshotScheduled = true
+    postOnAnimation {
+      renderSnapshotScheduled = false
+      renderSnapshot()
+    }
   }
 
   private fun emitResponse(response: ByteArray) {

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -23,6 +23,8 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     const val MAX_PENDING_REMOTE_DATA_BYTES = 8 * 1024 * 1024
   }
 
+  private data class PendingRemoteData(val data: ByteArray, val replay: Boolean)
+
   private val container = FrameLayout(context)
   private val terminalCanvas = TerminalCanvasView(context)
   private val inputView = EditText(context)
@@ -31,7 +33,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   private var terminalHandle = 0L
   private var fedBuffer = ""
   private var bufferedOutput = ""
-  private val pendingRemoteData = ArrayDeque<ByteArray>()
+  private val pendingRemoteData = ArrayDeque<PendingRemoteData>()
   private var pendingRemoteDataBytes = 0
   private var cols = 0
   private var rows = 0
@@ -61,12 +63,21 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     }
 
   fun writeRemoteData(data: String) {
+    writeRemoteData(data, replay = false)
+  }
+
+  fun writeReplayRemoteData(data: String) {
+    writeRemoteData(data, replay = true)
+  }
+
+  private fun writeRemoteData(data: String, replay: Boolean) {
     if (data.isEmpty()) return
     if (terminalHandle == 0L) {
-      appendPendingRemoteData(data)
+      appendPendingRemoteData(data, replay)
       return
     }
-    emitResponse(GhosttyBridge.nativeFeed(terminalHandle, data.toByteArray(Charsets.UTF_8)))
+    val response = GhosttyBridge.nativeFeed(terminalHandle, data.toByteArray(Charsets.UTF_8))
+    if (!replay) emitResponse(response)
     if (terminalCanvas.hasActiveSelection()) {
       GhosttyBridge.nativeClearSelection(terminalHandle)
       terminalCanvas.resetSelectionState()
@@ -394,35 +405,32 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       fedBuffer = initialBuffer
     }
     if (pendingRemoteData.isNotEmpty()) {
-      val pending = ByteArray(pendingRemoteDataBytes)
-      var offset = 0
       while (pendingRemoteData.isNotEmpty()) {
         val chunk = pendingRemoteData.removeFirst()
-        chunk.copyInto(pending, destinationOffset = offset)
-        offset += chunk.size
+        val response = GhosttyBridge.nativeFeed(terminalHandle, chunk.data)
+        if (!chunk.replay) emitResponse(response)
       }
-      emitResponse(GhosttyBridge.nativeFeed(terminalHandle, pending))
     }
     pendingRemoteDataBytes = 0
     renderSnapshot()
   }
 
-  private fun appendPendingRemoteData(data: String) {
+  private fun appendPendingRemoteData(data: String, replay: Boolean) {
     val encoded = data.toByteArray(Charsets.UTF_8)
     if (encoded.size > MAX_PENDING_REMOTE_DATA_BYTES) {
       var start = encoded.size - MAX_PENDING_REMOTE_DATA_BYTES
       while (start < encoded.size && (encoded[start].toInt() and 0xC0) == 0x80) start += 1
       val suffix = encoded.copyOfRange(start, encoded.size)
       pendingRemoteData.clear()
-      pendingRemoteData.addLast(suffix)
+      pendingRemoteData.addLast(PendingRemoteData(suffix, replay))
       pendingRemoteDataBytes = suffix.size
       return
     }
 
-    pendingRemoteData.addLast(encoded)
+    pendingRemoteData.addLast(PendingRemoteData(encoded, replay))
     pendingRemoteDataBytes += encoded.size
     while (pendingRemoteDataBytes > MAX_PENDING_REMOTE_DATA_BYTES) {
-      pendingRemoteDataBytes -= pendingRemoteData.removeFirst().size
+      pendingRemoteDataBytes -= pendingRemoteData.removeFirst().data.size
     }
   }
 

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -15,6 +15,7 @@ import android.widget.FrameLayout
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
+import java.util.ArrayDeque
 import kotlin.math.max
 
 class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
@@ -30,7 +31,8 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   private var terminalHandle = 0L
   private var fedBuffer = ""
   private var bufferedOutput = ""
-  private var pendingRemoteData = ""
+  private val pendingRemoteData = ArrayDeque<ByteArray>()
+  private var pendingRemoteDataBytes = 0
   private var cols = 0
   private var rows = 0
   private var clearingInput = false
@@ -75,7 +77,8 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   fun resetRemoteData(data: String) {
     destroyTerminal()
     bufferedOutput = data
-    pendingRemoteData = ""
+    pendingRemoteData.clear()
+    pendingRemoteDataBytes = 0
     if (data.isEmpty()) terminalCanvas.clearFrame()
     createTerminal()
     feedPendingBuffer()
@@ -391,24 +394,36 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
       fedBuffer = initialBuffer
     }
     if (pendingRemoteData.isNotEmpty()) {
-      val pending = pendingRemoteData
-      pendingRemoteData = ""
-      emitResponse(GhosttyBridge.nativeFeed(terminalHandle, pending.toByteArray(Charsets.UTF_8)))
+      val pending = ByteArray(pendingRemoteDataBytes)
+      var offset = 0
+      while (pendingRemoteData.isNotEmpty()) {
+        val chunk = pendingRemoteData.removeFirst()
+        chunk.copyInto(pending, destinationOffset = offset)
+        offset += chunk.size
+      }
+      emitResponse(GhosttyBridge.nativeFeed(terminalHandle, pending))
     }
+    pendingRemoteDataBytes = 0
     renderSnapshot()
   }
 
   private fun appendPendingRemoteData(data: String) {
-    val appended = pendingRemoteData + data
-    val encoded = appended.toByteArray(Charsets.UTF_8)
-    if (encoded.size <= MAX_PENDING_REMOTE_DATA_BYTES) {
-      pendingRemoteData = appended
+    val encoded = data.toByteArray(Charsets.UTF_8)
+    if (encoded.size > MAX_PENDING_REMOTE_DATA_BYTES) {
+      var start = encoded.size - MAX_PENDING_REMOTE_DATA_BYTES
+      while (start < encoded.size && (encoded[start].toInt() and 0xC0) == 0x80) start += 1
+      val suffix = encoded.copyOfRange(start, encoded.size)
+      pendingRemoteData.clear()
+      pendingRemoteData.addLast(suffix)
+      pendingRemoteDataBytes = suffix.size
       return
     }
 
-    var start = encoded.size - MAX_PENDING_REMOTE_DATA_BYTES
-    while (start < encoded.size && (encoded[start].toInt() and 0xC0) == 0x80) start += 1
-    pendingRemoteData = encoded.copyOfRange(start, encoded.size).toString(Charsets.UTF_8)
+    pendingRemoteData.addLast(encoded)
+    pendingRemoteDataBytes += encoded.size
+    while (pendingRemoteDataBytes > MAX_PENDING_REMOTE_DATA_BYTES) {
+      pendingRemoteDataBytes -= pendingRemoteData.removeFirst().size
+    }
   }
 
   private fun renderSnapshot() {

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -18,6 +18,10 @@ import expo.modules.kotlin.views.ExpoView
 import kotlin.math.max
 
 class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
+  private companion object {
+    const val MAX_PENDING_REMOTE_DATA_BYTES = 8 * 1024 * 1024
+  }
+
   private val container = FrameLayout(context)
   private val terminalCanvas = TerminalCanvasView(context)
   private val inputView = EditText(context)
@@ -57,7 +61,7 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   fun writeRemoteData(data: String) {
     if (data.isEmpty()) return
     if (terminalHandle == 0L) {
-      pendingRemoteData += data
+      appendPendingRemoteData(data)
       return
     }
     emitResponse(GhosttyBridge.nativeFeed(terminalHandle, data.toByteArray(Charsets.UTF_8)))
@@ -366,30 +370,45 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
   }
 
   private fun feedPendingBuffer() {
-    if (terminalHandle == 0L || initialBuffer == fedBuffer) return
-    if (!initialBuffer.startsWith(fedBuffer)) {
-      recreateTerminal()
-      if (terminalHandle == 0L) return
-    }
-    val suffix = initialBuffer.substring(fedBuffer.length)
-    if (suffix.isNotEmpty()) {
-      // Retained history is renderer input, not live PTY output. Discard any
-      // terminal query replies it generates instead of forwarding them to the shell.
-      GhosttyBridge.nativeFeed(terminalHandle, suffix.toByteArray(Charsets.UTF_8))
-      // New output invalidates an active selection (matches the web drawer);
-      // otherwise the copy toolbar drifts out of sync with the grid.
-      if (terminalCanvas.hasActiveSelection()) {
-        GhosttyBridge.nativeClearSelection(terminalHandle)
-        terminalCanvas.resetSelectionState()
+    if (terminalHandle == 0L) return
+    if (initialBuffer != fedBuffer) {
+      if (!initialBuffer.startsWith(fedBuffer)) {
+        recreateTerminal()
+        return
       }
+      val suffix = initialBuffer.substring(fedBuffer.length)
+      if (suffix.isNotEmpty()) {
+        // Retained history is renderer input, not live PTY output. Discard any
+        // terminal query replies it generates instead of forwarding them to the shell.
+        GhosttyBridge.nativeFeed(terminalHandle, suffix.toByteArray(Charsets.UTF_8))
+        // New output invalidates an active selection (matches the web drawer);
+        // otherwise the copy toolbar drifts out of sync with the grid.
+        if (terminalCanvas.hasActiveSelection()) {
+          GhosttyBridge.nativeClearSelection(terminalHandle)
+          terminalCanvas.resetSelectionState()
+        }
+      }
+      fedBuffer = initialBuffer
     }
-    fedBuffer = initialBuffer
     if (pendingRemoteData.isNotEmpty()) {
       val pending = pendingRemoteData
       pendingRemoteData = ""
       emitResponse(GhosttyBridge.nativeFeed(terminalHandle, pending.toByteArray(Charsets.UTF_8)))
     }
     renderSnapshot()
+  }
+
+  private fun appendPendingRemoteData(data: String) {
+    val appended = pendingRemoteData + data
+    val encoded = appended.toByteArray(Charsets.UTF_8)
+    if (encoded.size <= MAX_PENDING_REMOTE_DATA_BYTES) {
+      pendingRemoteData = appended
+      return
+    }
+
+    var start = encoded.size - MAX_PENDING_REMOTE_DATA_BYTES
+    while (start < encoded.size && (encoded[start].toInt() and 0xC0) == 0x80) start += 1
+    pendingRemoteData = encoded.copyOfRange(start, encoded.size).toString(Charsets.UTF_8)
   }
 
   private fun renderSnapshot() {

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/TerminalCanvasView.kt
@@ -181,6 +181,14 @@ internal class TerminalCanvasView(context: Context) : View(context) {
     invalidate()
   }
 
+  fun clearFrame() {
+    frame = null
+    cursorOn = true
+    removeCallbacks(cursorBlink)
+    resetSelectionState()
+    invalidate()
+  }
+
   fun resetSelectionState() {
     selectionActive = false
     dragSelecting = false

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
@@ -8,7 +8,7 @@ public class T3TerminalModule: Module {
     // logs so a stale native binary is distinguishable from a broken key pipeline.
     Constants([
       "hardwareKeyRevision": 3,
-      "streamingRevision": 1,
+      "streamingRevision": 2,
     ])
 
     View(T3TerminalView.self) {
@@ -56,6 +56,10 @@ public class T3TerminalModule: Module {
 
       AsyncFunction("write") { (view: T3TerminalView, data: String) in
         view.writeRemoteData(data)
+      }
+
+      AsyncFunction("writeReplay") { (view: T3TerminalView, data: String) in
+        view.writeReplayRemoteData(data)
       }
 
       AsyncFunction("reset") { (view: T3TerminalView, data: String) in

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
@@ -8,6 +8,7 @@ public class T3TerminalModule: Module {
     // logs so a stale native binary is distinguishable from a broken key pipeline.
     Constants([
       "hardwareKeyRevision": 3,
+      "streamingRevision": 1,
     ])
 
     View(T3TerminalView.self) {
@@ -52,6 +53,14 @@ public class T3TerminalModule: Module {
       }
 
       Events("onInput", "onResize")
+
+      AsyncFunction("write") { (view: T3TerminalView, data: String) in
+        view.writeRemoteData(data)
+      }
+
+      AsyncFunction("reset") { (view: T3TerminalView, data: String) in
+        view.resetRemoteData(data)
+      }
     }
   }
 }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -196,6 +196,7 @@ private extension UIColor {
 public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private static let minimumVerticalScrollStepPoints: CGFloat = 18
   private static let verticalScrollStepMultiplier: CGFloat = 1.15
+  private static let maxScrollbackBytes = 64 * 1024 * 1024
 
   private let terminalViewport = UIView()
   private let inputField = TerminalInputField()
@@ -205,6 +206,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private var lastContentScale: CGFloat = 0
   private var lastReportedGrid: (cols: Int, rows: Int)?
   private var lastAppliedBuffer = ""
+  private var redrawDisplayLink: CADisplayLink?
   private var pendingVerticalScrollPoints: CGFloat = 0
   private var app: ghostty_app_t?
   private var surface: ghostty_surface_t?
@@ -229,6 +231,21 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     didSet {
       applyRemoteBuffer(initialBuffer)
     }
+  }
+
+  func writeRemoteData(_ data: String) {
+    guard !data.isEmpty else { return }
+    if surface == nil {
+      createSurfaceIfPossible()
+    }
+    feedData(Data(data.utf8), redraw: false)
+    scheduleRedraw()
+  }
+
+  func resetRemoteData(_ data: String) {
+    resetSurface()
+    initialBuffer = data
+    createSurfaceIfPossible()
   }
 
   var fontSize: CGFloat = 10 {
@@ -518,6 +535,8 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   private func destroySurface() {
+    redrawDisplayLink?.invalidate()
+    redrawDisplayLink = nil
     if let surface {
       ghostty_surface_set_write_callback(surface, nil, nil)
       ghostty_surface_free(surface)
@@ -558,7 +577,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     lastAppliedBuffer = buffer
   }
 
-  private func feedData(_ data: Data) {
+  private func feedData(_ data: Data, redraw: Bool = true) {
     guard let surface, !data.isEmpty else { return }
 
     data.withUnsafeBytes { buffer in
@@ -568,6 +587,22 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
       ghostty_surface_feed_data(surface, pointer, buffer.count)
     }
 
+    if redraw {
+      redrawSurface()
+    }
+  }
+
+  private func scheduleRedraw() {
+    guard redrawDisplayLink == nil else { return }
+    let displayLink = CADisplayLink(target: self, selector: #selector(handleScheduledRedraw))
+    redrawDisplayLink = displayLink
+    displayLink.add(to: .main, forMode: .common)
+  }
+
+  @objc
+  private func handleScheduledRedraw() {
+    redrawDisplayLink?.invalidate()
+    redrawDisplayLink = nil
     redrawSurface()
   }
 
@@ -703,8 +738,9 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   private func writeThemeConfigFile() -> String? {
-    guard !themeConfig.isEmpty else { return nil }
-    let configContents = themeConfig
+    // Ghostty budgets its internal cell storage rather than raw replay bytes,
+    // so the configured limit must account for the expansion of terminal text.
+    let configContents = "scrollback-limit = \(Self.maxScrollbackBytes)\n\(themeConfig)"
     let url = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("t3-terminal-theme-\(appearance.rawValue).ghostty")
 

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -628,15 +628,13 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     pendingRemoteDataBytes += encoded.count
     while pendingRemoteDataBytes > Self.maxPendingRemoteDataBytes,
           pendingRemoteDataHead < pendingRemoteData.count,
-          let oldest = pendingRemoteData[pendingRemoteDataHead]
-    {
+          let oldest = pendingRemoteData[pendingRemoteDataHead] {
       pendingRemoteData[pendingRemoteDataHead] = nil
       pendingRemoteDataHead += 1
       pendingRemoteDataBytes -= oldest.count
     }
     if pendingRemoteDataHead >= 1_024,
-       pendingRemoteDataHead * 2 >= pendingRemoteData.count
-    {
+       pendingRemoteDataHead * 2 >= pendingRemoteData.count {
       pendingRemoteData = Array(pendingRemoteData[pendingRemoteDataHead...])
       pendingRemoteDataHead = 0
     }

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -197,6 +197,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private static let minimumVerticalScrollStepPoints: CGFloat = 18
   private static let verticalScrollStepMultiplier: CGFloat = 1.15
   private static let maxScrollbackBytes = 64 * 1024 * 1024
+  private static let maxPendingRemoteDataBytes = 8 * 1024 * 1024
 
   private let terminalViewport = UIView()
   private let inputField = TerminalInputField()
@@ -242,7 +243,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   func writeRemoteData(_ data: String) {
     guard !data.isEmpty else { return }
     if surface == nil {
-      pendingRemoteData += data
+      appendPendingRemoteData(data)
       createSurfaceIfPossible()
       return
     }
@@ -598,6 +599,19 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     let pending = pendingRemoteData
     pendingRemoteData = ""
     feedData(Data(pending.utf8))
+  }
+
+  private func appendPendingRemoteData(_ data: String) {
+    pendingRemoteData += data
+    let bytes = pendingRemoteData.utf8
+    let overflow = bytes.count - Self.maxPendingRemoteDataBytes
+    guard overflow > 0 else { return }
+
+    var start = bytes.index(bytes.startIndex, offsetBy: overflow)
+    while start < bytes.endIndex, bytes[start] & 0xC0 == 0x80 {
+      bytes.formIndex(after: &start)
+    }
+    pendingRemoteData = String(decoding: bytes[start...], as: UTF8.self)
   }
 
   private func feedData(_ data: Data, redraw: Bool = true) {

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -611,7 +611,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     while start < bytes.endIndex, bytes[start] & 0xC0 == 0x80 {
       bytes.formIndex(after: &start)
     }
-    pendingRemoteData = String(decoding: bytes[start...], as: UTF8.self)
+    pendingRemoteData = String(bytes: bytes[start...], encoding: .utf8) ?? ""
   }
 
   private func feedData(_ data: Data, redraw: Bool = true) {

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -205,6 +205,8 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private var lastViewportSize: CGSize = .zero
   private var lastContentScale: CGFloat = 0
   private var lastReportedGrid: (cols: Int, rows: Int)?
+  private var bufferedOutput = ""
+  private var pendingRemoteData = ""
   private var lastAppliedBuffer = ""
   private var redrawDisplayLink: CADisplayLink?
   private var pendingVerticalScrollPoints: CGFloat = 0
@@ -212,6 +214,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private var surface: ghostty_surface_t?
   private var isCreatingSurface = false
   private var surfaceCreationFailed = false
+  private var suppressInput = false
   private var appearance = TerminalAppearanceScheme.dark
   private var backgroundColorValue = UIColor(hexString: "#24292e")
 
@@ -227,16 +230,21 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     }
   }
 
-  var initialBuffer: String = "" {
-    didSet {
-      applyRemoteBuffer(initialBuffer)
+  var initialBuffer: String {
+    get { bufferedOutput }
+    set {
+      guard bufferedOutput != newValue else { return }
+      bufferedOutput = newValue
+      applyRemoteBuffer(bufferedOutput)
     }
   }
 
   func writeRemoteData(_ data: String) {
     guard !data.isEmpty else { return }
     if surface == nil {
+      pendingRemoteData += data
       createSurfaceIfPossible()
+      return
     }
     feedData(Data(data.utf8), redraw: false)
     scheduleRedraw()
@@ -244,7 +252,8 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
 
   func resetRemoteData(_ data: String) {
     resetSurface()
-    initialBuffer = data
+    bufferedOutput = data
+    pendingRemoteData = ""
     createSurfaceIfPossible()
   }
 
@@ -517,6 +526,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     setupWriteCallback()
     resizeSurface()
     feedBuffer(initialBuffer)
+    feedPendingRemoteData()
   }
 
   private func resetSurface() {
@@ -555,14 +565,14 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
     }
 
     if buffer.isEmpty {
-      feedData(Data("\u{1B}[3J\u{1B}[H\u{1B}[2J".utf8))
+      feedReplayData(Data("\u{1B}[3J\u{1B}[H\u{1B}[2J".utf8))
       lastAppliedBuffer = ""
       return
     }
 
     if buffer.hasPrefix(lastAppliedBuffer) {
       let suffix = String(buffer.dropFirst(lastAppliedBuffer.count))
-      feedData(Data(suffix.utf8))
+      feedReplayData(Data(suffix.utf8))
       lastAppliedBuffer = buffer
       return
     }
@@ -573,8 +583,21 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
 
   private func feedBuffer(_ buffer: String) {
     guard !buffer.isEmpty else { return }
-    feedData(Data(buffer.utf8))
+    feedReplayData(Data(buffer.utf8))
     lastAppliedBuffer = buffer
+  }
+
+  private func feedReplayData(_ data: Data) {
+    suppressInput = true
+    defer { suppressInput = false }
+    feedData(data)
+  }
+
+  private func feedPendingRemoteData() {
+    guard !pendingRemoteData.isEmpty else { return }
+    let pending = pendingRemoteData
+    pendingRemoteData = ""
+    feedData(Data(pending.utf8))
   }
 
   private func feedData(_ data: Data, redraw: Bool = true) {
@@ -615,6 +638,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
       let view = Unmanaged<T3TerminalView>.fromOpaque(userdata).takeUnretainedValue()
       let bytes = Data(bytes: data, count: len)
       guard let input = String(data: bytes, encoding: .utf8), !input.isEmpty else { return }
+      guard !view.suppressInput else { return }
 
       DispatchQueue.main.async {
         view.onInput(["data": input])

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -207,7 +207,9 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private var lastContentScale: CGFloat = 0
   private var lastReportedGrid: (cols: Int, rows: Int)?
   private var bufferedOutput = ""
-  private var pendingRemoteData = ""
+  private var pendingRemoteData: [Data?] = []
+  private var pendingRemoteDataHead = 0
+  private var pendingRemoteDataBytes = 0
   private var lastAppliedBuffer = ""
   private var redrawDisplayLink: CADisplayLink?
   private var pendingVerticalScrollPoints: CGFloat = 0
@@ -254,7 +256,9 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   func resetRemoteData(_ data: String) {
     resetSurface()
     bufferedOutput = data
-    pendingRemoteData = ""
+    pendingRemoteData = []
+    pendingRemoteDataHead = 0
+    pendingRemoteDataBytes = 0
     createSurfaceIfPossible()
   }
 
@@ -595,23 +599,47 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   private func feedPendingRemoteData() {
-    guard !pendingRemoteData.isEmpty else { return }
-    let pending = pendingRemoteData
-    pendingRemoteData = ""
-    feedData(Data(pending.utf8))
+    guard pendingRemoteDataHead < pendingRemoteData.count else { return }
+    var pending = Data(capacity: pendingRemoteDataBytes)
+    for case let chunk? in pendingRemoteData[pendingRemoteDataHead...] {
+      pending.append(chunk)
+    }
+    pendingRemoteData = []
+    pendingRemoteDataHead = 0
+    pendingRemoteDataBytes = 0
+    feedData(pending)
   }
 
   private func appendPendingRemoteData(_ data: String) {
-    pendingRemoteData += data
-    let bytes = pendingRemoteData.utf8
-    let overflow = bytes.count - Self.maxPendingRemoteDataBytes
-    guard overflow > 0 else { return }
-
-    var start = bytes.index(bytes.startIndex, offsetBy: overflow)
-    while start < bytes.endIndex, bytes[start] & 0xC0 == 0x80 {
-      bytes.formIndex(after: &start)
+    let encoded = Data(data.utf8)
+    if encoded.count > Self.maxPendingRemoteDataBytes {
+      var start = encoded.count - Self.maxPendingRemoteDataBytes
+      while start < encoded.count, encoded[start] & 0xC0 == 0x80 {
+        start += 1
+      }
+      let suffix = Data(encoded[start...])
+      pendingRemoteData = [suffix]
+      pendingRemoteDataHead = 0
+      pendingRemoteDataBytes = suffix.count
+      return
     }
-    pendingRemoteData = String(bytes: bytes[start...], encoding: .utf8) ?? ""
+
+    pendingRemoteData.append(encoded)
+    pendingRemoteDataBytes += encoded.count
+    while pendingRemoteDataBytes > Self.maxPendingRemoteDataBytes,
+          pendingRemoteDataHead < pendingRemoteData.count,
+          let oldest = pendingRemoteData[pendingRemoteDataHead]
+    {
+      pendingRemoteData[pendingRemoteDataHead] = nil
+      pendingRemoteDataHead += 1
+      pendingRemoteDataBytes -= oldest.count
+    }
+    if pendingRemoteDataHead >= 1_024,
+       pendingRemoteDataHead * 2 >= pendingRemoteData.count
+    {
+      pendingRemoteData = Array(pendingRemoteData[pendingRemoteDataHead...])
+      pendingRemoteDataHead = 0
+    }
   }
 
   private func feedData(_ data: Data, redraw: Bool = true) {

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -199,6 +199,11 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private static let maxScrollbackBytes = 64 * 1024 * 1024
   private static let maxPendingRemoteDataBytes = 8 * 1024 * 1024
 
+  private struct PendingRemoteData {
+    let data: Data
+    let replay: Bool
+  }
+
   private let terminalViewport = UIView()
   private let inputField = TerminalInputField()
   private let focusTapGesture = UITapGestureRecognizer()
@@ -207,7 +212,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   private var lastContentScale: CGFloat = 0
   private var lastReportedGrid: (cols: Int, rows: Int)?
   private var bufferedOutput = ""
-  private var pendingRemoteData: [Data?] = []
+  private var pendingRemoteData: [PendingRemoteData?] = []
   private var pendingRemoteDataHead = 0
   private var pendingRemoteDataBytes = 0
   private var lastAppliedBuffer = ""
@@ -243,13 +248,25 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   func writeRemoteData(_ data: String) {
+    writeRemoteData(data, replay: false)
+  }
+
+  func writeReplayRemoteData(_ data: String) {
+    writeRemoteData(data, replay: true)
+  }
+
+  private func writeRemoteData(_ data: String, replay: Bool) {
     guard !data.isEmpty else { return }
     if surface == nil {
-      appendPendingRemoteData(data)
+      appendPendingRemoteData(data, replay: replay)
       createSurfaceIfPossible()
       return
     }
-    feedData(Data(data.utf8), redraw: false)
+    if replay {
+      feedReplayData(Data(data.utf8), redraw: false)
+    } else {
+      feedData(Data(data.utf8), redraw: false)
+    }
     scheduleRedraw()
   }
 
@@ -593,24 +610,31 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   private func feedReplayData(_ data: Data) {
+    feedReplayData(data, redraw: true)
+  }
+
+  private func feedReplayData(_ data: Data, redraw: Bool) {
     suppressInput = true
     defer { suppressInput = false }
-    feedData(data)
+    feedData(data, redraw: redraw)
   }
 
   private func feedPendingRemoteData() {
     guard pendingRemoteDataHead < pendingRemoteData.count else { return }
-    var pending = Data(capacity: pendingRemoteDataBytes)
     for case let chunk? in pendingRemoteData[pendingRemoteDataHead...] {
-      pending.append(chunk)
+      if chunk.replay {
+        feedReplayData(chunk.data, redraw: false)
+      } else {
+        feedData(chunk.data, redraw: false)
+      }
     }
     pendingRemoteData = []
     pendingRemoteDataHead = 0
     pendingRemoteDataBytes = 0
-    feedData(pending)
+    redrawSurface()
   }
 
-  private func appendPendingRemoteData(_ data: String) {
+  private func appendPendingRemoteData(_ data: String, replay: Bool) {
     let encoded = Data(data.utf8)
     if encoded.count > Self.maxPendingRemoteDataBytes {
       var start = encoded.count - Self.maxPendingRemoteDataBytes
@@ -618,20 +642,20 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
         start += 1
       }
       let suffix = Data(encoded[start...])
-      pendingRemoteData = [suffix]
+      pendingRemoteData = [PendingRemoteData(data: suffix, replay: replay)]
       pendingRemoteDataHead = 0
       pendingRemoteDataBytes = suffix.count
       return
     }
 
-    pendingRemoteData.append(encoded)
+    pendingRemoteData.append(PendingRemoteData(data: encoded, replay: replay))
     pendingRemoteDataBytes += encoded.count
     while pendingRemoteDataBytes > Self.maxPendingRemoteDataBytes,
           pendingRemoteDataHead < pendingRemoteData.count,
           let oldest = pendingRemoteData[pendingRemoteDataHead] {
       pendingRemoteData[pendingRemoteDataHead] = nil
       pendingRemoteDataHead += 1
-      pendingRemoteDataBytes -= oldest.count
+      pendingRemoteDataBytes -= oldest.data.count
     }
     if pendingRemoteDataHead >= 1_024,
        pendingRemoteDataHead * 2 >= pendingRemoteData.count {

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -58,6 +58,8 @@ function isPendingNativeViewRegistration(error: unknown): boolean {
 interface TerminalSurfaceProps extends ViewProps {
   readonly terminalKey: string;
   readonly output: TerminalOutputState;
+  readonly replayStartVersion: number;
+  readonly replayCompleteVersion: number;
   readonly replayPaused?: boolean;
   readonly fontSize?: number;
   readonly isRunning: boolean;
@@ -204,7 +206,7 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
   const NativeTerminalSurfaceView = resolveNativeTerminalSurfaceView();
   const hasNativeSurface = Boolean(NativeTerminalSurfaceView);
   const streamingRevision = getNativeTerminalStreamingRevision();
-  const supportsStreaming = streamingRevision !== null && streamingRevision >= 1;
+  const supportsStreaming = streamingRevision !== null && streamingRevision >= 2;
   const themeConfig = buildGhosttyThemeConfig(theme);
   const nativeRef = useRef<NativeTerminalSurfaceHandle>(null);
   const nativeCommandQueueRef = useRef(Promise.resolve());
@@ -213,6 +215,7 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     lastChunkId: 0,
   });
   const streamIdentityRef = useRef("");
+  const replayBoundaryRef = useRef({ start: 0, complete: 0 });
   const resetIdentity = `${props.terminalKey}:${fontSize}:${themeAppearance}:${themeConfig}`;
   const legacyBuffer =
     supportsStreaming || props.replayPaused ? "" : terminalOutputText(props.output);
@@ -244,6 +247,13 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     if (!supportsStreaming) return;
     const streamIdentity = props.replayPaused ? `${resetIdentity}:paused` : resetIdentity;
     const forceReset = streamIdentityRef.current !== streamIdentity;
+    const replayStarted = props.replayStartVersion > replayBoundaryRef.current.start;
+    const writeAsReplay =
+      replayStarted || replayBoundaryRef.current.start > replayBoundaryRef.current.complete;
+    replayBoundaryRef.current = {
+      start: props.replayStartVersion,
+      complete: props.replayCompleteVersion,
+    };
     const update =
       forceReset || props.replayPaused
         ? {
@@ -263,13 +273,20 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
         for (let attempt = 0; attempt <= NATIVE_COMMAND_RETRY_FRAMES; attempt += 1) {
           if (streamIdentityRef.current !== streamIdentity) return;
           const handle = nativeRef.current;
-          const command = update.type === "reset" ? handle?.reset : handle?.write;
+          const command =
+            update.type === "reset"
+              ? handle?.reset
+              : writeAsReplay
+                ? handle?.writeReplay
+                : handle?.write;
           if (!command) {
             if (attempt < NATIVE_COMMAND_RETRY_FRAMES) {
               await nextAnimationFrame();
               continue;
             }
-            throw new Error(`Native terminal does not support ${update.type}`);
+            throw new Error(
+              `Native terminal does not support ${writeAsReplay ? "replay append" : update.type}`,
+            );
           }
 
           try {
@@ -292,7 +309,14 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
         }
         console.error("Failed to update native terminal output", error);
       });
-  }, [props.output, props.replayPaused, resetIdentity, supportsStreaming]);
+  }, [
+    props.output,
+    props.replayCompleteVersion,
+    props.replayPaused,
+    props.replayStartVersion,
+    resetIdentity,
+    supportsStreaming,
+  ]);
   const handleNativeInput = useCallback(
     (event: NativeSyntheticEvent<TerminalInputEvent>) => {
       if (!props.isRunning) {

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -21,6 +21,7 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
 import {
   getNativeTerminalHardwareKeyRevision,
   getNativeTerminalStreamingRevision,
+  NATIVE_TERMINAL_STREAMING_REVISION,
   resolveNativeTerminalSurfaceView,
   type NativeTerminalSurfaceHandle,
 } from "./nativeTerminalModule";
@@ -58,8 +59,6 @@ function isPendingNativeViewRegistration(error: unknown): boolean {
 interface TerminalSurfaceProps extends ViewProps {
   readonly terminalKey: string;
   readonly output: TerminalOutputState;
-  readonly replayStartVersion: number;
-  readonly replayCompleteVersion: number;
   readonly replayPaused?: boolean;
   readonly fontSize?: number;
   readonly isRunning: boolean;
@@ -206,7 +205,8 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
   const NativeTerminalSurfaceView = resolveNativeTerminalSurfaceView();
   const hasNativeSurface = Boolean(NativeTerminalSurfaceView);
   const streamingRevision = getNativeTerminalStreamingRevision();
-  const supportsStreaming = streamingRevision !== null && streamingRevision >= 2;
+  const supportsStreaming =
+    streamingRevision !== null && streamingRevision >= NATIVE_TERMINAL_STREAMING_REVISION;
   const themeConfig = buildGhosttyThemeConfig(theme);
   const nativeRef = useRef<NativeTerminalSurfaceHandle>(null);
   const nativeCommandQueueRef = useRef(Promise.resolve());
@@ -215,7 +215,6 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     lastChunkId: 0,
   });
   const streamIdentityRef = useRef("");
-  const replayBoundaryRef = useRef({ start: 0, complete: 0 });
   const resetIdentity = `${props.terminalKey}:${fontSize}:${themeAppearance}:${themeConfig}`;
   const legacyBuffer =
     supportsStreaming || props.replayPaused ? "" : terminalOutputText(props.output);
@@ -247,13 +246,6 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     if (!supportsStreaming) return;
     const streamIdentity = props.replayPaused ? `${resetIdentity}:paused` : resetIdentity;
     const forceReset = streamIdentityRef.current !== streamIdentity;
-    const replayStarted = props.replayStartVersion > replayBoundaryRef.current.start;
-    const writeAsReplay =
-      replayStarted || replayBoundaryRef.current.start > replayBoundaryRef.current.complete;
-    replayBoundaryRef.current = {
-      start: props.replayStartVersion,
-      complete: props.replayCompleteVersion,
-    };
     const update =
       forceReset || props.replayPaused
         ? {
@@ -268,36 +260,38 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     streamIdentityRef.current = streamIdentity;
     outputCursorRef.current = update.cursor;
     if (update.type === "none" || (!forceReset && props.replayPaused)) return;
+    const commands =
+      update.type === "reset"
+        ? [{ type: "reset" as const, data: update.data }]
+        : update.segments.map((segment) => ({
+            type: segment.delivery === "replay" ? ("writeReplay" as const) : ("write" as const),
+            data: segment.data,
+          }));
     nativeCommandQueueRef.current = nativeCommandQueueRef.current
       .then(async () => {
-        for (let attempt = 0; attempt <= NATIVE_COMMAND_RETRY_FRAMES; attempt += 1) {
-          if (streamIdentityRef.current !== streamIdentity) return;
-          const handle = nativeRef.current;
-          const command =
-            update.type === "reset"
-              ? handle?.reset
-              : writeAsReplay
-                ? handle?.writeReplay
-                : handle?.write;
-          if (!command) {
-            if (attempt < NATIVE_COMMAND_RETRY_FRAMES) {
-              await nextAnimationFrame();
-              continue;
+        for (const pending of commands) {
+          for (let attempt = 0; attempt <= NATIVE_COMMAND_RETRY_FRAMES; attempt += 1) {
+            if (streamIdentityRef.current !== streamIdentity) return;
+            const handle = nativeRef.current;
+            const command = handle?.[pending.type];
+            if (!command) {
+              if (attempt < NATIVE_COMMAND_RETRY_FRAMES) {
+                await nextAnimationFrame();
+                continue;
+              }
+              throw new Error(`Native terminal does not support ${pending.type}`);
             }
-            throw new Error(
-              `Native terminal does not support ${writeAsReplay ? "replay append" : update.type}`,
-            );
-          }
 
-          try {
-            await command.call(handle, update.data);
-            return;
-          } catch (error) {
-            if (attempt < NATIVE_COMMAND_RETRY_FRAMES && isPendingNativeViewRegistration(error)) {
-              await nextAnimationFrame();
-              continue;
+            try {
+              await command.call(handle, pending.data);
+              break;
+            } catch (error) {
+              if (attempt < NATIVE_COMMAND_RETRY_FRAMES && isPendingNativeViewRegistration(error)) {
+                await nextAnimationFrame();
+                continue;
+              }
+              throw error;
             }
-            throw error;
           }
         }
       })
@@ -309,14 +303,7 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
         }
         console.error("Failed to update native terminal output", error);
       });
-  }, [
-    props.output,
-    props.replayCompleteVersion,
-    props.replayPaused,
-    props.replayStartVersion,
-    resetIdentity,
-    supportsStreaming,
-  ]);
+  }, [props.output, props.replayPaused, resetIdentity, supportsStreaming]);
   const handleNativeInput = useCallback(
     (event: NativeSyntheticEvent<TerminalInputEvent>) => {
       if (!props.isRunning) {

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -1,3 +1,9 @@
+import {
+  readTerminalOutputUpdate,
+  terminalOutputText,
+  type TerminalOutputCursor,
+  type TerminalOutputState,
+} from "@t3tools/client-runtime/state/terminal";
 import { memo, useCallback, useEffect, useRef } from "react";
 import {
   Pressable,
@@ -14,7 +20,9 @@ import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import {
   getNativeTerminalHardwareKeyRevision,
+  getNativeTerminalStreamingRevision,
   resolveNativeTerminalSurfaceView,
+  type NativeTerminalSurfaceHandle,
 } from "./nativeTerminalModule";
 import {
   buildGhosttyThemeConfig,
@@ -32,9 +40,25 @@ interface TerminalResizeEvent {
   readonly rows: number;
 }
 
+const NATIVE_COMMAND_RETRY_FRAMES = 8;
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function isPendingNativeViewRegistration(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes("Unable to find the 'T3Terminal' view") ||
+      (error.message.includes("Unable to find the class") &&
+        error.message.includes("T3TerminalView view with tag")))
+  );
+}
+
 interface TerminalSurfaceProps extends ViewProps {
   readonly terminalKey: string;
-  readonly buffer: string;
+  readonly output: TerminalOutputState;
+  readonly replayPaused?: boolean;
   readonly fontSize?: number;
   readonly isRunning: boolean;
   readonly autoFocus?: boolean;
@@ -65,6 +89,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
   const statusLabel = props.isRunning
     ? "Native terminal unavailable. Using text fallback."
     : "Open terminal to start a shell.";
+  const buffer = props.replayPaused ? "" : terminalOutputText(props.output);
 
   const handleLayout = (event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
@@ -117,7 +142,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
               lineHeight: Math.round(fontSize * 1.35),
             }}
           >
-            {props.buffer || "$ "}
+            {buffer || "$ "}
           </Text>
         </ScrollView>
       </View>
@@ -178,6 +203,19 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
   const { onInput, onResize } = props;
   const NativeTerminalSurfaceView = resolveNativeTerminalSurfaceView();
   const hasNativeSurface = Boolean(NativeTerminalSurfaceView);
+  const streamingRevision = getNativeTerminalStreamingRevision();
+  const supportsStreaming = streamingRevision !== null && streamingRevision >= 1;
+  const themeConfig = buildGhosttyThemeConfig(theme);
+  const nativeRef = useRef<NativeTerminalSurfaceHandle>(null);
+  const nativeCommandQueueRef = useRef(Promise.resolve());
+  const outputCursorRef = useRef<TerminalOutputCursor>({
+    resetVersion: -1,
+    lastChunkId: 0,
+  });
+  const streamIdentityRef = useRef("");
+  const resetIdentity = `${props.terminalKey}:${fontSize}:${themeAppearance}:${themeConfig}`;
+  const legacyBuffer =
+    supportsStreaming || props.replayPaused ? "" : terminalOutputText(props.output);
 
   useEffect(() => {
     terminalDebugLog("native:surface", {
@@ -185,10 +223,76 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
       native: hasNativeSurface,
       // null = installed binary predates native hardware-key handling (rebuild needed).
       hardwareKeyRevision: getNativeTerminalHardwareKeyRevision(),
-      bufferLen: props.buffer.length,
+      retainedBytes: props.output.retainedBytes,
       isRunning: props.isRunning,
+      streamingRevision,
     });
-  }, [hasNativeSurface, props.buffer.length, props.isRunning, props.terminalKey]);
+  }, [
+    hasNativeSurface,
+    props.isRunning,
+    props.output.retainedBytes,
+    props.terminalKey,
+    streamingRevision,
+  ]);
+  useEffect(
+    () => () => {
+      streamIdentityRef.current = "";
+    },
+    [],
+  );
+  useEffect(() => {
+    if (!supportsStreaming) return;
+    const streamIdentity = props.replayPaused ? `${resetIdentity}:paused` : resetIdentity;
+    const forceReset = streamIdentityRef.current !== streamIdentity;
+    const update =
+      forceReset || props.replayPaused
+        ? {
+            type: "reset" as const,
+            data: props.replayPaused ? "" : terminalOutputText(props.output),
+            cursor: {
+              resetVersion: props.output.resetVersion,
+              lastChunkId: props.output.latestChunkId,
+            },
+          }
+        : readTerminalOutputUpdate(props.output, outputCursorRef.current);
+    streamIdentityRef.current = streamIdentity;
+    outputCursorRef.current = update.cursor;
+    if (update.type === "none" || (!forceReset && props.replayPaused)) return;
+    nativeCommandQueueRef.current = nativeCommandQueueRef.current
+      .then(async () => {
+        for (let attempt = 0; attempt <= NATIVE_COMMAND_RETRY_FRAMES; attempt += 1) {
+          if (streamIdentityRef.current !== streamIdentity) return;
+          const handle = nativeRef.current;
+          const command = update.type === "reset" ? handle?.reset : handle?.write;
+          if (!command) {
+            if (attempt < NATIVE_COMMAND_RETRY_FRAMES) {
+              await nextAnimationFrame();
+              continue;
+            }
+            throw new Error(`Native terminal does not support ${update.type}`);
+          }
+
+          try {
+            await command.call(handle, update.data);
+            return;
+          } catch (error) {
+            if (attempt < NATIVE_COMMAND_RETRY_FRAMES && isPendingNativeViewRegistration(error)) {
+              await nextAnimationFrame();
+              continue;
+            }
+            throw error;
+          }
+        }
+      })
+      .catch((error: unknown) => {
+        if (streamIdentityRef.current === streamIdentity) {
+          // The next output update will rebuild the native surface from the
+          // retained snapshot instead of continuing after a missing command.
+          streamIdentityRef.current = "";
+        }
+        console.error("Failed to update native terminal output", error);
+      });
+  }, [props.output, props.replayPaused, resetIdentity, supportsStreaming]);
   const handleNativeInput = useCallback(
     (event: NativeSyntheticEvent<TerminalInputEvent>) => {
       if (!props.isRunning) {
@@ -215,6 +319,7 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
     return (
       <View style={props.style}>
         <NativeTerminalSurfaceView
+          ref={nativeRef}
           appearanceScheme={themeAppearance}
           autoFocus={props.autoFocus ?? true}
           backgroundColor={theme.background}
@@ -222,10 +327,10 @@ export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurf
           foregroundColor={theme.foreground}
           mutedForegroundColor={theme.mutedForeground}
           terminalKey={props.terminalKey}
-          initialBuffer={props.buffer}
+          initialBuffer={legacyBuffer}
           fontSize={fontSize}
           style={{ flex: 1 }}
-          themeConfig={buildGhosttyThemeConfig(theme)}
+          themeConfig={themeConfig}
           onInput={handleNativeInput}
           onResize={handleNativeResize}
         />

--- a/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
@@ -261,6 +261,8 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
         onInput={handleInput}
         onResize={handleResize}
         output={terminal.output}
+        replayCompleteVersion={terminal.replayCompleteVersion}
+        replayStartVersion={terminal.replayStartVersion}
         style={{ flex: 1 }}
       />
     </View>

--- a/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
@@ -16,6 +16,7 @@ import { TerminalSurface } from "./NativeTerminalSurface";
 import {
   getNativeTerminalStreamingRevision,
   hasNativeTerminalSurface,
+  NATIVE_TERMINAL_REPLAY_STREAMING_REVISION,
 } from "./nativeTerminalModule";
 import {
   buildThreadTerminalAttachInput,
@@ -43,7 +44,8 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
   const closeTerminal = useAtomCommand(terminalEnvironment.close, "terminal close");
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
   const nativeTerminalAvailable = hasNativeTerminalSurface();
-  const supportsStreaming = (getNativeTerminalStreamingRevision() ?? 0) >= 1;
+  const supportsReplayStreaming =
+    (getNativeTerminalStreamingRevision() ?? 0) >= NATIVE_TERMINAL_REPLAY_STREAMING_REVISION;
   const terminalId = DEFAULT_TERMINAL_ID;
   const lastGridSizeRef = useRef<TerminalGridSize>({
     cols: DEFAULT_TERMINAL_COLS,
@@ -65,10 +67,10 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
         ? buildThreadTerminalAttachInput(
             subscriptionIdentity,
             lastGridSizeRef.current,
-            supportsStreaming ? EXTENDED_TERMINAL_REPLAY_BYTES : undefined,
+            supportsReplayStreaming ? EXTENDED_TERMINAL_REPLAY_BYTES : undefined,
           )
         : null,
-    [props.visible, subscriptionIdentity, supportsStreaming],
+    [props.visible, subscriptionIdentity, supportsReplayStreaming],
   );
   const terminal = useAttachedTerminalSession({
     environmentId: props.environmentId,
@@ -261,8 +263,6 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
         onInput={handleInput}
         onResize={handleResize}
         output={terminal.output}
-        replayCompleteVersion={terminal.replayCompleteVersion}
-        replayStartVersion={terminal.replayStartVersion}
         style={{ flex: 1 }}
       />
     </View>

--- a/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
@@ -1,4 +1,9 @@
-import { DEFAULT_TERMINAL_ID, type EnvironmentId, type ThreadId } from "@t3tools/contracts";
+import {
+  DEFAULT_TERMINAL_ID,
+  EXTENDED_TERMINAL_REPLAY_BYTES,
+  type EnvironmentId,
+  type ThreadId,
+} from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { Pressable, View } from "react-native";
@@ -8,7 +13,10 @@ import { terminalEnvironment } from "../../state/terminal";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useAttachedTerminalSession } from "../../state/use-terminal-session";
 import { TerminalSurface } from "./NativeTerminalSurface";
-import { hasNativeTerminalSurface } from "./nativeTerminalModule";
+import {
+  getNativeTerminalStreamingRevision,
+  hasNativeTerminalSurface,
+} from "./nativeTerminalModule";
 import {
   buildThreadTerminalAttachInput,
   type TerminalGridSize,
@@ -35,6 +43,7 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
   const closeTerminal = useAtomCommand(terminalEnvironment.close, "terminal close");
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
   const nativeTerminalAvailable = hasNativeTerminalSurface();
+  const supportsStreaming = (getNativeTerminalStreamingRevision() ?? 0) >= 1;
   const terminalId = DEFAULT_TERMINAL_ID;
   const lastGridSizeRef = useRef<TerminalGridSize>({
     cols: DEFAULT_TERMINAL_COLS,
@@ -53,9 +62,13 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
   const attachInput = useMemo(
     () =>
       props.visible
-        ? buildThreadTerminalAttachInput(subscriptionIdentity, lastGridSizeRef.current)
+        ? buildThreadTerminalAttachInput(
+            subscriptionIdentity,
+            lastGridSizeRef.current,
+            supportsStreaming ? EXTENDED_TERMINAL_REPLAY_BYTES : undefined,
+          )
         : null,
-    [props.visible, subscriptionIdentity],
+    [props.visible, subscriptionIdentity, supportsStreaming],
   );
   const terminal = useAttachedTerminalSession({
     environmentId: props.environmentId,
@@ -71,10 +84,9 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
   const runningTerminalKeyRef = useRef<string | null>(null);
   const reopenedStaleTerminalKeyRef = useRef<string | null>(null);
 
-  // Attach subscriptions are cached with an idle TTL; reopening the panel
-  // after its session ended reuses the stale stream without a new attach
-  // RPC. Issue an explicit open so the server respawns the session and its
-  // snapshot flows into the live subscription.
+  // Attaching to an exited session preserves its final history. The panel is
+  // an interactive shell, so explicitly reopen that session after the
+  // snapshot arrives.
   useEffect(() => {
     if (isRunning) {
       reopenedStaleTerminalKeyRef.current = null;
@@ -245,10 +257,10 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
       </View>
       <TerminalSurface
         terminalKey={terminalKey}
-        buffer={terminal.buffer}
         isRunning={isRunning}
         onInput={handleInput}
         onResize={handleResize}
+        output={terminal.output}
         style={{ flex: 1 }}
       />
     </View>

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -52,7 +52,10 @@ import { useSelectedThreadDetail } from "../../state/use-thread-detail";
 import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { TerminalSurface } from "./NativeTerminalSurface";
-import { getNativeTerminalStreamingRevision } from "./nativeTerminalModule";
+import {
+  getNativeTerminalStreamingRevision,
+  NATIVE_TERMINAL_REPLAY_STREAMING_REVISION,
+} from "./nativeTerminalModule";
 import { getMobileTerminalTheme } from "./terminalTheme";
 import { terminalDebugLog } from "./terminalDebugLog";
 import {
@@ -325,7 +328,8 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
             worktreePath: launchLocation.worktreePath,
             cols: initialAttachGridSize.cols,
             rows: initialAttachGridSize.rows,
-            ...((getNativeTerminalStreamingRevision() ?? 0) >= 1
+            ...((getNativeTerminalStreamingRevision() ?? 0) >=
+            NATIVE_TERMINAL_REPLAY_STREAMING_REVISION
               ? { replayBytes: EXTENDED_TERMINAL_REPLAY_BYTES }
               : {}),
             ...(pendingLaunch?.env ? { env: pendingLaunch.env } : {}),
@@ -1239,9 +1243,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 onInput={handleInput}
                 onResize={handleResize}
                 output={terminal.output}
-                replayCompleteVersion={terminal.replayCompleteVersion}
                 replayPaused={terminalReplayPaused}
-                replayStartVersion={terminal.replayStartVersion}
                 style={{ flex: 1 }}
                 terminalKey={terminalKey}
                 theme={terminalTheme}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -1,5 +1,13 @@
-import { DEFAULT_TERMINAL_ID, EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { type KnownTerminalSession } from "@t3tools/client-runtime/state/terminal";
+import {
+  DEFAULT_TERMINAL_ID,
+  EXTENDED_TERMINAL_REPLAY_BYTES,
+  EnvironmentId,
+  ThreadId,
+} from "@t3tools/contracts";
+import {
+  terminalOutputText,
+  type KnownTerminalSession,
+} from "@t3tools/client-runtime/state/terminal";
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "../../components/AppSymbol";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
@@ -44,11 +52,12 @@ import { useSelectedThreadDetail } from "../../state/use-thread-detail";
 import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { TerminalSurface } from "./NativeTerminalSurface";
+import { getNativeTerminalStreamingRevision } from "./nativeTerminalModule";
 import { getMobileTerminalTheme } from "./terminalTheme";
 import { terminalDebugLog } from "./terminalDebugLog";
 import {
   getTerminalBufferReplayKey,
-  getTerminalSurfaceReplayBuffer,
+  isTerminalBufferReplayPaused,
   TERMINAL_BUFFER_REPLAY_STABILITY_DELAY_MS,
 } from "./terminalBufferReplay";
 import {
@@ -316,6 +325,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
             worktreePath: launchLocation.worktreePath,
             cols: initialAttachGridSize.cols,
             rows: initialAttachGridSize.rows,
+            ...((getNativeTerminalStreamingRevision() ?? 0) >= 1
+              ? { replayBytes: EXTENDED_TERMINAL_REPLAY_BYTES }
+              : {}),
             ...(pendingLaunch?.env ? { env: pendingLaunch.env } : {}),
             ...(pendingLaunch ? { restartIfNotRunning: true } : {}),
           }
@@ -347,8 +359,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   if (lastBufferReplayKeyRef.current === null) {
     lastBufferReplayKeyRef.current = bufferReplayKey;
   }
-  const terminalSurfaceBuffer = getTerminalSurfaceReplayBuffer({
-    buffer: terminal.buffer,
+  const terminalReplayPaused = isTerminalBufferReplayPaused({
     replayKey: bufferReplayKey,
     readyReplayKey: readyBufferReplayKey,
   });
@@ -363,11 +374,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   const reopenedStaleTerminalKeyRef = useRef<string | null>(null);
   const pendingExitNavigationRef = useRef<string | null>(null);
 
-  // Attach subscriptions are cached with an idle TTL, so revisiting a
-  // terminal whose session ended while unobserved reuses the stale stream
-  // without a new attach RPC — the server never respawns anything. Detect
-  // that (dead status with processed events, never seen running here) and
-  // issue an explicit open; its snapshot flows into the live subscription.
+  // Attaching to an exited session preserves its final history. This route is
+  // an interactive shell, so explicitly reopen that session after its
+  // snapshot arrives unless this screen observed the exit itself.
   useEffect(() => {
     if (isRunning) {
       reopenedStaleTerminalKeyRef.current = null;
@@ -415,8 +424,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   useEffect(() => {
     terminalDebugLog("surface:props", {
       terminalKey,
-      atomBufferLen: terminal.buffer.length,
-      surfaceBufferLen: terminalSurfaceBuffer.length,
+      retainedBytes: terminal.output.retainedBytes,
+      retainedChunks: terminal.output.chunks.length,
+      replayPaused: terminalReplayPaused,
       replayKey: bufferReplayKey,
       readyReplayKey: readyBufferReplayKey,
       status: terminal.status,
@@ -425,11 +435,12 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   }, [
     bufferReplayKey,
     readyBufferReplayKey,
-    terminal.buffer.length,
+    terminal.output.chunks.length,
+    terminal.output.retainedBytes,
     terminal.status,
     terminal.version,
     terminalKey,
-    terminalSurfaceBuffer.length,
+    terminalReplayPaused,
   ]);
 
   useEffect(() => {
@@ -438,11 +449,11 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       status: terminal.status,
       error: terminal.error,
       summary: terminal.summary?.cwd ?? null,
-      bufferLen: terminal.buffer.length,
+      retainedBytes: terminal.output.retainedBytes,
       version: terminal.version,
     });
   }, [
-    terminal.buffer.length,
+    terminal.output.retainedBytes,
     terminal.error,
     terminal.status,
     terminal.summary?.cwd,
@@ -451,16 +462,16 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   ]);
 
   useEffect(() => {
-    if (terminal.buffer.length === 0 || firstNonEmptyBufferLoggedRef.current) {
+    if (terminal.output.retainedBytes === 0 || firstNonEmptyBufferLoggedRef.current) {
       return;
     }
     firstNonEmptyBufferLoggedRef.current = true;
     terminalDebugLog("session:first-nonempty-buffer", {
       terminalKey,
-      length: terminal.buffer.length,
-      preview: terminal.buffer.slice(0, 160),
+      length: terminal.output.retainedBytes,
+      preview: terminalOutputText(terminal.output).slice(0, 160),
     });
-  }, [terminal.buffer, terminal.buffer.length, terminalKey]);
+  }, [terminal.output, terminal.output.retainedBytes, terminalKey]);
   const cwd = terminal.summary?.cwd ?? selectedThreadProject?.workspaceRoot ?? null;
   const hostPlatform = useMemo(
     () => inferHostPlatform(selectedEnvironmentConnection?.environmentLabel ?? null),
@@ -1221,12 +1232,13 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
             <View className="flex-1" style={{ paddingBottom: terminalBottomInset }}>
               <TerminalSurface
                 autoFocus={!SHOWCASE_ENABLED}
-                buffer={terminalSurfaceBuffer}
                 fontSize={fontSize}
                 isRunning={isRunning}
                 keyboardFocusRequest={keyboardFocusRequest}
                 onInput={handleInput}
                 onResize={handleResize}
+                output={terminal.output}
+                replayPaused={terminalReplayPaused}
                 style={{ flex: 1 }}
                 terminalKey={terminalKey}
                 theme={terminalTheme}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -1239,7 +1239,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 onInput={handleInput}
                 onResize={handleResize}
                 output={terminal.output}
+                replayCompleteVersion={terminal.replayCompleteVersion}
                 replayPaused={terminalReplayPaused}
+                replayStartVersion={terminal.replayStartVersion}
                 style={{ flex: 1 }}
                 terminalKey={terminalKey}
                 theme={terminalTheme}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -678,7 +678,8 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     lastBufferReplayKeyRef.current = bufferReplayKey;
     clearBufferReplayTimer();
     setReadyBufferReplayKey(null);
-  }, [bufferReplayKey, clearBufferReplayTimer]);
+    scheduleBufferReplayReady();
+  }, [bufferReplayKey, clearBufferReplayTimer, scheduleBufferReplayReady]);
 
   useEffect(() => clearBufferReplayTimer, [clearBufferReplayTimer]);
 

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -39,6 +39,7 @@ export interface NativeTerminalSurfaceProps extends ViewProps {
 
 export interface NativeTerminalSurfaceHandle {
   readonly write?: (data: string) => Promise<void>;
+  readonly writeReplay?: (data: string) => Promise<void>;
   readonly reset?: (data: string) => Promise<void>;
 }
 
@@ -101,7 +102,7 @@ export function getNativeTerminalHardwareKeyRevision(): number | null {
   }
 }
 
-/** Revision 1 accepts append/reset commands instead of a growing buffer prop. */
+/** Revision 2 adds replay-safe append commands to the streaming API. */
 export function getNativeTerminalStreamingRevision(): number | null {
   try {
     if (typeof requireOptionalNativeModule !== "function") {

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -5,6 +5,8 @@ import { requireNativeView, requireOptionalNativeModule } from "expo";
 import { NativeViewResolutionError } from "../../native/nativeViewResolutionError";
 
 const NATIVE_TERMINAL_MODULE_NAME = "T3TerminalSurface";
+export const NATIVE_TERMINAL_STREAMING_REVISION = 1;
+export const NATIVE_TERMINAL_REPLAY_STREAMING_REVISION = 2;
 
 interface ExpoGlobalWithViewConfig {
   readonly expo?: {
@@ -102,7 +104,7 @@ export function getNativeTerminalHardwareKeyRevision(): number | null {
   }
 }
 
-/** Revision 2 adds replay-safe append commands to the streaming API. */
+/** Revision 2 adds replay-safe append commands to the revision 1 streaming API. */
 export function getNativeTerminalStreamingRevision(): number | null {
   try {
     if (typeof requireOptionalNativeModule !== "function") {

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import type { ComponentType, Ref } from "react";
 import type { NativeSyntheticEvent, ViewProps } from "react-native";
 import { requireNativeView, requireOptionalNativeModule } from "expo";
 
@@ -22,6 +22,7 @@ interface TerminalResizeEvent {
 }
 
 export interface NativeTerminalSurfaceProps extends ViewProps {
+  readonly ref?: Ref<NativeTerminalSurfaceHandle>;
   readonly appearanceScheme?: "light" | "dark";
   readonly autoFocus?: boolean;
   readonly focusRequest?: number;
@@ -34,6 +35,11 @@ export interface NativeTerminalSurfaceProps extends ViewProps {
   readonly fontSize: number;
   readonly onInput?: (event: NativeSyntheticEvent<TerminalInputEvent>) => void;
   readonly onResize?: (event: NativeSyntheticEvent<TerminalResizeEvent>) => void;
+}
+
+export interface NativeTerminalSurfaceHandle {
+  readonly write?: (data: string) => Promise<void>;
+  readonly reset?: (data: string) => Promise<void>;
 }
 
 let cachedNativeTerminalSurfaceView: ComponentType<NativeTerminalSurfaceProps> | undefined;
@@ -90,6 +96,21 @@ export function getNativeTerminalHardwareKeyRevision(): number | null {
       NATIVE_TERMINAL_MODULE_NAME,
     );
     return module?.hardwareKeyRevision ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Revision 1 accepts append/reset commands instead of a growing buffer prop. */
+export function getNativeTerminalStreamingRevision(): number | null {
+  try {
+    if (typeof requireOptionalNativeModule !== "function") {
+      return null;
+    }
+    const module = requireOptionalNativeModule<{ readonly streamingRevision?: number }>(
+      NATIVE_TERMINAL_MODULE_NAME,
+    );
+    return module?.streamingRevision ?? null;
   } catch {
     return null;
   }

--- a/apps/mobile/src/features/terminal/terminalBufferReplay.test.ts
+++ b/apps/mobile/src/features/terminal/terminalBufferReplay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { getTerminalBufferReplayKey, getTerminalSurfaceReplayBuffer } from "./terminalBufferReplay";
+import { getTerminalBufferReplayKey, isTerminalBufferReplayPaused } from "./terminalBufferReplay";
 
 describe("terminalBufferReplay", () => {
   it("keys replay readiness by terminal identity and font metrics", () => {
@@ -12,32 +12,29 @@ describe("terminalBufferReplay", () => {
     ).toBe("env-1:thread-1:default:10");
   });
 
-  it("shows terminal history while replay key is unset (initial mount / after key change)", () => {
+  it("pauses replay only while an older font layout is still ready", () => {
     const replayKey = getTerminalBufferReplayKey({
       terminalKey: "env-1:thread-1:default",
       fontSize: 10,
     });
 
     expect(
-      getTerminalSurfaceReplayBuffer({
-        buffer: "fastfetch output",
+      isTerminalBufferReplayPaused({
         replayKey,
         readyReplayKey: null,
       }),
-    ).toBe("fastfetch output");
+    ).toBe(false);
     expect(
-      getTerminalSurfaceReplayBuffer({
-        buffer: "fastfetch output",
+      isTerminalBufferReplayPaused({
         replayKey,
         readyReplayKey: "env-1:thread-1:default:11",
       }),
-    ).toBe("");
+    ).toBe(true);
     expect(
-      getTerminalSurfaceReplayBuffer({
-        buffer: "fastfetch output",
+      isTerminalBufferReplayPaused({
         replayKey,
         readyReplayKey: replayKey,
       }),
-    ).toBe("fastfetch output");
+    ).toBe(false);
   });
 });

--- a/apps/mobile/src/features/terminal/terminalBufferReplay.ts
+++ b/apps/mobile/src/features/terminal/terminalBufferReplay.ts
@@ -1,5 +1,3 @@
-import { terminalDebugLog } from "./terminalDebugLog";
-
 export const TERMINAL_BUFFER_REPLAY_STABILITY_DELAY_MS = 180;
 
 export function getTerminalBufferReplayKey(input: {
@@ -9,21 +7,9 @@ export function getTerminalBufferReplayKey(input: {
   return `${input.terminalKey}:${input.fontSize}`;
 }
 
-export function getTerminalSurfaceReplayBuffer(input: {
-  readonly buffer: string;
+export function isTerminalBufferReplayPaused(input: {
   readonly replayKey: string;
   readonly readyReplayKey: string | null;
-}): string {
-  // Pass live buffer whenever ready key is unset or matches. Only return "" when ready key is
-  // stale vs current replay key (e.g. mid font-size transition).
-  if (input.readyReplayKey !== null && input.readyReplayKey !== input.replayKey) {
-    terminalDebugLog("replay:stale-key-hiding-buffer", {
-      replayKey: input.replayKey,
-      readyReplayKey: input.readyReplayKey,
-      bufferLen: input.buffer.length,
-    });
-    return "";
-  }
-
-  return input.buffer;
+}): boolean {
+  return input.readyReplayKey !== null && input.readyReplayKey !== input.replayKey;
 }

--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { type KnownTerminalSession } from "@t3tools/client-runtime/state/terminal";
+import {
+  EMPTY_TERMINAL_SESSION_STATE,
+  type KnownTerminalSession,
+} from "@t3tools/client-runtime/state/terminal";
 import { DEFAULT_TERMINAL_ID, EnvironmentId, ThreadId } from "@t3tools/contracts";
 
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
@@ -55,7 +58,7 @@ function makeKnownSession(input: {
             updatedAt: input.updatedAt ?? "2026-04-15T20:00:00.000Z",
           }
         : null,
-      buffer: "",
+      output: EMPTY_TERMINAL_SESSION_STATE.output,
       status: input.status,
       error: null,
       hasRunningSubprocess: false,

--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -63,6 +63,7 @@ function makeKnownSession(input: {
       error: null,
       hasRunningSubprocess: false,
       updatedAt: input.updatedAt ?? "2026-04-15T20:00:00.000Z",
+      replayCompleteVersion: 0,
       version: 1,
     },
   };

--- a/apps/mobile/src/features/terminal/terminalMenu.test.ts
+++ b/apps/mobile/src/features/terminal/terminalMenu.test.ts
@@ -63,6 +63,7 @@ function makeKnownSession(input: {
       error: null,
       hasRunningSubprocess: false,
       updatedAt: input.updatedAt ?? "2026-04-15T20:00:00.000Z",
+      replayStartVersion: 0,
       replayCompleteVersion: 0,
       version: 1,
     },

--- a/apps/mobile/src/features/terminal/threadTerminalPanelModel.ts
+++ b/apps/mobile/src/features/terminal/threadTerminalPanelModel.ts
@@ -16,6 +16,7 @@ export interface TerminalGridSize {
 export function buildThreadTerminalAttachInput(
   identity: ThreadTerminalSubscriptionIdentity,
   gridSize: TerminalGridSize,
+  replayBytes?: number,
 ): TerminalAttachInput {
   return {
     threadId: identity.threadId,
@@ -24,5 +25,6 @@ export function buildThreadTerminalAttachInput(
     worktreePath: identity.worktreePath,
     cols: gridSize.cols,
     rows: gridSize.rows,
+    ...(replayBytes === undefined ? {} : { replayBytes }),
   };
 }

--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -53,6 +53,7 @@ const makeTerminalManagerLayer = (
   Layer.succeed(TerminalManager.TerminalManager, {
     ...overrides,
     attachStream: () => Effect.die(new Error("unused")),
+    readSnapshot: () => Effect.die(new Error("unused")),
     resize: () => Effect.void,
     clear: () => Effect.void,
     restart: () => Effect.die(new Error("unused")),

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -370,7 +370,12 @@ it.layer(
       yield* manager.open(openInput());
 
       const events = yield* Ref.get(attachEvents);
-      expect(events.map((event) => event.type)).toEqual(["snapshot", "closed", "snapshot"]);
+      expect(events.map((event) => event.type)).toEqual([
+        "snapshot",
+        "replay-complete",
+        "closed",
+        "snapshot",
+      ]);
       expect(
         events.filter((event) => event.type === "snapshot").map((event) => event.snapshot.status),
       ).toEqual(["running", "running"]);
@@ -1229,6 +1234,22 @@ it.layer(
     }),
   );
 
+  it.effect("does not start compacted history inside a terminal control sequence", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager({
+        historyTargetBytes: 8,
+        historyMaxBytes: 12,
+      });
+      const filePath = yield* historyLogPath(logsDir);
+      yield* writeFileString(filePath, "123456\u001b[31mhello");
+
+      const opened = yield* manager.open(openInput());
+
+      expect(opened.history).toBe("hello");
+      expect(yield* readFileString(filePath)).toBe("hello");
+    }),
+  );
+
   it.effect("keeps durable history larger than snapshots sent to clients", () =>
     Effect.gen(function* () {
       const { manager, logsDir } = yield* createManager({
@@ -1989,6 +2010,11 @@ it.layer(
               terminalId: DEFAULT_TERMINAL_ID,
             },
           },
+          {
+            type: "replay-complete",
+            threadId: "thread-1",
+            terminalId: DEFAULT_TERMINAL_ID,
+          },
         ]);
 
         process.emitData("hello from attach\n");
@@ -2036,6 +2062,7 @@ it.layer(
       expect(replayEvents.length).toBeGreaterThan(1);
       expect(replayEvents.every((event) => Buffer.byteLength(event.data) <= 64 * 1024)).toBe(true);
       expect(replayEvents.map((event) => event.data).join("")).toBe(history);
+      expect(deliveries.at(-1)?.event.type).toBe("replay-complete");
       expect(deliveries.every(({ delivery }) => delivery === "replay")).toBe(true);
     }),
   );
@@ -2108,6 +2135,7 @@ it.layer(
 
       expect(yield* Ref.get(attachEvents)).toMatchObject([
         { type: "snapshot" },
+        { type: "replay-complete" },
         { type: "output", data: "during snapshot\n" },
       ]);
     }),
@@ -2231,6 +2259,34 @@ it.layer(
       expect(outputEvents.map((event) => event.data).join("")).toBe(
         `${chunk.repeat(64)}${oversizedChunk}`,
       );
+    }),
+  );
+
+  it.effect("preserves a Unicode scalar split across PTY callbacks", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents, logsDir } = yield* createManager({
+        ptyAdapter: new FakePtyAdapter("async"),
+      });
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("\ud83d");
+      process.emitData("\ude42");
+      process.emitExit({ exitCode: 0, signal: 0 });
+
+      yield* waitFor(
+        Effect.map(getEvents, (events) => events.some((event) => event.type === "exited")),
+        "1200 millis",
+      );
+
+      const output = (yield* getEvents)
+        .filter((event) => event.type === "output")
+        .map((event) => event.data)
+        .join("");
+      expect(output).toBe("🙂");
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe("🙂");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import {
   DEFAULT_TERMINAL_ID,
+  EXTENDED_TERMINAL_REPLAY_BYTES,
   type TerminalAttachStreamEvent,
   type TerminalEvent,
   type TerminalMetadataStreamEvent,
@@ -10,6 +11,7 @@ import {
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
@@ -42,6 +44,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   readonly pid: number;
   writeFailure: unknown | undefined;
   resizeFailure: unknown | undefined;
+  killObserver: ((signal: string | undefined) => void) | undefined;
   private readonly dataListeners = new Set<(data: string) => void>();
   private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
   killed = false;
@@ -67,6 +70,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   kill(signal?: string): void {
     this.killed = true;
     this.killSignals.push(signal);
+    this.killObserver?.(signal);
   }
 
   onData(callback: (data: string) => void): () => void {
@@ -203,6 +207,12 @@ const multiTerminalHistoryLogPath = (
   );
 
 interface CreateManagerOptions {
+  historyTargetBytes?: number;
+  historyMaxBytes?: number;
+  replayHistoryTargetBytes?: number;
+  replayHistoryMaxBytes?: number;
+  outputBatchWindowMs?: number;
+  outputBatchMaxBytes?: number;
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: (terminalPid: number) => Effect.Effect<{
@@ -214,6 +224,7 @@ interface CreateManagerOptions {
   processKillGraceMs?: number;
   maxRetainedInactiveSessions?: number;
   ptyAdapter?: FakePtyAdapter;
+  managerScope?: Scope.Scope;
 }
 
 interface ManagerFixture {
@@ -225,7 +236,6 @@ interface ManagerFixture {
 }
 
 const createManager = (
-  historyLineLimit = 5,
   options: CreateManagerOptions = {},
 ): Effect.Effect<
   ManagerFixture,
@@ -239,9 +249,26 @@ const createManager = (
       const logsDir = join(baseDir, "userdata", "logs", "terminals");
       const ptyAdapter = options.ptyAdapter ?? new FakePtyAdapter();
 
-      const manager = yield* TerminalManager.makeWithOptions({
+      const managerEffect = TerminalManager.makeWithOptions({
         logsDir,
-        historyLineLimit,
+        ...(options.historyTargetBytes !== undefined
+          ? { historyTargetBytes: options.historyTargetBytes }
+          : {}),
+        ...(options.historyMaxBytes !== undefined
+          ? { historyMaxBytes: options.historyMaxBytes }
+          : {}),
+        ...(options.replayHistoryTargetBytes !== undefined
+          ? { replayHistoryTargetBytes: options.replayHistoryTargetBytes }
+          : {}),
+        ...(options.replayHistoryMaxBytes !== undefined
+          ? { replayHistoryMaxBytes: options.replayHistoryMaxBytes }
+          : {}),
+        ...(options.outputBatchWindowMs !== undefined
+          ? { outputBatchWindowMs: options.outputBatchWindowMs }
+          : {}),
+        ...(options.outputBatchMaxBytes !== undefined
+          ? { outputBatchMaxBytes: options.outputBatchMaxBytes }
+          : {}),
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
         ...(options.env !== undefined ? { env: options.env } : {}),
@@ -256,6 +283,9 @@ const createManager = (
           ? { maxRetainedInactiveSessions: options.maxRetainedInactiveSessions }
           : {}),
       });
+      const manager = yield* options.managerScope === undefined
+        ? managerEffect
+        : managerEffect.pipe(Effect.provideService(Scope.Scope, options.managerScope));
       const eventsRef = yield* Ref.make<ReadonlyArray<TerminalEvent>>([]);
       const unsubscribe = yield* manager.subscribe((event) =>
         Ref.update(eventsRef, (events) => [...events, event]),
@@ -444,6 +474,25 @@ it.layer(
       fs.writeFileString(filePath, contents),
     );
 
+  interface RecordedHistoryWrite {
+    readonly contents: string;
+    readonly flag: FileSystem.OpenFlag | undefined;
+  }
+
+  const recordHistoryWrites = (
+    fileSystem: FileSystem.FileSystem,
+    writes: Array<RecordedHistoryWrite>,
+  ): FileSystem.FileSystem =>
+    FileSystem.FileSystem.of({
+      ...fileSystem,
+      writeFileString: (filePath, contents, options) =>
+        Effect.sync(() => {
+          if (filePath.endsWith(".log")) {
+            writes.push({ contents, flag: options?.flag });
+          }
+        }).pipe(Effect.andThen(fileSystem.writeFileString(filePath, contents, options))),
+    });
+
   it.effect("reports a missing cwd without an artificial cause", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;
@@ -505,7 +554,7 @@ it.layer(
 
   it.effect("supports asynchronous PTY spawn effects", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
 
@@ -609,6 +658,25 @@ it.layer(
         terminalId: DEFAULT_TERMINAL_ID,
         deleteHistory: true,
       });
+      yield* manager.resize({
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        cols: 120,
+        rows: 30,
+      });
+
+      expect(process.resizeCalls).toEqual([]);
+    }),
+  );
+
+  it.effect("ignores duplicate resize requests", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      yield* manager.open(openInput({ cols: 120, rows: 30 }));
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
       yield* manager.resize({
         threadId: "thread-1",
         terminalId: DEFAULT_TERMINAL_ID,
@@ -892,7 +960,7 @@ it.layer(
         readonly childCommand: string | null;
         readonly processIds: ReadonlyArray<number>;
       } = { hasRunningSubprocess: false, childCommand: null, processIds: [] };
-      const { manager, getEvents } = yield* createManager(5, {
+      const { manager, getEvents } = yield* createManager({
         subprocessInspector: () => Effect.succeed(inspect),
         subprocessPollIntervalMs: 20,
       });
@@ -931,7 +999,7 @@ it.layer(
   it.effect("does not invoke subprocess polling until a terminal session is running", () =>
     Effect.gen(function* () {
       let checks = 0;
-      const { manager } = yield* createManager(5, {
+      const { manager } = yield* createManager({
         subprocessInspector: () => {
           checks += 1;
           return Effect.succeed({
@@ -979,7 +1047,7 @@ it.layer(
           }),
       };
 
-      const { manager, getEvents } = yield* createManager(5, {
+      const { manager, getEvents } = yield* createManager({
         subprocessPollIntervalMs: 20,
       }).pipe(
         Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
@@ -1040,7 +1108,7 @@ it.layer(
           }),
       };
 
-      const { manager, getEvents } = yield* createManager(5, {
+      const { manager, getEvents } = yield* createManager({
         subprocessPollIntervalMs: 20,
       }).pipe(
         Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
@@ -1073,20 +1141,182 @@ it.layer(
     }),
   );
 
-  it.effect("caps persisted history to configured line limit", () =>
+  it.effect("appends normal terminal output without rewriting history", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(3);
+      const fileSystem = yield* FileSystem.FileSystem;
+      const writes: Array<RecordedHistoryWrite> = [];
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
+        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
+      );
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
       if (!process) return;
 
-      process.emitData("line1\nline2\nline3\nline4\n");
+      const output = Array.from({ length: 100 }, (_, index) => `redraw ${index}\r`).join("");
+      for (let index = 0; index < 100; index += 1) {
+        process.emitData(`redraw ${index}\r`);
+      }
       yield* manager.close({ threadId: "thread-1" });
 
-      const reopened = yield* manager.open(openInput());
-      const nonEmptyLines = reopened.history.split("\n").filter((line) => line.length > 0);
-      expect(nonEmptyLines).toEqual(["line2", "line3", "line4"]);
+      expect(writes.length).toBeLessThan(100);
+      expect(writes.every((write) => write.flag === "a")).toBe(true);
+      expect(writes.map((write) => write.contents).join("")).toBe(output);
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(output);
+    }),
+  );
+
+  it.effect("uses truncation only for clear and restart resets", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const writes: Array<RecordedHistoryWrite> = [];
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
+        Effect.provideService(FileSystem.FileSystem, recordHistoryWrites(fileSystem, writes)),
+      );
+      yield* manager.open(openInput());
+      const firstProcess = ptyAdapter.processes[0];
+      expect(firstProcess).toBeDefined();
+      if (!firstProcess) return;
+
+      firstProcess.emitData("before clear\r");
+      yield* manager.clear({ threadId: "thread-1", terminalId: DEFAULT_TERMINAL_ID });
+      firstProcess.emitData("before restart\r");
+      yield* manager.restart(restartInput());
+
+      expect(writes.filter((write) => write.flag === "w")).toEqual([
+        { contents: "", flag: "w" },
+        { contents: "", flag: "w" },
+      ]);
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe("");
+    }),
+  );
+
+  it.effect("compacts carriage-return history at the configured byte limit", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager({
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("old-one\r");
+      process.emitData("old-two\r");
+      process.emitData("new-one\rnew-two\r");
+      yield* manager.close({ threadId: "thread-1" });
+
+      const persisted = yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString));
+      expect(persisted).toBe("new-two\r");
+      expect(Buffer.byteLength(persisted)).toBeLessThanOrEqual(12);
+    }),
+  );
+
+  it.effect("compacts oversized existing history on open", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager({
+        historyTargetBytes: 12,
+        historyMaxBytes: 24,
+      });
+      const filePath = yield* historyLogPath(logsDir);
+      yield* writeFileString(filePath, "old-one\rold-two\rnew-one\rnew-two\r");
+
+      const opened = yield* manager.open(openInput());
+
+      expect(opened.history).toBe("new-two\r");
+      expect(yield* readFileString(filePath)).toBe("new-two\r");
+    }),
+  );
+
+  it.effect("keeps durable history larger than snapshots sent to clients", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager({
+        historyTargetBytes: 64,
+        historyMaxBytes: 96,
+        replayHistoryTargetBytes: 12,
+        replayHistoryMaxBytes: 24,
+      });
+      const filePath = yield* historyLogPath(logsDir);
+      const durableHistory = "old-one\rold-two\rnew-one\rnew-two\r";
+      yield* writeFileString(filePath, durableHistory);
+
+      const opened = yield* manager.open(openInput());
+      const resynced = yield* manager.readSnapshot({
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+      });
+
+      expect(opened.history).toBe("new-two\r");
+      expect(Option.getOrThrow(resynced).history).toBe("new-two\r");
+      expect(yield* readFileString(filePath)).toBe(durableHistory);
+    }),
+  );
+
+  it.effect("recovers a partially written append with bounded history", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const failedAppend = yield* Deferred.make<void>();
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "writeFileString",
+        pathOrDescriptor: "terminal-history",
+      });
+      let shouldFailAppend = true;
+      const recoveringFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        writeFileString: (filePath, contents, options) => {
+          if (
+            filePath.endsWith(".log") &&
+            options?.flag === "a" &&
+            contents.length > 0 &&
+            shouldFailAppend
+          ) {
+            shouldFailAppend = false;
+            return fileSystem
+              .writeFileString(filePath, contents.slice(0, 4), options)
+              .pipe(
+                Effect.andThen(Deferred.succeed(failedAppend, undefined)),
+                Effect.andThen(Effect.fail(cause)),
+              );
+          }
+          return fileSystem.writeFileString(filePath, contents, options);
+        },
+      });
+      const { manager, ptyAdapter, logsDir } = yield* createManager().pipe(
+        Effect.provideService(FileSystem.FileSystem, recoveringFileSystem),
+      );
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("survives recovery\r");
+      yield* Deferred.await(failedAppend);
+      yield* manager.close({ threadId: "thread-1" });
+
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(
+        "survives recovery\r",
+      );
+    }),
+  );
+
+  it.effect("preserves Unicode split across terminal output chunks", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir } = yield* createManager();
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("before \ud83d");
+      process.emitData("\ude00 after\r");
+      yield* manager.close({ threadId: "thread-1" });
+
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(
+        "before 😀 after\r",
+      );
     }),
   );
 
@@ -1307,7 +1537,7 @@ it.layer(
 
   it.effect("escalates terminal shutdown to SIGKILL when process does not exit in time", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, { processKillGraceMs: 10 });
+      const { manager, ptyAdapter } = yield* createManager({ processKillGraceMs: 10 });
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
@@ -1340,7 +1570,7 @@ it.layer(
 
   it.effect("evicts oldest inactive terminal sessions when retention limit is exceeded", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, logsDir, getEvents } = yield* createManager(5, {
+      const { manager, ptyAdapter, logsDir, getEvents } = yield* createManager({
         maxRetainedInactiveSessions: 1,
       });
 
@@ -1403,7 +1633,7 @@ it.layer(
       const platform = yield* HostProcessPlatform;
       const missingShell =
         platform === "win32" ? "C:\\definitely\\missing-shell.exe" : "/definitely/missing-shell -l";
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         shellResolver: () => missingShell,
       });
       ptyAdapter.spawnFailures.push(new Error("posix_spawnp failed."));
@@ -1437,7 +1667,7 @@ it.layer(
 
   it.effect("prefers PowerShell over ComSpec for Windows terminals", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           ComSpec: "C:\\Windows\\System32\\cmd.exe",
           PATH: "C:\\Windows\\System32",
@@ -1459,7 +1689,7 @@ it.layer(
   it.effect("falls back to built-in PowerShell by absolute path on Windows", () =>
     Effect.gen(function* () {
       const ptyAdapter = new FakePtyAdapter();
-      const { manager } = yield* createManager(5, {
+      const { manager } = yield* createManager({
         ptyAdapter,
         shellResolver: () => "C:\\missing\\custom-shell.exe",
         env: {
@@ -1487,7 +1717,7 @@ it.layer(
 
   it.effect("filters app runtime env variables from terminal sessions", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           PORT: "5173",
           T3CODE_PORT: "3773",
@@ -1512,7 +1742,7 @@ it.layer(
   it.effect("strips AppImage runtime env from terminal sessions", () =>
     Effect.gen(function* () {
       const appDir = "/tmp/.mount_T3Codeabc123";
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           APPIMAGE: "/home/user/T3-Code.AppImage",
           APPDIR: appDir,
@@ -1553,7 +1783,7 @@ it.layer(
 
   it.effect("leaves the environment untouched when not launched from an AppImage", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         env: {
           PATH: "/usr/local/bin:/usr/bin:/bin",
           LD_LIBRARY_PATH: "/home/user/.local/lib",
@@ -1598,7 +1828,7 @@ it.layer(
   it.effect("starts zsh with prompt spacer disabled to avoid `%` end markers", () =>
     Effect.gen(function* () {
       if ((yield* HostProcessPlatform) === "win32") return;
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         shellResolver: () => "/bin/zsh",
       });
       yield* manager.open(openInput());
@@ -1612,7 +1842,7 @@ it.layer(
 
   it.effect("bridges PTY callbacks back into Effect-managed event streaming", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, getEvents } = yield* createManager(5, {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
 
@@ -1634,7 +1864,7 @@ it.layer(
 
   it.effect("pushes PTY callbacks to direct event subscribers", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
       const subscriberEvents = yield* Ref.make<ReadonlyArray<TerminalEvent>>([]);
@@ -1738,7 +1968,7 @@ it.layer(
     "streams attach snapshots followed by live events without duplicate start snapshots",
     () =>
       Effect.gen(function* () {
-        const { manager, ptyAdapter } = yield* createManager(5, {
+        const { manager, ptyAdapter } = yield* createManager({
           ptyAdapter: new FakePtyAdapter("async"),
         });
         const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
@@ -1775,9 +2005,80 @@ it.layer(
       }),
   );
 
+  it.effect("streams extended persisted history before live terminal output", () =>
+    Effect.gen(function* () {
+      const { manager, logsDir } = yield* createManager();
+      const history = Array.from(
+        { length: 12_000 },
+        (_, index) => `${String(index).padStart(5, "0")} ${"x".repeat(64)}\n`,
+      ).join("");
+      yield* historyLogPath(logsDir).pipe(
+        Effect.flatMap((filePath) => writeFileString(filePath, history)),
+      );
+
+      const deliveries: Array<{
+        readonly event: TerminalAttachStreamEvent;
+        readonly delivery: "replay" | "live";
+      }> = [];
+      const unsubscribe = yield* manager.attachStream(
+        { ...openInput(), replayBytes: EXTENDED_TERMINAL_REPLAY_BYTES },
+        (event, delivery) => Effect.sync(() => deliveries.push({ event, delivery })),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      expect(deliveries[0]).toMatchObject({
+        event: { type: "snapshot", snapshot: { history: "" } },
+        delivery: "replay",
+      });
+      const replayEvents = deliveries
+        .map(({ event }) => event)
+        .filter((event) => event.type === "output");
+      expect(replayEvents.length).toBeGreaterThan(1);
+      expect(replayEvents.every((event) => Buffer.byteLength(event.data) <= 64 * 1024)).toBe(true);
+      expect(replayEvents.map((event) => event.data).join("")).toBe(history);
+      expect(deliveries.every(({ delivery }) => delivery === "replay")).toBe(true);
+    }),
+  );
+
+  it.effect("cancels extended history replay when its attach scope closes", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, logsDir, getEvents } = yield* createManager();
+      const history = "history line\n".repeat(20_000);
+      yield* historyLogPath(logsDir).pipe(
+        Effect.flatMap((filePath) => writeFileString(filePath, history)),
+      );
+      const replayStarted = yield* Deferred.make<void>();
+      const replayChunks = yield* Ref.make(0);
+      const attachFiber = yield* manager
+        .attachStream({ ...openInput(), replayBytes: EXTENDED_TERMINAL_REPLAY_BYTES }, (event) => {
+          if (event.type !== "output") return Effect.void;
+          return Ref.update(replayChunks, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(replayStarted, undefined)),
+            Effect.andThen(Effect.never),
+          );
+        })
+        .pipe(Effect.forkScoped);
+
+      yield* Deferred.await(replayStarted);
+      yield* Fiber.interrupt(attachFiber);
+
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+      process.emitData("after cancel\n");
+      process.emitExit({ exitCode: 0, signal: 0 });
+      yield* waitFor(
+        Effect.map(getEvents, (events) => events.some((event) => event.type === "exited")),
+        "1200 millis",
+      );
+
+      expect(yield* Ref.get(replayChunks)).toBe(1);
+    }),
+  );
+
   it.effect("buffers attach output delivered during the initial snapshot callback", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, {
+      const { manager, ptyAdapter } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
       yield* manager.open(openInput());
@@ -1812,9 +2113,47 @@ it.layer(
     }),
   );
 
+  it.effect("does not duplicate pending output across extended replay and live events", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
+        ptyAdapter: new FakePtyAdapter("async"),
+      });
+      yield* manager.open(openInput());
+
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("pending\n");
+
+      const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
+      const unsubscribe = yield* manager.attachStream(
+        { ...openInput(), replayBytes: EXTENDED_TERMINAL_REPLAY_BYTES },
+        (event) => Ref.update(attachEvents, (events) => [...events, event]),
+      );
+      yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
+
+      yield* waitFor(
+        Effect.map(getEvents, (events) =>
+          events.some((event) => event.type === "output" && event.data === "pending\n"),
+        ),
+        "1200 millis",
+      );
+
+      const replayedText = (yield* Ref.get(attachEvents))
+        .map((event) => {
+          if (event.type === "snapshot") return event.snapshot.history;
+          if (event.type === "output") return event.data;
+          return "";
+        })
+        .join("");
+      expect(replayedText.split("pending\n")).toHaveLength(2);
+    }),
+  );
+
   it.effect("preserves queued PTY output ordering through exit callbacks", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter, getEvents } = yield* createManager(5, {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
       });
 
@@ -1832,7 +2171,7 @@ it.layer(
           const relevant = events.filter(
             (event) => event.type === "output" || event.type === "exited",
           );
-          return relevant.length >= 3;
+          return relevant.length >= 2;
         }),
         "1200 millis",
       );
@@ -1841,9 +2180,8 @@ it.layer(
         (event) => event.type === "output" || event.type === "exited",
       );
       expect(relevant).toEqual([
-        expect.objectContaining({ type: "output", data: "first\n", sequence: 2 }),
-        expect.objectContaining({ type: "output", data: "second\n", sequence: 3 }),
-        expect.objectContaining({ type: "exited", exitCode: 0, exitSignal: 0, sequence: 4 }),
+        expect.objectContaining({ type: "output", data: "first\nsecond\n", sequence: 2 }),
+        expect.objectContaining({ type: "exited", exitCode: 0, exitSignal: 0, sequence: 3 }),
       ]);
 
       const attachEvents = yield* Ref.make<ReadonlyArray<TerminalAttachStreamEvent>>([]);
@@ -1859,26 +2197,70 @@ it.layer(
       const snapshot = (yield* Ref.get(attachEvents)).find((event) => event.type === "snapshot");
       expect(snapshot).toBeDefined();
       if (!snapshot || snapshot.type !== "snapshot") return;
-      expect(snapshot.snapshot.sequence).toBe(4);
+      expect(snapshot.snapshot.sequence).toBe(3);
     }),
   );
 
-  it.effect("scoped runtime shutdown stops active terminals cleanly", () =>
+  it.effect("coalesces burst output without changing its bytes", () =>
     Effect.gen(function* () {
-      const scope = yield* Scope.make("sequential");
-      const { manager, ptyAdapter } = yield* createManager(5, {
-        processKillGraceMs: 10,
-      }).pipe(Effect.provideService(Scope.Scope, scope));
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
+        ptyAdapter: new FakePtyAdapter("async"),
+        outputBatchMaxBytes: 16 * 1024,
+      });
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
       if (!process) return;
 
+      const chunk = "x".repeat(1_024);
+      for (let index = 0; index < 64; index += 1) {
+        process.emitData(chunk);
+      }
+      const oversizedChunk = chunk.repeat(64);
+      process.emitData(oversizedChunk);
+      process.emitExit({ exitCode: 0, signal: 0 });
+
+      yield* waitFor(
+        Effect.map(getEvents, (events) => events.some((event) => event.type === "exited")),
+        "1200 millis",
+      );
+
+      const outputEvents = (yield* getEvents).filter((event) => event.type === "output");
+      expect(outputEvents).toHaveLength(8);
+      expect(outputEvents.every((event) => Buffer.byteLength(event.data) <= 16 * 1024)).toBe(true);
+      expect(outputEvents.map((event) => event.data).join("")).toBe(
+        `${chunk.repeat(64)}${oversizedChunk}`,
+      );
+    }),
+  );
+
+  it.effect("scoped runtime shutdown flushes history and stops active terminals", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make("sequential");
+      const { manager, ptyAdapter, logsDir } = yield* createManager({
+        processKillGraceMs: 10,
+        managerScope: scope,
+      });
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+      const sigtermSent = yield* Effect.callback<void>((resume) => {
+        process.killObserver = (signal) => {
+          if (signal === "SIGTERM") {
+            resume(Effect.void);
+          }
+        };
+      }).pipe(Effect.forkScoped);
+      const output = "x".repeat(64 * 1024);
+      process.emitData(output);
+
       const closeScope = yield* Scope.close(scope, Exit.void).pipe(Effect.forkScoped);
-      yield* Effect.yieldNow;
+      yield* Fiber.join(sigtermSent);
       yield* TestClock.adjust("10 millis");
       yield* Fiber.join(closeScope);
 
+      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(output);
       assert.equal(process.killSignals[0], "SIGTERM");
       expect(process.killSignals).toContain("SIGKILL");
     }).pipe(Effect.provide(TestClock.layer())),

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -47,6 +47,10 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   killObserver: ((signal: string | undefined) => void) | undefined;
   private readonly dataListeners = new Set<(data: string) => void>();
   private readonly exitListeners = new Set<(event: PtyAdapter.PtyExitEvent) => void>();
+  private readonly pausedData: string[] = [];
+  pauseCalls = 0;
+  resumeCalls = 0;
+  outputPaused = false;
   killed = false;
 
   constructor(pid: number) {
@@ -73,6 +77,23 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
     this.killObserver?.(signal);
   }
 
+  pauseOutput(): void {
+    if (this.outputPaused) return;
+    this.outputPaused = true;
+    this.pauseCalls += 1;
+  }
+
+  resumeOutput(): void {
+    if (!this.outputPaused) return;
+    this.outputPaused = false;
+    this.resumeCalls += 1;
+    while (!this.outputPaused) {
+      const data = this.pausedData.shift();
+      if (data === undefined) break;
+      this.notifyData(data);
+    }
+  }
+
   onData(callback: (data: string) => void): () => void {
     this.dataListeners.add(callback);
     return () => {
@@ -88,6 +109,14 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
   }
 
   emitData(data: string): void {
+    if (this.outputPaused) {
+      this.pausedData.push(data);
+      return;
+    }
+    this.notifyData(data);
+  }
+
+  private notifyData(data: string): void {
     for (const listener of this.dataListeners) {
       listener(data);
     }
@@ -213,6 +242,7 @@ interface CreateManagerOptions {
   replayHistoryMaxBytes?: number;
   outputBatchWindowMs?: number;
   outputBatchMaxBytes?: number;
+  pendingProcessEventMaxBytes?: number;
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
   subprocessInspector?: (terminalPid: number) => Effect.Effect<{
@@ -268,6 +298,9 @@ const createManager = (
           : {}),
         ...(options.outputBatchMaxBytes !== undefined
           ? { outputBatchMaxBytes: options.outputBatchMaxBytes }
+          : {}),
+        ...(options.pendingProcessEventMaxBytes !== undefined
+          ? { pendingProcessEventMaxBytes: options.pendingProcessEventMaxBytes }
           : {}),
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
@@ -2268,6 +2301,45 @@ it.layer(
       expect(outputEvents.every((event) => Buffer.byteLength(event.data) <= 64 * 1024)).toBe(true);
       expect(outputEvents.map((event) => event.data).join("")).toBe(
         `${chunk.repeat(64)}${oversizedChunk}`,
+      );
+    }),
+  );
+
+  it.effect("pauses PTY output while the bounded event backlog drains", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter, getEvents } = yield* createManager({
+        ptyAdapter: new FakePtyAdapter("async"),
+        outputBatchMaxBytes: 4,
+        pendingProcessEventMaxBytes: 8,
+      });
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      process.emitData("aaaa");
+      process.emitData("bbbb");
+
+      yield* waitFor(
+        Effect.map(
+          getEvents,
+          (events) =>
+            events
+              .filter((event) => event.type === "output")
+              .map((event) => event.data)
+              .join("") === "aaaabbbb",
+        ),
+        "1200 millis",
+      );
+
+      expect(process.pauseCalls).toBeGreaterThanOrEqual(1);
+      expect(process.resumeCalls).toBe(process.pauseCalls);
+      expect(process.outputPaused).toBe(false);
+
+      process.emitExit({ exitCode: 0, signal: 0 });
+      yield* waitFor(
+        Effect.map(getEvents, (events) => events.some((event) => event.type === "exited")),
+        "1200 millis",
       );
     }),
   );

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -2240,11 +2240,10 @@ it.layer(
     }),
   );
 
-  it.effect("coalesces burst output without changing its bytes", () =>
+  it.effect("coalesces a 128 KB PTY burst into two bounded output events", () =>
     Effect.gen(function* () {
       const { manager, ptyAdapter, getEvents } = yield* createManager({
         ptyAdapter: new FakePtyAdapter("async"),
-        outputBatchMaxBytes: 16 * 1024,
       });
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
@@ -2265,8 +2264,8 @@ it.layer(
       );
 
       const outputEvents = (yield* getEvents).filter((event) => event.type === "output");
-      expect(outputEvents).toHaveLength(8);
-      expect(outputEvents.every((event) => Buffer.byteLength(event.data) <= 16 * 1024)).toBe(true);
+      expect(outputEvents).toHaveLength(2);
+      expect(outputEvents.every((event) => Buffer.byteLength(event.data) <= 64 * 1024)).toBe(true);
       expect(outputEvents.map((event) => event.data).join("")).toBe(
         `${chunk.repeat(64)}${oversizedChunk}`,
       );

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -2318,7 +2318,7 @@ it.layer(
           }
         };
       }).pipe(Effect.forkScoped);
-      const output = "x".repeat(64 * 1024);
+      const output = `${"x".repeat(64 * 1024)}\ud83d`;
       process.emitData(output);
 
       const closeScope = yield* Scope.close(scope, Exit.void).pipe(Effect.forkScoped);
@@ -2326,7 +2326,16 @@ it.layer(
       yield* TestClock.adjust("10 millis");
       yield* Fiber.join(closeScope);
 
-      expect(yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString))).toBe(output);
+      const persisted = yield* historyLogPath(logsDir).pipe(Effect.flatMap(readFileString));
+      expect({
+        byteLength: Buffer.byteLength(persisted),
+        codePoints: [...persisted.slice(-4)].map((character) => character.codePointAt(0)),
+        length: persisted.length,
+      }).toEqual({
+        byteLength: 64 * 1024 + 3,
+        codePoints: [120, 120, 120, 65_533],
+        length: 64 * 1024 + 1,
+      });
       assert.equal(process.killSignals[0], "SIGTERM");
       expect(process.killSignals).toContain("SIGKILL");
     }).pipe(Effect.provide(TestClock.layer())),

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -371,6 +371,7 @@ it.layer(
 
       const events = yield* Ref.get(attachEvents);
       expect(events.map((event) => event.type)).toEqual([
+        "replay-start",
         "snapshot",
         "replay-complete",
         "closed",
@@ -2004,6 +2005,11 @@ it.layer(
 
         expect(yield* Ref.get(attachEvents)).toMatchObject([
           {
+            type: "replay-start",
+            threadId: "thread-1",
+            terminalId: DEFAULT_TERMINAL_ID,
+          },
+          {
             type: "snapshot",
             snapshot: {
               threadId: "thread-1",
@@ -2053,6 +2059,10 @@ it.layer(
       yield* Effect.addFinalizer(() => Effect.sync(unsubscribe));
 
       expect(deliveries[0]).toMatchObject({
+        event: { type: "replay-start" },
+        delivery: "replay",
+      });
+      expect(deliveries[1]).toMatchObject({
         event: { type: "snapshot", snapshot: { history: "" } },
         delivery: "replay",
       });
@@ -2134,6 +2144,7 @@ it.layer(
       );
 
       expect(yield* Ref.get(attachEvents)).toMatchObject([
+        { type: "replay-start" },
         { type: "snapshot" },
         { type: "replay-complete" },
         { type: "output", data: "during snapshot\n" },

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -8,6 +8,7 @@
  */
 import {
   DEFAULT_TERMINAL_ID,
+  DEFAULT_TERMINAL_REPLAY_BYTES,
   TerminalCwdError,
   TerminalCwdNotDirectoryError,
   TerminalCwdNotFoundError,
@@ -74,8 +75,16 @@ export {
   TerminalWriteError,
 };
 
-const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
+const DEFAULT_HISTORY_TARGET_BYTES = 8 * 1024 * 1024;
+const DEFAULT_HISTORY_MAX_BYTES = 12 * 1024 * 1024;
+const DEFAULT_REPLAY_HISTORY_TARGET_BYTES = 48 * 1024;
+const DEFAULT_REPLAY_HISTORY_MAX_BYTES = DEFAULT_TERMINAL_REPLAY_BYTES;
+const DEFAULT_OUTPUT_BATCH_WINDOW_MS = 8;
+const DEFAULT_OUTPUT_BATCH_MAX_BYTES = 16 * 1024;
+const DEFAULT_HISTORY_STREAM_CHUNK_BYTES = 64 * 1024;
+const DEFAULT_ATTACH_BUFFERED_EVENT_LIMIT = 32;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
+const DEFAULT_PERSIST_CHUNK_BYTES = 64 * 1024;
 const DEFAULT_SUBPROCESS_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_PROCESS_KILL_GRACE_MS = 1_000;
 const DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS = 128;
@@ -143,8 +152,16 @@ export class TerminalManager extends Context.Service<
      */
     readonly attachStream: (
       input: TerminalAttachInput,
-      listener: (event: TerminalAttachStreamEvent) => Effect.Effect<void>,
+      listener: (
+        event: TerminalAttachStreamEvent,
+        delivery: "replay" | "live",
+      ) => Effect.Effect<void>,
     ) => Effect.Effect<() => void, TerminalError>;
+
+    /** Read the current bounded snapshot for a slow-subscriber resync. */
+    readonly readSnapshot: (
+      input: TerminalClearInput,
+    ) => Effect.Effect<Option.Option<TerminalSessionSnapshot>>;
 
     /**
      * Write input bytes to a terminal session.
@@ -246,10 +263,14 @@ export interface TerminalSessionState {
   status: TerminalSessionStatus;
   pid: number | null;
   history: string;
+  historyBytes: number;
+  persistenceHistory: string;
+  persistenceHistoryBytes: number;
   pendingHistoryControlSequence: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
-  processEventDrainRunning: boolean;
+  processEventDrainPid: number | null;
+  processEventDrainSemaphore: Semaphore.Semaphore;
   exitCode: number | null;
   exitSignal: number | null;
   updatedAt: string;
@@ -265,13 +286,19 @@ export interface TerminalSessionState {
   runtimeEnv: Record<string, string> | null;
 }
 
-interface PersistHistoryRequest {
-  history: string;
+interface HistoryWrite {
+  contents: string;
+  mode: "append" | "truncate";
+}
+
+interface PersistHistoryRequest extends HistoryWrite {
+  authoritativeHistory: string;
+  contentsBytes: number;
   immediate: boolean;
 }
 
 type PendingProcessEvent =
-  | { type: "output"; data: string }
+  | { type: "output"; data: string; dataBytes: number }
   | { type: "exit"; event: PtyAdapter.PtyExitEvent };
 
 type DrainProcessEventAction =
@@ -281,8 +308,9 @@ type DrainProcessEventAction =
       threadId: string;
       terminalId: string;
       sequence: number;
-      history: string | null;
       data: string;
+      historyWrite: HistoryWrite | null;
+      authoritativeHistory: string;
     }
   | {
       type: "exit";
@@ -427,21 +455,58 @@ function cleanupProcessHandles(session: TerminalSessionState): void {
   session.unsubscribeExit = null;
 }
 
+function splitOutputByBytes(data: string, maxBytes: number): ReadonlyArray<string> {
+  const encoded = Buffer.from(data);
+  if (encoded.byteLength <= maxBytes) return [data];
+
+  const chunks: string[] = [];
+  let offset = 0;
+  while (offset < encoded.byteLength) {
+    let end = Math.min(offset + maxBytes, encoded.byteLength);
+    while (end < encoded.byteLength && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+      end -= 1;
+    }
+    if (end === offset) {
+      end = Math.min(offset + maxBytes, encoded.byteLength);
+      while (end < encoded.byteLength && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+        end += 1;
+      }
+    }
+    chunks.push(encoded.subarray(offset, end).toString());
+    offset = end;
+  }
+  return chunks;
+}
+
 function enqueueProcessEvent(
   session: TerminalSessionState,
   expectedPid: number,
   event: PendingProcessEvent,
+  outputBatchMaxBytes: number,
 ): boolean {
   if (!session.process || session.status !== "running" || session.pid !== expectedPid) {
     return false;
   }
 
-  session.pendingProcessEvents.push(event);
-  if (session.processEventDrainRunning) {
+  const lastPending = session.pendingProcessEvents.at(-1);
+  if (
+    event.type === "output" &&
+    lastPending?.type === "output" &&
+    lastPending.dataBytes + event.dataBytes <= outputBatchMaxBytes
+  ) {
+    session.pendingProcessEvents[session.pendingProcessEvents.length - 1] = {
+      type: "output",
+      data: `${lastPending.data}${event.data}`,
+      dataBytes: lastPending.dataBytes + event.dataBytes,
+    };
+  } else {
+    session.pendingProcessEvents.push(event);
+  }
+  if (session.processEventDrainPid === expectedPid) {
     return false;
   }
 
-  session.processEventDrainRunning = true;
+  session.processEventDrainPid = expectedPid;
   return true;
 }
 
@@ -784,16 +849,35 @@ const windowsProcessTableSnapshot = Effect.fn("terminal.windowsProcessTableSnaps
   },
 );
 
-function capHistory(history: string, maxLines: number): string {
-  if (history.length === 0) return history;
-  const hasTrailingNewline = history.endsWith("\n");
-  const lines = history.split("\n");
-  if (hasTrailingNewline) {
-    lines.pop();
+function capHistoryByBytes(history: string, targetBytes: number): string {
+  const encoded = Buffer.from(history);
+  if (encoded.byteLength <= targetBytes) return history;
+
+  let start = encoded.byteLength - targetBytes;
+  while (start < encoded.byteLength && ((encoded[start] ?? 0) & 0xc0) === 0x80) {
+    start += 1;
   }
-  if (lines.length <= maxLines) return history;
-  const capped = lines.slice(lines.length - maxLines).join("\n");
-  return hasTrailingNewline ? `${capped}\n` : capped;
+
+  const suffix = encoded.subarray(start).toString();
+  const previousByte = start > 0 ? encoded[start - 1] : undefined;
+  if (previousByte === 0x0a || (previousByte === 0x0d && encoded[start] !== 0x0a)) {
+    return suffix;
+  }
+
+  const newlineIndex = suffix.indexOf("\n");
+  const carriageReturnIndex = suffix.indexOf("\r");
+  const boundaryIndex =
+    newlineIndex === -1
+      ? carriageReturnIndex
+      : carriageReturnIndex === -1
+        ? newlineIndex
+        : Math.min(newlineIndex, carriageReturnIndex);
+  if (boundaryIndex === -1) return suffix;
+
+  const boundaryLength =
+    suffix[boundaryIndex] === "\r" && suffix[boundaryIndex + 1] === "\n" ? 2 : 1;
+  if (boundaryIndex + boundaryLength === suffix.length) return suffix;
+  return suffix.slice(boundaryIndex + boundaryLength);
 }
 
 function isCsiFinalByte(codePoint: number): boolean {
@@ -991,6 +1075,10 @@ function sanitizeTerminalHistoryChunk(
       continue;
     }
 
+    if (codePoint >= 0xd800 && codePoint <= 0xdbff && index + 1 === input.length) {
+      return { visibleText, pendingControlSequence: input.slice(index) };
+    }
+
     append(input[index] ?? "");
     index += 1;
   }
@@ -1110,7 +1198,12 @@ function normalizedRuntimeEnv(
 
 interface TerminalManagerOptions {
   logsDir: string;
-  historyLineLimit?: number;
+  historyTargetBytes?: number;
+  historyMaxBytes?: number;
+  replayHistoryTargetBytes?: number;
+  replayHistoryMaxBytes?: number;
+  outputBatchWindowMs?: number;
+  outputBatchMaxBytes?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
@@ -1148,9 +1241,17 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   const path = yield* Path.Path;
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
-
   const logsDir = options.logsDir;
-  const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
+  const historyTargetBytes = options.historyTargetBytes ?? DEFAULT_HISTORY_TARGET_BYTES;
+  const historyMaxBytes = options.historyMaxBytes ?? DEFAULT_HISTORY_MAX_BYTES;
+  const replayHistoryTargetBytes =
+    options.replayHistoryTargetBytes ?? DEFAULT_REPLAY_HISTORY_TARGET_BYTES;
+  const replayHistoryMaxBytes = options.replayHistoryMaxBytes ?? DEFAULT_REPLAY_HISTORY_MAX_BYTES;
+  const outputBatchWindowMs = options.outputBatchWindowMs ?? DEFAULT_OUTPUT_BATCH_WINDOW_MS;
+  const outputBatchMaxBytes = Math.max(
+    1,
+    options.outputBatchMaxBytes ?? DEFAULT_OUTPUT_BATCH_MAX_BYTES,
+  );
   const platform = yield* HostProcessPlatform;
   // Terminals must inherit the user's full environment (minus the blocklist
   // applied in createTerminalSpawnEnv) — an allowlist here silently strips
@@ -1205,6 +1306,35 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         yield* listener(event).pipe(Effect.ignoreCause({ log: true }));
       }
     });
+
+  const applyHistoryOutput = (
+    session: TerminalSessionState,
+    data: string,
+  ): { visibleText: string; write: HistoryWrite | null } => {
+    const sanitized = sanitizeTerminalHistoryChunk(session.pendingHistoryControlSequence, data);
+    session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
+    if (sanitized.visibleText.length === 0) {
+      return { visibleText: "", write: null };
+    }
+
+    const visibleBytes = Buffer.byteLength(sanitized.visibleText);
+    const nextHistory = `${session.persistenceHistory}${sanitized.visibleText}`;
+    if (session.persistenceHistoryBytes + visibleBytes <= historyMaxBytes) {
+      session.persistenceHistory = nextHistory;
+      session.persistenceHistoryBytes += visibleBytes;
+      return {
+        visibleText: sanitized.visibleText,
+        write: { contents: sanitized.visibleText, mode: "append" },
+      };
+    }
+
+    session.persistenceHistory = capHistoryByBytes(nextHistory, historyTargetBytes);
+    session.persistenceHistoryBytes = Buffer.byteLength(session.persistenceHistory);
+    return {
+      visibleText: sanitized.visibleText,
+      write: { contents: session.persistenceHistory, mode: "truncate" },
+    };
+  };
 
   const historyPath = (threadId: string, terminalId: string) => {
     const threadPart = toSafeThreadId(threadId);
@@ -1358,10 +1488,22 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     never,
     never
   >({
-    merge: (current, next) => ({
-      history: next.history,
-      immediate: current.immediate || next.immediate,
-    }),
+    merge: (current, next) => {
+      if (next.mode === "truncate") {
+        return next;
+      }
+
+      const contents = `${current.contents}${next.contents}`;
+      const contentsBytes = current.contentsBytes + next.contentsBytes;
+      return {
+        authoritativeHistory: next.authoritativeHistory,
+        contents,
+        contentsBytes,
+        mode: current.mode,
+        immediate:
+          current.immediate || next.immediate || contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
+      };
+    },
     process: Effect.fn("terminal.persistHistoryWorker")(function* (sessionKey, request) {
       if (!request.immediate) {
         yield* Effect.sleep(DEFAULT_PERSIST_DEBOUNCE_MS);
@@ -1372,26 +1514,50 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         return;
       }
 
-      yield* fileSystem.writeFileString(historyPath(threadId, terminalId), request.history).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to persist terminal history", {
-            threadId,
-            terminalId,
-            error,
+      const nextPath = historyPath(threadId, terminalId);
+      yield* fileSystem
+        .writeFileString(nextPath, request.contents, {
+          flag: request.mode === "append" ? "a" : "w",
+        })
+        .pipe(
+          Effect.catch((error) => {
+            if (request.mode === "truncate") {
+              return Effect.logWarning("failed to persist terminal history", {
+                threadId,
+                terminalId,
+                error,
+              });
+            }
+
+            return fileSystem
+              .writeFileString(nextPath, request.authoritativeHistory, { flag: "w" })
+              .pipe(
+                Effect.catch((fallbackError) =>
+                  Effect.logWarning("failed to recover terminal history append", {
+                    threadId,
+                    terminalId,
+                    error,
+                    fallbackError,
+                  }),
+                ),
+              );
           }),
-        ),
-      );
+        );
     }),
   });
 
   const queuePersist = Effect.fn("terminal.queuePersist")(function* (
     threadId: string,
     terminalId: string,
-    history: string,
+    write: HistoryWrite,
+    authoritativeHistory: string,
   ) {
+    const contentsBytes = Buffer.byteLength(write.contents);
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      history,
-      immediate: false,
+      ...write,
+      authoritativeHistory,
+      contentsBytes,
+      immediate: contentsBytes >= DEFAULT_PERSIST_CHUNK_BYTES,
     });
   });
 
@@ -1408,7 +1574,10 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     history: string,
   ) {
     yield* persistWorker.enqueue(toSessionKey(threadId, terminalId), {
-      history,
+      authoritativeHistory: history,
+      contents: history,
+      contentsBytes: Buffer.byteLength(history),
+      mode: "truncate",
       immediate: true,
     });
     yield* flushPersist(threadId, terminalId);
@@ -1435,7 +1604,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             (cause) => new TerminalHistoryError({ operation: "read", threadId, terminalId, cause }),
           ),
         );
-      const capped = capHistory(raw, historyLineLimit);
+      const capped =
+        Buffer.byteLength(raw) > historyMaxBytes ? capHistoryByBytes(raw, historyTargetBytes) : raw;
       if (capped !== raw) {
         yield* fileSystem
           .writeFileString(nextPath, capped)
@@ -1475,7 +1645,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             new TerminalHistoryError({ operation: "migrate", threadId, terminalId, cause }),
         ),
       );
-    const capped = capHistory(raw, historyLineLimit);
+    const capped =
+      Buffer.byteLength(raw) > historyMaxBytes ? capHistoryByBytes(raw, historyTargetBytes) : raw;
     yield* fileSystem
       .writeFileString(nextPath, capped)
       .pipe(
@@ -1627,16 +1798,19 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     },
   );
 
-  const drainProcessEvents = Effect.fn("terminal.drainProcessEvents")(function* (
+  const drainProcessEventsUnlocked = Effect.fn("terminal.drainProcessEventsUnlocked")(function* (
     session: TerminalSessionState,
     expectedPid: number,
   ) {
     while (true) {
       const action: DrainProcessEventAction = yield* Effect.sync(() => {
+        if (session.processEventDrainPid !== expectedPid) {
+          return { type: "idle" } as const;
+        }
         if (session.pid !== expectedPid || !session.process || session.status !== "running") {
           session.pendingProcessEvents = [];
           session.pendingProcessEventIndex = 0;
-          session.processEventDrainRunning = false;
+          session.processEventDrainPid = null;
           return { type: "idle" } as const;
         }
 
@@ -1644,7 +1818,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         if (!nextEvent) {
           session.pendingProcessEvents = [];
           session.pendingProcessEventIndex = 0;
-          session.processEventDrainRunning = false;
+          session.processEventDrainPid = null;
           return { type: "idle" } as const;
         }
 
@@ -1655,16 +1829,17 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         }
 
         if (nextEvent.type === "output") {
-          const sanitized = sanitizeTerminalHistoryChunk(
-            session.pendingHistoryControlSequence,
-            nextEvent.data,
-          );
-          session.pendingHistoryControlSequence = sanitized.pendingControlSequence;
-          if (sanitized.visibleText.length > 0) {
-            session.history = capHistory(
-              `${session.history}${sanitized.visibleText}`,
-              historyLineLimit,
-            );
+          const historyOutput = applyHistoryOutput(session, nextEvent.data);
+          if (historyOutput.visibleText.length > 0) {
+            const visibleBytes = Buffer.byteLength(historyOutput.visibleText);
+            const nextHistory = `${session.history}${historyOutput.visibleText}`;
+            if (session.historyBytes + visibleBytes <= replayHistoryMaxBytes) {
+              session.history = nextHistory;
+              session.historyBytes += visibleBytes;
+            } else {
+              session.history = capHistoryByBytes(nextHistory, replayHistoryTargetBytes);
+              session.historyBytes = Buffer.byteLength(session.history);
+            }
           }
           const eventStamp = advanceEventSequence(session);
 
@@ -1673,8 +1848,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             threadId: session.threadId,
             terminalId: session.terminalId,
             sequence: eventStamp.sequence,
-            history: sanitized.visibleText.length > 0 ? session.history : null,
             data: nextEvent.data,
+            historyWrite: historyOutput.write,
+            authoritativeHistory: session.persistenceHistory,
           } as const;
         }
 
@@ -1688,7 +1864,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
+        session.processEventDrainPid = null;
         session.exitCode = Number.isInteger(nextEvent.event.exitCode)
           ? nextEvent.event.exitCode
           : null;
@@ -1713,10 +1889,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       }
 
       if (action.type === "output") {
-        if (action.history !== null) {
-          yield* queuePersist(action.threadId, action.terminalId, action.history);
+        if (action.historyWrite !== null) {
+          yield* queuePersist(
+            action.threadId,
+            action.terminalId,
+            action.historyWrite,
+            action.authoritativeHistory,
+          );
         }
-
         yield* publishEvent({
           type: "output",
           threadId: action.threadId,
@@ -1732,6 +1912,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         threadId: action.threadId,
         terminalId: action.terminalId,
       });
+      yield* flushPersist(action.threadId, action.terminalId);
       yield* publishEvent({
         type: "exited",
         threadId: action.threadId,
@@ -1745,7 +1926,23 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     }
   });
 
+  const drainProcessEvents = Effect.fn("terminal.drainProcessEvents")(function* (
+    session: TerminalSessionState,
+    expectedPid: number,
+  ) {
+    yield* session.processEventDrainSemaphore.withPermit(
+      drainProcessEventsUnlocked(session, expectedPid),
+    );
+  });
+
   const stopProcess = Effect.fn("terminal.stopProcess")(function* (session: TerminalSessionState) {
+    // A lifecycle command is an ordering barrier. Drain bytes already accepted
+    // from the PTY before clearing its handlers or state so history and live
+    // events cannot diverge at close/restart boundaries.
+    if (session.processEventDrainPid !== null) {
+      yield* drainProcessEvents(session, session.processEventDrainPid);
+    }
+
     const process = session.process;
     if (!process) return;
 
@@ -1760,7 +1957,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.pendingHistoryControlSequence = "";
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
-      session.processEventDrainRunning = false;
+      session.processEventDrainPid = null;
       session.updatedAt = updatedAt;
       return [undefined, state] as const;
     });
@@ -1855,7 +2052,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.childCommandLabel = null;
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
-      session.processEventDrainRunning = false;
+      session.processEventDrainPid = null;
       session.updatedAt = startingAt;
       return [undefined, state] as const;
     });
@@ -1875,13 +2072,45 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
             const processPid = ptyProcess.pid;
             const unsubscribeData = ptyProcess.onData((data) => {
-              if (!enqueueProcessEvent(session, processPid, { type: "output", data })) {
+              if (!session.process || session.status !== "running" || session.pid !== processPid) {
                 return;
               }
-              runFork(drainProcessEvents(session, processPid));
+
+              let shouldStartDrain = false;
+              for (const outputData of splitOutputByBytes(data, outputBatchMaxBytes)) {
+                if (
+                  enqueueProcessEvent(
+                    session,
+                    processPid,
+                    {
+                      type: "output",
+                      data: outputData,
+                      dataBytes: Buffer.byteLength(outputData),
+                    },
+                    outputBatchMaxBytes,
+                  )
+                ) {
+                  shouldStartDrain = true;
+                }
+              }
+              if (!shouldStartDrain) {
+                return;
+              }
+              runFork(
+                Effect.sleep(outputBatchWindowMs).pipe(
+                  Effect.andThen(drainProcessEvents(session, processPid)),
+                ),
+              );
             });
             const unsubscribeExit = ptyProcess.onExit((event) => {
-              if (!enqueueProcessEvent(session, processPid, { type: "exit", event })) {
+              if (
+                !enqueueProcessEvent(
+                  session,
+                  processPid,
+                  { type: "exit", event },
+                  outputBatchMaxBytes,
+                )
+              ) {
                 return;
               }
               runFork(drainProcessEvents(session, processPid));
@@ -1932,7 +2161,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.childCommandLabel = null;
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
+        session.processEventDrainPid = null;
         advanceEventSequence(session);
         return [undefined, state] as const;
       });
@@ -1972,7 +2201,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     if (Option.isSome(session)) {
       yield* stopProcess(session.value);
       yield* unregisterTerminal({ threadId, terminalId });
-      yield* persistHistory(threadId, terminalId, session.value.history);
     }
 
     yield* flushPersist(threadId, terminalId);
@@ -2129,7 +2357,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       const cleanupSession = Effect.fn("terminal.cleanupSession")(function* (
         session: TerminalSessionState,
       ) {
+        if (session.processEventDrainPid !== null) {
+          yield* drainProcessEvents(session, session.processEventDrainPid);
+        }
         cleanupProcessHandles(session);
+        yield* flushPersist(session.threadId, session.terminalId);
         if (!session.process) return;
         yield* clearKillFiber(session.process);
         yield* runKillEscalation(session.process, session.threadId, session.terminalId);
@@ -2150,7 +2382,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     const existing = yield* getSession(input.threadId, terminalId);
     if (Option.isNone(existing)) {
       yield* flushPersist(input.threadId, terminalId);
-      const history = yield* readHistory(input.threadId, terminalId);
+      const persistenceHistory = yield* readHistory(input.threadId, terminalId);
+      const history =
+        Buffer.byteLength(persistenceHistory) > replayHistoryMaxBytes
+          ? capHistoryByBytes(persistenceHistory, replayHistoryTargetBytes)
+          : persistenceHistory;
       const cols = input.cols ?? DEFAULT_OPEN_COLS;
       const rows = input.rows ?? DEFAULT_OPEN_ROWS;
       const session: TerminalSessionState = {
@@ -2161,10 +2397,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         status: "starting",
         pid: null,
         history,
+        historyBytes: Buffer.byteLength(history),
+        persistenceHistory,
+        persistenceHistoryBytes: Buffer.byteLength(persistenceHistory),
         pendingHistoryControlSequence: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
-        processEventDrainRunning: false,
+        processEventDrainPid: null,
+        processEventDrainSemaphore: yield* Semaphore.make(1),
         exitCode: null,
         exitSignal: null,
         updatedAt: yield* nowIso,
@@ -2222,19 +2462,25 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.worktreePath = nextWorktreePath;
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.history = "";
+      liveSession.historyBytes = 0;
+      liveSession.persistenceHistory = "";
+      liveSession.persistenceHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
-      liveSession.processEventDrainRunning = false;
+      liveSession.processEventDrainPid = null;
       yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
     } else if (liveSession.status === "exited" || liveSession.status === "error") {
       liveSession.runtimeEnv = nextRuntimeEnv;
       liveSession.worktreePath = nextWorktreePath;
       liveSession.history = "";
+      liveSession.historyBytes = 0;
+      liveSession.persistenceHistory = "";
+      liveSession.persistenceHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
-      liveSession.processEventDrainRunning = false;
+      liveSession.processEventDrainPid = null;
       yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
     }
 
@@ -2274,6 +2520,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       Effect.gen(function* () {
         const terminalId = input.terminalId;
         const existing = yield* getSession(input.threadId, terminalId);
+        let session: TerminalSessionState;
 
         if (Option.isNone(existing)) {
           if (!input.cwd) {
@@ -2283,38 +2530,57 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             });
           }
 
-          return yield* openLocked({
+          yield* openLocked({
             ...input,
             terminalId,
             cwd: input.cwd,
           });
+          session = yield* requireSession(input.threadId, terminalId);
+        } else {
+          session = existing.value;
+          const targetCols = input.cols ?? session.cols;
+          const targetRows = input.rows ?? session.rows;
+
+          if (!session.process && input.cwd && input.restartIfNotRunning === true) {
+            yield* openLocked({
+              ...input,
+              terminalId,
+              cwd: input.cwd,
+            });
+            session = yield* requireSession(input.threadId, terminalId);
+          } else if (
+            session.process &&
+            session.status === "running" &&
+            (session.cols !== targetCols || session.rows !== targetRows)
+          ) {
+            const process = session.process;
+            yield* resizePtyProcess(session, process, targetCols, targetRows);
+            session.cols = targetCols;
+            session.rows = targetRows;
+            session.updatedAt = yield* nowIso;
+          }
         }
 
-        const session = existing.value;
-        const targetCols = input.cols ?? session.cols;
-        const targetRows = input.rows ?? session.rows;
-
-        if (!session.process && input.cwd && input.restartIfNotRunning === true) {
-          return yield* openLocked({
-            ...input,
-            terminalId,
-            cwd: input.cwd,
-          });
+        // Flush the short output batch before capturing history so the replay
+        // snapshot and its sequence describe the same point in the PTY stream.
+        if (session.processEventDrainPid !== null) {
+          yield* drainProcessEvents(session, session.processEventDrainPid);
         }
 
-        if (
-          session.process &&
-          session.status === "running" &&
-          (session.cols !== targetCols || session.rows !== targetRows)
-        ) {
-          const process = session.process;
-          yield* resizePtyProcess(session, process, targetCols, targetRows);
-          session.cols = targetCols;
-          session.rows = targetRows;
-          session.updatedAt = yield* nowIso;
+        const initialSnapshot = snapshot(session);
+        const requestedReplayBytes = input.replayBytes ?? DEFAULT_TERMINAL_REPLAY_BYTES;
+        if (requestedReplayBytes <= DEFAULT_TERMINAL_REPLAY_BYTES) {
+          return { snapshot: initialSnapshot, replayHistory: null } as const;
         }
 
-        return snapshot(session);
+        const replayHistory =
+          session.persistenceHistoryBytes > requestedReplayBytes
+            ? capHistoryByBytes(session.persistenceHistory, requestedReplayBytes)
+            : session.persistenceHistory;
+        return {
+          snapshot: { ...initialSnapshot, history: "" },
+          replayHistory,
+        } as const;
       }),
     );
 
@@ -2348,11 +2614,15 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       };
     });
 
+  const readSnapshot: TerminalManager["Service"]["readSnapshot"] = (input) =>
+    getSession(input.threadId, input.terminalId).pipe(Effect.map(Option.map(snapshot)));
+
   const attachStream: TerminalManager["Service"]["attachStream"] = (input, listener) => {
     let unsubscribe: (() => void) | null = null;
 
     return Effect.gen(function* () {
       const bufferedEvents: TerminalEvent[] = [];
+      let bufferedOverflow = false;
       let deliverLive = false;
 
       unsubscribe = yield* subscribe((event) => {
@@ -2361,33 +2631,79 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         }
 
         if (!deliverLive) {
+          if (bufferedEvents.length >= DEFAULT_ATTACH_BUFFERED_EVENT_LIMIT) {
+            bufferedEvents.splice(0);
+            bufferedOverflow = true;
+          }
           bufferedEvents.push(event);
           return Effect.void;
         }
 
         const attachEvent = terminalEventToAttachEvent(event);
-        return attachEvent ? listener(attachEvent) : Effect.void;
+        return attachEvent ? listener(attachEvent, "live") : Effect.void;
       });
 
-      const initialSnapshot = yield* openOrAttachForStream(input);
+      const bootstrap = yield* openOrAttachForStream(input);
+      let synchronizedSnapshot = bootstrap.snapshot;
 
-      yield* listener({
-        type: "snapshot",
-        snapshot: initialSnapshot,
-      });
+      yield* listener(
+        {
+          type: "snapshot",
+          snapshot: bootstrap.snapshot,
+        },
+        "replay",
+      );
 
-      for (const event of bufferedEvents) {
-        if (isDuplicateAttachSnapshotEvent(event, initialSnapshot)) {
-          continue;
-        }
-
-        const attachEvent = terminalEventToAttachEvent(event);
-        if (attachEvent) {
-          yield* listener(attachEvent);
+      if (bootstrap.replayHistory !== null && bootstrap.replayHistory.length > 0) {
+        for (const data of splitOutputByBytes(
+          bootstrap.replayHistory,
+          DEFAULT_HISTORY_STREAM_CHUNK_BYTES,
+        )) {
+          yield* listener(
+            {
+              type: "output",
+              threadId: input.threadId,
+              terminalId: input.terminalId,
+              ...(typeof bootstrap.snapshot.sequence === "number"
+                ? { sequence: bootstrap.snapshot.sequence }
+                : {}),
+              data,
+            },
+            "replay",
+          );
         }
       }
 
-      deliverLive = true;
+      while (true) {
+        if (bufferedOverflow) {
+          bufferedOverflow = false;
+          const latest = yield* readSnapshot(input);
+          if (Option.isSome(latest)) {
+            synchronizedSnapshot = latest.value;
+            yield* listener(
+              {
+                type: "snapshot",
+                snapshot: latest.value,
+              },
+              "replay",
+            );
+          }
+          continue;
+        }
+
+        const event = bufferedEvents.shift();
+        if (!event) {
+          deliverLive = true;
+          break;
+        }
+        if (isDuplicateAttachSnapshotEvent(event, synchronizedSnapshot)) continue;
+
+        const attachEvent = terminalEventToAttachEvent(event);
+        if (attachEvent) {
+          yield* listener(attachEvent, "replay");
+        }
+      }
+
       return () => {
         unsubscribe?.();
         unsubscribe = null;
@@ -2520,6 +2836,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     if (!process || session.value.status !== "running") {
       return;
     }
+    if (session.value.cols === input.cols && session.value.rows === input.rows) {
+      return;
+    }
     yield* resizePtyProcess(session.value, process, input.cols, input.rows);
     session.value.cols = input.cols;
     session.value.rows = input.rows;
@@ -2535,11 +2854,16 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       Effect.gen(function* () {
         const terminalId = input.terminalId;
         const session = yield* requireSession(input.threadId, terminalId);
+        if (session.processEventDrainPid !== null) {
+          yield* drainProcessEvents(session, session.processEventDrainPid);
+        }
         session.history = "";
+        session.historyBytes = 0;
+        session.persistenceHistory = "";
+        session.persistenceHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
         const eventStamp = advanceEventSequence(session);
         yield* persistHistory(input.threadId, terminalId, session.history);
         yield* publishEvent({
@@ -2573,10 +2897,14 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             status: "starting",
             pid: null,
             history: "",
+            historyBytes: 0,
+            persistenceHistory: "",
+            persistenceHistoryBytes: 0,
             pendingHistoryControlSequence: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
-            processEventDrainRunning: false,
+            processEventDrainPid: null,
+            processEventDrainSemaphore: yield* Semaphore.make(1),
             exitCode: null,
             exitSignal: null,
             updatedAt: yield* nowIso,
@@ -2609,10 +2937,13 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         const rows = input.rows ?? session.rows;
 
         session.history = "";
+        session.historyBytes = 0;
+        session.persistenceHistory = "";
+        session.persistenceHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
-        session.processEventDrainRunning = false;
+        session.processEventDrainPid = null;
         yield* persistHistory(input.threadId, terminalId, session.history);
         yield* startSession(
           session,
@@ -2656,6 +2987,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   return TerminalManager.of({
     open,
     attachStream,
+    readSnapshot,
     write,
     resize,
     clear,

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -267,6 +267,7 @@ export interface TerminalSessionState {
   persistenceHistory: string;
   persistenceHistoryBytes: number;
   pendingHistoryControlSequence: string;
+  pendingOutputHighSurrogate: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
   processEventDrainPid: number | null;
@@ -476,6 +477,22 @@ function splitOutputByBytes(data: string, maxBytes: number): ReadonlyArray<strin
     offset = end;
   }
   return chunks;
+}
+
+function splitCompleteOutput(
+  pendingHighSurrogate: string,
+  data: string,
+  flushTrailingHighSurrogate = false,
+): { readonly data: string; readonly pendingHighSurrogate: string } {
+  const combined = `${pendingHighSurrogate}${data}`;
+  const finalCodeUnit = combined.charCodeAt(combined.length - 1);
+  if (!flushTrailingHighSurrogate && finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+    return {
+      data: combined.slice(0, -1),
+      pendingHighSurrogate: combined.slice(-1),
+    };
+  }
+  return { data: combined, pendingHighSurrogate: "" };
 }
 
 function enqueueProcessEvent(
@@ -858,9 +875,14 @@ function capHistoryByBytes(history: string, targetBytes: number): string {
     start += 1;
   }
 
-  const suffix = encoded.subarray(start).toString();
+  const decodedPrefixLength = encoded.subarray(0, start).toString().length;
+  const safeStart = alignHistoryStartToControlBoundary(history, decodedPrefixLength);
+  const suffix = history.slice(safeStart);
   const previousByte = start > 0 ? encoded[start - 1] : undefined;
-  if (previousByte === 0x0a || (previousByte === 0x0d && encoded[start] !== 0x0a)) {
+  if (
+    safeStart === decodedPrefixLength &&
+    (previousByte === 0x0a || (previousByte === 0x0d && encoded[start] !== 0x0a))
+  ) {
     return suffix;
   }
 
@@ -878,6 +900,56 @@ function capHistoryByBytes(history: string, targetBytes: number): string {
     suffix[boundaryIndex] === "\r" && suffix[boundaryIndex + 1] === "\n" ? 2 : 1;
   if (boundaryIndex + boundaryLength === suffix.length) return suffix;
   return suffix.slice(boundaryIndex + boundaryLength);
+}
+
+function terminalControlSequenceEndIndex(input: string, start: number): number | null {
+  const codePoint = input.charCodeAt(start);
+  const isEscape = codePoint === 0x1b;
+  const nextCodePoint = input.charCodeAt(start + 1);
+
+  if (isEscape && Number.isNaN(nextCodePoint)) return input.length;
+  if (isEscape && nextCodePoint === 0x5b) {
+    for (let cursor = start + 2; cursor < input.length; cursor += 1) {
+      if (isCsiFinalByte(input.charCodeAt(cursor))) return cursor + 1;
+    }
+    return input.length;
+  }
+  if (codePoint === 0x9b) {
+    for (let cursor = start + 1; cursor < input.length; cursor += 1) {
+      if (isCsiFinalByte(input.charCodeAt(cursor))) return cursor + 1;
+    }
+    return input.length;
+  }
+
+  const isEscString =
+    isEscape &&
+    (nextCodePoint === 0x5d ||
+      nextCodePoint === 0x50 ||
+      nextCodePoint === 0x5e ||
+      nextCodePoint === 0x5f);
+  const isC1String =
+    codePoint === 0x9d || codePoint === 0x90 || codePoint === 0x9e || codePoint === 0x9f;
+  if (isEscString || isC1String) {
+    return findStringTerminatorIndex(input, start + (isEscape ? 2 : 1)) ?? input.length;
+  }
+  if (isEscape) {
+    return findEscapeSequenceEndIndex(input, start + 1) ?? input.length;
+  }
+  return null;
+}
+
+function alignHistoryStartToControlBoundary(history: string, requestedStart: number): number {
+  let index = 0;
+  while (index < requestedStart) {
+    const sequenceEnd = terminalControlSequenceEndIndex(history, index);
+    if (sequenceEnd === null) {
+      index += 1;
+      continue;
+    }
+    if (sequenceEnd > requestedStart) return sequenceEnd;
+    index = sequenceEnd;
+  }
+  return requestedStart;
 }
 
 function isCsiFinalByte(codePoint: number): boolean {
@@ -1334,6 +1406,40 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       visibleText: sanitized.visibleText,
       write: { contents: session.persistenceHistory, mode: "truncate" },
     };
+  };
+
+  const enqueueOutputData = (
+    session: TerminalSessionState,
+    expectedPid: number,
+    data: string,
+    flushTrailingHighSurrogate = false,
+  ): boolean => {
+    const complete = splitCompleteOutput(
+      session.pendingOutputHighSurrogate,
+      data,
+      flushTrailingHighSurrogate,
+    );
+    session.pendingOutputHighSurrogate = complete.pendingHighSurrogate;
+
+    let shouldStartDrain = false;
+    for (const outputData of splitOutputByBytes(complete.data, outputBatchMaxBytes)) {
+      if (
+        outputData.length > 0 &&
+        enqueueProcessEvent(
+          session,
+          expectedPid,
+          {
+            type: "output",
+            data: outputData,
+            dataBytes: Buffer.byteLength(outputData),
+          },
+          outputBatchMaxBytes,
+        )
+      ) {
+        shouldStartDrain = true;
+      }
+    }
+    return shouldStartDrain;
   };
 
   const historyPath = (threadId: string, terminalId: string) => {
@@ -1862,6 +1968,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.childCommandLabel = null;
         session.status = "exited";
         session.pendingHistoryControlSequence = "";
+        session.pendingOutputHighSurrogate = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainPid = null;
@@ -1939,6 +2046,9 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     // A lifecycle command is an ordering barrier. Drain bytes already accepted
     // from the PTY before clearing its handlers or state so history and live
     // events cannot diverge at close/restart boundaries.
+    if (session.process && session.pid !== null && session.pendingOutputHighSurrogate.length > 0) {
+      enqueueOutputData(session, session.pid, "", true);
+    }
     if (session.processEventDrainPid !== null) {
       yield* drainProcessEvents(session, session.processEventDrainPid);
     }
@@ -1955,6 +2065,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.childCommandLabel = null;
       session.status = "exited";
       session.pendingHistoryControlSequence = "";
+      session.pendingOutputHighSurrogate = "";
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
       session.processEventDrainPid = null;
@@ -2053,6 +2164,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
       session.processEventDrainPid = null;
+      session.pendingOutputHighSurrogate = "";
       session.updatedAt = startingAt;
       return [undefined, state] as const;
     });
@@ -2076,23 +2188,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
                 return;
               }
 
-              let shouldStartDrain = false;
-              for (const outputData of splitOutputByBytes(data, outputBatchMaxBytes)) {
-                if (
-                  enqueueProcessEvent(
-                    session,
-                    processPid,
-                    {
-                      type: "output",
-                      data: outputData,
-                      dataBytes: Buffer.byteLength(outputData),
-                    },
-                    outputBatchMaxBytes,
-                  )
-                ) {
-                  shouldStartDrain = true;
-                }
-              }
+              const shouldStartDrain = enqueueOutputData(session, processPid, data);
               if (!shouldStartDrain) {
                 return;
               }
@@ -2103,17 +2199,19 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
               );
             });
             const unsubscribeExit = ptyProcess.onExit((event) => {
+              const shouldStartDrain = enqueueOutputData(session, processPid, "", true);
               if (
-                !enqueueProcessEvent(
+                enqueueProcessEvent(
                   session,
                   processPid,
                   { type: "exit", event },
                   outputBatchMaxBytes,
                 )
               ) {
+                runFork(drainProcessEvents(session, processPid));
                 return;
               }
-              runFork(drainProcessEvents(session, processPid));
+              if (shouldStartDrain) runFork(drainProcessEvents(session, processPid));
             });
 
             let eventStamp: ReturnType<typeof advanceEventSequence> = {
@@ -2401,6 +2499,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         persistenceHistory,
         persistenceHistoryBytes: Buffer.byteLength(persistenceHistory),
         pendingHistoryControlSequence: "",
+        pendingOutputHighSurrogate: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
         processEventDrainPid: null,
@@ -2466,6 +2565,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.persistenceHistory = "";
       liveSession.persistenceHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
+      liveSession.pendingOutputHighSurrogate = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainPid = null;
@@ -2478,6 +2578,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.persistenceHistory = "";
       liveSession.persistenceHistoryBytes = 0;
       liveSession.pendingHistoryControlSequence = "";
+      liveSession.pendingOutputHighSurrogate = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
       liveSession.processEventDrainPid = null;
@@ -2674,6 +2775,18 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         }
       }
 
+      yield* listener(
+        {
+          type: "replay-complete",
+          threadId: input.threadId,
+          terminalId: input.terminalId,
+          ...(typeof bootstrap.snapshot.sequence === "number"
+            ? { sequence: bootstrap.snapshot.sequence }
+            : {}),
+        },
+        "replay",
+      );
+
       while (true) {
         if (bufferedOverflow) {
           bufferedOverflow = false;
@@ -2862,6 +2975,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.persistenceHistory = "";
         session.persistenceHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
+        session.pendingOutputHighSurrogate = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         const eventStamp = advanceEventSequence(session);
@@ -2901,6 +3015,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             persistenceHistory: "",
             persistenceHistoryBytes: 0,
             pendingHistoryControlSequence: "",
+            pendingOutputHighSurrogate: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
             processEventDrainPid: null,
@@ -2941,6 +3056,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.persistenceHistory = "";
         session.persistenceHistoryBytes = 0;
         session.pendingHistoryControlSequence = "";
+        session.pendingOutputHighSurrogate = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
         session.processEventDrainPid = null;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -488,11 +488,14 @@ function splitCompleteOutput(
 ): { readonly data: string; readonly pendingHighSurrogate: string } {
   const combined = `${pendingHighSurrogate}${data}`;
   const finalCodeUnit = combined.charCodeAt(combined.length - 1);
-  if (!flushTrailingHighSurrogate && finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
-    return {
-      data: combined.slice(0, -1),
-      pendingHighSurrogate: combined.slice(-1),
-    };
+  if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+    if (!flushTrailingHighSurrogate) {
+      return {
+        data: combined.slice(0, -1),
+        pendingHighSurrogate: combined.slice(-1),
+      };
+    }
+    return { data: `${combined.slice(0, -1)}\ufffd`, pendingHighSurrogate: "" };
   }
   return { data: combined, pendingHighSurrogate: "" };
 }
@@ -2457,6 +2460,13 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       const cleanupSession = Effect.fn("terminal.cleanupSession")(function* (
         session: TerminalSessionState,
       ) {
+        if (
+          session.process &&
+          session.pid !== null &&
+          session.pendingOutputHighSurrogate.length > 0
+        ) {
+          enqueueOutputData(session, session.pid, "", true);
+        }
         if (session.processEventDrainPid !== null) {
           yield* drainProcessEvents(session, session.processEventDrainPid);
         }

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -83,6 +83,10 @@ const DEFAULT_OUTPUT_BATCH_WINDOW_MS = 8;
 // Full-screen terminal apps commonly emit 20-40 KB synchronized updates. Keep
 // typical frames in one event while retaining a bounded live-subscriber queue.
 const DEFAULT_OUTPUT_BATCH_MAX_BYTES = 64 * 1024;
+// Bound output accepted ahead of the event drain. Node PTYs are paused before
+// this fills; adapters without producer flow control drop only overflow bytes
+// rather than allowing an unbounded server heap queue.
+const DEFAULT_PENDING_PROCESS_EVENT_MAX_BYTES = 4 * 1024 * 1024;
 const DEFAULT_HISTORY_STREAM_CHUNK_BYTES = 64 * 1024;
 const DEFAULT_ATTACH_BUFFERED_EVENT_LIMIT = 32;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
@@ -272,6 +276,8 @@ export interface TerminalSessionState {
   pendingOutputHighSurrogate: string;
   pendingProcessEvents: Array<PendingProcessEvent>;
   pendingProcessEventIndex: number;
+  pendingProcessEventBytes: number;
+  processOutputPaused: boolean;
   processEventDrainPid: number | null;
   processEventDrainSemaphore: Semaphore.Semaphore;
   exitCode: number | null;
@@ -458,11 +464,13 @@ function cleanupProcessHandles(session: TerminalSessionState): void {
   session.unsubscribeExit = null;
 }
 
-function splitOutputByBytes(data: string, maxBytes: number): ReadonlyArray<string> {
+function* splitOutputByBytes(data: string, maxBytes: number): Iterable<string> {
   const encoded = Buffer.from(data);
-  if (encoded.byteLength <= maxBytes) return [data];
+  if (encoded.byteLength <= maxBytes) {
+    yield data;
+    return;
+  }
 
-  const chunks: string[] = [];
   let offset = 0;
   while (offset < encoded.byteLength) {
     let end = Math.min(offset + maxBytes, encoded.byteLength);
@@ -475,10 +483,9 @@ function splitOutputByBytes(data: string, maxBytes: number): ReadonlyArray<strin
         end += 1;
       }
     }
-    chunks.push(encoded.subarray(offset, end).toString());
+    yield encoded.subarray(offset, end).toString();
     offset = end;
   }
-  return chunks;
 }
 
 function splitCompleteOutput(
@@ -505,8 +512,24 @@ function enqueueProcessEvent(
   expectedPid: number,
   event: PendingProcessEvent,
   outputBatchMaxBytes: number,
+  pendingProcessEventMaxBytes: number,
 ): boolean {
   if (!session.process || session.status !== "running" || session.pid !== expectedPid) {
+    return false;
+  }
+
+  if (
+    event.type === "output" &&
+    session.pendingProcessEventBytes + event.dataBytes > pendingProcessEventMaxBytes
+  ) {
+    if (!session.processOutputPaused) {
+      session.processOutputPaused = true;
+      try {
+        session.process.pauseOutput?.();
+      } catch {
+        // The byte ceiling remains authoritative if adapter flow control fails.
+      }
+    }
     return false;
   }
 
@@ -524,12 +547,52 @@ function enqueueProcessEvent(
   } else {
     session.pendingProcessEvents.push(event);
   }
+  if (event.type === "output") {
+    session.pendingProcessEventBytes += event.dataBytes;
+    const pauseAtBytes = Math.max(
+      outputBatchMaxBytes,
+      pendingProcessEventMaxBytes - outputBatchMaxBytes,
+    );
+    if (!session.processOutputPaused && session.pendingProcessEventBytes >= pauseAtBytes) {
+      session.processOutputPaused = true;
+      try {
+        session.process.pauseOutput?.();
+      } catch {
+        // The hard byte ceiling above still protects adapters whose optional
+        // producer-level flow control fails at runtime.
+      }
+    }
+  }
   if (session.processEventDrainPid === expectedPid) {
     return false;
   }
 
   session.processEventDrainPid = expectedPid;
   return true;
+}
+
+function resumeProcessOutput(
+  session: TerminalSessionState,
+  expectedPid: number,
+  pendingProcessEventResumeBytes: number,
+  force = false,
+): void {
+  if (
+    !session.processOutputPaused ||
+    session.pid !== expectedPid ||
+    !session.process ||
+    session.status !== "running" ||
+    (!force && session.pendingProcessEventBytes > pendingProcessEventResumeBytes)
+  ) {
+    return;
+  }
+
+  session.processOutputPaused = false;
+  try {
+    session.process.resumeOutput?.();
+  } catch {
+    // A failed optional resume cannot leave the manager queue marked paused.
+  }
 }
 
 function defaultShellResolver(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
@@ -1281,6 +1344,7 @@ interface TerminalManagerOptions {
   replayHistoryMaxBytes?: number;
   outputBatchWindowMs?: number;
   outputBatchMaxBytes?: number;
+  pendingProcessEventMaxBytes?: number;
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
@@ -1329,6 +1393,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
     1,
     options.outputBatchMaxBytes ?? DEFAULT_OUTPUT_BATCH_MAX_BYTES,
   );
+  const pendingProcessEventMaxBytes = Math.max(
+    outputBatchMaxBytes,
+    options.pendingProcessEventMaxBytes ?? DEFAULT_PENDING_PROCESS_EVENT_MAX_BYTES,
+  );
+  const pendingProcessEventResumeBytes = Math.floor(pendingProcessEventMaxBytes / 2);
   const platform = yield* HostProcessPlatform;
   // Terminals must inherit the user's full environment (minus the blocklist
   // applied in createTerminalSpawnEnv) — an allowlist here silently strips
@@ -1439,6 +1508,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             dataBytes: Buffer.byteLength(outputData),
           },
           outputBatchMaxBytes,
+          pendingProcessEventMaxBytes,
         )
       ) {
         shouldStartDrain = true;
@@ -1921,6 +1991,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         if (session.pid !== expectedPid || !session.process || session.status !== "running") {
           session.pendingProcessEvents = [];
           session.pendingProcessEventIndex = 0;
+          session.pendingProcessEventBytes = 0;
+          session.processOutputPaused = false;
           session.processEventDrainPid = null;
           return { type: "idle" } as const;
         }
@@ -1929,13 +2001,28 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         if (!nextEvent) {
           session.pendingProcessEvents = [];
           session.pendingProcessEventIndex = 0;
+          session.pendingProcessEventBytes = 0;
           session.processEventDrainPid = null;
           return { type: "idle" } as const;
         }
 
         session.pendingProcessEventIndex += 1;
+        if (nextEvent.type === "output") {
+          session.pendingProcessEventBytes = Math.max(
+            0,
+            session.pendingProcessEventBytes - nextEvent.dataBytes,
+          );
+        }
         if (session.pendingProcessEventIndex >= session.pendingProcessEvents.length) {
           session.pendingProcessEvents = [];
+          session.pendingProcessEventIndex = 0;
+        } else if (
+          session.pendingProcessEventIndex >= 64 &&
+          session.pendingProcessEventIndex * 2 >= session.pendingProcessEvents.length
+        ) {
+          session.pendingProcessEvents = session.pendingProcessEvents.slice(
+            session.pendingProcessEventIndex,
+          );
           session.pendingProcessEventIndex = 0;
         }
 
@@ -1976,6 +2063,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingOutputHighSurrogate = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
+        session.pendingProcessEventBytes = 0;
+        session.processOutputPaused = false;
         session.processEventDrainPid = null;
         session.exitCode = Number.isInteger(nextEvent.event.exitCode)
           ? nextEvent.event.exitCode
@@ -1997,6 +2086,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       });
 
       if (action.type === "idle") {
+        resumeProcessOutput(session, expectedPid, pendingProcessEventResumeBytes);
         return;
       }
 
@@ -2016,6 +2106,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
           sequence: action.sequence,
           data: action.data,
         });
+        resumeProcessOutput(session, expectedPid, pendingProcessEventResumeBytes);
         continue;
       }
 
@@ -2073,6 +2164,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.pendingOutputHighSurrogate = "";
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
+      session.pendingProcessEventBytes = 0;
+      session.processOutputPaused = false;
       session.processEventDrainPid = null;
       session.updatedAt = updatedAt;
       return [undefined, state] as const;
@@ -2168,6 +2261,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       session.childCommandLabel = null;
       session.pendingProcessEvents = [];
       session.pendingProcessEventIndex = 0;
+      session.pendingProcessEventBytes = 0;
+      session.processOutputPaused = false;
       session.processEventDrainPid = null;
       session.pendingOutputHighSurrogate = "";
       session.updatedAt = startingAt;
@@ -2211,6 +2306,7 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
                   processPid,
                   { type: "exit", event },
                   outputBatchMaxBytes,
+                  pendingProcessEventMaxBytes,
                 )
               ) {
                 runFork(drainProcessEvents(session, processPid));
@@ -2264,6 +2360,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.childCommandLabel = null;
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
+        session.pendingProcessEventBytes = 0;
+        session.processOutputPaused = false;
         session.processEventDrainPid = null;
         advanceEventSequence(session);
         return [undefined, state] as const;
@@ -2514,6 +2612,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         pendingOutputHighSurrogate: "",
         pendingProcessEvents: [],
         pendingProcessEventIndex: 0,
+        pendingProcessEventBytes: 0,
+        processOutputPaused: false,
         processEventDrainPid: null,
         processEventDrainSemaphore: yield* Semaphore.make(1),
         exitCode: null,
@@ -2580,6 +2680,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.pendingOutputHighSurrogate = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
+      liveSession.pendingProcessEventBytes = 0;
+      liveSession.processOutputPaused = false;
       liveSession.processEventDrainPid = null;
       yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
     } else if (liveSession.status === "exited" || liveSession.status === "error") {
@@ -2593,6 +2695,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       liveSession.pendingOutputHighSurrogate = "";
       liveSession.pendingProcessEvents = [];
       liveSession.pendingProcessEventIndex = 0;
+      liveSession.pendingProcessEventBytes = 0;
+      liveSession.processOutputPaused = false;
       liveSession.processEventDrainPid = null;
       yield* persistHistory(liveSession.threadId, liveSession.terminalId, liveSession.history);
     }
@@ -3002,6 +3106,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingOutputHighSurrogate = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
+        session.pendingProcessEventBytes = 0;
+        session.processOutputPaused = false;
         const eventStamp = advanceEventSequence(session);
         yield* persistHistory(input.threadId, terminalId, session.history);
         yield* publishEvent({
@@ -3042,6 +3148,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
             pendingOutputHighSurrogate: "",
             pendingProcessEvents: [],
             pendingProcessEventIndex: 0,
+            pendingProcessEventBytes: 0,
+            processOutputPaused: false,
             processEventDrainPid: null,
             processEventDrainSemaphore: yield* Semaphore.make(1),
             exitCode: null,
@@ -3083,6 +3191,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         session.pendingOutputHighSurrogate = "";
         session.pendingProcessEvents = [];
         session.pendingProcessEventIndex = 0;
+        session.pendingProcessEventBytes = 0;
+        session.processOutputPaused = false;
         session.processEventDrainPid = null;
         yield* persistHistory(input.threadId, terminalId, session.history);
         yield* startSession(

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -2086,7 +2086,6 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
       });
 
       if (action.type === "idle") {
-        resumeProcessOutput(session, expectedPid, pendingProcessEventResumeBytes);
         return;
       }
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -80,7 +80,9 @@ const DEFAULT_HISTORY_MAX_BYTES = 12 * 1024 * 1024;
 const DEFAULT_REPLAY_HISTORY_TARGET_BYTES = 48 * 1024;
 const DEFAULT_REPLAY_HISTORY_MAX_BYTES = DEFAULT_TERMINAL_REPLAY_BYTES;
 const DEFAULT_OUTPUT_BATCH_WINDOW_MS = 8;
-const DEFAULT_OUTPUT_BATCH_MAX_BYTES = 16 * 1024;
+// Full-screen terminal apps commonly emit 20-40 KB synchronized updates. Keep
+// typical frames in one event while retaining a bounded live-subscriber queue.
+const DEFAULT_OUTPUT_BATCH_MAX_BYTES = 64 * 1024;
 const DEFAULT_HISTORY_STREAM_CHUNK_BYTES = 64 * 1024;
 const DEFAULT_ATTACH_BUFFERED_EVENT_LIMIT = 32;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -2749,6 +2749,18 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
 
       yield* listener(
         {
+          type: "replay-start",
+          threadId: input.threadId,
+          terminalId: input.terminalId,
+          ...(typeof bootstrap.snapshot.sequence === "number"
+            ? { sequence: bootstrap.snapshot.sequence }
+            : {}),
+        },
+        "replay",
+      );
+
+      yield* listener(
+        {
           type: "snapshot",
           snapshot: bootstrap.snapshot,
         },

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -90,6 +90,14 @@ class NodePtyProcess implements PtyAdapter.PtyProcess {
     this.process.kill(signal);
   }
 
+  pauseOutput(): void {
+    this.process.pause();
+  }
+
+  resumeOutput(): void {
+    this.process.resume();
+  }
+
   onData(callback: (data: string) => void): () => void {
     const disposable = this.process.onData(callback);
     return () => {

--- a/apps/server/src/terminal/PtyAdapter.ts
+++ b/apps/server/src/terminal/PtyAdapter.ts
@@ -39,6 +39,10 @@ export interface PtyProcess {
   write(data: string): void;
   resize(cols: number, rows: number): void;
   kill(signal?: string): void;
+  /** Pause PTY output at the producer when the adapter supports flow control. */
+  pauseOutput?(): void;
+  /** Resume PTY output after the manager has drained its bounded backlog. */
+  resumeOutput?(): void;
   onData(callback: (data: string) => void): () => void;
   onExit(callback: (event: PtyExitEvent) => void): () => void;
 }

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -145,6 +145,7 @@ const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchComma
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const CONFIG_DISCOVERY_TIMEOUT = Duration.seconds(5);
+const TERMINAL_ATTACH_BUFFERED_EVENT_LIMIT = 32;
 
 const resolveDiscoveryForConfig = <A, E, R>(
   discovery: Effect.Effect<A, E, R>,
@@ -2250,11 +2251,44 @@ const makeWsRpcLayer = (
         [WS_METHODS.terminalAttach]: (input) =>
           observeRpcStream(
             WS_METHODS.terminalAttach,
-            Stream.callback<TerminalAttachStreamEvent, TerminalError>((queue) =>
-              Effect.acquireRelease(
-                terminalManager.attachStream(input, (event) => Queue.offer(queue, event)),
-                (unsubscribe) => Effect.sync(unsubscribe),
-              ),
+            Stream.callback<TerminalAttachStreamEvent, TerminalError>(
+              (queue) =>
+                Effect.acquireRelease(
+                  terminalManager.attachStream(
+                    input,
+                    (event, delivery): Effect.Effect<void> =>
+                      Effect.gen(function* () {
+                        if (delivery === "replay") {
+                          yield* Queue.offer(queue, event);
+                          return;
+                        }
+                        if (Queue.offerUnsafe(queue, event)) return;
+
+                        yield* Queue.clear(queue);
+                        if (event.type === "closed") {
+                          yield* Queue.offer(queue, event);
+                          return;
+                        }
+
+                        const latest = yield* terminalManager.readSnapshot(input);
+                        yield* Queue.offer(
+                          queue,
+                          Option.match(latest, {
+                            onNone: () => event,
+                            onSome: (snapshot) => ({ type: "snapshot" as const, snapshot }),
+                          }),
+                        );
+                        if (Option.isSome(latest) && event.type === "error") {
+                          yield* Queue.offer(queue, event);
+                        }
+                      }).pipe(Effect.ignore),
+                  ),
+                  (unsubscribe) => Effect.sync(unsubscribe),
+                ),
+              {
+                bufferSize: TERMINAL_ATTACH_BUFFERED_EVENT_LIMIT,
+                strategy: "suspend",
+              },
             ),
             { "rpc.aggregate": "terminal" },
           ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1051,12 +1051,12 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [onAddTerminalContext, visible],
   );
 
-  if (!project || !terminalUiState.terminalOpen || !cwd) {
+  if (!project || !terminalUiState.terminalOpen || !cwd || !visible) {
     return null;
   }
 
   return (
-    <div className={visible ? undefined : "hidden"}>
+    <div>
       <ThreadTerminalDrawer
         threadRef={threadRef}
         threadId={threadId}

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -6,6 +6,7 @@ import {
   shouldHandleTerminalSelectionMouseUp,
   terminalSelectionActionDelayForClickCount,
   terminalSelectionLineRange,
+  writeTerminalOutputSegments,
 } from "./ThreadTerminalDrawer";
 
 describe("resolveTerminalSelectionActionPosition", () => {
@@ -88,5 +89,28 @@ describe("resolveTerminalSelectionActionPosition", () => {
     expect(shouldHandleTerminalExit("exited", "running", false)).toBe(true);
     expect(shouldHandleTerminalExit("exited", "exited", false)).toBe(false);
     expect(shouldHandleTerminalExit("closed", "running", true)).toBe(false);
+  });
+});
+
+describe("writeTerminalOutputSegments", () => {
+  it("closes a streamed replay before writing live terminal output", () => {
+    const actions: string[] = [];
+    const result = writeTerminalOutputSegments({
+      terminal: {
+        beginStreamingReplay: (data) => actions.push(`begin:${data}`),
+        appendStreamingReplay: (data) => actions.push(`append:${data}`),
+        completeStreamingReplay: () => actions.push("complete"),
+        write: (data) => actions.push(`write:${data}`),
+      },
+      segments: [
+        { data: "history", delivery: "replay" },
+        { data: "\u001b[5n", delivery: "live" },
+      ],
+      replayState: "waiting",
+      onReplayComplete: () => actions.push("restore-scroll"),
+    });
+
+    expect(actions).toEqual(["begin:history", "complete", "restore-scroll", "write:\u001b[5n"]);
+    expect(result).toEqual({ replayState: "idle", didWrite: true });
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1013,8 +1013,8 @@ export function TerminalViewport({
     if (outputUpdate.type !== "none") terminal.clearSelection();
 
     if (
-      (current.replayCompleteVersion !== previous.replayCompleteVersion ||
-        (subscriptionChanged && current.replayCompleteVersion > 0)) &&
+      current.replayCompleteVersion > 0 &&
+      current.version !== previous.version &&
       pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity
     ) {
       pendingScrollbackReplayIdentityRef.current = null;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -493,11 +493,13 @@ export function TerminalViewport({
     },
   );
   const terminalVersion = terminalSession.version;
+  const terminalReplayStartVersion = terminalSession.replayStartVersion;
   const terminalReplayCompleteVersion = terminalSession.replayCompleteVersion;
   const previousSessionRef = useRef({
     output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
+    replayStartVersion: terminalReplayStartVersion,
     replayCompleteVersion: terminalReplayCompleteVersion,
     version: terminalVersion,
   });
@@ -506,6 +508,7 @@ export function TerminalViewport({
     output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
+    replayStartVersion: terminalReplayStartVersion,
     replayCompleteVersion: terminalReplayCompleteVersion,
     version: terminalVersion,
   };
@@ -985,6 +988,7 @@ export function TerminalViewport({
       output: terminalOutput,
       error: terminalError,
       status: terminalStatus,
+      replayStartVersion: terminalReplayStartVersion,
       replayCompleteVersion: terminalReplayCompleteVersion,
       version: terminalVersion,
     };
@@ -1001,11 +1005,18 @@ export function TerminalViewport({
 
     const outputUpdate = readTerminalOutputUpdate(current.output, outputCursorRef.current);
     outputCursorRef.current = outputUpdate.cursor;
+    if (
+      replayBytes === EXTENDED_TERMINAL_REPLAY_BYTES &&
+      current.replayStartVersion !== previous.replayStartVersion
+    ) {
+      scrollbackReplayRendererStateRef.current = "waiting";
+    }
     const scrollbackReplayPending =
       pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity;
+    const streamingReplay = scrollbackReplayRendererStateRef.current !== "idle";
     let didWriteOutput = false;
     if (outputUpdate.type === "append") {
-      if (scrollbackReplayPending) {
+      if (streamingReplay) {
         if (scrollbackReplayRendererStateRef.current === "waiting") {
           terminal.beginStreamingReplay(outputUpdate.data);
           scrollbackReplayRendererStateRef.current = "replaying";
@@ -1017,11 +1028,11 @@ export function TerminalViewport({
       }
       didWriteOutput = outputUpdate.data.length > 0;
     } else if (outputUpdate.type === "reset") {
-      if (scrollbackReplayPending && outputUpdate.data.length === 0) {
+      if (streamingReplay && outputUpdate.data.length === 0) {
         // The extended attach begins with an empty snapshot. Keep the current
         // screen visible until its first retained-history chunk arrives.
         scrollbackReplayRendererStateRef.current = "waiting";
-      } else if (scrollbackReplayPending) {
+      } else if (streamingReplay) {
         terminal.beginStreamingReplay(outputUpdate.data);
         scrollbackReplayRendererStateRef.current = "replaying";
         didWriteOutput = true;
@@ -1035,7 +1046,7 @@ export function TerminalViewport({
     if (
       current.replayCompleteVersion > 0 &&
       current.version !== previous.version &&
-      scrollbackReplayPending
+      streamingReplay
     ) {
       if (scrollbackReplayRendererStateRef.current === "waiting") {
         terminal.beginStreamingReplay(terminalOutputText(current.output));
@@ -1043,8 +1054,10 @@ export function TerminalViewport({
       }
       terminal.completeStreamingReplay();
       scrollbackReplayRendererStateRef.current = "idle";
-      pendingScrollbackReplayIdentityRef.current = null;
-      terminal.scrollToTopAfterWrites();
+      if (scrollbackReplayPending) {
+        pendingScrollbackReplayIdentityRef.current = null;
+        terminal.scrollToTopAfterWrites();
+      }
     }
 
     if (current.error !== null && current.error !== previous.error) {
@@ -1062,10 +1075,12 @@ export function TerminalViewport({
     terminalError,
     terminalOutput,
     terminalReplayCompleteVersion,
+    terminalReplayStartVersion,
     terminalStatus,
     terminalAttachIdentity,
     terminalSubscriptionIdentity,
     terminalVersion,
+    replayBytes,
   ]);
 
   useEffect(() => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -7,6 +7,7 @@ import {
   readTerminalOutputUpdate,
   terminalOutputText,
   type TerminalOutputCursor,
+  type TerminalOutputUpdate,
   type TerminalSessionState,
 } from "@t3tools/client-runtime/state/terminal";
 import {
@@ -104,6 +105,44 @@ function writeSystemMessage(terminal: GhosttyTerminalSurface, message: string): 
 
 function writeTerminalBuffer(terminal: GhosttyTerminalSurface, buffer: string): void {
   terminal.resetAndWrite(buffer);
+}
+
+type TerminalReplayRendererState = "idle" | "waiting" | "replaying";
+
+/** Preserve replay/live ordering when React reduces both deliveries before a render. */
+export function writeTerminalOutputSegments(options: {
+  terminal: Pick<
+    GhosttyTerminalSurface,
+    "appendStreamingReplay" | "beginStreamingReplay" | "completeStreamingReplay" | "write"
+  >;
+  segments: Extract<TerminalOutputUpdate, { type: "append" }>["segments"];
+  replayState: TerminalReplayRendererState;
+  onReplayComplete: () => void;
+}): { replayState: TerminalReplayRendererState; didWrite: boolean } {
+  let replayState = options.replayState;
+  let didWrite = false;
+
+  for (const segment of options.segments) {
+    if (segment.data.length === 0) continue;
+    didWrite = true;
+    if (segment.delivery === "replay" && replayState !== "idle") {
+      if (replayState === "waiting") {
+        options.terminal.beginStreamingReplay(segment.data);
+        replayState = "replaying";
+      } else {
+        options.terminal.appendStreamingReplay(segment.data);
+      }
+      continue;
+    }
+    if (segment.delivery === "live" && replayState !== "idle") {
+      if (replayState === "replaying") options.terminal.completeStreamingReplay();
+      replayState = "idle";
+      options.onReplayComplete();
+    }
+    options.terminal.write(segment.data);
+  }
+
+  return { replayState, didWrite };
 }
 
 function parseTerminalColor(value: string, fallback: GhosttyColor): GhosttyColor {
@@ -442,7 +481,7 @@ export function TerminalViewport({
   );
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
   const pendingScrollbackReplayIdentityRef = useRef<string | null>(null);
-  const scrollbackReplayRendererStateRef = useRef<"idle" | "waiting" | "replaying">("idle");
+  const scrollbackReplayRendererStateRef = useRef<TerminalReplayRendererState>("idle");
   const terminalAttachIdentity = useMemo(
     () =>
       JSON.stringify([
@@ -1048,19 +1087,21 @@ export function TerminalViewport({
     const scrollbackReplayPending =
       pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity;
     const streamingReplay = scrollbackReplayRendererStateRef.current !== "idle";
+    const completePendingScrollbackReplay = () => {
+      if (pendingScrollbackReplayIdentityRef.current !== terminalAttachIdentity) return;
+      pendingScrollbackReplayIdentityRef.current = null;
+      terminal.scrollToTopAfterWrites();
+    };
     let didWriteOutput = false;
     if (outputUpdate.type === "append") {
-      if (streamingReplay) {
-        if (scrollbackReplayRendererStateRef.current === "waiting") {
-          terminal.beginStreamingReplay(outputUpdate.data);
-          scrollbackReplayRendererStateRef.current = "replaying";
-        } else {
-          terminal.appendStreamingReplay(outputUpdate.data);
-        }
-      } else {
-        terminal.write(outputUpdate.data);
-      }
-      didWriteOutput = outputUpdate.data.length > 0;
+      const result = writeTerminalOutputSegments({
+        terminal,
+        segments: outputUpdate.segments,
+        replayState: scrollbackReplayRendererStateRef.current,
+        onReplayComplete: completePendingScrollbackReplay,
+      });
+      scrollbackReplayRendererStateRef.current = result.replayState;
+      didWriteOutput = result.didWrite;
     } else if (outputUpdate.type === "reset") {
       if (streamingReplay && outputUpdate.data.length === 0) {
         // The extended attach begins with an empty snapshot. Keep the current
@@ -1081,7 +1122,7 @@ export function TerminalViewport({
       current.replayCompleteVersion > 0 &&
       current.replayCompleteVersion >= current.replayStartVersion &&
       current.version !== previous.version &&
-      streamingReplay
+      scrollbackReplayRendererStateRef.current !== "idle"
     ) {
       if (scrollbackReplayRendererStateRef.current === "waiting") {
         terminal.beginStreamingReplay(terminalOutputText(current.output));
@@ -1089,10 +1130,7 @@ export function TerminalViewport({
       }
       terminal.completeStreamingReplay();
       scrollbackReplayRendererStateRef.current = "idle";
-      if (scrollbackReplayPending) {
-        pendingScrollbackReplayIdentityRef.current = null;
-        terminal.scrollToTopAfterWrites();
-      }
+      if (scrollbackReplayPending) completePendingScrollbackReplay();
     }
 
     if (current.error !== null && current.error !== previous.error) {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -410,10 +410,35 @@ export function TerminalViewport({
     }),
   );
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
-  const [replayBytes, setReplayBytes] = useState(DEFAULT_TERMINAL_REPLAY_BYTES);
+  const pendingScrollbackReplayIdentityRef = useRef<string | null>(null);
+  const terminalAttachIdentity = useMemo(
+    () =>
+      JSON.stringify([
+        environmentId,
+        threadId,
+        terminalId,
+        cwd,
+        worktreePath ?? null,
+        runtimeEnvKey,
+      ]),
+    [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath],
+  );
+  const [extendedReplayIdentity, setExtendedReplayIdentity] = useState<string | null>(null);
+  const replayBytes =
+    extendedReplayIdentity === terminalAttachIdentity
+      ? EXTENDED_TERMINAL_REPLAY_BYTES
+      : DEFAULT_TERMINAL_REPLAY_BYTES;
   const requestExtendedReplay = useEffectEvent(() => {
-    setReplayBytes(EXTENDED_TERMINAL_REPLAY_BYTES);
+    if (extendedReplayIdentity === terminalAttachIdentity) return;
+    pendingScrollbackReplayIdentityRef.current = terminalAttachIdentity;
+    setExtendedReplayIdentity(terminalAttachIdentity);
   });
+  useEffect(() => {
+    setExtendedReplayIdentity(null);
+    if (pendingScrollbackReplayIdentityRef.current !== terminalAttachIdentity) {
+      pendingScrollbackReplayIdentityRef.current = null;
+    }
+  }, [terminalAttachIdentity]);
   const terminalSession = useAttachedTerminalSession({
     environmentId,
     terminal: {
@@ -444,6 +469,8 @@ export function TerminalViewport({
     resetVersion: -1,
     lastChunkId: 0,
   });
+  const terminalSubscriptionIdentity = `${terminalAttachIdentity}:${replayBytes}`;
+  const outputSubscriptionIdentityRef = useRef(terminalSubscriptionIdentity);
   const synchronizedStatusRef = useRef<TerminalSessionState["status"]>("closed");
   const synchronizeTerminalStatus = useEffectEvent(
     (terminal: GhosttyTerminalSurface, status: TerminalSessionState["status"]) => {
@@ -463,10 +490,12 @@ export function TerminalViewport({
     },
   );
   const terminalVersion = terminalSession.version;
+  const terminalReplayCompleteVersion = terminalSession.replayCompleteVersion;
   const previousSessionRef = useRef({
     output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
+    replayCompleteVersion: terminalReplayCompleteVersion,
     version: terminalVersion,
   });
   const latestSessionRef = useRef(previousSessionRef.current);
@@ -474,6 +503,7 @@ export function TerminalViewport({
     output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
+    replayCompleteVersion: terminalReplayCompleteVersion,
     version: terminalVersion,
   };
 
@@ -541,6 +571,13 @@ export function TerminalViewport({
         resetVersion: latestSession.output.resetVersion,
         lastChunkId: latestSession.output.latestChunkId,
       };
+      if (
+        pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity &&
+        latestSession.replayCompleteVersion > 0
+      ) {
+        pendingScrollbackReplayIdentityRef.current = null;
+        terminal.scrollToTopAfterWrites();
+      }
       if (latestSession.error !== null) writeSystemMessage(terminal, latestSession.error);
       // Attaching to a session that already exited must still run exit handling
       // once, so mount synchronization starts from the empty "closed" state.
@@ -927,14 +964,32 @@ export function TerminalViewport({
     };
     // autoFocus is intentionally omitted;
     // it is only read at mount time and must not trigger terminal teardown/recreation.
-  }, [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath]);
+  }, [
+    cwd,
+    environmentId,
+    runtimeEnvKey,
+    terminalAttachIdentity,
+    terminalId,
+    threadId,
+    worktreePath,
+  ]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
+    const subscriptionChanged =
+      outputSubscriptionIdentityRef.current !== terminalSubscriptionIdentity;
+    if (subscriptionChanged) {
+      outputSubscriptionIdentityRef.current = terminalSubscriptionIdentity;
+      outputCursorRef.current = {
+        resetVersion: -1,
+        lastChunkId: 0,
+      };
+    }
     const current = {
       output: terminalOutput,
       error: terminalError,
       status: terminalStatus,
+      replayCompleteVersion: terminalReplayCompleteVersion,
       version: terminalVersion,
     };
     if (!terminal) {
@@ -944,7 +999,7 @@ export function TerminalViewport({
 
     const previous = previousSessionRef.current;
     synchronizeTerminalStatus(terminal, current.status);
-    if (current.version === previous.version) {
+    if (!subscriptionChanged && current.version === previous.version) {
       return;
     }
 
@@ -957,6 +1012,15 @@ export function TerminalViewport({
     }
     if (outputUpdate.type !== "none") terminal.clearSelection();
 
+    if (
+      (current.replayCompleteVersion !== previous.replayCompleteVersion ||
+        (subscriptionChanged && current.replayCompleteVersion > 0)) &&
+      pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity
+    ) {
+      pendingScrollbackReplayIdentityRef.current = null;
+      terminal.scrollToTopAfterWrites();
+    }
+
     if (current.error !== null && current.error !== previous.error) {
       writeSystemMessage(terminal, current.error);
     }
@@ -967,7 +1031,16 @@ export function TerminalViewport({
       });
     }
     previousSessionRef.current = current;
-  }, [autoFocus, terminalError, terminalOutput, terminalStatus, terminalVersion]);
+  }, [
+    autoFocus,
+    terminalError,
+    terminalOutput,
+    terminalReplayCompleteVersion,
+    terminalStatus,
+    terminalAttachIdentity,
+    terminalSubscriptionIdentity,
+    terminalVersion,
+  ]);
 
   useEffect(() => {
     if (!autoFocus) return;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -411,6 +411,7 @@ export function TerminalViewport({
   );
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
   const pendingScrollbackReplayIdentityRef = useRef<string | null>(null);
+  const scrollbackReplayRendererStateRef = useRef<"idle" | "waiting" | "replaying">("idle");
   const terminalAttachIdentity = useMemo(
     () =>
       JSON.stringify([
@@ -431,12 +432,14 @@ export function TerminalViewport({
   const requestExtendedReplay = useEffectEvent(() => {
     if (extendedReplayIdentity === terminalAttachIdentity) return;
     pendingScrollbackReplayIdentityRef.current = terminalAttachIdentity;
+    scrollbackReplayRendererStateRef.current = "waiting";
     setExtendedReplayIdentity(terminalAttachIdentity);
   });
   useEffect(() => {
     setExtendedReplayIdentity(null);
     if (pendingScrollbackReplayIdentityRef.current !== terminalAttachIdentity) {
       pendingScrollbackReplayIdentityRef.current = null;
+      scrollbackReplayRendererStateRef.current = "idle";
     }
   }, [terminalAttachIdentity]);
   const terminalSession = useAttachedTerminalSession({
@@ -571,13 +574,6 @@ export function TerminalViewport({
         resetVersion: latestSession.output.resetVersion,
         lastChunkId: latestSession.output.latestChunkId,
       };
-      if (
-        pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity &&
-        latestSession.replayCompleteVersion > 0
-      ) {
-        pendingScrollbackReplayIdentityRef.current = null;
-        terminal.scrollToTopAfterWrites();
-      }
       if (latestSession.error !== null) writeSystemMessage(terminal, latestSession.error);
       // Attaching to a session that already exited must still run exit handling
       // once, so mount synchronization starts from the empty "closed" state.
@@ -1005,18 +1001,48 @@ export function TerminalViewport({
 
     const outputUpdate = readTerminalOutputUpdate(current.output, outputCursorRef.current);
     outputCursorRef.current = outputUpdate.cursor;
+    const scrollbackReplayPending =
+      pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity;
+    let didWriteOutput = false;
     if (outputUpdate.type === "append") {
-      terminal.write(outputUpdate.data);
+      if (scrollbackReplayPending) {
+        if (scrollbackReplayRendererStateRef.current === "waiting") {
+          terminal.beginStreamingReplay(outputUpdate.data);
+          scrollbackReplayRendererStateRef.current = "replaying";
+        } else {
+          terminal.appendStreamingReplay(outputUpdate.data);
+        }
+      } else {
+        terminal.write(outputUpdate.data);
+      }
+      didWriteOutput = outputUpdate.data.length > 0;
     } else if (outputUpdate.type === "reset") {
-      writeTerminalBuffer(terminal, outputUpdate.data);
+      if (scrollbackReplayPending && outputUpdate.data.length === 0) {
+        // The extended attach begins with an empty snapshot. Keep the current
+        // screen visible until its first retained-history chunk arrives.
+        scrollbackReplayRendererStateRef.current = "waiting";
+      } else if (scrollbackReplayPending) {
+        terminal.beginStreamingReplay(outputUpdate.data);
+        scrollbackReplayRendererStateRef.current = "replaying";
+        didWriteOutput = true;
+      } else {
+        writeTerminalBuffer(terminal, outputUpdate.data);
+        didWriteOutput = true;
+      }
     }
-    if (outputUpdate.type !== "none") terminal.clearSelection();
+    if (didWriteOutput) terminal.clearSelection();
 
     if (
       current.replayCompleteVersion > 0 &&
       current.version !== previous.version &&
-      pendingScrollbackReplayIdentityRef.current === terminalAttachIdentity
+      scrollbackReplayPending
     ) {
+      if (scrollbackReplayRendererStateRef.current === "waiting") {
+        terminal.beginStreamingReplay(terminalOutputText(current.output));
+        terminal.clearSelection();
+      }
+      terminal.completeStreamingReplay();
+      scrollbackReplayRendererStateRef.current = "idle";
       pendingScrollbackReplayIdentityRef.current = null;
       terminal.scrollToTopAfterWrites();
     }

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1045,6 +1045,7 @@ export function TerminalViewport({
 
     if (
       current.replayCompleteVersion > 0 &&
+      current.replayCompleteVersion >= current.replayStartVersion &&
       current.version !== previous.version &&
       streamingReplay
     ) {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -3,7 +3,12 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { type TerminalSessionState } from "@t3tools/client-runtime/state/terminal";
+import {
+  readTerminalOutputUpdate,
+  terminalOutputText,
+  type TerminalOutputCursor,
+  type TerminalSessionState,
+} from "@t3tools/client-runtime/state/terminal";
 import {
   Plus,
   Square,
@@ -13,6 +18,8 @@ import {
   Trash2,
 } from "lucide-react";
 import {
+  DEFAULT_TERMINAL_REPLAY_BYTES,
+  EXTENDED_TERMINAL_REPLAY_BYTES,
   type ContextMenuItem,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
@@ -403,6 +410,10 @@ export function TerminalViewport({
     }),
   );
   const terminalFontRef = useRef({ family: terminalFontFamily, size: terminalFontSize });
+  const [replayBytes, setReplayBytes] = useState(DEFAULT_TERMINAL_REPLAY_BYTES);
+  const requestExtendedReplay = useEffectEvent(() => {
+    setReplayBytes(EXTENDED_TERMINAL_REPLAY_BYTES);
+  });
   const terminalSession = useAttachedTerminalSession({
     environmentId,
     terminal: {
@@ -411,6 +422,7 @@ export function TerminalViewport({
       cwd,
       ...(worktreePath !== undefined ? { worktreePath } : {}),
       ...(runtimeEnv ? { env: runtimeEnv } : {}),
+      replayBytes,
     },
   });
   const writeTerminal = useEffectEvent((data: string) =>
@@ -425,9 +437,13 @@ export function TerminalViewport({
       input: { threadId, terminalId, cols, rows },
     }),
   );
-  const terminalBuffer = terminalSession.buffer;
+  const terminalOutput = terminalSession.output;
   const terminalError = terminalSession.error;
   const terminalStatus = terminalSession.status;
+  const outputCursorRef = useRef<TerminalOutputCursor>({
+    resetVersion: -1,
+    lastChunkId: 0,
+  });
   const synchronizedStatusRef = useRef<TerminalSessionState["status"]>("closed");
   const synchronizeTerminalStatus = useEffectEvent(
     (terminal: GhosttyTerminalSurface, status: TerminalSessionState["status"]) => {
@@ -448,14 +464,14 @@ export function TerminalViewport({
   );
   const terminalVersion = terminalSession.version;
   const previousSessionRef = useRef({
-    buffer: terminalBuffer,
+    output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
     version: terminalVersion,
   });
   const latestSessionRef = useRef(previousSessionRef.current);
   latestSessionRef.current = {
-    buffer: terminalBuffer,
+    output: terminalOutput,
     error: terminalError,
     status: terminalStatus,
     version: terminalVersion,
@@ -490,6 +506,7 @@ export function TerminalViewport({
         onData: (data) => handleData(data),
         onResize: (cols, rows) => void resizeTerminal(cols, rows),
         onSelectionChange: () => handleSelectionChange(),
+        onScrollbackTop: () => requestExtendedReplay(),
         beforeKey: (event) => handleBeforeKey(event),
         onLinkActivate: (text, event) => handleLinkActivate(text, event),
         // The surface listens from construction, so a right-click can land
@@ -518,7 +535,12 @@ export function TerminalViewport({
       }
       const latestSession = latestSessionRef.current;
       previousSessionRef.current = latestSession;
-      if (latestSession.buffer.length > 0) terminal.resetAndWrite(latestSession.buffer);
+      const replay = terminalOutputText(latestSession.output);
+      if (replay.length > 0) terminal.resetAndWrite(replay);
+      outputCursorRef.current = {
+        resetVersion: latestSession.output.resetVersion,
+        lastChunkId: latestSession.output.latestChunkId,
+      };
       if (latestSession.error !== null) writeSystemMessage(terminal, latestSession.error);
       // Attaching to a session that already exited must still run exit handling
       // once, so mount synchronization starts from the empty "closed" state.
@@ -910,7 +932,7 @@ export function TerminalViewport({
   useEffect(() => {
     const terminal = terminalRef.current;
     const current = {
-      buffer: terminalBuffer,
+      output: terminalOutput,
       error: terminalError,
       status: terminalStatus,
       version: terminalVersion,
@@ -926,15 +948,14 @@ export function TerminalViewport({
       return;
     }
 
-    if (
-      current.buffer.length >= previous.buffer.length &&
-      current.buffer.startsWith(previous.buffer)
-    ) {
-      terminal.write(current.buffer.slice(previous.buffer.length));
-    } else {
-      writeTerminalBuffer(terminal, current.buffer);
+    const outputUpdate = readTerminalOutputUpdate(current.output, outputCursorRef.current);
+    outputCursorRef.current = outputUpdate.cursor;
+    if (outputUpdate.type === "append") {
+      terminal.write(outputUpdate.data);
+    } else if (outputUpdate.type === "reset") {
+      writeTerminalBuffer(terminal, outputUpdate.data);
     }
-    terminal.clearSelection();
+    if (outputUpdate.type !== "none") terminal.clearSelection();
 
     if (current.error !== null && current.error !== previous.error) {
       writeSystemMessage(terminal, current.error);
@@ -946,7 +967,7 @@ export function TerminalViewport({
       });
     }
     previousSessionRef.current = current;
-  }, [autoFocus, terminalBuffer, terminalError, terminalStatus, terminalVersion]);
+  }, [autoFocus, terminalError, terminalOutput, terminalStatus, terminalVersion]);
 
   useEffect(() => {
     if (!autoFocus) return;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -191,20 +191,51 @@ export function terminalThemeFromApp(mountElement?: HTMLElement | null): Ghostty
     "--terminal-selection-background",
     isDark ? "rgba(180, 203, 255, 0.25)" : "rgba(37, 63, 99, 0.2)",
   );
+  const colorProbe = document.createElement("span");
+  colorProbe.ariaHidden = "true";
+  colorProbe.style.cssText = "position:fixed;width:0;height:0;overflow:hidden;pointer-events:none";
+  drawerSurface.append(colorProbe);
+  const readResolvedThemeColor = (variable: string, fallback: string) => {
+    colorProbe.style.color = `var(${variable}, ${fallback})`;
+    return normalizeComputedColor(getComputedStyle(colorProbe).color, fallback);
+  };
+  const alternateBackground = readResolvedThemeColor(
+    "--terminal-alt-screen-background",
+    terminalBackground,
+  );
+  const alternateForeground = readResolvedThemeColor(
+    "--terminal-alt-screen-foreground",
+    terminalForeground,
+  );
+  const alternateCursor = readResolvedThemeColor("--terminal-alt-screen-cursor", terminalCursor);
+  const alternateSelection = readResolvedThemeColor(
+    "--terminal-alt-screen-selection-background",
+    terminalSelection,
+  );
+  colorProbe.remove();
+  const backgroundColor = parseTerminalColor(
+    terminalBackground,
+    isDark ? { r: 14, g: 18, b: 24 } : { r: 255, g: 255, b: 255 },
+  );
+  const foregroundColor = parseTerminalColor(
+    terminalForeground,
+    isDark ? { r: 237, g: 241, b: 247 } : { r: 28, g: 33, b: 41 },
+  );
+  const cursorColor = parseTerminalColor(
+    terminalCursor,
+    isDark ? { r: 180, g: 203, b: 255 } : { r: 38, g: 56, b: 78 },
+  );
   return {
-    background: parseTerminalColor(
-      terminalBackground,
-      isDark ? { r: 14, g: 18, b: 24 } : { r: 255, g: 255, b: 255 },
-    ),
-    foreground: parseTerminalColor(
-      terminalForeground,
-      isDark ? { r: 237, g: 241, b: 247 } : { r: 28, g: 33, b: 41 },
-    ),
-    cursor: parseTerminalColor(
-      terminalCursor,
-      isDark ? { r: 180, g: 203, b: 255 } : { r: 38, g: 56, b: 78 },
-    ),
+    background: backgroundColor,
+    foreground: foregroundColor,
+    cursor: cursorColor,
     selectionBackground: terminalSelection,
+    alternateScreen: {
+      background: parseTerminalColor(alternateBackground, backgroundColor),
+      foreground: parseTerminalColor(alternateForeground, foregroundColor),
+      cursor: parseTerminalColor(alternateCursor, cursorColor),
+      selectionBackground: alternateSelection,
+    },
   };
 }
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -999,7 +999,10 @@ export function TerminalViewport({
 
     const previous = previousSessionRef.current;
     synchronizeTerminalStatus(terminal, current.status);
-    if (!subscriptionChanged && current.version === previous.version) {
+    const replayBoundaryChanged =
+      current.replayStartVersion !== previous.replayStartVersion ||
+      current.replayCompleteVersion !== previous.replayCompleteVersion;
+    if (!subscriptionChanged && current.version === previous.version && !replayBoundaryChanged) {
       return;
     }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -988,7 +988,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --terminal-alt-screen-cursor: color-mix(in srgb, var(--terminal-cursor) 75%, rgb(255 255 255));
   --terminal-alt-screen-selection-background: color-mix(
     in srgb,
-    var(--terminal-selection-background) 80%,
+    var(--terminal-alt-screen-foreground) 25%,
     transparent
   );
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -977,6 +977,20 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --terminal-foreground: var(--foreground);
   --terminal-cursor: rgb(38 56 78);
   --terminal-selection-background: rgb(37 63 99 / 20%);
+  /* Full-screen TUIs commonly reset cells to terminal defaults. Derive a dark
+     companion from the active terminal palette so custom themes keep control. */
+  --terminal-alt-screen-background: color-mix(in srgb, var(--terminal-background) 5%, rgb(0 0 0));
+  --terminal-alt-screen-foreground: color-mix(
+    in srgb,
+    var(--terminal-foreground) 5%,
+    rgb(255 255 255)
+  );
+  --terminal-alt-screen-cursor: color-mix(in srgb, var(--terminal-cursor) 75%, rgb(255 255 255));
+  --terminal-alt-screen-selection-background: color-mix(
+    in srgb,
+    var(--terminal-selection-background) 80%,
+    transparent
+  );
 
   @variant dark {
     color-scheme: dark;

--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -38,6 +38,17 @@ describe("extractTerminalLinks", () => {
     ]);
   });
 
+  it("finds a bare file name when a source position makes it unambiguous", () => {
+    expect(extractTerminalLinks("failed at surface.ts:42:7")).toEqual([
+      {
+        kind: "path",
+        text: "surface.ts:42:7",
+        start: 10,
+        end: 25,
+      },
+    ]);
+  });
+
   it("classifies uppercase schemes as URLs at activation time too", () => {
     expect(isTerminalUrl("HTTPS://example.com/docs")).toBe(true);
     expect(isTerminalUrl("Http://example.com")).toBe(true);

--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -49,6 +49,12 @@ describe("extractTerminalLinks", () => {
     ]);
   });
 
+  it("does not treat host ports as bare file positions", () => {
+    expect(extractTerminalLinks("listening on api.example.com:8080 and 127.0.0.1:3000")).toEqual(
+      [],
+    );
+  });
+
   it("classifies uppercase schemes as URLs at activation time too", () => {
     expect(isTerminalUrl("HTTPS://example.com/docs")).toBe(true);
     expect(isTerminalUrl("Http://example.com")).toBe(true);

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -38,7 +38,7 @@ export interface WrappedTerminalLinkLine {
 
 const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/giu;
 const FILE_PATH_PATTERN =
-  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
+  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}|[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+(?::\d+){1,2}/g;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
 
 function trimClosingDelimiters(value: string): string {

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -38,7 +38,7 @@ export interface WrappedTerminalLinkLine {
 
 const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/giu;
 const FILE_PATH_PATTERN =
-  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}|[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+(?::\d+){1,2}/g;
+  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}|[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+(?::\d+){2}/g;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
 
 function trimClosingDelimiters(value: string): string {

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -488,6 +488,15 @@ export class GhosttyTerminalCore {
     );
   }
 
+  isSynchronizedOutput(): boolean {
+    this.ensureActive();
+    this.runtime.bytes(this.scratch, 1)[0] = 0;
+    return (
+      this.runtime.call("ghostty_terminal_mode_get", this.terminal, 2026, this.scratch) ===
+        GHOSTTY_SUCCESS && this.runtime.bytes(this.scratch, 1)[0] !== 0
+    );
+  }
+
   isAlternateScreen(): boolean {
     this.ensureActive();
     this.runtime.bytes(this.scratch, 4).fill(0);

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -9,7 +9,10 @@ import { GhosttyRuntime, loadGhosttyRuntime } from "./runtime";
 
 const GHOSTTY_SUCCESS = 0;
 const GHOSTTY_OUT_OF_SPACE = -3;
-const MAX_SCROLLBACK_ROWS = 10_000;
+// Despite the older libghostty-vt header calling this a line count, Ghostty's
+// screen implementation applies the value to its internal cell storage. A
+// 4 MB text replay expands substantially once every cell has terminal state.
+const MAX_SCROLLBACK_BYTES = 64 * 1024 * 1024;
 // wasm32 C ABI layout for GhosttyTerminalSelectionFormatOptions at the
 // libghostty-vt revision pinned alongside this module.
 const SELECTION_FORMAT_OPTIONS_SIZE = 16;
@@ -205,6 +208,7 @@ export class GhosttyTerminalCore {
   private mouseEvent = 0;
   private ptyWriterId = 0;
   private ptyWriter: ((data: string) => void) | null = null;
+  private replayActive = false;
   private scratch = 0;
   private style = 0;
   private scrollbar = 0;
@@ -249,7 +253,12 @@ export class GhosttyTerminalCore {
     const options = this.runtime.alloc(optionsSize);
     this.runtime.setField(options, "GhosttyTerminalOptions", "cols", cols);
     this.runtime.setField(options, "GhosttyTerminalOptions", "rows", rows);
-    this.runtime.setField(options, "GhosttyTerminalOptions", "max_scrollback", MAX_SCROLLBACK_ROWS);
+    this.runtime.setField(
+      options,
+      "GhosttyTerminalOptions",
+      "max_scrollback",
+      MAX_SCROLLBACK_BYTES,
+    );
     this.terminalSlot = this.runtime.allocOpaque();
     const terminalResult = this.runtime.call("ghostty_terminal_new", 0, this.terminalSlot, options);
     this.runtime.free(options, optionsSize);
@@ -323,24 +332,43 @@ export class GhosttyTerminalCore {
   }
 
   resetAndWrite(data: string): void {
+    this.beginReplay();
+    try {
+      this.writeReplay(data);
+    } finally {
+      this.endReplay();
+    }
+  }
+
+  /** Reset for ordered history replay while suppressing replay-generated PTY replies. */
+  beginReplay(): void {
     this.ensureActive();
+    if (this.replayActive) this.endReplay();
     this.runtime.call("ghostty_terminal_reset", this.terminal);
     // RIS returns the cursor to Ghostty's built-in steady default, so the
     // embedder default has to be applied again before the replay runs.
     this.applyDefaultCursorBlink();
     this.rows = [];
-    if (data.length === 0) return;
-    const writer = this.ptyWriter;
     if (this.ptyWriterId !== 0) {
       this.runtime.detachPtyWriter(this.terminal, this.ptyWriterId);
       this.ptyWriterId = 0;
     }
-    try {
-      this.write(data);
-    } finally {
-      if (writer !== null && !this.disposed) {
-        this.ptyWriterId = this.runtime.attachPtyWriter(this.terminal, writer);
-      }
+    this.replayActive = true;
+  }
+
+  writeReplay(data: string): void {
+    this.ensureActive();
+    if (!this.replayActive) {
+      throw new Error("Ghostty replay is not active");
+    }
+    this.write(data);
+  }
+
+  endReplay(): void {
+    if (!this.replayActive) return;
+    this.replayActive = false;
+    if (this.ptyWriter !== null && !this.disposed) {
+      this.ptyWriterId = this.runtime.attachPtyWriter(this.terminal, this.ptyWriter);
     }
   }
 
@@ -394,6 +422,15 @@ export class GhosttyTerminalCore {
     this.runtime.setField(scroll, "GhosttyTerminalScrollViewport", "tag", 2);
     const value = layout.fields.value!;
     this.runtime.view(scroll + value.offset, value.size).setInt32(0, deltaRows, true);
+    this.runtime.call("ghostty_terminal_scroll_viewport", this.terminal, scroll);
+    this.runtime.free(scroll, layout.size);
+  }
+
+  scrollToTop(): void {
+    this.ensureActive();
+    const layout = this.runtime.layout("GhosttyTerminalScrollViewport");
+    const scroll = this.runtime.alloc(layout.size);
+    this.runtime.setField(scroll, "GhosttyTerminalScrollViewport", "tag", 0);
     this.runtime.call("ghostty_terminal_scroll_viewport", this.terminal, scroll);
     this.runtime.free(scroll, layout.size);
   }

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -67,12 +67,17 @@ export interface GhosttyColor {
   readonly b: number;
 }
 
-export interface GhosttyTheme {
+export interface GhosttyScreenTheme {
   readonly foreground: GhosttyColor;
   readonly background: GhosttyColor;
   readonly cursor: GhosttyColor;
   /** CSS color the renderer overlays on selected cells; not sent to Ghostty. */
   readonly selectionBackground?: string;
+}
+
+export interface GhosttyTheme extends GhosttyScreenTheme {
+  /** Theme-owned defaults used while the standard alternate screen is active. */
+  readonly alternateScreen?: GhosttyScreenTheme;
 }
 
 export interface GhosttyCell {
@@ -413,6 +418,14 @@ export class GhosttyTerminalCore {
       this.runtime.call("ghostty_terminal_set", this.terminal, option, color);
     }
     this.runtime.free(color, 3);
+    // Theme changes can coincide with a primary/alternate screen swap. Force
+    // the next snapshot to refresh every cached row so colors from the screen
+    // we just left cannot survive under the new defaults.
+    this.runtime.view(this.scratch, 4).setUint32(0, 2, true);
+    this.assertSuccess(
+      "ghostty_render_state_set(theme dirty)",
+      this.runtime.call("ghostty_render_state_set", this.renderState, 0, this.scratch),
+    );
   }
 
   scroll(deltaRows: number): void {

--- a/apps/web/src/terminal/ghostty/renderer.test.ts
+++ b/apps/web/src/terminal/ghostty/renderer.test.ts
@@ -50,7 +50,7 @@ describe("measureGhosttyCell", () => {
     } as unknown as CanvasRenderingContext2D;
 
     expect(measureGhosttyCell(context, 12, "monospace")).toEqual({
-      width: 7.2,
+      width: 7,
       height: 16,
       baseline: 11,
     });
@@ -227,6 +227,72 @@ describe("renderGhosttySnapshot", () => {
       [4, 42, 10, 1],
       [14, 42, 10, 1],
     ]);
+  });
+
+  it("draws solid block elements to exact cell edges", () => {
+    const fillRectCalls: Array<{ args: number[]; style: string }> = [];
+    let fillStyle = "";
+    const context = {
+      canvas: { width: 100, height: 40 },
+      beginPath: () => {},
+      clip: () => {},
+      fillRect: (...args: number[]) => fillRectCalls.push({ args, style: fillStyle }),
+      fillText: () => {},
+      rect: () => {},
+      resetTransform: () => {},
+      restore: () => {},
+      save: () => {},
+      get fillStyle() {
+        return fillStyle;
+      },
+      set fillStyle(value: string | CanvasGradient | CanvasPattern) {
+        fillStyle = String(value);
+      },
+      set font(_value: string) {},
+      set textBaseline(_value: string) {},
+    } as unknown as CanvasRenderingContext2D;
+    const snapshot: GhosttySnapshot = {
+      cols: 3,
+      rows: 1,
+      foreground: { r: 255, g: 255, b: 255 },
+      background: { r: 0, g: 0, b: 0 },
+      cursor: { r: 255, g: 255, b: 255 },
+      cursorX: -1,
+      cursorY: -1,
+      cursorVisible: false,
+      cursorBlinking: false,
+      cursorStyle: 1,
+      dirtyRows: new Set([0]),
+      rowData: [
+        {
+          cells: [cell("▀"), cell("▄"), cell("█")],
+          text: "▀▄█",
+          isWrapContinuation: false,
+          wrapsToNext: false,
+        },
+      ],
+    };
+
+    renderGhosttySnapshot({
+      context,
+      snapshot,
+      metrics: { width: 10, height: 20, baseline: 15 },
+      fontSize: 12,
+      fontFamily: "monospace",
+      padding: 4,
+      forceFull: false,
+      cursorOn: false,
+    });
+
+    expect(fillRectCalls).toContainEqual({ args: [4, 4, 10, 10], style: "rgb(255, 255, 255)" });
+    expect(fillRectCalls).toContainEqual({
+      args: [14, 14, 10, 10],
+      style: "rgb(255, 255, 255)",
+    });
+    expect(fillRectCalls).toContainEqual({
+      args: [24, 4, 10, 20],
+      style: "rgb(255, 255, 255)",
+    });
   });
 
   it("constrains text runs and cursor glyphs to their terminal cells", () => {

--- a/apps/web/src/terminal/ghostty/renderer.test.ts
+++ b/apps/web/src/terminal/ghostty/renderer.test.ts
@@ -95,27 +95,32 @@ describe("renderGhosttySnapshot", () => {
       set textBaseline(_value: string) {},
     } as unknown as CanvasRenderingContext2D;
     const defaultCell = cell("a");
+    const inverseCell = {
+      ...cell("i"),
+      foreground: defaultCell.background,
+      background: defaultCell.foreground,
+    };
     const applicationCell = {
       ...cell("b"),
       foreground: { r: 10, g: 20, b: 30 },
       background: { r: 40, g: 50, b: 60 },
     };
     const snapshot: GhosttySnapshot = {
-      cols: 2,
+      cols: 3,
       rows: 1,
       foreground: defaultCell.foreground,
       background: defaultCell.background,
-      cursor: defaultCell.foreground,
-      cursorX: -1,
-      cursorY: -1,
-      cursorVisible: false,
+      cursor: { r: 9, g: 8, b: 7 },
+      cursorX: 0,
+      cursorY: 0,
+      cursorVisible: true,
       cursorBlinking: false,
-      cursorStyle: 1,
+      cursorStyle: 0,
       dirtyRows: new Set([0]),
       rowData: [
         {
-          cells: [defaultCell, applicationCell],
-          text: "ab",
+          cells: [defaultCell, inverseCell, applicationCell],
+          text: "aib",
           isWrapContinuation: false,
           wrapsToNext: false,
         },
@@ -130,11 +135,18 @@ describe("renderGhosttySnapshot", () => {
       fontFamily: "monospace",
       padding: 4,
       forceFull: true,
-      cursorOn: false,
+      cursorOn: true,
       defaultThemeOverride: {
-        background: { r: 1, g: 2, b: 3 },
-        foreground: { r: 250, g: 251, b: 252 },
-        cursor: { r: 200, g: 201, b: 202 },
+        source: {
+          background: defaultCell.background,
+          foreground: defaultCell.foreground,
+          cursor: defaultCell.foreground,
+        },
+        target: {
+          background: { r: 1, g: 2, b: 3 },
+          foreground: { r: 250, g: 251, b: 252 },
+          cursor: { r: 200, g: 201, b: 202 },
+        },
       },
     });
 
@@ -144,11 +156,20 @@ describe("renderGhosttySnapshot", () => {
     });
     expect(fillRectCalls).toContainEqual({
       args: [14, 4, 10, 20],
+      style: "rgb(250, 251, 252)",
+    });
+    expect(fillRectCalls).toContainEqual({
+      args: [24, 4, 10, 20],
       style: "rgb(40, 50, 60)",
+    });
+    expect(fillRectCalls).toContainEqual({
+      args: [4, 4, 2, 20],
+      style: "rgb(9, 8, 7)",
     });
     expect(fillTextCalls).toEqual([
       { args: ["a", 4, 19, 10], style: "rgb(250, 251, 252)" },
-      { args: ["b", 14, 19, 10], style: "rgb(10, 20, 30)" },
+      { args: ["i", 14, 19, 10], style: "rgb(1, 2, 3)" },
+      { args: ["b", 24, 19, 10], style: "rgb(10, 20, 30)" },
     ]);
   });
 

--- a/apps/web/src/terminal/ghostty/renderer.test.ts
+++ b/apps/web/src/terminal/ghostty/renderer.test.ts
@@ -71,6 +71,87 @@ describe("ghosttyTextRunEnd", () => {
 });
 
 describe("renderGhosttySnapshot", () => {
+  it("remaps terminal defaults without overriding explicit application colors", () => {
+    const fillRectCalls: Array<{ args: number[]; style: string }> = [];
+    const fillTextCalls: Array<{ args: unknown[]; style: string }> = [];
+    let fillStyle = "";
+    const context = {
+      canvas: { width: 200, height: 40 },
+      beginPath: () => {},
+      clip: () => {},
+      fillRect: (...args: number[]) => fillRectCalls.push({ args, style: fillStyle }),
+      fillText: (...args: unknown[]) => fillTextCalls.push({ args, style: fillStyle }),
+      rect: () => {},
+      resetTransform: () => {},
+      restore: () => {},
+      save: () => {},
+      get fillStyle() {
+        return fillStyle;
+      },
+      set fillStyle(value: string | CanvasGradient | CanvasPattern) {
+        fillStyle = String(value);
+      },
+      set font(_value: string) {},
+      set textBaseline(_value: string) {},
+    } as unknown as CanvasRenderingContext2D;
+    const defaultCell = cell("a");
+    const applicationCell = {
+      ...cell("b"),
+      foreground: { r: 10, g: 20, b: 30 },
+      background: { r: 40, g: 50, b: 60 },
+    };
+    const snapshot: GhosttySnapshot = {
+      cols: 2,
+      rows: 1,
+      foreground: defaultCell.foreground,
+      background: defaultCell.background,
+      cursor: defaultCell.foreground,
+      cursorX: -1,
+      cursorY: -1,
+      cursorVisible: false,
+      cursorBlinking: false,
+      cursorStyle: 1,
+      dirtyRows: new Set([0]),
+      rowData: [
+        {
+          cells: [defaultCell, applicationCell],
+          text: "ab",
+          isWrapContinuation: false,
+          wrapsToNext: false,
+        },
+      ],
+    };
+
+    renderGhosttySnapshot({
+      context,
+      snapshot,
+      metrics: { width: 10, height: 20, baseline: 15 },
+      fontSize: 12,
+      fontFamily: "monospace",
+      padding: 4,
+      forceFull: true,
+      cursorOn: false,
+      defaultThemeOverride: {
+        background: { r: 1, g: 2, b: 3 },
+        foreground: { r: 250, g: 251, b: 252 },
+        cursor: { r: 200, g: 201, b: 202 },
+      },
+    });
+
+    expect(fillRectCalls).toContainEqual({
+      args: [0, 0, 200, 40],
+      style: "rgb(1, 2, 3)",
+    });
+    expect(fillRectCalls).toContainEqual({
+      args: [14, 4, 10, 20],
+      style: "rgb(40, 50, 60)",
+    });
+    expect(fillTextCalls).toEqual([
+      { args: ["a", 4, 19, 10], style: "rgb(250, 251, 252)" },
+      { args: ["b", 14, 19, 10], style: "rgb(10, 20, 30)" },
+    ]);
+  });
+
   it("underlines every cell in a hovered wrapped link", () => {
     const fillRectCalls: number[][] = [];
     const context = {

--- a/apps/web/src/terminal/ghostty/renderer.ts
+++ b/apps/web/src/terminal/ghostty/renderer.ts
@@ -152,10 +152,10 @@ export function measureGhosttyCell(
   const glyphHeight = ascent + descent;
   const height = Math.max(1, Math.round(fontSize * 1.35), Math.ceil(glyphHeight));
   return {
-    // libghostty's cell and mouse APIs use integer logical pixels. Rendering
-    // the fractional browser measurement would make hit testing drift farther
-    // from the visible cell on every column.
-    width: Math.max(1, Math.round(widthMeasurement.width)),
+    // libghostty's cell and mouse APIs use integer logical pixels. Flooring
+    // also makes CanvasRenderingContext2D condense text into the same grid,
+    // keeping glyphs, backgrounds, and mouse hit targets aligned.
+    width: Math.max(1, Math.floor(widthMeasurement.width)),
     height,
     baseline: Math.round((height - glyphHeight) / 2 + ascent),
   };

--- a/apps/web/src/terminal/ghostty/renderer.ts
+++ b/apps/web/src/terminal/ghostty/renderer.ts
@@ -3,6 +3,7 @@ import {
   ghosttyColorsEqual,
   type GhosttyCell,
   type GhosttyColor,
+  type GhosttyScreenTheme,
   type GhosttySnapshot,
 } from "./core";
 
@@ -103,6 +104,8 @@ export function renderGhosttySnapshot(options: {
   readonly previousCursorY?: number | null;
   readonly focused?: boolean;
   readonly selectionBackground?: string;
+  /** Remap only terminal-default colors; explicit ANSI application colors win. */
+  readonly defaultThemeOverride?: GhosttyScreenTheme;
   readonly hoveredLinkRange?: GhosttyCellRange | null;
   /** Vertical origin of row 0; defaults to the horizontal padding. */
   readonly originY?: number;
@@ -120,6 +123,13 @@ export function renderGhosttySnapshot(options: {
   } = options;
   const focused = options.focused ?? true;
   const selectionBackground = options.selectionBackground ?? DEFAULT_SELECTION_BACKGROUND;
+  const defaultTheme = options.defaultThemeOverride;
+  const defaultBackground = defaultTheme?.background ?? snapshot.background;
+  const defaultForeground = defaultTheme?.foreground ?? snapshot.foreground;
+  const resolveBackground = (color: GhosttyColor) =>
+    defaultTheme && ghosttyColorsEqual(color, snapshot.background) ? defaultBackground : color;
+  const resolveForeground = (color: GhosttyColor) =>
+    defaultTheme && ghosttyColorsEqual(color, snapshot.foreground) ? defaultForeground : color;
   const hoveredLinkRange = options.hoveredLinkRange ?? null;
   const originY = options.originY ?? padding;
   const rowsToDraw = forceFull
@@ -140,7 +150,7 @@ export function renderGhosttySnapshot(options: {
   if (forceFull) {
     context.save();
     context.resetTransform();
-    context.fillStyle = cssColor(snapshot.background);
+    context.fillStyle = cssColor(defaultBackground);
     context.fillRect(0, 0, context.canvas.width, context.canvas.height);
     context.restore();
   }
@@ -151,30 +161,31 @@ export function renderGhosttySnapshot(options: {
     if (!row) continue;
     const top = originY + rowIndex * metrics.height;
 
-    context.fillStyle = cssColor(snapshot.background);
+    context.fillStyle = cssColor(defaultBackground);
     context.fillRect(padding, top, snapshot.cols * metrics.width, metrics.height);
 
     let backgroundStart = 0;
     while (backgroundStart < row.cells.length) {
       const first = row.cells[backgroundStart];
       if (!first) break;
+      const firstBackground = resolveBackground(first.background);
       let backgroundEnd = backgroundStart + 1;
       while (backgroundEnd < row.cells.length) {
         const next = row.cells[backgroundEnd];
         if (
           !next ||
           next.selected !== first.selected ||
-          !ghosttyColorsEqual(next.background, first.background)
+          !ghosttyColorsEqual(resolveBackground(next.background), firstBackground)
         ) {
           break;
         }
         backgroundEnd += 1;
       }
-      if (first.selected || !ghosttyColorsEqual(first.background, snapshot.background)) {
+      if (first.selected || !ghosttyColorsEqual(firstBackground, defaultBackground)) {
         const left = padding + backgroundStart * metrics.width;
         const width = (backgroundEnd - backgroundStart) * metrics.width;
-        if (!ghosttyColorsEqual(first.background, snapshot.background)) {
-          context.fillStyle = cssColor(first.background);
+        if (!ghosttyColorsEqual(firstBackground, defaultBackground)) {
+          context.fillStyle = cssColor(firstBackground);
           context.fillRect(left, top, width, metrics.height);
         }
         if (first.selected) {
@@ -209,7 +220,7 @@ export function renderGhosttySnapshot(options: {
         );
         context.clip();
         context.font = fontForCell(first, fontSize, fontFamily);
-        context.fillStyle = cssColor(first.foreground);
+        context.fillStyle = cssColor(resolveForeground(first.foreground));
         context.fillText(
           text,
           padding + runStart * metrics.width,
@@ -232,7 +243,7 @@ export function renderGhosttySnapshot(options: {
       if (!cell || (!cell.underline && !cell.strikethrough && !cell.overline && !hoveredLink)) {
         continue;
       }
-      context.fillStyle = cssColor(cell.foreground);
+      context.fillStyle = cssColor(resolveForeground(cell.foreground));
       const left = padding + column * metrics.width;
       if (cell.underline || hoveredLink) {
         context.fillRect(left, top + metrics.height - 2, metrics.width, 1);
@@ -247,24 +258,25 @@ export function renderGhosttySnapshot(options: {
   if (cursorOn && snapshot.cursorVisible && snapshot.cursorX >= 0 && snapshot.cursorY >= 0) {
     const left = padding + snapshot.cursorX * metrics.width;
     const top = originY + snapshot.cursorY * metrics.height;
-    context.fillStyle = cssColor(snapshot.cursor);
+    const cursor = defaultTheme?.cursor ?? snapshot.cursor;
+    context.fillStyle = cssColor(cursor);
     if (!focused) {
       // An unfocused terminal draws a hollow cursor so the active pane is obvious.
-      context.strokeStyle = cssColor(snapshot.cursor);
+      context.strokeStyle = cssColor(cursor);
       context.strokeRect(left + 0.5, top + 0.5, metrics.width - 1, metrics.height - 1);
     } else if (snapshot.cursorStyle === 0) {
       context.fillRect(left, top, 2, metrics.height);
     } else if (snapshot.cursorStyle === 2) {
       context.fillRect(left, top + metrics.height - 2, metrics.width, 2);
     } else if (snapshot.cursorStyle === 3) {
-      context.strokeStyle = cssColor(snapshot.cursor);
+      context.strokeStyle = cssColor(cursor);
       context.strokeRect(left + 0.5, top + 0.5, metrics.width - 1, metrics.height - 1);
     } else {
       context.fillRect(left, top, metrics.width, metrics.height);
       const cell = snapshot.rowData[snapshot.cursorY]?.cells[snapshot.cursorX];
       if (cell?.text) {
         context.font = fontForCell(cell, fontSize, fontFamily);
-        context.fillStyle = cssColor(snapshot.background);
+        context.fillStyle = cssColor(defaultBackground);
         context.fillText(cell.text, left, top + metrics.baseline, metrics.width);
       }
     }

--- a/apps/web/src/terminal/ghostty/renderer.ts
+++ b/apps/web/src/terminal/ghostty/renderer.ts
@@ -18,6 +18,8 @@ export interface GhosttyCellRange {
   readonly end: { readonly x: number; readonly y: number };
 }
 
+type TerminalBlockRect = readonly [x: number, y: number, width: number, height: number];
+
 const DEFAULT_SELECTION_BACKGROUND = "rgba(72, 122, 191, 0.35)";
 
 function cssColor(color: GhosttyColor): string {
@@ -61,6 +63,82 @@ function fontForCell(cell: GhosttyCell, fontSize: number, fontFamily: string): s
   return `${style} ${weight} ${fontSize}px ${fontFamily}`;
 }
 
+/** Solid Unicode block elements render as cell geometry, without font side-bearing seams. */
+function terminalBlockRects(text: string): readonly TerminalBlockRect[] | null {
+  const lower = (eighths: number): readonly TerminalBlockRect[] => [
+    [0, 1 - eighths / 8, 1, eighths / 8],
+  ];
+  const left = (eighths: number): readonly TerminalBlockRect[] => [[0, 0, eighths / 8, 1]];
+  switch (text) {
+    case "▀":
+      return [[0, 0, 1, 0.5]];
+    case "▁":
+    case "▂":
+    case "▃":
+    case "▄":
+    case "▅":
+    case "▆":
+    case "▇":
+      return lower(text.codePointAt(0)! - 0x2580);
+    case "█":
+      return [[0, 0, 1, 1]];
+    case "▉":
+    case "▊":
+    case "▋":
+    case "▌":
+    case "▍":
+    case "▎":
+    case "▏":
+      return left(0x2590 - text.codePointAt(0)!);
+    case "▐":
+      return [[0.5, 0, 0.5, 1]];
+    case "▔":
+      return [[0, 0, 1, 0.125]];
+    case "▕":
+      return [[0.875, 0, 0.125, 1]];
+    case "▖":
+      return [[0, 0.5, 0.5, 0.5]];
+    case "▗":
+      return [[0.5, 0.5, 0.5, 0.5]];
+    case "▘":
+      return [[0, 0, 0.5, 0.5]];
+    case "▙":
+      return [
+        [0, 0, 0.5, 1],
+        [0.5, 0.5, 0.5, 0.5],
+      ];
+    case "▚":
+      return [
+        [0, 0, 0.5, 0.5],
+        [0.5, 0.5, 0.5, 0.5],
+      ];
+    case "▛":
+      return [
+        [0, 0, 1, 0.5],
+        [0, 0.5, 0.5, 0.5],
+      ];
+    case "▜":
+      return [
+        [0, 0, 1, 0.5],
+        [0.5, 0.5, 0.5, 0.5],
+      ];
+    case "▝":
+      return [[0.5, 0, 0.5, 0.5]];
+    case "▞":
+      return [
+        [0.5, 0, 0.5, 0.5],
+        [0, 0.5, 0.5, 0.5],
+      ];
+    case "▟":
+      return [
+        [0.5, 0, 0.5, 1],
+        [0, 0.5, 0.5, 0.5],
+      ];
+    default:
+      return null;
+  }
+}
+
 export function measureGhosttyCell(
   context: CanvasRenderingContext2D,
   fontSize: number,
@@ -74,7 +152,10 @@ export function measureGhosttyCell(
   const glyphHeight = ascent + descent;
   const height = Math.max(1, Math.round(fontSize * 1.35), Math.ceil(glyphHeight));
   return {
-    width: Math.max(1, widthMeasurement.width),
+    // libghostty's cell and mouse APIs use integer logical pixels. Rendering
+    // the fractional browser measurement would make hit testing drift farther
+    // from the visible cell on every column.
+    width: Math.max(1, Math.round(widthMeasurement.width)),
     height,
     baseline: Math.round((height - glyphHeight) / 2 + ascent),
   };
@@ -231,7 +312,27 @@ export function renderGhosttySnapshot(options: {
         runStart += 1;
         continue;
       }
-      const runEnd = ghosttyTextRunEnd(row.cells, runStart, (cell) => sameTextStyle(cell, first));
+      const blockRects = terminalBlockRects(first.text);
+      if (blockRects !== null) {
+        if (!first.invisible) {
+          context.fillStyle = cssColor(resolveForeground(first.foreground));
+          const cellLeft = padding + runStart * metrics.width;
+          for (const [x, y, width, height] of blockRects) {
+            const left = cellLeft + Math.round(x * metrics.width);
+            const right = cellLeft + Math.round((x + width) * metrics.width);
+            const rectTop = top + Math.round(y * metrics.height);
+            const bottom = top + Math.round((y + height) * metrics.height);
+            context.fillRect(left, rectTop, right - left, bottom - rectTop);
+          }
+        }
+        runStart += 1;
+        continue;
+      }
+      const runEnd = ghosttyTextRunEnd(
+        row.cells,
+        runStart,
+        (cell) => terminalBlockRects(cell.text) === null && sameTextStyle(cell, first),
+      );
       const text = row.cells
         .slice(runStart, runEnd)
         .map((cell) => cell.text)

--- a/apps/web/src/terminal/ghostty/renderer.ts
+++ b/apps/web/src/terminal/ghostty/renderer.ts
@@ -105,7 +105,10 @@ export function renderGhosttySnapshot(options: {
   readonly focused?: boolean;
   readonly selectionBackground?: string;
   /** Remap only terminal-default colors; explicit ANSI application colors win. */
-  readonly defaultThemeOverride?: GhosttyScreenTheme;
+  readonly defaultThemeOverride?: {
+    readonly source: GhosttyScreenTheme;
+    readonly target: GhosttyScreenTheme;
+  };
   readonly hoveredLinkRange?: GhosttyCellRange | null;
   /** Vertical origin of row 0; defaults to the horizontal padding. */
   readonly originY?: number;
@@ -123,13 +126,37 @@ export function renderGhosttySnapshot(options: {
   } = options;
   const focused = options.focused ?? true;
   const selectionBackground = options.selectionBackground ?? DEFAULT_SELECTION_BACKGROUND;
-  const defaultTheme = options.defaultThemeOverride;
-  const defaultBackground = defaultTheme?.background ?? snapshot.background;
-  const defaultForeground = defaultTheme?.foreground ?? snapshot.foreground;
+  const themeOverride = options.defaultThemeOverride;
+  const defaultBackground = themeOverride?.target.background ?? snapshot.background;
+  const defaultForeground = themeOverride?.target.foreground ?? snapshot.foreground;
+  const resolveDefaultColor = (
+    color: GhosttyColor,
+    sourceDefault: GhosttyColor,
+    sourceInverse: GhosttyColor,
+    targetDefault: GhosttyColor,
+    targetInverse: GhosttyColor,
+  ) => {
+    if (!themeOverride) return color;
+    if (ghosttyColorsEqual(color, sourceDefault)) return targetDefault;
+    if (ghosttyColorsEqual(color, sourceInverse)) return targetInverse;
+    return color;
+  };
   const resolveBackground = (color: GhosttyColor) =>
-    defaultTheme && ghosttyColorsEqual(color, snapshot.background) ? defaultBackground : color;
+    resolveDefaultColor(
+      color,
+      themeOverride?.source.background ?? snapshot.background,
+      themeOverride?.source.foreground ?? snapshot.foreground,
+      defaultBackground,
+      defaultForeground,
+    );
   const resolveForeground = (color: GhosttyColor) =>
-    defaultTheme && ghosttyColorsEqual(color, snapshot.foreground) ? defaultForeground : color;
+    resolveDefaultColor(
+      color,
+      themeOverride?.source.foreground ?? snapshot.foreground,
+      themeOverride?.source.background ?? snapshot.background,
+      defaultForeground,
+      defaultBackground,
+    );
   const hoveredLinkRange = options.hoveredLinkRange ?? null;
   const originY = options.originY ?? padding;
   const rowsToDraw = forceFull
@@ -258,7 +285,10 @@ export function renderGhosttySnapshot(options: {
   if (cursorOn && snapshot.cursorVisible && snapshot.cursorX >= 0 && snapshot.cursorY >= 0) {
     const left = padding + snapshot.cursorX * metrics.width;
     const top = originY + snapshot.cursorY * metrics.height;
-    const cursor = defaultTheme?.cursor ?? snapshot.cursor;
+    const cursor =
+      themeOverride && ghosttyColorsEqual(snapshot.cursor, themeOverride.source.cursor)
+        ? themeOverride.target.cursor
+        : snapshot.cursor;
     context.fillStyle = cssColor(cursor);
     if (!focused) {
       // An unfocused terminal draws a hollow cursor so the active pane is obvious.

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -408,7 +408,7 @@ describe("vendored libghostty-vt WebAssembly", () => {
     free(options, 8);
   });
 
-  it("uses Ghostty for mouse encoding, word selection, and OSC 8 hit testing", async () => {
+  it("uses Ghostty for terminal modes, mouse encoding, selection, and link hit testing", async () => {
     const result = await WebAssembly.instantiate(
       decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,
       { env: { log: () => {} } },
@@ -454,6 +454,36 @@ describe("vendored libghostty-vt WebAssembly", () => {
     call("ghostty_terminal_vt_write", terminal, anyEventResetPointer, anyEventReset.length);
     expect(call("ghostty_terminal_mode_get", terminal, 1003, modeFlag)).toBe(0);
     expect(new Uint8Array(memory.buffer, modeFlag, 1)[0]).toBe(0);
+    const synchronizedOutput = new TextEncoder().encode("\u001b[?2026h");
+    const synchronizedOutputPointer = alloc(synchronizedOutput.length);
+    new Uint8Array(memory.buffer, synchronizedOutputPointer, synchronizedOutput.length).set(
+      synchronizedOutput,
+    );
+    call(
+      "ghostty_terminal_vt_write",
+      terminal,
+      synchronizedOutputPointer,
+      synchronizedOutput.length,
+    );
+    expect(call("ghostty_terminal_mode_get", terminal, 2026, modeFlag)).toBe(0);
+    expect(new Uint8Array(memory.buffer, modeFlag, 1)[0]).toBe(1);
+    const synchronizedOutputReset = new TextEncoder().encode("\u001b[?2026l");
+    const synchronizedOutputResetPointer = alloc(synchronizedOutputReset.length);
+    new Uint8Array(
+      memory.buffer,
+      synchronizedOutputResetPointer,
+      synchronizedOutputReset.length,
+    ).set(synchronizedOutputReset);
+    call(
+      "ghostty_terminal_vt_write",
+      terminal,
+      synchronizedOutputResetPointer,
+      synchronizedOutputReset.length,
+    );
+    expect(call("ghostty_terminal_mode_get", terminal, 2026, modeFlag)).toBe(0);
+    expect(new Uint8Array(memory.buffer, modeFlag, 1)[0]).toBe(0);
+    free(synchronizedOutputResetPointer, synchronizedOutputReset.length);
+    free(synchronizedOutputPointer, synchronizedOutput.length);
     free(anyEventResetPointer, anyEventReset.length);
     free(anyEventPointer, anyEventInput.length);
     free(modeFlag, 1);

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -631,7 +631,7 @@ describe("vendored libghostty-vt WebAssembly", () => {
     free(terminalOptions, 8);
   });
 
-  it("encodes modified printable keys in Kitty keyboard mode", async () => {
+  it("encodes legacy controls and modified printable keys in Kitty keyboard mode", async () => {
     const result = await WebAssembly.instantiate(
       decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,
       { env: { log: () => {} } },
@@ -651,11 +651,6 @@ describe("vendored libghostty-vt WebAssembly", () => {
     const terminalSlot = call("ghostty_wasm_alloc_opaque");
     expect(call("ghostty_terminal_new", 0, terminalSlot, terminalOptions)).toBe(0);
     const terminal = new DataView(memory.buffer).getUint32(terminalSlot, true);
-    const kittyMode = new TextEncoder().encode("\u001b[>1u");
-    const kittyModePointer = alloc(kittyMode.length);
-    new Uint8Array(memory.buffer, kittyModePointer, kittyMode.length).set(kittyMode);
-    call("ghostty_terminal_vt_write", terminal, kittyModePointer, kittyMode.length);
-
     const encoderSlot = call("ghostty_wasm_alloc_opaque");
     const eventSlot = call("ghostty_wasm_alloc_opaque");
     expect(call("ghostty_key_encoder_new", 0, encoderSlot)).toBe(0);
@@ -676,6 +671,31 @@ describe("vendored libghostty-vt WebAssembly", () => {
     call("ghostty_key_event_set_utf8", keyEvent, textPointer, text.length);
 
     const written = call("ghostty_wasm_alloc_usize");
+    expect(call("ghostty_key_encoder_encode", keyEncoder, keyEvent, 0, 0, written)).toBe(-3);
+    const legacyOutputSize = new DataView(memory.buffer, written, 4).getUint32(0, true);
+    const legacyOutput = alloc(legacyOutputSize);
+    expect(
+      call(
+        "ghostty_key_encoder_encode",
+        keyEncoder,
+        keyEvent,
+        legacyOutput,
+        legacyOutputSize,
+        written,
+      ),
+    ).toBe(0);
+    const legacyOutputLength = new DataView(memory.buffer, written, 4).getUint32(0, true);
+    expect(
+      new TextDecoder().decode(new Uint8Array(memory.buffer, legacyOutput, legacyOutputLength)),
+    ).toBe("\u0003");
+    free(legacyOutput, legacyOutputSize);
+
+    const kittyMode = new TextEncoder().encode("\u001b[>1u");
+    const kittyModePointer = alloc(kittyMode.length);
+    new Uint8Array(memory.buffer, kittyModePointer, kittyMode.length).set(kittyMode);
+    call("ghostty_terminal_vt_write", terminal, kittyModePointer, kittyMode.length);
+    call("ghostty_key_encoder_setopt_from_terminal", keyEncoder, terminal);
+
     expect(call("ghostty_key_encoder_encode", keyEncoder, keyEvent, 0, 0, written)).toBe(-3);
     const outputSize = new DataView(memory.buffer, written, 4).getUint32(0, true);
     const output = alloc(outputSize);

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -196,6 +196,11 @@ describe("vendored libghostty-vt WebAssembly", () => {
     expect(call("ghostty_terminal_get", terminal, 9, scrollbar)).toBe(0);
     expect(Number(scrollbarView.getBigUint64(8, true))).toBe(36);
 
+    scrollView.setUint32(0, 0, true);
+    call("ghostty_terminal_scroll_viewport", terminal, scroll);
+    expect(call("ghostty_terminal_get", terminal, 9, scrollbar)).toBe(0);
+    expect(Number(scrollbarView.getBigUint64(8, true))).toBe(0);
+
     call("ghostty_wasm_free_u8_array", scroll, 24);
     call("ghostty_wasm_free_u8_array", scrollbar, 24);
     call("ghostty_wasm_free_u8_array", inputPointer, input.length);

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -18,6 +18,7 @@ import {
   primeTerminalCopyInput,
   resolveTerminalMouseData,
   resolveTerminalMouseTrackingState,
+  resolveTerminalAsyncPasteClaim,
   shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
   terminalGridCellAt,
@@ -382,6 +383,23 @@ describe("isTerminalPasteShortcut", () => {
     expect(isTerminalPasteShortcut(event({ key: "Insert", shiftKey: true }), "MacIntel")).toBe(
       false,
     );
+  });
+});
+
+describe("resolveTerminalAsyncPasteClaim", () => {
+  it("leaves a duplicate marker while the native shortcut event can still arrive", () => {
+    expect(resolveTerminalAsyncPasteClaim(4, 4, true)).toEqual({
+      nextToken: 4,
+      deliveredToken: 4,
+    });
+  });
+
+  it("invalidates a late async marker after keyup ends the shortcut", () => {
+    expect(resolveTerminalAsyncPasteClaim(4, 4, false)).toEqual({
+      nextToken: 5,
+      deliveredToken: null,
+    });
+    expect(resolveTerminalAsyncPasteClaim(4, 5, false)).toBeNull();
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import type { GhosttyCell, GhosttyRow } from "./core";
+import type { GhosttyCell, GhosttyRow, GhosttyTheme } from "./core";
 import {
   DEFAULT_TERMINAL_FONT_FAMILY,
   DEFAULT_TERMINAL_FONT_SIZE,
@@ -23,6 +23,7 @@ import {
   terminalGridCellAt,
   terminalScrollbarGeometry,
   terminalScrollbarOffsetAtPointer,
+  terminalThemeForScreen,
   terminalLinkAtColumn,
   terminalLinkAtPosition,
   terminalLinkAtPositionWithRange,
@@ -32,6 +33,38 @@ import {
   terminalWheelArrowData,
   terminalWheelDeltaRows,
 } from "./surface";
+
+const lightTerminalTheme = {
+  background: { r: 255, g: 255, b: 255 },
+  foreground: { r: 20, g: 20, b: 20 },
+  cursor: { r: 38, g: 56, b: 78 },
+  selectionBackground: "rgb(37 63 99 / 20%)",
+} satisfies GhosttyTheme;
+
+describe("terminalThemeForScreen", () => {
+  it("keeps the app theme on the normal shell screen", () => {
+    expect(terminalThemeForScreen(lightTerminalTheme, false)).toBe(lightTerminalTheme);
+  });
+
+  it("uses coherent dark defaults for a full-screen app under a light host theme", () => {
+    expect(terminalThemeForScreen(lightTerminalTheme, true)).toEqual({
+      background: { r: 0, g: 0, b: 0 },
+      foreground: { r: 245, g: 245, b: 245 },
+      cursor: { r: 180, g: 203, b: 255 },
+      selectionBackground: "rgb(180 203 255 / 25%)",
+    });
+  });
+
+  it("leaves an existing dark app theme untouched in the alternate screen", () => {
+    const darkTheme = {
+      background: { r: 0, g: 0, b: 0 },
+      foreground: { r: 245, g: 245, b: 245 },
+      cursor: { r: 180, g: 203, b: 255 },
+    } satisfies GhosttyTheme;
+
+    expect(terminalThemeForScreen(darkTheme, true)).toBe(darkTheme);
+  });
+});
 
 const cell = (text: string): GhosttyCell => ({
   text,

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -39,6 +39,12 @@ const lightTerminalTheme = {
   foreground: { r: 20, g: 20, b: 20 },
   cursor: { r: 38, g: 56, b: 78 },
   selectionBackground: "rgb(37 63 99 / 20%)",
+  alternateScreen: {
+    background: { r: 12, g: 12, b: 12 },
+    foreground: { r: 244, g: 244, b: 244 },
+    cursor: { r: 199, g: 218, b: 255 },
+    selectionBackground: "rgb(37 63 99 / 16%)",
+  },
 } satisfies GhosttyTheme;
 
 describe("terminalThemeForScreen", () => {
@@ -47,12 +53,9 @@ describe("terminalThemeForScreen", () => {
   });
 
   it("uses coherent dark defaults for a full-screen app under a light host theme", () => {
-    expect(terminalThemeForScreen(lightTerminalTheme, true)).toEqual({
-      background: { r: 0, g: 0, b: 0 },
-      foreground: { r: 245, g: 245, b: 245 },
-      cursor: { r: 180, g: 203, b: 255 },
-      selectionBackground: "rgb(180 203 255 / 25%)",
-    });
+    expect(terminalThemeForScreen(lightTerminalTheme, true)).toBe(
+      lightTerminalTheme.alternateScreen,
+    );
   });
 
   it("leaves an existing dark app theme untouched in the alternate screen", () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -3,6 +3,7 @@ import { collectWrappedTerminalLinkLine, extractTerminalLinks } from "../../term
 import {
   GhosttyTerminalCore,
   type GhosttyScrollbar,
+  type GhosttyScreenTheme,
   type GhosttySnapshot,
   type GhosttyTheme,
 } from "./core";
@@ -49,12 +50,6 @@ const TERMINAL_IMMEDIATE_WRITE_CODE_UNITS = 16 * 1024;
 // outruns the display for long enough, finish the bounded backlog in one pass
 // instead of letting it grow without limit behind one 64 KB animation frame.
 const TERMINAL_WRITE_QUEUE_MAX_CODE_UNITS = 1024 * 1024;
-const ALTERNATE_SCREEN_DARK_THEME = {
-  background: { r: 0, g: 0, b: 0 },
-  foreground: { r: 245, g: 245, b: 245 },
-  cursor: { r: 180, g: 203, b: 255 },
-  selectionBackground: "rgb(180 203 255 / 25%)",
-} satisfies GhosttyTheme;
 const TERMINAL_FONT_LOAD_TEXT = "iMW0@# .";
 const TERMINAL_FONT_LOAD_VARIANTS = [
   "normal 400",
@@ -91,9 +86,9 @@ function terminalColorLuminance(color: GhosttyTheme["background"]): number {
 export function terminalThemeForScreen(
   theme: GhosttyTheme,
   alternateScreen: boolean,
-): GhosttyTheme {
+): GhosttyScreenTheme {
   if (!alternateScreen || terminalColorLuminance(theme.background) < 0.5) return theme;
-  return ALTERNATE_SCREEN_DARK_THEME;
+  return theme.alternateScreen ?? theme;
 }
 
 let symbolsFontLoad: Promise<void> | null = null;
@@ -661,7 +656,7 @@ export class GhosttyTerminalSurface {
   private resizeNotified = false;
   private canvasConfigured = false;
   private appTheme: GhosttyTheme;
-  private theme: GhosttyTheme;
+  private theme: GhosttyScreenTheme;
   private alternateScreenActive = false;
   private readonly suppressedKeyCodes = new Set<string>();
   private pasteShortcutToken = 0;
@@ -1006,6 +1001,7 @@ export class GhosttyTerminalSurface {
   setTheme(theme: GhosttyTheme): void {
     if (this.disposed) return;
     this.appTheme = theme;
+    this.core.setTheme(theme);
     this.synchronizeScreenTheme(true);
     this.requestRender();
   }
@@ -1015,7 +1011,7 @@ export class GhosttyTerminalSurface {
     if (!force && alternateScreen === this.alternateScreenActive) return;
     this.alternateScreenActive = alternateScreen;
     this.theme = terminalThemeForScreen(this.appTheme, alternateScreen);
-    this.core.setTheme(this.theme);
+    this.mount.style.backgroundColor = `rgb(${this.theme.background.r} ${this.theme.background.g} ${this.theme.background.b})`;
     this.forceFullRender = true;
   }
 
@@ -2046,6 +2042,7 @@ export class GhosttyTerminalSurface {
       previousCursorY: this.renderedCursorY,
       focused: this.focused,
       hoveredLinkRange: this.hoveredLink?.range ?? null,
+      ...(this.alternateScreenActive ? { defaultThemeOverride: this.theme } : {}),
       ...(this.theme.selectionBackground !== undefined
         ? { selectionBackground: this.theme.selectionBackground }
         : {}),

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -41,6 +41,12 @@ const CURSOR_BLINK_INTERVAL_MS = 500;
 const SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS = 500;
 const TERMINAL_WRITE_CHUNK_CODE_UNITS = 64 * 1024;
 const TERMINAL_IMMEDIATE_WRITE_CODE_UNITS = 16 * 1024;
+const ALTERNATE_SCREEN_DARK_THEME = {
+  background: { r: 0, g: 0, b: 0 },
+  foreground: { r: 245, g: 245, b: 245 },
+  cursor: { r: 180, g: 203, b: 255 },
+  selectionBackground: "rgb(180 203 255 / 25%)",
+} satisfies GhosttyTheme;
 const TERMINAL_FONT_LOAD_TEXT = "iMW0@# .";
 const TERMINAL_FONT_LOAD_VARIANTS = [
   "normal 400",
@@ -53,6 +59,33 @@ const TERMINAL_FONT_LOAD_VARIANTS = [
 export interface GhosttyTerminalFont {
   readonly family?: string;
   readonly size?: number;
+}
+
+function linearColorChannel(value: number): number {
+  const channel = value / 255;
+  return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function terminalColorLuminance(color: GhosttyTheme["background"]): number {
+  return (
+    0.2126 * linearColorChannel(color.r) +
+    0.7152 * linearColorChannel(color.g) +
+    0.0722 * linearColorChannel(color.b)
+  );
+}
+
+/**
+ * Full-screen terminal apps often reset cells to the terminal defaults while
+ * repainting a dark interface. Give a light host theme coherent dark defaults
+ * only while the standard alternate screen is active; explicit app colors
+ * still win, and returning to the shell restores the host theme.
+ */
+export function terminalThemeForScreen(
+  theme: GhosttyTheme,
+  alternateScreen: boolean,
+): GhosttyTheme {
+  if (!alternateScreen || terminalColorLuminance(theme.background) < 0.5) return theme;
+  return ALTERNATE_SCREEN_DARK_THEME;
 }
 
 let symbolsFontLoad: Promise<void> | null = null;
@@ -617,9 +650,12 @@ export class GhosttyTerminalSurface {
   private focused = false;
   private resizeNotified = false;
   private canvasConfigured = false;
+  private appTheme: GhosttyTheme;
   private theme: GhosttyTheme;
+  private alternateScreenActive = false;
   private readonly suppressedKeyCodes = new Set<string>();
   private pasteShortcutToken = 0;
+  private pasteShortcutDeliveredToken: number | null = null;
   private copyShortcutToken = 0;
   private clearSelectionAfterCopy = false;
   private primedCopySelection = "";
@@ -655,6 +691,7 @@ export class GhosttyTerminalSurface {
     this.mouseAnyEventTracking = core.isMouseAnyEventTracking();
     this.metrics = metrics;
     this.options = options;
+    this.appTheme = options.theme;
     this.theme = options.theme;
     this.fontFamily = fontFamily;
     this.requestedFontFamily = options.font?.family;
@@ -762,6 +799,7 @@ export class GhosttyTerminalSurface {
   }
 
   private didWriteOutput(): void {
+    this.synchronizeScreenTheme();
     this.synchronizeMouseTrackingState();
     // Restart the blink cycle from the visible phase so the cursor never sits
     // invisible through a stream of output or a burst of typing echo.
@@ -915,10 +953,18 @@ export class GhosttyTerminalSurface {
 
   setTheme(theme: GhosttyTheme): void {
     if (this.disposed) return;
-    this.theme = theme;
-    this.core.setTheme(theme);
-    this.forceFullRender = true;
+    this.appTheme = theme;
+    this.synchronizeScreenTheme(true);
     this.requestRender();
+  }
+
+  private synchronizeScreenTheme(force = false): void {
+    const alternateScreen = this.core.isAlternateScreen();
+    if (!force && alternateScreen === this.alternateScreenActive) return;
+    this.alternateScreenActive = alternateScreen;
+    this.theme = terminalThemeForScreen(this.appTheme, alternateScreen);
+    this.core.setTheme(this.theme);
+    this.forceFullRender = true;
   }
 
   async setFont(font: GhosttyTerminalFont): Promise<void> {
@@ -1238,17 +1284,18 @@ export class GhosttyTerminalSurface {
       this.suppressedKeyCodes.add(event.code);
       const clipboard = navigator.clipboard;
       if (typeof clipboard?.readText === "function") {
-        // Race the async clipboard read against the browser's own paste event:
-        // the native event (dispatched synchronously with the default action)
-        // always claims the token first when it fires, and the read covers
-        // browsers whose paste shortcut produces no paste event. Not preventing
-        // the default keeps the native path alive when the read is denied.
+        // Race the async clipboard read against the browser's own paste event.
+        // Either may arrive first, so the winning path records the gesture and
+        // the other path becomes a no-op. The read covers browsers whose paste
+        // shortcut produces no paste event; leaving the default intact keeps
+        // the native path alive when clipboard permission is denied.
         const token = ++this.pasteShortcutToken;
         void clipboard.readText().then(
           (text) => {
             if (this.disposed || this.pasteShortcutToken !== token) return;
-            this.pasteShortcutToken += 1;
-            if (text.length > 0) this.options.onData(this.core.encodePaste(text));
+            if (text.length === 0) return;
+            this.pasteShortcutDeliveredToken = token;
+            this.options.onData(this.core.encodePaste(text));
           },
           () => {
             // Clipboard read denied; the native paste event remains the path.
@@ -1274,7 +1321,15 @@ export class GhosttyTerminalSurface {
 
   private readonly onKeyUp = (event: KeyboardEvent) => {
     this.updateLinkModifier(event);
-    if (this.suppressedKeyCodes.delete(event.code)) return;
+    if (this.suppressedKeyCodes.delete(event.code)) {
+      // A native paste belongs to the same shortcut gesture and arrives before
+      // its keyup. Do not let an async-only shortcut suppress a later context-
+      // menu paste just because the browser never dispatched the native event.
+      if (event.code === "KeyV" || event.code === "Insert") {
+        this.pasteShortcutDeliveredToken = null;
+      }
+      return;
+    }
     if (isTerminalCompositionKey(event, this.composing)) {
       return;
     }
@@ -1355,8 +1410,14 @@ export class GhosttyTerminalSurface {
     event.preventDefault();
     const data = event.clipboardData?.getData("text/plain") ?? "";
     if (data.length === 0) return;
-    // The native paste won the race with actual text; a pending clipboard read
-    // must not double. An empty native paste leaves the read as the only path.
+    const token = this.pasteShortcutToken;
+    if (this.pasteShortcutDeliveredToken === token) {
+      this.pasteShortcutDeliveredToken = null;
+      this.pasteShortcutToken += 1;
+      return;
+    }
+    // The native paste won the race with actual text; invalidate a pending
+    // clipboard read. An empty native paste leaves the read as the only path.
     this.pasteShortcutToken += 1;
     this.options.onData(this.core.encodePaste(data));
   };

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -572,6 +572,7 @@ export class GhosttyTerminalSurface {
   private writeQueue: Array<{ data: string; offset: number; replay: boolean }> = [];
   private writeQueueIndex = 0;
   private replayActive = false;
+  private scrollToTopWhenWritesDrain = false;
   private cursorTimer: number | null = null;
   private compositionInputToSuppress: string | null = null;
   private compositionSuppressionTimer: number | null = null;
@@ -781,6 +782,15 @@ export class GhosttyTerminalSurface {
     this.requestRender();
   }
 
+  scrollToTopAfterWrites(): void {
+    if (this.disposed) return;
+    if (this.writeQueueIndex < this.writeQueue.length || this.replayActive) {
+      this.scrollToTopWhenWritesDrain = true;
+      return;
+    }
+    this.scrollToTop();
+  }
+
   private requestWriteDrain(): void {
     if (this.disposed || this.writeFrame !== 0) return;
     this.writeFrame = window.requestAnimationFrame(this.drainWrites);
@@ -816,6 +826,10 @@ export class GhosttyTerminalSurface {
       this.writeQueue = [];
       this.writeQueueIndex = 0;
       this.finishReplay();
+      if (this.scrollToTopWhenWritesDrain) {
+        this.scrollToTopWhenWritesDrain = false;
+        this.scrollToTop();
+      }
     } else {
       this.requestWriteDrain();
     }
@@ -835,6 +849,7 @@ export class GhosttyTerminalSurface {
     }
     this.writeQueue = [];
     this.writeQueueIndex = 0;
+    this.scrollToTopWhenWritesDrain = false;
     this.finishReplay();
   }
 
@@ -1042,6 +1057,13 @@ export class GhosttyTerminalSurface {
 
   scrollToBottom(): void {
     this.core.scrollToBottom();
+    this.forceFullRender = true;
+    this.scrollbarDirty = true;
+    this.requestRender();
+  }
+
+  scrollToTop(): void {
+    this.core.scrollToTop();
     this.forceFullRender = true;
     this.scrollbarDirty = true;
     this.requestRender();

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -430,6 +430,17 @@ export function isTerminalPasteShortcut(
   return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
 }
 
+export function resolveTerminalAsyncPasteClaim(
+  pendingToken: number,
+  currentToken: number,
+  shortcutActive: boolean,
+): { readonly nextToken: number; readonly deliveredToken: number | null } | null {
+  if (pendingToken !== currentToken) return null;
+  return shortcutActive
+    ? { nextToken: currentToken, deliveredToken: pendingToken }
+    : { nextToken: currentToken + 1, deliveredToken: null };
+}
+
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {
   return (
     event.inputType === "" ||
@@ -818,6 +829,7 @@ export class GhosttyTerminalSurface {
     this.lastMouseMotionData = "";
     this.core.beginReplay();
     this.replayActive = true;
+    this.synchronizeScreenTheme();
     if (data.length > 0) {
       this.enqueueWrite(data, true);
     } else {
@@ -840,6 +852,7 @@ export class GhosttyTerminalSurface {
     this.core.beginReplay();
     this.replayActive = true;
     this.replayStreamOpen = true;
+    this.synchronizeScreenTheme();
     if (data.length > 0) {
       this.enqueueWrite(data, true);
     }
@@ -1343,7 +1356,14 @@ export class GhosttyTerminalSurface {
           (text) => {
             if (this.disposed || this.pasteShortcutToken !== token) return;
             if (text.length === 0) return;
-            this.pasteShortcutDeliveredToken = token;
+            const claim = resolveTerminalAsyncPasteClaim(
+              token,
+              this.pasteShortcutToken,
+              this.suppressedKeyCodes.has(event.code),
+            );
+            if (claim === null) return;
+            this.pasteShortcutDeliveredToken = claim.deliveredToken;
+            this.pasteShortcutToken = claim.nextToken;
             this.options.onData(this.core.encodePaste(text));
           },
           () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -36,6 +36,8 @@ const CONTENT_PADDING = 4;
 const MIN_SCROLLBAR_THUMB_HEIGHT = 18;
 /** Half a blink cycle: the visible and hidden phases are equally long. */
 const CURSOR_BLINK_INTERVAL_MS = 500;
+const TERMINAL_WRITE_CHUNK_CODE_UNITS = 64 * 1024;
+const TERMINAL_IMMEDIATE_WRITE_CODE_UNITS = 16 * 1024;
 const TERMINAL_FONT_LOAD_TEXT = "iMW0@# .";
 const TERMINAL_FONT_LOAD_VARIANTS = [
   "normal 400",
@@ -534,6 +536,7 @@ export interface GhosttyTerminalSurfaceOptions {
   readonly onData: (data: string) => void;
   readonly onResize: (cols: number, rows: number) => void;
   readonly onSelectionChange: () => void;
+  readonly onScrollbackTop?: () => void;
   readonly beforeKey: (event: KeyboardEvent) => boolean;
   readonly onLinkActivate: (text: string, event: MouseEvent) => void;
   /**
@@ -565,6 +568,10 @@ export class GhosttyTerminalSurface {
   private readonly scrollbarThumb: HTMLDivElement;
   private snapshot: GhosttySnapshot | null = null;
   private frame = 0;
+  private writeFrame = 0;
+  private writeQueue: Array<{ data: string; offset: number; replay: boolean }> = [];
+  private writeQueueIndex = 0;
+  private replayActive = false;
   private cursorTimer: number | null = null;
   private compositionInputToSuppress: string | null = null;
   private compositionSuppressionTimer: number | null = null;
@@ -729,8 +736,22 @@ export class GhosttyTerminalSurface {
   }
 
   write(data: string): void {
-    if (this.disposed) return;
-    this.core.write(data);
+    if (this.disposed || data.length === 0) return;
+    if (
+      !this.replayActive &&
+      this.writeQueueIndex >= this.writeQueue.length &&
+      data.length <= TERMINAL_IMMEDIATE_WRITE_CODE_UNITS
+    ) {
+      this.core.write(data);
+      this.didWriteOutput();
+      return;
+    }
+
+    this.writeQueue.push({ data, offset: 0, replay: false });
+    this.requestWriteDrain();
+  }
+
+  private didWriteOutput(): void {
     this.synchronizeMouseTrackingState();
     // Restart the blink cycle from the visible phase so the cursor never sits
     // invisible through a stream of output or a burst of typing echo.
@@ -741,8 +762,16 @@ export class GhosttyTerminalSurface {
 
   resetAndWrite(data: string): void {
     if (this.disposed) return;
+    this.cancelPendingWrites();
     this.lastMouseMotionData = "";
-    this.core.resetAndWrite(data);
+    this.core.beginReplay();
+    this.replayActive = true;
+    if (data.length > 0) {
+      this.writeQueue.push({ data, offset: 0, replay: true });
+      this.requestWriteDrain();
+    } else {
+      this.finishReplay();
+    }
     this.synchronizeMouseTrackingState();
     // A replayed session starts from the visible phase like any other write:
     // reattaching mid-blink must not open on an invisible cursor.
@@ -750,6 +779,63 @@ export class GhosttyTerminalSurface {
     this.forceFullRender = true;
     this.scrollbarDirty = true;
     this.requestRender();
+  }
+
+  private requestWriteDrain(): void {
+    if (this.disposed || this.writeFrame !== 0) return;
+    this.writeFrame = window.requestAnimationFrame(this.drainWrites);
+  }
+
+  private readonly drainWrites = () => {
+    this.writeFrame = 0;
+    if (this.disposed) return;
+
+    const pending = this.writeQueue[this.writeQueueIndex];
+    if (pending) {
+      if (this.replayActive && !pending.replay) this.finishReplay();
+      let end = Math.min(pending.data.length, pending.offset + TERMINAL_WRITE_CHUNK_CODE_UNITS);
+      const lastCodeUnit = pending.data.charCodeAt(end - 1);
+      const nextCodeUnit = pending.data.charCodeAt(end);
+      if (
+        end < pending.data.length &&
+        lastCodeUnit >= 0xd800 &&
+        lastCodeUnit <= 0xdbff &&
+        nextCodeUnit >= 0xdc00 &&
+        nextCodeUnit <= 0xdfff
+      ) {
+        end -= 1;
+      }
+      const chunk = pending.data.slice(pending.offset, end);
+      if (pending.replay) this.core.writeReplay(chunk);
+      else this.core.write(chunk);
+      pending.offset = end;
+      if (pending.offset >= pending.data.length) this.writeQueueIndex += 1;
+    }
+
+    if (this.writeQueueIndex >= this.writeQueue.length) {
+      this.writeQueue = [];
+      this.writeQueueIndex = 0;
+      this.finishReplay();
+    } else {
+      this.requestWriteDrain();
+    }
+    this.didWriteOutput();
+  };
+
+  private finishReplay(): void {
+    if (!this.replayActive) return;
+    this.core.endReplay();
+    this.replayActive = false;
+  }
+
+  private cancelPendingWrites(): void {
+    if (this.writeFrame !== 0) {
+      window.cancelAnimationFrame(this.writeFrame);
+      this.writeFrame = 0;
+    }
+    this.writeQueue = [];
+    this.writeQueueIndex = 0;
+    this.finishReplay();
   }
 
   setTheme(theme: GhosttyTheme): void {
@@ -982,6 +1068,7 @@ export class GhosttyTerminalSurface {
       this.options.onResize(this.cols, this.rows);
     }
     if (this.frame !== 0) window.cancelAnimationFrame(this.frame);
+    if (this.writeFrame !== 0) window.cancelAnimationFrame(this.writeFrame);
     if (this.cursorTimer !== null) window.clearTimeout(this.cursorTimer);
     if (this.compositionSuppressionTimer !== null) {
       window.clearTimeout(this.compositionSuppressionTimer);
@@ -1555,12 +1642,27 @@ export class GhosttyTerminalSurface {
       case "PageDown":
         delta = Math.max(1, state.len);
         break;
-      case "Home":
-        delta = -state.offset;
-        break;
-      case "End":
-        delta = state.total - state.len - state.offset;
-        break;
+      case "Home": {
+        event.preventDefault();
+        event.stopPropagation();
+        this.core.scrollToTop();
+        this.scrollbarState = { ...state, offset: 0 };
+        this.options.onScrollbackTop?.();
+        this.forceFullRender = true;
+        this.scrollbarDirty = true;
+        this.requestRender();
+        return;
+      }
+      case "End": {
+        event.preventDefault();
+        event.stopPropagation();
+        this.core.scrollToBottom();
+        this.scrollbarState = { ...state, offset: Math.max(0, state.total - state.len) };
+        this.forceFullRender = true;
+        this.scrollbarDirty = true;
+        this.requestRender();
+        return;
+      }
       default:
         return;
     }
@@ -1627,6 +1729,7 @@ export class GhosttyTerminalSurface {
       const offset = Math.max(0, Math.min(state.offset + delta, maxOffset));
       delta = offset - state.offset;
       this.scrollbarState = { ...state, offset };
+      if (deltaRows < 0 && offset === 0) this.options.onScrollbackTop?.();
     }
     if (delta === 0) return;
     this.core.scroll(delta);

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -2042,7 +2042,9 @@ export class GhosttyTerminalSurface {
       previousCursorY: this.renderedCursorY,
       focused: this.focused,
       hoveredLinkRange: this.hoveredLink?.range ?? null,
-      ...(this.alternateScreenActive ? { defaultThemeOverride: this.theme } : {}),
+      ...(this.alternateScreenActive
+        ? { defaultThemeOverride: { source: this.appTheme, target: this.theme } }
+        : {}),
       ...(this.theme.selectionBackground !== undefined
         ? { selectionBackground: this.theme.selectionBackground }
         : {}),

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -666,6 +666,7 @@ export class GhosttyTerminalSurface {
   private focused = false;
   private resizeNotified = false;
   private canvasConfigured = false;
+  private canvasDevicePixelRatio = 0;
   private pendingCanvasConfiguration: {
     readonly width: number;
     readonly height: number;
@@ -1110,7 +1111,8 @@ export class GhosttyTerminalSurface {
     if (
       this.canvas.width !== pixelWidth ||
       this.canvas.height !== pixelHeight ||
-      !this.canvasConfigured
+      !this.canvasConfigured ||
+      this.canvasDevicePixelRatio !== ratio
     ) {
       // Changing a canvas backing size clears it immediately. Keep the last
       // complete frame visible until the gated paint can resize and redraw in
@@ -1715,7 +1717,10 @@ export class GhosttyTerminalSurface {
 
   private refreshHoveredLink(): void {
     const pointer = this.hoverPointer;
-    const link = pointer && this.linkModifierActive ? this.linkAt(pointer.x, pointer.y) : null;
+    // Make files and URLs discoverable on ordinary hover. The platform link
+    // modifier still gates activation and the pointer cursor, so an unmodified
+    // drag keeps its normal terminal-selection behavior.
+    const link = pointer ? this.linkAt(pointer.x, pointer.y) : null;
     this.setHoveredLink(link);
   }
 
@@ -1727,7 +1732,7 @@ export class GhosttyTerminalSurface {
       previous?.range.start.y === link?.range.start.y &&
       previous?.range.end.x === link?.range.end.x &&
       previous?.range.end.y === link?.range.end.y;
-    this.canvas.style.cursor = link ? "pointer" : "";
+    this.canvas.style.cursor = link && this.linkModifierActive ? "pointer" : "";
     if (unchanged) return;
     this.hoveredLink = link;
     this.forceFullRender = true;
@@ -2047,6 +2052,7 @@ export class GhosttyTerminalSurface {
       this.canvas.height = canvasConfiguration.height;
       this.context.setTransform(canvasConfiguration.ratio, 0, 0, canvasConfiguration.ratio, 0, 0);
       this.canvasConfigured = true;
+      this.canvasDevicePixelRatio = canvasConfiguration.ratio;
     }
     this.snapshot = this.core.snapshot();
     // A cursor that is not blinking right now must be drawn, never caught in an

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -800,10 +800,12 @@ export class GhosttyTerminalSurface {
     this.writeFrame = 0;
     if (this.disposed) return;
 
-    const pending = this.writeQueue[this.writeQueueIndex];
-    if (pending) {
+    let budget = TERMINAL_WRITE_CHUNK_CODE_UNITS;
+    while (budget > 0) {
+      const pending = this.writeQueue[this.writeQueueIndex];
+      if (!pending) break;
       if (this.replayActive && !pending.replay) this.finishReplay();
-      let end = Math.min(pending.data.length, pending.offset + TERMINAL_WRITE_CHUNK_CODE_UNITS);
+      let end = Math.min(pending.data.length, pending.offset + budget);
       const lastCodeUnit = pending.data.charCodeAt(end - 1);
       const nextCodeUnit = pending.data.charCodeAt(end);
       if (
@@ -816,8 +818,12 @@ export class GhosttyTerminalSurface {
         end -= 1;
       }
       const chunk = pending.data.slice(pending.offset, end);
+      // A one-code-unit remainder can land before a surrogate pair. Leave it
+      // for the next frame, whose full budget can consume the pair together.
+      if (chunk.length === 0) break;
       if (pending.replay) this.core.writeReplay(chunk);
       else this.core.write(chunk);
+      budget -= chunk.length;
       pending.offset = end;
       if (pending.offset >= pending.data.length) this.writeQueueIndex += 1;
     }

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -1128,10 +1128,10 @@ export class GhosttyTerminalSurface {
       this.scrollbarDirty = true;
       shouldRender = true;
     }
-    // Rendering synchronously keeps the repaint inside the same frame as the
-    // layout change: ResizeObserver fires before paint, so the browser never
-    // composites the old backing store stretched into the new element box.
-    if (shouldRender) this.renderFrame();
+    // ResizeObserver fires before paint, so the queued frame still updates the
+    // backing store before composition. Going through requestRender also keeps
+    // resize and DPR repaints behind DEC synchronized-output mode 2026.
+    if (shouldRender) this.requestRender();
     return true;
   }
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -36,6 +36,9 @@ const CONTENT_PADDING = 4;
 const MIN_SCROLLBAR_THUMB_HEIGHT = 18;
 /** Half a blink cycle: the visible and hidden phases are equally long. */
 const CURSOR_BLINK_INTERVAL_MS = 500;
+// A missing synchronized-output reset must not leave the visible terminal
+// frozen forever. A short fallback is no worse than rendering unsynchronized.
+const SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS = 500;
 const TERMINAL_WRITE_CHUNK_CODE_UNITS = 64 * 1024;
 const TERMINAL_IMMEDIATE_WRITE_CODE_UNITS = 16 * 1024;
 const TERMINAL_FONT_LOAD_TEXT = "iMW0@# .";
@@ -568,6 +571,7 @@ export class GhosttyTerminalSurface {
   private readonly scrollbarThumb: HTMLDivElement;
   private snapshot: GhosttySnapshot | null = null;
   private frame = 0;
+  private synchronizedRenderTimer: number | null = null;
   private writeFrame = 0;
   private writeQueue: Array<{ data: string; offset: number; replay: boolean }> = [];
   private writeQueueIndex = 0;
@@ -897,6 +901,7 @@ export class GhosttyTerminalSurface {
   }
 
   private cancelPendingWrites(): void {
+    this.cancelSynchronizedRenderTimer();
     if (this.writeFrame !== 0) {
       window.cancelAnimationFrame(this.writeFrame);
       this.writeFrame = 0;
@@ -1145,6 +1150,7 @@ export class GhosttyTerminalSurface {
       this.options.onResize(this.cols, this.rows);
     }
     if (this.frame !== 0) window.cancelAnimationFrame(this.frame);
+    this.cancelSynchronizedRenderTimer();
     if (this.writeFrame !== 0) window.cancelAnimationFrame(this.writeFrame);
     if (this.cursorTimer !== null) window.clearTimeout(this.cursorTimer);
     if (this.compositionSuppressionTimer !== null) {
@@ -1855,11 +1861,34 @@ export class GhosttyTerminalSurface {
   }
 
   private requestRender(): void {
-    if (this.disposed || this.frame !== 0) return;
+    if (this.disposed) return;
+    if (this.core.isSynchronizedOutput()) {
+      // A render requested before the opening marker may still be queued. Once
+      // Ghostty has accepted partial frame data, that paint is no longer safe.
+      if (this.frame !== 0) {
+        window.cancelAnimationFrame(this.frame);
+        this.frame = 0;
+      }
+      if (this.synchronizedRenderTimer === null) {
+        this.synchronizedRenderTimer = window.setTimeout(() => {
+          this.synchronizedRenderTimer = null;
+          this.renderFrame();
+        }, SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS);
+      }
+      return;
+    }
+    this.cancelSynchronizedRenderTimer();
+    if (this.frame !== 0) return;
     this.frame = window.requestAnimationFrame(() => {
       this.frame = 0;
       this.renderFrame();
     });
+  }
+
+  private cancelSynchronizedRenderTimer(): void {
+    if (this.synchronizedRenderTimer === null) return;
+    window.clearTimeout(this.synchronizedRenderTimer);
+    this.synchronizedRenderTimer = null;
   }
 
   private renderFrame(): void {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -749,7 +749,11 @@ export class GhosttyTerminalSurface {
       return;
     }
 
-    this.writeQueue.push({ data, offset: 0, replay: false });
+    // Output from the PTY only follows the server's replay-complete marker.
+    // Anything written while a streamed replay is open is renderer-local
+    // status text, so keep it ordered inside the replay instead of ending the
+    // stream before later history chunks arrive.
+    this.writeQueue.push({ data, offset: 0, replay: this.replayStreamOpen });
     this.requestWriteDrain();
   }
 
@@ -862,7 +866,7 @@ export class GhosttyTerminalSurface {
       // A one-code-unit remainder can land before a surrogate pair. Leave it
       // for the next frame, whose full budget can consume the pair together.
       if (chunk.length === 0) break;
-      if (pending.replay) this.core.writeReplay(chunk);
+      if (pending.replay && this.replayActive) this.core.writeReplay(chunk);
       else this.core.write(chunk);
       budget -= chunk.length;
       pending.offset = end;

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -666,6 +666,11 @@ export class GhosttyTerminalSurface {
   private focused = false;
   private resizeNotified = false;
   private canvasConfigured = false;
+  private pendingCanvasConfiguration: {
+    readonly width: number;
+    readonly height: number;
+    readonly ratio: number;
+  } | null = null;
   private appTheme: GhosttyTheme;
   private theme: GhosttyScreenTheme;
   private alternateScreenActive = false;
@@ -1107,13 +1112,21 @@ export class GhosttyTerminalSurface {
       this.canvas.height !== pixelHeight ||
       !this.canvasConfigured
     ) {
-      this.canvas.width = pixelWidth;
-      this.canvas.height = pixelHeight;
-      this.context.setTransform(ratio, 0, 0, ratio, 0, 0);
-      this.canvasConfigured = true;
+      // Changing a canvas backing size clears it immediately. Keep the last
+      // complete frame visible until the gated paint can resize and redraw in
+      // one callback, especially while a full-screen app owns mode 2026.
+      this.pendingCanvasConfiguration = {
+        width: pixelWidth,
+        height: pixelHeight,
+        ratio,
+      };
       this.forceFullRender = true;
       this.scrollbarDirty = true;
       shouldRender = true;
+    } else {
+      // A rapid drag can return to the currently painted size before its queued
+      // frame runs. Do not apply the stale intermediate backing dimensions.
+      this.pendingCanvasConfiguration = null;
     }
     const grid = terminalGridSize(width, height, this.metrics, CONTENT_PADDING);
     this.mountHeight = height;
@@ -2026,6 +2039,14 @@ export class GhosttyTerminalSurface {
     if (this.frame !== 0) {
       window.cancelAnimationFrame(this.frame);
       this.frame = 0;
+    }
+    const canvasConfiguration = this.pendingCanvasConfiguration;
+    if (canvasConfiguration !== null) {
+      this.pendingCanvasConfiguration = null;
+      this.canvas.width = canvasConfiguration.width;
+      this.canvas.height = canvasConfiguration.height;
+      this.context.setTransform(canvasConfiguration.ratio, 0, 0, canvasConfiguration.ratio, 0, 0);
+      this.canvasConfigured = true;
     }
     this.snapshot = this.core.snapshot();
     // A cursor that is not blinking right now must be drawn, never caught in an

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -45,6 +45,10 @@ const SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS = 500;
 const TERMINAL_WRITE_DRAIN_TIMEOUT_MS = 100;
 const TERMINAL_WRITE_CHUNK_CODE_UNITS = 64 * 1024;
 const TERMINAL_IMMEDIATE_WRITE_CODE_UNITS = 16 * 1024;
+// Normal visible writes yield between chunks to protect paints. If a producer
+// outruns the display for long enough, finish the bounded backlog in one pass
+// instead of letting it grow without limit behind one 64 KB animation frame.
+const TERMINAL_WRITE_QUEUE_MAX_CODE_UNITS = 1024 * 1024;
 const ALTERNATE_SCREEN_DARK_THEME = {
   background: { r: 0, g: 0, b: 0 },
   foreground: { r: 245, g: 245, b: 245 },
@@ -613,6 +617,7 @@ export class GhosttyTerminalSurface {
   private writeDrainTimer: number | null = null;
   private writeQueue: Array<{ data: string; offset: number; replay: boolean }> = [];
   private writeQueueIndex = 0;
+  private writeQueueCodeUnits = 0;
   private replayActive = false;
   private replayStreamOpen = false;
   private scrollToTopWhenWritesDrain = false;
@@ -799,8 +804,7 @@ export class GhosttyTerminalSurface {
     // Anything written while a streamed replay is open is renderer-local
     // status text, so keep it ordered inside the replay instead of ending the
     // stream before later history chunks arrive.
-    this.writeQueue.push({ data, offset: 0, replay: this.replayStreamOpen });
-    this.requestWriteDrain();
+    this.enqueueWrite(data, this.replayStreamOpen);
   }
 
   private didWriteOutput(): void {
@@ -820,8 +824,7 @@ export class GhosttyTerminalSurface {
     this.core.beginReplay();
     this.replayActive = true;
     if (data.length > 0) {
-      this.writeQueue.push({ data, offset: 0, replay: true });
-      this.requestWriteDrain();
+      this.enqueueWrite(data, true);
     } else {
       this.finishReplay();
     }
@@ -843,8 +846,7 @@ export class GhosttyTerminalSurface {
     this.replayActive = true;
     this.replayStreamOpen = true;
     if (data.length > 0) {
-      this.writeQueue.push({ data, offset: 0, replay: true });
-      this.requestWriteDrain();
+      this.enqueueWrite(data, true);
     }
     this.synchronizeMouseTrackingState();
     this.cursorOn = true;
@@ -859,8 +861,7 @@ export class GhosttyTerminalSurface {
       this.beginStreamingReplay(data);
       return;
     }
-    this.writeQueue.push({ data, offset: 0, replay: true });
-    this.requestWriteDrain();
+    this.enqueueWrite(data, true);
   }
 
   completeStreamingReplay(): void {
@@ -881,6 +882,25 @@ export class GhosttyTerminalSurface {
       return;
     }
     this.scrollToTop();
+  }
+
+  private enqueueWrite(data: string, replay: boolean): void {
+    this.writeQueue.push({ data, offset: 0, replay });
+    this.writeQueueCodeUnits += data.length;
+    if (this.writeQueueCodeUnits < TERMINAL_WRITE_QUEUE_MAX_CODE_UNITS) {
+      this.requestWriteDrain();
+      return;
+    }
+
+    if (this.writeFrame !== 0) {
+      window.cancelAnimationFrame(this.writeFrame);
+      this.writeFrame = 0;
+    }
+    if (this.writeDrainTimer !== null) {
+      window.clearTimeout(this.writeDrainTimer);
+      this.writeDrainTimer = null;
+    }
+    this.drainWrites(Number.POSITIVE_INFINITY);
   }
 
   private requestWriteDrain(): void {
@@ -936,6 +956,7 @@ export class GhosttyTerminalSurface {
       if (pending.replay && this.replayActive) this.core.writeReplay(chunk);
       else this.core.write(chunk);
       budget -= chunk.length;
+      this.writeQueueCodeUnits -= chunk.length;
       pending.offset = end;
       if (pending.offset >= pending.data.length) this.writeQueueIndex += 1;
     }
@@ -943,6 +964,7 @@ export class GhosttyTerminalSurface {
     if (this.writeQueueIndex >= this.writeQueue.length) {
       this.writeQueue = [];
       this.writeQueueIndex = 0;
+      this.writeQueueCodeUnits = 0;
       if (!this.replayStreamOpen) {
         this.finishReplay();
         if (this.scrollToTopWhenWritesDrain) {
@@ -975,6 +997,7 @@ export class GhosttyTerminalSurface {
     }
     this.writeQueue = [];
     this.writeQueueIndex = 0;
+    this.writeQueueCodeUnits = 0;
     this.replayStreamOpen = false;
     this.scrollToTopWhenWritesDrain = false;
     this.finishReplay();

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -39,6 +39,10 @@ const CURSOR_BLINK_INTERVAL_MS = 500;
 // A missing synchronized-output reset must not leave the visible terminal
 // frozen forever. A short fallback is no worse than rendering unsynchronized.
 const SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS = 500;
+// Hidden and occluded documents can suspend animation frames indefinitely.
+// The timeout drains the accumulated queue without a per-frame budget when
+// there is no paint cadence to protect.
+const TERMINAL_WRITE_DRAIN_TIMEOUT_MS = 100;
 const TERMINAL_WRITE_CHUNK_CODE_UNITS = 64 * 1024;
 const TERMINAL_IMMEDIATE_WRITE_CODE_UNITS = 16 * 1024;
 const ALTERNATE_SCREEN_DARK_THEME = {
@@ -606,6 +610,7 @@ export class GhosttyTerminalSurface {
   private frame = 0;
   private synchronizedRenderTimer: number | null = null;
   private writeFrame = 0;
+  private writeDrainTimer: number | null = null;
   private writeQueue: Array<{ data: string; offset: number; replay: boolean }> = [];
   private writeQueueIndex = 0;
   private replayActive = false;
@@ -879,15 +884,35 @@ export class GhosttyTerminalSurface {
   }
 
   private requestWriteDrain(): void {
-    if (this.disposed || this.writeFrame !== 0) return;
-    this.writeFrame = window.requestAnimationFrame(this.drainWrites);
+    if (this.disposed || this.writeFrame !== 0 || this.writeDrainTimer !== null) return;
+    this.writeFrame = window.requestAnimationFrame(this.drainWritesOnFrame);
+    this.writeDrainTimer = window.setTimeout(
+      this.drainWritesAfterFrameTimeout,
+      TERMINAL_WRITE_DRAIN_TIMEOUT_MS,
+    );
   }
 
-  private readonly drainWrites = () => {
+  private readonly drainWritesOnFrame = () => {
     this.writeFrame = 0;
+    if (this.writeDrainTimer !== null) {
+      window.clearTimeout(this.writeDrainTimer);
+      this.writeDrainTimer = null;
+    }
+    this.drainWrites(TERMINAL_WRITE_CHUNK_CODE_UNITS);
+  };
+
+  private readonly drainWritesAfterFrameTimeout = () => {
+    this.writeDrainTimer = null;
+    if (this.writeFrame !== 0) {
+      window.cancelAnimationFrame(this.writeFrame);
+      this.writeFrame = 0;
+    }
+    this.drainWrites(Number.POSITIVE_INFINITY);
+  };
+
+  private drainWrites(budget: number): void {
     if (this.disposed) return;
 
-    let budget = TERMINAL_WRITE_CHUNK_CODE_UNITS;
     while (budget > 0) {
       const pending = this.writeQueue[this.writeQueueIndex];
       if (!pending) break;
@@ -929,7 +954,7 @@ export class GhosttyTerminalSurface {
       this.requestWriteDrain();
     }
     this.didWriteOutput();
-  };
+  }
 
   private finishReplay(): void {
     if (!this.replayActive) return;
@@ -943,6 +968,10 @@ export class GhosttyTerminalSurface {
     if (this.writeFrame !== 0) {
       window.cancelAnimationFrame(this.writeFrame);
       this.writeFrame = 0;
+    }
+    if (this.writeDrainTimer !== null) {
+      window.clearTimeout(this.writeDrainTimer);
+      this.writeDrainTimer = null;
     }
     this.writeQueue = [];
     this.writeQueueIndex = 0;
@@ -1198,6 +1227,7 @@ export class GhosttyTerminalSurface {
     if (this.frame !== 0) window.cancelAnimationFrame(this.frame);
     this.cancelSynchronizedRenderTimer();
     if (this.writeFrame !== 0) window.cancelAnimationFrame(this.writeFrame);
+    if (this.writeDrainTimer !== null) window.clearTimeout(this.writeDrainTimer);
     if (this.cursorTimer !== null) window.clearTimeout(this.cursorTimer);
     if (this.compositionSuppressionTimer !== null) {
       window.clearTimeout(this.compositionSuppressionTimer);

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -572,6 +572,7 @@ export class GhosttyTerminalSurface {
   private writeQueue: Array<{ data: string; offset: number; replay: boolean }> = [];
   private writeQueueIndex = 0;
   private replayActive = false;
+  private replayStreamOpen = false;
   private scrollToTopWhenWritesDrain = false;
   private cursorTimer: number | null = null;
   private compositionInputToSuppress: string | null = null;
@@ -782,6 +783,46 @@ export class GhosttyTerminalSurface {
     this.requestRender();
   }
 
+  /** Reset once, then accept ordered replay chunks until the caller marks the stream complete. */
+  beginStreamingReplay(data: string): void {
+    if (this.disposed) return;
+    this.cancelPendingWrites();
+    this.lastMouseMotionData = "";
+    this.core.beginReplay();
+    this.replayActive = true;
+    this.replayStreamOpen = true;
+    if (data.length > 0) {
+      this.writeQueue.push({ data, offset: 0, replay: true });
+      this.requestWriteDrain();
+    }
+    this.synchronizeMouseTrackingState();
+    this.cursorOn = true;
+    this.forceFullRender = true;
+    this.scrollbarDirty = true;
+    this.requestRender();
+  }
+
+  appendStreamingReplay(data: string): void {
+    if (this.disposed || data.length === 0) return;
+    if (!this.replayStreamOpen) {
+      this.beginStreamingReplay(data);
+      return;
+    }
+    this.writeQueue.push({ data, offset: 0, replay: true });
+    this.requestWriteDrain();
+  }
+
+  completeStreamingReplay(): void {
+    if (this.disposed || !this.replayStreamOpen) return;
+    this.replayStreamOpen = false;
+    if (this.writeQueueIndex < this.writeQueue.length) return;
+    this.finishReplay();
+    if (this.scrollToTopWhenWritesDrain) {
+      this.scrollToTopWhenWritesDrain = false;
+      this.scrollToTop();
+    }
+  }
+
   scrollToTopAfterWrites(): void {
     if (this.disposed) return;
     if (this.writeQueueIndex < this.writeQueue.length || this.replayActive) {
@@ -831,10 +872,12 @@ export class GhosttyTerminalSurface {
     if (this.writeQueueIndex >= this.writeQueue.length) {
       this.writeQueue = [];
       this.writeQueueIndex = 0;
-      this.finishReplay();
-      if (this.scrollToTopWhenWritesDrain) {
-        this.scrollToTopWhenWritesDrain = false;
-        this.scrollToTop();
+      if (!this.replayStreamOpen) {
+        this.finishReplay();
+        if (this.scrollToTopWhenWritesDrain) {
+          this.scrollToTopWhenWritesDrain = false;
+          this.scrollToTop();
+        }
       }
     } else {
       this.requestWriteDrain();
@@ -846,6 +889,7 @@ export class GhosttyTerminalSurface {
     if (!this.replayActive) return;
     this.core.endReplay();
     this.replayActive = false;
+    this.replayStreamOpen = false;
   }
 
   private cancelPendingWrites(): void {
@@ -855,6 +899,7 @@ export class GhosttyTerminalSurface {
     }
     this.writeQueue = [];
     this.writeQueueIndex = 0;
+    this.replayStreamOpen = false;
     this.scrollToTopWhenWritesDrain = false;
     this.finishReplay();
   }

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -1143,10 +1143,14 @@ export class GhosttyTerminalSurface {
       this.scrollbarDirty = true;
       shouldRender = true;
     }
-    // ResizeObserver fires before paint, so the queued frame still updates the
-    // backing store before composition. Going through requestRender also keeps
-    // resize and DPR repaints behind DEC synchronized-output mode 2026.
-    if (shouldRender) this.requestRender();
+    // ResizeObserver runs after animation frame callbacks. Outside a gated TUI
+    // update, repaint now so this frame never stretches the old backing store.
+    // Mode 2026 keeps its atomicity and applies the pending size with its next
+    // complete synchronized frame.
+    if (shouldRender) {
+      if (this.core.isSynchronizedOutput()) this.requestRender();
+      else this.renderFrame();
+    }
     return true;
   }
 
@@ -1717,10 +1721,7 @@ export class GhosttyTerminalSurface {
 
   private refreshHoveredLink(): void {
     const pointer = this.hoverPointer;
-    // Make files and URLs discoverable on ordinary hover. The platform link
-    // modifier still gates activation and the pointer cursor, so an unmodified
-    // drag keeps its normal terminal-selection behavior.
-    const link = pointer ? this.linkAt(pointer.x, pointer.y) : null;
+    const link = pointer && this.linkModifierActive ? this.linkAt(pointer.x, pointer.y) : null;
     this.setHoveredLink(link);
   }
 
@@ -1732,7 +1733,7 @@ export class GhosttyTerminalSurface {
       previous?.range.start.y === link?.range.start.y &&
       previous?.range.end.x === link?.range.end.x &&
       previous?.range.end.y === link?.range.end.y;
-    this.canvas.style.cursor = link && this.linkModifierActive ? "pointer" : "";
+    this.canvas.style.cursor = link ? "pointer" : "";
     if (unchanged) return;
     this.hoveredLink = link;
     this.forceFullRender = true;

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -58,6 +58,28 @@ background-activity layers) and differ beyond that only in the platform layer th
 UI they build on top. React components never construct transports, retry loops,
 or RPC clients. See [connection-runtime.md](./connection-runtime.md).
 
+## Terminal streaming
+
+The server owns each PTY and keeps two histories with different budgets. [`Manager.ts`][terminal]
+allows durable history to grow to 12 MB before compacting it toward 8 MB. Its recent recovery
+snapshot is separate and grows to 64 KB before compacting toward 48 KB. Incremental renderers can
+request up to 8 MB when attaching. Web starts from the recent snapshot and requests 4 MB when the
+user reaches its top; extended history arrives as ordered 64 KB chunks before live output begins.
+
+PTY output is coalesced for up to 8 ms or 16 KB before `terminal.attach` publishes it. Initial
+history uses backpressure and cancels with the attach scope. Live delivery buffers at most 32 events.
+If a client cannot consume that queue, the server replaces queued deltas with its latest bounded
+snapshot. This applies equally to loopback, LAN, Tailscale, relay, and SSH-forwarded connections
+because they all use the same RPC stream.
+
+[`terminalSession.ts`][terminal-state] retains replay as byte-bounded chunks instead of rebuilding a
+growing string for every event. Web and native mobile renderers consume those chunks incrementally;
+if their cursor falls behind retained history, they reset from the current snapshot. The web
+renderer also yields between large Ghostty writes so extended replay does not monopolize the main
+thread. Hidden web drawers unmount their renderer and attach subscription while the server-owned PTY
+continues running. Ghostty renderers use a 64 MB internal scrollback budget so the 4 MB text replay
+remains available after it expands into styled terminal cells.
+
 ## Orchestration is event-sourced
 
 The server does not mutate app state directly. Clients dispatch typed commands; the engine turns them
@@ -152,3 +174,5 @@ already dispatch.
 [checkpoint]: ../../apps/server/src/orchestration/Layers/CheckpointReactor.ts
 [receipts]: ../../apps/server/src/orchestration/Layers/RuntimeReceiptBus.ts
 [drivers]: ../../apps/server/src/provider/builtInDrivers.ts
+[terminal]: ../../apps/server/src/terminal/Manager.ts
+[terminal-state]: ../../packages/client-runtime/src/state/terminalSession.ts

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -64,8 +64,9 @@ The server owns each PTY and keeps two histories with different budgets. [`Manag
 allows durable history to grow to 12 MB before compacting it toward 8 MB. Its recent recovery
 snapshot is separate and grows to 64 KB before compacting toward 48 KB. Incremental renderers can
 request up to 8 MB when attaching. Web starts from the recent snapshot and requests 4 MB when the
-user reaches its top; extended history arrives as ordered 64 KB chunks plus a completion marker
-before live output begins, allowing the renderer to restore the user's top-of-scrollback position.
+user reaches its top; extended history arrives as ordered 64 KB chunks between explicit replay
+start and completion markers before live output begins. Those boundaries re-arm replay suppression
+after a transport reconnect without forcing the viewport to jump.
 
 PTY output is coalesced for up to 8 ms or 16 KB before `terminal.attach` publishes it. Initial
 history uses backpressure and cancels with the attach scope. Live delivery buffers at most 32 events.

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -64,7 +64,8 @@ The server owns each PTY and keeps two histories with different budgets. [`Manag
 allows durable history to grow to 12 MB before compacting it toward 8 MB. Its recent recovery
 snapshot is separate and grows to 64 KB before compacting toward 48 KB. Incremental renderers can
 request up to 8 MB when attaching. Web starts from the recent snapshot and requests 4 MB when the
-user reaches its top; extended history arrives as ordered 64 KB chunks before live output begins.
+user reaches its top; extended history arrives as ordered 64 KB chunks plus a completion marker
+before live output begins, allowing the renderer to restore the user's top-of-scrollback position.
 
 PTY output is coalesced for up to 8 ms or 16 KB before `terminal.attach` publishes it. Initial
 history uses backpressure and cancels with the attach scope. Live delivery buffers at most 32 events.
@@ -76,7 +77,8 @@ because they all use the same RPC stream.
 growing string for every event. Web and native mobile renderers consume those chunks incrementally;
 if their cursor falls behind retained history, they reset from the current snapshot. The web
 renderer also yields between large Ghostty writes so extended replay does not monopolize the main
-thread. Hidden web drawers unmount their renderer and attach subscription while the server-owned PTY
+thread. Web and native renderers suppress terminal query replies while replaying retained history.
+Hidden web drawers unmount their renderer and attach subscription while the server-owned PTY
 continues running. Ghostty renderers use a 64 MB internal scrollback budget so the 4 MB text replay
 remains available after it expands into styled terminal cells.
 

--- a/packages/client-runtime/src/state/terminal.ts
+++ b/packages/client-runtime/src/state/terminal.ts
@@ -13,6 +13,7 @@ import { subscribe, type EnvironmentRpcInput } from "../rpc/client.ts";
 import {
   applyTerminalAttachStreamEvent,
   applyTerminalMetadataStreamEvent,
+  terminalOutputRetentionBytes,
   EMPTY_TERMINAL_BUFFER_STATE,
 } from "./terminalSession.ts";
 
@@ -45,7 +46,11 @@ export function createTerminalEnvironmentAtoms<R, E>(
       subscribe: (input: EnvironmentRpcInput<typeof WS_METHODS.terminalAttach>) =>
         subscribe(WS_METHODS.terminalAttach, input).pipe(
           Stream.scan(EMPTY_TERMINAL_BUFFER_STATE, (state, event) =>
-            applyTerminalAttachStreamEvent(state, event, input.replayBytes),
+            applyTerminalAttachStreamEvent(
+              state,
+              event,
+              terminalOutputRetentionBytes(input.replayBytes),
+            ),
           ),
         ),
     }),

--- a/packages/client-runtime/src/state/terminal.ts
+++ b/packages/client-runtime/src/state/terminal.ts
@@ -39,9 +39,14 @@ export function createTerminalEnvironmentAtoms<R, E>(
   return {
     attach: createEnvironmentSubscriptionAtomFamily(runtime, {
       label: "environment-data:terminal:attach",
+      // PTYs live on the server. Keeping an idle attach stream alive only
+      // burns output parsing and network work for a renderer that is gone.
+      idleTtlMs: 0,
       subscribe: (input: EnvironmentRpcInput<typeof WS_METHODS.terminalAttach>) =>
         subscribe(WS_METHODS.terminalAttach, input).pipe(
-          Stream.scan(EMPTY_TERMINAL_BUFFER_STATE, applyTerminalAttachStreamEvent),
+          Stream.scan(EMPTY_TERMINAL_BUFFER_STATE, (state, event) =>
+            applyTerminalAttachStreamEvent(state, event, input.replayBytes),
+          ),
         ),
     }),
     events: createEnvironmentRpcSubscriptionAtomFamily(runtime, {

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -10,6 +10,7 @@ import {
   readTerminalOutputUpdate,
   selectRunningSubprocessTerminalIds,
   terminalOutputText,
+  terminalOutputRetentionBytes,
 } from "./terminalSession.ts";
 
 const TARGET = {
@@ -33,6 +34,46 @@ const BASE_SNAPSHOT: TerminalSessionSnapshot = {
 };
 
 describe("terminal session reducers", () => {
+  it("retains adjacent maximum-size events after the smaller initial replay", () => {
+    const retentionBytes = terminalOutputRetentionBytes(64 * 1024);
+    expect(retentionBytes).toBe(512 * 1024);
+    expect(terminalOutputRetentionBytes(4 * 1024 * 1024)).toBe(4 * 1024 * 1024);
+
+    const snapshot = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      { type: "snapshot", snapshot: { ...BASE_SNAPSHOT, history: "" } },
+      retentionBytes,
+    );
+    const cursor = {
+      resetVersion: snapshot.output.resetVersion,
+      lastChunkId: snapshot.output.latestChunkId,
+    };
+    const first = applyTerminalAttachStreamEvent(
+      snapshot,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "a".repeat(64 * 1024),
+      },
+      retentionBytes,
+    );
+    const second = applyTerminalAttachStreamEvent(
+      first,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "b".repeat(64 * 1024),
+      },
+      retentionBytes,
+    );
+
+    const update = readTerminalOutputUpdate(second.output, cursor);
+    if (update.type !== "append") throw new Error(`Expected append, received ${update.type}`);
+    expect(update.data).toHaveLength(128 * 1024);
+  });
+
   it("prefers live attach status over stale metadata after the attach stream starts", () => {
     const summary = applyTerminalMetadataStreamEvent([], {
       type: "snapshot",

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -136,6 +136,31 @@ describe("terminal session reducers", () => {
     expect(terminalOutputText(output.output)).toBe(" world");
   });
 
+  it("advances repeated snapshots so renderers apply overflow resyncs", () => {
+    const first = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const second = applyTerminalAttachStreamEvent(first, {
+      type: "snapshot",
+      snapshot: { ...BASE_SNAPSHOT, history: "resynced" },
+    });
+
+    expect(second.version).toBe(2);
+    expect(terminalOutputText(second.output)).toBe("resynced");
+  });
+
+  it("exposes replay completion independently from output versions", () => {
+    const completed = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "replay-complete",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      sequence: 1,
+    });
+
+    expect(completed).toMatchObject({ replayCompleteVersion: 1, version: 1 });
+  });
+
   it("reduces terminal metadata snapshots, upserts, and removals", () => {
     const initial = applyTerminalMetadataStreamEvent([], {
       type: "snapshot",

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -153,20 +153,37 @@ describe("terminal session reducers", () => {
     });
 
     expect(second.version).toBe(2);
-    expect(second.replayStartVersion).toBe(2);
-    expect(cleared.replayStartVersion).toBe(2);
+    expect(second.replayStartVersion).toBe(0);
+    expect(cleared.replayStartVersion).toBe(0);
     expect(terminalOutputText(second.output)).toBe("resynced");
   });
 
-  it("exposes replay completion independently from output versions", () => {
-    const completed = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+  it("tracks replay boundaries independently from snapshots and output", () => {
+    const started = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "replay-start",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      sequence: 1,
+    });
+    const snapshot = applyTerminalAttachStreamEvent(started, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const completed = applyTerminalAttachStreamEvent(snapshot, {
       type: "replay-complete",
       threadId: TARGET.threadId,
       terminalId: TARGET.terminalId,
       sequence: 1,
     });
+    const reconnected = applyTerminalAttachStreamEvent(completed, {
+      type: "replay-start",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      sequence: 2,
+    });
 
-    expect(completed).toMatchObject({ replayCompleteVersion: 1, version: 1 });
+    expect(completed).toMatchObject({ replayStartVersion: 1, replayCompleteVersion: 1 });
+    expect(reconnected).toMatchObject({ replayStartVersion: 2, replayCompleteVersion: 1 });
   });
 
   it("reduces terminal metadata snapshots, upserts, and removals", () => {

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -186,6 +186,37 @@ describe("terminal session reducers", () => {
     expect(reconnected).toMatchObject({ replayStartVersion: 2, replayCompleteVersion: 1 });
   });
 
+  it("does not make replay-start override metadata before its snapshot arrives", () => {
+    const summary = applyTerminalMetadataStreamEvent([], {
+      type: "snapshot",
+      terminals: [
+        {
+          threadId: BASE_SNAPSHOT.threadId,
+          terminalId: BASE_SNAPSHOT.terminalId,
+          cwd: BASE_SNAPSHOT.cwd,
+          worktreePath: BASE_SNAPSHOT.worktreePath,
+          status: "running",
+          pid: BASE_SNAPSHOT.pid,
+          exitCode: BASE_SNAPSHOT.exitCode,
+          exitSignal: BASE_SNAPSHOT.exitSignal,
+          updatedAt: BASE_SNAPSHOT.updatedAt,
+          hasRunningSubprocess: false,
+          label: BASE_SNAPSHOT.label,
+        },
+      ],
+    })[0]!;
+    const started = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "replay-start",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      sequence: 1,
+    });
+
+    expect(started.version).toBe(0);
+    expect(started.replayStartVersion).toBe(1);
+    expect(combineTerminalSessionState(summary, started).status).toBe("running");
+  });
+
   it("reduces terminal metadata snapshots, upserts, and removals", () => {
     const initial = applyTerminalMetadataStreamEvent([], {
       type: "snapshot",

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -7,7 +7,9 @@ import {
   applyTerminalMetadataStreamEvent,
   combineTerminalSessionState,
   EMPTY_TERMINAL_BUFFER_STATE,
+  readTerminalOutputUpdate,
   selectRunningSubprocessTerminalIds,
+  terminalOutputText,
 } from "./terminalSession.ts";
 
 const TARGET = {
@@ -126,11 +128,12 @@ describe("terminal session reducers", () => {
     );
 
     expect(output).toMatchObject({
-      buffer: "lo world",
       status: "running",
       error: null,
       version: 2,
     });
+    expect(output.output.retainedBytes).toBeLessThanOrEqual(8);
+    expect(terminalOutputText(output.output)).toBe(" world");
   });
 
   it("reduces terminal metadata snapshots, upserts, and removals", () => {
@@ -182,6 +185,125 @@ describe("terminal session reducers", () => {
       4,
     );
 
-    expect(state.buffer).toBe("🙂");
+    expect(terminalOutputText(state.output)).toBe("🙂");
+    expect(state.output.retainedBytes).toBe(4);
+  });
+
+  it("clears a renderer when the byte budget cannot retain an output character", () => {
+    const initial = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "a",
+      },
+      1,
+    );
+    const cursor = {
+      resetVersion: initial.output.resetVersion,
+      lastChunkId: initial.output.latestChunkId,
+    };
+    const dropped = applyTerminalAttachStreamEvent(
+      initial,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "🙂",
+      },
+      1,
+    );
+
+    expect(readTerminalOutputUpdate(dropped.output, cursor)).toMatchObject({
+      type: "reset",
+      data: "",
+    });
+  });
+
+  it("delivers every append when multiple events reduce before the renderer reads", () => {
+    const snapshot = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const cursor = {
+      resetVersion: snapshot.output.resetVersion,
+      lastChunkId: snapshot.output.latestChunkId,
+    };
+    const first = applyTerminalAttachStreamEvent(snapshot, {
+      type: "output",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      data: " first",
+    });
+    const second = applyTerminalAttachStreamEvent(first, {
+      type: "output",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      data: " second",
+    });
+
+    expect(readTerminalOutputUpdate(second.output, cursor)).toMatchObject({
+      type: "append",
+      data: " first second",
+    });
+  });
+
+  it("resets a renderer that falls behind retained output", () => {
+    const first = applyTerminalAttachStreamEvent(
+      EMPTY_TERMINAL_BUFFER_STATE,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "first",
+      },
+      6,
+    );
+    const staleCursor = {
+      resetVersion: first.output.resetVersion,
+      lastChunkId: first.output.latestChunkId,
+    };
+    const second = applyTerminalAttachStreamEvent(
+      first,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "second",
+      },
+      6,
+    );
+    const third = applyTerminalAttachStreamEvent(
+      second,
+      {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "third",
+      },
+      6,
+    );
+
+    expect(readTerminalOutputUpdate(third.output, staleCursor)).toMatchObject({
+      type: "reset",
+      data: "third",
+    });
+  });
+
+  it("bounds chunk metadata without losing small output events", () => {
+    let state = EMPTY_TERMINAL_BUFFER_STATE;
+    for (let index = 0; index < 1_025; index += 1) {
+      state = applyTerminalAttachStreamEvent(state, {
+        type: "output",
+        threadId: TARGET.threadId,
+        terminalId: TARGET.terminalId,
+        data: "x",
+      });
+    }
+
+    expect(state.output.chunks.length).toBeLessThan(1_025);
+    expect(terminalOutputText(state.output)).toBe("x".repeat(1_025));
+    expect(state.output.resetVersion).toBe(1);
   });
 });

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -371,6 +371,48 @@ describe("terminal session reducers", () => {
     });
   });
 
+  it("keeps replay and live appends distinct when both reduce before a renderer reads", () => {
+    const snapshot = applyTerminalAttachStreamEvent(EMPTY_TERMINAL_BUFFER_STATE, {
+      type: "snapshot",
+      snapshot: BASE_SNAPSHOT,
+    });
+    const cursor = {
+      resetVersion: snapshot.output.resetVersion,
+      lastChunkId: snapshot.output.latestChunkId,
+    };
+    const replayStarted = applyTerminalAttachStreamEvent(snapshot, {
+      type: "replay-start",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+    });
+    const replayOutput = applyTerminalAttachStreamEvent(replayStarted, {
+      type: "output",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      data: " replay",
+    });
+    const replayCompleted = applyTerminalAttachStreamEvent(replayOutput, {
+      type: "replay-complete",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+    });
+    const liveOutput = applyTerminalAttachStreamEvent(replayCompleted, {
+      type: "output",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      data: " live",
+    });
+
+    expect(readTerminalOutputUpdate(liveOutput.output, cursor)).toMatchObject({
+      type: "append",
+      data: " replay live",
+      segments: [
+        { data: " replay", delivery: "replay" },
+        { data: " live", delivery: "live" },
+      ],
+    });
+  });
+
   it("resets a renderer that falls behind retained output", () => {
     const first = applyTerminalAttachStreamEvent(
       EMPTY_TERMINAL_BUFFER_STATE,

--- a/packages/client-runtime/src/state/terminalSession.test.ts
+++ b/packages/client-runtime/src/state/terminalSession.test.ts
@@ -145,8 +145,16 @@ describe("terminal session reducers", () => {
       type: "snapshot",
       snapshot: { ...BASE_SNAPSHOT, history: "resynced" },
     });
+    const cleared = applyTerminalAttachStreamEvent(second, {
+      type: "cleared",
+      threadId: TARGET.threadId,
+      terminalId: TARGET.terminalId,
+      sequence: 1,
+    });
 
     expect(second.version).toBe(2);
+    expect(second.replayStartVersion).toBe(2);
+    expect(cleared.replayStartVersion).toBe(2);
     expect(terminalOutputText(second.output)).toBe("resynced");
   });
 

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -294,7 +294,7 @@ export function terminalBufferStateFromSnapshot(
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
-    replayStartVersion: current.replayStartVersion + 1,
+    replayStartVersion: current.replayStartVersion,
     replayCompleteVersion: current.replayCompleteVersion,
     version: current.version + 1,
   };
@@ -329,6 +329,12 @@ export function applyTerminalAttachStreamEvent(
   maxBufferBytes = DEFAULT_MAX_TERMINAL_BUFFER_BYTES,
 ): TerminalBufferState {
   switch (event.type) {
+    case "replay-start":
+      return {
+        ...current,
+        replayStartVersion: current.replayStartVersion + 1,
+        version: current.version + 1,
+      };
     case "snapshot":
     case "restarted":
       return terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes, current);

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -11,6 +11,7 @@ export interface TerminalOutputChunk {
   readonly id: number;
   readonly data: string;
   readonly byteLength: number;
+  readonly delivery: "replay" | "live";
 }
 
 export interface TerminalOutputState {
@@ -31,9 +32,18 @@ export type TerminalOutputUpdate =
       readonly cursor: TerminalOutputCursor;
     }
   | {
-      readonly type: "append" | "reset";
+      readonly type: "reset";
       readonly data: string;
       readonly cursor: TerminalOutputCursor;
+    }
+  | {
+      readonly type: "append";
+      readonly data: string;
+      readonly cursor: TerminalOutputCursor;
+      readonly segments: ReadonlyArray<{
+        readonly data: string;
+        readonly delivery: "replay" | "live";
+      }>;
     };
 
 export interface TerminalSessionState {
@@ -142,6 +152,7 @@ function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
 function splitOutputChunks(
   data: string,
   firstChunkId: number,
+  delivery: "replay" | "live",
   maxChunkBytes = DEFAULT_TERMINAL_CHUNK_BYTES,
 ): {
   readonly chunks: ReadonlyArray<TerminalOutputChunk>;
@@ -172,6 +183,7 @@ function splitOutputChunks(
       id: nextChunkId,
       data: textDecoder.decode(bytes),
       byteLength: bytes.byteLength,
+      delivery,
     });
     nextChunkId += 1;
     offset = end;
@@ -188,10 +200,12 @@ function appendOutput(
   current: TerminalOutputState,
   data: string,
   maxBufferBytes: number,
+  delivery: "replay" | "live",
 ): TerminalOutputState {
   const appended = splitOutputChunks(
     data,
     current.latestChunkId + 1,
+    delivery,
     Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
   );
   if (appended.chunks.length === 0) return current;
@@ -249,6 +263,7 @@ function resetOutput(
   const reset = splitOutputChunks(
     retained,
     current.latestChunkId + 1,
+    "replay",
     Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
   );
   return {
@@ -283,9 +298,19 @@ export function readTerminalOutputUpdate(
   if (appended.length === 0) {
     return { type: "none", cursor: nextCursor };
   }
+  const segments: Array<{ data: string; delivery: "replay" | "live" }> = [];
+  for (const chunk of appended) {
+    const previous = segments.at(-1);
+    if (previous?.delivery === chunk.delivery) {
+      previous.data += chunk.data;
+    } else {
+      segments.push({ data: chunk.data, delivery: chunk.delivery });
+    }
+  }
   return {
     type: "append",
     data: appended.map((chunk) => chunk.data).join(""),
+    segments,
     cursor: nextCursor,
   };
 }
@@ -346,7 +371,12 @@ export function applyTerminalAttachStreamEvent(
     case "output":
       return {
         ...current,
-        output: appendOutput(current.output, event.data, maxBufferBytes),
+        output: appendOutput(
+          current.output,
+          event.data,
+          maxBufferBytes,
+          current.replayStartVersion > current.replayCompleteVersion ? "replay" : "live",
+        ),
         status: current.status === "closed" ? "running" : current.status,
         error: null,
         version: current.version + 1,

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -333,7 +333,6 @@ export function applyTerminalAttachStreamEvent(
       return {
         ...current,
         replayStartVersion: current.replayStartVersion + 1,
-        version: current.version + 1,
       };
     case "snapshot":
     case "restarted":

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -44,6 +44,7 @@ export interface TerminalSessionState {
   readonly error: string | null;
   readonly hasRunningSubprocess: boolean;
   readonly updatedAt: string | null;
+  readonly replayCompleteVersion: number;
   readonly version: number;
 }
 
@@ -52,6 +53,7 @@ export interface TerminalBufferState {
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly updatedAt: string | null;
+  readonly replayCompleteVersion: number;
   readonly version: number;
 }
 
@@ -84,6 +86,7 @@ export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
   status: "closed",
   error: null,
   updatedAt: null,
+  replayCompleteVersion: 0,
   version: 0,
 });
 
@@ -94,6 +97,7 @@ export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>(
   error: null,
   hasRunningSubprocess: false,
   updatedAt: null,
+  replayCompleteVersion: 0,
   version: 0,
 });
 
@@ -279,14 +283,15 @@ export function readTerminalOutputUpdate(
 export function terminalBufferStateFromSnapshot(
   snapshot: TerminalSessionSnapshot,
   maxBufferBytes: number,
-  currentOutput: TerminalOutputState = EMPTY_TERMINAL_BUFFER_STATE.output,
+  current: TerminalBufferState = EMPTY_TERMINAL_BUFFER_STATE,
 ): TerminalBufferState {
   return {
-    output: resetOutput(currentOutput, snapshot.history, maxBufferBytes),
+    output: resetOutput(current.output, snapshot.history, maxBufferBytes),
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
-    version: 1,
+    replayCompleteVersion: current.replayCompleteVersion,
+    version: current.version + 1,
   };
 }
 
@@ -307,6 +312,7 @@ export function combineTerminalSessionState(
     error: buffer.error,
     hasRunningSubprocess: summary?.hasRunningSubprocess ?? false,
     updatedAt: latestTimestamp(summary?.updatedAt ?? null, buffer.updatedAt),
+    replayCompleteVersion: buffer.replayCompleteVersion,
     version: buffer.version,
   };
 }
@@ -319,13 +325,19 @@ export function applyTerminalAttachStreamEvent(
   switch (event.type) {
     case "snapshot":
     case "restarted":
-      return terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes, current.output);
+      return terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes, current);
     case "output":
       return {
         ...current,
         output: appendOutput(current.output, event.data, maxBufferBytes),
         status: current.status === "closed" ? "running" : current.status,
         error: null,
+        version: current.version + 1,
+      };
+    case "replay-complete":
+      return {
+        ...current,
+        replayCompleteVersion: current.replayCompleteVersion + 1,
         version: current.version + 1,
       };
     case "cleared":

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -44,6 +44,7 @@ export interface TerminalSessionState {
   readonly error: string | null;
   readonly hasRunningSubprocess: boolean;
   readonly updatedAt: string | null;
+  readonly replayStartVersion: number;
   readonly replayCompleteVersion: number;
   readonly version: number;
 }
@@ -53,6 +54,7 @@ export interface TerminalBufferState {
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly updatedAt: string | null;
+  readonly replayStartVersion: number;
   readonly replayCompleteVersion: number;
   readonly version: number;
 }
@@ -86,6 +88,7 @@ export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
   status: "closed",
   error: null,
   updatedAt: null,
+  replayStartVersion: 0,
   replayCompleteVersion: 0,
   version: 0,
 });
@@ -97,6 +100,7 @@ export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>(
   error: null,
   hasRunningSubprocess: false,
   updatedAt: null,
+  replayStartVersion: 0,
   replayCompleteVersion: 0,
   version: 0,
 });
@@ -290,6 +294,7 @@ export function terminalBufferStateFromSnapshot(
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
+    replayStartVersion: current.replayStartVersion + 1,
     replayCompleteVersion: current.replayCompleteVersion,
     version: current.version + 1,
   };
@@ -312,6 +317,7 @@ export function combineTerminalSessionState(
     error: buffer.error,
     hasRunningSubprocess: summary?.hasRunningSubprocess ?? false,
     updatedAt: latestTimestamp(summary?.updatedAt ?? null, buffer.updatedAt),
+    replayStartVersion: buffer.replayStartVersion,
     replayCompleteVersion: buffer.replayCompleteVersion,
     version: buffer.version,
   };

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -1,15 +1,45 @@
-import type {
-  EnvironmentId,
-  TerminalAttachStreamEvent,
-  TerminalMetadataStreamEvent,
-  TerminalSessionSnapshot,
-  TerminalSummary,
-  ThreadId,
+import {
+  DEFAULT_TERMINAL_REPLAY_BYTES,
+  type EnvironmentId,
+  type TerminalAttachStreamEvent,
+  type TerminalMetadataStreamEvent,
+  type TerminalSessionSnapshot,
+  type TerminalSummary,
+  type ThreadId,
 } from "@t3tools/contracts";
+
+export interface TerminalOutputChunk {
+  readonly id: number;
+  readonly data: string;
+  readonly byteLength: number;
+}
+
+export interface TerminalOutputState {
+  readonly chunks: ReadonlyArray<TerminalOutputChunk>;
+  readonly retainedBytes: number;
+  readonly resetVersion: number;
+  readonly latestChunkId: number;
+}
+
+export interface TerminalOutputCursor {
+  readonly resetVersion: number;
+  readonly lastChunkId: number;
+}
+
+export type TerminalOutputUpdate =
+  | {
+      readonly type: "none";
+      readonly cursor: TerminalOutputCursor;
+    }
+  | {
+      readonly type: "append" | "reset";
+      readonly data: string;
+      readonly cursor: TerminalOutputCursor;
+    };
 
 export interface TerminalSessionState {
   readonly summary: TerminalSummary | null;
-  readonly buffer: string;
+  readonly output: TerminalOutputState;
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly hasRunningSubprocess: boolean;
@@ -18,7 +48,7 @@ export interface TerminalSessionState {
 }
 
 export interface TerminalBufferState {
-  readonly buffer: string;
+  readonly output: TerminalOutputState;
   readonly status: TerminalSessionSnapshot["status"] | "closed";
   readonly error: string | null;
   readonly updatedAt: string | null;
@@ -45,7 +75,12 @@ export function selectRunningSubprocessTerminalIds(
 }
 
 export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
-  buffer: "",
+  output: Object.freeze({
+    chunks: Object.freeze([]),
+    retainedBytes: 0,
+    resetVersion: 0,
+    latestChunkId: 0,
+  }),
   status: "closed",
   error: null,
   updatedAt: null,
@@ -54,7 +89,7 @@ export const EMPTY_TERMINAL_BUFFER_STATE = Object.freeze<TerminalBufferState>({
 
 export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>({
   summary: null,
-  buffer: "",
+  output: EMPTY_TERMINAL_BUFFER_STATE.output,
   status: "closed",
   error: null,
   hasRunningSubprocess: false,
@@ -62,7 +97,9 @@ export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>(
   version: 0,
 });
 
-export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = 512 * 1024;
+export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = DEFAULT_TERMINAL_REPLAY_BYTES;
+const DEFAULT_TERMINAL_CHUNK_BYTES = 16 * 1024;
+const MAX_TERMINAL_OUTPUT_CHUNKS = 1_024;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
@@ -88,12 +125,164 @@ function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
   return textDecoder.decode(encoded.subarray(start));
 }
 
+function splitOutputChunks(
+  data: string,
+  firstChunkId: number,
+  maxChunkBytes = DEFAULT_TERMINAL_CHUNK_BYTES,
+): {
+  readonly chunks: ReadonlyArray<TerminalOutputChunk>;
+  readonly latestChunkId: number;
+  readonly byteLength: number;
+} {
+  if (data.length === 0) {
+    return { chunks: [], latestChunkId: firstChunkId - 1, byteLength: 0 };
+  }
+
+  const encoded = textEncoder.encode(data);
+  const chunks: TerminalOutputChunk[] = [];
+  let offset = 0;
+  let nextChunkId = firstChunkId;
+  while (offset < encoded.byteLength) {
+    let end = Math.min(offset + maxChunkBytes, encoded.byteLength);
+    while (end < encoded.byteLength && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+      end -= 1;
+    }
+    if (end === offset) {
+      end = Math.min(offset + maxChunkBytes, encoded.byteLength);
+      while (end < encoded.byteLength && ((encoded[end] ?? 0) & 0xc0) === 0x80) {
+        end += 1;
+      }
+    }
+    const bytes = encoded.subarray(offset, end);
+    chunks.push({
+      id: nextChunkId,
+      data: textDecoder.decode(bytes),
+      byteLength: bytes.byteLength,
+    });
+    nextChunkId += 1;
+    offset = end;
+  }
+
+  return {
+    chunks,
+    latestChunkId: nextChunkId - 1,
+    byteLength: encoded.byteLength,
+  };
+}
+
+function appendOutput(
+  current: TerminalOutputState,
+  data: string,
+  maxBufferBytes: number,
+): TerminalOutputState {
+  const appended = splitOutputChunks(
+    data,
+    current.latestChunkId + 1,
+    Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
+  );
+  if (appended.chunks.length === 0) return current;
+  if (maxBufferBytes <= 0) {
+    return {
+      chunks: [],
+      retainedBytes: 0,
+      resetVersion: current.resetVersion + 1,
+      latestChunkId: appended.latestChunkId,
+    };
+  }
+
+  const chunks = [...current.chunks, ...appended.chunks];
+  let retainedBytes = current.retainedBytes + appended.byteLength;
+  let firstRetainedIndex = 0;
+  while (retainedBytes > maxBufferBytes && firstRetainedIndex < chunks.length) {
+    retainedBytes -= chunks[firstRetainedIndex]?.byteLength ?? 0;
+    firstRetainedIndex += 1;
+  }
+
+  const retainedChunks = firstRetainedIndex === 0 ? chunks : chunks.slice(firstRetainedIndex);
+  if (retainedChunks.length === 0) {
+    return {
+      chunks: [],
+      retainedBytes: 0,
+      resetVersion: current.resetVersion + 1,
+      latestChunkId: appended.latestChunkId,
+    };
+  }
+  if (retainedChunks.length > MAX_TERMINAL_OUTPUT_CHUNKS) {
+    return resetOutput(
+      {
+        ...current,
+        latestChunkId: appended.latestChunkId,
+      },
+      retainedChunks.map((chunk) => chunk.data).join(""),
+      maxBufferBytes,
+    );
+  }
+
+  return {
+    chunks: retainedChunks,
+    retainedBytes,
+    resetVersion: current.resetVersion,
+    latestChunkId: appended.latestChunkId,
+  };
+}
+
+function resetOutput(
+  current: TerminalOutputState,
+  data: string,
+  maxBufferBytes: number,
+): TerminalOutputState {
+  const retained = trimBufferToBytes(data, maxBufferBytes);
+  const reset = splitOutputChunks(
+    retained,
+    current.latestChunkId + 1,
+    Math.min(DEFAULT_TERMINAL_CHUNK_BYTES, Math.max(1, maxBufferBytes)),
+  );
+  return {
+    chunks: reset.chunks,
+    retainedBytes: reset.byteLength,
+    resetVersion: current.resetVersion + 1,
+    latestChunkId: reset.latestChunkId,
+  };
+}
+
+export function terminalOutputText(output: TerminalOutputState): string {
+  return output.chunks.map((chunk) => chunk.data).join("");
+}
+
+export function readTerminalOutputUpdate(
+  output: TerminalOutputState,
+  cursor: TerminalOutputCursor,
+): TerminalOutputUpdate {
+  const nextCursor = {
+    resetVersion: output.resetVersion,
+    lastChunkId: output.latestChunkId,
+  };
+  const firstChunk = output.chunks[0];
+  if (
+    cursor.resetVersion !== output.resetVersion ||
+    (firstChunk !== undefined && firstChunk.id > cursor.lastChunkId + 1)
+  ) {
+    return { type: "reset", data: terminalOutputText(output), cursor: nextCursor };
+  }
+
+  const appended = output.chunks.filter((chunk) => chunk.id > cursor.lastChunkId);
+  if (appended.length === 0) {
+    return { type: "none", cursor: nextCursor };
+  }
+  return {
+    type: "append",
+    data: appended.map((chunk) => chunk.data).join(""),
+    cursor: nextCursor,
+  };
+}
+
 export function terminalBufferStateFromSnapshot(
   snapshot: TerminalSessionSnapshot,
   maxBufferBytes: number,
+  currentOutput: TerminalOutputState = EMPTY_TERMINAL_BUFFER_STATE.output,
 ): TerminalBufferState {
   return {
-    buffer: trimBufferToBytes(snapshot.history, maxBufferBytes),
+    output: resetOutput(currentOutput, snapshot.history, maxBufferBytes),
     status: snapshot.status,
     error: null,
     updatedAt: snapshot.updatedAt,
@@ -113,7 +302,7 @@ export function combineTerminalSessionState(
 ): TerminalSessionState {
   return {
     summary,
-    buffer: buffer.buffer,
+    output: buffer.output,
     status: buffer.version > 0 ? buffer.status : (summary?.status ?? buffer.status),
     error: buffer.error,
     hasRunningSubprocess: summary?.hasRunningSubprocess ?? false,
@@ -130,11 +319,11 @@ export function applyTerminalAttachStreamEvent(
   switch (event.type) {
     case "snapshot":
     case "restarted":
-      return terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes);
+      return terminalBufferStateFromSnapshot(event.snapshot, maxBufferBytes, current.output);
     case "output":
       return {
         ...current,
-        buffer: trimBufferToBytes(`${current.buffer}${event.data}`, maxBufferBytes),
+        output: appendOutput(current.output, event.data, maxBufferBytes),
         status: current.status === "closed" ? "running" : current.status,
         error: null,
         version: current.version + 1,
@@ -142,7 +331,7 @@ export function applyTerminalAttachStreamEvent(
     case "cleared":
       return {
         ...current,
-        buffer: "",
+        output: resetOutput(current.output, "", maxBufferBytes),
         error: null,
         version: current.version + 1,
       };

--- a/packages/client-runtime/src/state/terminalSession.ts
+++ b/packages/client-runtime/src/state/terminalSession.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_TERMINAL_REPLAY_BYTES,
   type EnvironmentId,
   type TerminalAttachStreamEvent,
   type TerminalMetadataStreamEvent,
@@ -105,11 +104,18 @@ export const EMPTY_TERMINAL_SESSION_STATE = Object.freeze<TerminalSessionState>(
   version: 0,
 });
 
-export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = DEFAULT_TERMINAL_REPLAY_BYTES;
+// Retention needs enough headroom for the renderer to consume several adjacent
+// 64 KB server batches without falling behind and resetting its scrollback.
+export const DEFAULT_MAX_TERMINAL_BUFFER_BYTES = 512 * 1024;
 const DEFAULT_TERMINAL_CHUNK_BYTES = 16 * 1024;
 const MAX_TERMINAL_OUTPUT_CHUNKS = 1_024;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+
+/** Keep attach replay size and live client retention as separate budgets. */
+export function terminalOutputRetentionBytes(replayBytes?: number): number {
+  return Math.max(DEFAULT_MAX_TERMINAL_BUFFER_BYTES, replayBytes ?? 0);
+}
 
 function trimBufferToBytes(buffer: string, maxBufferBytes: number): string {
   if (maxBufferBytes <= 0) {

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -7,6 +7,7 @@ import {
   EXTENDED_TERMINAL_REPLAY_BYTES,
   MAX_TERMINAL_REPLAY_BYTES,
   TerminalAttachInput,
+  TerminalAttachStreamEvent,
   TerminalClearInput,
   TerminalCloseInput,
   TerminalEvent,
@@ -147,6 +148,19 @@ describe("TerminalAttachInput", () => {
         replayBytes: MAX_TERMINAL_REPLAY_BYTES + 1,
       }),
     ).toBe(false);
+  });
+});
+
+describe("TerminalAttachStreamEvent", () => {
+  it("accepts an ordered replay completion marker", () => {
+    expect(
+      decodes(TerminalAttachStreamEvent, {
+        type: "replay-complete",
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        sequence: 42,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -152,7 +152,15 @@ describe("TerminalAttachInput", () => {
 });
 
 describe("TerminalAttachStreamEvent", () => {
-  it("accepts an ordered replay completion marker", () => {
+  it("accepts ordered replay boundary markers", () => {
+    expect(
+      decodes(TerminalAttachStreamEvent, {
+        type: "replay-start",
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        sequence: 42,
+      }),
+    ).toBe(true);
     expect(
       decodes(TerminalAttachStreamEvent, {
         type: "replay-complete",

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   DEFAULT_TERMINAL_ID,
+  DEFAULT_TERMINAL_REPLAY_BYTES,
+  EXTENDED_TERMINAL_REPLAY_BYTES,
+  MAX_TERMINAL_REPLAY_BYTES,
   TerminalAttachInput,
   TerminalClearInput,
   TerminalCloseInput,
@@ -120,6 +123,30 @@ describe("TerminalAttachInput", () => {
     });
 
     expect(parsed.restartIfNotRunning).toBe(true);
+  });
+
+  it("bounds requested replay history", () => {
+    const parsed = decodeSync(TerminalAttachInput, {
+      threadId: "thread-1",
+      terminalId: DEFAULT_TERMINAL_ID,
+      replayBytes: EXTENDED_TERMINAL_REPLAY_BYTES,
+    });
+
+    expect(parsed.replayBytes).toBe(EXTENDED_TERMINAL_REPLAY_BYTES);
+    expect(
+      decodes(TerminalAttachInput, {
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        replayBytes: DEFAULT_TERMINAL_REPLAY_BYTES - 1,
+      }),
+    ).toBe(false);
+    expect(
+      decodes(TerminalAttachInput, {
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        replayBytes: MAX_TERMINAL_REPLAY_BYTES + 1,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -234,8 +234,14 @@ const TerminalAttachSnapshotEvent = Schema.Struct({
   snapshot: TerminalSessionSnapshot,
 });
 
+const TerminalReplayCompleteEvent = Schema.Struct({
+  ...TerminalEventBaseSchema.fields,
+  type: Schema.Literal("replay-complete"),
+});
+
 export const TerminalAttachStreamEvent = Schema.Union([
   TerminalAttachSnapshotEvent,
+  TerminalReplayCompleteEvent,
   TerminalOutputEvent,
   TerminalExitedEvent,
   TerminalClosedEvent,

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -234,12 +234,18 @@ const TerminalAttachSnapshotEvent = Schema.Struct({
   snapshot: TerminalSessionSnapshot,
 });
 
+const TerminalReplayStartEvent = Schema.Struct({
+  ...TerminalEventBaseSchema.fields,
+  type: Schema.Literal("replay-start"),
+});
+
 const TerminalReplayCompleteEvent = Schema.Struct({
   ...TerminalEventBaseSchema.fields,
   type: Schema.Literal("replay-complete"),
 });
 
 export const TerminalAttachStreamEvent = Schema.Union([
+  TerminalReplayStartEvent,
   TerminalAttachSnapshotEvent,
   TerminalReplayCompleteEvent,
   TerminalOutputEvent,

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -8,6 +8,15 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
  */
 export const DEFAULT_TERMINAL_ID = "term-1";
 
+/** Maximum terminal output replayed when a client attaches or resynchronizes. */
+export const DEFAULT_TERMINAL_REPLAY_BYTES = 64 * 1024;
+
+/** Deeper attach replay requested by clients that can consume output incrementally. */
+export const EXTENDED_TERMINAL_REPLAY_BYTES = 4 * 1024 * 1024;
+
+/** Upper bound accepted from a client for one terminal attach replay. */
+export const MAX_TERMINAL_REPLAY_BYTES = 8 * 1024 * 1024;
+
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const TerminalColsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)).check(
   Schema.isLessThanOrEqualTo(1000),
@@ -54,6 +63,11 @@ export const TerminalAttachInput = Schema.Struct({
   rows: Schema.optional(TerminalRowsSchema),
   env: Schema.optional(TerminalEnvSchema),
   restartIfNotRunning: Schema.optional(Schema.Boolean),
+  replayBytes: Schema.optional(
+    Schema.Int.check(Schema.isGreaterThanOrEqualTo(DEFAULT_TERMINAL_REPLAY_BYTES)).check(
+      Schema.isLessThanOrEqualTo(MAX_TERMINAL_REPLAY_BYTES),
+    ),
+  ),
 });
 export type TerminalAttachInput = Schema.Codec.Encoded<typeof TerminalAttachInput>;
 


### PR DESCRIPTION
Large terminal sessions repeatedly rebuilt retained output in server and client memory, rewrote growing log files, and could leave slow remote subscribers with unbounded queued deltas. The small attach snapshot limited scrollback, reopening a shell could redraw its prompt through an unchanged PTY resize, and full-screen apps such as `btop` visibly tore because synchronized updates were painted between PTY chunks.

This makes terminal output a bounded stream end to end:

- coalesces PTY output for up to 8 ms or 64 KB, caps the server pre-drain backlog at 4 MB, and pauses/resumes `node-pty` around a 2 MB low-water mark
- appends durable history with an 8 MB target / 12 MB ceiling
- starts web attaches with 64 KB, then requests and progressively renders up to 4 MB when the user reaches the top
- restores the top-of-scrollback viewport after deep replay and resets renderer cursors when attach identity or replay budget changes
- bounds each live subscriber to 32 events and resynchronizes a stalled client from the latest recent snapshot
- retains byte-counted chunks with replay/live provenance in shared client state and sends ordered append/reset/replay-append commands to native mobile renderers, even when replay completion and live output reduce in one render
- buffers typed native writes until surfaces mount, suppresses PTY replies for every streamed replay chunk, and clears stale empty frames
- unmounts hidden web terminal renderers and ignores unchanged PTY resize requests
- drains queued large writes through a 64 KB per-frame budget, immediately full-drains at a 1 MB visible backlog, and uses a 100 ms fallback when browsers suspend animation frames
- separates the 64 KB initial replay request from a 512 KB live client-retention floor, while extended attaches retain their full requested history
- honors DEC synchronized-output mode 2026 in the web/desktop Ghostty renderer, with a 500 ms safety flush for interrupted sequences
- routes resize and device-pixel-ratio repaints through the same synchronized-output gate and defers backing-store changes until that paint, keeping the last complete frame visible instead of flashing a cleared canvas
- tracks the installed device-pixel ratio independently of backing dimensions, so DPR-only transitions still schedule the same atomic resize and repaint
- uses one integer logical-pixel cell grid for canvas rendering, libghostty resize, and mouse encoding; solid Unicode block elements are drawn to exact cell edges so TUI art stays seamless and click targets stay aligned
- highlights URLs, paths, and unambiguous source-position file names on Ctrl/Command hover without misclassifying `host:port` endpoints
- makes paste shortcut delivery first-wins across the async Clipboard API and native paste event, so a single gesture reaches the PTY once
- keeps the normal shell on the host light/dark theme while applying theme-derived dark defaults only during the standard alternate screen used by `btop`, vim, htop, less, tmux, and similar TUIs; source-to-target remapping preserves reverse video and leaves the primary screen plus explicit ANSI/OSC colors untouched
- preserves legacy `Ctrl+C` as ETX before Kitty keyboard mode and verifies `Ctrl+Right` word navigation through the real shell

Measured on this checkout:

- 1 MB client replay, 1 KB events: 729.01 ms to 15.41 ms, 47.3x faster
- 1 MB client replay, 16 KB events: 48.80 ms to 0.843 ms, 57.9x faster
- 1 MB server retention loop: 479.69 ms to 0.265 ms, 1,812x faster
- 128 KB PTY burst: 65 callbacks to 2 output events while preserving exact bytes, 32.5x fewer events
- persistence model: 5.50 MB to 1.00 MB written across ten equal flushes
- `btop -u 100` at 150x37: largest synchronized update was 32,507 bytes across roughly six raw PTY callbacks; the fixed renderer painted at a 99.4 ms median interval, matching the requested 100 ms application cadence
- authenticated 5 MB output flood: reducing the bounded immediate-drain threshold from 4 MB to 1 MB lowered the worst observed animation-frame gap from 216.6 ms to 66.7 ms; p95 remained about 33.3 ms
- warm document fetch after five warmups: 20.68 ms local median and 37.54 ms public-route median across 25 requests; these are route checks, not terminal-input RTT measurements

Verification:

- 221 focused tests across contracts, server, client runtime, web Ghostty/drawer behavior, and mobile terminal behavior before the final rebase
- 159 focused server/contracts/client-runtime/web tests after rebasing onto current main
- typechecks for contracts, client runtime, server, web, and mobile; server and web rerun after rebase
- targeted formatting, lint, and mobile native static checks
- authenticated web passes for 64 KB initial replay, 4 MB on-demand history, hidden-drawer reattach, one prompt after switching away and back, the double-prompt regression, and synchronized `btop` rendering
- 112 focused web tests, lint, and typecheck after the final rebase
- final review hardening: 68 server tests, 83 focused web tests, 5 mobile terminal tests, all package typechecks, native static checks, and targeted lint
- latest mobile review pass: 15 client-runtime tests, 5 focused mobile tests, client-runtime/web/mobile typechecks, and targeted lint; revision 1 uses standard snapshot plus reset/write streaming while revision 2 gates extended replay
- server backpressure test verified PTY pause/resume and exact ordered delivery at a tiny test high-water mark
- browser verification that an async-first plus native paste race writes one marker, and a later context-menu paste remains independent
- browser verification that a clipboard read completing after shortcut key-up does not suppress the next independent paste
- browser verification that light-mode shell → `btop -u 100` → light-mode shell and light-mode shell → vim → light-mode shell switch without breakup or residual dark rows
- browser verification that an empty reset while `btop` owns the alternate screen immediately restores the canvas and mount to `rgb(252,252,252)`
- browser verification that vim visual selection retains a true inverse region and terminal text selection remains visible (`rgb(70,70,70)` selected versus `rgb(13,13,13)` unselected), then exits to a fully light canvas and mount
- browser stress verification across 60 consecutive live-`btop` resize frames (817↔857 px): zero blank frames, stable visible-content density, and a fully light canvas after exit
- browser verification that OpenCode's Unicode block logo renders without cell seams and that an SGR mouse click 350 px into the surface reports column 50, exactly matching the visible 7 px cell grid plus 4 px padding
- focused verification that URL, repository-path, and bare `file:line:column` highlighting remains modifier-gated while hostname and IPv4 `host:port` endpoints stay unlinked

Visual verification:

| Before: quitting a full-screen app left dark rows | After: btop stays coherent at 10 Hz | After exit: the light shell is fully restored |
| --- | --- | --- |
| ![Before full-screen exit](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/0a8894f9-32c5-45ac-8aa9-3c339ff2a2e2/terminal-fullscreen-exit-before.png) | ![btop in light app mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/883e2a76-8943-41f3-9d25-6c5c0c46e8ae/terminal-btop-light-mode-after.png) | ![Light shell restored after exit](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/b1a65b84-10c7-4e24-be15-6016650e1666/terminal-fullscreen-exit-after.png) |

| Before: font side bearings split block art | After: exact cell geometry joins blocks cleanly |
| --- | --- |
| ![OpenCode block art before](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/d9c6043c-a5ce-4919-89b2-e69b38bf8024/terminal-opencode-before.png) | ![OpenCode block art after](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/401be094-abe0-4dd4-98be-19db25f52df2/terminal-opencode-after.png) |

The repository already uses the latest stable `node-pty` 1.1.0. The 1.2.0-beta.15 line remains prerelease and has a reported Windows regression where persistent PTYs can exit before their first write, so this PR does not take that native dependency risk. The newer Ghostty source needs regenerated WASM, iOS, and Android artifacts plus cross-platform ABI/performance testing, so that vendor refresh remains separate. iOS, Android, and Windows native runtime profiling still require their platform toolchains. Mobile benefits from the 64 KB event ceiling and existing display-frame coalescing, but its native Ghostty APIs do not yet expose mode 2026 for protocol-level gating of updates larger than 64 KB.

Authored by GPT-5.6 Sol with the Codex harness through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream terminal output and history with byte-based batching and backpressure
> - Replaces line-based terminal history with byte-based budgets (`historyTargetBytes`, `historyMaxBytes`, replay variants) and adds output coalescing, chunked persistence, and PTY pause/resume backpressure in `TerminalManager`.
> - Introduces explicit `replay-start` / `replay-complete` stream events and chunked replay delivery (≤64 KB chunks), with a new `readSnapshot` method for subscriber resync on backpressure overflow in [ws.ts](https://github.com/pingdotgg/t3code/pull/8564/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125).
> - Reworks client session state to store output as UTF-8-safe `TerminalOutputChunk` segments with retention budgets, incremental `readTerminalOutputUpdate` cursors, and replay/live delivery tags in [terminalSession.ts](https://github.com/pingdotgg/t3code/pull/8564/files#diff-c939205ce2272b9eb963a11eb634ba5d09e9525a249ac2c259ef8b5fda367828).
> - Updates web `TerminalViewport` and mobile `NativeTerminalSurface` to consume structured output via streaming commands (`write`, `writeReplay`, `reset`), with on-demand extended replay (4 MiB) when scrolling to top.
> - Adds Ghostty renderer support for block-element geometry, alternate-screen theme remapping, synchronized output mode (2026), and replay-safe writes that suppress PTY replies.
> - Risk: `TerminalManagerOptions` removes `historyLineLimit`; any caller passing that option will fail. The `attach` listener signature gains a required `delivery` parameter, and `TerminalAttachInput` now validates `replayBytes` within `[64 KiB, 8 MiB]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f459a54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes span PTY lifecycle, attach streaming protocol, durable history I/O, and native/mobile rendering paths—any ordering or backpressure bug can lose output, duplicate history, or break interactive shells.
> 
> **Overview**
> Terminal sessions stop passing one giant `buffer` string through attach, persistence, and native renderers. Output is retained and delivered as **byte-bounded chunks** with **replay vs live** provenance, and the server **coalesces PTY output**, **appends durable history**, and **pauses the PTY** when subscribers fall behind.
> 
> **Server:** `TerminalManager` replaces line caps with separate durable (≈8–12 MB) and client-replay budgets, batches output (~8 ms / 64 KB), bounds the pre-drain queue (4 MB) with optional `pauseOutput`/`resumeOutput`, and wraps attach in **`replay-start` → snapshot → chunked history → `replay-complete`** before live events. Extended attach can request larger replay via `replayBytes`; `attachStream` listeners get a **`delivery`** flag (`replay` | `live`), and slow WS clients get a fresh snapshot instead of an unbounded delta queue. Adds **`readSnapshot`** and ignores duplicate resizes.
> 
> **Clients:** Shared state moves from `terminal.buffer` to **`TerminalOutputState`** with `readTerminalOutputUpdate` driving incremental **`write` / `writeReplay` / `reset`** on mobile (revision-gated `streamingRevision`) and ordered replay-then-live rendering on web (`writeTerminalOutputSegments`, extended replay when scrolling to top). Native Ghostty scrollback limits switch from row counts to **64 MB** byte budgets; replay feeds suppress PTY query replies from echoing to the shell.
> 
> **UI polish:** Hidden web terminal drawers unmount instead of staying mounted; buffer replay during font changes becomes an explicit **`replayPaused`** flag; terminal link detection gains unambiguous `file:line:column` patterns without treating `host:port` as paths; alternate-screen theme CSS variables support full-screen TUIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f459a54315179d869c8e371718cadbeb80d21da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

