### PR TITLE
fix(web): stop session activity timing test from blocking releases

### DIFF
--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -2281,7 +2281,7 @@ describe("session activity performance", () => {
     expect(appendedEntries[1]).toBe(initialEntries[1]);
   });
 
-  it("updates 20,000 ordered tool activities within 100 ms", () => {
+  it("reuses entries when appending to 20,000 ordered tool activities", () => {
     const activities = Array.from({ length: 20_000 }, (_, index) =>
       makeActivity({
         id: `benchmark-tool-${index}`,
@@ -2299,7 +2299,8 @@ describe("session activity performance", () => {
         },
       }),
     );
-    deriveWorkLogEntries(activities);
+    const initialEntries = deriveWorkLogEntries(activities);
+    expect(initialEntries).toHaveLength(20_000);
     const updatedActivities = [
       ...activities,
       makeActivity({
@@ -2316,8 +2317,13 @@ describe("session activity performance", () => {
       }),
     ];
 
-    const startedAt = performance.now();
-    expect(deriveWorkLogEntries(updatedActivities)).toHaveLength(20_001);
-    expect(performance.now() - startedAt).toBeLessThan(100);
+    const updatedEntries = deriveWorkLogEntries(updatedActivities);
+    expect(updatedEntries).toHaveLength(20_001);
+    expect(initialEntries.every((entry, index) => updatedEntries[index] === entry)).toBe(true);
+    expect(updatedEntries.at(-1)).toMatchObject({
+      id: "benchmark-tool-appended",
+      command: "git diff",
+      toolLifecycleStatus: "completed",
+    });
   });
 });


### PR DESCRIPTION
The [release job](https://github.com/pingdotgg/t3code/actions/runs/33204582675/job/98962493410) failed because a 20,000-activity unit test took 119 ms against a fixed 100 ms wall-clock limit. A rerun of the same commit passed.

The test now checks the intended cache behavior directly. It keeps the 20,000-activity fixture, confirms that every existing entry retains its identity after one activity is appended, and checks the appended command and lifecycle status.

Verified 82 focused unit tests, file lint and format checks, the diff check, and the web typecheck.

GPT-5.6 Sol made these changes with the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; removes CI-flaky timing and does not alter `deriveWorkLogEntries` or runtime behavior.
> 
> **Overview**
> Replaces a flaky **100 ms wall-clock** performance assertion on `deriveWorkLogEntries` with a **behavioral** check for incremental updates on a 20,000-activity fixture.
> 
> The renamed test still builds 20,000 ordered `tool.completed` activities, derives the initial work log, appends one more activity, and then asserts the result length is 20,001, **every prior entry is the same object reference** (`===`), and the new row matches the appended activity (`git diff`, completed lifecycle).
> 
> No production code changes—only the session activity performance test in `session-logic.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbeb4ad8de18ef37e71f5662c750669e37b175b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace timing assertions with structural checks in `session-logic.test.ts`
> Rewrites the `reuses entries when appending to 20,000 ordered tool activities` test to stop asserting a <100ms runtime via `performance.now()`, which was flaky and blocked releases. The test now verifies that preexisting entries are reference-equal after appending and that the new entry has the expected id, command, and `toolLifecycleStatus`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbeb4ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->