### PR TITLE
fix(server): make compatible Codex instance switches single-writer

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -301,6 +301,7 @@ describe("ProviderRuntimeIngestion", () => {
         threadId: ThreadId.make("thread-1"),
         status: "ready",
         providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
         runtimeMode: "approval-required",
         activeTurnId: null,
         updatedAt: createdAt,
@@ -310,6 +311,7 @@ describe("ProviderRuntimeIngestion", () => {
     });
     provider.setSession({
       provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
       status: "ready",
       runtimeMode: "approval-required",
       threadId: ThreadId.make("thread-1"),
@@ -678,6 +680,50 @@ describe("ProviderRuntimeIngestion", () => {
       );
       expect(thread?.session?.status).toBe("stopped");
       expect(thread?.session?.activeTurnId).toBeNull();
+    }),
+  );
+
+  effectIt.effect("ignores a delayed source exit after target ownership commits", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const threadId = asThreadId("thread-1");
+      const sourceInstanceId = ProviderInstanceId.make("codex-source");
+      const targetInstanceId = ProviderInstanceId.make("codex-target");
+      const committedAt = "2026-01-01T00:00:02.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-target-session-committed"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          providerInstanceId: targetInstanceId,
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: committedAt,
+        },
+        createdAt: committedAt,
+      });
+
+      harness.emit({
+        type: "session.exited",
+        eventId: asEventId("evt-delayed-source-exit"),
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: sourceInstanceId,
+        threadId,
+        createdAt: "2026-01-01T00:00:03.000Z",
+      });
+
+      yield* Effect.promise(() => harness.drain());
+      const thread = (yield* Effect.promise(() => harness.readModel())).threads.find(
+        (entry) => entry.id === threadId,
+      );
+      expect(thread?.session?.status).toBe("ready");
+      expect(thread?.session?.providerInstanceId).toBe(targetInstanceId);
+      expect(thread?.session?.updatedAt).toBe(committedAt);
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1497,6 +1497,20 @@ const make = Effect.gen(function* () {
     Effect.gen(function* () {
       const thread = yield* resolveThreadShell(event.threadId);
       if (!thread) return;
+      const projectedProviderInstanceId = thread.session?.providerInstanceId;
+      if (
+        projectedProviderInstanceId !== undefined &&
+        event.providerInstanceId !== undefined &&
+        projectedProviderInstanceId !== event.providerInstanceId
+      ) {
+        yield* Effect.logDebug("provider runtime ingestion ignored event from stale owner", {
+          threadId: event.threadId,
+          eventType: event.type,
+          eventProviderInstanceId: event.providerInstanceId,
+          projectedProviderInstanceId,
+        });
+        return;
+      }
 
       let loadedThreadDetail: OrchestrationThread | null | undefined;
       const getLoadedThreadDetail = () =>

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -23,6 +23,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, vi } from "@effect/vitest";
 
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -42,12 +43,17 @@ import type { CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
   type CodexSessionRuntimeOptions,
+  type CodexSessionRuntimeError,
   type CodexSessionRuntimeSendTurnInput,
   type CodexSessionRuntimeShape,
+  CodexSessionRuntimeThreadIdMismatchError,
   type CodexThreadSnapshot,
 } from "./CodexSessionRuntime.ts";
 import { makeCodexAdapter } from "./CodexAdapter.ts";
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
+const isCodexSessionRuntimeThreadIdMismatchError = Schema.is(
+  CodexSessionRuntimeThreadIdMismatchError,
+);
 
 // Test-local service tag so the rest of the file can keep using `yield* CodexAdapter`.
 class CodexAdapter extends Context.Service<CodexAdapter, CodexAdapterShape>()(
@@ -71,6 +77,7 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
       threadId: this.options.threadId,
       cwd: this.options.cwd,
       ...(this.options.model ? { model: this.options.model } : {}),
+      ...(this.options.resumeCursor ? { resumeCursor: this.options.resumeCursor } : {}),
       createdAt: this.now,
       updatedAt: this.now,
     } satisfies ProviderSession),
@@ -120,6 +127,9 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
 
   public readonly closeImpl = vi.fn(() => Promise.resolve(undefined));
 
+  public startEffect?: Effect.Effect<ProviderSession, CodexSessionRuntimeError>;
+  public closeEffect?: Effect.Effect<ProviderEvent>;
+
   readonly options: CodexSessionRuntimeOptions;
 
   constructor(options: CodexSessionRuntimeOptions) {
@@ -127,7 +137,7 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
   }
 
   start() {
-    return Effect.promise(() => this.startImpl());
+    return this.startEffect ?? Effect.promise(() => this.startImpl());
   }
 
   getSession = Effect.promise(() => this.startImpl());
@@ -162,7 +172,33 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
     return Stream.fromQueue(this.eventQueue);
   }
 
-  close = Effect.promise(() => this.closeImpl());
+  makeClosedEvent(): ProviderEvent {
+    return {
+      id: asEventId(`evt-close-${this.options.threadId}`),
+      kind: "session",
+      provider: ProviderDriverKind.make("codex"),
+      ...(this.options.providerInstanceId
+        ? { providerInstanceId: this.options.providerInstanceId }
+        : {}),
+      threadId: this.options.threadId,
+      createdAt: this.now,
+      method: "session/closed",
+      message: "Session stopped",
+    };
+  }
+
+  makeIgnoredCloseEvent(): ProviderEvent {
+    return {
+      ...this.makeClosedEvent(),
+      method: "test/session-closed",
+    };
+  }
+
+  close = Effect.suspend(
+    () =>
+      this.closeEffect ??
+      Effect.promise(() => this.closeImpl()).pipe(Effect.as(this.makeIgnoredCloseEvent())),
+  );
 
   emit(event: ProviderEvent) {
     return Queue.offer(this.eventQueue, event).pipe(Effect.asVoid);
@@ -185,7 +221,10 @@ function makeRuntimeFactory() {
   };
 }
 
-function makeScopedRuntimeFactory(options?: { readonly failConstruction?: boolean }) {
+function makeScopedRuntimeFactory(options?: {
+  readonly failConstruction?: boolean;
+  readonly configureRuntime?: (runtime: FakeCodexRuntime) => void;
+}) {
   const runtimes: Array<FakeCodexRuntime> = [];
   const releasedThreadIds: Array<ThreadId> = [];
 
@@ -206,6 +245,7 @@ function makeScopedRuntimeFactory(options?: { readonly failConstruction?: boolea
       }
 
       const runtime = new FakeCodexRuntime(runtimeOptions);
+      options?.configureRuntime?.(runtime);
       runtimes.push(runtime);
       return runtime;
     }),
@@ -295,6 +335,60 @@ validationLayer("CodexAdapterLive validation", (it) => {
         threadId: asThreadId("thread-1"),
         runtimeMode: "full-access",
       });
+    }),
+  );
+
+  it.effect("rejects an invalid Codex resume cursor instead of starting a new thread", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId: asThreadId("thread-invalid-cursor"),
+          runtimeMode: "full-access",
+          resumeCursor: { sessionId: "not-a-codex-thread-id" },
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.deepStrictEqual(
+        result.failure,
+        new ProviderAdapterValidationError({
+          provider: ProviderDriverKind.make("codex"),
+          operation: "startSession",
+          issue: "Invalid Codex resume cursor.",
+        }),
+      );
+      NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("rejects an empty Codex resume cursor", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId: asThreadId("thread-empty-cursor"),
+          runtimeMode: "full-access",
+          resumeCursor: { threadId: "" },
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.deepStrictEqual(
+        result.failure,
+        new ProviderAdapterValidationError({
+          provider: ProviderDriverKind.make("codex"),
+          operation: "startSession",
+          issue: "Invalid Codex resume cursor.",
+        }),
+      );
+      NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
     }),
   );
 });
@@ -1573,6 +1667,43 @@ scopedLifecycleLayer("CodexAdapterLive scoped lifecycle", (it) => {
       NodeAssert.equal(yield* adapter.hasSession(asThreadId("thread-stop")), false);
     }),
   );
+
+  it.effect("coalesces concurrent stop calls into one release and one close event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-concurrent-stop");
+      const closeStarted = yield* Deferred.make<void>();
+      const allowClose = yield* Deferred.make<void>();
+      let closeAttempts = 0;
+      yield* Effect.addFinalizer(() => Deferred.succeed(allowClose, undefined).pipe(Effect.asVoid));
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const runtime = scopedLifecycleRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      runtime.closeEffect = Effect.sync(() => {
+        closeAttempts += 1;
+      }).pipe(
+        Effect.andThen(Deferred.succeed(closeStarted, undefined)),
+        Effect.andThen(Deferred.await(allowClose)),
+        Effect.as(runtime.makeClosedEvent()),
+      );
+
+      const firstStop = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      const secondStop = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Deferred.await(closeStarted);
+      NodeAssert.equal(closeAttempts, 1);
+
+      yield* Deferred.succeed(allowClose, undefined);
+      yield* Fiber.join(firstStop);
+      yield* Fiber.join(secondStop);
+      NodeAssert.equal(closeAttempts, 1);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
 });
 
 const scopedFailureRuntimeFactory = makeScopedRuntimeFactory({ failConstruction: true });
@@ -1616,6 +1747,272 @@ scopedFailureLayer("CodexAdapterLive scoped startup failure", (it) => {
     }),
   );
 });
+
+const identityMismatchRuntimeFactory = makeScopedRuntimeFactory({
+  configureRuntime: (runtime) => {
+    runtime.startEffect = Effect.fail(
+      new CodexSessionRuntimeThreadIdMismatchError({
+        threadId: runtime.options.threadId,
+        requestedThreadId: "requested-native-thread",
+        returnedThreadId: "wrong-native-thread",
+      }),
+    );
+  },
+});
+const identityMismatchLayer = it.layer(
+  Layer.effect(
+    CodexAdapter,
+    Effect.gen(function* () {
+      const codexConfig = decodeCodexSettings({});
+      return yield* makeCodexAdapter(codexConfig, {
+        makeRuntime: identityMismatchRuntimeFactory.factory,
+      });
+    }),
+  ).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(ServerSettingsService.layerTest()),
+    Layer.provideMerge(providerSessionDirectoryTestLayer),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+identityMismatchLayer("CodexAdapterLive strict resume identity", (it) => {
+  it.effect("closes the target when native resume returns a different id", () =>
+    Effect.gen(function* () {
+      identityMismatchRuntimeFactory.releasedThreadIds.length = 0;
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-id-mismatch");
+
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor: { threadId: "requested-native-thread" },
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterProcessError");
+      NodeAssert.ok(isCodexSessionRuntimeThreadIdMismatchError(result.failure.cause));
+      const runtime = identityMismatchRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      NodeAssert.deepStrictEqual(runtime.options.resumeCursor, {
+        threadId: "requested-native-thread",
+      });
+      NodeAssert.equal(runtime.closeImpl.mock.calls.length, 1);
+      NodeAssert.deepStrictEqual(identityMismatchRuntimeFactory.releasedThreadIds, [threadId]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }),
+  );
+});
+
+const startupReleaseFailure = new Error("target release remained unproven");
+const startupReleaseFailureRuntimeFactory = makeScopedRuntimeFactory({
+  configureRuntime: (runtime) => {
+    runtime.startEffect = Effect.fail(
+      new CodexSessionRuntimeThreadIdMismatchError({
+        threadId: runtime.options.threadId,
+        requestedThreadId: "requested-native-thread",
+        returnedThreadId: "wrong-native-thread",
+      }),
+    );
+    runtime.closeEffect = Effect.die(startupReleaseFailure);
+  },
+});
+const startupReleaseFailureLayer = it.layer(
+  Layer.effect(
+    CodexAdapter,
+    Effect.gen(function* () {
+      const codexConfig = decodeCodexSettings({});
+      return yield* makeCodexAdapter(codexConfig, {
+        makeRuntime: startupReleaseFailureRuntimeFactory.factory,
+      });
+    }),
+  ).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(ServerSettingsService.layerTest()),
+    Layer.provideMerge(providerSessionDirectoryTestLayer),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+startupReleaseFailureLayer("CodexAdapterLive failed startup release", (it) => {
+  it.effect("retains ownership when a failed target cannot prove writer release", () =>
+    Effect.gen(function* () {
+      startupReleaseFailureRuntimeFactory.releasedThreadIds.length = 0;
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-startup-release-failure");
+
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor: { threadId: "requested-native-thread" },
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterProcessError");
+      NodeAssert.strictEqual(result.failure.cause, startupReleaseFailure);
+      NodeAssert.deepStrictEqual(startupReleaseFailureRuntimeFactory.releasedThreadIds, [threadId]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), true);
+      const sessions = yield* adapter.listSessions();
+      NodeAssert.equal(sessions.length, 1);
+      NodeAssert.deepStrictEqual(sessions[0]?.resumeCursor, {
+        threadId: "requested-native-thread",
+      });
+
+      const runtime = startupReleaseFailureRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      const turnResult = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "must not route",
+          attachments: [],
+        })
+        .pipe(Effect.result);
+      NodeAssert.equal(turnResult._tag, "Failure");
+      NodeAssert.equal(turnResult.failure._tag, "ProviderAdapterSessionNotFoundError");
+      NodeAssert.equal(runtime.sendTurnImpl.mock.calls.length, 0);
+    }),
+  );
+});
+
+it.effect("retains the session until runtime close and scope release both complete", () =>
+  Effect.gen(function* () {
+    const closeStarted = yield* Deferred.make<void>();
+    const allowClose = yield* Deferred.make<void>();
+    const releaseStarted = yield* Deferred.make<void>();
+    const allowRelease = yield* Deferred.make<void>();
+    let runtime: FakeCodexRuntime | undefined;
+    yield* Effect.addFinalizer(() =>
+      Deferred.succeed(allowClose, undefined).pipe(
+        Effect.andThen(Deferred.succeed(allowRelease, undefined)),
+        Effect.asVoid,
+      ),
+    );
+
+    const runtimeFactory = (runtimeOptions: CodexSessionRuntimeOptions) =>
+      Effect.gen(function* () {
+        yield* Scope.Scope;
+        yield* Effect.addFinalizer(() =>
+          Deferred.succeed(releaseStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(allowRelease)),
+          ),
+        );
+        const nextRuntime = new FakeCodexRuntime(runtimeOptions);
+        nextRuntime.closeEffect = Deferred.succeed(closeStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(allowClose)),
+          Effect.as(nextRuntime.makeClosedEvent()),
+        );
+        runtime = nextRuntime;
+        return nextRuntime;
+      });
+    const layer = Layer.effect(
+      CodexAdapter,
+      Effect.gen(function* () {
+        const codexConfig = decodeCodexSettings({});
+        return yield* makeCodexAdapter(codexConfig, { makeRuntime: runtimeFactory });
+      }),
+    ).pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(providerSessionDirectoryTestLayer),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    yield* Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-deferred-release");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      NodeAssert.ok(runtime);
+
+      const exitEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+      const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Deferred.await(closeStarted);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), true);
+      NodeAssert.equal(yield* Deferred.isDone(releaseStarted), false);
+
+      yield* Deferred.succeed(allowClose, undefined);
+      yield* Deferred.await(releaseStarted);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), true);
+      NodeAssert.equal(exitEventFiber.pollUnsafe(), undefined);
+
+      yield* Deferred.succeed(allowRelease, undefined);
+      yield* Fiber.join(stopFiber);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+      const exitEvent = yield* Fiber.join(exitEventFiber);
+      NodeAssert.equal(exitEvent._tag, "Some");
+      if (exitEvent._tag === "Some") {
+        NodeAssert.equal(exitEvent.value.type, "session.exited");
+      }
+    }).pipe(Effect.provide(layer));
+  }),
+);
+
+it.effect("propagates close failure and retains authoritative session ownership", () =>
+  Effect.gen(function* () {
+    const closeFailure = new Error("close failed before writer release");
+    const releasedThreadIds: Array<ThreadId> = [];
+    let runtime: FakeCodexRuntime | undefined;
+
+    const runtimeFactory = (runtimeOptions: CodexSessionRuntimeOptions) =>
+      Effect.gen(function* () {
+        yield* Scope.Scope;
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            releasedThreadIds.push(runtimeOptions.threadId);
+          }),
+        );
+        const nextRuntime = new FakeCodexRuntime(runtimeOptions);
+        nextRuntime.closeEffect = Effect.die(closeFailure);
+        runtime = nextRuntime;
+        return nextRuntime;
+      });
+    const layer = Layer.effect(
+      CodexAdapter,
+      Effect.gen(function* () {
+        const codexConfig = decodeCodexSettings({});
+        return yield* makeCodexAdapter(codexConfig, { makeRuntime: runtimeFactory });
+      }),
+    ).pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(providerSessionDirectoryTestLayer),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    yield* Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-close-failure");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      NodeAssert.ok(runtime);
+
+      const result = yield* adapter.stopSession(threadId).pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterProcessError");
+      NodeAssert.strictEqual(result.failure.cause, closeFailure);
+      NodeAssert.match(result.failure.detail, /close failed before writer release/);
+      NodeAssert.deepStrictEqual(releasedThreadIds, [threadId]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), true);
+
+      runtime.closeEffect = Effect.succeed(runtime.makeClosedEvent());
+      yield* adapter.stopSession(threadId);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+    }).pipe(Effect.provide(layer));
+  }),
+);
 
 it.effect("flushes managed native logs when the adapter layer shuts down", () =>
   Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1859,10 +1859,7 @@ startupReleaseFailureLayer("CodexAdapterLive failed startup release", (it) => {
       NodeAssert.deepStrictEqual(startupReleaseFailureRuntimeFactory.releasedThreadIds, [threadId]);
       NodeAssert.equal(yield* adapter.hasSession(threadId), true);
       const sessions = yield* adapter.listSessions();
-      NodeAssert.equal(sessions.length, 1);
-      NodeAssert.deepStrictEqual(sessions[0]?.resumeCursor, {
-        threadId: "requested-native-thread",
-      });
+      NodeAssert.equal(sessions.length, 0);
 
       const runtime = startupReleaseFailureRuntimeFactory.lastRuntime;
       NodeAssert.ok(runtime);
@@ -1938,6 +1935,16 @@ it.effect("retains the session until runtime close and scope release both comple
       yield* Deferred.await(closeStarted);
       NodeAssert.equal(yield* adapter.hasSession(threadId), true);
       NodeAssert.equal(yield* Deferred.isDone(releaseStarted), false);
+      const turnResult = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "must not route during teardown",
+          attachments: [],
+        })
+        .pipe(Effect.result);
+      NodeAssert.equal(turnResult._tag, "Failure");
+      NodeAssert.equal(turnResult.failure._tag, "ProviderAdapterSessionNotFoundError");
+      NodeAssert.equal(runtime.sendTurnImpl.mock.calls.length, 0);
 
       yield* Deferred.succeed(allowClose, undefined);
       yield* Deferred.await(releaseStarted);
@@ -2003,7 +2010,7 @@ it.effect("propagates close failure and retains authoritative session ownership"
       NodeAssert.equal(result._tag, "Failure");
       NodeAssert.equal(result.failure._tag, "ProviderAdapterProcessError");
       NodeAssert.strictEqual(result.failure.cause, closeFailure);
-      NodeAssert.match(result.failure.detail, /close failed before writer release/);
+      NodeAssert.equal(result.failure.detail, "Failed to release Codex session resources.");
       NodeAssert.deepStrictEqual(releasedThreadIds, [threadId]);
       NodeAssert.equal(yield* adapter.hasSession(threadId), true);
 
@@ -2014,7 +2021,7 @@ it.effect("propagates close failure and retains authoritative session ownership"
   }),
 );
 
-it.effect("flushes managed native logs when the adapter layer shuts down", () =>
+it.effect("shuts down streams and flushes managed logs when teardown stopAll fails", () =>
   Effect.gen(function* () {
     const tempDir = NodeFS.mkdtempSync(
       NodePath.join(NodeOS.tmpdir(), "t3-codex-adapter-native-log-"),
@@ -2064,8 +2071,13 @@ it.effect("flushes managed native logs when the adapter layer shuts down", () =>
       } satisfies ProviderEvent);
       yield* Fiber.join(firstEventFiber);
 
+      const streamCompletionFiber = yield* Stream.runDrain(adapter.streamEvents).pipe(
+        Effect.forkChild,
+      );
+      runtime.closeEffect = Effect.die(new Error("stopAll failed during adapter teardown"));
       yield* Scope.close(scope, Exit.void);
       scopeClosed = true;
+      yield* Fiber.await(streamCompletionFiber);
 
       const threadLogPath = NodePath.join(tempDir, "provider-native.thread-logger.log");
       NodeAssert.equal(NodeFS.existsSync(threadLogPath), true);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1692,7 +1692,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       return yield* new ProviderAdapterProcessError({
         provider: PROVIDER,
         threadId,
-        detail: cause instanceof Error ? cause.message : String(cause),
+        detail: "Failed to release Codex session resources.",
         cause,
       });
     }
@@ -2025,6 +2025,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           }
 
           session.stopResult = candidate;
+          session.routable = false;
           const stopExit = yield* Effect.exit(
             Effect.gen(function* () {
               yield* releaseSessionResources(
@@ -2059,7 +2060,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 
   const listSessions: CodexAdapterShape["listSessions"] = () =>
     Effect.forEach(
-      Array.from(sessions.values()).filter((session) => !session.stopped),
+      Array.from(sessions.values()).filter((session) => !session.stopped && session.routable),
       (session) => session.runtime.getSession,
       { concurrency: 1 },
     );
@@ -2075,8 +2076,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 
   yield* Effect.acquireRelease(Effect.void, () =>
     stopAll().pipe(
-      Effect.andThen(Queue.shutdown(runtimeEventQueue)),
-      Effect.andThen(managedNativeEventLogger?.close() ?? Effect.void),
+      Effect.ensuring(
+        Queue.shutdown(runtimeEventQueue).pipe(
+          Effect.ensuring(managedNativeEventLogger?.close() ?? Effect.void),
+        ),
+      ),
       Effect.ignore,
     ),
   );

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -26,8 +26,10 @@ import {
   ThreadId,
   ProviderSendTurnInput,
 } from "@t3tools/contracts";
-import * as Effect from "effect/Effect";
+import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
@@ -93,7 +95,9 @@ interface CodexAdapterSessionContext {
   readonly scope: Scope.Closeable;
   readonly runtime: CodexSessionRuntimeShape;
   readonly eventFiber: Fiber.Fiber<void, never>;
+  routable: boolean;
   stopped: boolean;
+  stopResult: Deferred.Deferred<void, ProviderAdapterError> | undefined;
 }
 
 function mapCodexRuntimeError(
@@ -1663,6 +1667,40 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
 
+  const writeNativeEvent = Effect.fnUntraced(function* (event: ProviderEvent) {
+    if (!nativeEventLogger) {
+      return;
+    }
+    yield* nativeEventLogger.write(event, event.threadId);
+  });
+
+  const releaseSessionResources = Effect.fn("releaseSessionResources")(function* (
+    threadId: ThreadId,
+    runtime: CodexSessionRuntimeShape,
+    scope: Scope.Closeable,
+    eventFiber: Fiber.Fiber<void, never>,
+  ) {
+    const cleanupExit = yield* Effect.exit(
+      runtime.close.pipe(
+        Effect.ensuring(Scope.close(scope, Exit.void)),
+        Effect.ensuring(Fiber.interrupt(eventFiber)),
+        Effect.uninterruptible,
+      ),
+    );
+    if (Exit.isFailure(cleanupExit)) {
+      const cause = Cause.squash(cleanupExit.cause);
+      return yield* new ProviderAdapterProcessError({
+        provider: PROVIDER,
+        threadId,
+        detail: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      });
+    }
+    const closedEvent = cleanupExit.value;
+    yield* writeNativeEvent(closedEvent);
+    yield* Queue.offerAll(runtimeEventQueue, mapToRuntimeEvents(closedEvent, threadId));
+  });
+
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -1671,6 +1709,13 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             provider: PROVIDER,
             operation: "startSession",
             issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+          });
+        }
+        if (input.resumeCursor !== undefined && !isCodexResumeCursorSchema(input.resumeCursor)) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: "Invalid Codex resume cursor.",
           });
         }
 
@@ -1757,7 +1802,17 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           }),
         ).pipe(Effect.forkIn(sessionScope));
 
