### PR TITLE
feat: add OMP (Oh My Pi) provider driver + Z.AI GLM docs

### DIFF
--- a/apps/mobile/src/components/ProviderIcon.tsx
+++ b/apps/mobile/src/components/ProviderIcon.tsx
@@ -1,4 +1,4 @@
-import { Path, Svg } from "react-native-svg";
+import { Path, Rect, Svg } from "react-native-svg";
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
 
 type ProviderIconProps = {
@@ -55,6 +55,29 @@ export function ProviderIcon(props: ProviderIconProps) {
       <Svg width={size} height={size} viewBox="0 0 32 40" fill="none">
         <Path d="M24 32H8V16H24V32Z" fill={isDarkMode ? "#4B4646" : "#CFCECD"} />
         <Path d="M24 8H8V32H24V8ZM32 40H0V0H32V40Z" fill={isDarkMode ? "#F1ECEC" : "#211E1E"} />
+      </Svg>
+    );
+  }
+
+  if (props.provider === "omp") {
+    const stroke = isDarkMode ? "#F5F5F5" : "#171717";
+    return (
+      <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+        <Rect
+          x="2.75"
+          y="2.75"
+          width="18.5"
+          height="18.5"
+          rx="4.5"
+          stroke={stroke}
+          strokeWidth="1.5"
+        />
+        <Path
+          d="M6.5 8.25h11M9.25 8.25V13.5a2.75 2.75 0 0 1-2.75 2.75M14.75 8.25v8"
+          stroke={stroke}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
       </Svg>
     );
   }

--- a/apps/server/src/provider/Drivers/OmpDriver.ts
+++ b/apps/server/src/provider/Drivers/OmpDriver.ts
@@ -1,0 +1,163 @@
+import { OmpSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeOmpTextGeneration } from "../../textGeneration/OmpTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeOmpAdapter } from "../Layers/OmpAdapter.ts";
+import {
+  buildInitialOmpProviderSnapshot,
+  checkOmpProviderStatus,
+  enrichOmpSnapshot,
+} from "../Layers/OmpProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+const decodeOmpSettings = Schema.decodeSync(OmpSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("omp");
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+  }),
+);
+
+export type OmpDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const OmpDriver: ProviderDriver<OmpSettings, OmpDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "OMP",
+    supportsMultipleInstances: true,
+  },
+  configSchema: OmpSettings,
+  defaultConfig: (): OmpSettings => decodeOmpSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies OmpSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeOmpAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeOmpTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkOmpProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<OmpSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialOmpProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichOmpSnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            httpClient,
+          }),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build OMP snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/OmpAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OmpAdapter.test.ts
@@ -1,0 +1,67 @@
+import { assert, it } from "@effect/vitest";
+
+import { selectOmpPermissionOptionId } from "./OmpAdapter.ts";
+
+function ompPermissionRequest(
+  options: ReadonlyArray<{
+    readonly optionId: string;
+    readonly kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  }>,
+) {
+  return {
+    sessionId: "mock-session-1",
+    toolCall: {
+      toolCallId: "tool-call-1",
+      title: "cat package.json",
+      kind: "execute" as const,
+      status: "pending" as const,
+    },
+    options: options.map((option) => ({
+      optionId: option.optionId,
+      name: option.kind,
+      kind: option.kind,
+    })),
+  };
+}
+
+it("prefers allow_always when OMP offers it", () => {
+  const request = ompPermissionRequest([
+    { optionId: "allow-once", kind: "allow_once" },
+    { optionId: "allow-always", kind: "allow_always" },
+    { optionId: "reject-once", kind: "reject_once" },
+  ]);
+
+  assert.equal(selectOmpPermissionOptionId(request, "acceptForSession"), "allow-always");
+  assert.equal(selectOmpPermissionOptionId(request, "acceptAlways"), "allow-always");
+  assert.equal(selectOmpPermissionOptionId(request, "accept"), "allow-once");
+  assert.equal(selectOmpPermissionOptionId(request, "decline"), "reject-once");
+});
+
+it("maps every always-allow decision to allow_once when OMP omits allow_always", () => {
+  const request = ompPermissionRequest([
+    { optionId: "allow-once", kind: "allow_once" },
+    { optionId: "reject-once", kind: "reject_once" },
+  ]);
+
+  assert.equal(selectOmpPermissionOptionId(request, "acceptForSession"), "allow-once");
+  assert.equal(selectOmpPermissionOptionId(request, "acceptAlways"), "allow-once");
+});
+
+it("skips blank option ids instead of cancelling the approval", () => {
+  const request = ompPermissionRequest([
+    { optionId: "   ", kind: "allow_always" },
+    { optionId: "allow-always-2", kind: "allow_always" },
+    { optionId: "  ", kind: "reject_once" },
+    { optionId: "reject-once-2", kind: "reject_once" },
+  ]);
+
+  assert.equal(selectOmpPermissionOptionId(request, "acceptForSession"), "allow-always-2");
+  assert.equal(selectOmpPermissionOptionId(request, "decline"), "reject-once-2");
+});
+
+it("returns undefined when OMP offers no usable option of any fallback kind", () => {
+  const request = ompPermissionRequest([{ optionId: "  ", kind: "allow_once" }]);
+
+  assert.equal(selectOmpPermissionOptionId(request, "accept"), undefined);
+  assert.equal(selectOmpPermissionOptionId(request, "acceptAlways"), undefined);
+});

