### PR TITLE
fix(server): avoid loading Codex history on resume

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -775,7 +775,7 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
-  it.effect("falls back to thread/start when resume fails recoverably", () =>
+  it.effect("requests metadata-only resume before falling back to thread/start", () =>
     Effect.gen(function* () {
       const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
       const started = makeThreadOpenResponse("fresh-thread");
@@ -812,6 +812,15 @@ describe("openCodexThread", () => {
         calls.map((call) => call.method),
         ["thread/resume", "thread/start"],
       );
+      NodeAssert.deepStrictEqual(calls[0]?.payload, {
+        threadId: "stale-thread",
+        excludeTurns: true,
+        cwd: "/tmp/project",
+        model: "gpt-5.3-codex",
+        approvalPolicy: "never",
+        approvalsReviewer: "user",
+        sandbox: "danger-full-access",
+      });
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -712,6 +712,7 @@ export const openCodexThread = (input: {
   return input.client
     .request("thread/resume", {
       threadId: resumeThreadId,
+      excludeTurns: true,
       ...startParams,
     })
     .pipe(

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -194,6 +194,18 @@ const Codex0150DefinitionSchemas: Record<string, Schema.Json> = {
   },
 };
 
+// The pinned Codex protocol marks these fields experimental, so its exported
+// JSON schemas omit them even though T3 negotiates the experimental API.
+const ExperimentalTopLevelSchemaProperties: Record<string, Record<string, Schema.Json>> = {
+  V2ThreadResumeParams: {
+    excludeTurns: {
+      type: "boolean",
+      description:
+        "When true, return only thread metadata and live-resume state without populating thread.turns.",
+    },
+  },
+};
+
 const getGeneratedPaths = Effect.fn("getGeneratedPaths")(function* () {
   const path = yield* Path.Path;
   const generatedDir = path.join(import.meta.dirname, "..", "src", "_generated");
@@ -624,6 +636,13 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
       if (key !== "definitions") {
         topLevelSchema[key] = value;
       }
+    }
+    const propertyPatches = ExperimentalTopLevelSchemaProperties[file.exportName];
+    if (propertyPatches) {
+      topLevelSchema.properties = {
+        ...(topLevelSchema.properties as Record<string, Schema.Json>),
+        ...propertyPatches,
+      };
     }
 
     aggregateSchemas[file.exportName] = stripNullDefaults(

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -40868,6 +40868,7 @@ export type V2ThreadResumeParams = {
   readonly config?: { readonly [x: string]: unknown } | null;
   readonly cwd?: string | null;
   readonly developerInstructions?: string | null;
+  readonly excludeTurns?: boolean;
   readonly model?: string | null;
   readonly modelProvider?: string | null;
   readonly personality?: V2ThreadResumeParams__Personality | null;
@@ -40891,6 +40892,12 @@ export const V2ThreadResumeParams = Schema.Struct({
   ),
   cwd: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
   developerInstructions: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
+  excludeTurns: Schema.optionalKey(
+    Schema.Boolean.annotate({
+      description:
+        "When true, return only thread metadata and live-resume state without populating thread.turns.",
+    }),
+  ),
   model: Schema.optionalKey(
     Schema.Union([
       Schema.String.annotate({

--- a/packages/effect-codex-app-server/src/schema.test.ts
+++ b/packages/effect-codex-app-server/src/schema.test.ts
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import * as CodexSchema from "./schema.ts";
 
 const isGetAccountResponse = Schema.is(CodexSchema.V2GetAccountResponse);
+const encodeThreadResumeParams = Schema.encodeUnknownSync(CodexSchema.V2ThreadResumeParams);
 
 it("accepts Codex 0.150 multi-agent values", () => {
   const schemas = [
@@ -95,4 +96,16 @@ it("accepts Codex 0.150 account plan values", () => {
 
     assert.equal(isGetAccountResponse(accountResponse), true);
   }
+});
+
+it("encodes metadata-only thread resume requests", () => {
+  const encoded = encodeThreadResumeParams({
+    threadId: "thread-1",
+    excludeTurns: true,
+  });
+
+  assert.deepEqual(encoded, {
+    threadId: "thread-1",
+    excludeTurns: true,
+  });
 });


### PR DESCRIPTION
## What Changed

Codex thread resume requests now send `excludeTurns: true`, so app-server returns thread metadata without reconstructing and serializing the complete turn history.

The generated protocol binding now includes the experimental `excludeTurns` field that the pinned Codex schema omits. T3 already negotiates the experimental API. Focused tests cover both the encoded request and the runtime resume payload.

## Why

T3 only reads the resumed thread id, working directory, and model. Loading every historical turn wastes memory and can exhaust the server heap on large, image-heavy Codex rollouts. Reporters reproduced the crash with histories between 673 MiB and roughly 1 GiB.

Fixes #7075

## Testing

- `vp test run packages/effect-codex-app-server/src apps/server/src/provider/Layers/CodexSessionRuntime.test.ts` passes, 65/65
- `vp run typecheck` passes in `packages/effect-codex-app-server`
- `vp run typecheck` passes in `apps/server`; it emits existing Effect suggestions outside the changed lines
- `vp lint` on changed files passes; it emits five existing `no-inline-schema-compile` warnings in `schema.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex session resume on a hot path; behavior is narrower (metadata-only) but aligns with what the server already consumes and is covered by runtime and schema tests.
> 
> **Overview**
> Codex session open now resumes with **`excludeTurns: true`**, so `thread/resume` returns thread metadata without serializing full turn history. Recoverable resume failures still fall back to `thread/start`; tests assert the resume payload includes `excludeTurns` plus the existing cwd/model/sandbox fields.
> 
> The **`effect-codex-app-server`** generator patches the pinned protocol schema to expose the experimental **`excludeTurns`** field on `V2ThreadResumeParams`, with generated types and an encode test so the flag is typed on the wire.
> 
> This targets server heap exhaustion when large Codex rollouts (hundreds of MiB to ~1 GiB of history) were loaded even though resume only needs the thread id and basic session fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c75dfee5b55c9b5dd2928d4f34dd1adc5264f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `excludeTurns: true` in `thread/resume` requests to skip loading Codex history
> - When resuming a Codex thread, `openCodexThread` now sends `excludeTurns: true` in the `thread/resume` payload, requesting metadata-only resume without populating `thread.turns`.
> - Patches the generated schema in [generate.ts](https://github.com/pingdotgg/t3code/pull/8629/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) via an `ExperimentalTopLevelSchemaProperties` map so `V2ThreadResumeParams` includes the new optional `excludeTurns?: boolean` field.
> - Updates tests to assert the first `thread/resume` request carries `excludeTurns: true` and that the schema encoder preserves it.
> - Behavioral Change: `thread/resume` responses will no longer include turn history; any consumer relying on populated `thread.turns` after resume must now fetch turns separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46c75df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->