-        const started = yield* runtime.start().pipe(
+        const sessionContext: CodexAdapterSessionContext = {
+          threadId: input.threadId,
+          scope: sessionScope,
+          runtime,
+          eventFiber,
+          routable: false,
+          stopped: false,
+          stopResult: undefined,
+        };
+
+        const startedExit = yield* runtime.start().pipe(
           Effect.mapError(
             (cause) =>
               new ProviderAdapterProcessError({
@@ -1767,22 +1822,26 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
                 cause,
               }),
           ),
-          Effect.onError(() =>
-            runtime.close.pipe(
-              Effect.andThen(Effect.ignore(Scope.close(sessionScope, Exit.void))),
-              Effect.andThen(Fiber.interrupt(eventFiber)),
-              Effect.ignore,
-            ),
-          ),
+          Effect.exit,
         );
+        if (Exit.isFailure(startedExit)) {
+          const releaseExit = yield* releaseSessionResources(
+            input.threadId,
+            runtime,
+            sessionScope,
+            eventFiber,
+          ).pipe(Effect.exit);
+          if (Exit.isFailure(releaseExit)) {
+            sessions.set(input.threadId, sessionContext);
+            sessionScopeTransferred = true;
+            return yield* Effect.failCause(releaseExit.cause);
+          }
+          return yield* Effect.failCause(startedExit.cause);
+        }
+        const started = startedExit.value;
 
-        sessions.set(input.threadId, {
-          threadId: input.threadId,
-          scope: sessionScope,
-          runtime,
-          eventFiber,
-          stopped: false,
-        });
+        sessionContext.routable = true;
+        sessions.set(input.threadId, sessionContext);
         sessionScopeTransferred = true;
 
         return started;
@@ -1860,7 +1919,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 
   const requireSession = Effect.fn("requireSession")(function* (threadId: ThreadId) {
     const session = sessions.get(threadId);
-    if (!session || session.stopped) {
+    if (!session || session.stopped || !session.routable) {
       return yield* new ProviderAdapterSessionNotFoundError({
         provider: PROVIDER,
         threadId,
@@ -1953,25 +2012,41 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       ),
     );
 
-  const writeNativeEvent = Effect.fnUntraced(function* (event: ProviderEvent) {
-    if (!nativeEventLogger) {
-      return;
-    }
-    yield* nativeEventLogger.write(event, event.threadId);
-  });
+  const stopSessionInternal = Effect.fn("stopSessionInternal")(
+    (session: CodexAdapterSessionContext) =>
+      Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const candidate = yield* Deferred.make<void, ProviderAdapterError>();
+          if (session.stopped) {
+            return;
+          }
+          if (session.stopResult !== undefined) {
+            return yield* restore(Deferred.await(session.stopResult));
+          }
 
-  const stopSessionInternal = Effect.fn("stopSessionInternal")(function* (
-    session: CodexAdapterSessionContext,
-  ) {
-    if (session.stopped) {
-      return;
-    }
-    session.stopped = true;
-    sessions.delete(session.threadId);
-    yield* session.runtime.close.pipe(Effect.ignore);
-    yield* Effect.ignore(Scope.close(session.scope, Exit.void));
-    yield* Fiber.interrupt(session.eventFiber).pipe(Effect.ignore);
-  });
+          session.stopResult = candidate;
+          const stopExit = yield* Effect.exit(
+            Effect.gen(function* () {
+              yield* releaseSessionResources(
+                session.threadId,
+                session.runtime,
+                session.scope,
+                session.eventFiber,
+              );
+              session.stopped = true;
+              if (sessions.get(session.threadId) === session) {
+                sessions.delete(session.threadId);
+              }
+            }),
+          );
+          yield* Deferred.done(candidate, stopExit);
+          if (Exit.isFailure(stopExit)) {
+            session.stopResult = undefined;
+            return yield* Effect.failCause(stopExit.cause);
+          }
+        }),
+      ),
+  );
 
   const stopSession: CodexAdapterShape["stopSession"] = (threadId) =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
+++ b/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts
@@ -160,6 +160,47 @@ const scriptPath = NodePath.join(import.meta.dirname, "../testFixtures/.collab-s
 const peerPath = NodePath.join(import.meta.dirname, "../testFixtures/codexCollabMockPeer.sh");
 
 describe("CodexSessionRuntime collab integration", () => {
+  it.effect("returns one close event without also enqueuing it", () =>
+    Effect.gen(function* () {
+      const script = {
+        rootThreadId: ROOT,
+        notifications: [],
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      NodeFS.writeFileSync(scriptPath, JSON.stringify(script), "utf8");
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          NodeFS.rmSync(scriptPath, { force: true });
+        }),
+      );
+
+      const runtime = yield* makeCodexSessionRuntime({
+        threadId: ThreadId.make("thread-codex-close-event"),
+        binaryPath: peerPath,
+        cwd: "/tmp",
+        runtimeMode: "full-access",
+        environment: { ...process.env, T3_CODEX_COLLAB_SCRIPT: scriptPath },
+      });
+      const queuedCloseEvents: Array<ProviderEvent> = [];
+      const queuedCloseEventsFiber = yield* runtime.events.pipe(
+        Stream.filter((event) => event.method === "session/closed"),
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            queuedCloseEvents.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+
+      yield* runtime.start();
+      const returnedCloseEvent = yield* runtime.close;
+      yield* Fiber.await(queuedCloseEventsFiber);
+
+      assert.equal(returnedCloseEvent.method, "session/closed");
+      assert.deepEqual(queuedCloseEvents, []);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("looks up child model metadata once after activity registration", () =>
     Effect.gen(function* () {
       const script = {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -17,14 +17,22 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  CodexSessionRuntimeWriterReleaseUnprovenError,
+  CodexSessionRuntimeThreadIdMismatchError,
   describeMcpElicitation,
   hasConfiguredMcpServer,
-  isRecoverableThreadResumeError,
   makeMemoryConsolidationNotificationFilter,
   openCodexThread,
+  proveCodexAppServerWriterReleased,
   toMcpElicitationResponse,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+const isCodexSessionRuntimeThreadIdMismatchError = Schema.is(
+  CodexSessionRuntimeThreadIdMismatchError,
+);
+const isCodexSessionRuntimeWriterReleaseUnprovenError = Schema.is(
+  CodexSessionRuntimeWriterReleaseUnprovenError,
+);
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {
@@ -41,6 +49,79 @@ describe("CodexSessionRuntimeIdentifierGenerationError", () => {
       "Failed to generate Codex App Server identifier for provider-event.",
     );
   });
+});
+
+describe("proveCodexAppServerWriterReleased", () => {
+  const threadId = ThreadId.make("thread-writer-release-proof");
+
+  it.effect("accepts an exited child that is no longer running", () =>
+    Effect.gen(function* () {
+      let checkedRunning = false;
+      yield* proveCodexAppServerWriterReleased({
+        threadId,
+        exitCode: Effect.succeed(0),
+        isRunning: Effect.sync(() => {
+          checkedRunning = true;
+          return false;
+        }),
+      });
+      NodeAssert.equal(checkedRunning, true);
+    }),
+  );
+
+  it.effect("accepts a signaled exit result when isRunning is false", () =>
+    Effect.gen(function* () {
+      let checkedRunning = false;
+      yield* proveCodexAppServerWriterReleased({
+        threadId,
+        exitCode: Effect.fail(new CodexSessionRuntimeWriterReleaseUnprovenError({ threadId })),
+        isRunning: Effect.sync(() => {
+          checkedRunning = true;
+          return false;
+        }),
+      });
+      NodeAssert.equal(checkedRunning, true);
+    }),
+  );
+
+  it.effect("rejects an exit-code timeout", () =>
+    Effect.gen(function* () {
+      let checkedRunning = false;
+      const error = yield* proveCodexAppServerWriterReleased({
+        threadId,
+        exitCode: Effect.never,
+        isRunning: Effect.sync(() => {
+          checkedRunning = true;
+          return false;
+        }),
+        exitProofTimeout: 0,
+      }).pipe(Effect.flip);
+      NodeAssert.equal(isCodexSessionRuntimeWriterReleaseUnprovenError(error), true);
+      NodeAssert.equal(checkedRunning, false);
+    }),
+  );
+
+  it.effect("rejects a child that still reports running", () =>
+    Effect.gen(function* () {
+      const error = yield* proveCodexAppServerWriterReleased({
+        threadId,
+        exitCode: Effect.succeed(0),
+        isRunning: Effect.succeed(true),
+      }).pipe(Effect.flip);
+      NodeAssert.equal(isCodexSessionRuntimeWriterReleaseUnprovenError(error), true);
+    }),
+  );
+
+  it.effect("rejects an isRunning probe failure", () =>
+    Effect.gen(function* () {
+      const error = yield* proveCodexAppServerWriterReleased({
+        threadId,
+        exitCode: Effect.succeed(0),
+        isRunning: Effect.fail(new CodexSessionRuntimeWriterReleaseUnprovenError({ threadId })),
+      }).pipe(Effect.flip);
+      NodeAssert.equal(isCodexSessionRuntimeWriterReleaseUnprovenError(error), true);
+    }),
+  );
 });
 
 function makeThreadOpenResponse(
@@ -715,67 +796,8 @@ describe("codexSessionAppServerArgs", () => {
   });
 });
 
-describe("isRecoverableThreadResumeError", () => {
-  it("matches missing thread errors", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Thread does not exist",
-        }),
-      ),
-      true,
-    );
-  });
-
-  it("matches a missing rollout for a known thread id", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "no rollout found for thread id 019fdf74-aaa9-7950-b252-7cc7a8650470",
-        }),
-      ),
-      true,
-    );
-  });
-
-  it("ignores non-recoverable resume errors", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Permission denied",
-        }),
-      ),
-      false,
-    );
-  });
-
-  it("ignores unrelated missing-resource errors that do not mention threads", () => {
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Config file not found",
-        }),
-      ),
-      false,
-    );
-    NodeAssert.equal(
-      isRecoverableThreadResumeError(
-        new CodexErrors.CodexAppServerRequestError({
-          code: -32603,
-          errorMessage: "Model does not exist",
-        }),
-      ),
-      false,
-    );
-  });
-});
-
 describe("openCodexThread", () => {
-  it.effect("falls back to thread/start when resume fails recoverably", () =>
+  it.effect("uses thread/start only for a new thread without a resume id", () =>
     Effect.gen(function* () {
       const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
       const started = makeThreadOpenResponse("fresh-thread");
@@ -785,14 +807,6 @@ describe("openCodexThread", () => {
           payload: CodexRpc.ClientRequestParamsByMethod[M],
         ) => {
           calls.push({ method, payload });
-          if (method === "thread/resume") {
-            return Effect.fail(
-              new CodexErrors.CodexAppServerRequestError({
-                code: -32603,
-                errorMessage: "thread not found",
-              }),
-            );
-          }
           return Effect.succeed(started as CodexRpc.ClientRequestResponsesByMethod[M]);
         },
       };
@@ -804,14 +818,114 @@ describe("openCodexThread", () => {
         cwd: "/tmp/project",
         requestedModel: "gpt-5.3-codex",
         serviceTier: undefined,
-        resumeThreadId: "stale-thread",
+        resumeThreadId: undefined,
       });
 
       NodeAssert.equal(opened.thread.id, "fresh-thread");
       NodeAssert.deepStrictEqual(
         calls.map((call) => call.method),
-        ["thread/resume", "thread/start"],
+        ["thread/start"],
       );
+    }),
+  );
+
+  it.effect("never falls back to thread/start when strict resume fails", () =>
+    Effect.gen(function* () {
+      const calls: Array<"thread/start" | "thread/resume"> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          method: M,
+          _payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push(method);
+          return Effect.fail(
+            new CodexErrors.CodexAppServerRequestError({
+              code: -32603,
+              errorMessage: "thread not found",
+            }),
+          );
+        },
+      };
+
+      const error = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "native-thread",
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexAppServerRequestError(error));
+      NodeAssert.equal(error.errorMessage, "thread not found");
+      NodeAssert.deepStrictEqual(calls, ["thread/resume"]);
+    }),
+  );
+
+  it.effect("rejects a resumed native id that differs from the requested id", () =>
+    Effect.gen(function* () {
+      const calls: Array<"thread/start" | "thread/resume"> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          method: M,
+          _payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push(method);
+          return Effect.succeed(
+            makeThreadOpenResponse(
+              "wrong-native-thread",
+            ) as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
+        },
+      };
+
+      const error = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "requested-native-thread",
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexSessionRuntimeThreadIdMismatchError(error));
+      NodeAssert.equal(error.requestedThreadId, "requested-native-thread");
+      NodeAssert.equal(error.returnedThreadId, "wrong-native-thread");
+      NodeAssert.deepStrictEqual(calls, ["thread/resume"]);
+    }),
+  );
+
+  it.effect("accepts strict resume only when the returned native id matches", () =>
+    Effect.gen(function* () {
+      const calls: Array<"thread/start" | "thread/resume"> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          method: M,
+          _payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push(method);
+          return Effect.succeed(
+            makeThreadOpenResponse(
+              "requested-native-thread",
+            ) as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
+        },
+      };
+
+      const opened = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "requested-native-thread",
+      });
+
+      NodeAssert.equal(opened.thread.id, "requested-native-thread");
+      NodeAssert.deepStrictEqual(calls, ["thread/resume"]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -114,12 +114,14 @@ describe("proveCodexAppServerWriterReleased", () => {
 
   it.effect("rejects an isRunning probe failure", () =>
     Effect.gen(function* () {
+      const probeFailure = new Error("isRunning probe failed");
       const error = yield* proveCodexAppServerWriterReleased({
         threadId,
         exitCode: Effect.succeed(0),
-        isRunning: Effect.fail(new CodexSessionRuntimeWriterReleaseUnprovenError({ threadId })),
+        isRunning: Effect.fail(probeFailure),
       }).pipe(Effect.flip);
       NodeAssert.equal(isCodexSessionRuntimeWriterReleaseUnprovenError(error), true);
+      NodeAssert.strictEqual(error.cause, probeFailure);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -22,9 +22,11 @@ import { normalizeModelSlug } from "@t3tools/shared/model";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -53,21 +55,14 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
 const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
-const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
-  "not found",
-  "missing thread",
-  "no such thread",
-  "unknown thread",
-  "does not exist",
-  "no rollout found",
-];
+const CODEX_APP_SERVER_EXIT_PROOF_TIMEOUT = "1 second" as const;
 
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {
   return appServerArgs?.some((argument) => argument.includes("mcp_servers.")) === true;
 }
 
 export const CodexResumeCursorSchema = Schema.Struct({
-  threadId: Schema.String,
+  threadId: Schema.String.check(Schema.isTrimmed(), Schema.isNonEmpty()),
 });
 const CodexUserInputAnswerObject = Schema.Struct({
   answers: Schema.Array(Schema.String),
@@ -213,7 +208,7 @@ export interface CodexSessionRuntimeShape {
     answers: ProviderUserInputAnswers,
   ) => Effect.Effect<void, CodexSessionRuntimeError>;
   readonly events: Stream.Stream<ProviderEvent, never>;
-  readonly close: Effect.Effect<void>;
+  readonly close: Effect.Effect<ProviderEvent, CodexSessionRuntimeError>;
 }
 
 export type CodexSessionRuntimeError =
@@ -221,7 +216,9 @@ export type CodexSessionRuntimeError =
   | CodexSessionRuntimePendingApprovalNotFoundError
   | CodexSessionRuntimePendingUserInputNotFoundError
   | CodexSessionRuntimeInvalidUserInputAnswersError
-  | CodexSessionRuntimeThreadIdMissingError;
+  | CodexSessionRuntimeThreadIdMissingError
+  | CodexSessionRuntimeThreadIdMismatchError
+  | CodexSessionRuntimeWriterReleaseUnprovenError;
 
 export class CodexSessionRuntimePendingApprovalNotFoundError extends Schema.TaggedErrorClass<CodexSessionRuntimePendingApprovalNotFoundError>()(
   "CodexSessionRuntimePendingApprovalNotFoundError",
@@ -266,6 +263,64 @@ export class CodexSessionRuntimeThreadIdMissingError extends Schema.TaggedErrorC
     return `Codex session is missing a provider thread id for ${this.threadId}`;
   }
 }
+
+export class CodexSessionRuntimeThreadIdMismatchError extends Schema.TaggedErrorClass<CodexSessionRuntimeThreadIdMismatchError>()(
+  "CodexSessionRuntimeThreadIdMismatchError",
+  {
+    threadId: Schema.String,
+    requestedThreadId: Schema.String,
+    returnedThreadId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Codex resumed native thread '${this.returnedThreadId}' instead of requested thread '${this.requestedThreadId}' for ${this.threadId}`;
+  }
+}
+
+export class CodexSessionRuntimeWriterReleaseUnprovenError extends Schema.TaggedErrorClass<CodexSessionRuntimeWriterReleaseUnprovenError>()(
+  "CodexSessionRuntimeWriterReleaseUnprovenError",
+  {
+    threadId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Codex App Server exit was not observed for ${this.threadId}`;
+  }
+}
+
+export const proveCodexAppServerWriterReleased = <
+  ExitError,
+  ExitRequirements,
+  RunningError,
+  RunningRequirements,
+>(input: {
+  readonly threadId: ThreadId;
+  readonly exitCode: Effect.Effect<number, ExitError, ExitRequirements>;
+  readonly isRunning: Effect.Effect<boolean, RunningError, RunningRequirements>;
+  readonly exitProofTimeout?: Duration.Input;
+}) =>
+  Effect.gen(function* () {
+    const childExit = yield* input.exitCode.pipe(
+      Effect.exit,
+      Effect.timeoutOption(input.exitProofTimeout ?? CODEX_APP_SERVER_EXIT_PROOF_TIMEOUT),
+    );
+    if (Option.isNone(childExit)) {
+      return yield* new CodexSessionRuntimeWriterReleaseUnprovenError({
+        threadId: input.threadId,
+      });
+    }
+    const childRunning = yield* input.isRunning.pipe(Effect.exit);
+    if (Exit.isFailure(childRunning) || childRunning.value) {
+      return yield* new CodexSessionRuntimeWriterReleaseUnprovenError({
+        threadId: input.threadId,
+      });
+    }
+  });
+
+type CodexSessionRuntimeCloseResult = Deferred.Deferred<ProviderEvent, CodexSessionRuntimeError>;
+type CodexSessionRuntimeCloseSelection =
+  | { readonly owner: true; readonly result: CodexSessionRuntimeCloseResult }
+  | { readonly owner: false; readonly result: CodexSessionRuntimeCloseResult };
 
 interface PendingApproval {
   readonly requestId: ApprovalRequestId;
@@ -667,14 +722,6 @@ function classifyCodexStderrLine(rawLine: string): { readonly message: string } 
   return { message: line };
 }
 
-export function isRecoverableThreadResumeError(error: unknown): boolean {
-  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
-  if (!message.includes("thread")) {
-    return false;
-  }
-  return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) => message.includes(snippet));
-}
-
 type CodexThreadOpenResponse =
   | CodexRpc.ClientRequestResponsesByMethod["thread/start"]
   | CodexRpc.ClientRequestResponsesByMethod["thread/resume"];
@@ -696,7 +743,10 @@ export const openCodexThread = (input: {
   readonly requestedModel: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
-}): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
+}): Effect.Effect<
+  CodexThreadOpenResponse,
+  CodexErrors.CodexAppServerError | CodexSessionRuntimeThreadIdMismatchError
+> => {
   const resumeThreadId = input.resumeThreadId;
   const startParams = buildThreadStartParams({
     cwd: input.cwd,
@@ -715,15 +765,18 @@ export const openCodexThread = (input: {
       ...startParams,
     })
     .pipe(
-      Effect.catchIf(isRecoverableThreadResumeError, (error) =>
-        Effect.logWarning("codex app-server thread resume fell back to fresh start", {
-          threadId: input.threadId,
-          requestedRuntimeMode: input.runtimeMode,
-          resumeThreadId,
-          recoverable: true,
-          cause: error,
-        }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
-      ),
+      Effect.flatMap((opened) => {
+        if (opened.thread.id === resumeThreadId) {
+          return Effect.succeed(opened);
+        }
+        return Effect.fail(
+          new CodexSessionRuntimeThreadIdMismatchError({
+            threadId: input.threadId,
+            requestedThreadId: resumeThreadId,
+            returnedThreadId: opened.thread.id,
+          }),
+        );
+      }),
     );
 };
 
@@ -1170,7 +1223,7 @@ export const makeCodexSessionRuntime = (
     /** Child provider-thread id → its currently running provider turn id. */
     const collabChildLiveTurnsRef = yield* Ref.make(new Map<string, string>());
     const suppressMemoryConsolidationNotification = makeMemoryConsolidationNotificationFilter();
-    const closedRef = yield* Ref.make(false);
+    const closeResultRef = yield* Ref.make<CodexSessionRuntimeCloseResult | undefined>(undefined);
 
     // `~` is not shell-expanded when env vars are set via
     // `child_process.spawn`; `expandHomePath` lets a configured
@@ -1246,13 +1299,15 @@ export const makeCodexSessionRuntime = (
     const emitEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
       Effect.gen(function* () {
         const id = yield* randomUUIDv4("provider-event");
-        return yield* offerEvent({
+        const providerEvent = {
           id: EventId.make(id),
           provider: PROVIDER,
           ...(options.providerInstanceId ? { providerInstanceId: options.providerInstanceId } : {}),
           createdAt: yield* nowIso,
           ...event,
-        });
+        } satisfies ProviderEvent;
+        yield* offerEvent(providerEvent);
+        return providerEvent;
       });
     const emitSessionEvent = (method: string, message: string) =>
       emitEvent({
@@ -2203,9 +2258,9 @@ export const makeCodexSessionRuntime = (
 
     yield* child.exitCode.pipe(
       Effect.flatMap((exitCode) =>
-        Ref.get(closedRef).pipe(
-          Effect.flatMap((closed) => {
-            if (closed) {
+        Ref.get(closeResultRef).pipe(
+          Effect.flatMap((closeResult) => {
+            if (closeResult !== undefined) {
               return Effect.void;
             }
             const nextStatus = exitCode === 0 ? "closed" : "error";
@@ -2269,26 +2324,57 @@ export const makeCodexSessionRuntime = (
       return providerThreadId;
     });
 
-    const close = Effect.gen(function* () {
-      const alreadyClosed = yield* Ref.getAndSet(closedRef, true);
-      if (alreadyClosed) {
-        return;
-      }
+    const performClose = Effect.gen(function* () {
       yield* settlePendingApprovals("cancel");
       yield* settlePendingUserInputs({});
+      yield* Scope.close(runtimeScope, Exit.void);
+      yield* proveCodexAppServerWriterReleased({
+        threadId: options.threadId,
+        exitCode: child.exitCode,
+        isRunning: child.isRunning,
+      });
       yield* updateSession(sessionRef, {
         status: "closed",
         activeTurnId: undefined,
       });
-      yield* emitSessionEvent("session/closed", "Session stopped").pipe(
-        Effect.catch((cause) =>
-          Effect.logError("Failed to emit Codex session closed event.", { cause }),
-        ),
-      );
-      yield* Scope.close(runtimeScope, Exit.void);
+      const closedEvent = yield* emitSessionEvent("session/closed", "Session stopped");
       yield* Queue.shutdown(serverNotifications);
       yield* Queue.shutdown(events);
+      return closedEvent;
     });
+
+    const close = Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const candidate = yield* Deferred.make<ProviderEvent, CodexSessionRuntimeError>();
+        const selection = yield* Ref.modify(
+          closeResultRef,
+          (
+            current,
+          ): readonly [
+            CodexSessionRuntimeCloseSelection,
+            CodexSessionRuntimeCloseResult | undefined,
+          ] => {
+            if (current !== undefined) {
+              return [{ owner: false, result: current }, current];
+            }
+            return [{ owner: true, result: candidate }, candidate];
+          },
+        );
+        if (!selection.owner) {
+          return yield* restore(Deferred.await(selection.result));
+        }
+
+        const closeExit = yield* Effect.exit(restore(performClose));
+        yield* Deferred.done(candidate, closeExit);
+        if (Exit.isFailure(closeExit)) {
+          yield* Ref.update(closeResultRef, (current) =>
+            current === candidate ? undefined : current,
+          );
+          return yield* Effect.failCause(closeExit.cause);
+        }
+        return closeExit.value;
+      }),
+    );
 
     return {
       start,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1304,18 +1304,29 @@ export const makeCodexSessionRuntime = (
     const sessionRef = yield* Ref.make<ProviderSession>(initialSession);
     const offerEvent = (event: ProviderEvent) => Queue.offer(events, event).pipe(Effect.asVoid);
 
-    const emitEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
+    const makeEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
       Effect.gen(function* () {
         const id = yield* randomUUIDv4("provider-event");
-        const providerEvent = {
+        return {
           id: EventId.make(id),
           provider: PROVIDER,
           ...(options.providerInstanceId ? { providerInstanceId: options.providerInstanceId } : {}),
           createdAt: yield* nowIso,
           ...event,
         } satisfies ProviderEvent;
+      });
+    const emitEvent = (event: Omit<ProviderEvent, "id" | "provider" | "createdAt">) =>
+      Effect.gen(function* () {
+        const providerEvent = yield* makeEvent(event);
         yield* offerEvent(providerEvent);
         return providerEvent;
+      });
+    const makeSessionEvent = (method: string, message: string) =>
+      makeEvent({
+        kind: "session",
+        threadId: options.threadId,
+        method,
+        message,
       });
     const emitSessionEvent = (method: string, message: string) =>
       emitEvent({
@@ -2345,7 +2356,10 @@ export const makeCodexSessionRuntime = (
         status: "closed",
         activeTurnId: undefined,
       });
-      const closedEvent = yield* emitSessionEvent("session/closed", "Session stopped");
+      // The adapter publishes the event returned by close after it has stopped
+      // the runtime event consumer. Keeping this event off the runtime queue
+      // prevents a normal stop from publishing the same lifecycle event twice.
+      const closedEvent = yield* makeSessionEvent("session/closed", "Session stopped");
       yield* Queue.shutdown(serverNotifications);
       yield* Queue.shutdown(events);
       return closedEvent;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -19,6 +19,7 @@ import {
 } from "@t3tools/contracts";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -281,6 +282,7 @@ export class CodexSessionRuntimeWriterReleaseUnprovenError extends Schema.Tagged
   "CodexSessionRuntimeWriterReleaseUnprovenError",
   {
     threadId: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -310,7 +312,13 @@ export const proveCodexAppServerWriterReleased = <
       });
     }
     const childRunning = yield* input.isRunning.pipe(Effect.exit);
-    if (Exit.isFailure(childRunning) || childRunning.value) {
+    if (Exit.isFailure(childRunning)) {
+      return yield* new CodexSessionRuntimeWriterReleaseUnprovenError({
+        threadId: input.threadId,
+        cause: Cause.squash(childRunning.cause),
+      });
+    }
+    if (childRunning.value) {
       return yield* new CodexSessionRuntimeWriterReleaseUnprovenError({
         threadId: input.threadId,
       });

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -76,6 +76,7 @@ const asThreadId = (value: string): ThreadId => ThreadId.make(value);
 const asTurnId = (value: string): TurnId => TurnId.make(value);
 const codexInstanceId = ProviderInstanceId.make("codex");
 const claudeAgentInstanceId = ProviderInstanceId.make("claudeAgent");
+const cursorInstanceId = ProviderInstanceId.make("cursor");
 const CODEX_DRIVER = ProviderDriverKind.make("codex");
 const CLAUDE_AGENT_DRIVER = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER = ProviderDriverKind.make("cursor");
@@ -751,7 +752,7 @@ it.effect("queues sendTurn behind handoff and routes the turn only to the commit
   }).pipe(Effect.provide(harness.layer));
 });
 
-it.effect("queues recovery-capable interrupt behind handoff without restarting source", () => {
+it.effect("queues interrupt behind handoff without restarting source", () => {
   const harness = makeCompatibleCodexSwitchHarness();
   return Effect.gen(function* () {
     const provider = yield* ProviderService.ProviderService;
@@ -796,6 +797,59 @@ it.effect("queues recovery-capable interrupt behind handoff without restarting s
     assert.equal(harness.source.startSession.mock.calls.length, 0);
     assert.equal(harness.source.interruptTurn.mock.calls.length, 0);
     assert.deepEqual(harness.target.interruptTurn.mock.calls, [[threadId, undefined]]);
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("queues interactive responses behind handoff and routes them to the target", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const threadId = asThreadId("thread-codex-response-handoff-race");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.respondToRequest.mockClear();
+    harness.target.respondToRequest.mockClear();
+    const sourceStopEntered = yield* Deferred.make<void>();
+    const releaseSource = yield* Deferred.make<void>();
+    const originalStop = harness.source.stopSession.getMockImplementation();
+    assert.exists(originalStop);
+    harness.source.stopSession.mockImplementation((stoppedThreadId) =>
+      Deferred.succeed(sourceStopEntered, undefined).pipe(
+        Effect.andThen(Deferred.await(releaseSource)),
+        Effect.andThen(originalStop(stoppedThreadId)),
+      ),
+    );
+
+    const switchFiber = yield* Effect.forkChild(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    yield* Deferred.await(sourceStopEntered);
+    const responseFiber = yield* Effect.forkChild(
+      provider.respondToRequest({
+        threadId,
+        requestId: asRequestId("request-during-codex-handoff"),
+        decision: "accept",
+      }),
+    );
+    yield* Effect.yieldNow;
+    assert.equal(harness.source.respondToRequest.mock.calls.length, 0);
+    assert.equal(harness.target.respondToRequest.mock.calls.length, 0);
+
+    yield* Deferred.succeed(releaseSource, undefined);
+    yield* Fiber.join(switchFiber);
+    yield* Fiber.join(responseFiber);
+
+    assert.equal(harness.source.respondToRequest.mock.calls.length, 0);
+    assert.deepEqual(harness.target.respondToRequest.mock.calls, [
+      [threadId, asRequestId("request-during-codex-handoff"), "accept"],
+    ]);
   }).pipe(Effect.provide(harness.layer));
 });
 
@@ -1299,6 +1353,95 @@ it.effect("stops the Codex target when target binding persistence fails", () => 
     assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
     assert.equal(binding?.status, "stopped");
     assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("blocks source recovery until a provisional Codex target is released", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-binding-and-cleanup-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.startSession.mockClear();
+    harness.source.sendTurn.mockClear();
+    harness.target.stopSession.mockClear();
+    const originalTargetStop = harness.target.stopSession.getMockImplementation();
+    assert.exists(originalTargetStop);
+    harness.target.stopSession.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: CODEX_DRIVER,
+          method: "stopSession",
+          detail: "Injected provisional target cleanup failure.",
+        }),
+      ),
+    );
+    harness.failTargetCommit();
+
+    const switchExit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(switchExit));
+    assert.isFalse(yield* harness.source.hasSession(threadId));
+    assert.isTrue(yield* harness.target.hasSession(threadId));
+
+    const blockedSend = yield* Effect.exit(
+      provider.sendTurn({
+        threadId,
+        input: "must not recover while target release is unproven",
+      }),
+    );
+    assert.isTrue(Exit.isFailure(blockedSend));
+    assert.equal(harness.source.startSession.mock.calls.length, 0);
+    assert.equal(harness.source.sendTurn.mock.calls.length, 0);
+    assert.isTrue(yield* harness.target.hasSession(threadId));
+    const blockedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(blockedBinding?.providerInstanceId, harness.sourceInstanceId);
+    assert.equal(blockedBinding?.status, "stopped");
+    assert.deepEqual(blockedBinding?.resumeCursor, { threadId: `native-${threadId}` });
+
+    const blockedStart = yield* Effect.exit(
+      provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: harness.sourceInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      }),
+    );
+    assert.isTrue(Exit.isFailure(blockedStart));
+    assert.equal(harness.source.startSession.mock.calls.length, 0);
+    assert.isTrue(yield* harness.target.hasSession(threadId));
+
+    harness.target.stopSession.mockImplementation(originalTargetStop);
+    const recovered = yield* provider.startSession(threadId, {
+      provider: CODEX_DRIVER,
+      providerInstanceId: harness.sourceInstanceId,
+      threadId,
+      runtimeMode: "full-access",
+    });
+    yield* provider.sendTurn({
+      threadId,
+      input: "recover only after target release",
+    });
+
+    assert.equal(harness.target.stopSession.mock.calls.length, 4);
+    assert.isFalse(yield* harness.target.hasSession(threadId));
+    assert.equal(harness.source.startSession.mock.calls.length, 1);
+    assert.equal(harness.source.sendTurn.mock.calls.length, 1);
+    assert.deepEqual(recovered.resumeCursor, { threadId: `native-${threadId}` });
+    const recoveredBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(recoveredBinding?.providerInstanceId, harness.sourceInstanceId);
+    assert.equal(recoveredBinding?.status, "running");
+    assert.deepEqual(recoveredBinding?.resumeCursor, { threadId: `native-${threadId}` });
   }).pipe(Effect.provide(harness.layer));
 });
 
@@ -1898,6 +2041,58 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
+  it.effect("replaces non-Codex bindings with Codex without entering native handoff", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const sources = [
+        {
+          name: "claude",
+          driver: CLAUDE_AGENT_DRIVER,
+          instanceId: claudeAgentInstanceId,
+          adapter: routing.claude,
+        },
+        {
+          name: "cursor",
+          driver: CURSOR_DRIVER,
+          instanceId: cursorInstanceId,
+          adapter: routing.cursor,
+        },
+      ] as const;
+
+      for (const source of sources) {
+        const threadId = asThreadId(`thread-${source.name}-to-codex`);
+        yield* provider.startSession(threadId, {
+          provider: source.driver,
+          providerInstanceId: source.instanceId,
+          threadId,
+          cwd: `/tmp/${source.name}-to-codex`,
+          runtimeMode: "full-access",
+          resumeCursor: { opaque: `${source.name}-resume-state` },
+        });
+        source.adapter.stopSession.mockClear();
+        routing.codex.startSession.mockClear();
+
+        const codexSession = yield* provider.startSession(threadId, {
+          provider: CODEX_DRIVER,
+          providerInstanceId: codexInstanceId,
+          threadId,
+          cwd: `/tmp/${source.name}-to-codex`,
+          runtimeMode: "full-access",
+        });
+
+        assert.equal(codexSession.providerInstanceId, codexInstanceId);
+        assert.deepEqual(source.adapter.stopSession.mock.calls, [[threadId]]);
+        assert.equal(routing.codex.startSession.mock.calls.length, 1);
+        assert.equal(routing.codex.startSession.mock.calls[0]?.[0]?.resumeCursor, undefined);
+        const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        assert.equal(binding?.provider, CODEX_DRIVER);
+        assert.equal(binding?.providerInstanceId, codexInstanceId);
+        yield* provider.stopSession({ threadId });
+      }
+    }),
+  );
+
   it.effect("routes provider operations and rollback conversation", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;
@@ -2619,6 +2814,173 @@ routing.layer("ProviderServiceLive routing", (it) => {
           assert.notEqual(runtimePayload.lastRuntimeEvent, "provider.sendTurn");
         }
       }
+    }),
+  );
+
+  it.effect("does not start a second writer when interrupt races stopped-session recovery", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+      const recoveryStarted = yield* Deferred.make<void>();
+      const releaseRecovery = yield* Deferred.make<void>();
+      const threadId = asThreadId("thread-stopped-send-interrupt-race");
+      const initial = yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* provider.stopSession({ threadId });
+
+      routing.codex.startSession.mockClear();
+      routing.codex.interruptTurn.mockClear();
+      const originalStart = routing.codex.startSession.getMockImplementation();
+      assert.exists(originalStart);
+      routing.codex.startSession.mockImplementationOnce((input) =>
+        Deferred.succeed(recoveryStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseRecovery)),
+          Effect.andThen(originalStart(input)),
+        ),
+      );
+
+      const sendFiber = yield* provider
+        .sendTurn({
+          threadId,
+          input: "recover exactly one writer",
+          attachments: [],
+        })
+        .pipe(Effect.exit, Effect.forkChild);
+      yield* Deferred.await(recoveryStarted);
+
+      const interruptExit = yield* Effect.exit(provider.interruptTurn({ threadId }));
+      assert.isTrue(Exit.isFailure(interruptExit));
+      assert.equal(routing.codex.startSession.mock.calls.length, 1);
+      assert.equal(routing.codex.interruptTurn.mock.calls.length, 0);
+
+      yield* Deferred.succeed(releaseRecovery, undefined);
+      const sendExit = yield* Fiber.join(sendFiber);
+      assert.isTrue(Exit.isSuccess(sendExit));
+      assert.equal(routing.codex.startSession.mock.calls.length, 1);
+      assert.deepEqual(
+        routing.codex.startSession.mock.calls[0]?.[0]?.resumeCursor,
+        initial.resumeCursor,
+      );
+      const activeSessions = (yield* routing.codex.listSessions()).filter(
+        (session) => session.threadId === threadId,
+      );
+      assert.equal(activeSessions.length, 1);
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(binding?.providerInstanceId, codexInstanceId);
+      assert.equal(binding?.status, "running");
+      assert.deepEqual(binding?.resumeCursor, initial.resumeCursor);
+    }),
+  );
+
+  it.effect("delivers approval and user-input responses while a send is blocked", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-interactive-send-responses");
+      yield* provider.startSession(threadId, {
+        provider: CURSOR_DRIVER,
+        providerInstanceId: cursorInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const approvalSendStarted = yield* Deferred.make<void>();
+      const approvalAnswered = yield* Deferred.make<void>();
+      routing.cursor.sendTurn.mockImplementationOnce(() =>
+        Deferred.succeed(approvalSendStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(approvalAnswered)),
+          Effect.as({ threadId, turnId: asTurnId("turn-approval-response") }),
+        ),
+      );
+      routing.cursor.respondToRequest.mockImplementationOnce(() =>
+        Deferred.succeed(approvalAnswered, undefined).pipe(Effect.asVoid),
+      );
+
+      const approvalSendFiber = yield* provider
+        .sendTurn({ threadId, input: "wait for approval", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(approvalSendStarted);
+      yield* provider.respondToRequest({
+        threadId,
+        requestId: asRequestId("request-while-send-blocked"),
+        decision: "accept",
+      });
+      yield* Fiber.join(approvalSendFiber);
+
+      const userInputSendStarted = yield* Deferred.make<void>();
+      const userInputAnswered = yield* Deferred.make<void>();
+      routing.cursor.sendTurn.mockImplementationOnce(() =>
+        Deferred.succeed(userInputSendStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(userInputAnswered)),
+          Effect.as({ threadId, turnId: asTurnId("turn-user-input-response") }),
+        ),
+      );
+      routing.cursor.respondToUserInput.mockImplementationOnce(() =>
+        Deferred.succeed(userInputAnswered, undefined).pipe(Effect.asVoid),
+      );
+
+      const userInputSendFiber = yield* provider
+        .sendTurn({ threadId, input: "wait for user input", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(userInputSendStarted);
+      yield* provider.respondToUserInput({
+        threadId,
+        requestId: asRequestId("user-input-while-send-blocked"),
+        answers: { choice: "continue" },
+      });
+      yield* Fiber.join(userInputSendFiber);
+
+      assert.deepEqual(routing.cursor.respondToRequest.mock.calls.at(-1), [
+        threadId,
+        asRequestId("request-while-send-blocked"),
+        "accept",
+      ]);
+      assert.deepEqual(routing.cursor.respondToUserInput.mock.calls.at(-1), [
+        threadId,
+        asRequestId("user-input-while-send-blocked"),
+        { choice: "continue" },
+      ]);
+    }),
+  );
+
+  it.effect("does not recover a stopped session to answer interactive requests", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-stopped-interactive-responses");
+      yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* provider.stopSession({ threadId });
+      routing.codex.startSession.mockClear();
+      routing.codex.respondToRequest.mockClear();
+      routing.codex.respondToUserInput.mockClear();
+
+      const approvalExit = yield* Effect.exit(
+        provider.respondToRequest({
+          threadId,
+          requestId: asRequestId("stopped-approval"),
+          decision: "accept",
+        }),
+      );
+      const userInputExit = yield* Effect.exit(
+        provider.respondToUserInput({
+          threadId,
+          requestId: asRequestId("stopped-user-input"),
+          answers: { choice: "continue" },
+        }),
+      );
+
+      assert.isTrue(Exit.isFailure(approvalExit));
+      assert.isTrue(Exit.isFailure(userInputExit));
+      assert.equal(routing.codex.startSession.mock.calls.length, 0);
+      assert.equal(routing.codex.respondToRequest.mock.calls.length, 0);
+      assert.equal(routing.codex.respondToUserInput.mock.calls.length, 0);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -2235,6 +2235,65 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("does not route or recover a retained non-routable session", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-retained-non-routable");
+
+      yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd: "/tmp/project-retained-non-routable",
+        runtimeMode: "full-access",
+      });
+
+      const originalHasSession = routing.codex.hasSession.getMockImplementation();
+      const originalListSessions = routing.codex.listSessions.getMockImplementation();
+      yield* Effect.gen(function* () {
+        let sessionProbeCount = 0;
+        routing.codex.hasSession.mockImplementation(() =>
+          Effect.sync(() => {
+            sessionProbeCount += 1;
+            return sessionProbeCount > 1;
+          }),
+        );
+        routing.codex.listSessions.mockImplementation(() => Effect.succeed([]));
+        routing.codex.startSession.mockClear();
+        routing.codex.sendTurn.mockClear();
+
+        const result = yield* provider
+          .sendTurn({
+            threadId,
+            input: "must not route",
+            attachments: [],
+          })
+          .pipe(Effect.result);
+
+        assert.equal(result._tag, "Failure");
+        if (result._tag === "Failure") {
+          assert.equal(result.failure._tag, "ProviderValidationError");
+          if (result.failure._tag === "ProviderValidationError") {
+            assert.match(result.failure.issue, /non-routable or ambiguous session/);
+          }
+        }
+        assert.equal(routing.codex.startSession.mock.calls.length, 0);
+        assert.equal(routing.codex.sendTurn.mock.calls.length, 0);
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (originalHasSession) {
+              routing.codex.hasSession.mockImplementation(originalHasSession);
+            }
+            if (originalListSessions) {
+              routing.codex.listSessions.mockImplementation(originalListSessions);
+            }
+          }),
+        ),
+      );
+    }),
+  );
+
   it.effect("recovers stale claudeAgent sessions for sendTurn using persisted cwd", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -42,6 +42,7 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import {
   ProviderAdapterRequestError,
   ProviderAdapterSessionNotFoundError,
+  ProviderSessionDirectoryPersistenceError,
   ProviderUnsupportedError,
   ProviderValidationError,
   type ProviderAdapterError,
@@ -96,27 +97,28 @@ function makeFakeCodexAdapter(provider: ProviderDriverKind = CODEX_DRIVER) {
   const sessions = new Map<ThreadId, ProviderSession>();
   const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
 
-  const startSession = vi.fn((input: ProviderSessionStartInput) =>
-    Effect.sync(() => {
-      const now = "2026-01-01T00:00:00.000Z";
-      const session: ProviderSession = {
-        provider,
-        ...(input.providerInstanceId !== undefined
-          ? { providerInstanceId: input.providerInstanceId }
-          : {}),
-        status: "ready",
-        runtimeMode: input.runtimeMode,
-        threadId: input.threadId,
-        resumeCursor: input.resumeCursor ?? {
-          opaque: `resume-${String(input.threadId)}`,
-        },
-        cwd: input.cwd ?? process.cwd(),
-        createdAt: now,
-        updatedAt: now,
-      };
-      sessions.set(session.threadId, session);
-      return session;
-    }),
+  const startSession = vi.fn(
+    (input: ProviderSessionStartInput): Effect.Effect<ProviderSession, ProviderAdapterError> =>
+      Effect.sync(() => {
+        const now = "2026-01-01T00:00:00.000Z";
+        const session: ProviderSession = {
+          provider,
+          ...(input.providerInstanceId !== undefined
+            ? { providerInstanceId: input.providerInstanceId }
+            : {}),
+          status: "ready",
+          runtimeMode: input.runtimeMode,
+          threadId: input.threadId,
+          resumeCursor: input.resumeCursor ?? {
+            opaque: `resume-${String(input.threadId)}`,
+          },
+          cwd: input.cwd ?? process.cwd(),
+          createdAt: now,
+          updatedAt: now,
+        };
+        sessions.set(session.threadId, session);
+        return session;
+      }),
   );
 
   const sendTurn = vi.fn(
@@ -332,6 +334,829 @@ function makeProviderServiceLayer() {
     layer,
   };
 }
+
+function makeCompatibleCodexSwitchHarness(options?: { readonly targetContinuationKey?: string }) {
+  const source = makeFakeCodexAdapter();
+  const target = makeFakeCodexAdapter();
+  const stale = makeFakeCodexAdapter();
+  const sourceInstanceId = ProviderInstanceId.make("codex-source");
+  const targetInstanceId = ProviderInstanceId.make("codex-target");
+  const staleInstanceId = ProviderInstanceId.make("codex-stale");
+  const continuationKey = "codex:home:/tmp/shared-codex-home";
+  const adapters = new Map([
+    [sourceInstanceId, source.adapter],
+    [targetInstanceId, target.adapter],
+    [staleInstanceId, stale.adapter],
+  ]);
+  const unsupported = (instanceId: ProviderInstanceId) =>
+    new ProviderUnsupportedError({ provider: ProviderDriverKind.make(instanceId) });
+  const registry: ProviderAdapterRegistry.ProviderAdapterRegistry["Service"] = {
+    getByInstance: (instanceId) => {
+      const adapter = adapters.get(instanceId);
+      return adapter ? Effect.succeed(adapter) : Effect.fail(unsupported(instanceId));
+    },
+    getInstanceInfo: (instanceId) =>
+      adapters.has(instanceId)
+        ? Effect.succeed({
+            instanceId,
+            driverKind: CODEX_DRIVER,
+            displayName: instanceId,
+            enabled: true,
+            continuationIdentity: {
+              driverKind: CODEX_DRIVER,
+              continuationKey:
+                instanceId === targetInstanceId
+                  ? (options?.targetContinuationKey ?? continuationKey)
+                  : continuationKey,
+            },
+          })
+        : Effect.fail(unsupported(instanceId)),
+    listInstances: () => Effect.succeed([sourceInstanceId, targetInstanceId, staleInstanceId]),
+    listProviders: () => Effect.succeed([CODEX_DRIVER]),
+    streamChanges: Stream.empty,
+    subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+      PubSub.subscribe(pubsub),
+    ),
+  };
+  const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+    Layer.provide(SqlitePersistenceMemory),
+  );
+  const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+  let failNextSourcePrepare = false;
+  let failNextSourceStopped = false;
+  let failNextTargetCommit = false;
+  const directoryProxyLayer = Layer.effect(
+    ProviderSessionDirectory.ProviderSessionDirectory,
+    Effect.map(ProviderSessionDirectory.ProviderSessionDirectory, (directory) => ({
+      ...directory,
+      upsert: (binding: ProviderSessionDirectory.ProviderRuntimeBinding) => {
+        const runtimePayload =
+          binding.runtimePayload !== null &&
+          typeof binding.runtimePayload === "object" &&
+          !Array.isArray(binding.runtimePayload)
+            ? binding.runtimePayload
+            : {};
+        const lastRuntimeEvent =
+          "lastRuntimeEvent" in runtimePayload ? runtimePayload.lastRuntimeEvent : undefined;
+        if (
+          failNextSourcePrepare &&
+          binding.providerInstanceId === sourceInstanceId &&
+          lastRuntimeEvent === "codex.handoff.prepared"
+        ) {
+          failNextSourcePrepare = false;
+          return Effect.fail(
+            new ProviderSessionDirectoryPersistenceError({
+              operation: "ProviderSessionDirectory.upsert:fixture",
+              detail: "Injected source cursor persistence failure.",
+            }),
+          );
+        }
+        if (
+          failNextSourceStopped &&
+          binding.providerInstanceId === sourceInstanceId &&
+          lastRuntimeEvent === "codex.handoff.source-stopped"
+        ) {
+          failNextSourceStopped = false;
+          return Effect.fail(
+            new ProviderSessionDirectoryPersistenceError({
+              operation: "ProviderSessionDirectory.upsert:fixture",
+              detail: "Injected stopped-source persistence failure.",
+            }),
+          );
+        }
+        if (failNextTargetCommit && binding.providerInstanceId === targetInstanceId) {
+          failNextTargetCommit = false;
+          return Effect.fail(
+            new ProviderSessionDirectoryPersistenceError({
+              operation: "ProviderSessionDirectory.upsert:fixture",
+              detail: "Injected target binding persistence failure.",
+            }),
+          );
+        }
+        return directory.upsert(binding);
+      },
+    })),
+  ).pipe(Layer.provide(directoryLayer));
+  const providerLayer = makeProviderServiceLive().pipe(
+    Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+    Layer.provide(directoryProxyLayer),
+    Layer.provide(defaultServerSettingsLayer),
+    Layer.provide(serverConfigTestLayer),
+    Layer.provide(AnalyticsService.layerTest),
+    Layer.provide(
+      Layer.succeed(
+        ProviderEventLoggers.ProviderEventLoggers,
+        ProviderEventLoggers.NoOpProviderEventLoggers,
+      ),
+    ),
+  );
+
+  return {
+    source,
+    target,
+    stale,
+    sourceInstanceId,
+    targetInstanceId,
+    staleInstanceId,
+    layer: Layer.mergeAll(
+      providerLayer,
+      directoryLayer,
+      runtimeRepositoryLayer,
+      NodeServices.layer,
+    ),
+    failSourcePrepare: () => {
+      failNextSourcePrepare = true;
+    },
+    failSourceStopped: () => {
+      failNextSourceStopped = true;
+    },
+    failTargetCommit: () => {
+      failNextTargetCommit = true;
+    },
+  };
+}
+
+function startCodexSwitchSource(input: {
+  readonly provider: ProviderService.ProviderService["Service"];
+  readonly threadId: ThreadId;
+  readonly sourceInstanceId: ProviderInstanceId;
+}) {
+  return input.provider.startSession(input.threadId, {
+    provider: CODEX_DRIVER,
+    providerInstanceId: input.sourceInstanceId,
+    threadId: input.threadId,
+    cwd: "/tmp/codex-switch-fixture",
+    runtimeMode: "full-access",
+    resumeCursor: { threadId: `native-${input.threadId}` },
+  });
+}
+
+function switchCodexTarget(input: {
+  readonly provider: ProviderService.ProviderService["Service"];
+  readonly threadId: ThreadId;
+  readonly targetInstanceId: ProviderInstanceId;
+  readonly resumeCursor?: unknown;
+}) {
+  return input.provider.startSession(input.threadId, {
+    provider: CODEX_DRIVER,
+    providerInstanceId: input.targetInstanceId,
+    threadId: input.threadId,
+    cwd: "/tmp/codex-switch-fixture",
+    runtimeMode: "full-access",
+    ...(input.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+  });
+}
+
+it.effect("stops the compatible Codex source before starting the target", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-stop-before-start");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+    const releaseSource = yield* Deferred.make<void>();
+    const originalStop = harness.source.stopSession.getMockImplementation();
+    assert.exists(originalStop);
+    harness.source.stopSession.mockImplementation((stoppedThreadId) =>
+      Deferred.await(releaseSource).pipe(Effect.andThen(originalStop(stoppedThreadId))),
+    );
+
+    const switchFiber = yield* Effect.forkChild(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    yield* Effect.yieldNow;
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    yield* Deferred.succeed(releaseSource, undefined);
+    const switched = yield* Fiber.join(switchFiber);
+
+    assert.equal(switched.providerInstanceId, harness.targetInstanceId);
+    assert.deepEqual(harness.source.stopSession.mock.calls, [[threadId]]);
+    assert.equal(harness.target.startSession.mock.calls.length, 1);
+    assert.deepEqual(harness.target.startSession.mock.calls[0]?.[0]?.resumeCursor, {
+      threadId: `native-${threadId}`,
+    });
+    assert.isFalse(yield* harness.source.hasSession(threadId));
+    assert.isTrue(yield* harness.target.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.targetInstanceId);
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("queues sendTurn behind handoff and routes the turn only to the committed target", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-send-race");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.startSession.mockClear();
+    harness.source.sendTurn.mockClear();
+    harness.target.sendTurn.mockClear();
+    const sourceStopEntered = yield* Deferred.make<void>();
+    const releaseSource = yield* Deferred.make<void>();
+    const originalStop = harness.source.stopSession.getMockImplementation();
+    assert.exists(originalStop);
+    harness.source.stopSession.mockImplementation((stoppedThreadId) =>
+      Deferred.succeed(sourceStopEntered, undefined).pipe(
+        Effect.andThen(Deferred.await(releaseSource)),
+        Effect.andThen(originalStop(stoppedThreadId)),
+      ),
+    );
+
+    const switchFiber = yield* Effect.forkChild(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    yield* Deferred.await(sourceStopEntered);
+    const sendFiber = yield* Effect.forkChild(
+      provider.sendTurn({ threadId, input: "queued until target commitment" }),
+    );
+    yield* Effect.yieldNow;
+    assert.equal(harness.source.sendTurn.mock.calls.length, 0);
+    assert.equal(harness.target.sendTurn.mock.calls.length, 0);
+    assert.equal(harness.source.startSession.mock.calls.length, 0);
+
+    yield* Deferred.succeed(releaseSource, undefined);
+    yield* Fiber.join(switchFiber);
+    yield* Fiber.join(sendFiber);
+
+    assert.equal(harness.source.sendTurn.mock.calls.length, 0);
+    assert.equal(harness.source.startSession.mock.calls.length, 0);
+    assert.equal(harness.target.sendTurn.mock.calls.length, 1);
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.targetInstanceId);
+    assert.equal(binding?.status, "running");
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("queues recovery-capable interrupt behind handoff without restarting source", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const threadId = asThreadId("thread-codex-interrupt-recovery-race");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.startSession.mockClear();
+    harness.source.interruptTurn.mockClear();
+    harness.target.interruptTurn.mockClear();
+    const sourceStopEntered = yield* Deferred.make<void>();
+    const releaseSource = yield* Deferred.make<void>();
+    const originalStop = harness.source.stopSession.getMockImplementation();
+    assert.exists(originalStop);
+    harness.source.stopSession.mockImplementation((stoppedThreadId) =>
+      Deferred.succeed(sourceStopEntered, undefined).pipe(
+        Effect.andThen(Deferred.await(releaseSource)),
+        Effect.andThen(originalStop(stoppedThreadId)),
+      ),
+    );
+
+    const switchFiber = yield* Effect.forkChild(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    yield* Deferred.await(sourceStopEntered);
+    const interruptFiber = yield* Effect.forkChild(provider.interruptTurn({ threadId }));
+    yield* Effect.yieldNow;
+    assert.equal(harness.source.startSession.mock.calls.length, 0);
+    assert.equal(harness.source.interruptTurn.mock.calls.length, 0);
+    assert.equal(harness.target.interruptTurn.mock.calls.length, 0);
+
+    yield* Deferred.succeed(releaseSource, undefined);
+    yield* Fiber.join(switchFiber);
+    yield* Fiber.join(interruptFiber);
+
+    assert.equal(harness.source.startSession.mock.calls.length, 0);
+    assert.equal(harness.source.interruptTurn.mock.calls.length, 0);
+    assert.deepEqual(harness.target.interruptTurn.mock.calls, [[threadId, undefined]]);
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("queues stopSession behind handoff and stops only the committed target", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-stop-race");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.stopSession.mockClear();
+    harness.target.stopSession.mockClear();
+    const sourceStopEntered = yield* Deferred.make<void>();
+    const releaseSource = yield* Deferred.make<void>();
+    const originalStop = harness.source.stopSession.getMockImplementation();
+    assert.exists(originalStop);
+    harness.source.stopSession.mockImplementation((stoppedThreadId) =>
+      Deferred.succeed(sourceStopEntered, undefined).pipe(
+        Effect.andThen(Deferred.await(releaseSource)),
+        Effect.andThen(originalStop(stoppedThreadId)),
+      ),
+    );
+
+    const switchFiber = yield* Effect.forkChild(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    yield* Deferred.await(sourceStopEntered);
+    const stopFiber = yield* Effect.forkChild(provider.stopSession({ threadId }));
+    yield* Effect.yieldNow;
+    assert.equal(harness.target.stopSession.mock.calls.length, 0);
+
+    yield* Deferred.succeed(releaseSource, undefined);
+    yield* Fiber.join(switchFiber);
+    yield* Fiber.join(stopFiber);
+
+    assert.deepEqual(harness.source.stopSession.mock.calls, [[threadId]]);
+    assert.deepEqual(harness.target.stopSession.mock.calls, [[threadId]]);
+    assert.isFalse(yield* harness.target.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.targetInstanceId);
+    assert.equal(binding?.status, "stopped");
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("does not start the Codex target when source release fails", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-stop-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.target.startSession.mockClear();
+    harness.source.stopSession.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: CODEX_DRIVER,
+          method: "stopSession",
+          detail: "Injected source release failure.",
+        }),
+      ),
+    );
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("does not start the Codex target when another stale writer cannot stop", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-stale-writer-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    yield* harness.stale.startSession({
+      provider: CODEX_DRIVER,
+      providerInstanceId: harness.staleInstanceId,
+      threadId,
+      cwd: "/tmp/codex-switch-fixture",
+      runtimeMode: "full-access",
+      resumeCursor: { threadId: `native-${threadId}` },
+    });
+    harness.target.startSession.mockClear();
+    harness.stale.stopSession.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: CODEX_DRIVER,
+          method: "stopSession",
+          detail: "Injected stale writer release failure.",
+        }),
+      ),
+    );
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isFalse(yield* harness.source.hasSession(threadId));
+    assert.isTrue(yield* harness.stale.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.equal(binding?.status, "stopped");
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("does not stop the Codex source when cursor persistence fails", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-cursor-persistence-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+    harness.failSourcePrepare();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.source.stopSession.mock.calls.length, 0);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isTrue(yield* harness.source.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("rejects a request cursor that conflicts with the Codex source owner", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-conflicting-request-cursor");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+        resumeCursor: { threadId: "redirected-native-thread" },
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.source.stopSession.mock.calls.length, 0);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isTrue(yield* harness.source.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("rejects incompatible Codex continuation identities before source teardown", () => {
+  const harness = makeCompatibleCodexSwitchHarness({
+    targetContinuationKey: "codex:home:/tmp/different-codex-home",
+  });
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const threadId = asThreadId("thread-codex-incompatible-continuation");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.source.stopSession.mock.calls.length, 0);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isTrue(yield* harness.source.hasSession(threadId));
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("rejects a non-idle Codex source before target start", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const threadId = asThreadId("thread-codex-non-idle-source");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.updateSession(threadId, (session) => ({
+      ...session,
+      status: "running",
+      activeTurnId: asTurnId("turn-still-active"),
+    }));
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.source.stopSession.mock.calls.length, 0);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isTrue(yield* harness.source.hasSession(threadId));
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("rejects an ambiguous active Codex source before target start", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const threadId = asThreadId("thread-codex-ambiguous-source");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.listSessions.mockImplementation(() => Effect.succeed([]));
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.source.stopSession.mock.calls.length, 0);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("rejects an invalid authoritative Codex source cursor", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const threadId = asThreadId("thread-codex-invalid-source-cursor");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.updateSession(threadId, (session) => ({
+      ...session,
+      resumeCursor: { threadId: "" },
+    }));
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(harness.source.stopSession.mock.calls.length, 0);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isTrue(yield* harness.source.hasSession(threadId));
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("does not start the Codex target when stopped-source persistence fails", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-stopped-source-persistence-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.source.stopSession.mockClear();
+    harness.target.startSession.mockClear();
+    harness.failSourceStopped();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.deepEqual(harness.source.stopSession.mock.calls, [[threadId]]);
+    assert.equal(harness.target.startSession.mock.calls.length, 0);
+    assert.isFalse(yield* harness.source.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("surfaces failed cleanup of a provisional Codex target", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-provisional-cleanup-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    const originalStart = harness.target.startSession.getMockImplementation();
+    assert.exists(originalStart);
+    harness.target.startSession.mockImplementation((startInput) =>
+      originalStart(startInput).pipe(
+        Effect.map((session) => ({
+          ...session,
+          resumeCursor: { threadId: "different-native-thread" },
+        })),
+      ),
+    );
+    harness.target.stopSession.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: CODEX_DRIVER,
+          method: "stopSession",
+          detail: "Injected provisional target cleanup failure.",
+        }),
+      ),
+    );
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.isTrue(yield* harness.target.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.equal(binding?.status, "stopped");
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("leaves the stopped Codex source cursor recoverable when target start fails", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-target-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.target.startSession.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: CODEX_DRIVER,
+          method: "startSession",
+          detail: "Injected target start failure.",
+        }),
+      ),
+    );
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.isFalse(yield* harness.source.hasSession(threadId));
+    assert.isFalse(yield* harness.target.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.equal(binding?.status, "stopped");
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("stops a mismatched Codex target and retains the source cursor", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-id-mismatch");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    const originalStart = harness.target.startSession.getMockImplementation();
+    assert.exists(originalStart);
+    harness.target.startSession.mockImplementation((startInput) =>
+      originalStart(startInput).pipe(
+        Effect.map((session) => ({
+          ...session,
+          resumeCursor: { threadId: "different-native-thread" },
+        })),
+      ),
+    );
+    harness.target.stopSession.mockClear();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.deepEqual(harness.target.stopSession.mock.calls, [[threadId]]);
+    assert.isFalse(yield* harness.target.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
+
+it.effect("stops the Codex target when target binding persistence fails", () => {
+  const harness = makeCompatibleCodexSwitchHarness();
+  return Effect.gen(function* () {
+    const provider = yield* ProviderService.ProviderService;
+    const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+    const threadId = asThreadId("thread-codex-binding-failure");
+    yield* startCodexSwitchSource({
+      provider,
+      threadId,
+      sourceInstanceId: harness.sourceInstanceId,
+    });
+    harness.target.stopSession.mockClear();
+    harness.failTargetCommit();
+
+    const exit = yield* Effect.exit(
+      switchCodexTarget({
+        provider,
+        threadId,
+        targetInstanceId: harness.targetInstanceId,
+      }),
+    );
+    assert.isTrue(Exit.isFailure(exit));
+    assert.deepEqual(harness.target.stopSession.mock.calls, [[threadId]]);
+    assert.isFalse(yield* harness.target.hasSession(threadId));
+    const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    assert.equal(binding?.providerInstanceId, harness.sourceInstanceId);
+    assert.equal(binding?.status, "stopped");
+    assert.deepEqual(binding?.resumeCursor, { threadId: `native-${threadId}` });
+  }).pipe(Effect.provide(harness.layer));
+});
 
 it.effect("ProviderServiceLive catches stopAll failures during shutdown", () =>
   Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -51,7 +51,7 @@ import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
 import * as ProviderService from "../Services/ProviderService.ts";
 import * as ProviderSessionDirectory from "../Services/ProviderSessionDirectory.ts";
-import { makeProviderServiceLive } from "./ProviderService.ts";
+import { makeProviderServiceLive, makeThreadLockManager } from "./ProviderService.ts";
 import * as ProviderEventLoggers from "./ProviderEventLoggers.ts";
 import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -334,6 +334,150 @@ function makeProviderServiceLayer() {
     layer,
   };
 }
+
+it.effect("serializes queued and late operations for the same thread", () =>
+  Effect.gen(function* () {
+    const locks = yield* makeThreadLockManager();
+    const threadId = asThreadId("thread-lock-serialized");
+    const firstEntered = yield* Deferred.make<void>();
+    const releaseFirst = yield* Deferred.make<void>();
+    const secondEntered = yield* Deferred.make<void>();
+    const releaseSecond = yield* Deferred.make<void>();
+    const thirdEntered = yield* Deferred.make<void>();
+
+    const firstFiber = yield* Effect.forkChild(
+      locks.withLock(
+        threadId,
+        Deferred.succeed(firstEntered, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseFirst)),
+        ),
+      ),
+    );
+    yield* Deferred.await(firstEntered);
+
+    const secondFiber = yield* Effect.forkChild(
+      locks.withLock(
+        threadId,
+        Deferred.succeed(secondEntered, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseSecond)),
+        ),
+      ),
+    );
+    yield* Effect.yieldNow;
+    assert.equal(yield* locks.userCount(threadId), 2);
+    assert.isFalse(yield* Deferred.isDone(secondEntered));
+
+    yield* Deferred.succeed(releaseFirst, undefined);
+    yield* Fiber.join(firstFiber);
+    yield* Deferred.await(secondEntered);
+
+    const thirdFiber = yield* Effect.forkChild(
+      locks.withLock(threadId, Deferred.succeed(thirdEntered, undefined)),
+    );
+    yield* Effect.yieldNow;
+    assert.equal(yield* locks.userCount(threadId), 2);
+    assert.isFalse(yield* Deferred.isDone(thirdEntered));
+
+    yield* Deferred.succeed(releaseSecond, undefined);
+    yield* Fiber.join(secondFiber);
+    yield* Fiber.join(thirdFiber);
+
+    assert.isTrue(yield* Deferred.isDone(thirdEntered));
+    assert.equal(yield* locks.userCount(threadId), 0);
+    assert.equal(yield* locks.lockCount, 0);
+  }),
+);
+
+it.effect("allows operations for different threads to run concurrently", () =>
+  Effect.gen(function* () {
+    const locks = yield* makeThreadLockManager();
+    const firstThreadId = asThreadId("thread-lock-concurrent-first");
+    const secondThreadId = asThreadId("thread-lock-concurrent-second");
+    const firstEntered = yield* Deferred.make<void>();
+    const releaseFirst = yield* Deferred.make<void>();
+    const secondEntered = yield* Deferred.make<void>();
+    const releaseSecond = yield* Deferred.make<void>();
+
+    const firstFiber = yield* Effect.forkChild(
+      locks.withLock(
+        firstThreadId,
+        Deferred.succeed(firstEntered, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseFirst)),
+        ),
+      ),
+    );
+    yield* Deferred.await(firstEntered);
+
+    const secondFiber = yield* Effect.forkChild(
+      locks.withLock(
+        secondThreadId,
+        Deferred.succeed(secondEntered, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseSecond)),
+        ),
+      ),
+    );
+    yield* Deferred.await(secondEntered);
+
+    assert.equal(yield* locks.lockCount, 2);
+    assert.equal(yield* locks.userCount(firstThreadId), 1);
+    assert.equal(yield* locks.userCount(secondThreadId), 1);
+
+    yield* Deferred.succeed(releaseFirst, undefined);
+    yield* Deferred.succeed(releaseSecond, undefined);
+    yield* Fiber.join(firstFiber);
+    yield* Fiber.join(secondFiber);
+
+    assert.equal(yield* locks.lockCount, 0);
+  }),
+);
+
+it.effect("cleans up a thread lock after the operation fails", () =>
+  Effect.gen(function* () {
+    const locks = yield* makeThreadLockManager();
+    const threadId = asThreadId("thread-lock-failure");
+    const exit = yield* Effect.exit(locks.withLock(threadId, Effect.fail("injected failure")));
+
+    assert.isTrue(Exit.isFailure(exit));
+    assert.equal(yield* locks.userCount(threadId), 0);
+    assert.equal(yield* locks.lockCount, 0);
+  }),
+);
+
+it.effect("cleans up active and queued thread locks after interruption", () =>
+  Effect.gen(function* () {
+    const locks = yield* makeThreadLockManager();
+    const threadId = asThreadId("thread-lock-interruption");
+    const firstEntered = yield* Deferred.make<void>();
+    const secondEntered = yield* Deferred.make<void>();
+
+    const firstFiber = yield* Effect.forkChild(
+      locks.withLock(
+        threadId,
+        Deferred.succeed(firstEntered, undefined).pipe(Effect.andThen(Effect.never)),
+      ),
+    );
+    yield* Deferred.await(firstEntered);
+
+    const secondFiber = yield* Effect.forkChild(
+      locks.withLock(
+        threadId,
+        Deferred.succeed(secondEntered, undefined).pipe(Effect.andThen(Effect.never)),
+      ),
+    );
+    yield* Effect.yieldNow;
+    assert.equal(yield* locks.userCount(threadId), 2);
+    assert.isFalse(yield* Deferred.isDone(secondEntered));
+
+    yield* Fiber.interrupt(secondFiber);
+    assert.equal(yield* locks.userCount(threadId), 1);
+    assert.equal(yield* locks.lockCount, 1);
+    assert.isFalse(yield* Deferred.isDone(secondEntered));
+
+    yield* Fiber.interrupt(firstFiber);
+    assert.equal(yield* locks.userCount(threadId), 0);
+    assert.equal(yield* locks.lockCount, 0);
+  }),
+);
 
 function makeCompatibleCodexSwitchHarness(options?: { readonly targetContinuationKey?: string }) {
   const source = makeFakeCodexAdapter();

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -497,6 +497,46 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     () => reconcileInstanceSubscriptions,
   ).pipe(Effect.forkScoped);
 
+  const stopStaleSessionsForThread = Effect.fn("stopStaleSessionsForThread")(function* (input: {
+    readonly threadId: ThreadId;
+    readonly currentInstanceId: ProviderInstanceId;
+    readonly failOnError?: boolean;
+  }) {
+    const currentAdapters = yield* getAdapterEntries;
+    yield* Effect.forEach(
+      currentAdapters,
+      ([instanceId, adapter]) =>
+        instanceId === input.currentInstanceId
+          ? Effect.void
+          : Effect.gen(function* () {
+              const hasSession = yield* adapter.hasSession(input.threadId);
+              if (!hasSession) {
+                return;
+              }
+
+              const stop = adapter.stopSession(input.threadId).pipe(
+                Effect.tap(() =>
+                  analytics.record("provider.session.stopped", {
+                    provider: adapter.provider,
+                  }),
+                ),
+              );
+              yield* input.failOnError
+                ? stop
+                : stop.pipe(
+                    Effect.catchCause((cause) =>
+                      Effect.logWarning("provider.session.stop-stale-failed", {
+                        threadId: input.threadId,
+                        provider: adapter.provider,
+                        cause,
+                      }),
+                    ),
+                  );
+            }),
+      { discard: true },
+    );
+  });
+
   const recoverSessionForThread = Effect.fn("recoverSessionForThread")(function* (input: {
     readonly binding: ProviderSessionDirectory.ProviderRuntimeBinding;
     readonly operation: string;
@@ -541,6 +581,17 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           input.operation,
           `Cannot recover thread '${input.binding.threadId}' because no provider resume state is persisted.`,
         );
+      }
+
+      if (input.binding.provider === "codex") {
+        // A previous Codex handoff may have started another instance before
+        // its binding commit or cleanup failed. Prove every non-owner writer
+        // is gone before recovering the persisted owner.
+        yield* stopStaleSessionsForThread({
+          threadId: input.binding.threadId,
+          currentInstanceId: bindingInstanceId,
+          failOnError: true,
+        });
       }
 
       const persistedCwd = readPersistedCwd(input.binding.runtimePayload);
@@ -636,46 +687,6 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     } as const;
   });
 
-  const stopStaleSessionsForThread = Effect.fn("stopStaleSessionsForThread")(function* (input: {
-    readonly threadId: ThreadId;
-    readonly currentInstanceId: ProviderInstanceId;
-    readonly failOnError?: boolean;
-  }) {
-    const currentAdapters = yield* getAdapterEntries;
-    yield* Effect.forEach(
-      currentAdapters,
-      ([instanceId, adapter]) =>
-        instanceId === input.currentInstanceId
-          ? Effect.void
-          : Effect.gen(function* () {
-              const hasSession = yield* adapter.hasSession(input.threadId);
-              if (!hasSession) {
-                return;
-              }
-
-              const stop = adapter.stopSession(input.threadId).pipe(
-                Effect.tap(() =>
-                  analytics.record("provider.session.stopped", {
-                    provider: adapter.provider,
-                  }),
-                ),
-              );
-              yield* input.failOnError
-                ? stop
-                : stop.pipe(
-                    Effect.catchCause((cause) =>
-                      Effect.logWarning("provider.session.stop-stale-failed", {
-                        threadId: input.threadId,
-                        provider: adapter.provider,
-                        cause,
-                      }),
-                    ),
-                  );
-            }),
-      { discard: true },
-    );
-  });
-
   const startSession: ProviderServiceMethod<"startSession"> = Effect.fn("startSession")(
     function* (threadId, rawInput) {
       const parsed = yield* decodeInputOrValidationError({
@@ -722,6 +733,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           const sourceInstanceId = persistedBinding?.providerInstanceId;
           const isCodexInstanceChange =
             resolvedProvider === "codex" &&
+            persistedBinding?.provider === "codex" &&
             sourceInstanceId !== undefined &&
             sourceInstanceId !== resolvedInstanceId;
 
@@ -821,14 +833,6 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             yield* clearMcpSession(threadId);
           }
 
-          if (handoffNativeThreadId !== undefined) {
-            yield* stopStaleSessionsForThread({
-              threadId,
-              currentInstanceId: resolvedInstanceId,
-              failOnError: true,
-            });
-          }
-
           const effectiveResumeCursor =
             handoffResumeCursor ??
             input.resumeCursor ??
@@ -841,6 +845,17 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             (persistedBinding?.providerInstanceId === resolvedInstanceId
               ? readPersistedCwd(persistedBinding.runtimePayload)
               : undefined);
+          const effectiveCodexNativeThreadId =
+            resolvedProvider === "codex"
+              ? readCodexNativeThreadId(effectiveResumeCursor)
+              : undefined;
+          if (effectiveCodexNativeThreadId !== undefined) {
+            yield* stopStaleSessionsForThread({
+              threadId,
+              currentInstanceId: resolvedInstanceId,
+              failOnError: true,
+            });
+          }
           yield* Effect.annotateCurrentSpan({
             "provider.kind": resolvedProvider,
             "provider.resume_cursor.source":
@@ -900,7 +915,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
             );
           }
 
-          if (handoffNativeThreadId === undefined) {
+          if (effectiveCodexNativeThreadId === undefined) {
             yield* stopStaleSessionsForThread({
               threadId,
               currentInstanceId: resolvedInstanceId,
@@ -1082,8 +1097,14 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           const routed = yield* resolveRoutableSession({
             threadId: input.threadId,
             operation: "ProviderService.interruptTurn",
-            allowRecovery: true,
+            allowRecovery: false,
           });
+          if (!routed.isActive) {
+            return yield* toValidationError(
+              "ProviderService.interruptTurn",
+              `Cannot interrupt thread '${input.threadId}' because its provider session is not active.`,
+            );
+          }
           metricProvider = routed.adapter.provider;
           yield* Effect.annotateCurrentSpan({
             "provider.operation": "interrupt-turn",
@@ -1116,14 +1137,20 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         payload: rawInput,
       });
       let metricProvider = "unknown";
-      return yield* withThreadLock(
+      return yield* withThreadRoutingLock(
         input.threadId,
         Effect.gen(function* () {
           const routed = yield* resolveRoutableSession({
             threadId: input.threadId,
             operation: "ProviderService.respondToRequest",
-            allowRecovery: true,
+            allowRecovery: false,
           });
+          if (!routed.isActive) {
+            return yield* toValidationError(
+              "ProviderService.respondToRequest",
+              `Cannot answer request '${input.requestId}' because thread '${input.threadId}' has no active provider session.`,
+            );
+          }
           metricProvider = routed.adapter.provider;
           yield* Effect.annotateCurrentSpan({
             "provider.operation": "respond-to-request",
@@ -1158,14 +1185,20 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       payload: rawInput,
     });
     let metricProvider = "unknown";
-    return yield* withThreadLock(
+    return yield* withThreadRoutingLock(
       input.threadId,
       Effect.gen(function* () {
         const routed = yield* resolveRoutableSession({
           threadId: input.threadId,
           operation: "ProviderService.respondToUserInput",
-          allowRecovery: true,
+          allowRecovery: false,
         });
+        if (!routed.isActive) {
+          return yield* toValidationError(
+            "ProviderService.respondToUserInput",
+            `Cannot answer user input '${input.requestId}' because thread '${input.threadId}' has no active provider session.`,
+          );
+        }
         metricProvider = routed.adapter.provider;
         yield* Effect.annotateCurrentSpan({
           "provider.operation": "respond-to-user-input",

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -473,18 +473,22 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         const existing = activeSessions.find(
           (session) => session.threadId === input.binding.threadId,
         );
-        if (existing) {
-          yield* upsertSessionBinding(
-            { ...existing, providerInstanceId: bindingInstanceId },
-            input.binding.threadId,
+        if (!existing) {
+          return yield* toValidationError(
+            input.operation,
+            `Provider instance '${bindingInstanceId}' retains a non-routable or ambiguous session for thread '${input.binding.threadId}'. Stop it before recovery.`,
           );
-          yield* analytics.record("provider.session.recovered", {
-            provider: existing.provider,
-            strategy: "adopt-existing",
-            hasResumeCursor: existing.resumeCursor !== undefined,
-          });
-          return { adapter, session: existing } as const;
         }
+        yield* upsertSessionBinding(
+          { ...existing, providerInstanceId: bindingInstanceId },
+          input.binding.threadId,
+        );
+        yield* analytics.record("provider.session.recovered", {
+          provider: existing.provider,
+          strategy: "adopt-existing",
+          hasResumeCursor: existing.resumeCursor !== undefined,
+        });
+        return { adapter, session: existing } as const;
       }
 
       if (!hasResumeCursor) {

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -316,8 +316,12 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     options?.revokeMcpCredential ?? McpSessionRegistry.revokeActiveMcpThread;
   const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
   const threadLockManager = yield* makeThreadLockManager();
+  const threadRoutingLockManager = yield* makeThreadLockManager();
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
   const withThreadLock = threadLockManager.withLock;
+  const withThreadRoutingLock = threadRoutingLockManager.withLock;
+  const withSessionLock = <A, E, R>(threadId: ThreadId, effect: Effect.Effect<A, E, R>) =>
+    withThreadLock(threadId, withThreadRoutingLock(threadId, effect));
   /**
    * Attach the `t3-code` MCP server to the session that is about to start.
    *
@@ -691,7 +695,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         "provider.thread_id": threadId,
         "provider.runtime_mode": parsed.runtimeMode,
       });
-      return yield* withThreadLock(
+      return yield* withSessionLock(
         threadId,
         Effect.gen(function* () {
           const instanceInfo = yield* registry.getInstanceInfo(resolvedInstanceId);
@@ -1070,7 +1074,9 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         payload: rawInput,
       });
       let metricProvider = "unknown";
-      return yield* withThreadLock(
+      // Interrupt remains out of band from turn operations so it can cancel a
+      // blocked send. The routing lock still orders it behind session handoffs.
+      return yield* withThreadRoutingLock(
         input.threadId,
         Effect.gen(function* () {
           const routed = yield* resolveRoutableSession({

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -85,6 +85,67 @@ export interface ProviderServiceLiveOptions {
 type ProviderServiceMethod<Name extends keyof ProviderService.ProviderService["Service"]> =
   ProviderService.ProviderService["Service"][Name];
 
+type ThreadLockEntry = {
+  readonly semaphore: Semaphore.Semaphore;
+  readonly users: number;
+};
+
+/** @internal */
+export const makeThreadLockManager = Effect.fn("makeThreadLockManager")(function* () {
+  const threadLocks = yield* SynchronizedRef.make(new Map<ThreadId, ThreadLockEntry>());
+
+  // Count callers before they wait for a permit so the entry stays registered
+  // until every active or queued caller has released its reference.
+  const acquire = (threadId: ThreadId) =>
+    SynchronizedRef.modifyEffect(threadLocks, (current) => {
+      const existing = current.get(threadId);
+      if (existing !== undefined) {
+        const next = new Map(current);
+        next.set(threadId, { ...existing, users: existing.users + 1 });
+        return Effect.succeed([existing.semaphore, next] as const);
+      }
+      return Semaphore.make(1).pipe(
+        Effect.map((semaphore) => {
+          const next = new Map(current);
+          next.set(threadId, { semaphore, users: 1 });
+          return [semaphore, next] as const;
+        }),
+      );
+    });
+
+  const release = (threadId: ThreadId, semaphore: Semaphore.Semaphore) =>
+    SynchronizedRef.updateEffect(threadLocks, (current) => {
+      const existing = current.get(threadId);
+      if (existing === undefined || existing.semaphore !== semaphore) {
+        return Effect.succeed(current);
+      }
+      const next = new Map(current);
+      if (existing.users === 1) {
+        next.delete(threadId);
+      } else {
+        next.set(threadId, { ...existing, users: existing.users - 1 });
+      }
+      return Effect.succeed(next);
+    });
+
+  const withLock = <A, E, R>(
+    threadId: ThreadId,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> =>
+    Effect.acquireUseRelease(
+      acquire(threadId),
+      (semaphore) => semaphore.withPermit(effect),
+      (semaphore) => release(threadId, semaphore),
+    );
+
+  return {
+    withLock,
+    lockCount: Effect.map(SynchronizedRef.get(threadLocks), (current) => current.size),
+    userCount: (threadId: ThreadId) =>
+      Effect.map(SynchronizedRef.get(threadLocks), (current) => current.get(threadId)?.users ?? 0),
+  } as const;
+});
+
 const ProviderRollbackConversationInput = Schema.Struct({
   threadId: ThreadId,
   numTurns: NonNegativeInt,
@@ -254,29 +315,9 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const revokeMcpCredential =
     options?.revokeMcpCredential ?? McpSessionRegistry.revokeActiveMcpThread;
   const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
-  const threadLocks = yield* SynchronizedRef.make(new Map<ThreadId, Semaphore.Semaphore>());
+  const threadLockManager = yield* makeThreadLockManager();
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
-
-  const getThreadLock = (threadId: ThreadId) =>
-    SynchronizedRef.modifyEffect(threadLocks, (current) => {
-      const existing = current.get(threadId);
-      if (existing !== undefined) {
-        return Effect.succeed([existing, current] as const);
-      }
-      return Semaphore.make(1).pipe(
-        Effect.map((semaphore) => {
-          const next = new Map(current);
-          next.set(threadId, semaphore);
-          return [semaphore, next] as const;
-        }),
-      );
-    });
-
-  const withThreadLock = <A, E, R>(
-    threadId: ThreadId,
-    effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, E, R> =>
-    Effect.flatMap(getThreadLock(threadId), (semaphore) => semaphore.withPermit(effect));
+  const withThreadLock = threadLockManager.withLock;
   /**
    * Attach the `t3-code` MCP server to the session that is about to start.
    *

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -28,13 +28,16 @@ import {
 import { causeErrorTag } from "@t3tools/shared/observability";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import * as ServerConfig from "../../config.ts";
@@ -175,6 +178,25 @@ function readPersistedCwd(
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function readPersistedActiveTurnId(
+  runtimePayload: ProviderSessionDirectory.ProviderRuntimeBinding["runtimePayload"],
+): unknown {
+  if (!runtimePayload || typeof runtimePayload !== "object" || Array.isArray(runtimePayload)) {
+    return undefined;
+  }
+  return "activeTurnId" in runtimePayload ? runtimePayload.activeTurnId : undefined;
+}
+
+function readCodexNativeThreadId(cursor: unknown): string | undefined {
+  if (cursor === null || typeof cursor !== "object" || Array.isArray(cursor)) {
+    return undefined;
+  }
+  const threadId = "threadId" in cursor ? cursor.threadId : undefined;
+  if (typeof threadId !== "string") return undefined;
+  const trimmed = threadId.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 const dieOnMissingBindingInstanceId = (
   operation: string,
   payload: {
@@ -232,7 +254,29 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const revokeMcpCredential =
     options?.revokeMcpCredential ?? McpSessionRegistry.revokeActiveMcpThread;
   const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+  const threadLocks = yield* SynchronizedRef.make(new Map<ThreadId, Semaphore.Semaphore>());
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+
+  const getThreadLock = (threadId: ThreadId) =>
+    SynchronizedRef.modifyEffect(threadLocks, (current) => {
+      const existing = current.get(threadId);
+      if (existing !== undefined) {
+        return Effect.succeed([existing, current] as const);
+      }
+      return Semaphore.make(1).pipe(
+        Effect.map((semaphore) => {
+          const next = new Map(current);
+          next.set(threadId, semaphore);
+          return [semaphore, next] as const;
+        }),
+      );
+    });
+
+  const withThreadLock = <A, E, R>(
+    threadId: ThreadId,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> =>
+    Effect.flatMap(getThreadLock(threadId), (semaphore) => semaphore.withPermit(effect));
   /**
    * Attach the `t3-code` MCP server to the session that is about to start.
    *
@@ -546,6 +590,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const stopStaleSessionsForThread = Effect.fn("stopStaleSessionsForThread")(function* (input: {
     readonly threadId: ThreadId;
     readonly currentInstanceId: ProviderInstanceId;
+    readonly failOnError?: boolean;
   }) {
     const currentAdapters = yield* getAdapterEntries;
     yield* Effect.forEach(
@@ -559,20 +604,24 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
                 return;
               }
 
-              yield* adapter.stopSession(input.threadId).pipe(
+              const stop = adapter.stopSession(input.threadId).pipe(
                 Effect.tap(() =>
                   analytics.record("provider.session.stopped", {
                     provider: adapter.provider,
                   }),
                 ),
-                Effect.catchCause((cause) =>
-                  Effect.logWarning("provider.session.stop-stale-failed", {
-                    threadId: input.threadId,
-                    provider: adapter.provider,
-                    cause,
-                  }),
-                ),
               );
+              yield* input.failOnError
+                ? stop
+                : stop.pipe(
+                    Effect.catchCause((cause) =>
+                      Effect.logWarning("provider.session.stop-stale-failed", {
+                        threadId: input.threadId,
+                        provider: adapter.provider,
+                        cause,
+                      }),
+                    ),
+                  );
             }),
       { discard: true },
     );
@@ -597,119 +646,259 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         "provider.thread_id": threadId,
         "provider.runtime_mode": parsed.runtimeMode,
       });
-      return yield* Effect.gen(function* () {
-        const instanceInfo = yield* registry.getInstanceInfo(resolvedInstanceId);
-        const resolvedProvider = instanceInfo.driverKind;
-        metricProvider = resolvedProvider;
-        if (parsed.provider !== undefined && parsed.provider !== resolvedProvider) {
-          return yield* toValidationError(
-            "ProviderService.startSession",
-            `Provider instance '${resolvedInstanceId}' belongs to driver '${resolvedProvider}', not '${parsed.provider}'.`,
-          );
-        }
-        const input = {
-          ...parsed,
-          threadId,
-          provider: resolvedProvider,
-        };
-        if (!instanceInfo.enabled) {
-          return yield* toValidationError(
-            "ProviderService.startSession",
-            `Provider instance '${resolvedInstanceId}' is disabled in T3 Code settings.`,
-          );
-        }
-        const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
-        const effectiveResumeCursor =
-          input.resumeCursor ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
-            ? persistedBinding.resumeCursor
-            : undefined);
-        const effectiveCwd =
-          input.cwd ??
-          (persistedBinding?.providerInstanceId === resolvedInstanceId
-            ? readPersistedCwd(persistedBinding.runtimePayload)
-            : undefined);
-        yield* Effect.annotateCurrentSpan({
-          "provider.kind": resolvedProvider,
-          "provider.resume_cursor.source":
-            input.resumeCursor !== undefined
-              ? "request"
-              : effectiveResumeCursor !== undefined &&
-                  persistedBinding?.providerInstanceId === resolvedInstanceId
-                ? "persisted"
-                : "none",
-          "provider.resume_cursor.present": effectiveResumeCursor !== undefined,
-          "provider.cwd.source":
-            input.cwd !== undefined
-              ? "request"
-              : effectiveCwd !== undefined &&
-                  persistedBinding?.providerInstanceId === resolvedInstanceId
-                ? "persisted"
-                : "none",
-          "provider.cwd.effective": effectiveCwd ?? "",
-        });
-        const adapter = yield* registry.getByInstance(resolvedInstanceId);
-        yield* prepareMcpSession(threadId, resolvedInstanceId);
-        const session = yield* adapter
-          .startSession({
-            ...input,
-            providerInstanceId: resolvedInstanceId,
-            ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
-            ...(effectiveResumeCursor !== undefined ? { resumeCursor: effectiveResumeCursor } : {}),
-          })
-          .pipe(Effect.onError(() => clearMcpSession(threadId)));
+      return yield* withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const instanceInfo = yield* registry.getInstanceInfo(resolvedInstanceId);
+          const resolvedProvider = instanceInfo.driverKind;
+          metricProvider = resolvedProvider;
+          if (parsed.provider !== undefined && parsed.provider !== resolvedProvider) {
+            return yield* toValidationError(
+              "ProviderService.startSession",
+              `Provider instance '${resolvedInstanceId}' belongs to driver '${resolvedProvider}', not '${parsed.provider}'.`,
+            );
+          }
+          const input = {
+            ...parsed,
+            threadId,
+            provider: resolvedProvider,
+          };
+          if (!instanceInfo.enabled) {
+            return yield* toValidationError(
+              "ProviderService.startSession",
+              `Provider instance '${resolvedInstanceId}' is disabled in T3 Code settings.`,
+            );
+          }
+          const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+          const sourceInstanceId = persistedBinding?.providerInstanceId;
+          const isCodexInstanceChange =
+            resolvedProvider === "codex" &&
+            sourceInstanceId !== undefined &&
+            sourceInstanceId !== resolvedInstanceId;
 
-        if (session.provider !== adapter.provider) {
-          yield* clearMcpSession(threadId);
-          return yield* toValidationError(
-            "ProviderService.startSession",
-            `Adapter/provider mismatch: requested '${adapter.provider}', received '${session.provider}'.`,
-          );
-        }
-        const sessionWithInstance = {
-          ...session,
-          providerInstanceId: resolvedInstanceId,
-        };
+          let handoffResumeCursor: unknown | undefined;
+          let handoffCwd: string | undefined;
+          let handoffNativeThreadId: string | undefined;
 
-        yield* stopStaleSessionsForThread({
-          threadId,
-          currentInstanceId: resolvedInstanceId,
-        });
-        yield* upsertSessionBinding(sessionWithInstance, threadId, {
-          modelSelection: input.modelSelection,
-        });
-        yield* analytics.record("provider.session.started", {
-          provider: sessionWithInstance.provider,
-          runtimeMode: input.runtimeMode,
-          hasResumeCursor: sessionWithInstance.resumeCursor !== undefined,
-          hasCwd: typeof effectiveCwd === "string" && effectiveCwd.trim().length > 0,
-          hasModel:
-            typeof input.modelSelection?.model === "string" &&
-            input.modelSelection.model.trim().length > 0,
-        });
+          if (isCodexInstanceChange && persistedBinding !== undefined) {
+            const sourceInfo = yield* registry.getInstanceInfo(sourceInstanceId);
+            const compatible =
+              sourceInfo.driverKind === resolvedProvider &&
+              sourceInfo.continuationIdentity.continuationKey ===
+                instanceInfo.continuationIdentity.continuationKey;
+            if (!compatible) {
+              return yield* toValidationError(
+                "ProviderService.startSession",
+                `Codex provider instances '${sourceInstanceId}' and '${resolvedInstanceId}' do not share a continuation identity.`,
+              );
+            }
 
-        // Changing runtime mode restarts the session, so the transition is only
-        // observable here, by diffing against the mode the previous session for
-        // this thread was bound to. Recording it separately is what makes the
-        // "started supervised, switched to full access" funnel answerable.
-        const previousRuntimeMode = persistedBinding?.runtimeMode;
-        if (previousRuntimeMode !== undefined && previousRuntimeMode !== input.runtimeMode) {
-          yield* analytics.record("provider.runtime_mode.changed", {
-            provider: sessionWithInstance.provider,
-            from: previousRuntimeMode,
-            to: input.runtimeMode,
+            const sourceAdapter = yield* registry.getByInstance(sourceInstanceId);
+            const sourceIsActive = yield* sourceAdapter.hasSession(threadId);
+            const sourceSession = sourceIsActive
+              ? (yield* sourceAdapter.listSessions()).find(
+                  (session) => session.threadId === threadId,
+                )
+              : undefined;
+            if (sourceIsActive && sourceSession === undefined) {
+              return yield* toValidationError(
+                "ProviderService.startSession",
+                `Codex provider instance '${sourceInstanceId}' retains an ambiguous session for thread '${threadId}'.`,
+              );
+            }
+            if (
+              sourceSession !== undefined &&
+              (sourceSession.status !== "ready" ||
+                sourceSession.activeTurnId !== undefined ||
+                (readPersistedActiveTurnId(persistedBinding.runtimePayload) !== undefined &&
+                  readPersistedActiveTurnId(persistedBinding.runtimePayload) !== null))
+            ) {
+              return yield* toValidationError(
+                "ProviderService.startSession",
+                `Codex provider instance '${sourceInstanceId}' must be idle before switching thread '${threadId}'.`,
+              );
+            }
+
+            handoffResumeCursor = sourceSession?.resumeCursor ?? persistedBinding.resumeCursor;
+            handoffNativeThreadId = readCodexNativeThreadId(handoffResumeCursor);
+            if (handoffNativeThreadId === undefined) {
+              return yield* toValidationError(
+                "ProviderService.startSession",
+                `Codex thread '${threadId}' has no valid native resume cursor for an instance switch.`,
+              );
+            }
+            if (
+              input.resumeCursor !== undefined &&
+              readCodexNativeThreadId(input.resumeCursor) !== handoffNativeThreadId
+            ) {
+              return yield* toValidationError(
+                "ProviderService.startSession",
+                `Codex thread '${threadId}' cannot switch with a resume cursor that differs from its current owner.`,
+              );
+            }
+            handoffCwd =
+              input.cwd ?? sourceSession?.cwd ?? readPersistedCwd(persistedBinding.runtimePayload);
+
+            const persistedRuntimePayload =
+              persistedBinding.runtimePayload !== null &&
+              typeof persistedBinding.runtimePayload === "object" &&
+              !Array.isArray(persistedBinding.runtimePayload)
+                ? persistedBinding.runtimePayload
+                : {};
+            const persistSourceBinding = (status: "running" | "stopped", event: string) =>
+              directory.upsert({
+                threadId,
+                provider: resolvedProvider,
+                providerInstanceId: sourceInstanceId,
+                runtimeMode:
+                  sourceSession?.runtimeMode ?? persistedBinding.runtimeMode ?? input.runtimeMode,
+                status,
+                resumeCursor: handoffResumeCursor,
+                runtimePayload: {
+                  ...persistedRuntimePayload,
+                  activeTurnId: null,
+                  lastRuntimeEvent: event,
+                },
+              });
+
+            yield* persistSourceBinding(
+              sourceIsActive ? "running" : "stopped",
+              "codex.handoff.prepared",
+            );
+            if (sourceIsActive) {
+              yield* sourceAdapter.stopSession(threadId);
+            }
+            yield* persistSourceBinding("stopped", "codex.handoff.source-stopped");
+            yield* clearMcpSession(threadId);
+          }
+
+          if (handoffNativeThreadId !== undefined) {
+            yield* stopStaleSessionsForThread({
+              threadId,
+              currentInstanceId: resolvedInstanceId,
+              failOnError: true,
+            });
+          }
+
+          const effectiveResumeCursor =
+            handoffResumeCursor ??
+            input.resumeCursor ??
+            (persistedBinding?.providerInstanceId === resolvedInstanceId
+              ? persistedBinding.resumeCursor
+              : undefined);
+          const effectiveCwd =
+            handoffCwd ??
+            input.cwd ??
+            (persistedBinding?.providerInstanceId === resolvedInstanceId
+              ? readPersistedCwd(persistedBinding.runtimePayload)
+              : undefined);
+          yield* Effect.annotateCurrentSpan({
+            "provider.kind": resolvedProvider,
+            "provider.resume_cursor.source":
+              input.resumeCursor !== undefined
+                ? "request"
+                : effectiveResumeCursor !== undefined &&
+                    persistedBinding?.providerInstanceId === resolvedInstanceId
+                  ? "persisted"
+                  : "none",
+            "provider.resume_cursor.present": effectiveResumeCursor !== undefined,
+            "provider.cwd.source":
+              input.cwd !== undefined
+                ? "request"
+                : effectiveCwd !== undefined &&
+                    persistedBinding?.providerInstanceId === resolvedInstanceId
+                  ? "persisted"
+                  : "none",
+            "provider.cwd.effective": effectiveCwd ?? "",
           });
-        }
+          const adapter = yield* registry.getByInstance(resolvedInstanceId);
+          yield* prepareMcpSession(threadId, resolvedInstanceId);
+          const session = yield* adapter
+            .startSession({
+              ...input,
+              providerInstanceId: resolvedInstanceId,
+              ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
+              ...(effectiveResumeCursor !== undefined
+                ? { resumeCursor: effectiveResumeCursor }
+                : {}),
+            })
+            .pipe(Effect.onError(() => clearMcpSession(threadId)));
 
-        return sessionWithInstance;
-      }).pipe(
-        withMetrics({
-          counter: providerSessionsTotal,
-          attributes: () =>
-            providerMetricAttributes(metricProvider, {
-              operation: "start",
+          const stopProvisionalTarget = Effect.suspend(() => adapter.stopSession(threadId)).pipe(
+            Effect.ensuring(clearMcpSession(threadId)),
+          );
+
+          if (session.provider !== adapter.provider) {
+            yield* stopProvisionalTarget;
+            return yield* toValidationError(
+              "ProviderService.startSession",
+              `Adapter/provider mismatch: requested '${adapter.provider}', received '${session.provider}'.`,
+            );
+          }
+          const sessionWithInstance = {
+            ...session,
+            providerInstanceId: resolvedInstanceId,
+          };
+
+          if (
+            handoffNativeThreadId !== undefined &&
+            readCodexNativeThreadId(sessionWithInstance.resumeCursor) !== handoffNativeThreadId
+          ) {
+            yield* stopProvisionalTarget;
+            return yield* toValidationError(
+              "ProviderService.startSession",
+              `Codex provider instance '${resolvedInstanceId}' resumed a different native thread.`,
+            );
+          }
+
+          if (handoffNativeThreadId === undefined) {
+            yield* stopStaleSessionsForThread({
+              threadId,
+              currentInstanceId: resolvedInstanceId,
+            });
+          }
+          const bindingExit = yield* Effect.exit(
+            upsertSessionBinding(sessionWithInstance, threadId, {
+              modelSelection: input.modelSelection,
             }),
-        }),
+          );
+          if (Exit.isFailure(bindingExit)) {
+            yield* stopProvisionalTarget;
+            return yield* Effect.failCause(bindingExit.cause);
+          }
+          yield* analytics.record("provider.session.started", {
+            provider: sessionWithInstance.provider,
+            runtimeMode: input.runtimeMode,
+            hasResumeCursor: sessionWithInstance.resumeCursor !== undefined,
+            hasCwd: typeof effectiveCwd === "string" && effectiveCwd.trim().length > 0,
+            hasModel:
+              typeof input.modelSelection?.model === "string" &&
+              input.modelSelection.model.trim().length > 0,
+          });
+
+          // Changing runtime mode restarts the session, so the transition is only
+          // observable here, by diffing against the mode the previous session for
+          // this thread was bound to. Recording it separately is what makes the
+          // "started supervised, switched to full access" funnel answerable.
+          const previousRuntimeMode = persistedBinding?.runtimeMode;
+          if (previousRuntimeMode !== undefined && previousRuntimeMode !== input.runtimeMode) {
+            yield* analytics.record("provider.runtime_mode.changed", {
+              provider: sessionWithInstance.provider,
+              from: previousRuntimeMode,
+              to: input.runtimeMode,
+            });
+          }
+
+          return sessionWithInstance;
+        }).pipe(
+          withMetrics({
+            counter: providerSessionsTotal,
+            attributes: () =>
+              providerMetricAttributes(metricProvider, {
+                operation: "start",
+              }),
+          }),
+        ),
       );
     },
   );
@@ -765,63 +954,66 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     });
     let metricProvider = "unknown";
     let metricModel = input.modelSelection?.model;
-    return yield* Effect.gen(function* () {
-      const routed = yield* resolveRoutableSession({
-        threadId: input.threadId,
-        operation: "ProviderService.sendTurn",
-        allowRecovery: true,
-      });
-      metricProvider = routed.adapter.provider;
-      metricModel = input.modelSelection?.model;
-      yield* Effect.annotateCurrentSpan({
-        "provider.kind": routed.adapter.provider,
-        ...(input.modelSelection?.model ? { "provider.model": input.modelSelection.model } : {}),
-      });
-      // A turn is the clearest sign a session is still alive. The MCP
-      // credential is minted once at session start and cannot be rotated into
-      // an already-spawned agent process, so we keep the existing token valid
-      // rather than issuing a new one: sessions that go a long time between
-      // browser tool calls used to lose the toolkit outright.
-      yield* McpSessionRegistry.touchActiveMcpThread(input.threadId);
-      const turn = yield* routed.adapter.sendTurn(input);
-      yield* directory.upsert({
-        threadId: input.threadId,
-        provider: routed.adapter.provider,
-        providerInstanceId: routed.instanceId,
-        status: "running",
-        ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
-        runtimePayload: {
-          ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
-          activeTurnId: turn.turnId,
-          lastRuntimeEvent: "provider.sendTurn",
-          lastRuntimeEventAt: yield* nowIso,
-        },
-      });
-      yield* analytics.record("provider.turn.sent", {
-        provider: routed.adapter.provider,
-        model: input.modelSelection?.model,
-        interactionMode: input.interactionMode,
-        // Session-start events alone skew runtime mode toward users who toggle
-        // often, since every toggle restarts the session. Recording it per turn
-        // gives a usage-weighted view and lets it cross with interactionMode.
-        runtimeMode: routed.runtimeMode,
-        attachmentCount: attachments.length,
-        hasInput: typeof input.input === "string" && input.input.trim().length > 0,
-      });
-      return turn;
-    }).pipe(
-      withMetrics({
-        counter: providerTurnsTotal,
-        timer: providerTurnDuration,
-        attributes: () =>
-          providerTurnMetricAttributes({
-            provider: metricProvider,
-            model: metricModel,
-            extra: {
-              operation: "send",
-            },
-          }),
-      }),
+    return yield* withThreadLock(
+      input.threadId,
+      Effect.gen(function* () {
+        const routed = yield* resolveRoutableSession({
+          threadId: input.threadId,
+          operation: "ProviderService.sendTurn",
+          allowRecovery: true,
+        });
+        metricProvider = routed.adapter.provider;
+        metricModel = input.modelSelection?.model;
+        yield* Effect.annotateCurrentSpan({
+          "provider.kind": routed.adapter.provider,
+          ...(input.modelSelection?.model ? { "provider.model": input.modelSelection.model } : {}),
+        });
+        // A turn is the clearest sign a session is still alive. The MCP
+        // credential is minted once at session start and cannot be rotated into
+        // an already-spawned agent process, so we keep the existing token valid
+        // rather than issuing a new one: sessions that go a long time between
+        // browser tool calls used to lose the toolkit outright.
+        yield* McpSessionRegistry.touchActiveMcpThread(input.threadId);
+        const turn = yield* routed.adapter.sendTurn(input);
+        yield* directory.upsert({
+          threadId: input.threadId,
+          provider: routed.adapter.provider,
+          providerInstanceId: routed.instanceId,
+          status: "running",
+          ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
+          runtimePayload: {
+            ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
+            activeTurnId: turn.turnId,
+            lastRuntimeEvent: "provider.sendTurn",
+            lastRuntimeEventAt: yield* nowIso,
+          },
+        });
+        yield* analytics.record("provider.turn.sent", {
+          provider: routed.adapter.provider,
+          model: input.modelSelection?.model,
+          interactionMode: input.interactionMode,
+          // Session-start events alone skew runtime mode toward users who toggle
+          // often, since every toggle restarts the session. Recording it per turn
+          // gives a usage-weighted view and lets it cross with interactionMode.
+          runtimeMode: routed.runtimeMode,
+          attachmentCount: attachments.length,
+          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
+        });
+        return turn;
+      }).pipe(
+        withMetrics({
+          counter: providerTurnsTotal,
+          timer: providerTurnDuration,
+          attributes: () =>
+            providerTurnMetricAttributes({
+              provider: metricProvider,
+              model: metricModel,
+              extra: {
+                operation: "send",
+              },
+            }),
+        }),
+      ),
     );
   });
 
@@ -833,31 +1025,34 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         payload: rawInput,
       });
       let metricProvider = "unknown";
-      return yield* Effect.gen(function* () {
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.interruptTurn",
-          allowRecovery: true,
-        });
-        metricProvider = routed.adapter.provider;
-        yield* Effect.annotateCurrentSpan({
-          "provider.operation": "interrupt-turn",
-          "provider.kind": routed.adapter.provider,
-          "provider.thread_id": input.threadId,
-          "provider.turn_id": input.turnId,
-        });
-        yield* routed.adapter.interruptTurn(routed.threadId, input.turnId);
-        yield* analytics.record("provider.turn.interrupted", {
-          provider: routed.adapter.provider,
-        });
-      }).pipe(
-        withMetrics({
-          counter: providerTurnsTotal,
-          outcomeAttributes: () =>
-            providerMetricAttributes(metricProvider, {
-              operation: "interrupt",
-            }),
-        }),
+      return yield* withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const routed = yield* resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.interruptTurn",
+            allowRecovery: true,
+          });
+          metricProvider = routed.adapter.provider;
+          yield* Effect.annotateCurrentSpan({
+            "provider.operation": "interrupt-turn",
+            "provider.kind": routed.adapter.provider,
+            "provider.thread_id": input.threadId,
+            "provider.turn_id": input.turnId,
+          });
+          yield* routed.adapter.interruptTurn(routed.threadId, input.turnId);
+          yield* analytics.record("provider.turn.interrupted", {
+            provider: routed.adapter.provider,
+          });
+        }).pipe(
+          withMetrics({
+            counter: providerTurnsTotal,
+            outcomeAttributes: () =>
+              providerMetricAttributes(metricProvider, {
+                operation: "interrupt",
+              }),
+          }),
+        ),
       );
     },
   );
@@ -870,32 +1065,35 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         payload: rawInput,
       });
       let metricProvider = "unknown";
-      return yield* Effect.gen(function* () {
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.respondToRequest",
-          allowRecovery: true,
-        });
-        metricProvider = routed.adapter.provider;
-        yield* Effect.annotateCurrentSpan({
-          "provider.operation": "respond-to-request",
-          "provider.kind": routed.adapter.provider,
-          "provider.thread_id": input.threadId,
-          "provider.request_id": input.requestId,
-        });
-        yield* routed.adapter.respondToRequest(routed.threadId, input.requestId, input.decision);
-        yield* analytics.record("provider.request.responded", {
-          provider: routed.adapter.provider,
-          decision: input.decision,
-        });
-      }).pipe(
-        withMetrics({
-          counter: providerTurnsTotal,
-          outcomeAttributes: () =>
-            providerMetricAttributes(metricProvider, {
-              operation: "approval-response",
-            }),
-        }),
+      return yield* withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const routed = yield* resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.respondToRequest",
+            allowRecovery: true,
+          });
+          metricProvider = routed.adapter.provider;
+          yield* Effect.annotateCurrentSpan({
+            "provider.operation": "respond-to-request",
+            "provider.kind": routed.adapter.provider,
+            "provider.thread_id": input.threadId,
+            "provider.request_id": input.requestId,
+          });
+          yield* routed.adapter.respondToRequest(routed.threadId, input.requestId, input.decision);
+          yield* analytics.record("provider.request.responded", {
+            provider: routed.adapter.provider,
+            decision: input.decision,
+          });
+        }).pipe(
+          withMetrics({
+            counter: providerTurnsTotal,
+            outcomeAttributes: () =>
+              providerMetricAttributes(metricProvider, {
+                operation: "approval-response",
+              }),
+          }),
+        ),
       );
     },
   );
@@ -909,28 +1107,31 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       payload: rawInput,
     });
     let metricProvider = "unknown";
-    return yield* Effect.gen(function* () {
-      const routed = yield* resolveRoutableSession({
-        threadId: input.threadId,
-        operation: "ProviderService.respondToUserInput",
-        allowRecovery: true,
-      });
-      metricProvider = routed.adapter.provider;
-      yield* Effect.annotateCurrentSpan({
-        "provider.operation": "respond-to-user-input",
-        "provider.kind": routed.adapter.provider,
-        "provider.thread_id": input.threadId,
-        "provider.request_id": input.requestId,
-      });
-      yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
-    }).pipe(
-      withMetrics({
-        counter: providerTurnsTotal,
-        outcomeAttributes: () =>
-          providerMetricAttributes(metricProvider, {
-            operation: "user-input-response",
-          }),
-      }),
+    return yield* withThreadLock(
+      input.threadId,
+      Effect.gen(function* () {
+        const routed = yield* resolveRoutableSession({
+          threadId: input.threadId,
+          operation: "ProviderService.respondToUserInput",
+          allowRecovery: true,
+        });
+        metricProvider = routed.adapter.provider;
+        yield* Effect.annotateCurrentSpan({
+          "provider.operation": "respond-to-user-input",
+          "provider.kind": routed.adapter.provider,
+          "provider.thread_id": input.threadId,
+          "provider.request_id": input.requestId,
+        });
+        yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
+      }).pipe(
+        withMetrics({
+          counter: providerTurnsTotal,
+          outcomeAttributes: () =>
+            providerMetricAttributes(metricProvider, {
+              operation: "user-input-response",
+            }),
+        }),
+      ),
     );
   });
 
@@ -942,42 +1143,45 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         payload: rawInput,
       });
       let metricProvider = "unknown";
-      return yield* Effect.gen(function* () {
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.stopSession",
-          allowRecovery: false,
-        });
-        metricProvider = routed.adapter.provider;
-        yield* Effect.annotateCurrentSpan({
-          "provider.operation": "stop-session",
-          "provider.kind": routed.adapter.provider,
-          "provider.thread_id": input.threadId,
-        });
-        if (routed.isActive) {
-          yield* routed.adapter.stopSession(routed.threadId);
-        }
-        yield* clearMcpSession(input.threadId);
-        yield* directory.upsert({
-          threadId: input.threadId,
-          provider: routed.adapter.provider,
-          providerInstanceId: routed.instanceId,
-          status: "stopped",
-          runtimePayload: {
-            activeTurnId: null,
-          },
-        });
-        yield* analytics.record("provider.session.stopped", {
-          provider: routed.adapter.provider,
-        });
-      }).pipe(
-        withMetrics({
-          counter: providerSessionsTotal,
-          outcomeAttributes: () =>
-            providerMetricAttributes(metricProvider, {
-              operation: "stop",
-            }),
-        }),
+      return yield* withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const routed = yield* resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.stopSession",
+            allowRecovery: false,
+          });
+          metricProvider = routed.adapter.provider;
+          yield* Effect.annotateCurrentSpan({
+            "provider.operation": "stop-session",
+            "provider.kind": routed.adapter.provider,
+            "provider.thread_id": input.threadId,
+          });
+          if (routed.isActive) {
+            yield* routed.adapter.stopSession(routed.threadId);
+          }
+          yield* clearMcpSession(input.threadId);
+          yield* directory.upsert({
+            threadId: input.threadId,
+            provider: routed.adapter.provider,
+            providerInstanceId: routed.instanceId,
+            status: "stopped",
+            runtimePayload: {
+              activeTurnId: null,
+            },
+          });
+          yield* analytics.record("provider.session.stopped", {
+            provider: routed.adapter.provider,
+          });
+        }).pipe(
+          withMetrics({
+            counter: providerSessionsTotal,
+            outcomeAttributes: () =>
+              providerMetricAttributes(metricProvider, {
+                operation: "stop",
+              }),
+          }),
+        ),
       );
     },
   );
@@ -1087,32 +1291,35 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       return;
     }
     let metricProvider = "unknown";
-    return yield* Effect.gen(function* () {
-      const routed = yield* resolveRoutableSession({
-        threadId: input.threadId,
-        operation: "ProviderService.rollbackConversation",
-        allowRecovery: true,
-      });
-      metricProvider = routed.adapter.provider;
-      yield* Effect.annotateCurrentSpan({
-        "provider.operation": "rollback-conversation",
-        "provider.kind": routed.adapter.provider,
-        "provider.thread_id": input.threadId,
-        "provider.rollback_turns": input.numTurns,
-      });
-      yield* routed.adapter.rollbackThread(routed.threadId, input.numTurns);
-      yield* analytics.record("provider.conversation.rolled_back", {
-        provider: routed.adapter.provider,
-        turns: input.numTurns,
-      });
-    }).pipe(
-      withMetrics({
-        counter: providerTurnsTotal,
-        outcomeAttributes: () =>
-          providerMetricAttributes(metricProvider, {
-            operation: "rollback",
-          }),
-      }),
+    return yield* withThreadLock(
+      input.threadId,
+      Effect.gen(function* () {
+        const routed = yield* resolveRoutableSession({
+          threadId: input.threadId,
+          operation: "ProviderService.rollbackConversation",
+          allowRecovery: true,
+        });
+        metricProvider = routed.adapter.provider;
+        yield* Effect.annotateCurrentSpan({
+          "provider.operation": "rollback-conversation",
+          "provider.kind": routed.adapter.provider,
+          "provider.thread_id": input.threadId,
+          "provider.rollback_turns": input.numTurns,
+        });
+        yield* routed.adapter.rollbackThread(routed.threadId, input.numTurns);
+        yield* analytics.record("provider.conversation.rolled_back", {
+          provider: routed.adapter.provider,
+          turns: input.numTurns,
+        });
+      }).pipe(
+        withMetrics({
+          counter: providerTurnsTotal,
+          outcomeAttributes: () =>
+            providerMetricAttributes(metricProvider, {
+              operation: "rollback",
+            }),
+        }),
+      ),
     );
   });
 
@@ -1123,37 +1330,42 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         schema: ProviderUploadFeedbackInput,
         payload: rawInput,
       });
-      let routed = yield* resolveRoutableSession({
-        threadId: input.threadId,
-        operation: "ProviderService.uploadFeedback",
-        allowRecovery: false,
-      });
-      if (routed.adapter.uploadFeedback === undefined) {
-        return yield* toValidationError(
-          "ProviderService.uploadFeedback",
-          `Provider '${routed.adapter.provider}' does not support feedback uploads.`,
-        );
-      }
-      if (!routed.isActive) {
-        routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.uploadFeedback",
-          allowRecovery: true,
-        });
-      }
-      const uploadFeedback = routed.adapter.uploadFeedback;
-      if (uploadFeedback === undefined) {
-        return yield* toValidationError(
-          "ProviderService.uploadFeedback",
-          `Provider '${routed.adapter.provider}' does not support feedback uploads.`,
-        );
-      }
-      yield* Effect.annotateCurrentSpan({
-        "provider.operation": "upload-feedback",
-        "provider.kind": routed.adapter.provider,
-        "provider.thread_id": input.threadId,
-      });
-      return yield* uploadFeedback(input);
+      return yield* withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          let routed = yield* resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.uploadFeedback",
+            allowRecovery: false,
+          });
+          if (routed.adapter.uploadFeedback === undefined) {
+            return yield* toValidationError(
+              "ProviderService.uploadFeedback",
+              `Provider '${routed.adapter.provider}' does not support feedback uploads.`,
+            );
+          }
+          if (!routed.isActive) {
+            routed = yield* resolveRoutableSession({
+              threadId: input.threadId,
+              operation: "ProviderService.uploadFeedback",
+              allowRecovery: true,
+            });
+          }
+          const uploadFeedback = routed.adapter.uploadFeedback;
+          if (uploadFeedback === undefined) {
+            return yield* toValidationError(
+              "ProviderService.uploadFeedback",
+              `Provider '${routed.adapter.provider}' does not support feedback uploads.`,
+            );
+          }
+          yield* Effect.annotateCurrentSpan({
+            "provider.operation": "upload-feedback",
+            "provider.kind": routed.adapter.provider,
+            "provider.thread_id": input.threadId,
+          });
+          return yield* uploadFeedback(input);
+        }),
+      );
     },
   );
 


### PR DESCRIPTION
Fixes #8259

## TLDR

Before this change, the picker could show separately authenticated provider instances, but an existing thread remained bound to its current instance. Switching did not safely transfer that conversation. It could start the target before fully releasing the source or silently create a fresh native thread instead of preserving the same ID.

Now a manual switch between compatible Codex instances stops the old writer, strictly resumes the same native conversation, verifies its identity, and only then commits the new owner. Separate histories remain supported and are still the default for instances with different continuation identities. Only deliberately compatible instances can hand off one history.

Current switching starts the target before stopping the source. Source-stop failures are suppressed, so two app-server instances can compete for one native thread

A simple reorder is insufficient:

1. Cross-instance start can lose the persisted source cursor
2. thread/resume can fall back to thread/start
3. That fallback silently creates a new native thread
4. Adapter shutdown removes session state before cleanup completes
5. Runtime-close failures are currently suppressed
6. Delayed source events can overwrite target-owned state

This change:

1. Serializes recovery-capable operations with cleanup-safe per-thread locks
2. Requires compatible continuation identities
3. Requires an idle source and valid persisted cursor
4. Persists the cursor before teardown
5. Stops the source before target startup
6. Proves child-process release before target resume
7. Propagates stop and release failures
8. Uses strict thread/resume whenever a cursor exists
9. Never falls back to thread/start during handoff
10. Requires the returned native ID to match
11. Stops provisional targets after identity or persistence failure
12. Commits target ownership only after readiness and persistence
13. Ignores delayed events from stale owners
14. Keeps turn interruption out of band from a blocked send while ordering it behind handoff
15. Proves non-owner Codex writers are released before any native resume
16. Delivers approval and user-input responses outside the long-running turn lock without recovery
17. Restricts native Codex handoff rules to Codex-to-Codex switches

Failure behavior:

1. Cursor persistence failure leaves the source running
2. Release failure prevents target startup
3. Target failure leaves the source stopped with a recoverable cursor
4. Identity mismatch stops the target
5. Binding failure stops the target
6. Unproven cleanup remains visible and blocks retry
7. Failed target cleanup blocks source recovery and direct restart

Verification:

1. 197 focused tests pass
2. Server typecheck exits 0
3. git diff --check passes
4. Tests cover release, cursor, identity, compensation, stale events, lock cleanup, interruption, interactive responses, and cross-provider replacement

Scope:

1. Existing manual switching only
2. No UI or schema changes
3. No automatic routing
4. No quota logic
5. No native-history import
6. No Claude changes
7. No token handling