--- a/apps/server/src/provider/Layers/OmpAdapter.ts
+++ b/apps/server/src/provider/Layers/OmpAdapter.ts
@@ -1,0 +1,1757 @@
+import {
+  ApprovalRequestId,
+  EventId,
+  type OmpSettings,
+  type ProviderApprovalDecision,
+  ProviderDriverKind,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { stableStringify } from "@t3tools/shared/relaySigning";
+import * as Clock from "effect/Clock";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import {
+  applyOmpAcpModelSelection,
+  currentOmpModelIdFromSessionSetup,
+  currentOmpReasoningEffortFromSessionSetup,
+  makeOmpAcpRuntime,
+  normalizeOmpReasoningEffort,
+  resolveOmpAcpBaseModelId,
+} from "../acp/OmpAcpSupport.ts";
+import { type OmpAdapterShape } from "../Services/OmpAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
+
+const PROVIDER = ProviderDriverKind.make("omp");
+const OMP_RESUME_VERSION = 1 as const;
+const NANOS_PER_MILLI = 1_000_000n;
+// ACP does not expose the agent's private reasoning phase. Once OMP has
+// emitted standard ACP progress, ten silent minutes is long enough to avoid
+// treating legitimate reasoning as a stalled stream.
+const DEFAULT_OMP_TURN_INACTIVITY_TIMEOUT_MS = 10 * 60 * 1_000;
+// A tool can legitimately run without emitting text for much longer than
+// reasoning. It still needs a deadline so a lost tool update cannot leave the
+// turn working forever.
+const DEFAULT_OMP_ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1_000;
+
+function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
+  const result = encodeUnknownJsonStringExit(input);
+  return Exit.isSuccess(result) ? result.value : undefined;
+}
+
+export interface OmpAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly instanceId?: ProviderInstanceId;
+  /** Override the conservative ACP turn liveness timeout in focused tests. */
+  readonly turnInactivityTimeoutMs?: number;
+  /** Override the longer active-tool liveness timeout in focused tests. */
+  readonly activeToolInactivityTimeoutMs?: number;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+interface OmpTurnLivenessSignal {
+  readonly turnId: TurnId;
+}
+
+interface OmpSessionContext {
+  readonly threadId: ThreadId;
+  readonly acpSessionId: string;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  lastPlanFingerprint: string | undefined;
+  activeTurnId: TurnId | undefined;
+  /** Turns already interrupted; late prompt RPCs must not resurrect them. */
+  interruptedTurnIds: Set<TurnId>;
+  /** Number of sendTurn prompts currently in flight or being prepared.
+   * >0 means a turn is actively running, so a new sendTurn is a steer that
+   * continues it, and only the last remaining prompt settles the turn. */
+  promptsInFlight: number;
+  readonly livenessSignals: Queue.Queue<OmpTurnLivenessSignal>;
+  livenessTurnId: TurnId | undefined;
+  lastTurnActivityAtNanos: bigint | undefined;
+  readonly activeToolCallIds: Set<string>;
+  livenessUpdatesInFlight: number;
+  /** Prompt RPCs that returned before their turn settlement acquired the lock. */
+  promptResponsesReady: number;
+  currentModelId: string | undefined;
+  currentReasoningEffort: string | undefined;
+  stopped: boolean;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    Array.from(pendingApprovals.values()),
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+function appendPromptResultToTurn(
+  ctx: OmpSessionContext,
+  turnId: TurnId,
+  promptParts: ReadonlyArray<EffectAcpSchema.ContentBlock>,
+  result: EffectAcpSchema.PromptResponse,
+): void {
+  const existingTurnRecord = ctx.turns.find((turn) => turn.id === turnId);
+  ctx.turns = existingTurnRecord
+    ? ctx.turns.map((turn) =>
+        turn.id === turnId
+          ? { ...turn, items: [...turn.items, { prompt: promptParts, result }] }
+          : turn,
+      )
+    : [...ctx.turns, { id: turnId, items: [{ prompt: promptParts, result }] }];
+}
+
+const resolveNotificationTurnId = (ctx: OmpSessionContext): TurnId | undefined => ctx.activeTurnId;
+
+const resolveCallbackTurnId = (ctx: OmpSessionContext): TurnId | undefined => ctx.activeTurnId;
+
+const resolveSessionCallbackTurnId = (
+  sessions: ReadonlyMap<ThreadId, OmpSessionContext>,
+  threadId: ThreadId,
+): TurnId | undefined => {
+  const ctx = sessions.get(threadId);
+  return ctx ? resolveCallbackTurnId(ctx) : undefined;
+};
+
+function parseOmpResume(raw: unknown): { sessionId: string } | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined;
+  const record = raw as Record<string, unknown>;
+  if (record.schemaVersion !== OMP_RESUME_VERSION) return undefined;
+  if (typeof record.sessionId !== "string" || !record.sessionId.trim()) return undefined;
+  return { sessionId: record.sessionId.trim() };
+}
+
+export function selectOmpPermissionOptionId(
+  request: EffectAcpSchema.RequestPermissionRequest,
+  decision: Exclude<ProviderApprovalDecision, "cancel">,
+): string | undefined {
+  const preferredKind =
+    decision === "acceptForSession" || decision === "acceptAlways"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  const pick = (kind: string) =>
+    request.options.find((entry) => entry.kind === kind && entry.optionId.trim())?.optionId.trim();
+  const preferredId = pick(preferredKind);
+  if (preferredId) {
+    return preferredId;
+  }
+  // Agents sometimes omit allow_always. T3 still offers "Always allow this session".
+  if (decision === "acceptForSession" || decision === "acceptAlways") {
+    const onceId = pick("allow_once");
+    if (onceId) {
+      return onceId;
+    }
+  }
+  return undefined;
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  return (
+    selectOmpPermissionOptionId(request, "acceptForSession") ??
+    selectOmpPermissionOptionId(request, "accept")
+  );
+}
+
+function completedStopReasonFromPromptResponse(
+  response: EffectAcpSchema.PromptResponse | undefined,
+): EffectAcpSchema.StopReason | null {
+  return response === undefined ? null : response.stopReason;
+}
+
+export function ompPromptSettlementBelongsToContext(input: {
+  readonly liveAcpSessionId: string;
+  readonly expectedAcpSessionId: string;
+  readonly liveActiveTurnId: TurnId | undefined;
+  readonly liveSessionActiveTurnId: TurnId | undefined;
+  readonly turnId: TurnId;
+}): boolean {
+  return (
+    input.liveAcpSessionId === input.expectedAcpSessionId &&
+    (input.liveActiveTurnId === input.turnId || input.liveSessionActiveTurnId === input.turnId)
+  );
+}
+
+export function makeOmpAdapter(ompSettings: OmpSettings, options?: OmpAdapterLiveOptions) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("omp");
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, OmpSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+    const requestedTurnInactivityTimeoutMs = options?.turnInactivityTimeoutMs;
+    const turnInactivityTimeoutMs =
+      typeof requestedTurnInactivityTimeoutMs === "number" &&
+      Number.isFinite(requestedTurnInactivityTimeoutMs)
+        ? Math.max(1, Math.floor(requestedTurnInactivityTimeoutMs))
+        : DEFAULT_OMP_TURN_INACTIVITY_TIMEOUT_MS;
+    const turnInactivityTimeoutNanos = BigInt(turnInactivityTimeoutMs) * NANOS_PER_MILLI;
+    const requestedActiveToolInactivityTimeoutMs = options?.activeToolInactivityTimeoutMs;
+    const activeToolInactivityTimeoutMs =
+      typeof requestedActiveToolInactivityTimeoutMs === "number" &&
+      Number.isFinite(requestedActiveToolInactivityTimeoutMs)
+        ? Math.max(1, Math.floor(requestedActiveToolInactivityTimeoutMs))
+        : DEFAULT_OMP_ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS;
+    const activeToolInactivityTimeoutNanos =
+      BigInt(activeToolInactivityTimeoutMs) * NANOS_PER_MILLI;
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate OMP runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapAcpCallbackFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process OMP ACP callback.",
+              cause,
+            }),
+        ),
+      );
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const signalTurnLiveness = (ctx: OmpSessionContext, turnId: TurnId) =>
+      Queue.offer(ctx.livenessSignals, { turnId }).pipe(Effect.asVoid);
+
+    const beginTurnLiveness = (ctx: OmpSessionContext, turnId: TurnId) =>
+      Effect.sync(() => {
+        ctx.livenessTurnId = turnId;
+        // Do not start a deadline until ACP has made observable progress.
+        // The agent's private reasoning phase is not present in the ACP stream.
+        ctx.lastTurnActivityAtNanos = undefined;
+        ctx.activeToolCallIds.clear();
+      });
+
+    const clearTurnLiveness = (ctx: OmpSessionContext) => {
+      const turnId = ctx.livenessTurnId;
+      ctx.livenessTurnId = undefined;
+      ctx.lastTurnActivityAtNanos = undefined;
+      ctx.activeToolCallIds.clear();
+      ctx.livenessUpdatesInFlight = 0;
+      ctx.promptResponsesReady = 0;
+      return turnId === undefined ? Effect.void : signalTurnLiveness(ctx, turnId);
+    };
+
+    const recordTurnActivity = Effect.fn("OmpAdapter.recordTurnActivity")(function* (
+      ctx: OmpSessionContext,
+      turnId: TurnId,
+      event: Extract<
+        AcpSessionRuntime.AcpSessionRuntimeEvent,
+        {
+          _tag:
+            | "AssistantItemStarted"
+            | "AssistantItemCompleted"
+            | "PlanUpdated"
+            | "ToolCallUpdated"
+            | "ContentDelta";
+        }
+      >,
+    ) {
+      if (
+        ctx.livenessTurnId !== turnId ||
+        (event._tag === "ContentDelta" && event.text.length === 0)
+      ) {
+        return;
+      }
+      ctx.livenessUpdatesInFlight += 1;
+      try {
+        const activityAtNanos = yield* Clock.monotonicTimeNanos;
+        if (ctx.livenessTurnId !== turnId || ctx.interruptedTurnIds.has(turnId)) {
+          return;
+        }
+        if (event._tag === "ToolCallUpdated") {
+          if (event.toolCall.status === "completed" || event.toolCall.status === "failed") {
+            ctx.activeToolCallIds.delete(event.toolCall.toolCallId);
+          } else {
+            // A tool update without a terminal status receives a longer
+            // deadline so a long-running tool is not mistaken for a stall.
+            ctx.activeToolCallIds.add(event.toolCall.toolCallId);
+          }
+        }
+        ctx.lastTurnActivityAtNanos = activityAtNanos;
+      } finally {
+        // Decrement before signaling. The watchdog treats in-flight updates as a
+        // pause; if it consumed a signal while the counter was still > 0 it would
+        // wait on the next take with no follow-up wake after this decrement.
+        ctx.livenessUpdatesInFlight = Math.max(0, ctx.livenessUpdatesInFlight - 1);
+        yield* signalTurnLiveness(ctx, turnId);
+      }
+    });
+
+    const hasLivenessPause = (ctx: OmpSessionContext) =>
+      ctx.pendingApprovals.size > 0 || ctx.livenessUpdatesInFlight > 0;
+
+    const livenessTimeoutFor = (ctx: OmpSessionContext) =>
+      ctx.activeToolCallIds.size > 0
+        ? {
+            milliseconds: activeToolInactivityTimeoutMs,
+            nanos: activeToolInactivityTimeoutNanos,
+          }
+        : { milliseconds: turnInactivityTimeoutMs, nanos: turnInactivityTimeoutNanos };
+
+    const signalSessionTurnLiveness = (threadId: ThreadId, turnId: TurnId | undefined) => {
+      const ctx = sessions.get(threadId);
+      return ctx && turnId !== undefined ? signalTurnLiveness(ctx, turnId) : Effect.void;
+    };
+
+    const resumeSessionTurnLiveness = Effect.fn("OmpAdapter.resumeSessionTurnLiveness")(function* (
+      threadId: ThreadId,
+      turnId: TurnId | undefined,
+    ) {
+      const ctx = sessions.get(threadId);
+      if (!ctx || turnId === undefined || ctx.livenessTurnId !== turnId) {
+        return;
+      }
+      // An approval wait can last longer than the watchdog. Its resolution
+      // gives the provider a fresh window to resume output.
+      ctx.lastTurnActivityAtNanos = yield* Clock.monotonicTimeNanos;
+      yield* signalTurnLiveness(ctx, turnId);
+    });
+
+    const refreshSessionTurnLiveness = Effect.fn("OmpAdapter.refreshSessionTurnLiveness")(
+      function* (threadId: ThreadId, turnId: TurnId | undefined) {
+        const ctx = sessions.get(threadId);
+        if (
+          !ctx ||
+          turnId === undefined ||
+          ctx.livenessTurnId !== turnId ||
+          ctx.lastTurnActivityAtNanos === undefined
+        ) {
+          return;
+        }
+        ctx.lastTurnActivityAtNanos = yield* Clock.monotonicTimeNanos;
+        yield* signalTurnLiveness(ctx, turnId);
+      },
+    );
+
+    const markPromptResponseReady = Effect.fn("OmpAdapter.markPromptResponseReady")(function* (
+      threadId: ThreadId,
+      acpSessionId: string,
+      turnId: TurnId,
+    ) {
+      const ctx = sessions.get(threadId);
+      if (
+        ctx &&
+        ctx.acpSessionId === acpSessionId &&
+        !ctx.stopped &&
+        !ctx.interruptedTurnIds.has(turnId) &&
+        ctx.livenessTurnId === turnId &&
+        ctx.activeTurnId === turnId &&
+        ctx.session.activeTurnId === turnId
+      ) {
+        ctx.promptResponsesReady += 1;
+        yield* signalTurnLiveness(ctx, turnId);
+      }
+    });
+
+    const consumePromptResponseReady = (ctx: OmpSessionContext) => {
+      ctx.promptResponsesReady = Math.max(0, ctx.promptResponsesReady - 1);
+    };
+
+    const settlePromptInFlight = (
+      threadId: ThreadId,
+      turnId: TurnId,
+      expectedAcpSessionId: string,
+      options?: {
+        readonly errorMessage?: string;
+        readonly completedStopReason?: EffectAcpSchema.StopReason | null;
+        readonly emitTurnCompletion?: boolean;
+        /** Interrupt/cancel: drop every outstanding prompt slot and settle once. */
+        readonly settleAllPrompts?: boolean;
+      },
+    ) =>
+      Effect.gen(function* () {
+        const liveCtx = sessions.get(threadId);
+        if (!liveCtx) {
+          return;
+        }
+        const settlementBelongsToLiveContext = ompPromptSettlementBelongsToContext({
+          liveAcpSessionId: liveCtx.acpSessionId,
+          expectedAcpSessionId,
+          liveActiveTurnId: liveCtx.activeTurnId,
+          liveSessionActiveTurnId: liveCtx.session.activeTurnId,
+          turnId,
+        });
+        if (!settlementBelongsToLiveContext) {
+          // interruptTurn already consumed every prompt slot for this turn. A
+          // late prompt result must neither emit a second terminal event nor
+          // consume a slot belonging to a newer turn on the same ACP session.
+          if (
+            liveCtx.acpSessionId !== expectedAcpSessionId ||
+            liveCtx.interruptedTurnIds.has(turnId)
+          ) {
+            return;
+          }
+          if (options?.emitTurnCompletion !== false) {
+            if (options?.errorMessage !== undefined) {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId,
+                turnId,
+                payload: {
+                  state: "failed",
+                  errorMessage: options.errorMessage,
+                },
+              });
+            } else if (options?.completedStopReason !== undefined) {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId,
+                turnId,
+                payload: {
+                  state: options.completedStopReason === "cancelled" ? "cancelled" : "completed",
+                  stopReason: options.completedStopReason ?? null,
+                },
+              });
+            }
+          }
+          return;
+        }
+        let settleTurnId = turnId;
+        if (options?.settleAllPrompts) {
+          liveCtx.promptsInFlight = 0;
+          if (liveCtx.activeTurnId !== turnId && liveCtx.session.activeTurnId !== turnId) {
+            const fallbackTurnId = liveCtx.activeTurnId ?? liveCtx.session.activeTurnId;
+            if (!fallbackTurnId) {
+              if (liveCtx.session.status === "running" || liveCtx.session.status === "connecting") {
+                const updatedAt = yield* nowIso;
+                const { activeTurnId: _activeTurnId, ...readySession } = liveCtx.session;
+                liveCtx.activeTurnId = undefined;
+                liveCtx.session = {
+                  ...readySession,
+                  status: "ready",
+                  updatedAt,
+                };
+              }
+              yield* clearTurnLiveness(liveCtx);
+              return;
+            }
+            settleTurnId = fallbackTurnId;
+          }
+        } else {
+          const remainingPrompts = Math.max(0, liveCtx.promptsInFlight - 1);
+          if (
+            remainingPrompts > 0 ||
+            liveCtx.activeTurnId !== settleTurnId ||
+            liveCtx.session.activeTurnId !== settleTurnId
+          ) {
+            liveCtx.promptsInFlight = remainingPrompts;
+            return;
+          }
+          liveCtx.promptsInFlight = remainingPrompts;
+        }
+        yield* clearTurnLiveness(liveCtx);
+        const updatedAt = yield* nowIso;
+        const canEmitTurnCompletion =
+          liveCtx.session.status === "running" || liveCtx.session.status === "connecting";
+        const shouldEmitFailedTurn = options?.errorMessage !== undefined && canEmitTurnCompletion;
+        const shouldEmitCompletedTurn =
+          options?.completedStopReason !== undefined && canEmitTurnCompletion;
+        const { activeTurnId: _activeTurnId, ...readySession } = liveCtx.session;
+        liveCtx.activeTurnId = undefined;
+        liveCtx.session = {
+          ...readySession,
+          status: "ready",
+          updatedAt,
+        };
+        if (options?.emitTurnCompletion === false) {
+          return;
+        }
+        if (shouldEmitFailedTurn) {
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId,
+            turnId: settleTurnId,
+            payload: {
+              state: "failed",
+              errorMessage: options.errorMessage,
+            },
+          });
+        } else if (shouldEmitCompletedTurn) {
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId,
+            turnId: settleTurnId,
+            payload: {
+              state: options.completedStopReason === "cancelled" ? "cancelled" : "completed",
+              stopReason: options.completedStopReason ?? null,
+            },
+          });
+        }
+      });
+
+    const isLiveTurn = (ctx: OmpSessionContext, turnId: TurnId) =>
+      ctx.promptsInFlight > 0 &&
+      ctx.promptsInFlight > ctx.promptResponsesReady &&
+      ctx.activeTurnId === turnId &&
+      ctx.session.activeTurnId === turnId &&
+      (ctx.session.status === "running" || ctx.session.status === "connecting");
+
+    const settleStalledTurn = Effect.fn("OmpAdapter.settleStalledTurn")(function* (
+      ctx: OmpSessionContext,
+      turnId: TurnId,
+    ) {
+      return yield* withThreadLock(
+        ctx.threadId,
+        Effect.gen(function* () {
+          const liveCtx = sessions.get(ctx.threadId);
+          if (
+            liveCtx !== ctx ||
+            ctx.stopped ||
+            !isLiveTurn(ctx, turnId) ||
+            ctx.interruptedTurnIds.has(turnId) ||
+            hasLivenessPause(ctx)
+          ) {
+            return;
+          }
+          const lastActivityAtNanos = ctx.lastTurnActivityAtNanos;
+          if (lastActivityAtNanos === undefined) {
+            return;
+          }
+          const nowNanos = yield* Clock.monotonicTimeNanos;
+          if (
+            ctx.interruptedTurnIds.has(turnId) ||
+            !isLiveTurn(ctx, turnId) ||
+            hasLivenessPause(ctx) ||
+            nowNanos - lastActivityAtNanos < livenessTimeoutFor(ctx).nanos
+          ) {
+            return;
+          }
+
+          // Mark before cancel/drain so notifications already in flight finish
+          // before the terminal event, while late notifications are dropped.
+          ctx.interruptedTurnIds.add(turnId);
+          yield* Effect.ignore(
+            ctx.acp.cancel.pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, ctx.threadId, "session/cancel", error),
+              ),
+            ),
+          );
+          yield* Effect.ignore(ctx.acp.drainEvents);
+          yield* settlePromptInFlight(ctx.threadId, turnId, ctx.acpSessionId, {
+            errorMessage: `OMP ACP turn stalled without content or tool progress for ${livenessTimeoutFor(ctx).milliseconds}ms.`,
+            settleAllPrompts: true,
+          });
+        }),
+      );
+    });
+
+    const runTurnLivenessWatchdog = Effect.fn("OmpAdapter.runTurnLivenessWatchdog")(
+      function* (ctx: OmpSessionContext) {
+        while (true) {
+          if (ctx.stopped) {
+            return;
+          }
+          const turnId = ctx.livenessTurnId;
+          if (
+            turnId === undefined ||
+            ctx.interruptedTurnIds.has(turnId) ||
+            !isLiveTurn(ctx, turnId) ||
+            hasLivenessPause(ctx)
+          ) {
+            yield* Queue.take(ctx.livenessSignals);
+            continue;
+          }
+
+          const lastActivityAtNanos = ctx.lastTurnActivityAtNanos;
+          if (lastActivityAtNanos === undefined) {
+            yield* Queue.take(ctx.livenessSignals);
+            continue;
+          }
+          const nowNanos = yield* Clock.monotonicTimeNanos;
+          const remainingNanos = livenessTimeoutFor(ctx).nanos - (nowNanos - lastActivityAtNanos);
+          if (remainingNanos <= 0n) {
+            yield* settleStalledTurn(ctx, turnId);
+            continue;
+          }
+
+          const wakeReason = yield* Effect.raceFirst(
+            Effect.sleep(Duration.nanos(remainingNanos)).pipe(Effect.as("timeout" as const)),
+            Queue.take(ctx.livenessSignals).pipe(Effect.as("activity" as const)),
+          );
+          if (wakeReason === "timeout") {
+            yield* settleStalledTurn(ctx, turnId);
+          }
+        }
+      },
+      Effect.catch(() => Effect.void),
+    );
+
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Failed to write native OMP notification log.", {
+            cause,
+            threadId,
+            method,
+          }),
+        ),
+      );
+
+    const emitPlanUpdate = (
+      ctx: OmpSessionContext,
+      turnId: TurnId | undefined,
+      stamp: { readonly eventId: EventId; readonly createdAt: string },
+      payload: {
+        readonly explanation?: string | null;
+        readonly plan: ReadonlyArray<{
+          readonly step: string;
+          readonly status: "pending" | "inProgress" | "completed";
+        }>;
+      },
+      rawPayload: unknown,
+      method: string,
+    ) =>
+      Effect.gen(function* () {
+        const fingerprint = `${turnId ?? "no-turn"}:${encodeJsonStringForDiagnostics(payload) ?? "[unserializable payload]"}`;
+        if (ctx.lastPlanFingerprint === fingerprint) {
+          return;
+        }
+        ctx.lastPlanFingerprint = fingerprint;
+        yield* offerRuntimeEvent(
+          makeAcpPlanUpdatedEvent({
+            stamp,
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId,
+            payload,
+            source: "acp.jsonrpc",
+            method,
+            rawPayload,
+          }),
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<OmpSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: OmpSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: OmpAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const ompModelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const sessionApprovedOperations = new Set<string>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+
+          const resumeSessionId = parseOmpResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+          const acp = yield* makeOmpAcpRuntime({
+            ompSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(mcpSession
+              ? {
+                  mcpServers: [
+                    {
+                      type: "http" as const,
+                      name: "t3-code",
+                      url: mcpSession.endpoint,
+                      headers: [
+                        {
+                          name: "Authorization",
+                          value: mcpSession.authorizationHeader,
+                        },
+                      ],
+                    },
+                  ],
+                }
+              : {}),
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Crypto.Crypto, crypto),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              mapAcpCallbackFailure(
+                Effect.gen(function* () {
+                  yield* logNative(input.threadId, "session/request_permission", params);
+                  const permissionRequest = parsePermissionRequest(params);
+                  const command = permissionRequest.toolCall?.command;
+                  const { kind, title, rawInput, locations } = params.toolCall;
+                  const rawInputFields =
+                    typeof rawInput === "object" && rawInput !== null && !Array.isArray(rawInput)
+                      ? (rawInput as Record<string, unknown>)
+                      : undefined;
+                  let operationInput = rawInput;
+                  if (rawInputFields?.variant === "Bash") {
+                    const { description: _description, ...shellInput } = rawInputFields;
+                    operationInput = shellInput;
+                  }
+                  // Remember the operation, not the tool-call id or every future tool.
+                  // Generic titles without input cannot identify an operation safely.
+                  const approvalKey =
+                    command ||
+                    (rawInputFields !== undefined && Object.keys(rawInputFields).length > 0)
+                      ? stableStringify({ kind, title, command, input: operationInput, locations })
+                      : undefined;
+                  const alreadyApproved =
+                    approvalKey !== undefined && sessionApprovedOperations.has(approvalKey);
+                  if (input.runtimeMode === "full-access" || alreadyApproved) {
+                    const autoApprovedOptionId =
+                      input.runtimeMode === "full-access"
+                        ? selectAutoApprovedPermissionOption(params)
+                        : selectOmpPermissionOptionId(params, "accept");
+                    if (autoApprovedOptionId !== undefined) {
+                      return {
+                        outcome: {
+                          outcome: "selected" as const,
+                          optionId: autoApprovedOptionId,
+                        },
+                      };
+                    }
+                  }
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
+                  pendingApprovals.set(requestId, { decision });
+                  yield* signalSessionTurnLiveness(input.threadId, turnId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail:
+                        permissionRequest.detail ??
+                        encodeJsonStringForDiagnostics(params)?.slice(0, 2000) ??
+                        "[unserializable params]",
+                      args: params,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: params,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* resumeSessionTurnLiveness(input.threadId, turnId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  const selectedOptionId =
+                    resolved === "cancel"
+                      ? undefined
+                      : selectOmpPermissionOptionId(params, resolved);
+                  if (
+                    resolved === "acceptForSession" &&
+                    selectedOptionId &&
+                    approvalKey !== undefined
+                  ) {
+                    sessionApprovedOperations.add(approvalKey);
+                  }
+                  return {
+                    outcome: selectedOptionId
+                      ? {
+                          outcome: "selected" as const,
+                          optionId: selectedOptionId,
+                        }
+                      : ({ outcome: "cancelled" } as const),
+                  };
+                }),
+              ),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          const requestedStartModelId = ompModelSelection?.model
+            ? resolveOmpAcpBaseModelId(ompModelSelection.model)
+            : undefined;
+          const currentStartModelId = currentOmpModelIdFromSessionSetup(started.sessionSetupResult);
+          const currentStartReasoningEffort = currentOmpReasoningEffortFromSessionSetup(
+            started.sessionSetupResult,
+          );
+          const requestedStartReasoningEffort = getModelSelectionStringOptionValue(
+            ompModelSelection,
+            "reasoningEffort",
+          );
+          const boundModelId = yield* applyOmpAcpModelSelection({
+            runtime: acp,
+            currentModelId: currentStartModelId,
+            currentReasoningEffort: currentStartReasoningEffort,
+            requestedModelId: requestedStartModelId,
+            requestedReasoningEffort: requestedStartReasoningEffort,
+            mapError: (cause) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+          });
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            ...(boundModelId ? { model: resolveOmpAcpBaseModelId(boundModelId) } : {}),
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: OMP_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          const ctx: OmpSessionContext = {
+            threadId: input.threadId,
+            acpSessionId: started.sessionId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            turns: [],
+            lastPlanFingerprint: undefined,
+            activeTurnId: undefined,
+            interruptedTurnIds: new Set(),
+            promptsInFlight: 0,
+            livenessSignals: yield* Queue.sliding<OmpTurnLivenessSignal>(1),
+            livenessTurnId: undefined,
+            lastTurnActivityAtNanos: undefined,
+            activeToolCallIds: new Set(),
+            livenessUpdatesInFlight: 0,
+            promptResponsesReady: 0,
+            currentModelId: boundModelId,
+            currentReasoningEffort:
+              requestedStartReasoningEffort !== undefined
+                ? normalizeOmpReasoningEffort(requestedStartReasoningEffort)
+                : currentStartReasoningEffort,
+            stopped: false,
+          };
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                if (event._tag === "EventStreamBarrier") {
+                  yield* Deferred.succeed(event.acknowledge, undefined);
+                  return;
+                }
+                if (
+                  event._tag === "PlanUpdated" ||
+                  event._tag === "ToolCallUpdated" ||
+                  event._tag === "ContentDelta"
+                ) {
+                  yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                }
+
+                if (event._tag === "ModeChanged") {
+                  return;
+                }
+
+                const notificationTurnId = resolveNotificationTurnId(ctx);
+                if (
+                  notificationTurnId === undefined ||
+                  ctx.interruptedTurnIds.has(notificationTurnId)
+                ) {
+                  return;
+                }
+                if (
+                  event._tag === "AssistantItemStarted" ||
+                  event._tag === "AssistantItemCompleted" ||
+                  event._tag === "PlanUpdated" ||
+                  event._tag === "ToolCallUpdated" ||
+                  event._tag === "ContentDelta"
+                ) {
+                  yield* recordTurnActivity(ctx, notificationTurnId, event);
+                }
+                const stamp = yield* makeEventStamp();
+
+                switch (event._tag) {
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* emitPlanUpdate(
+                      ctx,
+                      notificationTurnId,
+                      stamp,
+                      event.payload,
+                      event.rawPayload,
+                      "session/update",
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp,
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: notificationTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process OMP runtime notification.", { cause }),
+            ),
+            // Fork into the session scope, not the calling fiber. `forkChild`
+            // makes this a child of `startSession`, and Effect interrupts a
+            // fiber's children when it completes, so the consumer died as soon
+            // as `startSession` returned and every later notification was
+            // dropped. The scope is created, stored on the context and closed
+            // on teardown already; only the fork target was wrong.
+            Effect.forkIn(ctx.scope),
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          yield* runTurnLivenessWatchdog(ctx).pipe(Effect.forkIn(ctx.scope), Effect.asVoid);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "OMP ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: OmpAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const prepared = yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(input.threadId);
+            // A sendTurn while a prompt is in flight is a steer: the agent
+            // folds the new prompt into the ongoing work, so the active turn
+            // id is reused instead of opening a new turn.
+            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+            // Count this prompt immediately so a superseded in-flight prompt
+            // resolving from here on does not settle the turn; decremented on
+            // preparation failure here, and after the prompt below otherwise.
+            ctx.promptsInFlight += 1;
+            // Bind the turn id before cooperative yields so interruptTurn can
+            // settle this prompt even if stop arrives during preparation.
+            ctx.activeTurnId = turnId;
+            ctx.session = {
+              ...ctx.session,
+              status: steeringTurnId === undefined ? "connecting" : "running",
+              activeTurnId: turnId,
+              updatedAt: yield* nowIso,
+            };
+
+            return yield* Effect.gen(function* () {
+              const turnModelSelection =
+                input.modelSelection?.instanceId === boundInstanceId
+                  ? input.modelSelection
+                  : undefined;
+              const requestedTurnModelId = turnModelSelection?.model
+                ? resolveOmpAcpBaseModelId(turnModelSelection.model)
+                : undefined;
+              const requestedTurnReasoningEffort = getModelSelectionStringOptionValue(
+                turnModelSelection,
+                "reasoningEffort",
+              );
+
+              const text = input.input?.trim();
+              // OMP ingests images only. Generic files reach the agent
+              // through the path line ProviderService puts in the prompt.
+              const imagePromptParts = yield* Effect.forEach(
+                (input.attachments ?? []).filter((attachment) => attachment.type === "image"),
+                (attachment) =>
+                  Effect.gen(function* () {
+                    const attachmentPath = resolveAttachmentPath({
+                      attachmentsDir: serverConfig.attachmentsDir,
+                      attachment,
+                    });
+                    if (!attachmentPath) {
+                      return yield* new ProviderAdapterRequestError({
+                        provider: PROVIDER,
+                        method: "session/prompt",
+                        detail: `Invalid attachment id '${attachment.id}'.`,
+                      });
+                    }
+                    const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ProviderAdapterRequestError({
+                            provider: PROVIDER,
+                            method: "session/prompt",
+                            detail: cause.message,
+                            cause,
+                          }),
+                      ),
+                    );
+                    return {
+                      type: "image",
+                      data: Buffer.from(bytes).toString("base64"),
+                      mimeType: attachment.mimeType,
+                    } satisfies EffectAcpSchema.ContentBlock;
+                  }),
+              );
+              const promptParts: Array<EffectAcpSchema.ContentBlock> = [
+                ...(text ? [{ type: "text" as const, text }] : []),
+                ...imagePromptParts,
+              ];
+
+              if (promptParts.length === 0) {
+                return yield* new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "sendTurn",
+                  issue: "Turn requires non-empty text or attachments.",
+                });
+              }
+
+              const currentModelId = yield* applyOmpAcpModelSelection({
+                runtime: ctx.acp,
+                currentModelId: ctx.currentModelId,
+                currentReasoningEffort: ctx.currentReasoningEffort,
+                requestedModelId: requestedTurnModelId,
+                requestedReasoningEffort: requestedTurnReasoningEffort,
+                mapError: (cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
+              ctx.currentModelId = currentModelId;
+              if (requestedTurnReasoningEffort !== undefined) {
+                ctx.currentReasoningEffort = normalizeOmpReasoningEffort(
+                  requestedTurnReasoningEffort,
+                );
+              }
+              const displayModel = currentModelId
+                ? resolveOmpAcpBaseModelId(currentModelId)
+                : undefined;
+              for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
+                yield* Effect.yieldNow;
+              }
+              if (ctx.interruptedTurnIds.has(turnId)) {
+                yield* settlePromptInFlight(input.threadId, turnId, ctx.acpSessionId, {
+                  completedStopReason: "cancelled",
+                  emitTurnCompletion: false,
+                  settleAllPrompts: true,
+                });
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/prompt",
+                  detail: "OMP prompt was interrupted during preparation.",
+                });
+              }
+              if (steeringTurnId === undefined) {
+                ctx.lastPlanFingerprint = undefined;
+              }
+              ctx.session = {
+                ...ctx.session,
+                status: "running",
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+                ...(displayModel ? { model: displayModel } : {}),
+              };
+              if (steeringTurnId === undefined) {
+                yield* beginTurnLiveness(ctx, turnId);
+              } else {
+                yield* refreshSessionTurnLiveness(input.threadId, turnId);
+              }
+
+              if (steeringTurnId === undefined) {
+                yield* offerRuntimeEvent({
+                  type: "turn.started",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId,
+                  payload: displayModel ? { model: displayModel } : {},
+                });
+              }
+
+              return {
+                acp: ctx.acp,
+                acpSessionId: ctx.acpSessionId,
+                displayModel,
+                promptParts,
+                turnId,
+              };
+            }).pipe(
+              Effect.tapCause(() =>
+                Effect.gen(function* () {
+                  const liveCtx = sessions.get(input.threadId);
+                  if (!liveCtx) {
+                    return;
+                  }
+                  yield* settlePromptInFlight(input.threadId, turnId, liveCtx.acpSessionId, {
+                    errorMessage: "OMP prompt preparation failed.",
+                    emitTurnCompletion: false,
+                  });
+                }),
+              ),
+            );
+          }),
+        );
+        const promptSettled = yield* Ref.make(false);
+        const promptRpcSucceeded = yield* Ref.make(false);
+        const promptResultRef = yield* Ref.make<EffectAcpSchema.PromptResponse | undefined>(
+          undefined,
+        );
+
+        const promptFailureMessageRef = yield* Ref.make<string | undefined>(undefined);
+
+        return yield* Effect.gen(function* () {
+          const result = yield* prepared.acp
+            .prompt({
+              prompt: prepared.promptParts,
+            })
+            .pipe(
+              Effect.tap((promptResult) =>
+                Effect.all(
+                  [
+                    Ref.set(promptRpcSucceeded, true),
+                    Ref.set(promptResultRef, promptResult),
+                    markPromptResponseReady(input.threadId, prepared.acpSessionId, prepared.turnId),
+                  ],
+                  { discard: true },
+                ),
+              ),
+              Effect.tapError((error) =>
+                Ref.set(
+                  promptFailureMessageRef,
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error).message,
+                ).pipe(Effect.andThen(prepared.acp.drainEvents)),
+              ),
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+
+          return yield* withThreadLock(
+            input.threadId,
+            Effect.gen(function* () {
+              const ctx = yield* requireSession(input.threadId);
+              if (ctx.acpSessionId !== prepared.acpSessionId) {
+                yield* settlePromptInFlight(
+                  input.threadId,
+                  prepared.turnId,
+                  prepared.acpSessionId,
+                  {
+                    errorMessage: "OMP session changed before the turn completed.",
+                    settleAllPrompts: true,
+                  },
+                );
+                yield* Ref.set(promptSettled, true);
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/prompt",
+                  detail: "OMP session changed before the turn completed.",
+                });
+              }
+              // Keep prompt settlement atomic with respect to Stop and steering.
+              // interruptTurn marks its target before waiting for this lock, so
+              // cancellation can still win while queued ACP events are drained.
+              for (let yieldAttempt = 0; yieldAttempt < 8; yieldAttempt += 1) {
+                yield* Effect.yieldNow;
+              }
+              yield* prepared.acp.drainEvents;
+              consumePromptResponseReady(ctx);
+              if (ctx.interruptedTurnIds.has(prepared.turnId)) {
+                yield* Ref.set(promptSettled, true);
+                return {
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
+
+              if (
+                ctx.promptsInFlight <= 0 ||
+                ctx.activeTurnId !== prepared.turnId ||
+                ctx.session.activeTurnId !== prepared.turnId
+              ) {
+                yield* Ref.set(promptSettled, true);
+                return {
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
+
+              appendPromptResultToTurn(ctx, prepared.turnId, prepared.promptParts, result);
+              ctx.session = {
+                ...ctx.session,
+                status: "running",
+                activeTurnId: prepared.turnId,
+                updatedAt: yield* nowIso,
+                ...(prepared.displayModel ? { model: prepared.displayModel } : {}),
+              };
+              const remainingPrompts = Math.max(0, ctx.promptsInFlight - 1);
+              ctx.promptsInFlight = remainingPrompts;
+
+              // Only the last remaining prompt settles the turn. A steer-
+              // superseded prompt resolving while another is in flight or
+              // pending must leave the merged turn running.
+              if (
+                remainingPrompts === 0 &&
+                ctx.activeTurnId === prepared.turnId &&
+                ctx.session.activeTurnId === prepared.turnId
+              ) {
+                if (ctx.interruptedTurnIds.has(prepared.turnId)) {
+                  yield* Ref.set(promptSettled, true);
+                  return {
+                    threadId: input.threadId,
+                    turnId: prepared.turnId,
+                    resumeCursor: ctx.session.resumeCursor,
+                  };
+                }
+                const completedAt = yield* nowIso;
+                const { activeTurnId: _completedTurnId, ...readySession } = ctx.session;
+                ctx.activeTurnId = undefined;
+                ctx.session = {
+                  ...readySession,
+                  status: "ready",
+                  updatedAt: completedAt,
+                  ...(prepared.displayModel ? { model: prepared.displayModel } : {}),
+                };
+                yield* clearTurnLiveness(ctx);
+                const completedStopReason = completedStopReasonFromPromptResponse(result);
+                yield* offerRuntimeEvent({
+                  type: "turn.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  payload: {
+                    state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                    stopReason: completedStopReason,
+                  },
+                });
+                ctx.interruptedTurnIds.delete(prepared.turnId);
+                yield* Ref.set(promptSettled, true);
+              } else if (remainingPrompts > 0) {
+                yield* Ref.set(promptSettled, true);
+              }
+
+              return {
+                threadId: input.threadId,
+                turnId: prepared.turnId,
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }),
+          );
+        }).pipe(
+          Effect.ensuring(
+            Effect.gen(function* () {
+              if (yield* Ref.get(promptSettled)) {
+                return;
+              }
+
+              if (yield* Ref.get(promptRpcSucceeded)) {
+                const promptResult = yield* Ref.get(promptResultRef);
+                if (promptResult === undefined) {
+                  return;
+                }
+                yield* withThreadLock(
+                  input.threadId,
+                  Effect.gen(function* () {
+                    const ctx = yield* requireSession(input.threadId);
+                    if (ctx.acpSessionId !== prepared.acpSessionId) {
+                      yield* settlePromptInFlight(
+                        input.threadId,
+                        prepared.turnId,
+                        prepared.acpSessionId,
+                        {
+                          errorMessage: "OMP session changed before the turn completed.",
+                          settleAllPrompts: true,
+                        },
+                      );
+                      return;
+                    }
+                    if (ctx.interruptedTurnIds.has(prepared.turnId)) {
+                      return;
+                    }
+                    consumePromptResponseReady(ctx);
+                    if (
+                      ctx.promptsInFlight <= 0 ||
+                      ctx.activeTurnId !== prepared.turnId ||
+                      ctx.session.activeTurnId !== prepared.turnId
+                    ) {
+                      return;
+                    }
+                    appendPromptResultToTurn(
+                      ctx,
+                      prepared.turnId,
+                      prepared.promptParts,
+                      promptResult,
+                    );
+                    yield* settlePromptInFlight(
+                      input.threadId,
+                      prepared.turnId,
+                      prepared.acpSessionId,
+                      {
+                        completedStopReason: completedStopReasonFromPromptResponse(promptResult),
+                      },
+                    );
+                  }),
+                );
+                return;
+              }
+
+              const errorMessage = yield* Ref.get(promptFailureMessageRef);
+              yield* withThreadLock(
+                input.threadId,
+                settlePromptInFlight(input.threadId, prepared.turnId, prepared.acpSessionId, {
+                  errorMessage: errorMessage ?? "OMP prompt request failed.",
+                }),
+              );
+            }).pipe(Effect.catch(() => Effect.void)),
+          ),
+        );
+      });
+
+    const interruptTurn: OmpAdapterShape["interruptTurn"] = (threadId, turnId) =>
+      Effect.gen(function* () {
+        const observed = yield* Effect.sync(() => {
+          const ctx = sessions.get(threadId);
+          if (!ctx || ctx.stopped) {
+            return {
+              _tag: "Proceed" as const,
+              acpSessionId: undefined,
+              interruptedTurnId: turnId,
+            };
+          }
+          const activeTurnId = ctx.activeTurnId ?? ctx.session.activeTurnId;
+          if (turnId !== undefined && activeTurnId !== undefined && activeTurnId !== turnId) {
+            return { _tag: "Ignore" as const };
+          }
+          const interruptedTurnId = turnId ?? activeTurnId;
+          if (interruptedTurnId !== undefined) {
+            ctx.interruptedTurnIds.add(interruptedTurnId);
+          }
+          return {
+            _tag: "Proceed" as const,
+            acpSessionId: ctx.acpSessionId,
+            interruptedTurnId,
+          };
+        });
+        if (observed._tag === "Ignore") {
+          return;
+        }
+
+        yield* withThreadLock(
+          threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(threadId);
+            if (observed.acpSessionId !== undefined && ctx.acpSessionId !== observed.acpSessionId) {
+              return;
+            }
+            const activeTurnId = ctx.activeTurnId ?? ctx.session.activeTurnId;
+            if (turnId !== undefined && activeTurnId !== undefined && activeTurnId !== turnId) {
+              return;
+            }
+            if (
+              observed.interruptedTurnId !== undefined &&
+              activeTurnId !== undefined &&
+              activeTurnId !== observed.interruptedTurnId
+            ) {
+              return;
+            }
+            const interruptedTurnId =
+              observed.interruptedTurnId ?? turnId ?? activeTurnId ?? ctx.session.activeTurnId;
+            yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+            yield* Effect.ignore(
+              ctx.acp.cancel.pipe(
+                Effect.mapError((error) =>
+                  mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+                ),
+              ),
+            );
+            if (interruptedTurnId) {
+              ctx.interruptedTurnIds.add(interruptedTurnId);
+              yield* settlePromptInFlight(threadId, interruptedTurnId, ctx.acpSessionId, {
+                completedStopReason: "cancelled",
+                settleAllPrompts: true,
+              });
+            } else if (
+              ctx.promptsInFlight > 0 ||
+              ctx.session.status === "running" ||
+              ctx.session.status === "connecting"
+            ) {
+              const updatedAt = yield* nowIso;
+              ctx.promptsInFlight = 0;
+              ctx.activeTurnId = undefined;
+              const { activeTurnId: _activeTurnId, ...readySession } = ctx.session;
+              ctx.session = {
+                ...readySession,
+                status: "ready",
+                updatedAt,
+              };
+              yield* clearTurnLiveness(ctx);
+            }
+          }),
+        );
+      });
+
+    const respondToRequest: OmpAdapterShape["respondToRequest"] = (threadId, requestId, decision) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: OmpAdapterShape["respondToUserInput"] = (threadId, requestId) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        // OMP exposes no structured user-input extension method, so no
+        // user-input request can ever be pending on this adapter.
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "respondToUserInput",
+          detail: `Unknown pending user-input request: ${requestId}`,
+        });
+      });
+
+    const readThread: OmpAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: OmpAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread/rollback",
+          detail: "OMP ACP sessions do not support provider-side rollback yet.",
+        });
+      });
+
+    const stopSession: OmpAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: OmpAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: OmpAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: OmpAdapterShape["stopAll"] = () =>
+      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.ignore(stopAll()).pipe(
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies OmpAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/OmpProvider.ts
+++ b/apps/server/src/provider/Layers/OmpProvider.ts
@@ -1,0 +1,430 @@
+import {
+  type ModelCapabilities,
+  type OmpSettings,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import {
+  isValidOmpReasoningEffortToken,
+  makeOmpAcpRuntime,
+  resolveOmpAcpBaseModelId,
+} from "../acp/OmpAcpSupport.ts";
+
+const OMP_PRESENTATION = {
+  displayName: "OMP",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: false,
+  requiresNewThreadForModelChange: true,
+} as const;
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+const OMP_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+
+const OMP_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [];
+
+export function buildInitialOmpProviderSnapshot(
+  ompSettings: OmpSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = ompModelsFromSettings(ompSettings.customModels);
+
+    if (!ompSettings.enabled) {
+      return buildServerProvider({
+        presentation: OMP_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "OMP is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking OMP CLI availability...",
+      },
+    });
+  });
+}
+
+function ompModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = OMP_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim() || undefined : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function ompReasoningOptionsFromModel(model: EffectAcpSchema.ModelInfo): {
+  readonly options: ReadonlyArray<{
+    value: string;
+    label: string;
+    description?: string;
+    isDefault?: boolean;
+  }>;
+  readonly currentValue: string | undefined;
+} {
+  const meta = model._meta;
+  if (!meta || meta.supportsReasoningEffort === false) {
+    return { options: [], currentValue: undefined };
+  }
+
+  const currentEffort = nonEmptyString(meta.reasoningEffort);
+  const advertisedOptions = Array.isArray(meta.reasoningEfforts) ? meta.reasoningEfforts : [];
+  const seen = new Set<string>();
+  const options: Array<{
+    value: string;
+    label: string;
+    description?: string;
+    advertisedDefault: boolean;
+  }> = [];
+
+  for (const entry of advertisedOptions) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const rawValue = nonEmptyString(entry.value);
+    const rawId = nonEmptyString(entry.id);
+    const value =
+      rawValue && isValidOmpReasoningEffortToken(rawValue)
+        ? rawValue
+        : rawId && isValidOmpReasoningEffortToken(rawId)
+          ? rawId
+          : undefined;
+    if (value === undefined || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    const description = nonEmptyString(entry.description);
+    options.push({
+      value,
+      label: nonEmptyString(entry.label) ?? value,
+      ...(description ? { description } : {}),
+      advertisedDefault: entry.default === true || entry.isDefault === true,
+    });
+  }
+
+  const currentValue =
+    currentEffort && options.some((option) => option.value === currentEffort)
+      ? currentEffort
+      : undefined;
+  const advertisedDefaults = options.filter((option) => option.advertisedDefault);
+  const selectedDefault =
+    advertisedDefaults.find((option) => option.value === currentValue)?.value ??
+    advertisedDefaults[0]?.value;
+  return {
+    options: options.map(({ value, label, description }) => ({
+      value,
+      label,
+      ...(description ? { description } : {}),
+      ...(value === selectedDefault ? { isDefault: true } : {}),
+    })),
+    currentValue: currentValue ?? selectedDefault,
+  };
+}
+
+export function buildOmpModelCapabilities(model: EffectAcpSchema.ModelInfo): ModelCapabilities {
+  const reasoning = ompReasoningOptionsFromModel(model);
+  return reasoning.options.length > 0
+    ? createModelCapabilities({
+        optionDescriptors: [
+          {
+            id: "reasoningEffort",
+            label: "Reasoning",
+            type: "select",
+            options: reasoning.options.map((option) => ({
+              id: option.value,
+              label: option.label,
+              ...(option.description ? { description: option.description } : {}),
+              ...(option.isDefault ? { isDefault: true } : {}),
+            })),
+            ...(reasoning.currentValue ? { currentValue: reasoning.currentValue } : {}),
+          },
+        ],
+      })
+    : EMPTY_CAPABILITIES;
+}
+
+function buildOmpDiscoveredModelsFromSessionModelState(
+  modelState: EffectAcpSchema.SessionModelState | null | undefined,
+): ReadonlyArray<ServerProviderModel> {
+  if (!modelState || modelState.availableModels.length === 0) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return modelState.availableModels
+    .map((model): ServerProviderModel | undefined => {
+      const slug = resolveOmpAcpBaseModelId(model.modelId);
+      if (!slug || seen.has(slug)) {
+        return undefined;
+      }
+      seen.add(slug);
+      return {
+        slug,
+        name: model.name.trim() || slug,
+        isCustom: false,
+        capabilities: buildOmpModelCapabilities(model),
+      };
+    })
+    .filter((model): model is ServerProviderModel => model !== undefined);
+}
+
+const discoverOmpModelsViaAcp = (
+  ompSettings: OmpSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const acp = yield* makeOmpAcpRuntime({
+      ompSettings,
+      environment,
+      childProcessSpawner,
+      cwd: process.cwd(),
+      clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
+    });
+    const started = yield* acp.start();
+    return buildOmpDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
+  }).pipe(Effect.scoped);
+
+const runOmpVersionCommand = (
+  ompSettings: OmpSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const command = ompSettings.binaryPath || "omp";
+    const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
+      env: environment,
+    });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+      }),
+    );
+  });
+
+export const checkOmpProviderStatus = Effect.fn("checkOmpProviderStatus")(function* (
+  ompSettings: OmpSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.fn.Return<
+  ServerProviderDraft,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+> {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const fallbackModels = ompModelsFromSettings(ompSettings.customModels);
+
+  if (!ompSettings.enabled) {
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: false,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "OMP is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  const versionResult = yield* runOmpVersionCommand(ompSettings, environment).pipe(
+    Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(versionResult)) {
+    const error = versionResult.failure;
+    yield* Effect.logWarning("OMP CLI health check failed.", {
+      errorTag: error._tag,
+    });
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: ompSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: !isCommandMissingCause(error),
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: isCommandMissingCause(error)
+          ? "OMP CLI (`omp`) is not installed or not on PATH. Install it or set the binary path in settings."
+          : "Failed to execute OMP CLI health check.",
+      },
+    });
+  }
+
+  if (Option.isNone(versionResult.success)) {
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: ompSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "OMP CLI is installed but timed out while running `omp --version`.",
+      },
+    });
+  }
+
+  const versionOutput = versionResult.success.value;
+  const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+  if (versionOutput.code !== 0) {
+    yield* Effect.logWarning("OMP CLI version probe exited with a non-zero status.", {
+      exitCode: versionOutput.code,
+      stdoutLength: versionOutput.stdout.length,
+      stderrLength: versionOutput.stderr.length,
+    });
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: ompSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "OMP CLI is installed but failed to run.",
+      },
+    });
+  }
+
+  const discoveryExit = yield* discoverOmpModelsViaAcp(ompSettings, environment).pipe(
+    Effect.timeoutOption(OMP_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
+    Effect.exit,
+  );
+  if (Exit.isFailure(discoveryExit)) {
+    yield* Effect.logWarning("OMP ACP model discovery failed", {
+      errorTag: causeErrorTag(discoveryExit.cause),
+    });
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: ompSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "OMP CLI is installed but ACP startup failed. Check server logs for details.",
+      },
+    });
+  }
+  if (Option.isNone(discoveryExit.value)) {
+    yield* Effect.logWarning(
+      `OMP ACP model discovery timed out after ${OMP_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+    );
+    return buildServerProvider({
+      presentation: OMP_PRESENTATION,
+      enabled: ompSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: `OMP CLI is installed but ACP startup timed out after ${OMP_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+      },
+    });
+  }
+  const discoveredModels = discoveryExit.value.value;
+  const models =
+    discoveredModels.length > 0
+      ? ompModelsFromSettings(ompSettings.customModels, discoveredModels)
+      : fallbackModels;
+
+  return buildServerProvider({
+    presentation: OMP_PRESENTATION,
+    enabled: ompSettings.enabled,
+    checkedAt,
+    models,
+    probe: {
+      installed: true,
+      version,
+      status: "ready",
+      auth: { status: "unknown" },
+    },
+  });
+});
+
+export const enrichOmpSnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("OMP version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1972,6 +1972,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 "codex",
                 "cursor",
                 "grok",
+                "omp",
                 "opencode",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);

