### PR TITLE
Require human review for pull requests changing product defaults

### DIFF
--- a/.macroscope/approvability.md
+++ b/.macroscope/approvability.md
@@ -1,1 +1,3 @@
 Use Macroscope's default approvability criteria.
+
+Additionally, any pull request that changes product defaults is not auto-approvable and requires human review.


### PR DESCRIPTION
## What Changed

Updated Macroscope approvability guidance to state that pull requests changing product defaults are not auto-approvable and require human review.

## Why

Product default changes can affect user behavior and system outcomes, so they should receive explicit human oversight instead of being automatically approved.

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy update with no code or security behavior changes.
> 
> **Overview**
> Extends **Macroscope approvability** policy in `.macroscope/approvability.md` so PRs that **change product defaults** are explicitly **not auto-approvable** and must get **human review**, on top of Macroscope’s default criteria.
> 
> This is guidance-only: it does not change runtime approval logic in application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39376bc912d3c0ea64138717fcdb0c5aa2904034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require human review for pull requests changing product defaults
> Appends a new policy line to [approvability.md](https://github.com/pingdotgg/t3code/pull/8603/files#diff-0053fa10537722c469ec3bdb87b7826994e81ec54fe5e568510987e334d94391) stating that PRs changing product defaults are not auto-approvable and require human review.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39376bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->