### PR TITLE
fix(server): classify GLM 5.3 Flash as current

### DIFF
--- a/apps/server/src/provider/ModelManifest.test.ts
+++ b/apps/server/src/provider/ModelManifest.test.ts
@@ -28,6 +28,7 @@ describe("isLegacyModel (bundled manifest)", () => {
         "gpt-5.6-sol",
         "gpt-daybreak-blue-latest",
         "gpt-daybreak-red-latest",
+        "z-ai/glm-5.3-flash",
         "gpt-5.4",
       ].map((model) => [model, isLegacyModel(BUNDLED_MODEL_MANIFEST, CODEX, model)]),
       [
@@ -36,6 +37,7 @@ describe("isLegacyModel (bundled manifest)", () => {
         ["gpt-5.6-sol", false],
         ["gpt-daybreak-blue-latest", false],
         ["gpt-daybreak-red-latest", false],
+        ["z-ai/glm-5.3-flash", false],
         ["gpt-5.4", true],
       ],
     );

--- a/apps/server/src/provider/model-manifest.json
+++ b/apps/server/src/provider/model-manifest.json
@@ -6,7 +6,8 @@
       "gpt-5.6-terra",
       "gpt-5.6-sol",
       "gpt-daybreak-blue-latest",
-      "gpt-daybreak-red-latest"
+      "gpt-daybreak-red-latest",
+      "z-ai/glm-5.3-flash"
     ],
     "claudeAgent": ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]
   }


### PR DESCRIPTION
Codex model catalogs can expose Z.ai GLM 5.3 Flash through an OpenRouter provider. T3 currently puts the returned model in the legacy section because its slug is absent from the current Codex model manifest.

Add `z-ai/glm-5.3-flash` to the Codex manifest and cover its classification in the existing focused test.

Testing:
- `vp test run apps/server/src/provider/ModelManifest.test.ts`
- `vp fmt --check apps/server/src/provider/ModelManifest.test.ts apps/server/src/provider/model-manifest.json`

Created with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest data and test-only update; no changes to classification logic or runtime behavior beyond which slug is listed as current.
> 
> **Overview**
> **Adds `z-ai/glm-5.3-flash` to the bundled Codex `currentModels` list** so models returned from OpenRouter-backed catalogs are treated as current instead of legacy.
> 
> The existing `isLegacyModel` bundled-manifest test is extended to assert this slug is **not** flagged legacy (same expectation as other current Codex models).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a303545e9ab8d79a629c84acc6090c55a57cdb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `z-ai/glm-5.3-flash` to current models in `model-manifest.json`
> Adds the `z-ai/glm-5.3-flash` entry to the current models array in [model-manifest.json](https://github.com/pingdotgg/t3code/pull/8604/files#diff-fdf6ac0d1183f70794b15b8034d7d7405e3a3d35139c12a62e154b44322ea175) so `isLegacyModel` returns false for it. Updates the bundled manifest test in [ModelManifest.test.ts](https://github.com/pingdotgg/t3code/pull/8604/files#diff-6c2f59aceb04c442bc4e6cba801e7fa4ca415305c4b422091753a1283ad11567) to assert the model is not legacy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a303545.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->