--- a/apps/server/src/provider/Services/OmpAdapter.ts
+++ b/apps/server/src/provider/Services/OmpAdapter.ts
@@ -1,0 +1,16 @@
+/**
+ * OmpAdapter — shape type for the OMP provider adapter.
+ *
+ * The driver model ({@link ../Drivers/OmpDriver}) bundles one adapter per
+ * instance as a captured closure, so this module only retains the shape
+ * interface as a naming anchor for the driver bundle.
+ *
+ * @module OmpAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * OmpAdapterShape — per-instance OMP adapter contract.
+ */
+export interface OmpAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/OmpAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/OmpAcpCliProbe.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Optional integration check against a real `omp acp` install.
+ * Enable with: T3_OMP_ACP_PROBE=1 bun run test --filter OmpAcpCliProbe
+ */
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { describe, expect } from "vite-plus/test";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+describe.runIf(process.env.T3_OMP_ACP_PROBE === "1")("OMP ACP CLI probe", () => {
+  it.effect("initialize, authenticate, and create a session against real omp acp", () =>
+    Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
+      const started = yield* runtime.start();
+
+      expect(started.initializeResult.agentInfo?.name).toBe("oh-my-pi");
+      expect(started.sessionId).toBeTruthy();
+
+      const setup = started.sessionSetupResult;
+      if ("sessionId" in setup) {
+        expect(setup.sessionId).toBe(started.sessionId);
+      }
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: "omp",
+            args: ["acp"],
+            cwd: process.cwd(),
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "t3-probe", version: "0.0.0" },
+          authMethodId: "agent",
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    ),
+  );
+});

