### PR TITLE
fix(codex): avoid quadratic app-server input buffering

### DIFF
--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -23,6 +23,14 @@ adapter in a child scope. Adapter implementations live beside them in
 [`ProviderAdapter.ts`][adapter]. Read the driver plus its adapter to see how a specific agent's
 transport, config, and event shapes are mapped.
 
+## Codex app-server framing
+
+The Codex client reads newline-delimited JSON from the app-server process's stdout through
+[`protocol.ts`][codex-protocol]. Messages can span thousands of pipe reads, so the reader scans only
+new chunks and keeps unfinished lines as fragments, joining once per complete line. Repeatedly
+concatenating and splitting the pending line makes large messages quadratic in size. CRLF is
+accepted, and a final line without a newline is processed only when the input stream ends normally.
+
 ## Registry and routing
 
 Two registries separate configuration from live processes:
@@ -161,6 +169,7 @@ when a request opens (approval) or user input is requested, via
 
 [drivers]: ../../apps/server/src/provider/builtInDrivers.ts
 [codex]: ../../apps/server/src/provider/Drivers/CodexDriver.ts
+[codex-protocol]: ../../packages/effect-codex-app-server/src/protocol.ts
 [claude]: ../../apps/server/src/provider/Drivers/ClaudeDriver.ts
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -23,14 +23,6 @@ adapter in a child scope. Adapter implementations live beside them in
 [`ProviderAdapter.ts`][adapter]. Read the driver plus its adapter to see how a specific agent's
 transport, config, and event shapes are mapped.
 
-## Codex app-server framing
-
-The Codex client reads newline-delimited JSON from the app-server process's stdout through
-[`protocol.ts`][codex-protocol]. Messages can span thousands of pipe reads, so the reader scans only
-new chunks and keeps unfinished lines as fragments, joining once per complete line. Repeatedly
-concatenating and splitting the pending line makes large messages quadratic in size. CRLF is
-accepted, and a final line without a newline is processed only when the input stream ends normally.
-
 ## Registry and routing
 
 Two registries separate configuration from live processes:
@@ -169,7 +161,6 @@ when a request opens (approval) or user input is requested, via
 
 [drivers]: ../../apps/server/src/provider/builtInDrivers.ts
 [codex]: ../../apps/server/src/provider/Drivers/CodexDriver.ts
-[codex-protocol]: ../../packages/effect-codex-app-server/src/protocol.ts
 [claude]: ../../apps/server/src/provider/Drivers/ClaudeDriver.ts
 [cursor]: ../../apps/server/src/provider/Drivers/CursorDriver.ts
 [grok]: ../../apps/server/src/provider/Drivers/GrokDriver.ts

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -290,6 +290,114 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
       }),
   );
 
