### PR TITLE
fix(mobile): prevent header overflow and back-button artifacts

### DIFF
--- a/apps/mobile/src/components/CompactBrandTitle.tsx
+++ b/apps/mobile/src/components/CompactBrandTitle.tsx
@@ -1,32 +1,18 @@
 import Constants from "expo-constants";
-import type {
-  NativeStackHeaderItem,
-  NativeStackNavigationOptions,
-} from "@react-navigation/native-stack";
+import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
 import { Platform, View } from "react-native";
 
 import { AppText as Text } from "./AppText";
 import { T3Wordmark } from "./T3Wordmark";
 import { IPAD_HOME_TITLE_OFFSET } from "../lib/layoutMetrics";
 import { resolveMobileStageLabel } from "../lib/mobileBranding";
-import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../native/native-glass";
-
-// Native leading items inherit different UIKit margins than title views.
-const IOS_NATIVE_LEADING_TITLE_OFFSET = -6;
-const IPAD_NATIVE_LEADING_TITLE_OFFSET = 7;
-
-// Branding and connection status share an identity distinct from navigation buttons.
-export const BRAND_HEADER_ITEM_IDENTIFIER = "workspace-brand";
 
 /**
  * Horizontal correction applied to content rendered in the brand title slot,
  * shared with the connection-status swap so both align identically.
  */
