### PR TITLE
feat(codex): surface active goals in thread status

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -55,6 +55,8 @@ const STATUS_LABEL_BY_STATUS: Partial<
   approval: { label: "Approval", className: "text-adaptive-amber-700-300" },
   input: { label: "Input", className: "text-adaptive-indigo-600-300" },
   working: { label: "Working", className: "text-adaptive-sky-600-400" },
+  monitoring: { label: "Monitoring", className: "text-adaptive-sky-600-400" },
+  goal: { label: "Goal active", className: "text-adaptive-sky-600-400" },
   failed: { label: "Failed", className: "text-adaptive-red-700-300" },
 };
 

--- a/apps/mobile/src/features/threads/threadListV2.test.ts
+++ b/apps/mobile/src/features/threads/threadListV2.test.ts
@@ -193,6 +193,49 @@ describe("resolveThreadListV2Status", () => {
       "ready",
     );
   });
+
+  it("shows the most specific background liveness after a turn settles", () => {
+    expect(
+      resolveThreadListV2Status(
+        makeThread({
+          id: ThreadId.make("monitoring"),
+          title: "monitoring",
+          backgroundLiveness: "monitoring",
+        }),
+      ),
+    ).toBe("monitoring");
+    expect(
+      resolveThreadListV2Status(
+        makeThread({
+          id: ThreadId.make("goal"),
+          title: "goal",
+          backgroundLiveness: "goal",
+        }),
+      ),
+    ).toBe("goal");
+  });
+
+  it("keeps an error above stale background liveness", () => {
+    expect(
+      resolveThreadListV2Status(
+        makeThread({
+          id: ThreadId.make("failed"),
+          title: "failed",
+          backgroundLiveness: "goal",
+          session: {
+            threadId: ThreadId.make("failed"),
+            status: "error",
+            providerName: "Codex",
+            providerInstanceId: ProviderInstanceId.make("codex"),
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: "failed",
+            updatedAt: NOW,
+          },
+        }),
+      ),
+    ).toBe("failed");
+  });
 });
 
 describe("resolveThreadListV2SwipeActions", () => {

--- a/apps/mobile/src/features/threads/threadListV2.ts
+++ b/apps/mobile/src/features/threads/threadListV2.ts
@@ -30,7 +30,14 @@ export { snoozeWakeLabel };
  * (approval), "in motion" (working), and "broken" (failed). Ready is the
  * unlabeled resting state.
  */
-export type ThreadListV2Status = "approval" | "input" | "working" | "failed" | "ready";
+export type ThreadListV2Status =
+  | "approval"
+  | "input"
+  | "working"
+  | "monitoring"
+  | "goal"
+  | "failed"
+  | "ready";
 export type ThreadListV2SwipeAction = "archive" | "settle" | "unsettle" | "snooze" | "unsnooze";
 
 export interface ThreadListV2ChangeRequestState extends ChangeRequestSettleSource {
@@ -158,7 +165,10 @@ export function resolveThreadListV2Enabled(input: {
 }
 
 export function resolveThreadListV2Status(
-  thread: Pick<EnvironmentThreadShell, "hasPendingApprovals" | "hasPendingUserInput" | "session">,
+  thread: Pick<
+    EnvironmentThreadShell,
+    "hasPendingApprovals" | "hasPendingUserInput" | "session" | "backgroundLiveness"
+  >,
 ): ThreadListV2Status {
   if (thread.hasPendingApprovals) {
     return "approval";
@@ -171,6 +181,15 @@ export function resolveThreadListV2Status(
   }
   if (thread.session?.status === "error") {
     return "failed";
+  }
+  if (thread.backgroundLiveness === "working") {
+    return "working";
+  }
+  if (thread.backgroundLiveness === "monitoring") {
+    return "monitoring";
+  }
+  if (thread.backgroundLiveness === "goal") {
+    return "goal";
   }
   return "ready";
 }

--- a/apps/mobile/src/features/threads/threadPresentation.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.ts
@@ -11,6 +11,8 @@ export type ThreadStatusKind =
   | "pending-approval"
   | "awaiting-input"
   | "working"
+  | "monitoring"
+  | "goal"
   | "connecting"
   | "error"
   | "plan-ready";
@@ -105,6 +107,42 @@ export function resolveThreadStatus(
       textClassName: "text-adaptive-rose-700-300",
       iconColor: "#ff453a",
       iconBackground: "rgba(255,69,58,0.22)",
+      pulse: false,
+    };
+  }
+
+  if (thread.backgroundLiveness === "working") {
+    return {
+      kind: "working",
+      label: "Working",
+      pillClassName: "bg-adaptive-sky-500-a12-a16",
+      textClassName: "text-adaptive-sky-700-300",
+      iconColor: "#0a84ff",
+      iconBackground: "rgba(10,132,255,0.22)",
+      pulse: true,
+    };
+  }
+
+  if (thread.backgroundLiveness === "monitoring") {
+    return {
+      kind: "monitoring",
+      label: "Monitoring",
+      pillClassName: "bg-adaptive-sky-500-a12-a16",
+      textClassName: "text-adaptive-sky-700-300",
+      iconColor: "#0a84ff",
+      iconBackground: "rgba(10,132,255,0.22)",
+      pulse: false,
+    };
+  }
+
+  if (thread.backgroundLiveness === "goal") {
+    return {
+      kind: "goal",
+      label: "Goal active",
+      pillClassName: "bg-adaptive-sky-500-a12-a16",
+      textClassName: "text-adaptive-sky-700-300",
+      iconColor: "#0a84ff",
+      iconBackground: "rgba(10,132,255,0.22)",
       pulse: false,
     };
   }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1923,6 +1923,22 @@ const make = Effect.gen(function* () {
         }
       }
 
+      if (event.type === "thread.goal.updated") {
+        threadBackgroundLiveness.recordGoalLiveness({
+          threadId: thread.id,
+          goalId: "provider-goal",
+          status: event.payload.status,
+        });
+      }
+
+      if (event.type === "thread.goal.cleared") {
+        threadBackgroundLiveness.recordGoalLiveness({
+          threadId: thread.id,
+          goalId: "provider-goal",
+          status: "complete",
+        });
+      }
+
       if (event.type === "turn.diff.updated") {
         const turnId = toTurnId(event.turnId);
         const checkpointContext = turnId

--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
@@ -95,6 +95,50 @@ describe("ThreadBackgroundLiveness", () => {
     expect(liveness.getThreadBackgroundLiveness(threadId)).toBeNull();
   });
 
+  it("reports an active provider goal only after live agent and monitor work settle", () => {
+    const liveness = ThreadBackgroundLiveness.make();
+    const threadId = "t-goal";
+    liveness.recordGoalLiveness({ threadId, goalId: "codex-goal", status: "active" });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBe("goal");
+
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "watch",
+      taskType: "monitor",
+      status: "running",
+      kind: "started",
+    });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBe("monitoring");
+
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "worker",
+      taskType: "subagent",
+      status: "running",
+      kind: "started",
+    });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBe("working");
+
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "worker",
+      taskType: "subagent",
+      status: "completed",
+      kind: "completed",
+    });
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "watch",
+      taskType: "monitor",
+      status: "completed",
+      kind: "completed",
+    });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBe("goal");
+
+    liveness.recordGoalLiveness({ threadId, goalId: "codex-goal", status: "complete" });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBeNull();
+  });
+
   it("terminal rows without a taskType still clear monitor entries", () => {
     const liveness = ThreadBackgroundLiveness.make();
     const threadId = "t-live-2";

--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
@@ -20,11 +20,12 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-export type ThreadBackgroundLiveness = "working" | "monitoring" | null;
+export type ThreadBackgroundLiveness = "working" | "monitoring" | "goal" | null;
 
 interface ThreadLivenessState {
   readonly agents: Set<string>;
   readonly monitors: Set<string>;
+  readonly goals: Set<string>;
 }
 
 // Classification sets are the shared contracts copies (MONITOR_TASK_TYPES:
@@ -64,10 +65,16 @@ export class ThreadBackgroundLivenessService extends Context.Service<
     /** Session death orphans all of a thread's background work. */
     readonly clearThreadLiveness: (threadId: string) => void;
 
-    /**
-     * Two-state vocabulary by design: any live agent work is "working";
-     * "monitoring" only when watch loops are the ONLY live work.
-     */
+    /** Record a durable provider goal. Goals are not watch loops: they have
+     * their own calm sidebar state and never invent a next-run time. */
+    readonly recordGoalLiveness: (input: {
+      readonly threadId: string;
+      readonly goalId: string;
+      readonly status: string;
+    }) => void;
+
+    /** Any live agent work is "working"; monitor tasks outrank durable goals,
+     * and "monitoring" only describes actual watch loops. */
     readonly getThreadBackgroundLiveness: (threadId: string) => ThreadBackgroundLiveness;
   }
 >()("t3/orchestration/ThreadBackgroundLiveness/ThreadBackgroundLivenessService") {}
@@ -80,7 +87,11 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
     if (existing) {
       return existing;
     }
-    const created: ThreadLivenessState = { agents: new Set(), monitors: new Set() };
+    const created: ThreadLivenessState = {
+      agents: new Set(),
+      monitors: new Set(),
+      goals: new Set(),
+    };
     stateByThreadId.set(threadId, created);
     return created;
   };
