### PR TITLE
fix(server): allow large Azure DevOps PR lists

### DIFF
--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -97,6 +97,46 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("reads an Azure pull request page larger than the VCS default output limit", () =>
+    Effect.gen(function* () {
+      const rows = pullRequestRows(100, 1).map((row) => ({
+        ...row,
+        description: "x".repeat(10_000),
+      }));
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const response = JSON.stringify(rows);
+      expect(Buffer.byteLength(response)).toBeGreaterThan(1_000_000);
+
+      mockedExecute.mockImplementationOnce((input) => {
+        const maxOutputBytes =
+          "maxOutputBytes" in input && typeof input.maxOutputBytes === "number"
+            ? input.maxOutputBytes
+            : 1_000_000;
+        return Effect.succeed(
+          maxOutputBytes >= Buffer.byteLength(response)
+            ? output(response)
+            : {
+                ...output(response.slice(0, maxOutputBytes)),
+                stdoutTruncated: true,
+              },
+        );
+      });
+      const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "web",
+        state: "merged",
+        involvement: "all",
+        viewer: "bilal@acme.dev",
+        limit: 99,
+      });
+
+      assert.strictEqual(batch.items.length, 99);
+      assert.isTrue(batch.truncated);
+    }),
+  );
+
   it.effect("reads the page unnarrowed when asked to search, having nothing to search with", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(3, 1))));

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -111,6 +111,7 @@ export type AzureDevOpsPullRequestCliError =
 
 /** The version every REST call below is pinned to, so a new default cannot reshape a response. */
 const REST_API_VERSION = "7.1";
+const PULL_REQUEST_LIST_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 
 export class AzureDevOpsPullRequestCli extends Context.Service<
   AzureDevOpsPullRequestCli,
@@ -258,10 +259,15 @@ export const make = Effect.gen(function* () {
   // how to read all of them.
   const detectArgs = ["--detect", "true"] as const;
 
-  const executeJson = (input: { readonly cwd: string; readonly args: ReadonlyArray<string> }) =>
+  const executeJson = (input: {
+    readonly cwd: string;
+    readonly args: ReadonlyArray<string>;
+    readonly maxOutputBytes?: number;
+  }) =>
     azure.execute({
       cwd: input.cwd,
       args: [...input.args, "--only-show-errors", "--output", "json"],
+      ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
     });
 
   /**
@@ -290,6 +296,7 @@ export const make = Effect.gen(function* () {
     const top = remaining + 1;
     return executeJson({
       cwd: input.cwd,
+      maxOutputBytes: PULL_REQUEST_LIST_MAX_OUTPUT_BYTES,
       args: [
         "repos",
         "pr",

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -332,6 +332,28 @@ describe("AzureDevOpsCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("forwards explicit output limits to the process boundary", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      yield* az.execute({
+        cwd: "/repo",
+        args: ["repos", "pr", "list"],
+        maxOutputBytes: 16 * 1024 * 1024,
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        args: ["repos", "pr", "list"],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+        maxOutputBytes: 16 * 1024 * 1024,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("preserves VCS causes without copying upstream details into messages", () =>
     Effect.gen(function* () {
       const cause = new VcsProcessExitError({

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -218,6 +218,7 @@ export class AzureDevOpsCli extends Context.Service<
       readonly cwd: string;
       readonly args: ReadonlyArray<string>;
       readonly timeoutMs?: number;
+      readonly maxOutputBytes?: number;
     }) => Effect.Effect<VcsProcess.VcsProcessOutput, AzureDevOpsCliError>;
 
     readonly listPullRequests: (input: {
@@ -362,6 +363,7 @@ export const make = Effect.gen(function* () {
         args: input.args,
         cwd: input.cwd,
         timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        ...(input.maxOutputBytes === undefined ? {} : { maxOutputBytes: input.maxOutputBytes }),
       })
       .pipe(
         Effect.mapError((error) =>


### PR DESCRIPTION
## What Changed

- Allow the paginated Azure DevOps pull request list command to collect up to 16 MiB of output.
- Add regression coverage for a valid 100-row response above the shared 1 MB VCS limit and for output-limit propagation.

## Why

The default 100-row Azure DevOps response can exceed the generic VCS output cap. The process runner then truncates valid JSON, the decoder rejects it, and the repository appears unavailable. The larger allowance applies only to this bounded list command.

Fixes #8077.

## Testing

- 42 focused Azure DevOps CLI and pull request tests
- Server package typecheck
- Targeted lint and format checks

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Generated by gpt-daybreak-blue-latest with xhigh reasoning via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Azure CLI list pagination with an explicit output cap; no auth or data-model changes.
> 
> **Overview**
> Fixes Azure DevOps pull request listing when a single `az repos pr list` page is larger than the shared **1 MiB** VCS stdout cap. Truncated JSON was failing decode and making repos look unavailable.
> 
> **`AzureDevOpsCli.execute`** now accepts optional **`maxOutputBytes`** and passes it through to **`VcsProcess.run`**. **`AzureDevOpsPullRequestCli`** uses that only for paginated list calls, with a **16 MiB** ceiling (`PULL_REQUEST_LIST_MAX_OUTPUT_BYTES`).
> 
> New tests cover a **>1 MiB** 100-row list (mock respects the limit) and that **`maxOutputBytes`** reaches the process layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d46c7c6d669f0304cc80e4c821973d4e3f15498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `maxOutputBytes` to 16 MiB for Azure DevOps PR listing
> - Adds `PULL_REQUEST_LIST_MAX_OUTPUT_BYTES` constant (16 MiB) and passes it through `executeJson` → `AzureDevOps.Service.execute` → `VcsProcess.run` when listing pull requests.
> - Previously, `az repos pr list` output was capped at the default process boundary limit, causing large PR pages to be truncated and fewer results returned.
> - Risk: callers of `AzureDevOps.Service.execute` that omit `maxOutputBytes` are unaffected; only the PR listing path uses the new limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d46c7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure DevOps pull request listing for responses larger than the default output limit.
  * Large pull request results are now capped safely while accurately indicating when results were truncated.
  * Increased reliability when processing pull requests with lengthy descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->