### PR TITLE
fix(web): closing a file tab no longer overwrites newer changes

### DIFF
--- a/apps/web/src/components/files/fileSaveCoordinator.test.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.test.ts
@@ -73,6 +73,117 @@ describe("FileSaveCoordinator", () => {
     expect(onPendingChange.mock.calls.at(-1)).toEqual([false]);
   });
 
+  it("does not rewrite already saved contents when the editor closes", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("edited");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(persist).toHaveBeenCalledOnce();
+
+    coordinator.dispose();
+    await vi.runAllTimersAsync();
+    expect(persist).toHaveBeenCalledOnce();
+  });
+
+  it("saves an edit made inside the debounce window when the editor closes", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("unsaved");
+    coordinator.dispose();
+    await vi.runAllTimersAsync();
+    expect(persist).toHaveBeenCalledOnce();
+    expect(persist).toHaveBeenCalledWith("unsaved");
+  });
+
+  it("flushes an edit made while a write was in flight when the editor closes", async () => {
+    vi.useFakeTimers();
+    const inFlight = deferred();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockReturnValueOnce(inFlight.promise)
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("first");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.change("latest");
+    coordinator.dispose();
+    inFlight.resolve(AsyncResult.success(undefined));
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenLastCalledWith("latest");
+  });
+
+  it("does not rewrite a write that lands while the editor closes", async () => {
+    vi.useFakeTimers();
+    const inFlight = deferred();
+    const persist = vi
+      .fn<(contents: string) => Promise<AtomCommandResult<void, never>>>()
+      .mockReturnValueOnce(inFlight.promise)
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("only");
+    await vi.advanceTimersByTimeAsync(500);
+    coordinator.dispose();
+    inFlight.resolve(AsyncResult.success(undefined));
+    await vi.runAllTimersAsync();
+
+    expect(persist).toHaveBeenCalledOnce();
+  });
+
+  it("retries a failed write when the editor closes", async () => {
+    vi.useFakeTimers();
+    const persist = vi
+      .fn()
+      .mockResolvedValueOnce(AsyncResult.failure(Cause.fail(new Error("write failed"))))
+      .mockResolvedValue(AsyncResult.success(undefined));
+    const coordinator = new FileSaveCoordinator({
+      debounceMs: 500,
+      persist,
+      onPendingChange: vi.fn(),
+      onConfirmed: vi.fn(),
+    });
+
+    coordinator.change("latest");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(persist).toHaveBeenCalledOnce();
+
+    coordinator.dispose();
+    await vi.runAllTimersAsync();
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenLastCalledWith("latest");
+  });
+
   it("leaves the file pending when the latest write fails", async () => {
     vi.useFakeTimers();
     const onPendingChange = vi.fn();

--- a/apps/web/src/components/files/fileSaveCoordinator.ts
+++ b/apps/web/src/components/files/fileSaveCoordinator.ts
@@ -11,6 +11,9 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private latestContents = "";
   private latestRevision = 0;
+  // Revision of the last edit confirmed on disk, so `dispose` can tell an
+  // unsaved edit from one the debounce already wrote and only flush the former.
+  private persistedRevision = 0;
   private lastChangeAt = 0;
   private saving = false;
   private disposed = false;
@@ -28,7 +31,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
   dispose(): void {
     this.disposed = true;
     this.clearTimer();
-    if (this.latestRevision > 0) void this.persistLatest();
+    if (this.latestRevision > this.persistedRevision) void this.persistLatest();
   }
 
   private schedule(delay: number): void {
@@ -54,6 +57,7 @@ export class FileSaveCoordinator<A = unknown, E = unknown> {
     const result = await this.options.persist(contents);
     const succeeded = result._tag === "Success";
     if (succeeded) {
+      this.persistedRevision = revision;
       this.options.onConfirmed(contents);
     }
 


### PR DESCRIPTION
## What Changed

`FileSaveCoordinator` now tracks the revision it last confirmed on disk and flushes on `dispose` only when the buffer holds an edit newer than that. Previously `dispose` flushed whenever `latestRevision > 0`, and `latestRevision` was only ever incremented, never reconciled with what was actually written.

## Why

Closing or switching a file tab re-wrote the tab's remembered buffer even when the debounce had already saved it. If the file changed on disk after that save — an agent turn, another client, a shell — the close replaced the newer content with the stale buffer, with nothing in the UI or the event store recording the loss. Fixes #8475.

Flush-on-dispose is deliberate: it saves edits made inside the 500 ms debounce window right before a tab closes. That still works, and a write that failed before the close is still retried. A write already in flight when the tab closes is unchanged from before this PR: if it fails and no newer edit exists, it is not retried.

Full disk-staleness reconciliation is deliberately out of scope. `ProjectWriteFileInput` carries only `cwd`, `relativePath` and `contents`, so a write precondition would be a contract change across server, web, mobile and desktop. The remaining case: an edit made inside the debounce window that races an external write still flushes.

Related: #8424 touches this file for a different bug and, as a side effect, would also fix #8475 by zeroing `latestRevision` on success. This PR uses a separate counter instead, because `latestRevision` is also the in-flight ordering token — zeroing it makes the `revision === latestRevision` check after a successful write never hold. Whichever lands second needs a rebase.

## UI Changes

None. Nothing rendered changes; the observable difference is the file's contents on disk after a tab close.

Before (`main`) and after, same steps — open `probe.txt`, type a character, wait past the debounce, delete it, wait, then `echo APPENDED_BY_AGENT >> probe.txt` from a shell, then close the tab:

```
=== BEFORE: disk after closing the file tab ===
line one
line two                      <- APPENDED_BY_AGENT destroyed

=== AFTER: disk after closing the file tab ===
line one
line two
APPENDED_BY_AGENT             <- survives
```

## Verification

```bash
vp test run apps/web/src/components/files/fileSaveCoordinator.test.ts   # 8 passed
cd apps/web && pnpm typecheck
vp lint apps/web/src/components/files/fileSaveCoordinator.ts apps/web/src/components/files/fileSaveCoordinator.test.ts
vp format --check apps/web/src/components/files/fileSaveCoordinator.ts apps/web/src/components/files/fileSaveCoordinator.test.ts
git diff --check
```

`does not rewrite already saved contents when the editor closes` fails on `main` (`expected "vi.fn()" to be called once, but got 2 times`) and passes here. The other new cases cover dispose inside the debounce window, dispose while a write is in flight (with and without a newer edit), and retry after a failed write. Also verified by hand in a dev client against a scratch `--home-dir`, per the transcript above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A — nothing rendered changed; disk transcript above)
- [x] I included a video for animation/interaction changes (N/A)

Model: Claude Opus 5 (1M context). Harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file persistence on tab close in a coordinator used by the editor; incorrect logic could lose edits or skip needed flushes, but scope is small and well-tested.
> 
> **Overview**
> **Fixes closing a file tab re-writing disk with a stale buffer** after the debounce had already persisted the same revision—e.g. when the file changed externally afterward (#8475).
> 
> `FileSaveCoordinator` now keeps a **`persistedRevision`** updated on each successful `persist` and only runs flush-on-`dispose` when **`latestRevision > persistedRevision`**, instead of whenever `latestRevision > 0`. **Flush-on-close behavior is preserved** for edits still inside the debounce window, newer edits while a write is in flight, and **retries after a failed write**; it does **not** trigger a second write when the last edit was already confirmed.
> 
> Tests add coverage for those dispose/close scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38876e5cef8b9d1ac400e7402fd81dafe4ca0cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `FileSaveCoordinator.dispose` overwriting newer changes by tracking `persistedRevision`
> - Adds `persistedRevision` field to `FileSaveCoordinator` to track the last successfully saved revision, set on each successful persist in `persistLatest`
> - Changes `dispose` to only flush when `latestRevision > persistedRevision`, so closing a tab no longer rewrites content that was already saved
> - Failed writes leave `persistedRevision` unchanged, allowing `dispose` to retry pending or failed writes
> - Behavioral Change: `dispose` now skips persisting when all edits are already confirmed; previously it always persisted if `latestRevision > 0`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38876e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->