### PR TITLE
fix(web): keep project switcher rows inside the dropdown

### DIFF
--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -175,7 +175,7 @@ function ComboboxPopup({
           )}
         >
           <ComboboxPrimitive.Popup
-            className="flex max-h-[min(var(--available-height),23rem)] flex-1 flex-col text-foreground"
+            className="flex max-h-[min(var(--available-height),23rem)] min-w-0 flex-1 flex-col text-foreground"
             data-slot="combobox-popup"
             {...props}
           >


### PR DESCRIPTION
## What Changed

Added `min-w-0` to the popup element inside `ComboboxPopup` (one class in `apps/web/src/components/ui/combobox.tsx`) so a width-constrained combobox popup clips and truncates its content instead of letting rows spill past the panel edge.

## Why

Fixes #8612.

The sidebar project switcher pins its popup to the trigger width with `w-(--anchor-width)`. That class lands on the `dropdown-glass` panel span in `ComboboxPopup`, but the Base UI popup inside is a flex child without `min-w-0`, so its automatic minimum size is the min-content width of its widest row, and the `truncate` on row labels cannot reduce that. With a project name wider than the sidebar trigger, the rows, each row's settings gear, and the search field's underline all render past the panel's right edge, floating over the thread list behind the dropdown. Nothing on that path clips horizontally.

With `min-w-0` the popup shrinks to the panel width, labels truncate, and the gears sit inside the panel. Popups without an explicit width class are unaffected: the panel still sizes to content between `min-w-(--anchor-width)` and `max-w-(--available-width)`.

The regression shipped with #5931 (first stable release v0.0.36); before that the project filter was a `MenuPopup`, which puts the width class directly on the panel and wraps children in a `w-full` scroller.

Verified with `vp fmt --check`, `vp lint`, and `tsgo --noEmit` scoped to the change, plus the before/after below from a dev instance.

## UI Changes

Project switcher open, one project name wider than the trigger.

**Before:**

<img width="1274" height="684" alt="before-project-switcher-overflow" src="https://github.com/user-attachments/assets/f13c43df-09d9-4f27-9e77-43cbd8f4dace" />

**After:**

<img width="1274" height="684" alt="after-project-switcher-fixed" src="https://github.com/user-attachments/assets/266fcfac-d1cf-42ac-b8e7-74ece5b2cabc" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (static layout fix, no motion)

Diagnosed and written by Claude Code running Claude Fable 5, via `t3 triage`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on shared combobox popup styling; no logic or data-path changes, with broad but positive layout behavior in constrained-width popups.
> 
> **Overview**
> Fixes horizontal overflow in width-pinned combobox popups (notably the sidebar **project switcher** with `w-(--anchor-width)` on `ComboboxPopup`).
> 
> Adds **`min-w-0`** to the inner `ComboboxPrimitive.Popup` in `combobox.tsx` so the flex child can shrink below its min-content width. Long project names and row actions now stay inside the panel and **`truncate`** on labels works instead of drawing over the thread list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea9aefbbed84ef0ac882a43b874fb969f3902ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project switcher overflow by adding `min-w-0` to `ComboboxPopup`
> Adds the Tailwind class `min-w-0` to the popup element in [combobox.tsx](https://github.com/pingdotgg/t3code/pull/8616/files#diff-10ddf105a1e88483c98dd15827574c77c53320d7ae56a262c90bfad67e790ef9). This lets the popup shrink below its intrinsic minimum width inside flex containers, keeping project switcher rows contained within the dropdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fea9aef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

