### PR TITLE
chore(deps): bump @clerk/electron to 0.0.38

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ overrides:
   '@clerk/clerk-js>@solana/wallet-adapter-react': '-'
   '@clerk/clerk-js>@solana/wallet-standard': '-'
   '@clerk/clerk-js>@wallet-standard/core': '-'
-  '@clerk/electron': 0.0.37
+  '@clerk/electron': 0.0.38
   '@clerk/electron-passkeys': 0.0.3
   '@clerk/expo': 4.2.0
   '@clerk/react': 6.14.7
@@ -130,8 +130,8 @@ importers:
   apps/desktop:
     dependencies:
       '@clerk/electron':
-        specifier: 0.0.37
-        version: 0.0.37(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@44.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.0.38
+        version: 0.0.38(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@44.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron-passkeys':
         specifier: 0.0.3
         version: 0.0.3
@@ -578,8 +578,8 @@ importers:
         specifier: ^1.4.1
         version: 1.5.0(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron':
-        specifier: 0.0.37
-        version: 0.0.37(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@44.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.0.38
+        version: 0.0.38(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@44.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/react':
         specifier: 6.14.7
         version: 6.14.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1837,8 +1837,8 @@ packages:
     resolution: {integrity: sha512-OHhIe88qDL+FxyBalXdXNHAS5eEramr6Rerp+6iNkfkjqT8rx4hHNmfpmjg5/T1/am8QfknbOBZkqoXZlCrjPg==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/electron@0.0.37':
-    resolution: {integrity: sha512-NsATM6rMISdL1K3mlKVPqZpDUA4h+uWmbGv8h9PK3zYfnwMgSpDKRX2y341Lt0fhz+eWkZpMU5SQmlZPNqwiww==}
+  '@clerk/electron@0.0.38':
+    resolution: {integrity: sha512-He4x9Jdxri6JmOdn5sUM5n0ZoXsWJxiv2CiWEQqhzSQ+49Fp2Y9hvUpV/FQbFvGRbjv6LJXrRrFi6NXozDreAA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       '@clerk/electron-passkeys': 0.0.3
@@ -12430,7 +12430,7 @@ snapshots:
       '@clerk/electron-passkeys-win32-arm64-msvc': 0.0.3
       '@clerk/electron-passkeys-win32-x64-msvc': 0.0.3
 
-  '@clerk/electron@0.0.37(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@44.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@clerk/electron@0.0.38(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@44.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@clerk/clerk-js': 6.30.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/react': 6.14.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ allowBuilds:
 catalog:
   "@clerk/backend": 3.14.0
   "@clerk/clerk-js": 6.30.1
-  "@clerk/electron": 0.0.37
+  "@clerk/electron": 0.0.38
   "@clerk/electron-passkeys": 0.0.3
   "@clerk/expo": 4.2.0
   "@clerk/react": 6.14.7
@@ -59,7 +59,7 @@ catalog:
 minimumReleaseAgeExclude:
   - "@clerk/backend@3.14.0"
   - "@clerk/clerk-js@6.30.1"
-  - "@clerk/electron@0.0.37"
+  - "@clerk/electron@0.0.38"
   - "@clerk/expo@4.2.0"
   - "@clerk/react@6.14.7"
   - "@clerk/shared@4.30.1"


### PR DESCRIPTION
Clerk Electron 0.0.38 includes [the main-process token fallback](https://github.com/clerk/javascript/pull/9588) for cases where secure persistence is unavailable or fails. T3 still pins 0.0.37, so affected Electron sign-in attempts can remain stuck in the "You are signed out" loop.

This bumps the workspace catalog, supply-chain age exemption, and lockfile to 0.0.38. No application code changes.

Tests:
- pnpm install --lockfile-only --frozen-lockfile
- pnpm exec vp test run apps/desktop/src/app/DesktopClerk.test.ts
- pnpm --filter @t3tools/desktop typecheck
- pnpm --filter @t3tools/web typecheck
- git diff --check

Model: GPT-5.6
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it touches Clerk auth/token persistence in Electron where regressions would affect sign-in; scope is limited to a small patch bump with an explicit fallback fix.
> 
> **Overview**
> Bumps **`@clerk/electron`** from **0.0.37** to **0.0.38** via the workspace catalog, **`minimumReleaseAgeExclude`**, and **`pnpm-lock.yaml`** for **`apps/desktop`** and **`apps/web`**. There are **no application source changes**.
> 
> The new Clerk release adds a **main-process token fallback** when secure persistence is unavailable or fails, which should address Electron sign-in getting stuck in a **"You are signed out"** loop on 0.0.37.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14da3a7efb8abc1d3a60999625355bda989ce71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `@clerk/electron` from 0.0.37 to 0.0.38
> Updates the workspace catalog and `minimumReleaseAgeExclude` list in [pnpm-workspace.yaml](https://github.com/pingdotgg/t3code/pull/8590/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c) to reference `@clerk/electron@0.0.38`, and refreshes [pnpm-lock.yaml](https://github.com/pingdotgg/t3code/pull/8590/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb) accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c14da3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release configuration to align with the latest supported component version.
  * No user-facing features, behavior changes, or bug fixes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->