### PR TITLE
feat(web): expose chat messages as headings

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -2623,27 +2623,57 @@ const ChatMarkdownRendererContext = React.createContext<
 const CHAT_MARKDOWN_COMPONENTS = {
   h1: function MarkdownHeading1({ node: _node, ...props }) {
     const { headingLevelOffset } = use(ChatMarkdownRendererContext);
-    return <h1 {...props} aria-level={headingLevelOffset ? Math.min(6, 1 + headingLevelOffset) : undefined} />;
+    return (
+      <h1
+        {...props}
+        aria-level={headingLevelOffset ? Math.min(6, 1 + headingLevelOffset) : undefined}
+      />
+    );
   },
   h2: function MarkdownHeading2({ node: _node, ...props }) {
     const { headingLevelOffset } = use(ChatMarkdownRendererContext);
-    return <h2 {...props} aria-level={headingLevelOffset ? Math.min(6, 2 + headingLevelOffset) : undefined} />;
+    return (
+      <h2
+        {...props}
+        aria-level={headingLevelOffset ? Math.min(6, 2 + headingLevelOffset) : undefined}
+      />
+    );
   },
   h3: function MarkdownHeading3({ node: _node, ...props }) {
     const { headingLevelOffset } = use(ChatMarkdownRendererContext);
-    return <h3 {...props} aria-level={headingLevelOffset ? Math.min(6, 3 + headingLevelOffset) : undefined} />;
+    return (
+      <h3
+        {...props}
+        aria-level={headingLevelOffset ? Math.min(6, 3 + headingLevelOffset) : undefined}
+      />
+    );
   },
   h4: function MarkdownHeading4({ node: _node, ...props }) {
     const { headingLevelOffset } = use(ChatMarkdownRendererContext);
-    return <h4 {...props} aria-level={headingLevelOffset ? Math.min(6, 4 + headingLevelOffset) : undefined} />;
+    return (
+      <h4
+        {...props}
+        aria-level={headingLevelOffset ? Math.min(6, 4 + headingLevelOffset) : undefined}
+      />
+    );
   },
   h5: function MarkdownHeading5({ node: _node, ...props }) {
     const { headingLevelOffset } = use(ChatMarkdownRendererContext);
-    return <h5 {...props} aria-level={headingLevelOffset ? Math.min(6, 5 + headingLevelOffset) : undefined} />;
+    return (
+      <h5
+        {...props}
+        aria-level={headingLevelOffset ? Math.min(6, 5 + headingLevelOffset) : undefined}
+      />
+    );
   },
   h6: function MarkdownHeading6({ node: _node, ...props }) {
     const { headingLevelOffset } = use(ChatMarkdownRendererContext);
-    return <h6 {...props} aria-level={headingLevelOffset ? Math.min(6, 6 + headingLevelOffset) : undefined} />;
+    return (
+      <h6
+        {...props}
+        aria-level={headingLevelOffset ? Math.min(6, 6 + headingLevelOffset) : undefined}
+      />
+    );
   },
   div: function MarkdownDiv({ node, children, ...props }) {
     const { onUseArtifactTemplate } = use(ChatMarkdownRendererContext);

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -198,6 +198,8 @@ interface ChatMarkdownProps {
   lineBreaks?: boolean;
   /** Parse sanitized raw HTML instead of displaying its source text. */
   parseRawHtml?: boolean;
+  /** Nest markdown headings below their message without changing visual styles. */
+  headingLevelOffset?: number;
   /** Append a prompt that invokes a newly created artifact-template skill. */
   onUseArtifactTemplate?: ((template: CodexArtifactTemplate) => void) | undefined;
   /** Directory that anchors relative links and images; defaults to `cwd`. Set
@@ -2159,6 +2161,7 @@ function useChatMarkdownState({
   onTaskListChange,
   isStreaming = false,
   skills = EMPTY_MARKDOWN_SKILLS,
+  headingLevelOffset = 0,
   onUseArtifactTemplate,
   imageBaseDir,
   onImageExpand,
@@ -2551,6 +2554,7 @@ function useChatMarkdownState({
       environmentId,
       expandMedia,
       fileLinkChip,
+      headingLevelOffset,
       imageBaseDir,
       inlineCodeFileLinkMetaByText,
       isStreaming,
@@ -2578,6 +2582,7 @@ function useChatMarkdownState({
       environmentId,
       expandMedia,
       fileLinkChip,
+      headingLevelOffset,
       imageBaseDir,
       inlineCodeFileLinkMetaByText,
       isStreaming,
@@ -2616,6 +2621,30 @@ const ChatMarkdownRendererContext = React.createContext<
 
 // Keep component types stable when streaming changes the message state.
 const CHAT_MARKDOWN_COMPONENTS = {
+  h1: function MarkdownHeading1({ node: _node, ...props }) {
+    const { headingLevelOffset } = use(ChatMarkdownRendererContext);
+    return <h1 {...props} aria-level={headingLevelOffset ? Math.min(6, 1 + headingLevelOffset) : undefined} />;
+  },
+  h2: function MarkdownHeading2({ node: _node, ...props }) {
+    const { headingLevelOffset } = use(ChatMarkdownRendererContext);
+    return <h2 {...props} aria-level={headingLevelOffset ? Math.min(6, 2 + headingLevelOffset) : undefined} />;
+  },
+  h3: function MarkdownHeading3({ node: _node, ...props }) {
+    const { headingLevelOffset } = use(ChatMarkdownRendererContext);
+    return <h3 {...props} aria-level={headingLevelOffset ? Math.min(6, 3 + headingLevelOffset) : undefined} />;
+  },
+  h4: function MarkdownHeading4({ node: _node, ...props }) {
+    const { headingLevelOffset } = use(ChatMarkdownRendererContext);
+    return <h4 {...props} aria-level={headingLevelOffset ? Math.min(6, 4 + headingLevelOffset) : undefined} />;
+  },
+  h5: function MarkdownHeading5({ node: _node, ...props }) {
+    const { headingLevelOffset } = use(ChatMarkdownRendererContext);
+    return <h5 {...props} aria-level={headingLevelOffset ? Math.min(6, 5 + headingLevelOffset) : undefined} />;
+  },
+  h6: function MarkdownHeading6({ node: _node, ...props }) {
+    const { headingLevelOffset } = use(ChatMarkdownRendererContext);
+    return <h6 {...props} aria-level={headingLevelOffset ? Math.min(6, 6 + headingLevelOffset) : undefined} />;
+  },
   div: function MarkdownDiv({ node, children, ...props }) {
     const { onUseArtifactTemplate } = use(ChatMarkdownRendererContext);
     const artifactTemplate = artifactTemplateFromHastProperties(node?.properties);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1302,6 +1302,9 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       }
       data-message-role={row.kind === "message" ? row.message.role : undefined}
     >
+      {row.kind === "message" ? (
+        <h3 className="sr-only">{row.message.role === "user" ? "You" : "T3 Code"}</h3>
+      ) : null}
       {row.kind === "work" ? (
         <WorkGroupSection
           anchorKey={row.id}
@@ -1678,6 +1681,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
             isStreaming={Boolean(row.message.streaming)}
             lineBreaks={shouldPreserveAssistantLineBreaks(messageText)}
             skills={ctx.skills}
+            headingLevelOffset={3}
             onUseArtifactTemplate={ctx.onUseArtifactTemplate}
             onImageExpand={ctx.onImageExpand}
           />
@@ -2574,6 +2578,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
             cwd={props.markdownCwd}
             threadRef={ctx.threadRef ?? undefined}
             skills={props.skills}
+            headingLevelOffset={3}
             className="text-message-foreground"
             lineBreaks
             parseRawHtml={false}
@@ -2597,6 +2602,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
                   cwd={props.markdownCwd}
                   threadRef={ctx.threadRef ?? undefined}
                   skills={props.skills}
+                  headingLevelOffset={3}
                   className="text-message-foreground"
                   lineBreaks
                   parseRawHtml={false}
@@ -2686,6 +2692,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           cwd={props.markdownCwd}
           threadRef={ctx.threadRef ?? undefined}
           skills={props.skills}
+          headingLevelOffset={3}
           className="text-message-foreground"
           lineBreaks
           parseRawHtml={false}
@@ -2712,6 +2719,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
       cwd={props.markdownCwd}
       threadRef={ctx.threadRef ?? undefined}
       skills={props.skills}
+      headingLevelOffset={3}
       className="text-message-foreground"
       lineBreaks
       parseRawHtml={false}
@@ -2748,6 +2756,7 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
           cwd={ctx.markdownCwd}
           threadRef={ctx.threadRef ?? undefined}
           skills={ctx.skills}
+          headingLevelOffset={3}
           className="text-message-foreground"
         />
       )}


### PR DESCRIPTION
Chat messages lack semantic boundaries for heading navigation. Add screen-reader-only h3 author headings for user and assistant messages, below the chat title's h2, and offset markdown heading levels beneath each message without changing visual styles.

The rebase preserves main's stable CHAT_MARKDOWN_COMPONENTS and carries headingLevelOffset through ChatMarkdownRendererContext. The original static-markup accessibility test has been removed because it does not establish screen-reader behavior.

Validation: all 90 existing markdown and timeline tests pass, web typecheck passes, and scoped lint reports existing warnings. Chromium accessibility-tree verification passes at 1440×1000 and 390×844 with 80 synthetic turns: author levels 3, nested markdown levels 4–6, chronological reading order after virtualizer settlement, four keyboard-triggered older-history loads to turn 1, and Home/End/Enter navigation back to turn 80. Only 12–15 messages were mounted at checkpoints. No browser console errors or error overlay. Native screen-reader and Electron-shell behavior remain untested. LegendList’s existing 500 ms DOM-order debounce means intermediate scrolling snapshots can be out of order; checks wait for observable order before inspecting the accessibility tree.

[Browser verification evidence](https://github.com/yashranaway/t3code/releases/tag/pr-8631-browser-evidence) includes the executed script, fixtures, accessibility trees, and result checkpoints.

| Before | After |
| --- | --- |
| ![Before](https://github.com/yashranaway/t3code/releases/download/pr-8631-browser-evidence/before.png) | ![After](https://github.com/yashranaway/t3code/releases/download/pr-8631-browser-evidence/after.png) |

Closes #8535.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved heading hierarchy in chat messages to better fit the surrounding page structure.
  - Added screen-reader-only labels identifying the speaker for each timeline message.
  - Preserved visual styling while providing more accurate heading levels to assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->