### PR TITLE
fix(mobile): show OpenCode model sources in picker

### DIFF
--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -93,7 +93,7 @@ function ModelRow(props: {
 }) {
   return (
     <Pressable
-      accessibilityLabel={props.option.label}
+      accessibilityLabel={[props.option.label, props.option.subtitle].filter(Boolean).join(", ")}
       accessibilityRole="radio"
       accessibilityState={{ checked: props.selected }}
       onPress={props.onPress}
@@ -103,20 +103,31 @@ function ModelRow(props: {
         props.isLast ? "rounded-b-2xl" : "border-b border-border-subtle",
       )}
     >
-      <Text className="min-w-0 shrink text-base font-t3-medium text-foreground" numberOfLines={1}>
-        {props.option.label}
-      </Text>
-      {props.option.isDefault ? (
-        <View className="rounded-md bg-subtle-strong px-1.5 py-0.5">
-          <Text className="text-3xs font-t3-bold text-foreground-muted">Default</Text>
+      <View className="min-w-0 flex-1">
+        <View className="flex-row items-center gap-2">
+          <Text
+            className="min-w-0 shrink text-base font-t3-medium text-foreground"
+            numberOfLines={1}
+          >
+            {props.option.label}
+          </Text>
+          {props.option.isDefault ? (
+            <View className="rounded-md bg-subtle-strong px-1.5 py-0.5">
+              <Text className="text-3xs font-t3-bold text-foreground-muted">Default</Text>
+            </View>
+          ) : null}
+          {props.option.isLegacy ? (
+            <View className="rounded-md bg-subtle px-1.5 py-0.5">
+              <Text className="text-3xs font-t3-bold text-foreground-muted">Legacy</Text>
+            </View>
+          ) : null}
         </View>
-      ) : null}
-      {props.option.isLegacy ? (
-        <View className="rounded-md bg-subtle px-1.5 py-0.5">
-          <Text className="text-3xs font-t3-bold text-foreground-muted">Legacy</Text>
-        </View>
-      ) : null}
-      <View className="flex-1" />
+        {props.option.subtitle ? (
+          <Text className="text-xs text-foreground-muted" numberOfLines={1}>
+            {props.option.subtitle}
+          </Text>
+        ) : null}
+      </View>
       {props.selected ? (
         <SymbolView
           name="checkmark"

--- a/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-sheet-state.test.ts
@@ -12,7 +12,7 @@ function modelOption(
   return {
     key: `codex:${model}`,
     label: model,
-    subtitle: "Codex",
+    subtitle: "",
     providerKey: "codex",
     providerLabel: "Codex",
     providerDriver: "codex",
@@ -46,6 +46,21 @@ describe("thread settings sheet state", () => {
         query: "   ",
       }),
     ).toBe(true);
+  });
+
+  it("matches the upstream provider's display name", () => {
+    const model = {
+      ...modelOption("opencode/claude-fable-5"),
+      label: "Claude Fable 5",
+      subtitle: "OpenCode Zen",
+    };
+
+    expect(modelMatchesCatalogQuery({ model, providerLabel: "OpenCode", query: " ZEN " })).toBe(
+      true,
+    );
+    expect(modelMatchesCatalogQuery({ model, providerLabel: "OpenCode", query: "copilot" })).toBe(
+      false,
+    );
   });
 
   it("clears staging when the applied model is pressed", () => {

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -44,10 +44,59 @@ describe("mobile model options", () => {
         providerKey: "codex",
         providerLabel: "Codex",
         models: [
-          { key: "codex:gpt-5.6-sol", label: "GPT-5.6 Sol", isLegacy: false },
+          { key: "codex:gpt-5.6-sol", label: "GPT-5.6 Sol", subtitle: "", isLegacy: false },
           { key: "codex:gpt-5.4", label: "GPT-5.4", isLegacy: true },
         ],
       },
+    ]);
+  });
+
+  it("distinguishes same-name OpenCode models without changing their routing", () => {
+    const sources = [
+      { id: "anthropic", label: "Anthropic" },
+      { id: "github-copilot", label: "GitHub Copilot" },
+      { id: "opencode", label: "OpenCode Zen" },
+    ];
+    const config = {
+      providers: [
+        {
+          instanceId: "opencode_work",
+          driver: "opencode",
+          displayName: "OpenCode Work",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          models: sources.map((source) => ({
+            slug: `${source.id}/claude-fable-5`,
+            name: "Claude Fable 5",
+            subProvider: source.label,
+            isCustom: false,
+            capabilities: null,
+          })),
+        },
+      ],
+    } as unknown as ServerConfig;
+    const selection = {
+      instanceId: ProviderInstanceId.make("opencode_work"),
+      model: "github-copilot/claude-fable-5",
+    };
+
+    const options = buildModelOptions(config, selection);
+
+    expect(options).toMatchObject(
+      sources.map((source) => ({
+        key: `opencode_work:${source.id}/claude-fable-5`,
+        label: "Claude Fable 5",
+        subtitle: source.label,
+        providerLabel: "OpenCode Work",
+        selection: {
+          instanceId: "opencode_work",
+          model: `${source.id}/claude-fable-5`,
+        },
+      })),
+    );
+    expect(groupByProvider(options)).toEqual([
+      { providerKey: "opencode_work", providerLabel: "OpenCode Work", models: options },
     ]);
   });
 

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -121,7 +121,7 @@ export function buildModelOptions(
       options.set(key, {
         key,
         label: model.name,
-        subtitle: providerLabel,
+        subtitle: model.subProvider ?? "",
         providerKey: provider.instanceId,
         providerLabel,
         providerDriver: provider.driver,
@@ -152,7 +152,7 @@ export function buildModelOptions(
       options.set(key, {
         key,
         label: fallbackModelSelection.model,
-        subtitle: providerLabel,
+        subtitle: "",
         providerKey: fallbackModelSelection.instanceId,
         providerLabel,
         providerDriver: fallbackModelSelection.instanceId,

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -10,6 +10,10 @@ becomes available after every upload finishes. Failed uploads can be retried or 
 On web and desktop, HEIC and HEIF photos are automatically converted to JPEG when you drag them into
 the composer or paste them into a message.
 
+On mobile, the model picker shows each OpenCode model's upstream provider, such as Anthropic,
+GitHub Copilot, or OpenCode Zen, beneath its name. Search by that provider name to narrow the list
+when starting a thread or changing an existing thread's model.
+
 ## Commands and skills
 
 Type `/` to open the command menu. Type `$` to find and add a skill. Skill rows show their source,


### PR DESCRIPTION
OpenCode can expose the same model through Anthropic, GitHub Copilot, and OpenCode Zen. Mobile discarded the upstream provider name, so those models appeared as identical rows and searches such as “Zen” returned nothing. [Reported here](https://x.com/idontfinishanyt/status/2093128024833077333).

Keep the existing catalog's `subProvider` as the row subtitle and include it in the accessibility label. The shared picker now shows and searches that source in both new-thread drafts and existing threads. Models without a source keep their compact rows; provider instance IDs, model IDs, and the wire format are unchanged. Web and desktop already display this metadata.

Verified on iPhone 17 Pro / iOS 27 with a local T3 server and a fixture OpenCode inventory (no model requests sent): source search, selection, Save, Cancel, and reopening both pickers. Checked the persisted drafts retain the exact Copilot and Zen model IDs. The UI is shared with Android; Android was not run.

- 11 focused model-option and picker-state tests pass.
- Mobile typecheck, targeted lint, formatting, and diff checks pass.

| Before | After |
| --- | --- |
| <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/979f72ef10fcfa89/before.png" width="300" alt="Duplicate model names with no upstream provider" /> | <img src="https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/85ce29abdd62ef8e/after.png" width="300" alt="Model names labeled with Anthropic, GitHub Copilot, or OpenCode Zen" /> |

Before interactions: identical rows and an unsuccessful Zen search (15 seconds).

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7fe39ca413bb7e49/before.mp4

After, existing thread: search Copilot, save, reopen, then cancel a different source (31 seconds).

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5e3935d48f1eba3a/after-switch-save-cancel.mp4

After, new thread: open the picker, search Zen, save, and reopen with Zen selected (31 seconds).

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3d2e91fa86325a88/after-new-thread.mp4


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and search metadata only; model selection IDs and routing are unchanged.
> 
> **Overview**
> Fixes duplicate-looking OpenCode rows on mobile by using each catalog model's **`subProvider`** (e.g. Anthropic, GitHub Copilot, OpenCode Zen) as the picker **subtitle** instead of the OpenCode provider instance name. Models without a source keep an empty subtitle and the same compact row layout.
> 
> **`ModelRow`** in the thread settings sheet shows that subtitle under the model name and folds it into the accessibility label. Catalog search already matches `subtitle`, so queries like "Zen" or "Copilot" now filter correctly when starting or editing a thread.
> 
> Model keys, instance IDs, and selection routing are unchanged. User docs for the composer note the mobile picker behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533b55db01ca8d2736ce9c22e04d98317f1dfc8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show OpenCode model upstream provider as subtitle in mobile model picker
> - `buildModelOptions` in [modelOptions.ts](https://github.com/pingdotgg/t3code/pull/8573/files#diff-e728e5b82529c8d8d8ae7017fbd0ee4021eea3e722dc156b9f3b209951cc7dea) sets `ModelOption.subtitle` from the model's `subProvider` field instead of the provider display label; subtitle is empty when no subProvider exists
> - `ModelRow` in [ThreadSettingsSheet.tsx](https://github.com/pingdotgg/t3code/pull/8573/files#diff-c7889046e38baae09b395b2fe1b43d588c686f9827763c7b5ff624f88481d6ea) renders the subtitle beneath the model name and includes it in the accessibility label
> - Catalog search now matches on the upstream provider name shown in the subtitle, so users can filter models by source provider on mobile
> - Risk: standard Codex model options now have an empty subtitle instead of the provider label; any code or tests that relied on `ModelOption.subtitle` containing the provider name will need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 533b55d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->