--- a/apps/server/src/provider/acp/OmpAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/OmpAcpSupport.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as EffectAcpErrors from "effect-acp/errors";
+
+import {
+  applyOmpAcpModelSelection,
+  buildOmpAcpSpawnInput,
+  isValidOmpReasoningEffortToken,
+  normalizeOmpReasoningEffort,
+  resolveOmpAcpBaseModelId,
+} from "./OmpAcpSupport.ts";
+
+describe("resolveOmpAcpBaseModelId", () => {
+  it("treats blank input as no request instead of an empty model id", () => {
+    expect(resolveOmpAcpBaseModelId(undefined)).toBeUndefined();
+    expect(resolveOmpAcpBaseModelId(null)).toBeUndefined();
+    expect(resolveOmpAcpBaseModelId("   ")).toBeUndefined();
+  });
+
+  it("keeps OMP's provider-prefixed ids intact", () => {
+    expect(resolveOmpAcpBaseModelId("  anthropic/claude-sonnet-5  ")).toBe(
+      "anthropic/claude-sonnet-5",
+    );
+    expect(resolveOmpAcpBaseModelId("zai-coding/glm-5.3")).toBe("zai-coding/glm-5.3");
+  });
+});
+
+describe("buildOmpAcpSpawnInput", () => {
+  it("serves the ACP agent over stdio and falls back to the `omp` binary", () => {
+    expect(buildOmpAcpSpawnInput(null, "/tmp/project", { PATH: "/usr/bin" })).toEqual({
+      command: "omp",
+      args: ["acp"],
+      cwd: "/tmp/project",
+      env: { PATH: "/usr/bin" },
+    });
+  });
+
+  it("uses the configured binary path", () => {
+    expect(buildOmpAcpSpawnInput({ binaryPath: "/opt/omp" }, "/tmp/project").command).toBe(
+      "/opt/omp",
+    );
+  });
+});
+
+describe("normalizeOmpReasoningEffort", () => {
+  it("accepts ACP effort tokens and drops malformed metadata values", () => {
+    expect(isValidOmpReasoningEffortToken("max")).toBe(true);
+    expect(isValidOmpReasoningEffortToken("not a token")).toBe(false);
+    expect(normalizeOmpReasoningEffort("  high  ")).toBe("high");
+    expect(normalizeOmpReasoningEffort("not a token")).toBeUndefined();
+    expect(normalizeOmpReasoningEffort(undefined)).toBeUndefined();
+  });
+});
+
+describe("applyOmpAcpModelSelection", () => {
+  const makeRecordingRuntime = (failure?: EffectAcpErrors.AcpError) => {
+    const modelCalls: Array<{
+      modelId: string;
+      meta?: { readonly [key: string]: unknown } | null;
+    }> = [];
+    const runtime = {
+      setSessionModel: (modelId: string, meta?: { readonly [key: string]: unknown } | null) =>
+        Effect.gen(function* () {
+          modelCalls.push(meta === undefined ? { modelId } : { modelId, meta });
+          if (failure) return yield* failure;
+          return {};
+        }),
+    };
+    return { runtime, modelCalls };
+  };
+
+  it.effect("calls session/set_model when the requested model differs from current", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyOmpAcpModelSelection({
+        runtime,
+        currentModelId: "anthropic/claude-sonnet-5",
+        requestedModelId: "zai-coding/glm-5.3",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "zai-coding/glm-5.3" }]);
+      expect(result).toBe("zai-coding/glm-5.3");
+    }),
+  );
+
+  it.effect("keeps the agent's own model when nothing was requested", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyOmpAcpModelSelection({
+        runtime,
+        currentModelId: "anthropic/claude-sonnet-5",
+        requestedModelId: resolveOmpAcpBaseModelId("   "),
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([]);
+      expect(result).toBe("anthropic/claude-sonnet-5");
+    }),
+  );
+
+  it.effect("applies reasoning effort through session/set_model metadata", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      yield* applyOmpAcpModelSelection({
+        runtime,
+        currentModelId: "anthropic/claude-opus-5",
+        currentReasoningEffort: "high",
+        requestedModelId: "anthropic/claude-opus-5",
+        requestedReasoningEffort: "max",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([
+        { modelId: "anthropic/claude-opus-5", meta: { reasoningEffort: "max" } },
+      ]);
+    }),
+  );
+
+  it.effect("drops malformed effort metadata instead of sending it", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      yield* applyOmpAcpModelSelection({
+        runtime,
+        currentModelId: "anthropic/claude-opus-5",
+        currentReasoningEffort: "high",
+        requestedModelId: "anthropic/claude-opus-5",
+        requestedReasoningEffort: "not a token",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "anthropic/claude-opus-5" }]);
+    }),
+  );
+
+  it.effect("does not clear reasoning when same-model selection omits effort", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      yield* applyOmpAcpModelSelection({
+        runtime,
+        currentModelId: "anthropic/claude-opus-5",
+        currentReasoningEffort: "high",
+        requestedModelId: "anthropic/claude-opus-5",
+        requestedReasoningEffort: undefined,
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([]);
+    }),
+  );
+
+  it.effect("propagates session/set_model failures via mapError", () =>
+    Effect.gen(function* () {
+      const failure = EffectAcpErrors.AcpRequestError.invalidParams("session id not known");
+      const { runtime } = makeRecordingRuntime(failure);
+      const error = yield* Effect.flip(
+        applyOmpAcpModelSelection({
+          runtime,
+          currentModelId: "anthropic/claude-sonnet-5",
+          requestedModelId: "zai-coding/glm-5.3",
+          mapError: (cause) => cause.message,
+        }),
+      );
+      expect(error).toBe(failure.message);
+    }),
+  );
+});

