### PR TITLE
fix(web): avoid stale file writes on close

### DIFF
--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -73,6 +73,98 @@ describe("FileSaveCoordinator", () => {
     expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
   });
 
+  it("saves an edit made inside the debounce window when the editor closes", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("unsaved");
+    coordinator.dispose();
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledOnce();
+    expect(persist).toHaveBeenCalledWith("unsaved");
+  });
+
+  it("flushes an edit made while a write was in flight when the editor closes", async () => {
+    vi.useFakeTimers();
+    const inFlight = deferred();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockReturnValueOnce(inFlight.promise)
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("first");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.change("latest");
+    coordinator.dispose();
+    inFlight.resolve(AsyncResult.success(undefined));
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenLastCalledWith("latest");
+  });
+
+  it("does not rewrite a write that lands while the editor closes", async () => {
+    vi.useFakeTimers();
+    const inFlight = deferred();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockReturnValueOnce(inFlight.promise)
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("only");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.dispose();
+    inFlight.resolve(AsyncResult.success(undefined));
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledOnce();
+  });
+
+  it("retries a failed write when the editor closes", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn()
+      .mockResolvedValueOnce(AsyncResult.failure(Cause.fail(new Error("write failed"))))
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(persist).toHaveBeenCalledOnce();
+
+    coordinator.dispose();
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenLastCalledWith("latest");
+  });
+
   it("leaves the file pending when the latest write fails", async () => {
     vi.useFakeTimers();
     const onPendingChange = vi.fn();

--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -91,4 +91,49 @@ describe("FileSaveCoordinator", () => {
     expect(onPendingChange).toHaveBeenCalledWith(true);
     expect(onPendingChange).not.toHaveBeenCalledWith(false);
   });
+
+  it("ignores editor changes emitted after disposal", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const onPendingChange = vi.fn();
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange,
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.dispose();
+    coordinator.change("stale contents");
+    await vi.runAllTimersAsync();
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(onPendingChange).not.toHaveBeenCalled();
+  });
+
+  it("does not persist confirmed contents again on disposal", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("temporary edit");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.change("original contents");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(persist).toHaveBeenCalledTimes(2);
+
+    coordinator.dispose();
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -11,6 +11,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private latestContents = "";
   private latestRevision = 0;
+  private confirmedRevision = 0;
   private lastChangeAt = 0;
   private saving = false;
   private disposed = false;
@@ -18,6 +19,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
   constructor(private readonly options: FileSaveCoordinatorOptions<A, E>) {}
 
   change(contents: string): void {
+    if (this.disposed) return;
     this.latestContents = contents;
     this.latestRevision += 1;
     this.lastChangeAt = Date.now();
@@ -46,7 +48,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
   }
 
   private async persistLatest(): Promise<void> {
-    if (this.saving || this.latestRevision === 0) return;
+    if (this.saving || this.latestRevision === this.confirmedRevision) return;
 
     this.saving = true;
     const contents = this.latestContents;
@@ -54,6 +56,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
     const result = await this.options.persist(contents);
     const succeeded = result._tag === "Success";
     if (succeeded) {
+      this.confirmedRevision = revision;
       this.options.onConfirmed(contents);
     }
 


### PR DESCRIPTION
## What Changed

- track the latest confirmed file revision in the debounced save coordinator
- flush only revisions that are still pending when a file surface is disposed
- ignore editor callbacks that arrive after the coordinator has been disposed
- add regressions for confirmed-content disposal and post-disposal editor changes

## Why

Closing a file could write an already-confirmed in-memory buffer back to disk. If another device or process had updated the file since that confirmation, the close-time write replaced those newer contents with stale data.

Closes #8475.

## Testing

- `vp test run apps/web/src/components/files/fileSaveCoordinator.test.ts`
- `vp lint apps/web/src/components/files/fileSaveCoordinator.ts apps/web/src/components/files/fileSaveCoordinator.test.ts`
- `vp run --filter @t3tools/web typecheck`

## Checklist

- [x] focused regression tests added
- [x] lint passes for changed files
- [x] web typecheck passes
- [x] rebased onto latest upstream `main`
- [x] no visual change; screenshots are not applicable

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes debounced file persistence on editor close; incorrect revision tracking could drop unsaved edits or still overwrite disk, though behavior is heavily regression-tested.
> 
> **Overview**
> **Fixes `FileSaveCoordinator` re-writing already-confirmed buffer contents when a file editor closes**, which could overwrite newer on-disk changes from elsewhere.
> 
> The coordinator now tracks **`confirmedRevision`** after each successful persist and **skips `persistLatest` when there is nothing newer than what was last confirmed**, including the flush triggered by **`dispose()`**. **`change()` is ignored once disposed**, so late editor callbacks cannot schedule another save.
> 
> Regression tests cover debounce-close flushes, in-flight writes, failed-write retry on close, post-disposal changes, and the case where disposal must **not** trigger an extra persist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f126f671cd5b362311b5679ec245c0ebe905b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale file writes on close in `FileSaveCoordinator`
> - `dispose()` now cancels the debounce timer and flushes any unconfirmed revision, so edits pending in the debounce window or during an in-flight write are persisted when the editor closes.
> - Adds `confirmedRevision` tracking in `persistLatest()` so already-written contents are not re-persisted on disposal.
> - `change()` early-returns when the coordinator is disposed, ignoring editor changes emitted after close.
> - Risk: `dispose()` now triggers a persistence call whenever a newer-than-confirmed revision exists; callers that relied on disposal silently dropping pending writes will see an extra write in [fileSaveCoordinator.ts](https://github.com/pingdotgg/t3code/pull/8630/files#diff-67f64badd76dbf67ba15fd639faf5cd0a8a893bb64558b3370a535ffdb61f18d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38f126f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->