### PR TITLE
fix(mobile): stabilize iOS header item transitions

### DIFF
--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -15,6 +15,9 @@ import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../native/native-glass";
 const IOS_NATIVE_LEADING_TITLE_OFFSET = -6;
 const IPAD_NATIVE_LEADING_TITLE_OFFSET = 7;
 
+// Branding and connection status share an identity distinct from navigation buttons.
+export const BRAND_HEADER_ITEM_IDENTIFIER = "workspace-brand";
+
 /**
  * Horizontal correction applied to content rendered in the brand title slot,
  * shared with the connection-status swap so both align identically.
@@ -76,6 +79,7 @@ export function renderCompactBrandHeaderItems(): NativeStackHeaderItem[] {
     {
       element: <CompactBrandTitle nativeLeadingItem />,
       hidesSharedBackground: true,
+      identifier: BRAND_HEADER_ITEM_IDENTIFIER,
       type: "custom",
     },
   ];

--- a/apps/mobile/src/features/home/WorkspaceConnectionTitle.tsx
+++ b/apps/mobile/src/features/home/WorkspaceConnectionTitle.tsx
@@ -7,7 +7,11 @@ import { ActivityIndicator, Animated, Platform, Pressable, View } from "react-na
 
 import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text } from "../../components/AppText";
-import { brandTitleOffset, CompactBrandTitle } from "../../components/CompactBrandTitle";
+import {
+  BRAND_HEADER_ITEM_IDENTIFIER,
+  brandTitleOffset,
+  CompactBrandTitle,
+} from "../../components/CompactBrandTitle";
 import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { useWorkspaceState } from "../../state/workspace";
 import {
@@ -172,6 +176,7 @@ export function getConnectionAwareBrandHeaderOptions(opts: {
             />
           ),
           hidesSharedBackground: true,
+          identifier: BRAND_HEADER_ITEM_IDENTIFIER,
           type: "custom",
         },
       ],

--- a/docs/internals/mobile-navigation.md
+++ b/docs/internals/mobile-navigation.md
@@ -1,0 +1,31 @@
+# Mobile navigation headers
+
+The iOS Home and thread routes share the root native stack in
+[`Stack.tsx`](../../apps/mobile/src/Stack.tsx). Keeping them in one navigation
+controller lets UIKit animate the header between routes. The iPad sidebar owns
+a separate, single-screen stack; Android uses its own in-flow headers.
+
+On Liquid Glass iOS, Home keeps a transparent native title and renders its brand
+as a custom leading item. A custom `headerTitle` previously shortened the scroll
+fade and removed the blur behind the logo. Preserve the native title when
+changing the brand or its connection-status replacement.
+
+Both brand states use `BRAND_HEADER_ITEM_IDENTIFIER` from
+[`CompactBrandTitle.tsx`](../../apps/mobile/src/components/CompactBrandTitle.tsx).
+The native-stack and react-native-screens patches forward custom item identifiers
+to `UIBarButtonItem.identifier`, just as they do for native buttons and menus.
+UIKit otherwise matches transition items using their position and content, so
+the brand needs an explicit identity separate from navigation controls. Connection
+status changes retain that identity. See [Apple's identifier documentation](https://developer.apple.com/documentation/uikit/uibarbuttonitem/identifier).
+
+The react-native-screens patch caches leading, trailing, and center item groups
+independently. A button can belong to only one group: constructing another group
+with the same button removes it from the previous one. Unrelated menu updates
+must therefore preserve the other groups while UIKit may be animating them.
+Each cache includes the owning header config, its item values, and custom native
+item identities, so changed content or remounted event emitters still rebuild.
+
+Custom header identifiers require native code generation and a new mobile build;
+an over-the-air JavaScript update alone is insufficient. The Android view manager
+implements the generated identifier setter as a no-op because this behavior is
+specific to iOS 26 and later.

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -132,6 +132,7 @@ already dispatch.
 ## Related
 
 - [Workspace layout](./workspace-layout.md), [Glossary](./glossary.md)
+- [Mobile navigation headers](./mobile-navigation.md)
 - [Remote environments](./remote.md), [Server updates](./server-updates.md)
 - [Resource telemetry](./resource-telemetry.md)
 - [Product analytics](./product-analytics.md)

--- a/patches/@react-navigation%2Fnative-stack@7.17.6.patch
+++ b/patches/@react-navigation%2Fnative-stack@7.17.6.patch
@@ -1,107 +1,5 @@
-diff --git a/lib/module/views/useHeaderConfigProps.js b/lib/module/views/useHeaderConfigProps.js
-index 0b75c70b4e0d233ee3b5faaf9cfbc40d4f8ed494..eb174e3fde91a7783f132b3fb16b01175ec19220 100644
---- a/lib/module/views/useHeaderConfigProps.js
-+++ b/lib/module/views/useHeaderConfigProps.js
-@@ -19,6 +19,12 @@
-       }
-       return item;
-     }
-+    if (item.type === 'mailSearchToolbar') {
-+      return {
-+        ...item,
-+        index
-+      };
-+    }
-     if (item.type === 'button' || item.type === 'menu') {
-       if (item.type === 'menu' && item.menu == null) {
-         throw new Error(`Menu item must have a 'menu' property defined: ${JSON.stringify(item)}`);
-@@ -79,7 +85,7 @@
-       }
-       return processedItem;
-     }
--    throw new Error(`Invalid item type: ${JSON.stringify(item)}. Valid types are 'button', 'menu', 'custom' and 'spacing'.`);
-+    throw new Error(`Invalid item type: ${JSON.stringify(item)}. Valid types are 'button', 'menu', 'custom', 'spacing' and 'mailSearchToolbar'.`);
-   }).filter(item => item != null);
- };
- const transformIcon = icon => {
-@@ -158,8 +164,12 @@
-   headerBack,
-   route,
-   title,
-+  unstable_headerCenterItems: headerCenterItems,
-   unstable_headerLeftItems: headerLeftItems,
--  unstable_headerRightItems: headerRightItems
-+  unstable_headerRightItems: headerRightItems,
-+  unstable_headerSubtitle: headerSubtitle,
-+  unstable_headerToolbarItems: headerToolbarItems,
-+  unstable_navigationItemStyle: navigationItemStyle
- }) {
-   const {
-     direction
-@@ -255,6 +265,10 @@
-     tintColor,
-     canGoBack
-   });
-+  const centerItems = headerCenterItems?.({
-+    tintColor,
-+    canGoBack
-+  });
-   let rightItems = headerRightItems?.({
-     tintColor,
-     canGoBack
-@@ -264,6 +278,10 @@
-     // So we need to reverse them here to match the order
-     rightItems = [...rightItems].reverse();
-   }
-+  const toolbarItems = headerToolbarItems?.({
-+    tintColor,
-+    canGoBack
-+  });
-   const children = /*#__PURE__*/_jsxs(_Fragment, {
-     children: [Platform.OS === 'ios' ? /*#__PURE__*/_jsxs(_Fragment, {
-       children: [leftItems ? leftItems.map((item, index) => {
-@@ -278,7 +296,15 @@
-         return null;
-       }) : headerLeftElement != null ? /*#__PURE__*/_jsx(ScreenStackHeaderLeftView, {
-         children: headerLeftElement
--      }) : null, headerTitleElement != null ? /*#__PURE__*/_jsx(ScreenStackHeaderCenterView, {
-+      }) : null, centerItems ? centerItems.map((item, index) => {
-+        if (item.type === 'custom') {
-+          return /*#__PURE__*/_jsx(ScreenStackHeaderCenterView, {
-+            hidesSharedBackground: item.hidesSharedBackground,
-+            children: item.element
-+          }, index);
-+        }
-+        return null;
-+      }) : headerTitleElement != null ? /*#__PURE__*/_jsx(ScreenStackHeaderCenterView, {
-         children: headerTitleElement
-       }) : null]
-     }) : /*#__PURE__*/_jsxs(_Fragment, {
-@@ -356,6 +382,7 @@
-     largeTitleFontWeight,
-     largeTitleHideShadow: headerLargeTitleShadowVisible === false,
-     title: titleText,
-+    subtitle: headerSubtitle,
-     titleColor,
-     titleFontFamily,
-     titleFontSize,
-@@ -364,9 +391,12 @@
-     disableTopInsetApplication: !headerTopInsetEnabled,
-     translucent: translucent === true,
-     children,
-+    navigationItemStyle,
-+    headerToolbarItems: processBarButtonItems(toolbarItems, colors, fonts),
-+    headerCenterBarButtonItems: processBarButtonItems(centerItems, colors, fonts),
-     headerLeftBarButtonItems: processBarButtonItems(leftItems, colors, fonts),
-     headerRightBarButtonItems: processBarButtonItems(rightItems, colors, fonts),
-     experimental_userInterfaceStyle: dark ? 'dark' : 'light'
-   };
- }
--//# sourceMappingURL=useHeaderConfigProps.js.map
-\ No newline at end of file
-+//# sourceMappingURL=useHeaderConfigProps.js.map
 diff --git a/lib/module/views/NativeStackView.native.js b/lib/module/views/NativeStackView.native.js
-index c342e90..5d3e440 100644
+index c342e90bffde9ad5044b6167bdde2e19be219270..5d3e4407aa1bb68b873cf164adf5a9f0b487bb0b 100644
 --- a/lib/module/views/NativeStackView.native.js
 +++ b/lib/module/views/NativeStackView.native.js
 @@ -370,6 +370,17 @@ export function NativeStackView({
@@ -122,3 +20,172 @@ index c342e90..5d3e440 100644
        children: state.routes.concat(state.preloadedRoutes).map((route, index) => {
          const descriptor = descriptors[route.key] ?? preloadedDescriptors[route.key];
          const isFocused = state.index === index;
+diff --git a/lib/module/views/useHeaderConfigProps.js b/lib/module/views/useHeaderConfigProps.js
+index 9c21aa48cb580704aa17e59d9cdadcc612a1e4ff..a1b3a38368c5ef2257570f382e87df5d6f55b11e 100644
+--- a/lib/module/views/useHeaderConfigProps.js
++++ b/lib/module/views/useHeaderConfigProps.js
+@@ -19,6 +19,12 @@ const processBarButtonItems = (items, colors, fonts) => {
+       }
+       return item;
+     }
++    if (item.type === 'mailSearchToolbar') {
++      return {
++        ...item,
++        index
++      };
++    }
+     if (item.type === 'button' || item.type === 'menu') {
+       if (item.type === 'menu' && item.menu == null) {
+         throw new Error(`Menu item must have a 'menu' property defined: ${JSON.stringify(item)}`);
+@@ -79,7 +85,7 @@ const processBarButtonItems = (items, colors, fonts) => {
+       }
+       return processedItem;
+     }
+-    throw new Error(`Invalid item type: ${JSON.stringify(item)}. Valid types are 'button', 'menu', 'custom' and 'spacing'.`);
++    throw new Error(`Invalid item type: ${JSON.stringify(item)}. Valid types are 'button', 'menu', 'custom', 'spacing' and 'mailSearchToolbar'.`);
+   }).filter(item => item != null);
+ };
+ const transformIcon = icon => {
+@@ -158,8 +164,12 @@ export function useHeaderConfigProps({
+   headerBack,
+   route,
+   title,
++  unstable_headerCenterItems: headerCenterItems,
+   unstable_headerLeftItems: headerLeftItems,
+-  unstable_headerRightItems: headerRightItems
++  unstable_headerRightItems: headerRightItems,
++  unstable_headerSubtitle: headerSubtitle,
++  unstable_headerToolbarItems: headerToolbarItems,
++  unstable_navigationItemStyle: navigationItemStyle
+ }) {
+   const {
+     direction
+@@ -255,6 +265,10 @@ export function useHeaderConfigProps({
+     tintColor,
+     canGoBack
+   });
++  const centerItems = headerCenterItems?.({
++    tintColor,
++    canGoBack
++  });
+   let rightItems = headerRightItems?.({
+     tintColor,
+     canGoBack
+@@ -264,6 +278,10 @@ export function useHeaderConfigProps({
+     // So we need to reverse them here to match the order
+     rightItems = [...rightItems].reverse();
+   }
++  const toolbarItems = headerToolbarItems?.({
++    tintColor,
++    canGoBack
++  });
+   const children = /*#__PURE__*/_jsxs(_Fragment, {
+     children: [Platform.OS === 'ios' ? /*#__PURE__*/_jsxs(_Fragment, {
+       children: [leftItems ? leftItems.map((item, index) => {
+@@ -272,13 +290,23 @@ export function useHeaderConfigProps({
+           // eslint-disable-next-line @eslint-react/no-array-index-key
+           , {
+             hidesSharedBackground: item.hidesSharedBackground,
++            identifier: item.identifier,
+             children: item.element
+           }, index);
+         }
+         return null;
+       }) : headerLeftElement != null ? /*#__PURE__*/_jsx(ScreenStackHeaderLeftView, {
+         children: headerLeftElement
+-      }) : null, headerTitleElement != null ? /*#__PURE__*/_jsx(ScreenStackHeaderCenterView, {
++      }) : null, centerItems ? centerItems.map((item, index) => {
++        if (item.type === 'custom') {
++          return /*#__PURE__*/_jsx(ScreenStackHeaderCenterView, {
++            hidesSharedBackground: item.hidesSharedBackground,
++            identifier: item.identifier,
++            children: item.element
++          }, index);
++        }
++        return null;
++      }) : headerTitleElement != null ? /*#__PURE__*/_jsx(ScreenStackHeaderCenterView, {
+         children: headerTitleElement
+       }) : null]
+     }) : /*#__PURE__*/_jsxs(_Fragment, {
+@@ -321,6 +349,7 @@ export function useHeaderConfigProps({
+         // eslint-disable-next-line @eslint-react/no-array-index-key
+         , {
+           hidesSharedBackground: item.hidesSharedBackground,
++          identifier: item.identifier,
+           children: item.element
+         }, index);
+       }
+@@ -356,6 +385,7 @@ export function useHeaderConfigProps({
+     largeTitleFontWeight,
+     largeTitleHideShadow: headerLargeTitleShadowVisible === false,
+     title: titleText,
++    subtitle: headerSubtitle,
+     titleColor,
+     titleFontFamily,
+     titleFontSize,
+@@ -364,6 +394,9 @@ export function useHeaderConfigProps({
+     disableTopInsetApplication: !headerTopInsetEnabled,
+     translucent: translucent === true,
+     children,
++    navigationItemStyle,
++    headerToolbarItems: processBarButtonItems(toolbarItems, colors, fonts),
++    headerCenterBarButtonItems: processBarButtonItems(centerItems, colors, fonts),
+     headerLeftBarButtonItems: processBarButtonItems(leftItems, colors, fonts),
+     headerRightBarButtonItems: processBarButtonItems(rightItems, colors, fonts),
+     experimental_userInterfaceStyle: dark ? 'dark' : 'light'
+diff --git a/lib/typescript/src/types.d.ts b/lib/typescript/src/types.d.ts
+index 2f1351a89f0f2e67e854dc81e392198326b71834..ccf8556911fa1fa17588f06b56edb2151a712bf0 100644
+--- a/lib/typescript/src/types.d.ts
++++ b/lib/typescript/src/types.d.ts
+@@ -1091,6 +1091,13 @@ export type NativeStackHeaderItemSpacing = {
+  */
+ export type NativeStackHeaderItemCustom = {
+     type: 'custom';
++    /**
++     * An identifier used to match items across transitions.
++     * Only available from iOS 26.0 and later.
++     *
++     * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/identifier
++     */
++    identifier?: string;
+     /**
+      * A React Element to display as the item.
+      */
+diff --git a/src/types.tsx b/src/types.tsx
+index 7488b1cf20afe36b5c585fbfcd369471fdb6ab8d..f4bd78e48c687024ba84e998fac79e9eb16f1a80 100644
+--- a/src/types.tsx
++++ b/src/types.tsx
+@@ -1156,6 +1156,13 @@ export type NativeStackHeaderItemSpacing = {
+  */
+ export type NativeStackHeaderItemCustom = {
+   type: 'custom';
++  /**
++   * An identifier used to match items across transitions.
++   * Only available from iOS 26.0 and later.
++   *
++   * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/identifier
++   */
++  identifier?: string;
+   /**
+    * A React Element to display as the item.
+    */
+diff --git a/src/views/useHeaderConfigProps.tsx b/src/views/useHeaderConfigProps.tsx
+index 3f3fff405048b3c2250afbe99dd7f35cecb9a6d5..bb062b898cfa77f8c02f951dc9d81b51672d7d0e 100644
+--- a/src/views/useHeaderConfigProps.tsx
++++ b/src/views/useHeaderConfigProps.tsx
+@@ -397,6 +397,7 @@ export function useHeaderConfigProps({
+                     // eslint-disable-next-line @eslint-react/no-array-index-key
+                     key={index}
+                     hidesSharedBackground={item.hidesSharedBackground}
++                    identifier={item.identifier}
+                   >
+                     {item.element}
+                   </ScreenStackHeaderLeftView>
+@@ -471,6 +472,7 @@ export function useHeaderConfigProps({
+                 // eslint-disable-next-line @eslint-react/no-array-index-key
+                 key={index}
+                 hidesSharedBackground={item.hidesSharedBackground}
++                identifier={item.identifier}
+               >
+                 {item.element}
+               </ScreenStackHeaderRightView>

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -37,6 +37,23 @@ index 03d8d9f3a5c403c93282d53cbacf1a339e877e85..54d5eabc6c8a408e711a5be97286fdbb
      override fun setTitleFontFamily(
          config: ScreenStackHeaderConfig,
          titleFontFamily: String?,
+diff --git a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt
+index 64f14f0c5ade16eb9519b8780d4ce013f88fbd3a..6cb1d69f97a95759c662a6006a9626925d9fefd9 100644
+--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt
++++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderSubviewManager.kt
+@@ -47,6 +47,12 @@ class ScreenStackHeaderSubviewManager :
+         Log.w("[RNScreens]", "hidesSharedBackground prop is not available on Android")
+     }
+ 
++    // Bar button transition identifiers only apply on iOS.
++    override fun setIdentifier(
++        view: ScreenStackHeaderSubview,
++        identifier: String?,
++    ) = Unit
++
+     // synchronousShadowStateUpdatesEnabled is not available on Android atm,
+     // however we must override their setters
+     override fun setSynchronousShadowStateUpdatesEnabled(
 diff --git a/ios/RNSBarButtonItem.h b/ios/RNSBarButtonItem.h
 index ea5325ea8d17b1ddfa790ff8dab48ce83142d4d3..acd2fd7ceb7162ed300abc4d3c9f0c24f4d63898 100644
 --- a/ios/RNSBarButtonItem.h
@@ -140,10 +157,10 @@ index 919b984edc9f91ee9ac26faf257d8a721e26457c..5bb0cd6736ed6bc51db57e2a9326f758
  
  NS_ASSUME_NONNULL_END
 diff --git a/ios/RNSScreenStackHeaderConfig.mm b/ios/RNSScreenStackHeaderConfig.mm
-index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb2199dcbd58 100644
+index 5970e3e3a624b9498b8dedfc16831df03a274d0c..c23776376110b6eda77072b134da29428f4bcba3 100644
 --- a/ios/RNSScreenStackHeaderConfig.mm
 +++ b/ios/RNSScreenStackHeaderConfig.mm
-@@ -25,11 +25,33 @@
+@@ -25,11 +25,46 @@
  #import "RNSSearchBar.h"
  #import "UINavigationBar+RNSUtility.h"
  
@@ -153,10 +170,23 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  
  static const NSNumber *const DEFAULT_TITLE_FONT_SIZE = @17;
 +
-+// Keys for the last-applied JS bar button configs, associated with the
-+// navigation item so unrelated header updates (title, subtitle, tint) don't
-+// recreate the native buttons they configure.
-+static char RNSAppliedHeaderBarButtonConfigsKey;
++#if !TARGET_OS_TV
++// Each placement keeps its own cache so changes to one side do not move live
++// items on the other side into new groups during a navigation transition.
++static char RNSAppliedLeadingHeaderItemsKey;
++static char RNSAppliedTrailingHeaderItemsKey;
++static char RNSAppliedCenterHeaderItemsKey;
++
++// Records a placement's owner and contents, returning whether they changed.
++static BOOL RNSUpdateHeaderItemsCache(UINavigationItem *navitem, const void *key, NSArray *itemsKey)
++{
++  if ([objc_getAssociatedObject(navitem, key) isEqual:itemsKey]) {
++    return NO;
++  }
++  objc_setAssociatedObject(navitem, key, itemsKey, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
++  return YES;
++}
++#endif
 +static char RNSAppliedToolbarConfigsKey;
  static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
  
@@ -177,7 +207,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  @interface RCTImageLoader (Private)
  - (id<RCTImageCache>)imageCache;
  @end
-@@ -47,6 +69,9 @@ + (BOOL)rnscreens_isBlankOrNull:(NSString *)string
+@@ -47,6 +82,9 @@ + (BOOL)rnscreens_isBlankOrNull:(NSString *)string
  @end
  
  @interface RNSScreenStackHeaderConfig () <RCTMountingTransactionObserving>
@@ -187,7 +217,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  @end
  
  @implementation RNSScreenStackHeaderConfig {
-@@ -81,6 +106,7 @@ - (void)initProps
+@@ -81,6 +119,7 @@ - (void)initProps
    self.hidden = YES;
    _reactSubviews = [NSMutableArray new];
    _backTitleVisible = YES;
@@ -195,7 +225,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
    _blurEffect = RNSBlurEffectStyleNone;
  }
  
-@@ -496,6 +522,10 @@ + (void)updateViewController:(UIViewController *)vc
+@@ -496,6 +535,10 @@ + (void)updateViewController:(UIViewController *)vc
  
    if (shouldHide) {
      navitem.title = config.title;
@@ -206,7 +236,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  
      // Setting navigation bar visibility is split to mitigate iOS 26 bug with bar button items.
      [navctr setNavigationBarHidden:YES animated:animated];
-@@ -512,11 +542,19 @@ + (void)updateViewController:(UIViewController *)vc
+@@ -512,11 +555,19 @@ + (void)updateViewController:(UIViewController *)vc
    }
    navitem.largeTitleDisplayMode =
        config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
@@ -226,19 +256,19 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  
  // appearance does not apply to the tvOS so we need to use lagacy customization
  #if TARGET_OS_TV
-@@ -550,31 +588,25 @@ + (void)updateViewController:(UIViewController *)vc
+@@ -548,8 +599,6 @@ + (void)updateViewController:(UIViewController *)vc
+   navitem.leftItemsSupplementBackButton = config.backButtonInCustomView;
+ #endif
    navitem.titleView = nil;
 -  navitem.leftBarButtonItems = nil;
 -  navitem.rightBarButtonItems = nil;
--
-+
+ 
  #if !TARGET_OS_TV
    // We want to set navitem.searchController to nil only if we are sure
-   // that we are removing the search bar from the header.
+@@ -557,22 +606,18 @@ + (void)updateViewController:(UIViewController *)vc
    bool searchBarPresent = false;
  #endif /* !TARGET_OS_TV */
--
-+
+ 
 +  NSMutableArray<UIBarButtonItem *> *subviewLeftItems = [NSMutableArray array];
 +  NSMutableArray<UIBarButtonItem *> *subviewRightItems = [NSMutableArray array];
    for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
@@ -262,9 +292,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
          break;
        }
        case RNSScreenStackHeaderSubviewTypeCenter:
-       case RNSScreenStackHeaderSubviewTypeTitle: {
-         navitem.titleView = subview;
-@@ -637,10 +669,467 @@ + (void)updateViewController:(UIViewController *)vc
+@@ -637,10 +682,453 @@ + (void)updateViewController:(UIViewController *)vc
    // This assignment should be done after `navitem.titleView = ...` assignment (iOS 16.0 bug).
    // See: https://github.com/software-mansion/react-native-screens/issues/1570 (comments)
    navitem.title = config.title;
@@ -272,9 +300,6 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
 -                                                withCurrentItems:navitem.leftBarButtonItems];
 -  navitem.rightBarButtonItems = [config barButtonItemsFromConfigs:config.headerRightBarButtonItems
 -                                                 withCurrentItems:navitem.rightBarButtonItems];
-+  NSArray *headerLeftConfigs = config.headerLeftBarButtonItems ?: @[];
-+  NSArray *headerRightConfigs = config.headerRightBarButtonItems ?: @[];
-+  NSArray *headerCenterConfigs = config.headerCenterBarButtonItems ?: @[];
 +  // Retain the config in the key so its address cannot be reused while cached.
 +  // Items capture this config's event emitter in their press handlers, so a
 +  // remounted header-config view with value-equal configs must still rebuild
@@ -283,59 +308,48 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
 +  // subview. Include those native identities in the key so React-backed
 +  // items can use the same cache without reusing a group after its view was
 +  // replaced.
-+  NSArray *headerItemsKey = @[
-+    config,
-+    headerLeftConfigs,
-+    headerRightConfigs,
-+    headerCenterConfigs,
-+    subviewLeftItems,
-+    subviewRightItems,
-+  ];
-+  // Rebuilding bar button items creates brand-new native buttons (glass
-+  // UIButton custom views on iOS 26). Replacing them while UIKit animates an
-+  // existing one (menu capsule morph, push/pop glass transitions) strands the
-+  // animation overlay — a stuck expanded capsule or an unmasked square back
-+  // button. When both the JS configs and React-backed item identities are
-+  // unchanged, keep the already-applied item groups. Item groups are only
-+  // available from iOS 16, so older platforms keep the legacy rebuild path.
-+  BOOL canReuseHeaderBarButtonItems = NO;
++  // A bar button item can belong to only one group. Even if the item itself
++  // is reused, constructing a new group removes it from the old group that
++  // UIKit may still be animating. Preserve each unchanged placement's group,
++  // including the empty leading group beside the system back button.
 +#if !TARGET_OS_TV
 +  if (@available(iOS 16.0, *)) {
-+    canReuseHeaderBarButtonItems = YES;
-+  }
++    NSArray *headerLeftConfigs = config.headerLeftBarButtonItems ?: @[];
++    NSArray *headerRightConfigs = config.headerRightBarButtonItems ?: @[];
++    NSArray *headerCenterConfigs = config.headerCenterBarButtonItems ?: @[];
++    if (RNSUpdateHeaderItemsCache(
++            navitem, &RNSAppliedLeadingHeaderItemsKey, @[ config, headerLeftConfigs, subviewLeftItems ])) {
++      NSArray *items = [config barButtonItemsFromConfigs:config.headerLeftBarButtonItems
++                                      withCurrentItems:subviewLeftItems
++                                        navigationItem:navitem];
++      navitem.leadingItemGroups = [config barButtonItemGroupsFromItems:items];
++    }
++    if (RNSUpdateHeaderItemsCache(
++            navitem, &RNSAppliedTrailingHeaderItemsKey, @[ config, headerRightConfigs, subviewRightItems ])) {
++      NSArray *items = [config barButtonItemsFromConfigs:config.headerRightBarButtonItems
++                                      withCurrentItems:subviewRightItems
++                                        navigationItem:navitem];
++      navitem.trailingItemGroups = [config barButtonItemGroupsFromItems:items];
++    }
++    if (@available(iOS 26.0, *)) {
++      if (RNSUpdateHeaderItemsCache(navitem, &RNSAppliedCenterHeaderItemsKey, @[ config, headerCenterConfigs ])) {
++        NSArray *items = [config barButtonItemsFromConfigs:config.headerCenterBarButtonItems
++                                        withCurrentItems:@[]
++                                          navigationItem:navitem];
++        navitem.centerItemGroups = [config barButtonItemGroupsFromItems:items];
++      }
++    }
++  } else
 +#endif
-+  BOOL reuseHeaderBarButtonItems = canReuseHeaderBarButtonItems &&
-+      [objc_getAssociatedObject(navitem, &RNSAppliedHeaderBarButtonConfigsKey) isEqual:headerItemsKey];
-+  if (!reuseHeaderBarButtonItems) {
++  {
 +    NSArray<UIBarButtonItem *> *leftBarButtonItems = [config barButtonItemsFromConfigs:config.headerLeftBarButtonItems
 +                                                                      withCurrentItems:subviewLeftItems
 +                                                                        navigationItem:navitem];
 +    NSArray<UIBarButtonItem *> *rightBarButtonItems = [config barButtonItemsFromConfigs:config.headerRightBarButtonItems
 +                                                                       withCurrentItems:subviewRightItems
 +                                                                         navigationItem:navitem];
-+    NSArray<UIBarButtonItem *> *centerBarButtonItems = [config barButtonItemsFromConfigs:config.headerCenterBarButtonItems
-+                                                                        withCurrentItems:@[]
-+                                                                          navigationItem:navitem];
-+#if !TARGET_OS_TV
-+    if (@available(iOS 16.0, *)) {
-+      navitem.leadingItemGroups = [config barButtonItemGroupsFromItems:leftBarButtonItems];
-+      navitem.trailingItemGroups = [config barButtonItemGroupsFromItems:rightBarButtonItems];
-+      if (@available(iOS 26.0, *)) {
-+        navitem.centerItemGroups = [config barButtonItemGroupsFromItems:centerBarButtonItems];
-+      }
-+    } else {
-+      navitem.leftBarButtonItems = leftBarButtonItems;
-+      navitem.rightBarButtonItems = rightBarButtonItems;
-+    }
-+#else
 +    navitem.leftBarButtonItems = leftBarButtonItems;
 +    navitem.rightBarButtonItems = rightBarButtonItems;
-+#endif
-+    objc_setAssociatedObject(
-+        navitem,
-+        &RNSAppliedHeaderBarButtonConfigsKey,
-+        headerItemsKey,
-+        OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 +  }
 +  NSDictionary<NSString *, id> *mailSearchToolbarConfig = nil;
 +  for (NSDictionary<NSString *, id> *toolbarConfig in config.headerToolbarItems) {
@@ -736,7 +750,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  
    // Setting navigation bar visibility is split to mitigate iOS 26 bug with bar button items
    // (setting nav bar visibility should be done after `navitem.*BarButtonItems`).
-@@ -773,6 +1262,7 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
+@@ -773,6 +1261,7 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
  
  - (NSArray<UIBarButtonItem *> *)barButtonItemsFromConfigs:(NSArray<NSDictionary<NSString *, id> *> *)dicts
                                           withCurrentItems:(NSArray<UIBarButtonItem *> *)currentItems
@@ -744,7 +758,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  {
    if (dicts.count == 0) {
      return currentItems;
-@@ -781,7 +1271,197 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
+@@ -781,7 +1270,197 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
    [items addObjectsFromArray:currentItems];
    for (NSUInteger i = 0; i < dicts.count; i++) {
      NSDictionary *dict = dicts[i];
@@ -943,7 +957,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
        RNSBarButtonItem *item = [[RNSBarButtonItem alloc] initWithConfig:dict
            action:^(NSString *buttonId) {
              auto eventEmitter = std::static_pointer_cast<const facebook::react::RNSScreenStackHeaderConfigEventEmitter>(
-@@ -803,19 +1483,23 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
+@@ -803,19 +1482,23 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
            }
            imageLoader:_imageLoader];
        NSNumber *index = dict[@"index"];
@@ -973,7 +987,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
          [items insertObject:item atIndex:index.integerValue];
        } else {
          [items addObject:item];
-@@ -825,6 +1509,47 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
+@@ -825,6 +1508,47 @@ - (void)applySemanticContentAttributeIfNeededToNavCtrl:(UINavigationController *
    return items;
  }
  
@@ -1021,7 +1035,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  RNS_IGNORE_SUPER_CALL_BEGIN
  - (void)insertReactSubview:(RNSScreenStackHeaderSubview *)subview atIndex:(NSInteger)atIndex
  {
-@@ -1013,6 +1738,8 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
+@@ -1013,6 +1737,8 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
    }
  
    _title = RCTNSStringFromStringNilIfEmpty(newScreenProps.title);
@@ -1030,7 +1044,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
    if (newScreenProps.titleFontFamily != oldScreenProps.titleFontFamily) {
      _titleFontFamily = RCTNSStringFromStringNilIfEmpty(newScreenProps.titleFontFamily);
    }
-@@ -1038,6 +1765,7 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
+@@ -1038,6 +1764,7 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
    _disableBackButtonMenu = newScreenProps.disableBackButtonMenu;
    _backButtonDisplayMode =
        [RNSConvert UINavigationItemBackButtonDisplayModeFromCppEquivalent:newScreenProps.backButtonDisplayMode];
@@ -1038,7 +1052,7 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
  
    if (newScreenProps.userInterfaceStyle != oldScreenProps.userInterfaceStyle) {
      _userInterfaceStyle = [RNSConvert UIUserInterfaceStyleFromCppEquivalent:newScreenProps.userInterfaceStyle];
-@@ -1084,6 +1812,30 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
+@@ -1084,6 +1811,30 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
      _headerRightBarButtonItems = array;
    }
  
@@ -1069,6 +1083,65 @@ index 5970e3e3a624b9498b8dedfc16831df03a274d0c..5ebff085788d813f1139eb6f9129fb21
    [self updateViewControllerIfNeeded];
  
    if (needsNavigationControllerLayout) {
+diff --git a/ios/RNSScreenStackHeaderSubview.mm b/ios/RNSScreenStackHeaderSubview.mm
+index 15c0da5242372c4be833a1403663bd1dfa244362..d1f838cdfd831abd6397be6fe61e00a50f87bea3 100644
+--- a/ios/RNSScreenStackHeaderSubview.mm
++++ b/ios/RNSScreenStackHeaderSubview.mm
+@@ -21,6 +21,7 @@ @implementation RNSScreenStackHeaderSubview {
+   // This is a strong reference to UIBarButtonItem which creates a retain cycle.
+   // The cycle is cleared via `invalidateUIBarButtonItem` method, called by `invalidate` callback.
+   UIBarButtonItem *_barButtonItem;
++  NSString *_barButtonItemIdentifier;
+   BOOL _hidesSharedBackground;
+ }
+ 
+@@ -128,6 +129,7 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
+   const auto &newHeaderSubviewProps = *std::static_pointer_cast<const react::RNSScreenStackHeaderSubviewProps>(props);
+ 
+   [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
++  [self setBarButtonItemIdentifier:RCTNSStringFromStringNilIfEmpty(newHeaderSubviewProps.identifier)];
+   [self setHidesSharedBackground:newHeaderSubviewProps.hidesSharedBackground];
+   [self setSynchronousShadowStateUpdatesEnabled:newHeaderSubviewProps.synchronousShadowStateUpdatesEnabled];
+   [super updateProps:props oldProps:oldProps];
+@@ -281,7 +283,14 @@ - (void)configureBarButtonItem
+ #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+   if (@available(iOS 26.0, *)) {
+     if (_barButtonItem != nil) {
+-      [_barButtonItem setHidesSharedBackground:_hidesSharedBackground];
++      NSString *currentIdentifier = _barButtonItem.identifier;
++      if (currentIdentifier != _barButtonItemIdentifier &&
++          ![currentIdentifier isEqualToString:_barButtonItemIdentifier]) {
++        _barButtonItem.identifier = _barButtonItemIdentifier;
++      }
++      if (_barButtonItem.hidesSharedBackground != _hidesSharedBackground) {
++        _barButtonItem.hidesSharedBackground = _hidesSharedBackground;
++      }
+     }
+   }
+ #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+@@ -289,10 +298,22 @@ - (void)configureBarButtonItem
+ 
+ - (void)setHidesSharedBackground:(BOOL)hidesSharedBackground
+ {
++  if (_hidesSharedBackground == hidesSharedBackground) {
++    return;
++  }
+   _hidesSharedBackground = hidesSharedBackground;
+   [self configureBarButtonItem];
+ }
+ 
++- (void)setBarButtonItemIdentifier:(nullable NSString *)identifier
++{
++  if (_barButtonItemIdentifier == identifier || [_barButtonItemIdentifier isEqualToString:identifier]) {
++    return;
++  }
++  _barButtonItemIdentifier = [identifier copy];
++  [self configureBarButtonItem];
++}
++
+ #pragma mark - Dynamic frameworks support
+ 
+ // Needed because of this: https://github.com/facebook/react-native/pull/37274
 diff --git a/lib/commonjs/components/ScreenStackHeaderConfig.js b/lib/commonjs/components/ScreenStackHeaderConfig.js
 index 16b979bb3dfb41ff247403f1632c300a9a60d549..01415d4cba66086a8d8e5af728f809aee5190d91 100644
 --- a/lib/commonjs/components/ScreenStackHeaderConfig.js
@@ -1347,8 +1420,20 @@ index b7568ecfebd4f4420f2a8d3fec5184d7fc728dd1..41ca1f273f0175929e73105faa463978
      onPressHeaderBarButtonItem?: CT.DirectEventHandler<OnPressHeaderBarButtonItemEvent> | undefined;
      onPressHeaderBarButtonMenuItem?: CT.DirectEventHandler<OnPressHeaderBarButtonMenuItemEvent> | undefined;
      synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+diff --git a/lib/typescript/fabric/ScreenStackHeaderSubviewNativeComponent.d.ts b/lib/typescript/fabric/ScreenStackHeaderSubviewNativeComponent.d.ts
+index 1da0ea65ede8082de83884dd38c7c46b1988db67..1168b5d031efd3f796bb4448c1128e14de70f3fa 100644
+--- a/lib/typescript/fabric/ScreenStackHeaderSubviewNativeComponent.d.ts
++++ b/lib/typescript/fabric/ScreenStackHeaderSubviewNativeComponent.d.ts
+@@ -3,6 +3,7 @@ export type HeaderSubviewTypes = 'back' | 'right' | 'left' | 'title' | 'center'
+ export interface NativeProps extends ViewProps {
+     type?: CT.WithDefault<HeaderSubviewTypes, 'left'>;
+     hidesSharedBackground?: boolean | undefined;
++    identifier?: string | undefined;
+     synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+ }
+ declare const _default: import("react-native").HostComponent<NativeProps>;
 diff --git a/lib/typescript/types.d.ts b/lib/typescript/types.d.ts
-index 3b384e03891e38e936f370372a682d73440e7ec2..861ffed850e90f27916c427853b503dbe6ee9840 100644
+index 3b384e03891e38e936f370372a682d73440e7ec2..f8ec3b46a92bf20e2845eb5867af5c372215a532 100644
 --- a/lib/typescript/types.d.ts
 +++ b/lib/typescript/types.d.ts
 @@ -10,6 +10,7 @@ export type SearchBarCommands = {
@@ -1422,7 +1507,21 @@ index 3b384e03891e38e936f370372a682d73440e7ec2..861ffed850e90f27916c427853b503db
      /**
       * Allows for setting text color of the title.
       */
-@@ -1001,6 +1044,11 @@ interface SharedHeaderBarButtonItem {
+@@ -963,6 +1006,13 @@ export interface SearchBarProps {
+     shouldShowHintSearchIcon?: boolean | undefined;
+ }
+ export interface ScreenStackHeaderSubviewProps {
++    /**
++     * An identifier used to match this item across navigation bar transitions.
++     * Only applicable to type="right" and type="left" subviews on iOS 26.0 and later.
++     *
++     * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/identifier
++     */
++    identifier?: string | undefined;
+     /**
+      * A boolean value indicating whether the background this item may share with other items in the bar should be hidden.
+      * Only applicable to type="right" and type="left" subviews.
+@@ -1001,6 +1051,11 @@ interface SharedHeaderBarButtonItem {
       * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/style-swift.property
       */
      variant?: 'plain' | 'done' | 'prominent' | undefined;
@@ -1434,7 +1533,7 @@ index 3b384e03891e38e936f370372a682d73440e7ec2..861ffed850e90f27916c427853b503db
      /**
       * The tint color to apply to the item.
       *
-@@ -1145,8 +1193,38 @@ export interface HeaderBarButtonItemWithMenu extends SharedHeaderBarButtonItem {
+@@ -1145,8 +1200,38 @@ export interface HeaderBarButtonItemWithMenu extends SharedHeaderBarButtonItem {
  export interface HeaderBarButtonItemSpacing {
      type: 'spacing';
      spacing: number;
@@ -1688,8 +1787,20 @@ index ba2479de0f49c112470f78c5084059ddd9e2f3e8..8677583a8f8daa4839340467466bfab8
    onPressHeaderBarButtonItem?:
      | CT.DirectEventHandler<OnPressHeaderBarButtonItemEvent>
      | undefined;
+diff --git a/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts b/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+index 9b7832bff0e1c8226ed652d3c90b3a330c6d9b20..17a7eace328f9a825c570a92d549d69195e94568 100644
+--- a/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
++++ b/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+@@ -14,6 +14,7 @@ export type HeaderSubviewTypes =
+ export interface NativeProps extends ViewProps {
+   type?: CT.WithDefault<HeaderSubviewTypes, 'left'>;
+   hidesSharedBackground?: boolean | undefined;
++  identifier?: string | undefined;
+   synchronousShadowStateUpdatesEnabled?: CT.WithDefault<boolean, false>;
+ }
+ 
 diff --git a/src/types.tsx b/src/types.tsx
-index 76a83f3acb6fd3f0af7f027798848b7124100286..9e4499f076f9988e3266df4be7201e131d21242b 100644
+index 76a83f3acb6fd3f0af7f027798848b7124100286..39f0ae8065f4dc99a1571a3fc1cb3398caf03ff7 100644
 --- a/src/types.tsx
 +++ b/src/types.tsx
 @@ -26,6 +26,7 @@ export type SearchBarCommands = {
@@ -1763,7 +1874,21 @@ index 76a83f3acb6fd3f0af7f027798848b7124100286..9e4499f076f9988e3266df4be7201e13
    /**
     * Allows for setting text color of the title.
     */
-@@ -1125,6 +1168,11 @@ interface SharedHeaderBarButtonItem {
+@@ -1084,6 +1127,13 @@ export interface SearchBarProps {
+ }
+ 
+ export interface ScreenStackHeaderSubviewProps {
++  /**
++   * An identifier used to match this item across navigation bar transitions.
++   * Only applicable to type="right" and type="left" subviews on iOS 26.0 and later.
++   *
++   * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/identifier
++   */
++  identifier?: string | undefined;
+   /**
+    * A boolean value indicating whether the background this item may share with other items in the bar should be hidden.
+    * Only applicable to type="right" and type="left" subviews.
+@@ -1125,6 +1175,11 @@ interface SharedHeaderBarButtonItem {
     * Read more: https://developer.apple.com/documentation/uikit/uibarbuttonitem/style-swift.property
     */
    variant?: 'plain' | 'done' | 'prominent' | undefined;
@@ -1775,7 +1900,7 @@ index 76a83f3acb6fd3f0af7f027798848b7124100286..9e4499f076f9988e3266df4be7201e13
    /**
     * The tint color to apply to the item.
     *
-@@ -1279,11 +1327,47 @@ export interface HeaderBarButtonItemWithMenu extends SharedHeaderBarButtonItem {
+@@ -1279,11 +1334,47 @@ export interface HeaderBarButtonItemWithMenu extends SharedHeaderBarButtonItem {
  export interface HeaderBarButtonItemSpacing {
    type: 'spacing';
    spacing: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,13 +88,13 @@ patchedDependencies:
   '@pierre/diffs@1.3.0-beta.10': 7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa
   '@react-native-menu/menu@2.0.0': c7f66d121c726ade4f5c4e1aed11a691e5711d244c544084e289ac26132a0045
   '@react-native/gradle-plugin@0.85.3': c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784
-  '@react-navigation/native-stack@7.17.6': 0365b727005b3a830af80ccbd0b637666cc0338d33ddcb7a25b6de51a21ea027
+  '@react-navigation/native-stack@7.17.6': e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552
   effect@4.0.0-beta.103: af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6
   expo-modules-jsi@56.0.10: 9170f8074ae4e35a0a086e756c8f815794fd3abe51eac67ca3ba02804225ec1f
   react-native-gesture-handler@2.31.2: 808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3
   react-native-keyboard-controller@1.21.13: 20be72c84d74253acdcfefbc6defe36dc396944f1a44cab2bdd0e3cd572ae008
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
-  react-native-screens@4.25.2: b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc
+  react-native-screens@4.25.2: 7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e
 
 importers:
 
@@ -248,7 +248,7 @@ importers:
         version: 7.3.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@react-navigation/native-stack':
         specifier: 7.17.6
-        version: 7.17.6(patch_hash=0365b727005b3a830af80ccbd0b637666cc0338d33ddcb7a25b6de51a21ea027)(e49ba4adb65ddb2cde0c8b8b274b705b)
+        version: 7.17.6(patch_hash=e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552)(8effe605a545f8a17acafbaed58f0e86)
       '@shikijs/core':
         specifier: 4.2.0
         version: 4.2.0
@@ -416,7 +416,7 @@ importers:
         version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-screens:
         specifier: 4.25.2
-        version: 4.25.2(patch_hash=b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 4.25.2(patch_hash=7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-shiki-engine:
         specifier: ^0.3.12
         version: 0.3.12(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -12252,7 +12252,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(b91ff5333bc046aa08fb7484e4e065d6)
+      expo-router: 56.2.11(1d12f8130d9562de288829ccb10045a7)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12328,7 +12328,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(f8b3939b2a15129a8b59814542a58c1b)
+      expo-router: 56.2.11(5cef6fdc582974f4d93d5694873ec814)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12668,7 +12668,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-router: 56.2.11(b91ff5333bc046aa08fb7484e4e065d6)
+      expo-router: 56.2.11(1d12f8130d9562de288829ccb10045a7)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -12683,7 +12683,7 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-router: 56.2.11(f8b3939b2a15129a8b59814542a58c1b)
+      expo-router: 56.2.11(5cef6fdc582974f4d93d5694873ec814)
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
@@ -14268,7 +14268,7 @@ snapshots:
     optionalDependencies:
       '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
-  '@react-navigation/native-stack@7.17.6(patch_hash=0365b727005b3a830af80ccbd0b637666cc0338d33ddcb7a25b6de51a21ea027)(e49ba4adb65ddb2cde0c8b8b274b705b)':
+  '@react-navigation/native-stack@7.17.6(patch_hash=e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552)(8effe605a545f8a17acafbaed58f0e86)':
     dependencies:
       '@react-navigation/elements': 2.9.26(c6a2ad0e2c930f8e3896e77c3ba11bc4)
       '@react-navigation/native': 7.3.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -14276,7 +14276,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(patch_hash=b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(patch_hash=7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -17062,7 +17062,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@56.2.11(b91ff5333bc046aa08fb7484e4e065d6):
+  expo-router@56.2.11(1d12f8130d9562de288829ccb10045a7):
     dependencies:
       '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -17093,7 +17093,7 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-drawer-layout: 4.2.4(05364bd849de538917a7364cc7dee3f5)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.25.2(patch_hash=b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.25.2(patch_hash=7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -17113,7 +17113,7 @@ snapshots:
       - supports-color
     optional: true
 
-  expo-router@56.2.11(f8b3939b2a15129a8b59814542a58c1b):
+  expo-router@56.2.11(5cef6fdc582974f4d93d5694873ec814):
     dependencies:
       '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/metro-runtime': 56.0.15(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
@@ -17144,7 +17144,7 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-native-drawer-layout: 4.2.4(de9b2f2dc96a3557fdc0df187a8417ee)
       react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      react-native-screens: 4.25.2(patch_hash=b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      react-native-screens: 4.25.2(patch_hash=7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -19959,14 +19959,14 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-screens@4.25.2(patch_hash=b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-screens@4.25.2(patch_hash=7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
 
-  react-native-screens@4.25.2(patch_hash=b3d86ac8bf77b40f4112672f92225853bce6faca485a4aeb609a07a70162a5cc)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+  react-native-screens@4.25.2(patch_hash=7474c207dfb4c474b90901a53afa13a8c869a185518d6fbe907686dc4439056e)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-freeze: 1.0.4(react@19.2.6)


### PR DESCRIPTION
## What Changed

This updates the mobile native-stack header patches so iOS can preserve header item identity during transitions. Custom header items now forward an optional `identifier` through React Navigation and react-native-screens, and the workspace brand/connection header item uses a shared identifier so UIKit does not confuse it with navigation controls.

The react-native-screens patch also caches leading, trailing, and center item groups independently to avoid rebuilding unrelated `UIBarButtonItemGroup`s while UIKit is animating them. Internal mobile navigation docs were added to capture the constraints around Liquid Glass headers, custom item identifiers, and native rebuild requirements.

## Why

On iOS, replacing or regrouping bar button items during push/pop or menu transitions can leave visible header artifacts, including stuck glass capsules and malformed back button transitions. Giving the brand item a stable identity and preserving unchanged item groups lets UIKit match the right header elements across route transitions.

This keeps the fix scoped to the mobile native header integration while documenting the behavior so future header changes do not accidentally reintroduce the issue.

## UI Changes

This is a mobile UI behavior fix for iOS header transitions. Before/after screenshots or video should be included with the PR if available from simulator or device verification.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches patched native navigation stack code on iOS 26+ where incorrect header caching or identifiers could cause visible bar glitches; scope is mobile headers only, not auth or data paths.
> 
> **Overview**
> **Stabilizes Liquid Glass iOS navigation headers** by giving the workspace brand a stable UIKit bar-button identity and avoiding unnecessary native header rebuilds during transitions.
> 
> The app exports `BRAND_HEADER_ITEM_IDENTIFIER` (`workspace-brand`) and assigns it to the custom leading brand item in both the static brand header and the connection-status swap, so UIKit can match the same slot across route changes instead of treating it like a new control.
> 
> **Patches** extend `@react-navigation/native-stack` and `react-native-screens` to forward optional `identifier` on custom header subviews into `UIBarButtonItem.identifier`, and to cache leading, trailing, and center `UIBarButtonItemGroup`s separately so unrelated header updates do not regroup items UIKit may still be animating. New internals doc [`mobile-navigation.md`](docs/internals/mobile-navigation.md) records Liquid Glass header constraints and notes that identifiers require a native rebuild, not OTA JS alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5752498e07bcd6dda9e297421984fed2d7753ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize iOS header item transitions via `BRAND_HEADER_ITEM_IDENTIFIER` and `react-native-screens` caching
> - Adds exported constant `BRAND_HEADER_ITEM_IDENTIFIER` ("workspace-brand") in [CompactBrandTitle.tsx](https://github.com/pingdotgg/t3code/pull/8607/files#diff-9008a2fcd464d4becff4c056a0518de19fc4835d6145099fd41e722900eb7054) and assigns it to the custom header item in `renderCompactBrandHeaderItems` and `getConnectionAwareBrandHeaderOptions` in [WorkspaceConnectionTitle.tsx](https://github.com/pingdotgg/t3code/pull/8607/files#diff-9639ae6af617b37a8d0fc59b72b49dc2c4f436628bba50d5d289078200b9b3c4)
> - Patches `@react-navigation/native-stack` to propagate an `identifier` field on custom header items through `useHeaderConfigProps` to native left/right/center header subviews, emit a navigator-level `finishTransitioning` event, and support custom center header items
> - Patches `react-native-screens` so iOS caches and reuses `UIBarButtonItem` groups per placement (leading/trailing/center) keyed by config and item values, avoiding recreation during transitions; on iOS 26+ forwards `identifier` to `UIBarButtonItem.identifier`; Android accepts the `identifier` prop as a no-op
> - Documents the navigation header architecture and identifier usage in [mobile-navigation.md](https://github.com/pingdotgg/t3code/pull/8607/files#diff-dd38c6d3af8e9869be3116760816f0095c3920741ce6b13d62e245150fe1dd17)
> - Behavioral Change: iOS header item rendering now relies on cached bar button item groups; on iOS 16+ uses `leadingItemGroups`/`trailingItemGroups` and on iOS 26+ uses `centerItemGroups`, with fallback to `leftBarButtonItems`/`rightBarButtonItems` on older platforms. The `finishTransitioning` event and custom center header item support are new native-stack behaviors introduced by the patch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5752498.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->