### PR TITLE
fix(mobile): show composer menus when starting a task

### DIFF
--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -127,6 +127,7 @@ const CommandRow = memo(function CommandRow(props: {
 
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={props.onPress}
       className="flex-row items-center gap-2.5 border-border px-3.5 py-2.5 active:opacity-60"
       style={{ borderBottomWidth: props.isLast ? 0 : StyleSheet.hairlineWidth }}

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -34,6 +34,8 @@ import { ProviderIcon } from "../../components/ProviderIcon";
 import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text } from "../../components/AppText";
 import { ComposerSurface } from "./ThreadComposer";
+import { ComposerCommandPopover } from "./ComposerCommandPopover";
+import { useComposerCommandMenu } from "./use-composer-command-menu";
 import {
   useThreadSettingsSheetPresentation,
   type NavigationWithFinishTransitioning,
@@ -216,6 +218,16 @@ export function NewTaskDraftScreen(props: {
   const isIncomingShareTransferPending = Boolean(
     incomingShare && cancelledIncomingShareId !== props.incomingShareId,
   );
+  const composerMenu = useComposerCommandMenu({
+    draftMessage: flow.prompt,
+    environmentId: selectedProject?.environmentId ?? null,
+    projectCwd: (flow.selectedWorktreePath ?? selectedProject?.workspaceRoot) || null,
+    selectedProviderStatus: flow.selectedProviderStatus,
+    hasThread: false,
+    enabled: isComposerFocused && !isIncomingShareTransferPending,
+    onChangeDraftMessage: flow.setPrompt,
+    onUpdateInteractionMode: flow.planModeEnabled ? flow.setInteractionMode : undefined,
+  });
   usePreventRemove(
     (isIncomingShareTransferPending && !isProjectPickerReturnActive) || isCancellingShareImport,
     () => undefined,
@@ -828,8 +840,10 @@ export function NewTaskDraftScreen(props: {
       multiline
       scrollEnabled
       value={flow.prompt}
-      skills={flow.selectedProviderSkills}
+      skills={flow.selectedProviderStatus?.skills ?? []}
+      selection={composerMenu.selection}
       onChangeText={flow.setPrompt}
+      onSelectionChange={composerMenu.onSelectionChange}
       onFocus={() => setIsComposerFocused(true)}
       onBlur={() => setIsComposerFocused(false)}
       onPasteImages={(uris) => void handleNativePasteImages(uris)}
@@ -964,6 +978,16 @@ export function NewTaskDraftScreen(props: {
 
   const composerDock = (
     <View className="bg-sheet px-4 pt-1" style={{ paddingBottom: controlsBottomPadding }}>
+      {composerMenu.trigger && composerMenu.items.length > 0 ? (
+        <View className="mb-2">
+          <ComposerCommandPopover
+            items={composerMenu.items}
+            triggerKind={composerMenu.trigger.kind}
+            isLoading={composerMenu.isLoading}
+            onSelect={composerMenu.onSelect}
+          />
+        </View>
+      ) : null}
       <View className="pb-1">{workspaceControls}</View>
 
       <ComposerSurface

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -221,7 +221,10 @@ export function NewTaskDraftScreen(props: {
   const composerMenu = useComposerCommandMenu({
     draftMessage: flow.prompt,
     environmentId: selectedProject?.environmentId ?? null,
-    projectCwd: (flow.selectedWorktreePath ?? selectedProject?.workspaceRoot) || null,
+    projectCwd:
+      (flow.workspaceMode === "worktree"
+        ? selectedProject?.workspaceRoot
+        : (flow.selectedWorktreePath ?? selectedProject?.workspaceRoot)) || null,
     selectedProviderStatus: flow.selectedProviderStatus,
     hasThread: false,
     enabled: isComposerFocused && !isIncomingShareTransferPending,

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -7,12 +7,6 @@ import type {
   RuntimeMode,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
-import {
-  detectComposerTrigger,
-  replaceTextRange,
-  serializeComposerFileLink,
-  type ComposerTrigger,
-} from "@t3tools/shared/composerTrigger";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
@@ -32,11 +26,7 @@ import { scopedThreadKey } from "../../lib/scopedEntities";
 import { AppText as Text } from "../../components/AppText";
 import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStrip";
 import { GlassSurface } from "../../components/GlassSurface";
-import {
-  ComposerEditor,
-  type ComposerEditorHandle,
-  type ComposerEditorSelection,
-} from "../../components/ComposerEditor";
+import { ComposerEditor, type ComposerEditorHandle } from "../../components/ComposerEditor";
 import {
   ComposerInlineControl,
   ComposerToolbarButton,
@@ -49,15 +39,9 @@ import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import type { RemoteClientConnectionState } from "../../lib/connection";
-import {
-  insertRankedSearchResult,
-  normalizeSearchQuery,
-  scoreQueryMatch,
-} from "@t3tools/shared/searchRanking";
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
-import { useComposerPathSearch } from "../../state/use-composer-path-search";
-import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
-import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
+import { ComposerCommandPopover } from "./ComposerCommandPopover";
+import { useComposerCommandMenu } from "./use-composer-command-menu";
 import {
   type ExistingThreadSettingsRouteSession,
   useExistingThreadSettingsRoutePresentation,
@@ -329,196 +313,16 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     );
   }, [props.serverConfig, props.selectedThread.modelSelection.instanceId]);
 
-  // ── Trigger detection ────────────────────────────────────
-  const [composerSelection, setComposerSelection] = useState(() => ({
-    start: props.draftMessage.length,
-    end: props.draftMessage.length,
-  }));
-
-  const handleSelectionChange = useCallback((selection: ComposerEditorSelection) => {
-    setComposerSelection(selection);
-  }, []);
-  useEffect(() => {
-    const end = props.draftMessage.length;
-    setComposerSelection((selection) => {
-      const start = Math.min(selection.start, end);
-      const selectionEnd = Math.min(selection.end, end);
-      if (start === selection.start && selectionEnd === selection.end) {
-        return selection;
-      }
-      return { start, end: selectionEnd };
-    });
-  }, [props.draftMessage.length]);
-
-  const composerTrigger = useMemo<ComposerTrigger | null>(() => {
-    if (composerSelection.start !== composerSelection.end) {
-      return null;
-    }
-    return detectComposerTrigger(props.draftMessage, composerSelection.end);
-  }, [composerSelection, props.draftMessage]);
-  const pathSearch = useComposerPathSearch({
+  const composerMenu = useComposerCommandMenu({
+    draftMessage: props.draftMessage,
     environmentId: props.environmentId,
-    cwd: composerTrigger?.kind === "path" ? props.projectCwd : null,
-    query: composerTrigger?.kind === "path" ? composerTrigger.query : null,
+    projectCwd: props.projectCwd,
+    selectedProviderStatus,
+    hasThread: true,
+    onChangeDraftMessage: props.onChangeDraftMessage,
+    onUpdateInteractionMode: props.onUpdateInteractionMode,
   });
-
-  const composerMenuItems: ComposerCommandItem[] = useMemo(() => {
-    if (!composerTrigger) return [];
-
-    if (composerTrigger.kind === "slash-command") {
-      const q = composerTrigger.query.toLowerCase();
-      const allBuiltIn = [
-        {
-          id: "cmd:model",
-          type: "slash-command" as const,
-          command: "model",
-          label: "/model",
-          description: "Switch model",
-        },
-        {
-          id: "cmd:plan",
-          type: "slash-command" as const,
-          command: "plan",
-          label: "/plan",
-          description: "Switch to plan mode",
-        },
-        {
-          id: "cmd:default",
-          type: "slash-command" as const,
-          command: "default",
-          label: "/default",
-          description: "Switch to default mode",
-        },
-      ];
-      const builtIn = allBuiltIn.filter((item) => item.command.includes(q));
-
-      const providerCommands: ComposerCommandItem[] = [];
-      for (const cmd of selectedProviderStatus?.slashCommands ?? []) {
-        if (!cmd.name.toLowerCase().includes(q)) continue;
-        providerCommands.push({
-          id: `pcmd:${cmd.name}`,
-          type: "provider-slash-command" as const,
-          command: cmd,
-          label: `/${cmd.name}`,
-          description: cmd.description ?? "",
-        });
-      }
-
-      const skillItems = (selectedProviderStatus?.skills ?? [])
-        .filter((skill) => matchesSlashSkillQuery(skill, q))
-        .map((skill) => ({
-          id: `skill:${skill.name}`,
-          type: "skill" as const,
-          skill,
-          label: `skill:${skill.name}`,
-          description: skill.shortDescription ?? skill.description ?? "",
-        }));
-
-      return [...builtIn, ...providerCommands, ...skillItems];
-    }
-
-    if (composerTrigger.kind === "skill") {
-      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((s) => s.enabled);
-      const normalizedQuery = normalizeSearchQuery(composerTrigger.query, {
-        trimLeadingPattern: /^\$+/,
-      });
-
-      if (!normalizedQuery) {
-        return enabledSkills.slice(0, 20).map((skill) => ({
-          id: `skill:${skill.name}`,
-          type: "skill" as const,
-          skill,
-          label: skill.displayName ?? skill.name,
-          description: skill.shortDescription ?? skill.description ?? "",
-        }));
-      }
-
-      const ranked: Array<{
-        item: (typeof enabledSkills)[number];
-        score: number;
-        tieBreaker: string;
-      }> = [];
-      for (const skill of enabledSkills) {
-        const displayLabel = (skill.displayName ?? skill.name).toLowerCase();
-        const scores = [
-          scoreQueryMatch({
-            value: skill.name.toLowerCase(),
-            query: normalizedQuery,
-            exactBase: 0,
-            prefixBase: 2,
-            boundaryBase: 4,
-            includesBase: 6,
-            fuzzyBase: 100,
-            boundaryMarkers: ["-", "_", "/"],
-          }),
-          scoreQueryMatch({
-            value: displayLabel,
-            query: normalizedQuery,
-            exactBase: 1,
-            prefixBase: 3,
-            boundaryBase: 5,
-            includesBase: 7,
-            fuzzyBase: 110,
-          }),
-          scoreQueryMatch({
-            value: skill.shortDescription?.toLowerCase() ?? "",
-            query: normalizedQuery,
-            exactBase: 20,
-            prefixBase: 22,
-            boundaryBase: 24,
-            includesBase: 26,
-          }),
-          scoreQueryMatch({
-            value: skill.description?.toLowerCase() ?? "",
-            query: normalizedQuery,
-            exactBase: 30,
-            prefixBase: 32,
-            boundaryBase: 34,
-            includesBase: 36,
-          }),
-        ].filter((s): s is number => s !== null);
-
-        if (scores.length > 0) {
-          insertRankedSearchResult(
-            ranked,
-            {
-              item: skill,
-              score: Math.min(...scores),
-              tieBreaker: `${displayLabel}\u0000${skill.name}`,
-            },
-            20,
-          );
-        }
-      }
-
-      return ranked.map(({ item: skill }) => ({
-        id: `skill:${skill.name}`,
-        type: "skill" as const,
-        skill,
-        label: skill.displayName ?? skill.name,
-        description: skill.shortDescription ?? skill.description ?? "",
-      }));
-    }
-
-    if (composerTrigger.kind === "path") {
-      return pathSearch.entries.map((entry) => {
-        const parts = entry.path.split("/");
-        return {
-          id: `path:${entry.path}`,
-          type: "path" as const,
-          path: entry.path,
-          kind: entry.kind,
-          label: parts[parts.length - 1] ?? entry.path,
-          description: parts.length > 1 ? parts.slice(0, -1).join("/") : "",
-        };
-      });
-    }
-
-    return [];
-  }, [composerTrigger, pathSearch.entries, selectedProviderStatus]);
-
-  // ── Handle command selection ──────────────────────────────
-  const { onChangeDraftMessage, onUpdateInteractionMode, draftMessage, onSendMessage } = props;
+  const { onSendMessage } = props;
 
   const handleSend = useCallback(async () => {
     const threadKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
@@ -548,48 +352,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     props.selectedThread.id,
     props.selectedThread.title,
   ]);
-  const handleCommandSelect = useCallback(
-    (item: ComposerCommandItem) => {
-      if (!composerTrigger) return;
-
-      if (
-        item.type === "slash-command" &&
-        (item.command === "plan" || item.command === "default")
-      ) {
-        const result = replaceTextRange(
-          draftMessage,
-          composerTrigger.rangeStart,
-          composerTrigger.rangeEnd,
-          "",
-        );
-        setComposerSelection({ start: result.cursor, end: result.cursor });
-        onChangeDraftMessage(result.text);
-        onUpdateInteractionMode(item.command);
-        return;
-      }
-
-      let replacement = "";
-      if (item.type === "path") {
-        replacement = `${serializeComposerFileLink(item.path)} `;
-      } else if (item.type === "skill") {
-        replacement = `$${item.skill.name} `;
-      } else if (item.type === "slash-command") {
-        replacement = `/${item.command} `;
-      } else if (item.type === "provider-slash-command") {
-        replacement = `/${item.command.name} `;
-      }
-
-      const result = replaceTextRange(
-        draftMessage,
-        composerTrigger.rangeStart,
-        composerTrigger.rangeEnd,
-        replacement,
-      );
-      setComposerSelection({ start: result.cursor, end: result.cursor });
-      onChangeDraftMessage(result.text);
-    },
-    [composerTrigger, draftMessage, onChangeDraftMessage, onUpdateInteractionMode],
-  );
 
   // ── Model menu ───────────────────────────────────────────
   const modelOptions = useMemo(
@@ -704,13 +466,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         layout={COMPOSER_LAYOUT_TRANSITION}
         style={{ maxWidth: props.contentMaxWidth }}
       >
-        {composerTrigger && composerMenuItems.length > 0 ? (
+        {composerMenu.trigger && composerMenu.items.length > 0 ? (
           <View className="absolute inset-x-0 bottom-full z-10 mb-2">
             <ComposerCommandPopover
-              items={composerMenuItems}
-              triggerKind={composerTrigger.kind}
-              isLoading={pathSearch.isPending}
-              onSelect={handleCommandSelect}
+              items={composerMenu.items}
+              triggerKind={composerMenu.trigger.kind}
+              isLoading={composerMenu.isLoading}
+              onSelect={composerMenu.onSelect}
             />
           </View>
         ) : null}
@@ -765,9 +527,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               multiline
               value={props.draftMessage}
               skills={selectedProviderStatus?.skills ?? []}
-              selection={composerSelection}
+              selection={composerMenu.selection}
               onChangeText={props.onChangeDraftMessage}
-              onSelectionChange={handleSelectionChange}
+              onSelectionChange={composerMenu.onSelectionChange}
               onPasteImages={(uris) => void props.onNativePasteImages(uris)}
               placeholder={props.placeholder}
               onFocus={handleFocus}

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -7,7 +7,7 @@ import type {
   ProviderInteractionMode,
   ProviderOptionSelection,
   RuntimeMode,
-  ServerProviderSkill,
+  ServerProvider,
 } from "@t3tools/contracts";
 import {
   CommandId,
@@ -156,7 +156,7 @@ type NewTaskFlowContextValue = {
   readonly modelOptions: ReadonlyArray<ModelOption>;
   readonly selectedModel: ModelSelection | null;
   readonly selectedModelOption: ModelOption | null;
-  readonly selectedProviderSkills: ReadonlyArray<ServerProviderSkill>;
+  readonly selectedProviderStatus: ServerProvider | null;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly filteredBranches: ReadonlyArray<VcsRef>;
   readonly reset: () => void;
@@ -459,11 +459,11 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         option.selection.instanceId === selectedModel.instanceId &&
         option.selection.model === selectedModel.model,
     ) ?? null;
-  const selectedProviderSkills = useMemo(
+  const selectedProviderStatus = useMemo(
     () =>
       selectedEnvironmentServerConfig?.providers.find(
         (provider) => provider.instanceId === selectedModel?.instanceId,
-      )?.skills ?? [],
+      ) ?? null,
     [selectedEnvironmentServerConfig, selectedModel?.instanceId],
   );
   const setSelectedModelKey = useCallback(
@@ -1044,7 +1044,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       modelOptions,
       selectedModel,
       selectedModelOption,
-      selectedProviderSkills,
+      selectedProviderStatus,
       providerGroups,
       filteredBranches,
       reset,
@@ -1106,7 +1106,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       selectedModelKey,
       selectedModelOption,
       selectedProjectDraftKey,
-      selectedProviderSkills,
+      selectedProviderStatus,
       setSelectedModelOptions,
       selectedProject,
       selectedProjectKey,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -1,0 +1,283 @@
+import type { EnvironmentId, ProviderInteractionMode, ServerProvider } from "@t3tools/contracts";
+import {
+  detectComposerTrigger,
+  replaceTextRange,
+  serializeComposerFileLink,
+} from "@t3tools/shared/composerTrigger";
+import {
+  insertRankedSearchResult,
+  normalizeSearchQuery,
+  scoreQueryMatch,
+} from "@t3tools/shared/searchRanking";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { ComposerEditorSelection } from "../../components/ComposerEditor";
+import { useComposerPathSearch } from "../../state/use-composer-path-search";
+import type { ComposerCommandItem } from "./ComposerCommandPopover";
+import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
+
+/** Shared autocomplete for thread composers and unsent new-task drafts. */
+export function useComposerCommandMenu({
+  draftMessage,
+  environmentId,
+  projectCwd,
+  selectedProviderStatus,
+  hasThread,
+  enabled = true,
+  onChangeDraftMessage,
+  onUpdateInteractionMode,
+}: {
+  readonly draftMessage: string;
+  readonly environmentId: EnvironmentId | null;
+  readonly projectCwd: string | null;
+  readonly selectedProviderStatus: ServerProvider | null;
+  readonly hasThread: boolean;
+  readonly enabled?: boolean;
+  readonly onChangeDraftMessage: (value: string) => void;
+  readonly onUpdateInteractionMode?: (mode: ProviderInteractionMode) => void;
+}) {
+  const [selection, setSelection] = useState(() => ({
+    start: draftMessage.length,
+    end: draftMessage.length,
+  }));
+  const onSelectionChange = useCallback((nextSelection: ComposerEditorSelection) => {
+    setSelection(nextSelection);
+  }, []);
+  useEffect(() => {
+    const end = draftMessage.length;
+    setSelection((current) => {
+      const start = Math.min(current.start, end);
+      const selectionEnd = Math.min(current.end, end);
+      if (start === current.start && selectionEnd === current.end) {
+        return current;
+      }
+      return { start, end: selectionEnd };
+    });
+  }, [draftMessage.length]);
+
+  const trigger = useMemo(() => {
+    if (!enabled || selection.start !== selection.end) {
+      return null;
+    }
+    return detectComposerTrigger(draftMessage, selection.end);
+  }, [draftMessage, enabled, selection]);
+  const pathSearch = useComposerPathSearch({
+    environmentId,
+    cwd: trigger?.kind === "path" ? projectCwd : null,
+    query: trigger?.kind === "path" ? trigger.query : null,
+  });
+
+  const items = useMemo<ComposerCommandItem[]>(() => {
+    if (!trigger) return [];
+
+    if (trigger.kind === "slash-command") {
+      const q = trigger.query.toLowerCase();
+      const allBuiltIn = [
+        {
+          id: "cmd:model",
+          type: "slash-command" as const,
+          command: "model",
+          label: "/model",
+          description: "Switch model",
+        },
+        {
+          id: "cmd:plan",
+          type: "slash-command" as const,
+          command: "plan",
+          label: "/plan",
+          description: "Switch to plan mode",
+        },
+        {
+          id: "cmd:default",
+          type: "slash-command" as const,
+          command: "default",
+          label: "/default",
+          description: "Switch to default mode",
+        },
+      ];
+      const builtIn = allBuiltIn.filter(
+        (item) =>
+          item.command.includes(q) &&
+          (item.command === "model" || onUpdateInteractionMode !== undefined),
+      );
+
+      const providerCommands: ComposerCommandItem[] = [];
+      for (const command of selectedProviderStatus?.slashCommands ?? []) {
+        if (!command.name.toLowerCase().includes(q)) continue;
+        // Codex feedback uploads an existing thread's session and logs.
+        if (
+          !hasThread &&
+          selectedProviderStatus?.driver === "codex" &&
+          command.name === "feedback"
+        ) {
+          continue;
+        }
+        providerCommands.push({
+          id: `pcmd:${command.name}`,
+          type: "provider-slash-command",
+          command,
+          label: `/${command.name}`,
+          description: command.description ?? "",
+        });
+      }
+
+      const skillItems = (selectedProviderStatus?.skills ?? [])
+        .filter((skill) => matchesSlashSkillQuery(skill, q))
+        .map((skill) => ({
+          id: `skill:${skill.name}`,
+          type: "skill" as const,
+          skill,
+          label: `skill:${skill.name}`,
+          description: skill.shortDescription ?? skill.description ?? "",
+        }));
+
+      return [...builtIn, ...providerCommands, ...skillItems];
+    }
+
+    if (trigger.kind === "skill") {
+      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((skill) => skill.enabled);
+      const normalizedQuery = normalizeSearchQuery(trigger.query, {
+        trimLeadingPattern: /^\$+/,
+      });
+
+      if (!normalizedQuery) {
+        return enabledSkills.slice(0, 20).map((skill) => ({
+          id: `skill:${skill.name}`,
+          type: "skill" as const,
+          skill,
+          label: skill.displayName ?? skill.name,
+          description: skill.shortDescription ?? skill.description ?? "",
+        }));
+      }
+
+      const ranked: Array<{
+        item: (typeof enabledSkills)[number];
+        score: number;
+        tieBreaker: string;
+      }> = [];
+      for (const skill of enabledSkills) {
+        const displayLabel = (skill.displayName ?? skill.name).toLowerCase();
+        const scores = [
+          scoreQueryMatch({
+            value: skill.name.toLowerCase(),
+            query: normalizedQuery,
+            exactBase: 0,
+            prefixBase: 2,
+            boundaryBase: 4,
+            includesBase: 6,
+            fuzzyBase: 100,
+            boundaryMarkers: ["-", "_", "/"],
+          }),
+          scoreQueryMatch({
+            value: displayLabel,
+            query: normalizedQuery,
+            exactBase: 1,
+            prefixBase: 3,
+            boundaryBase: 5,
+            includesBase: 7,
+            fuzzyBase: 110,
+          }),
+          scoreQueryMatch({
+            value: skill.shortDescription?.toLowerCase() ?? "",
+            query: normalizedQuery,
+            exactBase: 20,
+            prefixBase: 22,
+            boundaryBase: 24,
+            includesBase: 26,
+          }),
+          scoreQueryMatch({
+            value: skill.description?.toLowerCase() ?? "",
+            query: normalizedQuery,
+            exactBase: 30,
+            prefixBase: 32,
+            boundaryBase: 34,
+            includesBase: 36,
+          }),
+        ].filter((score): score is number => score !== null);
+
+        if (scores.length > 0) {
+          insertRankedSearchResult(
+            ranked,
+            {
+              item: skill,
+              score: Math.min(...scores),
+              tieBreaker: `${displayLabel}\u0000${skill.name}`,
+            },
+            20,
+          );
+        }
+      }
+
+      return ranked.map(({ item: skill }) => ({
+        id: `skill:${skill.name}`,
+        type: "skill" as const,
+        skill,
+        label: skill.displayName ?? skill.name,
+        description: skill.shortDescription ?? skill.description ?? "",
+      }));
+    }
+
+    if (trigger.kind === "path") {
+      return pathSearch.entries.map((entry) => {
+        const parts = entry.path.split("/");
+        return {
+          id: `path:${entry.path}`,
+          type: "path" as const,
+          path: entry.path,
+          kind: entry.kind,
+          label: parts[parts.length - 1] ?? entry.path,
+          description: parts.length > 1 ? parts.slice(0, -1).join("/") : "",
+        };
+      });
+    }
+
+    return [];
+  }, [hasThread, onUpdateInteractionMode, pathSearch.entries, selectedProviderStatus, trigger]);
+
+  const onSelect = useCallback(
+    (item: ComposerCommandItem) => {
+      if (!trigger) return;
+
+      if (
+        item.type === "slash-command" &&
+        (item.command === "plan" || item.command === "default")
+      ) {
+        const result = replaceTextRange(draftMessage, trigger.rangeStart, trigger.rangeEnd, "");
+        setSelection({ start: result.cursor, end: result.cursor });
+        onChangeDraftMessage(result.text);
+        onUpdateInteractionMode?.(item.command);
+        return;
+      }
+
+      let replacement = "";
+      if (item.type === "path") {
+        replacement = `${serializeComposerFileLink(item.path)} `;
+      } else if (item.type === "skill") {
+        replacement = `$${item.skill.name} `;
+      } else if (item.type === "slash-command") {
+        replacement = `/${item.command} `;
+      } else if (item.type === "provider-slash-command") {
+        replacement = `/${item.command.name} `;
+      }
+
+      const result = replaceTextRange(
+        draftMessage,
+        trigger.rangeStart,
+        trigger.rangeEnd,
+        replacement,
+      );
+      setSelection({ start: result.cursor, end: result.cursor });
+      onChangeDraftMessage(result.text);
+    },
+    [draftMessage, onChangeDraftMessage, onUpdateInteractionMode, trigger],
+  );
+
+  return {
+    selection,
+    onSelectionChange,
+    trigger,
+    items,
+    isLoading: pathSearch.isPending,
+    onSelect,
+  };
+}

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -19,6 +19,9 @@ when starting a thread or changing an existing thread's model.
 Type `/` to open the command menu. Type `$` to find and add a skill. Skill rows show their source,
 such as System, Personal, Project, or App.
 
+On mobile, these menus are available on the **New task** screen before you start a thread. They
+use the skills and commands from the selected environment and provider.
+
 By default, the `/` menu includes skills. To keep this menu command-only, turn off **Show skills in
 slash menu** in **Settings → General**. Skill results use the `/skill:Skill Name` label and add the
 same `$name` skill token to your message. The original skill name remains searchable. If the provider


### PR DESCRIPTION
The mobile New task screen did not show skill or command suggestions, even though the selected provider's catalog was already loaded.

Share autocomplete logic with the thread composer and show the same skill, command, and file menus above the new-task composer. Suggestions follow the selected environment and checkout. Thread-only feedback stays hidden until a thread exists, and menu rows are exposed as accessible buttons.

Verified with real typing and taps on an iPhone 17 Pro simulator running iOS 27: opening and filtering both menus, scrolling and selecting a skill, deleting its chip, and inserting a file reference. No prompts were submitted.

- 64 focused tests passed across six files.
- Mobile typecheck, changed-file lint, formatting, and diff checks passed.

| Before | After |
| --- | --- |
| ![New task without skill suggestions](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c292ae0a0460894d/before.png) | ![New task with skill suggestions](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c33fb9facdbf68df/after.png) |

Before interaction: typing `$ui` and `/skill:ui` produces no suggestions.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/62b839039742f8d8/before.mp4

After interaction: open, filter, and select skills through both menus.

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1e4ba33b5b03eb2e/after.mp4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus feature parity on New task; main API change is the new-task flow context rename from `selectedProviderSkills` to `selectedProviderStatus`.
> 
> **Overview**
> Mobile **New task** now shows the same `/` command, `$` skill, and file autocomplete as an open thread, driven by the selected environment, workspace checkout, and provider.
> 
> Composer trigger detection, path search, menu ranking, and insert-on-select logic move into shared **`useComposerCommandMenu`**, which **`ThreadComposer`** adopts in place of its inline implementation. **`NewTaskFlowProvider`** exposes **`selectedProviderStatus`** (full provider) instead of **`selectedProviderSkills`** so menus can use slash commands and driver-specific rules—for example Codex **`/feedback`** stays out of the list until a thread exists. The new-task menu runs only while the composer is focused and not during an incoming share import.
> 
> Command popover rows get **`accessibilityRole="button"`**. User docs note pre-thread menus on mobile New task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d584646cb9ad6eaec0d3ce9544a113ab1436eee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add composer autocomplete menus to `NewTaskDraftScreen`
> - Extracts composer autocomplete logic (slash commands, skills, path entries) into a shared `useComposerCommandMenu` hook in [use-composer-command-menu.ts](https://github.com/pingdotgg/t3code/pull/8587/files#diff-765bb6c8049500163389336a7a5e0c83873e041f5b14c72e5f5804359e6492d9), used by both `NewTaskDraftScreen` and `ThreadComposer`
> - Wires the hook into [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/8587/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) so the New task screen shows a `ComposerCommandPopover` for slash, skill, and path triggers
> - Changes `NewTaskFlowContext` to provide `selectedProviderStatus` (full `ServerProvider`) instead of `selectedProviderSkills` (skills array) in [new-task-flow-provider.tsx](https://github.com/pingdotgg/t3code/pull/8587/files#diff-70cedfb5c403f777ceda2ca120dd7f822b033acf06053841f85a63b7d0cd3192); skills are now derived from `selectedProviderStatus?.skills`
> - Behavioral Change: `/plan` and `/default` commands only appear when `onUpdateInteractionMode` is provided; the Codex `feedback` slash command is excluded when `hasThread` is false; `ThreadComposer` consumers depending on `selectedProviderSkills` on the context must switch to `selectedProviderStatus`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d584646.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->