### PR TITLE
fix(mobile): restore composer glass and rounded shadows

### DIFF
--- a/apps/mobile/src/components/ComposerToolbar.tsx
+++ b/apps/mobile/src/components/ComposerToolbar.tsx
@@ -252,7 +252,8 @@ export function ComposerToolbarButton(props: {
         // so callers can lift it with max-w-full — flex-filling pills in the
         // thread composer stretch to the row's edge. The numeric maxWidth
         // prop still wins via the inline style below.
-        "h-11 max-w-[172px] flex-row items-center justify-center rounded-full border shadow-lg shadow-adaptive-black-a10-a25 active:opacity-70",
+        "h-11 max-w-[172px] flex-row items-center justify-center rounded-full border active:opacity-70",
+        variant === "primary" && "shadow-lg shadow-adaptive-black-a10-a25 disabled:shadow-none",
         isCircle ? "w-11" : "gap-2 px-3.5",
         variant === "primary"
           ? props.disabled
@@ -279,7 +280,6 @@ export function ComposerToolbarButton(props: {
           maxWidth: props.maxWidth,
           minWidth: props.minWidth,
           opacity: props.disabled ? 0.55 : pressed ? 0.72 : 1,
-          shadowOpacity: props.disabled ? 0 : 1,
         },
         props.style,
       ]}

--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -13,7 +13,11 @@ import { withUniwind } from "uniwind";
 
 import { cn } from "../lib/cn";
 
-const ThemedGlassView = withUniwind(GlassView);
+// Explicit mappings keep the native glassEffectStyle enum out of style-array conversion.
+const ThemedGlassView = withUniwind(GlassView, {
+  style: { fromClassName: "className" },
+  tintColor: { fromClassName: "tintColorClassName", styleProperty: "accentColor" },
+});
 
 interface GlassSurfaceProps extends ViewProps {
   readonly children: ReactNode;

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -119,21 +119,17 @@ export function ComposerSurface(props: {
   /** Existing thread composers morph between pill and card layouts. */
   readonly animateLayout?: boolean;
 }) {
-  // Drop shadow lives on a wrapper: `overflow: "hidden"` on the surface itself
-  // (needed to clip content to the pill shape) would clip the shadow on iOS.
-  const shadowStyle: ViewStyle = {
-    borderRadius: props.style.borderRadius,
-    shadowOpacity: 1,
-    shadowRadius: 14,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 10,
-  };
-
+  // A box shadow follows the rounded surface even when the glass is transparent.
+  // Keep it outside the clipped content so the shadow can extend past the edge.
   return (
     <Animated.View
-      className="shadow-adaptive-black-a15-a35"
+      className="shadow-[0_6px_28px] shadow-adaptive-black-a15-a35"
       layout={props.animateLayout === false ? undefined : COMPOSER_LAYOUT_TRANSITION}
-      style={shadowStyle}
+      style={{
+        borderRadius: props.style.borderRadius,
+        // Android versions before 9 do not support outset box shadows.
+        elevation: Platform.OS === "android" && Platform.Version < 28 ? 10 : undefined,
+      }}
     >
       <GlassSurface
         chrome="none"

--- a/docs/user/mobile-appearance.md
+++ b/docs/user/mobile-appearance.md
@@ -4,6 +4,9 @@ T3 Code Mobile includes the T3 Code, T3 Chat, Grove, Ocean, Ember, and Iris them
 light and dark colors that apply throughout the app, including code reviews, file previews, the
 terminal, native headers, and sheets.
 
+On supported iOS versions, the new-task and thread composers use the system glass material.
+Other platforms use a themed background.
+
 To change themes:
 
 1. Open **Settings**.


### PR DESCRIPTION
Both mobile composers could lose their glass background and cast heavy shadows around text and controls.

The automatic Uniwind wrapper treated `glassEffectStyle` as a layout style, changing `"regular"` into an array before it reached Expo's native view. Explicit mappings now convert only layout and tint classes, preserving the native glass setting. Runtime inspection confirmed the invalid array before and the correct string after; the same installed simulator build now renders real glass.

Use a rounded box shadow for the composer instead of a shadow derived from its transparent contents. Keep the elevation fallback on Android below API 28. Remove duplicate native button shadows and keep scrolled toolbar controls flat so their shadows cannot be clipped; the enabled send button retains its shadow.

Verified New task and both thread layouts on an iPhone 17 Pro simulator running iOS 27, including dark appearance and skill selection. No prompts were submitted.

- 39 focused appearance and capability tests passed.
- Mobile typecheck, changed-file lint, formatting, and diff checks passed.

| State | Before | After |
| --- | --- | --- |
| New task | ![New task without material](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0f01c28200488f29/before-new-task.png) | ![New task with glass and rounded shadow](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8ef5a5516c6549e2/after-new-task.png) |
| Thread, collapsed | ![Collapsed thread composer without material](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9d6f095c72047467/before-thread-collapsed.png) | ![Collapsed thread composer with glass](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6bccaa7183e9ee9a/after-thread-collapsed.png) |
| Thread, expanded | ![Expanded thread composer with text and button halos](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c18c7708ded3f06f/before-thread-expanded.png) | ![Expanded thread composer with glass and clean controls](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/abd9458a86b98adf/after-thread-expanded.png) |

Native interaction recordings: [before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e0482a3e893809b0/before-interaction.mp4) · [after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/28cb703a96990c21/after-interaction.mp4). Both show focusing and typing into the thread composer.

[Dark appearance verification](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/1dbfb53595965e42/after-new-task-dark.png).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Appearance-only mobile UI changes (shadows, Uniwind glass wiring, docs) with no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes mobile composers losing **native glass** and showing **heavy halos** around text and toolbar controls.
> 
> **`GlassSurface`** now passes explicit `withUniwind` mappings so only layout (`className`) and tint classes are converted—`glassEffectStyle` stays a native enum string instead of being mangled into a style array.
> 
> **`ComposerSurface`** draws the composer shadow as a **rounded box shadow** on an outer wrapper (with **elevation** only on Android below API 28), so transparent glass no longer casts shadows from inner content and clipping does not eat the shadow.
> 
> **`ComposerToolbarButton`** limits drop shadow to the **enabled primary** send-style pill (`disabled:shadow-none`) and drops redundant `shadowOpacity` inline styling so default/scrolled toolbar controls stay flat.
> 
> User docs note that supported **iOS** composers use system glass; other platforms keep the themed fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ae947b418f54e9b3c1c1ff3697dfbaad06be28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore glass styling and rounded shadows on mobile composer
> - `ThemedGlassView` now derives `style` from `className` and applies `tintColor` from `tintColorClassName` via the `accentColor` style property, keeping native props out of the style-array conversion
> - `ComposerSurface` replaces the inline `shadowStyle` object with Tailwind classes (`shadow-[0_6px_28px] shadow-adaptive-black-a15-a35`) and applies `elevation` only on Android `Platform.Version < 28`
> - `ComposerToolbarButton` renders a drop shadow only for `variant="primary"` (suppressed when disabled) and drops the inline `shadowOpacity` property
> - Documents that iOS uses the system glass material for new-task and thread composers, while other platforms use a themed background
> - Risk: `GlassSurface.tsx` prop mapping change alters how class-derived styling reaches `GlassView`; out-of-tree consumers passing inline `style` or `tintColor` directly may no longer see the same effect
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24ae947.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->