+  it.effect("routes a large notification fragmented across thousands of input chunks", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const notifications: Array<CodexProtocol.CodexAppServerIncomingNotification> = [];
+      const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({
+        stdio,
+        onNotification: (notification) =>
+          Effect.sync(() => {
+            notifications.push(notification);
+          }),
+      });
+      const response = yield* transport.request("thread/read", {}).pipe(Effect.forkScoped);
+      yield* Queue.take(output);
+
+      const notification = {
+        method: "turn/diff/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          diff: "x".repeat(4 * 1024 * 1024),
+        },
+      };
+      const bytes = encoder.encode(
+        `${encodeUnknownJsonString(notification)}\n${encodeUnknownJsonString({ id: 1, result: { ok: true } })}\n`,
+      );
+      for (let offset = 0; offset < bytes.length; offset += 1024) {
+        yield* Queue.offer(input, bytes.subarray(offset, offset + 1024));
+      }
+
+      assert.deepEqual(yield* Fiber.join(response), { ok: true });
+      assert.deepEqual(notifications, [notification]);
+    }),
+  );
+
+  it.effect.each([1, 7, 1024])(
+    "preserves JSONL framing and UTF-8 across %i-byte input chunks",
+    (chunkSize) =>
+      Effect.gen(function* () {
+        const { stdio, input } = yield* makeInMemoryStdio();
+        const notifications: Array<CodexProtocol.CodexAppServerIncomingNotification> = [];
+        const rawLines: Array<unknown> = [];
+        const termination = yield* Deferred.make<CodexError.CodexAppServerError>();
+        yield* CodexProtocol.makeCodexAppServerPatchedProtocol({
+          stdio,
+          logIncoming: true,
+          logger: (event) =>
+            Effect.sync(() => {
+              if (event.stage === "raw") {
+                rawLines.push(event.payload);
+              }
+            }),
+          onNotification: (notification) =>
+            Effect.sync(() => {
+              notifications.push(notification);
+            }),
+          onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+        });
+
+        const firstLine = '{"method":"x/first",\r"params":{"text":"hé🙂"}}';
+        const secondLine = '{"method":"x/second","params":{"value":2}}';
+        const finalLine = '{"method":"x/final","params":{"text":"最後"}}\r';
+        const bytes = encoder.encode(`\n \t\r\n${firstLine}\r\n\n${secondLine}\n${finalLine}`);
+        for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+          yield* Queue.offer(input, bytes.subarray(offset, offset + chunkSize));
+        }
+        yield* Queue.end(input);
+
+        assert.instanceOf(
+          yield* Deferred.await(termination),
+          CodexError.CodexAppServerInputStreamEndedError,
+        );
+        assert.deepEqual(notifications, [
+          { method: "x/first", params: { text: "hé🙂" } },
+          { method: "x/second", params: { value: 2 } },
+          { method: "x/final", params: { text: "最後" } },
+        ]);
+        assert.deepEqual(rawLines, [firstLine, secondLine, finalLine]);
+      }),
+  );
+
+  it.effect("reports a malformed fragmented final line before input stream termination", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const termination = yield* Deferred.make<CodexError.CodexAppServerError>();
+      const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({
+        stdio,
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+      const response = yield* transport.request("thread/read", {}).pipe(Effect.forkScoped);
+      yield* Queue.take(output);
+
+      yield* Queue.offer(input, encoder.encode('{"id":1,'));
+      yield* Queue.offer(input, encoder.encode('"result":'));
+      yield* Queue.end(input);
+
+      const error = yield* Deferred.await(termination);
+      assert.instanceOf(error, CodexError.CodexAppServerProtocolParseError);
+      assert.equal(error.operation, "decode-wire-message");
+      const responseError = yield* Fiber.join(response).pipe(
+        Effect.match({
+          onFailure: (failure) => failure,
+          onSuccess: () => assert.fail("Expected the malformed response to fail the request"),
+        }),
+      );
+      assert.strictEqual(responseError, error);
+    }),
+  );
+
   it.effect("surfaces JSON encoding failures as protocol parse errors", () =>
     Effect.gen(function* () {
       const { stdio } = yield* makeInMemoryStdio();

--- a/packages/effect-codex-app-server/src/protocol.ts
+++ b/packages/effect-codex-app-server/src/protocol.ts
@@ -157,7 +157,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     const incomingRequests = yield* Queue.unbounded<CodexAppServerIncomingRequest>();
     const pending = yield* Ref.make(new Map<string, CodexAppServerPendingRequest>());
     const nextRequestId = yield* Ref.make(1);
-    const remainder = yield* Ref.make("");
+    const remainder: Array<string> = [];
     const terminationHandled = yield* Ref.make(false);
 
     const logProtocol = (event: CodexAppServerProtocolLogEvent) => {
@@ -354,11 +354,24 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     yield* options.stdio.stdin.pipe(
       Stream.decodeText(),
       Stream.runForEach((chunk) =>
-        Ref.modify(remainder, (current) => {
-          const combined = current + chunk;
-          const lines = combined.split("\n");
-          const nextRemainder = lines.pop() ?? "";
-          return [lines.map((line) => line.replace(/\r$/, "")), nextRemainder] as const;
+        Effect.sync(() => {
+          const lines: Array<string> = [];
+          let start = 0;
+          for (
+            let newline = chunk.indexOf("\n");
+            newline !== -1;
+            newline = chunk.indexOf("\n", start)
+          ) {
+            remainder.push(chunk.slice(start, newline));
+            lines.push(remainder.join("").replace(/\r$/, ""));
+            remainder.length = 0;
+            start = newline + 1;
+          }
+          // Keep unfinished lines in fragments so each chunk is scanned only once.
+          if (start < chunk.length) {
+            remainder.push(chunk.slice(start));
+          }
+          return lines;
         }).pipe(Effect.flatMap((lines) => Effect.forEach(lines, handleLine, { discard: true }))),
       ),
       Effect.matchEffect({
@@ -367,8 +380,12 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
             Effect.succeed(normalizeIncomingError(error, "read-input-stream")),
           ),
         onSuccess: () =>
-          Ref.get(remainder).pipe(
-            Effect.flatMap((line) => (line.trim().length === 0 ? Effect.void : handleLine(line))),
+          Effect.sync(() => {
+            const line = remainder.join("");
+            remainder.length = 0;
+            return line;
+          }).pipe(
+            Effect.flatMap(handleLine),
             Effect.matchEffect({
               onFailure: (error) => handleTermination(() => Effect.succeed(error)),
               onSuccess: () =>


### PR DESCRIPTION
Closes #5389

## What Changed

Updated Codex app-server JSONL parsing to retain incomplete input as fragments and scan each incoming chunk once, avoiding quadratic buffering for large messages. Added coverage for large fragmented notifications, UTF-8 and CRLF framing, and malformed final lines. Documented the framing behavior.

## Why

Large app-server messages could require repeated concatenation and splitting of the pending input, causing quadratic processing and degraded performance. Fragment-based buffering preserves framing correctness while keeping parsing efficient.

## UI Changes

Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core wire-protocol framing for all Codex app-server stdin traffic; behavior is heavily tested but mistakes could break large payloads or stream shutdown.
> 
> **Overview**
> **Fixes quadratic stdin buffering** in `makeCodexAppServerPatchedProtocol` when large JSONL messages arrive in many small chunks.
> 
> Incomplete lines are kept as a **fragment array** and each decoded chunk is scanned once for `\n`, instead of repeatedly concatenating the full pending buffer and splitting it. Complete lines are joined from fragments, trailing `\r` is stripped, and the tail stays fragmented until the next chunk or stream end.
> 
> On **input stream close**, any leftover fragments are joined and passed through `handleLine` (including parse errors for truncated JSON) before normal termination handling.
> 
> **Tests** cover a ~4MB notification split into 1KB chunks, JSONL/UTF-8/CRLF framing at chunk sizes 1/7/1024, and malformed fragmented response lines that fail the pending request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d310c203a308ed0becfaa2e5444859e7659d0208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix quadratic input buffering in `makeCodexAppServerPatchedProtocol` line assembly
> Replaces the `Ref<string>` remainder with a local `Array<string>` fragment buffer in the stdin stream consumer. Each chunk is scanned once for newlines; completed lines are emitted by joining fragments, and only the unfinished tail is retained—avoiding repeated string concatenation across thousands of fragmented chunks.
> - At stream termination, any remaining fragments are now unconditionally joined and passed to `handleLine`, including when the remainder is empty or whitespace-only.
> - Adds tests covering large fragmented notifications, JSONL framing across varied chunk sizes, and malformed final-line error propagation.
> - Risk: `handleLine` is now called once more at termination with a possibly empty string; any handler that assumes it only receives non-empty content may behave differently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d310c20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->