### PR TITLE
fix(web): keep project picker popup inside the sidebar

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -617,7 +617,7 @@ export default function DiffPanel({
               </ComboboxTrigger>
               <ComboboxPopup
                 align="start"
-                className="w-72 min-w-0 max-w-[calc(100vw-1rem)] overflow-hidden [&>[data-slot=combobox-popup]]:min-w-0 [&>[data-slot=combobox-popup]]:overflow-hidden"
+                className="w-72 min-w-0 max-w-[calc(100vw-1rem)] overflow-hidden"
               >
                 <div className="min-w-0 shrink-0 px-3 pt-2.5">
                   <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3586,7 +3586,10 @@ export default function Sidebar() {
                     </span>
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />
                   </ComboboxTrigger>
-                  <ComboboxPopup align="start" className="w-(--anchor-width)">
+                  <ComboboxPopup
+                    align="start"
+                    className="w-(--anchor-width) min-w-0 overflow-hidden [&>[data-slot=combobox-popup]]:min-w-0 [&>[data-slot=combobox-popup]]:overflow-hidden"
+                  >
                     <div className="shrink-0 px-3 pt-2.5">
                       <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
                         <SearchIcon

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3588,7 +3588,7 @@ export default function Sidebar() {
                   </ComboboxTrigger>
                   <ComboboxPopup
                     align="start"
-                    className="w-(--anchor-width) min-w-0 overflow-hidden [&>[data-slot=combobox-popup]]:min-w-0 [&>[data-slot=combobox-popup]]:overflow-hidden"
+                    className="w-(--anchor-width) min-w-0 overflow-hidden"
                   >
                     <div className="shrink-0 px-3 pt-2.5">
                       <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -175,7 +175,7 @@ function ComboboxPopup({
           )}
         >
           <ComboboxPrimitive.Popup
-            className="flex max-h-[min(var(--available-height),23rem)] flex-1 flex-col text-foreground"
+            className="flex min-w-0 max-h-[min(var(--available-height),23rem)] flex-1 flex-col overflow-hidden text-foreground"
             data-slot="combobox-popup"
             {...props}
           >


### PR DESCRIPTION
## What changed

This bugfix keeps searchable combobox content inside its positioned shell. The shared combobox primitive now lets its inner flex item shrink and clips horizontal overflow.

The project picker still pins its outer shell to the sidebar trigger. The diff base-ref picker keeps its viewport-capped width without duplicating the primitive's inner containment rules. The shared web renderer covers web and desktop. Mobile, server, contracts, providers, and connection handling are unchanged.

## Why

Long project names could preserve the inner popup's intrinsic minimum width. That made the menu spill past the sidebar even though its outer shell was anchored to the trigger.

## UI changes

Before:

![Project picker overflowing the sidebar](https://codex-file-host.shawnadedeji.workers.dev/files/project-picker-overflow/dc13ba1af733-8cb61c5d-960a-42c6-b1b8-be1928e943ae-80883258-4b69-443f-ac02-b5ef15b882df.png)

After:

![Project picker contained to its trigger width](https://codex-file-host.shawnadedeji.workers.dev/files/project-picker-overflow/7326ec006292-browser-screenshot-localhost-mtdxxnhe.png)

## Verification

- 206 tests across sidebar project scope, branch toolbar, appearance fonts, and diff panel state
- 29 shared UI component tests
- Targeted formatting and lint for the three changed files
- `pnpm exec vp run --filter @t3tools/web typecheck`
- `git diff --check`
- Real-client T3 pass with five fixture projects. The inner popup measured 153px wide with a 153px scroll width inside its 155px anchored shell.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or timing changed, so this does not need a video

Built with GPT-5.6 Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout containment in the shared combobox; low risk aside from possible clipping in other combobox menus that relied on unconstrained width.
> 
> **Overview**
> Fixes searchable combobox menus spilling past their anchored shell when long labels preserve intrinsic minimum width (notably the sidebar **project scope** picker).
> 
> **Shared `ComboboxPopup`:** the inner popup (`data-slot=combobox-popup`) now uses **`min-w-0`** and **`overflow-hidden`** so flex children can shrink and horizontal overflow is clipped by default.
> 
> **Call sites:** the sidebar project picker adds matching **`min-w-0 overflow-hidden`** on its outer shell (still **`w-(--anchor-width)`**). The diff panel **base-ref** combobox drops redundant descendant selectors that duplicated the primitive’s inner rules while keeping viewport-capped width on the shell.
> 
> **Behavior:** every `ComboboxPopup` instance inherits the stricter clipping; content that previously grew wider than the anchor may truncate or scroll inside the menu instead of expanding the popup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0adc2b47744e1f56c7f488df4f5137d0f04edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep project picker popup inside sidebar by constraining `ComboboxPopup`
> - Moves `min-w-0` and `overflow-hidden` styling into the shared `ComboboxPopup` component so popups clip content by default.
> - Applies these constraints to the project scope popup in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/8627/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to prevent overflow.
> - Removes redundant nested popup styling from the base-ref selector in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/8627/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3).
> - Behavioral Change: All `ComboboxPopup` instances now enforce `min-w-0` and `overflow-hidden`, which may clip content that previously expanded beyond the anchor width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad0adc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown sizing so project and branch comparison menus align with their trigger controls.
  * Prevented horizontal overflow and ensured popup contents remain within available space.
  * Improved layout behavior for combobox menus in constrained viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->