-export function brandTitleOffset(nativeLeadingItem: boolean): number {
+export function brandTitleOffset(): number {
   if (Platform.OS !== "ios") return 0;
-  if (nativeLeadingItem) {
-    return Platform.isPad ? IPAD_NATIVE_LEADING_TITLE_OFFSET : IOS_NATIVE_LEADING_TITLE_OFFSET;
-  }
   return Platform.isPad ? IPAD_HOME_TITLE_OFFSET : 0;
 }
 
@@ -36,11 +22,10 @@ export function brandTitleOffset(nativeLeadingItem: boolean): number {
 export function CompactBrandTitle(
   props: {
     readonly allowFontScaling?: boolean;
-    readonly nativeLeadingItem?: boolean;
   } = {},
 ) {
   const stageLabel = resolveMobileStageLabel(Constants.expoConfig?.extra?.appVariant);
-  const titleOffset = brandTitleOffset(props.nativeLeadingItem === true);
+  const titleOffset = brandTitleOffset();
 
   return (
     <View
@@ -74,32 +59,13 @@ export function renderCompactBrandTitle() {
   return <CompactBrandTitle allowFontScaling={Platform.OS === "ios"} />;
 }
 
-export function renderCompactBrandHeaderItems(): NativeStackHeaderItem[] {
-  return [
-    {
-      element: <CompactBrandTitle nativeLeadingItem />,
-      hidesSharedBackground: true,
-      identifier: BRAND_HEADER_ITEM_IDENTIFIER,
-      type: "custom",
-    },
-  ];
-}
-
 export function getCompactBrandHeaderOptions(
   fallbackTitleStyle?: NativeStackNavigationOptions["headerTitleStyle"],
 ): NativeStackNavigationOptions {
-  if (Platform.OS === "ios" && NATIVE_LIQUID_GLASS_SUPPORTED) {
-    return {
-      headerTitle: "Threads",
-      headerTitleStyle: { color: "transparent", fontSize: 18, fontWeight: "800" },
-      title: "Threads",
-      unstable_headerLeftItems: renderCompactBrandHeaderItems,
-    };
-  }
-
   return {
     headerTitle: renderCompactBrandTitle,
     headerTitleStyle: fallbackTitleStyle,
     title: "Threads",
+    unstable_headerLeftItems: undefined,
   };
 }

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -2,7 +2,7 @@ import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
 import { useNavigation } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
-import { Platform } from "react-native";
+import { Platform, useWindowDimensions } from "react-native";
 
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useProjects, useThreadShells } from "../../state/entities";
@@ -25,6 +25,7 @@ import { getConnectionAwareBrandHeaderOptions } from "./WorkspaceConnectionTitle
 /* ─── Route screen ───────────────────────────────────────────────────── */
 
 export function HomeRouteScreen() {
+  const { width: windowWidth } = useWindowDimensions();
   const { layout } = useAdaptiveWorkspaceLayout();
   const projects = useProjects();
   const threads = useThreadShells();
@@ -138,8 +139,10 @@ export function HomeRouteScreen() {
             shallow-merged. The brand slot also doubles as the connection
             status surface while an environment reconnects. */}
         <NativeStackScreenOptions
+          optionsVersion={windowWidth}
           options={{
             ...getConnectionAwareBrandHeaderOptions({
+              headerWidth: windowWidth,
               onOpenEnvironments: () =>
                 navigation.navigate("SettingsSheet", {
                   screen: "SettingsContent",

--- a/apps/mobile/src/features/home/WorkspaceConnectionTitle.tsx
+++ b/apps/mobile/src/features/home/WorkspaceConnectionTitle.tsx
@@ -1,18 +1,14 @@
-import type {
-  NativeStackHeaderItem,
-  NativeStackNavigationOptions,
-} from "@react-navigation/native-stack";
+import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { ActivityIndicator, Animated, Platform, Pressable, View } from "react-native";
+import { ActivityIndicator, Animated, Pressable, View } from "react-native";
 
 import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text } from "../../components/AppText";
 import {
-  BRAND_HEADER_ITEM_IDENTIFIER,
   brandTitleOffset,
   CompactBrandTitle,
+  getCompactBrandHeaderOptions,
 } from "../../components/CompactBrandTitle";
-import { NATIVE_LIQUID_GLASS_SUPPORTED } from "../../native/native-glass";
 import { useWorkspaceState } from "../../state/workspace";
 import {
   workspaceConnectionStatusPresentation,
@@ -55,7 +51,11 @@ function useDelayedConnectionStatus(): WorkspaceConnectionStatusPresentation | n
  * native-driver animated nodes blank the re-hosted view entirely. The JS driver
  * updates opacity through the ordinary style path, which those subviews handle.
  */
-function StatusFadeIn(props: { readonly children: ReactNode; readonly grow?: boolean }) {
+function StatusFadeIn(props: {
+  readonly children: ReactNode;
+  readonly grow?: boolean;
+  readonly maxWidth?: number;
+}) {
   const opacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -71,7 +71,7 @@ function StatusFadeIn(props: { readonly children: ReactNode; readonly grow?: boo
   return (
     <Animated.View
       style={[
-        { alignItems: "center", flexDirection: "row", opacity },
+        { alignItems: "center", flexDirection: "row", maxWidth: props.maxWidth, opacity },
         props.grow ? { flex: 1, minWidth: 0 } : null,
       ]}
     >
@@ -100,6 +100,8 @@ export function WorkspaceConnectionTitle(props: {
   readonly size?: "navbar" | "pageTitle";
   /** Horizontal correction so the status aligns with the brand in native title slots. */
   readonly statusOffset?: number;
+  /** Space available beside the native header actions. */
+  readonly maxWidth?: number;
 }) {
   const status = useDelayedConnectionStatus();
   const size = props.size ?? "navbar";
@@ -115,7 +117,7 @@ export function WorkspaceConnectionTitle(props: {
   }
 
   return (
-    <StatusFadeIn grow={props.grow}>
+    <StatusFadeIn grow={props.grow} maxWidth={props.maxWidth}>
       <Pressable
         accessibilityHint="Opens environment settings"
         accessibilityLabel={status.label}
@@ -124,7 +126,7 @@ export function WorkspaceConnectionTitle(props: {
         hitSlop={8}
         onPress={props.onPress}
         className="flex-row items-center gap-2"
-        style={{ marginLeft: props.statusOffset ?? 0 }}
+        style={{ flexShrink: 1, marginLeft: props.statusOffset ?? 0 }}
       >
         {status.showsProgress ? (
           <ActivityIndicator colorClassName={"accent-icon-muted"} size="small" />
@@ -158,40 +160,24 @@ export function WorkspaceConnectionTitle(props: {
  * this over the static brand options at mount.
  */
 export function getConnectionAwareBrandHeaderOptions(opts: {
+  readonly headerWidth: number;
+  readonly trailingItemCount?: number;
   readonly onOpenEnvironments: () => void;
   readonly fallbackTitleStyle?: NativeStackNavigationOptions["headerTitleStyle"];
 }): NativeStackNavigationOptions {
-  if (Platform.OS === "ios" && NATIVE_LIQUID_GLASS_SUPPORTED) {
-    return {
-      headerTitle: "Threads",
-      headerTitleStyle: { color: "transparent", fontSize: 18, fontWeight: "800" },
-      title: "Threads",
-      unstable_headerLeftItems: (): NativeStackHeaderItem[] => [
-        {
-          element: (
-            <WorkspaceConnectionTitle
-              brand={<CompactBrandTitle nativeLeadingItem />}
-              onPress={opts.onOpenEnvironments}
-              statusOffset={brandTitleOffset(true)}
-            />
-          ),
-          hidesSharedBackground: true,
-          identifier: BRAND_HEADER_ITEM_IDENTIFIER,
-          type: "custom",
-        },
-      ],
-    };
-  }
+  // Leave room for bar margins, title spacing and the 44-point native actions.
+  // Long status labels must not push Settings into UIKit's overflow menu.
+  const maxWidth = Math.max(0, opts.headerWidth - 64 - 44 * (opts.trailingItemCount ?? 1));
 
   return {
+    ...getCompactBrandHeaderOptions(opts.fallbackTitleStyle),
     headerTitle: () => (
       <WorkspaceConnectionTitle
         brand={<CompactBrandTitle />}
+        maxWidth={maxWidth}
         onPress={opts.onOpenEnvironments}
-        statusOffset={brandTitleOffset(false)}
+        statusOffset={brandTitleOffset()}
       />
     ),
-    headerTitleStyle: opts.fallbackTitleStyle,
-    title: "Threads",
   };
 }

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1158,12 +1158,14 @@ function ThreadNavigationSidebarPane(
     return (
       <>
         <NativeStackScreenOptions
-          optionsVersion={nativeHeaderItems}
+          optionsVersion={[nativeHeaderItems, props.width]}
           options={{
             // Re-applies the shell's static brand slot with the
             // connection-status swap so reconnects surface in the header
             // instead of shifting the list.
             ...getConnectionAwareBrandHeaderOptions({
+              headerWidth: props.width,
+              trailingItemCount: nativeHeaderItems.length,
               onOpenEnvironments: props.onOpenEnvironmentSettings,
               fallbackTitleStyle: { fontSize: 18, fontWeight: "800" },
             }),

--- a/docs/internals/mobile-navigation.md
+++ b/docs/internals/mobile-navigation.md
@@ -5,23 +5,30 @@ The iOS Home and thread routes share the root native stack in
 controller lets UIKit animate the header between routes. The iPad sidebar owns
 a separate, single-screen stack; Android uses its own in-flow headers.
 
-On Liquid Glass iOS, Home keeps a transparent native title and renders its brand
-as a custom leading item. A custom `headerTitle` previously shortened the scroll
-fade and removed the blur behind the logo. Preserve the native title when
-changing the brand or its connection-status replacement.
+Home and the iPad sidebar render their brand and connection status through
+`headerTitle`, with `Threads` retained as the route title. The editor-style native
+bar aligns that title on the leading side. Do not model the brand as a toolbar
+button: on iOS 26.5 UIKit morphs a background-free custom leading item's rectangle
+into the next screen's glass back button, even with distinct item identifiers.
+Using the title slot lets the brand and native back button animate separately.
 
-Both brand states use `BRAND_HEADER_ITEM_IDENTIFIER` from
-[`CompactBrandTitle.tsx`](../../apps/mobile/src/components/CompactBrandTitle.tsx).
-The native-stack and react-native-screens patches forward custom item identifiers
-to `UIBarButtonItem.identifier`, just as they do for native buttons and menus.
-UIKit otherwise matches transition items using their position and content, so
-the brand needs an explicit identity separate from navigation controls. Connection
-status changes retain that identity. See [Apple's identifier documentation](https://developer.apple.com/documentation/uikit/uibarbuttonitem/identifier).
+The connection-status title has a maximum width based on its header's width and
+trailing actions. A long environment name or larger text must not push Settings
+into UIKit's overflow menu. Keep the full status as the accessibility label
+while visually truncating it. The iPad sidebar uses its pane width, not the full
+window width.
+
+On iOS 26, UIKit does not recognize Fabric's custom text views when shaping the
+native scroll-edge fade. The screens patch gives custom title subviews an empty,
+non-interactive native label matching their bounds. This supplies the fade's
+geometry without drawing anything or turning the title back into a toolbar item.
+Check the top scroll fade as well as push/pop when changing these title views.
 
 The react-native-screens patch caches leading, trailing, and center item groups
 independently. A button can belong to only one group: constructing another group
 with the same button removes it from the previous one. Unrelated menu updates
 must therefore preserve the other groups while UIKit may be animating them.
+
 Each cache includes the owning header config, its item values, and custom native
 item identities, so changed content or remounted event emitters still rebuild.
 
@@ -29,3 +36,8 @@ Custom header identifiers require native code generation and a new mobile build;
 an over-the-air JavaScript update alone is insufficient. The Android view manager
 implements the generated identifier setter as a no-op because this behavior is
 specific to iOS 26 and later.
+
+After changing a dependency patch, refresh CocoaPods before rebuilding an
+existing iOS project. pnpm installs each patch hash in a different directory;
+an old Pods project can keep compiling the previous directory even though Metro
+and `apps/mobile/node_modules` resolve to the new patch.

--- a/patches/react-native-screens@4.26.2.patch
+++ b/patches/react-native-screens@4.26.2.patch
@@ -1107,18 +1107,45 @@ index 1c844846a5c66e31cfa530ca462774d2fb6bbea1..a60b96b44e85d3f4b29dc0d190b95ab6
  
    if (needsNavigationControllerLayout) {
 diff --git a/ios/RNSScreenStackHeaderSubview.mm b/ios/RNSScreenStackHeaderSubview.mm
-index add33c4807e038dcd846f6c72b2fc472ded02809..9a7c7a8a775579c85de39f921e7a362241a72075 100644
+index add33c4807e038dcd846f6c72b2fc472ded02809..489afa5fa2da09c1ec6986d1832b58bb595396ae 100644
 --- a/ios/RNSScreenStackHeaderSubview.mm
 +++ b/ios/RNSScreenStackHeaderSubview.mm
-@@ -20,6 +20,7 @@ @implementation RNSScreenStackHeaderSubview {
+@@ -20,7 +20,9 @@ @implementation RNSScreenStackHeaderSubview {
    // This is a strong reference to UIBarButtonItem which creates a retain cycle.
    // The cycle is cleared via `invalidateUIBarButtonItem` method, called by `invalidate` callback.
    UIBarButtonItem *_barButtonItem;
 +  NSString *_barButtonItemIdentifier;
    BOOL _hidesSharedBackground;
++  UILabel *_titleScrollEdgeEffectGuide;
  }
  
-@@ -124,6 +125,7 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
+ #pragma mark - Common
+@@ -102,5 +104,24 @@ - (void)updateShadowStateWithFrame:(CGRect)frame
+ - (void)layoutSubviews
+ {
+   [super layoutSubviews];
++#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
++  if (@available(iOS 26.0, *)) {
++    if (_type == RNSScreenStackHeaderSubviewTypeTitle || _type == RNSScreenStackHeaderSubviewTypeCenter) {
++      // UIKit shapes the navigation bar's scroll-edge fade around native labels,
++      // but does not recognize Fabric's custom text views. An empty, non-interactive
++      // label supplies the title's geometry without drawing or becoming a bar item.
++      if (_titleScrollEdgeEffectGuide == nil) {
++        _titleScrollEdgeEffectGuide = [UILabel new];
++        _titleScrollEdgeEffectGuide.accessibilityElementsHidden = YES;
++        // Append after Fabric's children so their mount/unmount indices stay intact.
++        [self addSubview:_titleScrollEdgeEffectGuide];
++      }
++      _titleScrollEdgeEffectGuide.frame = self.bounds;
++    } else {
++      [_titleScrollEdgeEffectGuide removeFromSuperview];
++      _titleScrollEdgeEffectGuide = nil;
++    }
++  }
++#endif
+   [self updateShadowStateInContextOfAncestorView:[self findNavigationBar]];
+ }
+@@ -124,6 +145,7 @@ - (void)updateProps:(react::Props::Shared const &)props oldProps:(react::Props::
    const auto &newHeaderSubviewProps = *std::static_pointer_cast<const react::RNSScreenStackHeaderSubviewProps>(props);
  
    [self setType:[RNSConvert RNSScreenStackHeaderSubviewTypeFromCppEquivalent:newHeaderSubviewProps.type]];
@@ -1126,7 +1153,7 @@ index add33c4807e038dcd846f6c72b2fc472ded02809..9a7c7a8a775579c85de39f921e7a3622
    [self setHidesSharedBackground:newHeaderSubviewProps.hidesSharedBackground];
    [self setSynchronousShadowStateUpdatesEnabled:newHeaderSubviewProps.synchronousShadowStateUpdatesEnabled];
    [super updateProps:props oldProps:oldProps];
-@@ -276,7 +278,14 @@ - (void)configureBarButtonItem
+@@ -276,7 +298,14 @@ - (void)configureBarButtonItem
  #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
    if (@available(iOS 26.0, *)) {
      if (_barButtonItem != nil) {
@@ -1142,7 +1169,7 @@ index add33c4807e038dcd846f6c72b2fc472ded02809..9a7c7a8a775579c85de39f921e7a3622
      }
    }
  #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-@@ -284,10 +293,22 @@ - (void)configureBarButtonItem
+@@ -284,10 +313,22 @@ - (void)configureBarButtonItem
  
  - (void)setHidesSharedBackground:(BOOL)hidesSharedBackground
  {
@@ -1166,7 +1193,7 @@ index add33c4807e038dcd846f6c72b2fc472ded02809..9a7c7a8a775579c85de39f921e7a3622
  
  // Needed because of this: https://github.com/facebook/react-native/pull/37274
 diff --git a/lib/commonjs/components/ScreenStackHeaderConfig.js b/lib/commonjs/components/ScreenStackHeaderConfig.js
-index 8c509f2657105cfd86448347c1a01fb73651ff9e..5e3b5185c0ea33c6b98f5daed69239d2c0d0ce90 100644
+index 8c509f2657105cfd86448347c1a01fb73651ff9e..e668e089a1788973cb122a150be7846364a2a2cf 100644
 --- a/lib/commonjs/components/ScreenStackHeaderConfig.js
 +++ b/lib/commonjs/components/ScreenStackHeaderConfig.js
 @@ -26,17 +26,42 @@ const ScreenStackHeaderConfig = exports.ScreenStackHeaderConfig = /*#__PURE__*/_
@@ -1338,7 +1365,7 @@ index ab93f62e4a7049d63c6681cecbd6cf8b1d07ce10..9dca2ab640e92161eb647b819a989acd
  //# sourceMappingURL=prepareHeaderBarButtonItems.js.map
 \ No newline at end of file
 diff --git a/lib/module/components/ScreenStackHeaderConfig.js b/lib/module/components/ScreenStackHeaderConfig.js
-index 68e3ba6a78314aba908d07098bb6982d11e6ee80..b787b3cf0284ffb81c80360a06c4059277bf4c1e 100644
+index 68e3ba6a78314aba908d07098bb6982d11e6ee80..db5d17bfdac19ed3e664b55b6a73ce49766ac7c5 100644
 --- a/lib/module/components/ScreenStackHeaderConfig.js
 +++ b/lib/module/components/ScreenStackHeaderConfig.js
 @@ -22,17 +22,42 @@ export const ScreenStackHeaderConfig = /*#__PURE__*/React.forwardRef((props, ref

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ patchedDependencies:
   react-native-gesture-handler@2.32.0: 808eb26f9e57cf4945efd3985af4d9c764da6f91f4c9764433cc868602bbf4d3
   react-native-keyboard-controller@1.21.13: 20be72c84d74253acdcfefbc6defe36dc396944f1a44cab2bdd0e3cd572ae008
   react-native-nitro-modules@0.35.9: 825622aae63a8fb5b904f3c77908a0e216261d727ea171709f2c0b6088422675
-  react-native-screens@4.26.2: 5d2e7beefe55f0b7ee157993cbc0ec38d32aa558e4e780764381fe8f96ba728d
+  react-native-screens@4.26.2: 149bef30a66351ea9b26b42f87b78c539cb52b880f2387bb323ec80dcac84006
 
 importers:
 
@@ -248,7 +248,7 @@ importers:
         version: 7.3.4(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@react-navigation/native-stack':
         specifier: 7.17.6
-        version: 7.17.6(patch_hash=e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552)(1d8c6f507069f6f6aada9b6419c84a6c)
+        version: 7.17.6(patch_hash=e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552)(d307537762dff86bcf277a4ec64a11d8)
       '@shikijs/core':
         specifier: 4.2.0
         version: 4.2.0
@@ -416,7 +416,7 @@ importers:
         version: 5.7.0(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-screens:
         specifier: ~4.26.0
-        version: 4.26.2(patch_hash=5d2e7beefe55f0b7ee157993cbc0ec38d32aa558e4e780764381fe8f96ba728d)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+        version: 4.26.2(patch_hash=149bef30a66351ea9b26b42f87b78c539cb52b880f2387bb323ec80dcac84006)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-shiki-engine:
         specifier: ^0.3.12
         version: 0.3.12(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -13880,7 +13880,7 @@ snapshots:
     optionalDependencies:
       '@react-native-masked-view/masked-view': 0.3.2(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
 
-  '@react-navigation/native-stack@7.17.6(patch_hash=e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552)(1d8c6f507069f6f6aada9b6419c84a6c)':
+  '@react-navigation/native-stack@7.17.6(patch_hash=e667c3cef8c78bb9ff4882ee5bd23a432247b843060a9499eb5f07e9e2295552)(d307537762dff86bcf277a4ec64a11d8)':
     dependencies:
       '@react-navigation/elements': 2.9.26(c10301b6e0c42fc6434d2b643197a81e)
       '@react-navigation/native': 7.3.4(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -13888,7 +13888,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-safe-area-context: 5.7.0(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      react-native-screens: 4.26.2(patch_hash=5d2e7beefe55f0b7ee157993cbc0ec38d32aa558e4e780764381fe8f96ba728d)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      react-native-screens: 4.26.2(patch_hash=149bef30a66351ea9b26b42f87b78c539cb52b880f2387bb323ec80dcac84006)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -19492,7 +19492,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-  react-native-screens@4.26.2(patch_hash=5d2e7beefe55f0b7ee157993cbc0ec38d32aa558e4e780764381fe8f96ba728d)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+  react-native-screens@4.26.2(patch_hash=149bef30a66351ea9b26b42f87b78c539cb52b880f2387bb323ec80dcac84006)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)


### PR DESCRIPTION
## Why

Long connection-status content can crowd the iOS header, hide its leading content, and turn the direct Settings button into UIKit's overflow menu. Separately, iOS 26.5 morphs the custom leading brand item's rectangle into the next screen's glass back button during navigation.

## What Changed

- Render the brand and connection status in the native title slot, separate from toolbar buttons and Back.
- Bound status width using the header's available width and trailing actions, including the iPad sidebar's pane width. Preserve the full accessibility label.
- Preserve the native scroll-edge fade with a non-interactive, empty native label matching the custom title's bounds. Keep Fabric child mounting indices intact.
- Document the title-slot behavior and native rebuild requirements.

## Verification

Fresh native Debug build on **iPhone 17 Pro, iOS 26.5**, using a disposable local environment:

- Three Settings → thread → Back cycles: direct Settings presentation, visible thread actions, and restored branding.
- Native edge-swipe Back and frame-by-frame push/pop inspection: no rectangular back-button morph.
- Accessibility-large text while disconnected: visible, truncated status; no overflow menu; Settings opens directly.
- Status-title tap opens Environments; reconnecting restores the brand.
- Scrolled content retains the blur behind the brand.
- Existing connection-status tests: **8 passed** (`vp test run apps/mobile/src/features/home/workspace-connection-status.test.ts`).
- Mobile typecheck, targeted lint/formatting, and `git diff --check` passed.

## UI Changes

Header-only crops from the simulator recordings:

Before — the leading rectangle morphs into Back:

![Before: rectangular header transition](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/eb34bf1c199b3d83/pr-header-before.png)

After — Back remains a separate round control:

![After: round back-button transition](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5177405d765a7d72/pr-header-after.png)

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f1e613b91d8dda3a/pr-header-before.mp4) · [After push/pop recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/6416a9207b7b0d5d/pr-header-after.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included videos for animation/interaction changes

**Requires a native dev-client rebuild.** Refresh CocoaPods after installing the updated patch; a Metro reload alone cannot apply the native change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core iOS navigation header rendering and ships a native dependency patch; incorrect title/fade behavior would affect every Home/sidebar session and requires a full iOS rebuild to deploy.
> 
> **Overview**
> **Moves iOS Home and sidebar branding off custom leading toolbar items and into the native `headerTitle` slot**, so the glass back button no longer morphs from the brand rectangle on push/pop (iOS 26.5). Liquid Glass–specific paths (`unstable_headerLeftItems`, transparent title, `BRAND_HEADER_ITEM_IDENTIFIER`) are removed from `CompactBrandTitle` and `getConnectionAwareBrandHeaderOptions`.
> 
> **Connection-status headers are width-bounded** using available header width minus trailing bar actions (`headerWidth`, `trailingItemCount`), with truncation/`flexShrink` so long labels do not force Settings into UIKit’s overflow menu. Home passes window width; the iPad sidebar passes pane width and refreshes options when width or header items change.
> 
> **The `react-native-screens` patch adds an empty native `UILabel` guide** on title/center header subviews (iOS 26) so scroll-edge fade geometry works with Fabric custom title views without drawing over the brand. Internal docs describe the title-slot policy and note that **a native dev-client rebuild (CocoaPods refresh)** is required for the patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eed8204a1a0d705965332ff639eb9cf0617907c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix header overflow and back-button artifacts by moving brand title to `headerTitle` slot
> - Moves brand and connection-status rendering from `unstable_headerLeftItems` to the `headerTitle` slot across Home and iPad sidebar headers, avoiding UIKit toolbar-item behavior on iOS 26.5.
> - Simplifies `brandTitleOffset()` to return `IPAD_HOME_TITLE_OFFSET` on iPad and `0` elsewhere; removes the native-leading-item offset path and deletes `renderCompactBrandHeaderItems`.
> - Adds `maxWidth` support to `WorkspaceConnectionTitle` and `StatusFadeIn` so long labels truncate within available header space; `HomeRouteScreen` and `ThreadNavigationSidebarPane` recompute header options on width changes.
> - Patches `react-native-screens@4.26.2` so iOS 26+ custom title/center subviews contribute geometry for UIKit's scroll-edge fade and support `UIBarButtonItem.identifier` for transition matching.
> - Risk: `getCompactBrandHeaderOptions` always sets `unstable_headerLeftItems` to `undefined`; any caller that previously relied on `renderCompactBrandHeaderItems` for custom leading items will no longer render them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eed8204.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->