### PR TITLE
fix(server): keep Codex auth-like shadow entries private

### DIFF
--- a/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
@@ -10,10 +10,21 @@ import { CodexSettings } from "@t3tools/contracts";
 import {
   CodexShadowHomeEntryConflictError,
   CodexShadowHomePathConflictError,
+  CodexShadowHomePrivateEntrySymlinkError,
+  classifyCodexShadowHomeEntry,
   materializeCodexShadowHome,
   resolveCodexHomeLayout,
 } from "./CodexHomeLayout.ts";
 const decodeCodexSettingsValue = Schema.decodeSync(CodexSettings);
+
+const AUTH_LIKE_ENTRY_NAMES = [
+  "auth.json",
+  "auth-fixture-a.json",
+  "auth-fixture-b.json",
+  "auth-fixture-c.json",
+  "auth.json.bak",
+  "auth_fixture_d.json",
+] as const;
 
 const decodeCodexSettings = (input: {
   readonly enabled?: boolean;
@@ -39,6 +50,22 @@ const writeTextFile = Effect.fn("CodexHomeLayout.test.writeTextFile")(function* 
 });
 
 it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
+  describe("classifyCodexShadowHomeEntry", () => {
+    it("fails closed for auth-like names without matching normal shared names", () => {
+      for (const entryName of AUTH_LIKE_ENTRY_NAMES) {
+        expect(classifyCodexShadowHomeEntry(entryName)).toBe("credential-private");
+      }
+      expect(classifyCodexShadowHomeEntry("AUTH-FIXTURE-E.JSON")).toBe("credential-private");
+      expect(classifyCodexShadowHomeEntry("author.json")).toBe("shared");
+      expect(classifyCodexShadowHomeEntry("sessions")).toBe("shared");
+      expect(classifyCodexShadowHomeEntry("config.toml")).toBe("shared");
+      expect(classifyCodexShadowHomeEntry("skills")).toBe("shared");
+      expect(classifyCodexShadowHomeEntry("cache")).toBe("shared");
+      expect(classifyCodexShadowHomeEntry("models_cache.json")).toBe("private");
+      expect(classifyCodexShadowHomeEntry("memories")).toBe("shadow-local");
+    });
+  });
+
   describe("resolveCodexHomeLayout", () => {
     it.effect("uses direct CODEX_HOME when no shadow home is configured", () =>
       Effect.gen(function* () {
@@ -84,7 +111,7 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
   });
 
   describe("materializeCodexShadowHome", () => {
-    it.effect("materializes a shadow home with shared state links and private auth", () =>
+    it.effect("keeps auth-like files private while sharing normal Codex state", () =>
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
@@ -93,11 +120,16 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
         const shadowHome = path.join(shadowRoot, "shadow");
 
         yield* fileSystem.makeDirectory(path.join(sharedHome, "sessions"));
+        yield* writeTextFile(path.join(sharedHome, "skills", "fixture", "SKILL.md"), "fixture\n");
+        yield* writeTextFile(path.join(sharedHome, "cache", "fixture.json"), "{}\n");
         yield* writeTextFile(path.join(sharedHome, "config.toml"), 'model = "gpt-5-codex"\n');
         yield* writeTextFile(path.join(sharedHome, "models_cache.json"), '{"models":["shared"]}\n');
-        yield* writeTextFile(path.join(sharedHome, "auth.json"), '{"shared":true}\n');
+        yield* writeTextFile(path.join(sharedHome, "author.json"), '{"kind":"fixture"}\n');
         yield* fileSystem.makeDirectory(shadowHome, { recursive: true });
-        yield* writeTextFile(path.join(shadowHome, "auth.json"), '{"shadow":true}\n');
+        for (const entryName of AUTH_LIKE_ENTRY_NAMES) {
+          yield* writeTextFile(path.join(sharedHome, entryName), '{"scope":"shared-fixture"}\n');
+          yield* writeTextFile(path.join(shadowHome, entryName), '{"scope":"shadow-fixture"}\n');
+        }
         yield* fileSystem.symlink(
           path.join(sharedHome, "models_cache.json"),
           path.join(shadowHome, "models_cache.json"),
@@ -114,23 +146,65 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
 
         const sessionsTarget = yield* fileSystem.readLink(path.join(shadowHome, "sessions"));
         const configTarget = yield* fileSystem.readLink(path.join(shadowHome, "config.toml"));
+        const skillsTarget = yield* fileSystem.readLink(path.join(shadowHome, "skills"));
+        const cacheTarget = yield* fileSystem.readLink(path.join(shadowHome, "cache"));
+        const authorTarget = yield* fileSystem.readLink(path.join(shadowHome, "author.json"));
         const mcpOauthLocksTarget = yield* fileSystem.readLink(
           path.join(shadowHome, "mcp-oauth-locks"),
         );
         const modelsCacheExists = yield* fileSystem.exists(
           path.join(shadowHome, "models_cache.json"),
         );
-        const authLinkResult = yield* fileSystem
-          .readLink(path.join(shadowHome, "auth.json"))
-          .pipe(Effect.result);
-        const authContents = yield* fileSystem.readFileString(path.join(shadowHome, "auth.json"));
 
         expect(sessionsTarget).toBe(path.join(sharedHome, "sessions"));
         expect(configTarget).toBe(path.join(sharedHome, "config.toml"));
+        expect(skillsTarget).toBe(path.join(sharedHome, "skills"));
+        expect(cacheTarget).toBe(path.join(sharedHome, "cache"));
+        expect(authorTarget).toBe(path.join(sharedHome, "author.json"));
         expect(mcpOauthLocksTarget).toBe(path.join(sharedHome, "mcp-oauth-locks"));
         expect(modelsCacheExists).toBe(false);
-        expect(authLinkResult._tag).toBe("Failure");
-        expect(authContents).toContain("shadow");
+        for (const entryName of AUTH_LIKE_ENTRY_NAMES) {
+          const authLinkResult = yield* fileSystem
+            .readLink(path.join(shadowHome, entryName))
+            .pipe(Effect.result);
+          const authContents = yield* fileSystem.readFileString(path.join(shadowHome, entryName));
+          expect(authLinkResult._tag).toBe("Failure");
+          expect(authContents).toContain("shadow-fixture");
+        }
+      }),
+    );
+
+    it.effect("rejects an auth-like entry that is already a shadow-home symlink", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const sharedHome = yield* makeTempDir("t3code-codex-shared-");
+        const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
+        const shadowHome = path.join(shadowRoot, "shadow");
+        const entryName = "auth-fixture-a.json";
+        const sharedAuthPath = path.join(sharedHome, entryName);
+        const shadowAuthPath = path.join(shadowHome, entryName);
+
+        yield* writeTextFile(sharedAuthPath, '{"scope":"shared-fixture"}\n');
+        yield* fileSystem.makeDirectory(shadowHome, { recursive: true });
+        yield* fileSystem.symlink(sharedAuthPath, shadowAuthPath);
+
+        const layout = yield* resolveCodexHomeLayout(
+          decodeCodexSettings({
+            homePath: sharedHome,
+            shadowHomePath: shadowHome,
+          }),
+        );
+
+        const error = yield* materializeCodexShadowHome(layout).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(CodexShadowHomePrivateEntrySymlinkError);
+        expect(error).toMatchObject({
+          sharedHomePath: sharedHome,
+          effectiveHomePath: shadowHome,
+          entryName,
+          path: shadowAuthPath,
+        });
       }),
     );
 

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.ts
@@ -29,9 +29,22 @@ const KNOWN_SHARED_DIRECTORIES = [
   "mcp-oauth-locks",
 ] as const;
 
-const PRIVATE_ENTRY_NAMES = new Set(["auth.json", "models_cache.json"]);
+const ALWAYS_PRIVATE_ENTRY_NAMES = new Set(["models_cache.json"]);
 const SHADOW_LOCAL_ENTRY_NAMES = new Set(["log", "memories", "tmp"]);
 const REPLACEABLE_SHARED_RUNTIME_DIRECTORIES = new Set(["mcp-oauth-locks"]);
+
+export type CodexShadowHomeEntryDisposition =
+  | "credential-private"
+  | "private"
+  | "shadow-local"
+  | "shared";
+
+export function classifyCodexShadowHomeEntry(entryName: string): CodexShadowHomeEntryDisposition {
+  if (/^auth(?:$|[._-])/i.test(entryName)) return "credential-private";
+  if (ALWAYS_PRIVATE_ENTRY_NAMES.has(entryName)) return "private";
+  if (SHADOW_LOCAL_ENTRY_NAMES.has(entryName)) return "shadow-local";
+  return "shared";
+}
 
 function resolveHomePath(path: Path.Path, value: string | undefined): string {
   const expanded =
@@ -292,30 +305,29 @@ const ensureSymlink = Effect.fn("CodexHomeLayout.ensureSymlink")(function* (inpu
   }
 });
 
-const ensureShadowAuthIsPrivate = Effect.fn("CodexHomeLayout.ensureShadowAuthIsPrivate")(
-  function* (input: {
-    readonly fileSystem: FileSystem.FileSystem;
-    readonly sharedHomePath: string;
-    readonly effectiveHomePath: string;
-  }): Effect.fn.Return<void, CodexShadowHomeError, Path.Path> {
-    const path = yield* Path.Path;
-    const entryName = "auth.json";
-    const authPath = path.join(input.effectiveHomePath, entryName);
-    const state = yield* readLinkState({
-      ...input,
-      entryName,
-      linkPath: authPath,
+const ensureShadowCredentialIsPrivate = Effect.fn(
+  "CodexHomeLayout.ensureShadowCredentialIsPrivate",
+)(function* (input: {
+  readonly fileSystem: FileSystem.FileSystem;
+  readonly sharedHomePath: string;
+  readonly effectiveHomePath: string;
+  readonly entryName: string;
+}): Effect.fn.Return<void, CodexShadowHomeError, Path.Path> {
+  const path = yield* Path.Path;
+  const credentialPath = path.join(input.effectiveHomePath, input.entryName);
+  const state = yield* readLinkState({
+    ...input,
+    linkPath: credentialPath,
+  });
+  if (state._tag === "Symlink") {
+    return yield* new CodexShadowHomePrivateEntrySymlinkError({
+      sharedHomePath: input.sharedHomePath,
+      effectiveHomePath: input.effectiveHomePath,
+      entryName: input.entryName,
+      path: credentialPath,
     });
-    if (state._tag === "Symlink") {
-      return yield* new CodexShadowHomePrivateEntrySymlinkError({
-        sharedHomePath: input.sharedHomePath,
-        effectiveHomePath: input.effectiveHomePath,
-        entryName,
-        path: authPath,
-      });
-    }
-  },
-);
+  }
+});
 
 export const materializeCodexShadowHome = Effect.fn("materializeCodexShadowHome")(function* (
   layout: CodexHomeLayout,
@@ -347,6 +359,20 @@ export const materializeCodexShadowHome = Effect.fn("materializeCodexShadowHome"
       }),
     );
 
+  const readDirectory = (directoryPath: string) =>
+    fileSystem.readDirectory(directoryPath).pipe(
+      Effect.catchTags({
+        PlatformError: (cause) =>
+          new CodexShadowHomeFileSystemError({
+            sharedHomePath: layout.sharedHomePath,
+            effectiveHomePath,
+            operation: "readDirectory",
+            path: directoryPath,
+            cause,
+          }),
+      }),
+    );
+
   yield* Effect.all(
     [
       makeDirectory(layout.sharedHomePath),
@@ -358,60 +384,61 @@ export const materializeCodexShadowHome = Effect.fn("materializeCodexShadowHome"
     { concurrency: "unbounded" },
   );
 
-  const sharedEntryNames = yield* fileSystem.readDirectory(layout.sharedHomePath).pipe(
-    Effect.catchTags({
-      PlatformError: (cause) =>
-        new CodexShadowHomeFileSystemError({
-          sharedHomePath: layout.sharedHomePath,
-          effectiveHomePath,
-          operation: "readDirectory",
-          path: layout.sharedHomePath,
-          cause,
-        }),
-    }),
-  );
+  const sharedEntryNames = yield* readDirectory(layout.sharedHomePath);
   const entries = new Set<string>(KNOWN_SHARED_DIRECTORIES);
+  const credentialEntryNames = new Set<string>(["auth.json"]);
   for (const entryName of sharedEntryNames) {
-    if (!PRIVATE_ENTRY_NAMES.has(entryName) && !SHADOW_LOCAL_ENTRY_NAMES.has(entryName)) {
+    const disposition = classifyCodexShadowHomeEntry(entryName);
+    if (disposition === "credential-private") {
+      credentialEntryNames.add(entryName);
+    }
+    if (disposition === "shared") {
       entries.add(entryName);
     }
   }
 
+  const shadowEntryNames = yield* readDirectory(effectiveHomePath);
+  for (const entryName of shadowEntryNames) {
+    if (classifyCodexShadowHomeEntry(entryName) === "credential-private") {
+      credentialEntryNames.add(entryName);
+    }
+  }
+
   yield* Effect.forEach(
-    PRIVATE_ENTRY_NAMES,
+    ALWAYS_PRIVATE_ENTRY_NAMES,
     (entryName) =>
-      entryName === "auth.json"
-        ? Effect.void
-        : removePrivateSymlink({
-            fileSystem,
-            sharedHomePath: layout.sharedHomePath,
-            effectiveHomePath,
-            entryName,
-          }),
+      removePrivateSymlink({
+        fileSystem,
+        sharedHomePath: layout.sharedHomePath,
+        effectiveHomePath,
+        entryName,
+      }),
     { discard: true },
   );
 
   yield* Effect.forEach(
     entries,
-    (entryName) => {
-      if (PRIVATE_ENTRY_NAMES.has(entryName)) {
-        return Effect.void;
-      }
-      return ensureSymlink({
+    (entryName) =>
+      ensureSymlink({
         fileSystem,
         sharedHomePath: layout.sharedHomePath,
         effectiveHomePath,
         entryName,
-      });
-    },
+      }),
     { discard: true },
   );
 
-  yield* ensureShadowAuthIsPrivate({
-    fileSystem,
-    sharedHomePath: layout.sharedHomePath,
-    effectiveHomePath,
-  });
+  yield* Effect.forEach(
+    credentialEntryNames,
+    (entryName) =>
+      ensureShadowCredentialIsPrivate({
+        fileSystem,
+        sharedHomePath: layout.sharedHomePath,
+        effectiveHomePath,
+        entryName,
+      }),
+    { discard: true },
+  );
 });
 
 export function codexContinuationIdentity(layout: CodexHomeLayout) {


### PR DESCRIPTION
Closes #8578

Codex shadow-home materialization currently classifies only exact auth.json as private. Other auth-like files are symlinked from the shared home into every shadow home

This change:

1. Classifies auth-like names as credential-private, case-insensitively
2. Matches auth followed by end-of-name, dot, underscore, or hyphen
3. Applies classification to shared and shadow entries
4. Never creates shared symlinks for credential-like entries
5. Rejects existing credential-like shadow symlinks
6. Keeps author.json and normal Codex state shareable
7. Preserves existing models_cache.json and shadow-local behavior

Verification:

1. 10 CodexHomeLayout tests pass
2. Server typecheck exits 0
3. git diff --check passes
4. Tests use harmless fixtures only

Scope:

1. No provider lifecycle changes
2. No token handling
3. No database migration
4. No UI changes
5. No file copying, moving, or real-home mutation


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep all auth-like Codex shadow entries private instead of only `auth.json`
> - Adds `classifyCodexShadowHomeEntry` to classify each Codex home entry as `credential-private`, `private`, `shadow-local`, or `shared` based on name patterns and known sets
> - Treats any name matching `/^auth(?:$|[._-])/i` as credential-private, not just `auth.json`
> - Refactors `materializeCodexShadowHome` to symlink only entries classified as `shared` (e.g. skills, cache, `author.json`), while keeping `models_cache.json` and all auth-like files shadow-local
> - Generalizes `ensureShadowCredentialIsPrivate` to reject symlinks for any credential-private entry with `CodexShadowHomePrivateEntrySymlinkError`
> - Behavioral Change: `auth.json` is removed from `ALWAYS_PRIVATE_ENTRY_NAMES` and privacy is now governed by `classifyCodexShadowHomeEntry`; auth-like filenames with `.`, `_`, or `-` separators (case-insensitive) are no longer symlinked and must not be symlinks in the shadow home
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4ebb35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential isolation for Codex shadow homes (filesystem layout around auth-like files); scope is limited to `CodexHomeLayout` with expanded tests, but misclassification could affect multi-tenant credential separation.
> 
> **Overview**
> Codex shadow-home setup no longer treats only `auth.json` as non-shareable. **Auth-like filenames** (case-insensitive `auth` plus end-of-name or `.`, `_`, `-`) are classified as **credential-private**, so they are never symlinked from the shared home and existing shadow symlinks for those names fail with `CodexShadowHomePrivateEntrySymlinkError`.
> 
> `materializeCodexShadowHome` now uses exported `classifyCodexShadowHomeEntry` to decide what to link (`shared`), what stays shadow-local (`models_cache.json`, `log`/`memories`/`tmp`), and which credential paths to validate via the generalized `ensureShadowCredentialIsPrivate`. It also scans both shared and shadow directories for credential-private names. Normal state such as `skills`, `cache`, and `author.json` continues to symlink as before.
> 
> Tests cover the classifier, multi-name auth fixtures, and rejection when an auth-like shadow entry is already a symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ebb35c647d5bbcf50dd85fd07fea8ad73accaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->