@@ -96,7 +107,8 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
     }
     state.agents.delete(taskId);
     state.monitors.delete(taskId);
-    if (state.agents.size === 0 && state.monitors.size === 0) {
+    state.goals.delete(taskId);
+    if (state.agents.size === 0 && state.monitors.size === 0 && state.goals.size === 0) {
       stateByThreadId.delete(threadId);
     }
   };
@@ -153,6 +165,14 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
       stateByThreadId.delete(threadId);
     },
 
+    recordGoalLiveness: ({ threadId, goalId, status }) => {
+      drop(threadId, goalId);
+      if (status !== "active") {
+        return;
+      }
+      stateFor(threadId).goals.add(goalId);
+    },
+
     getThreadBackgroundLiveness: (threadId) => {
       const state = stateByThreadId.get(threadId);
       if (!state) {
@@ -163,6 +183,9 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
       }
       if (state.monitors.size > 0) {
         return "monitoring";
+      }
+      if (state.goals.size > 0) {
+        return "goal";
       }
       return null;
     },

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -557,6 +557,56 @@ function startLifecycleRuntime() {
 }
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
+  it.effect("maps Codex goal lifecycle notifications into canonical thread events", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 2)).pipe(
+        Effect.forkChild,
+      );
+
+      yield* runtime.emit({
+        id: asEventId("evt-goal-updated"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "thread/goal/updated",
+        threadId: asThreadId("thread-1"),
+        payload: {
+          threadId: "provider-thread-1",
+          goal: {
+            threadId: "provider-thread-1",
+            objective: "Keep watching CI",
+            status: "active",
+            createdAt: 1,
+            updatedAt: 2,
+            timeUsedSeconds: 3,
+            tokensUsed: 4,
+            tokenBudget: 100,
+          },
+        },
+      });
+      yield* runtime.emit({
+        id: asEventId("evt-goal-cleared"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:01.000Z",
+        method: "thread/goal/cleared",
+        threadId: asThreadId("thread-1"),
+        payload: { threadId: "provider-thread-1" },
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      NodeAssert.deepStrictEqual(
+        events.map((event) => event.type),
+        ["thread.goal.updated", "thread.goal.cleared"],
+      );
+      if (events[0]?.type === "thread.goal.updated") {
+        NodeAssert.equal(events[0].payload.objective, "Keep watching CI");
+        NodeAssert.equal(events[0].payload.status, "active");
+      }
+    }),
+  );
+
   it.effect("carries child model metadata through every task event", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1021,6 +1021,42 @@ function mapToRuntimeEvents(
     ];
   }
 
+  if (event.method === "thread/goal/updated") {
+    const payload = readPayload(EffectCodexSchema.V2ThreadGoalUpdatedNotification, event.payload);
+    const goal = payload?.goal;
+    if (!goal || !trimText(goal.objective)) {
+      return [];
+    }
+    return [
+      {
+        type: "thread.goal.updated",
+        ...runtimeEventBase(event, canonicalThreadId),
+        payload: {
+          objective: trimText(goal.objective)!,
+          status: goal.status,
+          ...(goal.tokenBudget !== undefined && goal.tokenBudget !== null
+            ? { tokenBudget: Math.max(0, goal.tokenBudget) }
+            : {}),
+          tokensUsed: Math.max(0, goal.tokensUsed),
+          timeUsedSeconds: Math.max(0, goal.timeUsedSeconds),
+        },
+      },
+    ];
+  }
+
+  if (event.method === "thread/goal/cleared") {
+    if (!readPayload(EffectCodexSchema.V2ThreadGoalClearedNotification, event.payload)) {
+      return [];
+    }
+    return [
+      {
+        type: "thread.goal.cleared",
+        ...runtimeEventBase(event, canonicalThreadId),
+        payload: {},
+      },
+    ];
+  }
+
   if (event.method === "thread/tokenUsage/updated") {
     const payload = readPayload(
       EffectCodexSchema.V2ThreadTokenUsageUpdatedNotification,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -25,6 +25,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -2256,6 +2257,23 @@ export const makeCodexSessionRuntime = (
       } satisfies ProviderSession;
       yield* Ref.set(sessionRef, session);
       yield* emitSessionEvent("session/ready", "Codex App Server session ready.");
+      // Goals are durable Codex thread state, unlike a live turn. Hydrate the
+      // shell after reconnect so a settled thread does not lose its truthful
+      // Goal active indication until the next goal notification arrives.
+      const goalResponse = yield* client
+        .request("thread/goal/get", { threadId: providerThreadId })
+        .pipe(Effect.option);
+      if (Option.isSome(goalResponse) && goalResponse.value.goal) {
+        yield* emitEvent({
+          kind: "notification",
+          threadId: options.threadId,
+          method: "thread/goal/updated",
+          payload: {
+            threadId: providerThreadId,
+            goal: goalResponse.value.goal,
+          },
+        });
+      }
       return session;
     });
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4713,6 +4713,7 @@ function ChatViewContent(props: ChatViewProps) {
       return null;
     }
     const working = activeBackgroundLiveness === "working";
+    const goal = activeBackgroundLiveness === "goal";
     const liveCount = agentPanelModel.liveCount;
     return {
       id: `background-liveness:${activeThread.id}`,
@@ -4727,7 +4728,9 @@ function ChatViewContent(props: ChatViewProps) {
         ? liveCount > 0
           ? `${liveCount} ${liveCount === 1 ? "agent" : "agents"} working`
           : "Background work"
-        : "Monitoring",
+        : goal
+          ? "Goal active"
+          : "Monitoring",
       actions: (
         <Button
           size="xs"

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -739,6 +739,23 @@ describe("resolveSidebarThreadStatus", () => {
     ).toBe("working");
   });
 
+  it("reports an active goal after live work, but before ready", () => {
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        session: null,
+        backgroundLiveness: "goal",
+      }),
+    ).toBe("goal");
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        session,
+        backgroundLiveness: "goal",
+      }),
+    ).toBe("working");
+  });
+
   it("reports failed only while the session status is error", () => {
     expect(
       resolveSidebarThreadStatus({

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -129,6 +129,7 @@ export interface ThreadStatusPill {
   label:
     | "Working"
     | "Monitoring"
+    | "Goal active"
     | "Connecting"
     | "Completed"
     | "Pending Approval"
@@ -149,6 +150,7 @@ const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
   Connecting: 4,
   "Plan Ready": 3,
   Monitoring: 2,
+  "Goal active": 2,
   Completed: 1,
 };
 
@@ -472,6 +474,7 @@ export type SidebarThreadStatus =
   | "input"
   | "working"
   | "monitoring"
+  | "goal"
   | "failed"
   | "ready";
 
@@ -502,6 +505,9 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
   }
   if (thread.backgroundLiveness === "monitoring") {
     return "monitoring";
+  }
+  if (thread.backgroundLiveness === "goal") {
+    return "goal";
   }
   return "ready";
 }
@@ -761,6 +767,15 @@ export function resolveThreadStatusPill(input: {
   if (thread.backgroundLiveness === "monitoring") {
     return {
       label: "Monitoring",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
+      pulse: false,
+    };
+  }
+
+  if (thread.backgroundLiveness === "goal") {
+    return {
+      label: "Goal active",
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: false,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -851,7 +851,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // working threads aren't your problem yet) — only the colored status label
   // stands out.
   const isInFlight =
-    status === "working" || status === "monitoring" || status === "approval" || status === "input";
+    status === "working" ||
+    status === "monitoring" ||
+    status === "goal" ||
+    status === "approval" ||
+    status === "input";
   const shouldRecede =
     (status === "ready" || isInFlight) && !isUnread && !isWoke && !props.isActive && !isSelected;
   // Status hues follow the system-wide convention set by sidebar v1 and the
@@ -877,6 +881,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             icon: null,
             className: "text-sky-600 dark:text-sky-400",
           }
+        : status === "goal"
+          ? {
+              label: "Goal active",
+              icon: null,
+              className: "text-sky-600 dark:text-sky-400",
+            }
         : status === "approval"
           ? {
               label: "Approval",

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -547,7 +547,9 @@ export const OrchestrationThreadShell = Schema.Struct({
    * subagents/workflows run, "monitoring" when watch loops are the only
    * live work. Optional so old servers/clients interop; absent = none.
    */
-  backgroundLiveness: Schema.optional(Schema.NullOr(Schema.Literals(["working", "monitoring"]))),
+  backgroundLiveness: Schema.optional(
+    Schema.NullOr(Schema.Literals(["working", "monitoring", "goal"])),
+  ),
   /**
    * Current plan step while a turn runs, for the Working indicators
    * (sidebar row, in-chat working line). Cleared when the turn settles —

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -155,6 +155,8 @@ const ProviderRuntimeEventType = Schema.Literals([
   "thread.started",
   "thread.state.changed",
   "thread.metadata.updated",
+  "thread.goal.updated",
+  "thread.goal.cleared",
   "thread.token-usage.updated",
   "thread.realtime.started",
   "thread.realtime.item-added",
@@ -206,6 +208,8 @@ const SessionExitedType = Schema.Literal("session.exited");
 const ThreadStartedType = Schema.Literal("thread.started");
 const ThreadStateChangedType = Schema.Literal("thread.state.changed");
 const ThreadMetadataUpdatedType = Schema.Literal("thread.metadata.updated");
+const ThreadGoalUpdatedType = Schema.Literal("thread.goal.updated");
+const ThreadGoalClearedType = Schema.Literal("thread.goal.cleared");
 const ThreadTokenUsageUpdatedType = Schema.Literal("thread.token-usage.updated");
 const ThreadRealtimeStartedType = Schema.Literal("thread.realtime.started");
 const ThreadRealtimeItemAddedType = Schema.Literal("thread.realtime.item-added");
@@ -307,6 +311,31 @@ const ThreadMetadataUpdatedPayload = Schema.Struct({
   metadata: Schema.optional(UnknownRecordSchema),
 });
 export type ThreadMetadataUpdatedPayload = typeof ThreadMetadataUpdatedPayload.Type;
+
+/** A provider-owned durable objective. This is intentionally separate from a
+ * watch loop: a goal proves the provider reports work as active, but it does
+ * not imply a scheduler exists or that there is a next run time. */
+export const ThreadGoalStatus = Schema.Literals([
+  "active",
+  "paused",
+  "blocked",
+  "usageLimited",
+  "budgetLimited",
+  "complete",
+]);
+export type ThreadGoalStatus = typeof ThreadGoalStatus.Type;
+
+const ThreadGoalUpdatedPayload = Schema.Struct({
+  objective: TrimmedNonEmptyStringSchema,
+  status: ThreadGoalStatus,
+  tokenBudget: Schema.optional(NonNegativeInt),
+  tokensUsed: NonNegativeInt,
+  timeUsedSeconds: NonNegativeInt,
+});
+export type ThreadGoalUpdatedPayload = typeof ThreadGoalUpdatedPayload.Type;
+
+const ThreadGoalClearedPayload = Schema.Struct({});
+export type ThreadGoalClearedPayload = typeof ThreadGoalClearedPayload.Type;
 
 export const ThreadTokenUsageSnapshot = Schema.Struct({
   usedTokens: NonNegativeInt,
@@ -834,6 +863,22 @@ const ProviderRuntimeThreadMetadataUpdatedEvent = Schema.Struct({
 export type ProviderRuntimeThreadMetadataUpdatedEvent =
   typeof ProviderRuntimeThreadMetadataUpdatedEvent.Type;
 
+const ProviderRuntimeThreadGoalUpdatedEvent = Schema.Struct({
+  ...ProviderRuntimeEventBase.fields,
+  type: ThreadGoalUpdatedType,
+  payload: ThreadGoalUpdatedPayload,
+});
+export type ProviderRuntimeThreadGoalUpdatedEvent =
+  typeof ProviderRuntimeThreadGoalUpdatedEvent.Type;
+
+const ProviderRuntimeThreadGoalClearedEvent = Schema.Struct({
+  ...ProviderRuntimeEventBase.fields,
+  type: ThreadGoalClearedType,
+  payload: ThreadGoalClearedPayload,
+});
+export type ProviderRuntimeThreadGoalClearedEvent =
+  typeof ProviderRuntimeThreadGoalClearedEvent.Type;
+
 const ProviderRuntimeThreadTokenUsageUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: ThreadTokenUsageUpdatedType,
@@ -1149,6 +1194,8 @@ export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeThreadStartedEvent,
   ProviderRuntimeThreadStateChangedEvent,
   ProviderRuntimeThreadMetadataUpdatedEvent,
+  ProviderRuntimeThreadGoalUpdatedEvent,
+  ProviderRuntimeThreadGoalClearedEvent,
   ProviderRuntimeThreadTokenUsageUpdatedEvent,
   ProviderRuntimeThreadRealtimeStartedEvent,
   ProviderRuntimeThreadRealtimeItemAddedEvent,


### PR DESCRIPTION
Codex can report an active goal, but that information was not reflected in durable thread status or the thread list. This makes a goal-backed background task look indistinguishable from an idle thread.

This adds Codex goal lifecycle ingestion, derives the appropriate background liveness state, and renders that state in the web sidebar and mobile thread list. It also covers lifecycle transitions and the relevant status projections.

Testing:
- `pnpm exec vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts apps/web/src/components/Sidebar.logic.test.ts apps/mobile/src/features/threads/threadListV2.test.ts`
- 206 tests passed

Model: GPT-5.6-Terra
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex provider event mapping, in-memory liveness derivation, and cross-platform thread status UI; incorrect goal or priority logic could mislabel threads but does not touch auth or persisted data.
> 
> **Overview**
> **Codex durable thread goals** now flow from provider notifications into thread status so settled threads with an active goal no longer look idle.
> 
> The stack adds canonical `thread.goal.updated` / `thread.goal.cleared` events (contracts + Codex adapter), hydrates goal state on session reconnect via `thread/goal/get`, and feeds **`ThreadBackgroundLiveness`** with a new **`goal`** tier (below working/monitoring, above null). Runtime ingestion maps goal lifecycle into that registry.
> 
> **Web and mobile** thread lists, sidebar pills, and the chat background-liveness banner show **"Goal active"** (and existing **monitoring** labels where added on mobile v2) using the extended `backgroundLiveness` field on thread shells. Status resolvers keep errors and live sessions ahead of stale background state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e895f878c92717c65845aadebed65cec1cb3ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `goal` and `monitoring` background liveness to thread status across server, web, and mobile
> - Server maps Codex `thread/goal/updated` and `thread/goal/cleared` provider notifications into canonical runtime events in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/8615/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d), and records them via `ThreadBackgroundLivenessService.recordGoalLiveness` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/8615/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7)
> - `ThreadBackgroundLiveness` now tracks a per-thread `goals` set; precedence is agents > monitors > goals, so a goal only surfaces when no agent or monitor is live
> - [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/8615/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) queries `thread/goal/get` on session ready to hydrate existing goal state without waiting for a provider notification
> - Contracts in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/8615/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7) add `thread.goal.updated` / `thread.goal.cleared` event schemas, and [orchestration.ts](https://github.com/pingdotgg/t3code/pull/8615/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) extends `backgroundLiveness` with `'goal'`
> - Web sidebar, chat banner, and mobile thread list now render a non-pulsing 'Goal active' status pill when `backgroundLiveness` is `'goal'`
> - Behavioral Change: `resolveThreadListV2Status`, `resolveThreadStatus`, and `resolveSidebarThreadStatus` may now return `'goal'` or `'monitoring'` where they previously returned `'ready'` for quiescent threads; session errors and active input/approval checks still take precedence
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6e895f8. 12 files reviewed, 3 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->