### PR TITLE
feat(dev): reuse pairing across ports and worktrees

### DIFF
--- a/apps/server/src/auth/DevSessionStorage.test.ts
+++ b/apps/server/src/auth/DevSessionStorage.test.ts
@@ -1,0 +1,147 @@
+// @effect-diagnostics nodeBuiltinImport:off - verifies SQLite file permissions at the OS boundary.
+import * as NodeFS from "node:fs";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { AuthSessionId } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { expect, it } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { makeRuntimeSqliteLayer } from "../persistence/Layers/Sqlite.ts";
+import { makeDevSessionStorage } from "./DevSessionStorage.ts";
+
+it.layer(NodeServices.layer)("DevSessionStorage", (it) => {
+  it.effect("initializes concurrent stores with one key and one session database", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const platform = yield* HostProcessPlatform;
+      const devAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-dev-session-storage-test-",
+      });
+
+      const [first, second] = yield* Effect.all(
+        [makeDevSessionStorage(devAuthDir), makeDevSessionStorage(devAuthDir)],
+        { concurrency: "unbounded" },
+      );
+
+      expect(first.signingSecret).toHaveLength(32);
+      expect(second.signingSecret).toEqual(first.signingSecret);
+
+      const sessionId = AuthSessionId.make("shared-session");
+      const issuedAt = yield* DateTime.now;
+      const expiresAt = DateTime.add(issuedAt, { days: 30 });
+      yield* first.authSessions.create({
+        sessionId,
+        subject: "one-time-token",
+        scopes: ["orchestration:read"],
+        method: "browser-session-cookie",
+        client: {
+          label: null,
+          ipAddress: null,
+          userAgent: null,
+          deviceType: "desktop",
+          os: null,
+          browser: null,
+        },
+        issuedAt,
+        expiresAt,
+      });
+      expect(Option.getOrThrow(yield* second.authSessions.getById({ sessionId })).sessionId).toBe(
+        sessionId,
+      );
+
+      const dbPath = path.join(devAuthDir, "sessions-v1.sqlite");
+      const inspectionContext = yield* Layer.build(makeRuntimeSqliteLayer({ filename: dbPath }));
+      const tables = yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        return yield* sql<{ readonly name: string }>`
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'table'
+          ORDER BY name
+        `;
+      }).pipe(Effect.provide(inspectionContext));
+
+      expect(tables.map((table) => table.name)).toEqual(["auth_sessions", "dev_auth_metadata"]);
+      if (platform !== "win32") {
+        expect(NodeFS.statSync(devAuthDir).mode & 0o777).toBe(0o700);
+        expect(NodeFS.statSync(dbPath).mode & 0o777).toBe(0o600);
+      }
+    }),
+  );
+
+  it.effect("rejects an empty stored signing key", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const devAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-dev-session-key-test-",
+      });
+      yield* makeDevSessionStorage(devAuthDir);
+
+      const dbPath = path.join(devAuthDir, "sessions-v1.sqlite");
+      const inspectionContext = yield* Layer.build(makeRuntimeSqliteLayer({ filename: dbPath }));
+      yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql`UPDATE dev_auth_metadata SET value = ''`;
+      }).pipe(Effect.provide(inspectionContext));
+
+      const error = yield* makeDevSessionStorage(devAuthDir).pipe(Effect.flip);
+      expect(error._tag).toBe("SchemaError");
+    }),
+  );
+
+  it.effect("retains the signing key and sessions after every store scope closes", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const devAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-dev-session-restart-test-",
+      });
+      const sessionId = AuthSessionId.make("session-after-restart");
+
+      const firstKey = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const storage = yield* makeDevSessionStorage(devAuthDir);
+          const issuedAt = yield* DateTime.now;
+          yield* storage.authSessions.create({
+            sessionId,
+            subject: "one-time-token",
+            scopes: ["orchestration:read"],
+            method: "browser-session-cookie",
+            client: {
+              label: null,
+              ipAddress: null,
+              userAgent: null,
+              deviceType: "desktop",
+              os: null,
+              browser: null,
+            },
+            issuedAt,
+            expiresAt: DateTime.add(issuedAt, { days: 30 }),
+          });
+          return storage.signingSecret;
+        }),
+      );
+
+      const reopened = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const storage = yield* makeDevSessionStorage(devAuthDir);
+          return {
+            signingSecret: storage.signingSecret,
+            session: yield* storage.authSessions.getById({ sessionId }),
+          };
+        }),
+      );
+
+      expect(reopened.signingSecret).toEqual(firstKey);
+      expect(Option.getOrThrow(reopened.session).sessionId).toBe(sessionId);
+    }),
+  );
+});

