### PR TITLE
fix(web): match update button radius to sidebar controls

### DIFF
--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -315,7 +315,8 @@ function SidebarUpdateControl() {
               aria-label={tooltip}
               aria-disabled={isInteractionDisabled || undefined}
               className={cn(
-                "inline-flex size-8 items-center justify-center rounded-[var(--control-radius)] outline-hidden ring-ring transition-colors focus-visible:ring-2",
+                "inline-flex size-8 items-center justify-center outline-hidden ring-ring transition-colors focus-visible:ring-2",
+                showUpdateDetails ? "rounded-full" : "rounded-[var(--control-radius)]",
                 isInteractionDisabled ? "cursor-not-allowed" : "cursor-pointer",
                 showUpdateIconState
                   ? cn(

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -315,7 +315,7 @@ function SidebarUpdateControl() {
               aria-label={tooltip}
               aria-disabled={isInteractionDisabled || undefined}
               className={cn(
-                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2",
+                "inline-flex size-8 items-center justify-center rounded-[var(--control-radius)] outline-hidden ring-ring transition-colors focus-visible:ring-2",
                 isInteractionDisabled ? "cursor-not-allowed" : "cursor-pointer",
                 showUpdateIconState
                   ? cn(


### PR DESCRIPTION
## What Changed

Use the shared `--control-radius` while the desktop sidebar update control is idle or checking. Keep the control fully circular once an update is available, downloading, or ready to install.

## Why

In its ghost state, the update control was the only bottom-left sidebar button with a circular hover background. The conditional radius makes that state match the neighboring controls while preserving the circular update indicator and download progress ring.

## UI Changes

### Before:
<img width="248" height="64" alt="Screenshot 2026-08-29 at 01 56 41" src="https://github.com/user-attachments/assets/1a5f5088-9cdc-4d55-a2bb-80ca551f0085" />
<img width="255" height="69" alt="Screenshot 2026-08-29 at 01 56 53" src="https://github.com/user-attachments/assets/764ca21b-bb12-44d4-9678-f5e109721e9c" />

### After:
<img width="251" height="81" alt="Screenshot 2026-08-29 at 02 03 52" src="https://github.com/user-attachments/assets/ac71d010-cd5b-4d29-aa83-78bdfd821307" />
<img width="254" height="66" alt="Screenshot 2026-08-29 at 02 04 01" src="https://github.com/user-attachments/assets/f5b57d13-3f10-4135-8fb4-ae1c8a734c61" />


## Verification

- `pnpm exec vp run --filter @t3tools/web typecheck`
- `pnpm exec vp lint apps/web/src/components/sidebar/SidebarUpdatePill.tsx`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for this UI change
- [x] No video is needed because this changes only the static corner radius

Created with GPT-5.6 in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match `SidebarUpdateControl` button radius to sidebar controls
> Changes the update button in [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/8595/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf) from `rounded-full` to `rounded-[var(--control-radius)]` so it uses the theme-provided corner radius instead of a fully circular pill.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f33403e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic className change only; no behavior, auth, or data handling impact.
> 
> **Overview**
> The desktop sidebar **update** button no longer always uses a circular shape. In the default “check for updates” state it now uses `rounded-[var(--control-radius)]` so its hover/focus shape matches neighboring sidebar controls and theme settings.
> 
> When an update is active (`showUpdateDetails`), the control still uses **`rounded-full`** so the highlighted update affordance keeps its pill look.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a472ca68b9a708d8f36a1d9b673c7b3a46b41297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->