--- a/apps/server/src/provider/acp/OmpAcpSupport.ts
+++ b/apps/server/src/provider/acp/OmpAcpSupport.ts
@@ -1,0 +1,150 @@
+import { type OmpSettings, ProviderDriverKind } from "@t3tools/contracts";
+import { normalizeModelSlug } from "@t3tools/shared/model";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+const OMP_AUTH_METHOD_AGENT = "agent";
+const OMP_DRIVER_KIND = ProviderDriverKind.make("omp");
+
+type OmpAcpRuntimeOmpSettings = Pick<OmpSettings, "binaryPath">;
+
+interface OmpAcpRuntimeInput extends Omit<
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly ompSettings: OmpAcpRuntimeOmpSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export function buildOmpAcpSpawnInput(
+  ompSettings: OmpAcpRuntimeOmpSettings | null | undefined,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): AcpSessionRuntime.AcpSpawnInput {
+  // `omp acp` serves the ACP agent over stdio and reuses the local omp
+  // credentials; approvals flow back through ACP permission requests, so no
+  // CLI permission-mode flags are needed.
+  return {
+    command: ompSettings?.binaryPath || "omp",
+    args: ["acp"],
+    cwd,
+    env: { ...environment },
+  };
+}
+
+export const makeOmpAcpRuntime = (
+  input: OmpAcpRuntimeInput,
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Crypto.Crypto | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildOmpAcpSpawnInput(input.ompSettings, input.cwd, input.environment),
+        authMethodId: OMP_AUTH_METHOD_AGENT,
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    const runtime = yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
+    return runtime;
+  });
+
+export function resolveOmpAcpBaseModelId(model: string | null | undefined): string | undefined {
+  const trimmed = model?.trim();
+  // OMP has no provider-owned default model id: the agent reports its own
+  // current model through ACP session state. Blank input means "no request",
+  // never an empty model id - sending "" to session/set_model clears the
+  // agent's own choice.
+  return trimmed ? (normalizeModelSlug(trimmed, OMP_DRIVER_KIND) ?? trimmed) : undefined;
+}
+
+const OMP_REASONING_EFFORT_TOKEN = /^[a-z0-9][a-z0-9._-]{0,31}$/i;
+
+export function isValidOmpReasoningEffortToken(value: string): boolean {
+  return OMP_REASONING_EFFORT_TOKEN.test(value);
+}
+
+export function normalizeOmpReasoningEffort(value: string | undefined): string | undefined {
+  const effort = value?.trim();
+  return effort && isValidOmpReasoningEffortToken(effort) ? effort : undefined;
+}
+
+export function currentOmpModelIdFromSessionSetup(
+  sessionSetupResult:
+    | EffectAcpSchema.LoadSessionResponse
+    | EffectAcpSchema.NewSessionResponse
+    | EffectAcpSchema.ResumeSessionResponse,
+): string | undefined {
+  return sessionSetupResult.models?.currentModelId?.trim() || undefined;
+}
+
+export function currentOmpReasoningEffortFromSessionSetup(
+  sessionSetupResult:
+    | EffectAcpSchema.LoadSessionResponse
+    | EffectAcpSchema.NewSessionResponse
+    | EffectAcpSchema.ResumeSessionResponse,
+): string | undefined {
+  const modelState = sessionSetupResult.models;
+  if (!modelState) {
+    return undefined;
+  }
+  const currentModelId = modelState.currentModelId.trim();
+  if (currentModelId.length === 0) {
+    return undefined;
+  }
+  const currentModel = modelState.availableModels.find(
+    (model) => model.modelId.trim() === currentModelId,
+  );
+  const reasoningEffort = currentModel?._meta?.reasoningEffort;
+  return typeof reasoningEffort === "string"
+    ? normalizeOmpReasoningEffort(reasoningEffort)
+    : undefined;
+}
+
+export function applyOmpAcpModelSelection<E>(input: {
+  readonly runtime: Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "setSessionModel">;
+  readonly currentModelId: string | undefined;
+  readonly currentReasoningEffort?: string | undefined;
+  readonly requestedModelId: string | undefined;
+  readonly requestedReasoningEffort?: string | undefined;
+  readonly mapError: (cause: EffectAcpErrors.AcpError) => E;
+}): Effect.Effect<string | undefined, E> {
+  const modelChanged =
+    input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
+  const reasoningProvided = input.requestedReasoningEffort !== undefined;
+  const reasoningEffort = reasoningProvided
+    ? normalizeOmpReasoningEffort(input.requestedReasoningEffort)
+    : undefined;
+  const reasoningEffortChanged =
+    reasoningProvided && reasoningEffort !== input.currentReasoningEffort;
+  const targetModelId = input.requestedModelId ?? input.currentModelId;
+  if ((!modelChanged && !reasoningEffortChanged) || targetModelId === undefined) {
+    return Effect.succeed(input.currentModelId);
+  }
+  const reasoningMeta =
+    reasoningProvided && reasoningEffort !== undefined ? { reasoningEffort } : undefined;
+  // When reasoning was explicitly provided but invalid (normalize => undefined), we deliberately
+  // send no meta so the invalid value is dropped rather than forwarded. When reasoning was not
+  // provided at all, we also send no meta, but we only reach this call when the model itself
+  // changed - an omitted reasoning preference must not be treated as an explicit clear of the
+  // CLI-advertised default (e.g. Extra High) on same-model reselections.
+  return input.runtime
+    .setSessionModel(targetModelId, reasoningMeta)
+    .pipe(Effect.mapError(input.mapError), Effect.as(targetModelId));
+}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
+import { OmpDriver, type OmpDriverEnv } from "./Drivers/OmpDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
@@ -37,6 +38,7 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
+  | OmpDriverEnv
   | OpenCodeDriverEnv;
 
 /**
@@ -50,4 +52,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,
+  OmpDriver,
 ];

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -237,6 +237,7 @@ const PersistedOptionalProviderSettings = Schema.Struct({
       cursor: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       grok: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       opencode: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
+      omp: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
     }),
   ),
 });
@@ -264,7 +265,8 @@ function restoreUsedProviders(
       instance.enabled === undefined &&
       (instance.driver === "cursor" ||
         instance.driver === "grok" ||
-        instance.driver === "opencode") &&
+        instance.driver === "opencode" ||
+        instance.driver === "omp") &&
       usedProviderInstances.has(instanceId)
         ? { ...instance, enabled: true }
         : instance,
@@ -286,6 +288,10 @@ function restoreUsedProviders(
       opencode: {
         ...settings.providers.opencode,
         enabled: persisted.providers?.opencode?.enabled ?? usedProviders.has("opencode"),
+      },
+      omp: {
+        ...settings.providers.omp,
+        enabled: persisted.providers?.omp?.enabled ?? usedProviders.has("omp"),
       },
     },
     providerInstances,
@@ -334,6 +340,7 @@ const PERSISTED_SERVER_SETTINGS_DEFAULTS = {
     cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: undefined },
     grok: { ...DEFAULT_SERVER_SETTINGS.providers.grok, enabled: undefined },
     opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: undefined },
+    omp: { ...DEFAULT_SERVER_SETTINGS.providers.omp, enabled: undefined },
   },
 };
 
@@ -443,13 +450,13 @@ const make = Effect.gen(function* () {
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM projection_thread_sessions
-      WHERE provider_name IN ('cursor', 'grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'opencode', 'omp')
       UNION
       SELECT DISTINCT
         provider_name AS "providerName",
         provider_instance_id AS "providerInstanceId"
       FROM provider_session_runtime
-      WHERE provider_name IN ('cursor', 'grok', 'opencode')
+      WHERE provider_name IN ('cursor', 'grok', 'opencode', 'omp')
     `.pipe(
       Effect.mapError(
         (cause) =>

--- a/apps/server/src/textGeneration/OmpTextGeneration.ts
+++ b/apps/server/src/textGeneration/OmpTextGeneration.ts
@@ -1,0 +1,269 @@
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import { type ModelSelection, type OmpSettings, TextGenerationError } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import {
+  applyOmpAcpModelSelection,
+  currentOmpModelIdFromSessionSetup,
+  currentOmpReasoningEffortFromSessionSetup,
+  makeOmpAcpRuntime,
+  resolveOmpAcpBaseModelId,
+} from "../provider/acp/OmpAcpSupport.ts";
+
+const OMP_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+export const makeOmpTextGeneration = Effect.fn("makeOmpTextGeneration")(function* (
+  ompSettings: OmpSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const runOmpJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const resolvedModel = resolveOmpAcpBaseModelId(modelSelection.model);
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeOmpAcpRuntime({
+        ompSettings,
+        environment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      }).pipe(Effect.provideService(Crypto.Crypto, crypto));
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        const started = yield* runtime.start();
+        const requestedReasoningEffort = getModelSelectionStringOptionValue(
+          modelSelection,
+          "reasoningEffort",
+        );
+        yield* applyOmpAcpModelSelection({
+          runtime,
+          currentModelId: currentOmpModelIdFromSessionSetup(started.sessionSetupResult),
+          currentReasoningEffort: currentOmpReasoningEffortFromSessionSetup(
+            started.sessionSetupResult,
+          ),
+          requestedModelId: resolvedModel,
+          requestedReasoningEffort,
+          mapError: (cause) =>
+            new TextGenerationError({
+              operation,
+              detail: "Failed to set OMP ACP base model for text generation.",
+              cause,
+            }),
+        });
+
+        return yield* runtime.prompt({
+          prompt: [{ type: "text", text: prompt }],
+        });
+      }).pipe(
+        Effect.timeoutOption(OMP_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({ operation, detail: "OMP ACP request timed out." }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause: EffectAcpErrors.AcpError | TextGenerationError) =>
+          isTextGenerationError(cause)
+            ? cause
+            : new TextGenerationError({
+                operation,
+                detail: "OMP ACP request failed.",
+                cause,
+              }),
+        ),
+      );
+
+      const trimmed = (yield* Ref.get(outputRef)).trim();
+      if (!trimmed) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "OMP ACP request was cancelled."
+              : "OMP Agent returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(trimmed)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "OMP Agent returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "OMP ACP text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGeneration.TextGeneration["Service"]["generateCommitMessage"] =
+    Effect.fn("OmpTextGeneration.generateCommitMessage")(function* (input) {
+      const { prompt, outputSchema } = buildCommitMessagePrompt({
+        branch: input.branch,
+        stagedSummary: input.stagedSummary,
+        stagedPatch: input.stagedPatch,
+        includeBranch: input.includeBranch === true,
+        policy: input.policy,
+      });
+
+      const generated = yield* runOmpJson({
+        operation: "generateCommitMessage",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        subject: sanitizeCommitSubject(generated.subject),
+        body: generated.body.trim(),
+        ...("branch" in generated && typeof generated.branch === "string"
+          ? { branch: sanitizeFeatureBranchName(generated.branch) }
+          : {}),
+      };
+    });
+
+  const generatePrContent: TextGeneration.TextGeneration["Service"]["generatePrContent"] =
+    Effect.fn("OmpTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+        policy: input.policy,
+        changeRequestTemplate: input.changeRequestTemplate,
+      });
+
+      const generated = yield* runOmpJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body.trim(),
+      };
+    });
+
+  const generateBranchName: TextGeneration.TextGeneration["Service"]["generateBranchName"] =
+    Effect.fn("OmpTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runOmpJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        branch: sanitizeBranchFragment(generated.branch),
+      };
+    });
+
+  const generateThreadTitle: TextGeneration.TextGeneration["Service"]["generateThreadTitle"] =
+    Effect.fn("OmpTextGeneration.generateThreadTitle")(function* (input) {
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        previousTitle: input.previousTitle,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runOmpJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizeThreadTitle(generated.title),
+      } satisfies TextGeneration.ThreadTitleGenerationResult;
+    });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGeneration.TextGeneration["Service"];
+});

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -8,7 +8,13 @@ import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstance
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import type { TextGenerationPolicy } from "./TextGenerationPolicy.ts";
 
-export type TextGenerationProvider = "codex" | "claudeAgent" | "cursor" | "grok" | "opencode";
+export type TextGenerationProvider =
+  | "codex"
+  | "claudeAgent"
+  | "cursor"
+  | "grok"
+  | "opencode"
+  | "omp";
 
 export interface CommitMessageGenerationInput {
   cwd: string;

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -214,6 +214,22 @@ export const GrokIcon: Icon = ({ className, ...props }) => (
   </svg>
 );
 
+export const OmpIcon: Icon = ({ className, ...props }) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    className={cn("stroke-[#0F0F0F] dark:stroke-[#F5F5F5]", className)}
+  >
+    <rect x="2.75" y="2.75" width="18.5" height="18.5" rx="4.5" strokeWidth="1.5" />
+    <path
+      d="M6.5 8.25h11M9.25 8.25V13.5a2.75 2.75 0 0 1-2.75 2.75M14.75 8.25v8"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
 export const TraeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 24 24" fill="currentColor">
     {/* Back rectangle: left strip + bottom strip drawn separately — empty bottom-left corner is the gap between them */}

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, Icon, OmpIcon, OpenAI, OpenCodeIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +8,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("omp")]: OmpIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -3,11 +3,12 @@ import {
   CodexSettings,
   CursorSettings,
   GrokSettings,
+  OmpSettings,
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OmpIcon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -66,6 +67,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("omp"),
+    label: "OMP",
+    icon: OmpIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: OmpSettings,
   },
 ];
 

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -95,7 +95,7 @@ The live backend agent implementation and its event stream. The main service is 
 
 #### Provider
 