--- a/apps/server/src/auth/DevSessionStorage.ts
+++ b/apps/server/src/auth/DevSessionStorage.ts
@@ -1,0 +1,103 @@
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import * as AuthSessions from "../persistence/AuthSessions.ts";
+import { makeRuntimeSqliteLayer } from "../persistence/Layers/Sqlite.ts";
+
+const DATABASE_NAME = "sessions-v1.sqlite";
+const SIGNING_SECRET_NAME = "session-signing-key-v1";
+const SigningSecretText = Schema.String.check(
+  Schema.isLengthBetween(43, 43),
+  Schema.isPattern(/^[A-Za-z0-9_-]{43}$/),
+);
+const SigningSecretRows = Schema.Tuple([Schema.Struct({ value: SigningSecretText })]);
+const decodeSigningSecretRows = Schema.decodeUnknownEffect(SigningSecretRows);
+
+const setupSchema = Effect.fn("DevSessionStorage.setupSchema")(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`PRAGMA busy_timeout = 5000;`;
+  yield* sql`PRAGMA journal_mode = WAL;`;
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS auth_sessions (
+      session_id TEXT PRIMARY KEY,
+      subject TEXT NOT NULL,
+      scopes TEXT NOT NULL,
+      method TEXT NOT NULL,
+      client_label TEXT,
+      client_ip_address TEXT,
+      client_user_agent TEXT,
+      client_device_type TEXT NOT NULL DEFAULT 'unknown',
+      client_os TEXT,
+      client_browser TEXT,
+      issued_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      last_connected_at TEXT,
+      revoked_at TEXT,
+      client_surface TEXT,
+      client_app_version TEXT
+    )
+  `;
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_auth_sessions_active
+    ON auth_sessions(revoked_at, expires_at, issued_at)
+  `;
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS dev_auth_metadata (
+      name TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `;
+});
+
+export const makeDevSessionStorage = Effect.fn("makeDevSessionStorage")(function* (
+  devAuthDir: string,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const dbPath = path.join(devAuthDir, DATABASE_NAME);
+
+  yield* fs.makeDirectory(devAuthDir, { recursive: true });
+  yield* fs.chmod(devAuthDir, 0o700);
+  yield* Effect.scoped(fs.open(dbPath, { flag: "a", mode: 0o600 }).pipe(Effect.asVoid));
+  yield* fs.chmod(dbPath, 0o600);
+
+  const sqlLayer = makeRuntimeSqliteLayer({
+    filename: dbPath,
+    spanAttributes: {
+      "db.name": DATABASE_NAME,
+      "service.name": "t3-dev-auth",
+    },
+  });
+  const sqlContext = yield* Layer.build(sqlLayer);
+  const storage = yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* setupSchema();
+
+    const candidate = Encoding.encodeBase64Url(yield* crypto.randomBytes(32));
+    yield* sql`
+      INSERT INTO dev_auth_metadata (name, value)
+      VALUES (${SIGNING_SECRET_NAME}, ${candidate})
+      ON CONFLICT(name) DO NOTHING
+    `;
+    const rows = yield* sql<{ readonly value: unknown }>`
+      SELECT value AS "value"
+      FROM dev_auth_metadata
+      WHERE name = ${SIGNING_SECRET_NAME}
+    `;
+    const decodedRows = yield* decodeSigningSecretRows(rows);
+    const signingSecret = Uint8Array.from(Buffer.from(decodedRows[0].value, "base64url"));
+    const authSessions = yield* AuthSessions.make;
+
+    return { authSessions, signingSecret };
+  }).pipe(Effect.provide(sqlContext));
+
+  return storage;
+});

--- a/apps/server/src/auth/EnvironmentAuth.test.ts
+++ b/apps/server/src/auth/EnvironmentAuth.test.ts
@@ -1,7 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { AuthAdministrativeScopes } from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 
 import * as ServerConfig from "../config.ts";
@@ -58,6 +60,49 @@ const requestMetadata = {
 };
 
 it.layer(NodeServices.layer)("EnvironmentAuth.layer", (it) => {
+  it.effect("accepts one dev browser session across independent HTTP auth stores", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const devAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-environment-shared-auth-test-",
+      });
+      const makeLayer = (port: number) =>
+        makeEnvironmentAuthLayer({
+          mode: "web",
+          port,
+          devUrl: new URL(`http://localhost:${String(port + 1_000)}`),
+          devAuthDir,
+        });
+      const firstContext = yield* Layer.build(makeLayer(13_773));
+      const secondContext = yield* Layer.build(makeLayer(14_773));
+      const firstAuth = Context.get(firstContext, EnvironmentAuth.EnvironmentAuth);
+      const secondAuth = Context.get(secondContext, EnvironmentAuth.EnvironmentAuth);
+      const firstSessions = Context.get(firstContext, SessionStore.SessionStore);
+      const secondSessions = Context.get(secondContext, SessionStore.SessionStore);
+
+      const pairing = yield* firstAuth.issuePairingCredential();
+      const browserSession = yield* firstAuth.createBrowserSession(
+        pairing.credential,
+        requestMetadata,
+      );
+      const authenticated = yield* secondAuth.authenticateHttpRequest(
+        makeCookieRequest(secondSessions.cookieName, browserSession.sessionToken),
+      );
+      const ticket = yield* secondAuth.issueWebSocketTicket(authenticated);
+      const verifiedTicket = yield* secondSessions.verifyWebSocketToken(ticket.ticket);
+
+      expect(secondSessions.cookieName).toBe(firstSessions.cookieName);
+      expect(authenticated.subject).toBe("one-time-token");
+      expect(verifiedTicket.sessionId).toBe(authenticated.sessionId);
+
+      const localPairing = yield* firstAuth.issuePairingCredential();
+      const error = yield* secondAuth
+        .createBrowserSession(localPairing.credential, requestMetadata)
+        .pipe(Effect.flip);
+      expect(error._tag).toBe("ServerAuthInvalidCredentialError");
+    }),
+  );
+
   it.effect("classifies invalid bootstrap credential failures for the HTTP boundary", () =>
     Effect.sync(() => {
       const error = EnvironmentAuth.toBootstrapExchangeError(

--- a/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
@@ -137,6 +137,42 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
     ),
   );
 
+  it.effect("uses the shared dev cookie only for web development", () =>
+    Effect.gen(function* () {
+      const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
+      const descriptor = yield* policy.getDescriptor();
+
+      expect(descriptor.sessionCookieName).toMatch(/^t3_session_dev_[a-f0-9]{12}$/);
+    }).pipe(
+      Effect.provide(
+        makeEnvironmentAuthPolicyLayer({
+          mode: "web",
+          port: 5775,
+          devUrl: new URL("http://127.0.0.1:5736"),
+          devAuthDir: "/tmp/t3-shared-dev-auth",
+        }),
+      ),
+    ),
+  );
+
+  it.effect("ignores an inherited dev auth directory outside web development", () =>
+    Effect.gen(function* () {
+      const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
+      const descriptor = yield* policy.getDescriptor();
+
+      expect(descriptor.sessionCookieName).toBe("t3_session_3773");
+    }).pipe(
+      Effect.provide(
+        makeEnvironmentAuthPolicyLayer({
+          mode: "desktop",
+          port: 3773,
+          devUrl: new URL("http://127.0.0.1:5736"),
+          devAuthDir: "/tmp/t3-shared-dev-auth",
+        }),
+      ),
+    ),
+  );
+
   it.effect("uses remote-reachable policy for non-loopback web hosts", () =>
     Effect.gen(function* () {
       const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;

--- a/apps/server/src/auth/EnvironmentAuthPolicy.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.ts
@@ -15,6 +15,7 @@ export class EnvironmentAuthPolicy extends Context.Service<
 
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig.ServerConfig;
+  const devAuthDir = ServerConfig.resolveActiveDevAuthDir(config);
   const isRemoteReachable = isRemoteReachableHost(config.host);
 
   const policy =
@@ -43,6 +44,7 @@ export const make = Effect.gen(function* () {
       host: config.host,
       instanceKey: config.stateDir,
       development: config.devUrl !== undefined,
+      devAuthDir,
     }),
   };
 

--- a/apps/server/src/auth/SessionStore.test.ts
+++ b/apps/server/src/auth/SessionStore.test.ts
@@ -1,7 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as TestClock from "effect/testing/TestClock";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -13,9 +15,7 @@ import * as AuthSessions from "../persistence/AuthSessions.ts";
 import * as SessionStore from "./SessionStore.ts";
 import * as ServerSecretStore from "./ServerSecretStore.ts";
 
-const makeServerConfigLayer = (
-  overrides?: Partial<Pick<ServerConfig.ServerConfig["Service"], "desktopBootstrapToken">>,
-) =>
+const makeServerConfigLayer = (overrides?: Partial<ServerConfig.ServerConfig["Service"]>) =>
   Layer.effect(
     ServerConfig.ServerConfig,
     Effect.gen(function* () {
@@ -27,9 +27,7 @@ const makeServerConfigLayer = (
     }),
   ).pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-auth-session-test-" })));
 
-const makeSessionStoreLayer = (
-  overrides?: Partial<Pick<ServerConfig.ServerConfig["Service"], "desktopBootstrapToken">>,
-) =>
+const makeSessionStoreLayer = (overrides?: Partial<ServerConfig.ServerConfig["Service"]>) =>
   SessionStore.layer.pipe(
     Layer.provide(SqlitePersistenceMemory),
     Layer.provide(ServerSecretStore.layer),
@@ -62,6 +60,105 @@ const failingSessionLookupCredentialLayer = Layer.effect(
 );
 
 it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
+  it.effect("shares dev browser sessions across independent server stores", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const devAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-shared-dev-session-test-",
+      });
+      const makeSharedLayer = (port: number, authDir = devAuthDir) =>
+        makeSessionStoreLayer({
+          mode: "web",
+          port,
+          devUrl: new URL(`http://localhost:${String(port + 1_000)}`),
+          devAuthDir: authDir,
+        });
+      const firstContext = yield* Layer.build(makeSharedLayer(13_773));
+      const secondContext = yield* Layer.build(makeSharedLayer(14_773));
+      const first = Context.get(firstContext, SessionStore.SessionStore);
+      const second = Context.get(secondContext, SessionStore.SessionStore);
+
+      const issued = yield* first.issue({ subject: "shared-browser" });
+      const verified = yield* second.verify(issued.token);
+      const websocket = yield* second.issueWebSocketToken(issued.sessionId);
+      const verifiedWebSocket = yield* second.verifyWebSocketToken(websocket.token);
+
+      expect(second.cookieName).toBe(first.cookieName);
+      expect(verified.sessionId).toBe(issued.sessionId);
+      expect(verifiedWebSocket.sessionId).toBe(issued.sessionId);
+
+      const restartedContext = yield* Layer.build(makeSharedLayer(15_773));
+      const restarted = Context.get(restartedContext, SessionStore.SessionStore);
+      expect((yield* restarted.verify(issued.token)).sessionId).toBe(issued.sessionId);
+
+      const otherDevAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-other-dev-session-test-",
+      });
+      const otherContext = yield* Layer.build(makeSharedLayer(16_773, otherDevAuthDir));
+      const other = Context.get(otherContext, SessionStore.SessionStore);
+      expect((yield* Effect.flip(other.verify(issued.token)))._tag).toBe(
+        "InvalidSessionTokenSignatureError",
+      );
+
+      const isolatedContext = yield* Layer.build(
+        makeSessionStoreLayer({
+          mode: "web",
+          port: 17_773,
+          devUrl: new URL("http://localhost:18773"),
+          devAuthDir: undefined,
+        }),
+      );
+      const isolated = Context.get(isolatedContext, SessionStore.SessionStore);
+      expect((yield* Effect.flip(isolated.verify(issued.token)))._tag).toBe(
+        "InvalidSessionTokenSignatureError",
+      );
+
+      const desktopContext = yield* Layer.build(
+        makeSessionStoreLayer({
+          mode: "desktop",
+          port: 18_773,
+          devUrl: new URL("http://localhost:19773"),
+          devAuthDir,
+        }),
+      );
+      const desktop = Context.get(desktopContext, SessionStore.SessionStore);
+      expect((yield* Effect.flip(desktop.verify(issued.token)))._tag).toBe(
+        "InvalidSessionTokenSignatureError",
+      );
+
+      const ordinaryWebContext = yield* Layer.build(
+        makeSessionStoreLayer({
+          mode: "web",
+          port: 19_773,
+          devUrl: undefined,
+          devAuthDir,
+        }),
+      );
+      const ordinaryWeb = Context.get(ordinaryWebContext, SessionStore.SessionStore);
+      expect((yield* Effect.flip(ordinaryWeb.verify(issued.token)))._tag).toBe(
+        "InvalidSessionTokenSignatureError",
+      );
+
+      expect(yield* second.revoke(issued.sessionId)).toBe(true);
+      expect((yield* Effect.flip(first.verify(issued.token)))._tag).toBe(
+        "SessionTokenRevokedError",
+      );
+
+      const current = yield* first.issue({ subject: "current" });
+      const revokedByOtherStore = yield* first.issue({ subject: "revoke-from-second" });
+      expect(yield* second.revokeAllExcept(current.sessionId)).toBe(1);
+      expect((yield* Effect.flip(first.verify(revokedByOtherStore.token)))._tag).toBe(
+        "SessionTokenRevokedError",
+      );
+
+      const expiring = yield* first.issue({ subject: "expiring", ttl: Duration.seconds(1) });
+      yield* TestClock.adjust(Duration.seconds(2));
+      expect((yield* Effect.flip(second.verify(expiring.token)))._tag).toBe(
+        "SessionTokenExpiredError",
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
   it.effect("issues and verifies signed browser session tokens", () =>
     Effect.gen(function* () {
       const sessions = yield* SessionStore.SessionStore;

--- a/apps/server/src/auth/SessionStore.ts
+++ b/apps/server/src/auth/SessionStore.ts
@@ -23,6 +23,7 @@ import * as Option from "effect/Option";
 import * as ServerConfig from "../config.ts";
 import * as AuthSessions from "../persistence/AuthSessions.ts";
 import * as ServerSecretStore from "./ServerSecretStore.ts";
+import { makeDevSessionStorage } from "./DevSessionStorage.ts";
 import {
   base64UrlDecodeUtf8,
   base64UrlEncode,
@@ -471,8 +472,16 @@ export const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const serverConfig = yield* ServerConfig.ServerConfig;
   const secretStore = yield* ServerSecretStore.ServerSecretStore;
-  const authSessions = yield* AuthSessions.AuthSessionRepository;
-  const signingSecret = yield* secretStore.getOrCreateRandom(SIGNING_SECRET_NAME, 32);
+  const localAuthSessions = yield* AuthSessions.AuthSessionRepository;
+  const devAuthDir = ServerConfig.resolveActiveDevAuthDir(serverConfig);
+  const storage =
+    devAuthDir === undefined
+      ? {
+          authSessions: localAuthSessions,
+          signingSecret: yield* secretStore.getOrCreateRandom(SIGNING_SECRET_NAME, 32),
+        }
+      : yield* makeDevSessionStorage(devAuthDir);
+  const { authSessions, signingSecret } = storage;
   const connectedSessionsRef = yield* Ref.make(new Map<string, number>());
   const changesPubSub = yield* PubSub.unbounded<SessionCredentialChange>();
   const cookieName = resolveSessionCookieName({
@@ -481,6 +490,7 @@ export const make = Effect.gen(function* () {
     host: serverConfig.host,
     instanceKey: serverConfig.stateDir,
     development: serverConfig.devUrl !== undefined,
+    devAuthDir,
   });
 
   const emitUpsert = (clientSession: AuthClientSession) =>

--- a/apps/server/src/auth/utils.test.ts
+++ b/apps/server/src/auth/utils.test.ts
@@ -58,6 +58,39 @@ describe("deriveAuthClientMetadata", () => {
 });
 
 describe("session cookie isolation", () => {
+  it("shares one cookie name across ports and worktrees in the same dev auth group", () => {
+    const devAuthDir = "/tmp/t3-shared-dev-auth";
+    const first = resolveSessionCookieName({
+      mode: "web",
+      port: 5775,
+      host: "0.0.0.0",
+      instanceKey: "/tmp/t3-agent-one",
+      development: true,
+      devAuthDir,
+    });
+    const second = resolveSessionCookieName({
+      mode: "web",
+      port: 5888,
+      host: "0.0.0.0",
+      instanceKey: "/tmp/t3-agent-two",
+      development: true,
+      devAuthDir,
+    });
+
+    expect(first).toMatch(/^t3_session_dev_[a-f0-9]{12}$/);
+    expect(second).toBe(first);
+    expect(
+      resolveSessionCookieName({
+        mode: "web",
+        port: 5775,
+        host: "0.0.0.0",
+        instanceKey: "/tmp/t3-agent-one",
+        development: true,
+        devAuthDir: "/tmp/another-dev-auth-group",
+      }),
+    ).not.toBe(first);
+  });
+
   it("isolates loopback web servers by port and server state", () => {
     const first = resolveSessionCookieName({
       mode: "web",

--- a/apps/server/src/auth/utils.ts
+++ b/apps/server/src/auth/utils.ts
@@ -16,12 +16,15 @@ const SESSION_COOKIE_NAME = "t3_session";
  * clobbers the first's session and both sides see "Invalid session token
  * signature" until someone clears cookies by hand.
  *
- * Two populations qualify, for the same reason but from different causes:
+ * Two populations can require scoped names, for the same reason but from
+ * different causes:
  *
- * - **Dev servers** (`devUrl` set), which run several at a time across worktrees.
+ * - **Isolated dev servers** (`devUrl` set without a shared auth directory),
+ *   which run several at a time across worktrees.
  * - **Desktop**, which scans upward from 3773 for a free port and binds
  *   127.0.0.1, so a second instance lands on a different port and the same host.
  *
+ * Dev servers with one shared auth directory use one directory-scoped name.
  * Hosted deployments keep the stable production name: their public port can
  * change between releases, and scoping it would log every user out.
  */
@@ -31,6 +34,7 @@ export function resolveSessionCookieName(input: {
   readonly host: string | undefined;
   readonly instanceKey: string;
   readonly development: boolean;
+  readonly devAuthDir?: string | undefined;
 }): string {
   if (input.mode === "desktop") {
     return `${SESSION_COOKIE_NAME}_${input.port}`;
@@ -38,6 +42,14 @@ export function resolveSessionCookieName(input: {
 
   if (!input.development && isRemoteReachableHost(input.host)) {
     return SESSION_COOKIE_NAME;
+  }
+
+  if (input.development && input.devAuthDir !== undefined) {
+    const authGroupHash = NodeCrypto.createHash("sha256")
+      .update(input.devAuthDir)
+      .digest("hex")
+      .slice(0, 12);
+    return `${SESSION_COOKIE_NAME}_dev_${authGroupHash}`;
   }
 
   // Cookies are scoped by host, not port. Loopback development servers need an

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -18,7 +18,8 @@ import {
 import * as NetService from "@t3tools/shared/Net";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { deriveServerPaths } from "../config.ts";
-import { resolveServerConfig } from "./config.ts";
+import { persistServerRuntimeState } from "../serverRuntimeState.ts";
+import { resolveCliAuthConfig, resolveServerConfig } from "./config.ts";
 
 const deriveExplicitServerPaths = (baseDir: string, devUrl: URL | undefined) =>
   deriveServerPaths(baseDir, devUrl, { baseDirIsExplicit: true });
@@ -134,6 +135,182 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServePort: 443,
       });
       assert.equal(resolved.stateDir, join(baseDir, "userdata"));
+    }),
+  );
+
+  it.effect("enables shared auth only for web development config", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const baseDir = yield* (yield* FileSystem.FileSystem).makeTempDirectoryScoped({
+        prefix: "t3-cli-dev-auth-config-",
+      });
+      const resolve = (mode: "web" | "desktop") =>
+        resolveServerConfig(
+          {
+            mode: Option.some(mode),
+            port: Option.some(4_111),
+            host: Option.none(),
+            baseDir: Option.some(baseDir),
+            cwd: Option.none(),
+            devUrl: Option.some(new URL("http://localhost:5733")),
+            noBrowser: Option.none(),
+            bootstrapFd: Option.none(),
+            autoBootstrapProjectFromCwd: Option.none(),
+            logWebSocketEvents: Option.none(),
+            tailscaleServeEnabled: Option.none(),
+            tailscaleServePort: Option.none(),
+          },
+          Option.none(),
+        ).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              ConfigProvider.layer(
+                ConfigProvider.fromEnv({ env: { T3CODE_DEV_AUTH_DIR: "relative-auth" } }),
+              ),
+              NetService.layer,
+            ),
+          ),
+        );
+
+      const web = yield* resolve("web");
+      const desktop = yield* resolve("desktop");
+
+      expect(web.devAuthDir).toBe(path.resolve("relative-auth"));
+      expect("devAuthDir" in desktop).toBe(false);
+    }),
+  );
+
+  it.effect("uses auth metadata from the exact base-dir runtime target", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cli-auth-target-" });
+      const userdataPaths = yield* deriveExplicitServerPaths(baseDir, undefined);
+      const devPaths = yield* deriveServerPaths(baseDir, new URL("http://localhost"));
+      const targetDevAuthDir = path.join(baseDir, "target-dev-auth");
+      yield* persistServerRuntimeState({
+        path: userdataPaths.serverRuntimeStatePath,
+        state: {
+          version: 1,
+          pid: process.pid,
+          port: 13_773,
+          origin: "http://127.0.0.1:13773",
+          devUrl: "http://localhost:5733/",
+          devAuthDir: targetDevAuthDir,
+          startedAt: "2026-08-28T00:00:00.000Z",
+        },
+      });
+      yield* persistServerRuntimeState({
+        path: devPaths.serverRuntimeStatePath,
+        state: {
+          version: 1,
+          pid: process.pid,
+          port: 13_774,
+          origin: "http://127.0.0.1:13774",
+          devUrl: "http://localhost:5734/",
+          devAuthDir: path.join(baseDir, "wrong-dev-auth"),
+          startedAt: "2026-08-28T00:00:00.000Z",
+        },
+      });
+
+      const resolved = yield* resolveCliAuthConfig(
+        {
+          baseDir: Option.some(baseDir),
+          devUrl: Option.some(new URL("http://localhost:9999")),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  T3CODE_MODE: "desktop",
+                  VITE_DEV_SERVER_URL: "http://localhost:8888",
+                  T3CODE_DEV_AUTH_DIR: path.join(baseDir, "caller-dev-auth"),
+                },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.stateDir).toBe(userdataPaths.stateDir);
+      expect(resolved.mode).toBe("web");
+      expect(resolved.devUrl?.toString()).toBe("http://localhost:5733/");
+      expect(resolved.devAuthDir).toBe(targetDevAuthDir);
+    }),
+  );
+
+  it.effect("strips ambient shared auth for a recorded non-dev target", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cli-auth-nondev-" });
+      const paths = yield* deriveExplicitServerPaths(baseDir, undefined);
+      yield* persistServerRuntimeState({
+        path: paths.serverRuntimeStatePath,
+        state: {
+          version: 1,
+          pid: process.pid,
+          port: 3_773,
+          origin: "http://127.0.0.1:3773",
+          startedAt: "2026-08-28T00:00:00.000Z",
+        },
+      });
+
+      const resolved = yield* resolveCliAuthConfig(
+        { baseDir: Option.some(baseDir), devUrl: Option.none() },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  VITE_DEV_SERVER_URL: "http://localhost:8888",
+                  T3CODE_DEV_AUTH_DIR: "/tmp/caller-dev-auth",
+                },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.devUrl).toBeUndefined();
+      expect("devAuthDir" in resolved).toBe(false);
+    }),
+  );
+
+  it.effect("supports explicit offline shared auth config without runtime metadata", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cli-auth-offline-" });
+      const devAuthDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-auth-offline-shared-",
+      });
+
+      const resolved = yield* resolveCliAuthConfig(
+        {
+          baseDir: Option.some(baseDir),
+          devUrl: Option.some(new URL("http://localhost:5733")),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({ env: { T3CODE_DEV_AUTH_DIR: devAuthDir } }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.mode).toBe("web");
+      expect(resolved.devUrl?.toString()).toBe("http://localhost:5733/");
+      expect(resolved.devAuthDir).toBe(devAuthDir);
     }),
   );
 

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -16,6 +16,7 @@ import { Argument, Flag } from "effect/unstable/cli";
 import { readBootstrapEnvelope } from "../bootstrap.ts";
 import * as ServerConfig from "../config.ts";
 import { expandHomePath, resolveBaseDir } from "../os-jank.ts";
+import { readPersistedServerRuntimeState } from "../serverRuntimeState.ts";
 
 export const modeFlag = Flag.choice("mode", ServerConfig.RuntimeMode.literals).pipe(
   Flag.withDescription("Runtime mode. `desktop` keeps loopback defaults unless overridden."),
@@ -106,6 +107,10 @@ const EnvServerConfig = Config.all({
   host: Config.string("T3CODE_HOST").pipe(Config.option, Config.map(Option.getOrUndefined)),
   t3Home: Config.string("T3CODE_HOME").pipe(Config.option, Config.map(Option.getOrUndefined)),
   devUrl: Config.url("VITE_DEV_SERVER_URL").pipe(Config.option, Config.map(Option.getOrUndefined)),
+  devAuthDir: Config.string("T3CODE_DEV_AUTH_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
   devAllowedOrigins: Config.string("T3CODE_DEV_ALLOWED_ORIGINS").pipe(
     Config.withDefault(""),
     Config.map((value) =>
@@ -270,6 +275,11 @@ export const resolveServerConfig = (
       resolveOptionPrecedence(normalizedFlags.devUrl, Option.fromUndefinedOr(env.devUrl)),
       () => undefined,
     );
+    const configuredDevAuthDir = env.devAuthDir;
+    const devAuthDir =
+      mode === "web" && devUrl !== undefined && configuredDevAuthDir?.trim()
+        ? path.resolve(yield* expandHomePath(configuredDevAuthDir.trim()))
+        : undefined;
     const explicitBaseDir = resolveOptionPrecedence(
       normalizedFlags.baseDir,
       Option.fromUndefinedOr(env.t3Home),
@@ -375,6 +385,7 @@ export const resolveServerConfig = (
       host,
       staticDir,
       devUrl,
+      ...(devAuthDir === undefined ? {} : { devAuthDir }),
       devAllowedOrigins: env.devAllowedOrigins,
       noBrowser,
       startupPresentation,
@@ -395,23 +406,40 @@ export const resolveCliAuthConfig = (
   flags: CliAuthLocationFlags,
   cliLogLevel: Option.Option<LogLevel.LogLevel>,
 ) =>
-  resolveServerConfig(
-    {
-      mode: Option.none(),
-      port: Option.none(),
-      host: Option.none(),
-      baseDir: flags.baseDir,
-      cwd: Option.none(),
-      devUrl: flags.devUrl ?? Option.none(),
-      noBrowser: Option.none(),
-      bootstrapFd: Option.none(),
-      autoBootstrapProjectFromCwd: Option.none(),
-      logWebSocketEvents: Option.none(),
-      tailscaleServeEnabled: Option.none(),
-      tailscaleServePort: Option.none(),
-    },
-    cliLogLevel,
-  );
+  Effect.gen(function* () {
+    const config = yield* resolveServerConfig(
+      {
+        mode: Option.none(),
+        port: Option.none(),
+        host: Option.none(),
+        baseDir: flags.baseDir,
+        cwd: Option.none(),
+        devUrl: flags.devUrl ?? Option.none(),
+        noBrowser: Option.none(),
+        bootstrapFd: Option.none(),
+        autoBootstrapProjectFromCwd: Option.none(),
+        logWebSocketEvents: Option.none(),
+        tailscaleServeEnabled: Option.none(),
+        tailscaleServePort: Option.none(),
+      },
+      cliLogLevel,
+    );
+    const runtimeState = yield* readPersistedServerRuntimeState(config.serverRuntimeStatePath);
+    if (Option.isNone(runtimeState)) {
+      return config;
+    }
+
+    const { devAuthDir: _ambientDevAuthDir, ...configWithoutDevAuthDir } = config;
+    const targetDevUrl = runtimeState.value.devUrl ? new URL(runtimeState.value.devUrl) : undefined;
+    return {
+      ...configWithoutDevAuthDir,
+      ...(targetDevUrl === undefined ? {} : { mode: "web" as const }),
+      devUrl: targetDevUrl,
+      ...(targetDevUrl !== undefined && runtimeState.value.devAuthDir !== undefined
+        ? { devAuthDir: runtimeState.value.devAuthDir }
+        : {}),
+    } satisfies ServerConfig.ServerConfig["Service"];
+  });
 
 const DurationShorthandPattern = /^(?<value>\d+)(?<unit>ms|s|m|h|d|w)$/i;
 

--- a/apps/server/src/cli/pair.ts
+++ b/apps/server/src/cli/pair.ts
@@ -340,6 +340,9 @@ const makePairServerConfig = Effect.fn(function* (input: {
     ...derivedPaths,
     staticDir: undefined,
     devUrl,
+    ...(devUrl !== undefined && state.devAuthDir !== undefined
+      ? { devAuthDir: state.devAuthDir }
+      : {}),
     devAllowedOrigins: [],
     noBrowser: true,
     startupPresentation: "headless",

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -75,6 +75,7 @@ export class ServerConfig extends Context.Service<
     readonly baseDir: string;
     readonly staticDir: string | undefined;
     readonly devUrl: URL | undefined;
+    readonly devAuthDir?: string | undefined;
     readonly devAllowedOrigins: ReadonlyArray<string>;
     readonly noBrowser: boolean;
     readonly startupPresentation: StartupPresentation;
@@ -96,6 +97,13 @@ export class ServerConfig extends Context.Service<
 }
 
 export const make = (config: ServerConfig["Service"]) => ServerConfig.of(config);
+
+export const resolveActiveDevAuthDir = (config: {
+  readonly mode: RuntimeMode;
+  readonly devUrl: URL | undefined;
+  readonly devAuthDir?: string | undefined;
+}): string | undefined =>
+  config.mode === "web" && config.devUrl !== undefined ? config.devAuthDir : undefined;
 
 export const layer = (config: ServerConfig["Service"]) => Layer.succeed(ServerConfig, make(config));
 

--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -8,7 +8,7 @@ import type { SqlError } from "effect/unstable/sql/SqlError";
 import { runMigrations } from "../Migrations.ts";
 import { ServerConfig } from "../../config.ts";
 
-type RuntimeSqliteLayerConfig = {
+export type RuntimeSqliteLayerConfig = {
   readonly filename: string;
   readonly spanAttributes?: Record<string, unknown>;
 };
@@ -21,7 +21,7 @@ const defaultSqliteClientLoaders = {
   node: () => import("../NodeSqliteClient.ts"),
 } satisfies Record<string, () => Promise<Loader>>;
 
-const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
+export const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
   config: RuntimeSqliteLayerConfig,
 ) {
   const runtime = process.versions.bun !== undefined ? "bun" : "node";

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -47,11 +47,17 @@ describe("serverRuntimeState", () => {
   it.effect("records the dev web URL when the server fronts a dev server", () =>
     Effect.gen(function* () {
       const state = yield* ServerRuntimeState.makePersistedServerRuntimeState({
-        config: { host: undefined, devUrl: new URL("http://localhost:5733") },
+        config: {
+          mode: "web",
+          host: undefined,
+          devUrl: new URL("http://localhost:5733"),
+          devAuthDir: "/tmp/t3-dev-auth",
+        },
         port: 13_773,
       });
 
       assert.equal(state.devUrl, "http://localhost:5733/");
+      assert.equal(state.devAuthDir, "/tmp/t3-dev-auth");
       assert.equal(state.origin, "http://127.0.0.1:13773");
 
       const withoutDev = yield* ServerRuntimeState.makePersistedServerRuntimeState({
@@ -59,6 +65,17 @@ describe("serverRuntimeState", () => {
         port: 13_773,
       });
       assert.isFalse("devUrl" in withoutDev);
+
+      const desktop = yield* ServerRuntimeState.makePersistedServerRuntimeState({
+        config: {
+          mode: "desktop",
+          host: undefined,
+          devUrl: new URL("http://localhost:5733"),
+          devAuthDir: "/tmp/t3-dev-auth",
+        },
+        port: 13_773,
+      });
+      assert.isFalse("devAuthDir" in desktop);
     }),
   );
 

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -17,6 +17,8 @@ export const PersistedServerRuntimeState = Schema.Struct({
   // Present when the server fronts a dev web server (VITE_DEV_SERVER_URL).
   // Dev is single-origin: browsers must pair through this URL, not `origin`.
   devUrl: Schema.optional(Schema.String),
+  // Present only when this dev server shares browser sessions with other dev servers.
+  devAuthDir: Schema.optional(Schema.String),
   startedAt: Schema.String,
 });
 export type PersistedServerRuntimeState = typeof PersistedServerRuntimeState.Type;
@@ -48,7 +50,8 @@ const runtimeOriginForConfig = (
 };
 
 export const makePersistedServerRuntimeState = (input: {
-  readonly config: Pick<ServerConfig.ServerConfig["Service"], "host" | "devUrl">;
+  readonly config: Pick<ServerConfig.ServerConfig["Service"], "host" | "devUrl"> &
+    Partial<Pick<ServerConfig.ServerConfig["Service"], "mode" | "devAuthDir">>;
   readonly port: number;
 }): Effect.Effect<PersistedServerRuntimeState> =>
   Effect.map(DateTime.now, (now) => ({
@@ -58,6 +61,9 @@ export const makePersistedServerRuntimeState = (input: {
     port: input.port,
     origin: runtimeOriginForConfig(input.config, input.port),
     ...(input.config.devUrl ? { devUrl: input.config.devUrl.toString() } : {}),
+    ...(input.config.mode === "web" && input.config.devUrl && input.config.devAuthDir
+      ? { devAuthDir: input.config.devAuthDir }
+      : {}),
     startedAt: DateTime.formatIso(now),
   }));
 

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -37,6 +37,44 @@ browser session cookie. The cookie is an HTTP transport adapter for the same
 scoped session model; the response never exposes the session secret to browser
 JavaScript.
 
+#### Shared dev browser sessions
+
+The repository dev runner sets `T3CODE_DEV_AUTH_DIR` to `~/.t3/dev-auth` for
+`dev`, `dev:web`, and `dev:server`. Dev servers in this auth group use one
+session database and one cookie name. A browser pairs once, then sends the same
+cookie when another worktree uses the same hostname on another port or reuses
+the old port. Existing per-worktree cookies do not transfer, so each browser
+needs one initial pairing after this behavior is enabled.
+
+Cookie rules still apply. Cookies are scoped to a hostname and browser profile,
+not to a port. Hostname aliases and separate browser profiles do not share a
+session. Native clients and remote environments added in a client keep their
+per-environment pairing flow.
+
+Pass `--isolated-auth` to keep the old per-worktree session behavior. Set a
+nonempty `T3CODE_DEV_AUTH_DIR` before running the dev runner to select another
+auth group. For offline auth commands, set `T3CODE_DEV_AUTH_DIR` and pass
+`--dev-url` when `server-runtime.json` is not available. For example:
+
+```sh
+T3CODE_DEV_AUTH_DIR="$HOME/.t3/dev-auth" node apps/server/src/bin.ts auth session list \
+  --base-dir /path/to/worktree/.t3 --dev-url http://localhost:5733
+```
+
+Session records and their signing key are shared. This includes browser,
+bearer, and DPoP records, but only browser cookies get automatic reuse. Saved
+native connections stay bound to one environment ID. Each worktree keeps its
+own environment ID, data, other secrets, and one-time pairing grants. Browser
+sessions still expire after 30 days. DPoP sessions still expire after one hour.
+Revocation in one worktree applies when another worktree next authenticates
+that session. Existing WebSocket connections and process-local connection
+status do not change until those connections close or authenticate again.
+
+An open tab must reload when another worktree takes over its URL. The RPC
+reconnect check rejects a server whose environment ID differs from the tab's
+prepared connection. Reloading discovers the new environment. Desktop dev does
+not use the shared directory.
+
 ### Bearer Access Token
 
 Non-browser clients use `POST /oauth/token` with an

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -215,6 +215,40 @@ const completeInitialConfig = Effect.fn("TestRpcSessionFactory.completeInitialCo
 });
 
 describe("RpcSessionFactory", () => {
+  it.effect("rejects a reused URL that now serves another environment", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { factory, sockets } = yield* makeFactory();
+        const session = yield* factory.connect(PREPARED);
+        const readyFiber = yield* Effect.forkChild(Effect.flip(session.ready));
+        const configFiber = yield* Effect.forkChild(Effect.flip(session.initialConfig));
+        const socket = yield* awaitSocket(sockets);
+        const actualEnvironmentId = EnvironmentId.make("environment-2");
+
+        socket.open();
+        yield* completeInitialConfig(
+          socket,
+          encodeServerConfig({
+            ...SERVER_CONFIG,
+            environment: {
+              ...SERVER_CONFIG.environment,
+              environmentId: actualEnvironmentId,
+            },
+          }),
+        );
+
+        const readyError = yield* Fiber.join(readyFiber);
+        const configError = yield* Fiber.join(configFiber);
+        for (const error of [readyError, configError]) {
+          expect(error).toMatchObject({
+            reason: "configuration",
+            detail: `Connected environment ${actualEnvironmentId} does not match ${TARGET.environmentId}.`,
+          });
+        }
+      }),
+    ),
+  );
+
   it.effect("owns one scoped websocket attempt and exposes readiness and closure", () =>
     Effect.gen(function* () {
       const { factory, sockets } = yield* makeFactory();

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -19,6 +19,7 @@ import {
   ConnectionBlockedError,
   ConnectionTransientError as ConnectionTransientErrorClass,
 } from "../connection/model.ts";
+import { environmentMismatchError } from "../connection/errors.ts";
 
 const SOCKET_OPEN_TIMEOUT = "15 seconds";
 
@@ -117,6 +118,14 @@ export const make = Effect.gen(function* () {
     const initialConfig = yield* Effect.cached(
       client[WS_METHODS.serverGetConfig]({}).pipe(
         Effect.mapError(mapSessionRpcError),
+        Effect.flatMap((config) =>
+          config.environment.environmentId === connection.environmentId
+            ? Effect.succeed(config)
+            : environmentMismatchError({
+                expected: connection.environmentId,
+                actual: config.environment.environmentId,
+              }),
+        ),
         Effect.withSpan("environment.initialSync"),
       ),
     );

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -138,6 +138,63 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
   });
 
   describe("createDevRunnerEnv", () => {
+    it.effect("defaults browser dev modes to the shared dev auth directory", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const env = yield* createDevRunnerEnv({
+          mode: "dev",
+          baseEnv: {},
+          serverOffset: 0,
+          webOffset: 0,
+          t3Home: undefined,
+          browser: undefined,
+          autoBootstrapProjectFromCwd: undefined,
+          logWebSocketEvents: undefined,
+          host: undefined,
+          port: undefined,
+          devUrl: undefined,
+        });
+
+        assert.equal(env.T3CODE_DEV_AUTH_DIR, path.join(NodeOS.homedir(), ".t3", "dev-auth"));
+      }),
+    );
+
+    it.effect("resolves a custom dev auth directory and supports isolated auth", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const shared = yield* createDevRunnerEnv({
+          mode: "dev:server",
+          baseEnv: { T3CODE_DEV_AUTH_DIR: "relative-dev-auth" },
+          serverOffset: 0,
+          webOffset: 0,
+          t3Home: undefined,
+          browser: undefined,
+          autoBootstrapProjectFromCwd: undefined,
+          logWebSocketEvents: undefined,
+          host: undefined,
+          port: undefined,
+          devUrl: undefined,
+        });
+        const isolated = yield* createDevRunnerEnv({
+          mode: "dev:server",
+          baseEnv: { T3CODE_DEV_AUTH_DIR: "/tmp/inherited-dev-auth" },
+          serverOffset: 0,
+          webOffset: 0,
+          t3Home: undefined,
+          browser: undefined,
+          autoBootstrapProjectFromCwd: undefined,
+          logWebSocketEvents: undefined,
+          host: undefined,
+          port: undefined,
+          devUrl: undefined,
+          isolatedAuth: true,
+        });
+
+        assert.equal(shared.T3CODE_DEV_AUTH_DIR, path.resolve("relative-dev-auth"));
+        assert.equal(isolated.T3CODE_DEV_AUTH_DIR, undefined);
+      }),
+    );
+
     it.effect("leaves the shared home implicit and disables browser auto-open", () =>
       Effect.gen(function* () {
         const env = yield* createDevRunnerEnv({
@@ -330,6 +387,7 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
             T3CODE_HOST: "0.0.0.0",
             VITE_DEV_SERVER_URL: "http://127.0.0.1:8526",
             VITE_WS_URL: "ws://localhost:13773",
+            T3CODE_DEV_AUTH_DIR: "/tmp/inherited-dev-auth",
           },
           serverOffset: 0,
           webOffset: 0,
@@ -352,6 +410,7 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
         assert.equal(env.T3CODE_NO_BROWSER, undefined);
         assert.equal(env.T3CODE_HOST, undefined);
         assert.equal(env.VITE_WS_URL, "ws://127.0.0.1:4222");
+        assert.equal(env.T3CODE_DEV_AUTH_DIR, undefined);
       }),
     );
 

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -70,6 +70,9 @@ export function isProxiableBindHost(host: string): boolean {
 export const DEFAULT_T3_HOME = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(NodeOS.homedir(), ".t3"),
 );
+export const DEFAULT_DEV_AUTH_DIR = Effect.map(Effect.service(Path.Path), (path) =>
+  path.join(NodeOS.homedir(), ".t3", "dev-auth"),
+);
 
 const MODE_ARGS = {
   dev: [
@@ -302,6 +305,7 @@ interface CreateDevRunnerEnvInput {
   readonly host: string | undefined;
   readonly port: number | undefined;
   readonly devUrl: URL | undefined;
+  readonly isolatedAuth?: boolean | undefined;
 }
 
 export function createDevRunnerEnv({
@@ -316,8 +320,10 @@ export function createDevRunnerEnv({
   host,
   port,
   devUrl,
+  isolatedAuth,
 }: CreateDevRunnerEnvInput): Effect.Effect<NodeJS.ProcessEnv, never, Path.Path> {
   return Effect.gen(function* () {
+    const path = yield* Path.Path;
     const serverPort = port ?? BASE_SERVER_PORT + serverOffset;
     const webPort = BASE_WEB_PORT + webOffset;
     // Precedence (--home-dir > worktree .t3 > ambient T3CODE_HOME) is resolved
@@ -338,6 +344,15 @@ export function createDevRunnerEnv({
       output.T3CODE_HOME = resolvedBaseDir;
     } else {
       delete output.T3CODE_HOME;
+    }
+
+    if (isDesktopMode || isolatedAuth === true) {
+      delete output.T3CODE_DEV_AUTH_DIR;
+    } else {
+      const configuredDevAuthDir = baseEnv.T3CODE_DEV_AUTH_DIR?.trim();
+      output.T3CODE_DEV_AUTH_DIR = configuredDevAuthDir
+        ? path.resolve(configuredDevAuthDir)
+        : yield* DEFAULT_DEV_AUTH_DIR;
     }
 
     // A dev-runner server is never launcher-managed. When the shell that runs
@@ -627,6 +642,7 @@ interface DevRunnerCliInput {
   readonly devUrl: URL | undefined;
   readonly dryRun: boolean;
   readonly share: boolean;
+  readonly isolatedAuth?: boolean | undefined;
   readonly runArgs: ReadonlyArray<string>;
 }
 
@@ -697,6 +713,7 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
       host: input.host,
       port: input.port,
       devUrl: input.devUrl,
+      isolatedAuth: input.isolatedAuth,
     });
 
     const selectionSuffix =
@@ -706,7 +723,7 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
     const baseDir = env.T3CODE_HOME ?? (yield* DEFAULT_T3_HOME);
 
     yield* Effect.logInfo(
-      `[dev-runner] mode=${input.mode} source=${source}${selectionSuffix} serverPort=${String(env.T3CODE_PORT)} webPort=${String(env.PORT)} baseDir=${baseDir}`,
+      `[dev-runner] mode=${input.mode} source=${source}${selectionSuffix} serverPort=${String(env.T3CODE_PORT)} webPort=${String(env.PORT)} baseDir=${baseDir} devAuthDir=${env.T3CODE_DEV_AUTH_DIR ?? "isolated"}`,
     );
 
     // Before the share block: --dry-run only resolves and prints. Sharing would
@@ -904,6 +921,10 @@ const devRunnerCli = Command.make("dev-runner", {
     Flag.withDescription(
       "Publish the web dev server on this machine's tailnet over HTTPS (via `tailscale serve`) and print the pairing URL for it. Removed again on exit.",
     ),
+    Flag.withDefault(false),
+  ),
+  isolatedAuth: Flag.boolean("isolated-auth").pipe(
+    Flag.withDescription("Keep browser sessions isolated to this dev server."),
     Flag.withDefault(false),
   ),
   runArgs: Argument.string("run-arg").pipe(


### PR DESCRIPTION
Contributors repeatedly pair the same browser when Tailscale-hosted dev servers change ports or worktrees on one hostname. Cookie names, signing keys, and session records are currently worktree-local.

The web/server dev runner now defaults to `~/.t3/dev-auth`. Servers in this group share a directory-scoped cookie name and `sessions-v1.sqlite`, containing only session records and the signing key. SQLite selects one complete key when processes start together. The auth schema is versioned separately, without app migrations.

Worktree databases, environment IDs, other secrets, and pairing grants stay local. Production and desktop auth do not change. Auth CLI commands read the target runtime metadata.

## Risks and limits

- Authentication is shared across participating dev servers. Browser, bearer, and DPoP sessions retain their scopes across the group. Worktree access is not isolated. Only direct browser connections get automatic cookie reuse.
- `--isolated-auth` restores separate auth. `T3CODE_DEV_AUTH_DIR` selects another group. Neither protects against malicious branch code running as the same OS user.
- Existing credentials do not migrate, so each browser needs one initial pairing. Cookies remain specific to each hostname and browser profile. Browser sessions last 30 days, DPoP sessions one hour. Native and added remote connections still pair per environment.
- Revocation applies at the next authentication. Open WebSockets are not forcibly disconnected, and live connection status stays process-local.
- An open tab must reload when another environment replaces its URL. The RPC identity check rejects that mismatch before readiness.
- Offline auth commands without runtime metadata need `T3CODE_DEV_AUTH_DIR` and `--dev-url`. See [dev auth](https://github.com/pingdotgg/t3code/blob/864b1c0a344adcb3e2ec829ebd026f76994d8cd5/docs/internals/environment-auth.md#shared-dev-browser-sessions).

## Verification

After rebase, all 231 focused tests passed again: 90 server, 74 scripts, 49 client runtime, and 18 web auth. All three scoped typechecks, targeted lint/format checks, and `git diff --check` passed. Typechecks reported only pre-existing suggestions. Two Node processes shared a fresh database, key, and session. No browser or Tailscale end-to-end test was run.

Written by GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication storage, signing keys, and session sharing in development; misconfiguration could widen session reuse across dev servers on the same machine.
> 
> **Overview**
> **Shared dev browser sessions** so one pairing works across parallel web dev servers on the same host (different ports/worktrees) without cookie clashes.
> 
> Web dev with `VITE_DEV_SERVER_URL` can set **`T3CODE_DEV_AUTH_DIR`** (dev runner defaults to `~/.t3/dev-auth`). **`SessionStore`** then uses new **`DevSessionStorage`**: a shared SQLite file (`sessions-v1.sqlite`) for session rows and a single signing key, with restrictive file permissions. Otherwise behavior stays per-worktree via the local DB and **`ServerSecretStore`**.
> 
> **Cookie naming** switches from port/instance scoping to a **`t3_session_dev_<hash>`** name derived from the auth directory when shared dev auth is active; desktop and production paths are unchanged.
> 
> **Config and tooling**: `devAuthDir` is persisted in **`server-runtime.json`**, **`resolveCliAuthConfig`** prefers that metadata for offline auth CLI, and the dev runner adds **`--isolated-auth`** to opt out. **RPC reconnect** now fails fast when the server’s environment ID no longer matches the tab’s prepared connection.
> 
> Pairing grants and per-worktree data stay local; only browser cookie transport gets automatic reuse within an auth group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 864b1c0a344adcb3e2ec829ebd026f76994d8cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared dev session storage across ports and worktrees
> - Adds `DevSessionStorage`, a shared SQLite-backed store for dev sessions and signing keys activated by `devAuthDir`.
> - Updates `resolveSessionCookieName` to use a shared dev cookie name derived from the `devAuthDir`.
> - Persists `devAuthDir` in runtime state and passes it to CLI pairing commands so they target the correct auth group.
> - Adds `--isolated-auth` to the dev runner to opt out of the default shared `~/.t3/dev-auth` directory.
> - Behavioral Change: `RpcSessionFactory.connect` now rejects reused URLs serving a different environment with an `environmentMismatchError`. Active dev sessions may break if `devAuthDir` changes without clearing cookies.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 864b1c0. 12 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->