### PR TITLE
chore: vouch ryanrhughes

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -48,6 +48,7 @@ github:PollyGlot
 github:RakshithBhat03
 github:realAhmedRoach
 github:Rishet11
+github:ryanrhughes
 github:saphid
 github:sethwebster
 github:shiroyasha9


### PR DESCRIPTION
Ryan Hughes authored [#8569](https://github.com/pingdotgg/t3code/pull/8569), but `ryanrhughes` is not in the trusted contributor list. Add the account so future PRs use the vouched workflow.

Validation:
- `git diff --check origin/main...HEAD`
- Verified one `github:ryanrhughes` entry and case-insensitive alphabetical order

Made by GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line trust-list update with no runtime or security logic changes.
> 
> **Overview**
> Adds **`github:ryanrhughes`** to `.github/VOUCHED.td` so the vouch workflow treats that account as a trusted external contributor (alphabetically between `Rishet11` and `saphid`).
> 
> This follows their authorship of an earlier PR and lets future contributions from that user skip the “not yet trusted” vouch path used by `pr-vouch.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d750d938e2caa737e06ebc7ef9483ce6896c3c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `github:ryanrhughes` to `VOUCHED.td`
> Adds the GitHub handle `ryanrhughes` to the vouched users list in [VOUCHED.td](https://github.com/pingdotgg/t3code/pull/8613/files#diff-98d74b85391a94d09bfa48e57f8d6c673093c12dde140f21c9e7d01153e9cab0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d750d93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->