-The backend agent runtime that actually performs work. Five drivers ship built in: Codex, Claude, Cursor, Grok, and OpenCode. See [ProviderService.ts][14], [ProviderAdapter.ts][15], and [CodexAdapter.ts][17] as a representative adapter.
+The backend agent runtime that actually performs work. Six drivers ship built in: Codex, Claude, Cursor, Grok, OpenCode, and OMP. See [ProviderService.ts][14], [ProviderAdapter.ts][15], and [CodexAdapter.ts][17] as a representative adapter.
 
 #### Session
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -18,13 +18,13 @@ there, never in the client.
 ┌──────────────────▼─────────────────────────────┐
 │ apps/server                                    │
 │  orchestration engine (event-sourced)          │
-│  provider driver registry (5 built-in drivers) │
+│  provider driver registry (6 built-in drivers) │
 │  checkpointing, VCS, terminals, filesystem     │
 └──────────────────┬─────────────────────────────┘
                    │ per-driver transport
 ┌──────────────────▼─────────────────────────────┐
 │ Agent CLIs: Codex, Claude, Cursor, Grok,       │
-│ OpenCode                                       │
+│ OpenCode, OMP                                  │
 └────────────────────────────────────────────────┘
 ```
 
@@ -106,8 +106,8 @@ build production behavior on receipts.
 
 ## Provider drivers
 
-Five drivers ship built in, registered in [`builtInDrivers.ts`][drivers] as `BUILT_IN_DRIVERS`:
-Codex, Claude, Cursor, Grok, and OpenCode. A driver declares its kind and config schema and creates a
+Six drivers ship built in, registered in [`builtInDrivers.ts`][drivers] as `BUILT_IN_DRIVERS`:
+Codex, Claude, Cursor, Grok, OpenCode, and OMP. A driver declares its kind and config schema and creates a
 scoped adapter; `ProviderInstanceRegistry` owns live instances and `ProviderAdapterRegistry` resolves
 an instance to its adapter, so `ProviderService` routes session and turn operations without knowing
 which agent is behind them. See [providers.md](./providers.md).

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -7,7 +7,7 @@ orchestration layer does not know which one is behind a thread.
 
 ## Built-in drivers
 
-[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with five entries:
+[`builtInDrivers.ts`][drivers] exports `BUILT_IN_DRIVERS` with six entries:
 
 | Driver kind   | Driver source                           |
 | ------------- | --------------------------------------- |
@@ -16,6 +16,7 @@ orchestration layer does not know which one is behind a thread.
 | `cursor`      | [`Drivers/CursorDriver.ts`][cursor]     |
 | `grok`        | [`Drivers/GrokDriver.ts`][grok]         |
 | `opencode`    | [`Drivers/OpenCodeDriver.ts`][opencode] |
+| `omp`         | [`Drivers/OmpDriver.ts`][omp]           |
 
 Each driver declares its `driverKind`, a `configSchema`, and a `create` function that builds an
 adapter in a child scope. Adapter implementations live beside them in
@@ -165,6 +166,7 @@ when a request opens (approval) or user input is requested, via
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts
 [opencode]: ../../apps/server/src/provider/Drivers/OpenCodeDriver.ts
+[omp]: ../../apps/server/src/provider/Drivers/OmpDriver.ts
 [opencode-server-owner]: ../../apps/server/src/provider/OpenCodeServerOwner.ts
 [adapter]: ../../apps/server/src/provider/Services/ProviderAdapter.ts
 [instances]: ../../apps/server/src/provider/Services/ProviderInstanceRegistry.ts

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -71,8 +71,9 @@ to use, then authenticate it.
 | Cursor     | [Cursor CLI](https://cursor.com/cli)                  | `cursor-agent` | `agent login`         |
 | Grok Build | [Grok Build CLI](https://x.ai/cli)                    | `grok`         | `grok login`          |
 | OpenCode   | [OpenCode](https://opencode.ai)                       | `opencode`     | `opencode auth login` |
+| OMP        | [Oh My Pi](https://github.com/can1357/oh-my-pi)       | `omp`          | `omp setup`           |
 
-Codex and Claude are on by default. Cursor, Grok Build, and OpenCode are off by default; turn
+Codex and Claude are on by default. Cursor, Grok Build, OpenCode, and OMP are off by default; turn
 them on in **Settings** → the provider's card when you want to use them.
 
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -194,6 +194,80 @@ You can also check the OpenRouter activity dashboard for requests from your API 
 OpenRouter's setup can change over time. Use its upstream Claude Code guide for the current details:
 <https://openrouter.ai/docs/guides/guides/claude-code-integration>.
 
+## I Want To Use Z.AI (GLM Coding Plan)
+
+Use this when you want Claude Code to run on Z.AI's GLM Coding Plan instead of an Anthropic
+login. Z.AI exposes a Claude-compatible endpoint, so this is a plain Claude provider with
+environment variables — no router needed.
+
+### Configure A Claude Z.AI Provider
+
+Add or edit a Claude provider in T3 Code Settings:
+
+```text
+Display name: Claude Z.AI
+Binary path: claude
+CLAUDE_CONFIG_DIR path: ~/.claude_zai_home
+```
+
+In that provider's Environment variables section, add:
+
+```text
+ANTHROPIC_BASE_URL   https://api.z.ai/api/anthropic
+ANTHROPIC_AUTH_TOKEN <your Z.AI API key>       Sensitive
+API_TIMEOUT_MS       3000000
+```
+
+Mark `ANTHROPIC_AUTH_TOKEN` as sensitive. T3 Code stores the value as a server secret and does not
+send it back to the app after saving.
+
+If you want this setup isolated from your normal Claude account, create that home first:
+
+```bash
+mkdir -p ~/.claude_zai_home
+```
+
+If you previously used the same Claude home with a normal Anthropic login, run `/logout` in a
+Claude Code session for that home before using Z.AI. Otherwise Claude Code may keep using cached
+Anthropic credentials instead of the Z.AI token.
+
+### Pick GLM Models
+
+Claude Code's default model roles can be mapped to GLM model IDs:
+
+```text
+ANTHROPIC_DEFAULT_OPUS_MODEL    glm-4.7
+ANTHROPIC_DEFAULT_SONNET_MODEL  glm-4.7
+ANTHROPIC_DEFAULT_HAIKU_MODEL   glm-4.5-air
+```
+
+Add those to the same provider's Environment variables section if you want stable model choices.
+Use lowercase model IDs.
+
+### Verify Z.AI Is Being Used
+
+Open a Claude session and run:
+
+```text
+/status
+```
+
+You should see the Anthropic base URL set to:
+
+```text
+https://api.z.ai/api/anthropic
+```
+
+### Common Z.AI Mistakes
+
+- Use `https://api.z.ai/api/anthropic`, not the OpenAI-compatible coding endpoint, for Claude Code.
+- Set `ANTHROPIC_AUTH_TOKEN` to your Z.AI API key, not `ANTHROPIC_API_KEY`.
+- Set `ANTHROPIC_API_KEY` to an empty string if Claude Code still tries an Anthropic login.
+- Put these variables on the Claude provider instance, not in global shell startup files.
+
+Z.AI's setup can change over time. Use its upstream Claude Code guide for the current details:
+<https://docs.z.ai/devpack/tool/claude>.
+
 ## I Want To Use Claude Code Router
 
 Claude Code Router is useful when you want a local routing layer with more control than a direct

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -236,8 +236,8 @@ Anthropic credentials instead of the Z.AI token.
 Claude Code's default model roles can be mapped to GLM model IDs:
 
 ```text
-ANTHROPIC_DEFAULT_OPUS_MODEL    glm-4.7
-ANTHROPIC_DEFAULT_SONNET_MODEL  glm-4.7
+ANTHROPIC_DEFAULT_OPUS_MODEL    glm-5.3
+ANTHROPIC_DEFAULT_SONNET_MODEL  glm-5.3
 ANTHROPIC_DEFAULT_HAIKU_MODEL   glm-4.5-air
 ```
 

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const OMP_DRIVER_KIND = ProviderDriverKind.make("omp");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -147,6 +148,13 @@ export const PREFERRED_DEFAULT_CODEX_MODELS: ReadonlyArray<string> = [
 export const DEFAULT_TEXT_GENERATION_MODEL = "gpt-5.6-luna";
 export const DEFAULT_TEXT_GENERATION_REASONING_EFFORT = "low";
 
+/**
+ * Last-resort model per driver, used only when a provider snapshot advertises
+ * no models of its own. `omp` is deliberately absent: it is a harness whose
+ * backends differ per install, and it reports its own current model through
+ * ACP session state, so any static slug here would be forced onto installs
+ * that do not have it.
+ */
 export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, string>> = {
   [CODEX_DRIVER_KIND]: DEFAULT_MODEL,
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-5",
@@ -222,4 +230,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [OMP_DRIVER_KIND]: "OMP",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -564,6 +564,32 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const OmpSettings = makeProviderSettingsSchema(
+  {
+    // Off by default (like Cursor, Grok, and OpenCode). Users opt in from
+    // Settings.
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("omp").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Oh My Pi binary.",
+        providerSettingsForm: { placeholder: "omp", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type OmpSettings = typeof OmpSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -717,6 +743,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    omp: OmpSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -869,6 +896,11 @@ const OpenCodeSettingsPatch = Schema.Struct({
   serverPassword: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
+const OmpSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
 
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
@@ -911,6 +943,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      omp: Schema.optionalKey(OmpSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
Two related additions, split from a working fork ([branch](https://github.com/FelipeMayerDev/t3code/tree/zai-glm-coding-plan)):

## 1. OMP (Oh My Pi) provider driver
Adds `omp` as a sixth built-in driver, driving the [Oh My Pi](https://github.com/can1357/oh-my-pi) CLI through its native ACP server (`omp acp`) via the shared `AcpSessionRuntime` — same pattern as the Cursor and Grok drivers.

- **contracts**: `OmpSettings` (off by default, like Cursor/Grok/OpenCode), `omp` driver kind, display name
- **server**: `OmpDriver`, `OmpAdapter` (ported from GrokAdapter), `OmpProvider` (ACP model discovery, `--version` probe), `OmpAcpSupport` (spawn `omp acp`, auth method `agent`), `OmpTextGeneration`; opt-in registration in `serverSettings`
- **web/mobile**: OMP entry in the provider picker with a new `OmpIcon`
- **docs**: install/providers/glossary/overview updated to six drivers
- **probe**: `OmpAcpCliProbe.test.ts` integration check gated by `T3_OMP_ACP_PROBE=1`

Deliberately out of scope for v1: usage/transcript reading, skills discovery, and xAI-style ask-user/plan extensions (OMP's ACP implementation doesn't declare them).

## 2. Z.AI GLM Coding Plan docs
Adds a Z.AI section to the Claude providers guide, mirroring the existing OpenRouter walkthrough — it is the same mechanism the guide already documents (a Claude provider instance with `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`, `ANTHROPIC_AUTH_TOKEN`, `API_TIMEOUT_MS`, optional GLM model-role mapping). Docs-only; no code.

## Testing
- Workspace typecheck clean; provider test suite 809 passed (one expectation updated: built-in driver set 5→6)
- `T3_OMP_ACP_PROBE=1` probe passes against a real `omp acp` install: initialize, auth (`agent`), session/new

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new ACP adapter and subprocess integration on the provider path; OMP lacks rollback and structured user-input ACP extensions, so those operations error by design.
> 
> **Overview**
> Adds **OMP (Oh My Pi)** as a sixth built-in provider, wired like Cursor/Grok through **`omp acp`** and the shared ACP session runtime. Contracts gain **`OmpSettings`** (off by default), server settings persistence, and registry wiring; **`OmpDriver`** composes an ACP adapter, CLI health/model discovery, and git helper text generation. The adapter maps ACP turns (steering, permissions, stall watchdogs, in-session model/reasoning) into provider runtime events; web and mobile pick up an **OMP** icon and settings entry.
> 
> Docs expand install/providers/internals to six drivers and add a **Z.AI (GLM Coding Plan)** Claude provider walkthrough (docs only, no runtime changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5aa27eb9f7ccb0c313cc54f2aa82ff5056a61c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OMP (`oh-my-pi`) provider driver with ACP adapter and text generation
> - Introduces a complete `omp` provider driver: [OmpDriver.ts](https://github.com/pingdotgg/t3code/pull/8583/files#diff-f34450952d0c0b60419cd949cb0220852c6d3cacf81d2bb75afa994282db18a3) composes an ACP-backed adapter ([OmpAdapter.ts](https://github.com/pingdotgg/t3code/pull/8583/files#diff-3940ce275f46846cec7d22f3f4a83aab4b3294f5626461dde4ef6a45d7055825)), a text generation service ([OmpTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/8583/files#diff-3f1545b9a5b18cb06397244f19614f5e1ca02bd6a17e12504b6fcb7038c09558)), and a health/status checker ([OmpProvider.ts](https://github.com/pingdotgg/t3code/pull/8583/files#diff-4ed64bd6b90b60cff98cc834f010194ecb234fd7f10bccba95adc038dce41af5)) that probes the `omp` CLI and discovers models via ACP startup
> - Adds `OmpSettings` schema with `enabled` (default `false`), `binaryPath`, and `customModels` to contracts and server settings, plus auto-enable logic based on usage history
> - Registers `omp` in the built-in driver registry, provider registry tests, web/mobile provider icons, and `PROVIDER_CLIENT_DEFINITIONS` with an "Early Access" badge
> - Documents the new driver in user/internals docs and adds a section for Z.AI (GLM Coding Plan) with Claude Code in [providers-claude.md](https://github.com/pingdotgg/t3code/pull/8583/files#diff-f3b54bb573c78b526a8c1181ccd8146c7df38119b974038b08aff6f4e5a3819d)
> - Risk: `OmpAdapter.respondToUserInput` and `rollbackThread` always return errors (ACP lacks those extension points); `OmpTextGeneration` enforces a 180s timeout per operation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d5aa27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->