### PR TITLE
fix(server): reject HTTP turn bootstrap clearly

### DIFF
--- a/apps/server/src/orchestration/http.ts
+++ b/apps/server/src/orchestration/http.ts
@@ -93,9 +93,6 @@ export const orchestrationHttpApiLayer = HttpApiBuilder.group(
         Effect.fn("environment.orchestration.dispatch")(function* (args) {
           yield* annotateEnvironmentRequest(args.endpoint.name);
           yield* requireEnvironmentScope(AuthOrchestrationOperateScope);
-          if (args.payload.type === "thread.turn.start" && args.payload.bootstrap !== undefined) {
-            return yield* failEnvironmentInvalidRequest("http_bootstrap_not_supported");
-          }
           const normalizedCommand = yield* normalizeDispatchCommand(args.payload).pipe(
             Effect.catch(() => failEnvironmentInvalidRequest("invalid_command")),
           );

--- a/apps/server/src/orchestration/http.ts
+++ b/apps/server/src/orchestration/http.ts
@@ -93,6 +93,9 @@ export const orchestrationHttpApiLayer = HttpApiBuilder.group(
         Effect.fn("environment.orchestration.dispatch")(function* (args) {
           yield* annotateEnvironmentRequest(args.endpoint.name);
           yield* requireEnvironmentScope(AuthOrchestrationOperateScope);
+          if (args.payload.type === "thread.turn.start" && args.payload.bootstrap !== undefined) {
+            return yield* failEnvironmentInvalidRequest("http_bootstrap_not_supported");
+          }
           const normalizedCommand = yield* normalizeDispatchCommand(args.payload).pipe(
             Effect.catch(() => failEnvironmentInvalidRequest("invalid_command")),
           );

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1484,7 +1484,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  it.effect("rejects WebSocket-only turn bootstrap over HTTP with a typed error", () =>
+  it.effect("rejects WebSocket-only turn bootstrap at the HTTP schema", () =>
     Effect.gen(function* () {
       yield* buildAppUnderTest();
 
@@ -1521,18 +1521,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           createdAt,
         }),
       });
-      const body = (yield* response.json) as {
-        readonly _tag: string;
-        readonly code: string;
-        readonly reason: string;
-        readonly traceId: string;
-      };
-
       assert.equal(response.status, 400);
-      assert.equal(body._tag, "EnvironmentRequestInvalidError");
-      assert.equal(body.code, "invalid_request");
-      assert.equal(body.reason, "http_bootstrap_not_supported");
-      assert.equal(typeof body.traceId, "string");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1484,6 +1484,58 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("rejects WebSocket-only turn bootstrap over HTTP with a typed error", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const response = yield* HttpClient.post("/api/orchestration/dispatch", {
+        headers: {
+          cookie: yield* getAuthenticatedSessionCookieHeader(),
+        },
+        body: yield* HttpBody.json({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-http-bootstrap-turn-start"),
+          threadId: ThreadId.make("thread-http-bootstrap"),
+          message: {
+            messageId: MessageId.make("msg-http-bootstrap"),
+            role: "user",
+            text: "hello",
+            attachments: [],
+          },
+          modelSelection: defaultModelSelection,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          bootstrap: {
+            createThread: {
+              projectId: defaultProjectId,
+              title: "Bootstrap Thread",
+              modelSelection: defaultModelSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: "main",
+              worktreePath: null,
+              createdAt,
+            },
+          },
+          createdAt,
+        }),
+      });
+      const body = (yield* response.json) as {
+        readonly _tag: string;
+        readonly code: string;
+        readonly reason: string;
+        readonly traceId: string;
+      };
+
+      assert.equal(response.status, 400);
+      assert.equal(body._tag, "EnvironmentRequestInvalidError");
+      assert.equal(body.code, "invalid_request");
+      assert.equal(body.reason, "http_bootstrap_not_supported");
+      assert.equal(typeof body.traceId, "string");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("serves static index content for GET / when staticDir is configured", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/packages/contracts/src/environmentHttp.ts
+++ b/packages/contracts/src/environmentHttp.ts
@@ -67,6 +67,7 @@ export const EnvironmentRequestInvalidReason = Schema.Literals([
   "invalid_scope",
   "scope_not_granted",
   "invalid_command",
+  "http_bootstrap_not_supported",
 ]);
 export type EnvironmentRequestInvalidReason = typeof EnvironmentRequestInvalidReason.Type;
 

--- a/packages/contracts/src/environmentHttp.ts
+++ b/packages/contracts/src/environmentHttp.ts
@@ -32,8 +32,8 @@ import {
 } from "./baseSchemas.ts";
 import { ExecutionEnvironmentDescriptor } from "./environment.ts";
 import {
-  ClientOrchestrationCommand,
   DispatchResult,
+  HttpOrchestrationCommand,
   OrchestrationReadModel,
   OrchestrationShellSnapshot,
   OrchestrationThreadDetailSnapshot,
@@ -67,7 +67,6 @@ export const EnvironmentRequestInvalidReason = Schema.Literals([
   "invalid_scope",
   "scope_not_granted",
   "invalid_command",
-  "http_bootstrap_not_supported",
 ]);
 export type EnvironmentRequestInvalidReason = typeof EnvironmentRequestInvalidReason.Type;
 
@@ -532,7 +531,7 @@ export class EnvironmentOrchestrationHttpApi extends HttpApiGroup.make("orchestr
   .add(
     HttpApiEndpoint.post("dispatch", "/api/orchestration/dispatch", {
       headers: OptionalBearerHeaders,
-      payload: ClientOrchestrationCommand,
+      payload: HttpOrchestrationCommand,
       success: DispatchResult,
       error: EnvironmentOrchestrationDispatchErrors,
     }).middleware(EnvironmentAuthenticatedAuth),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -912,7 +912,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
-const ClientThreadTurnStartCommand = Schema.Struct({
+const ClientThreadTurnStartCommandFields = {
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
@@ -926,9 +926,17 @@ const ClientThreadTurnStartCommand = Schema.Struct({
   titleSeed: Schema.optional(TrimmedNonEmptyString),
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
-  bootstrap: Schema.optional(ThreadTurnStartBootstrap),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
   createdAt: IsoDateTime,
+};
+
+const ClientThreadTurnStartCommand = Schema.Struct({
+  ...ClientThreadTurnStartCommandFields,
+  bootstrap: Schema.optional(ThreadTurnStartBootstrap),
+});
+
+const HttpThreadTurnStartCommand = Schema.Struct(ClientThreadTurnStartCommandFields).annotate({
+  parseOptions: { onExcessProperty: "error" },
 });
 
 const ThreadTurnInterruptCommand = Schema.Struct({
@@ -1032,6 +1040,33 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadSessionStopCommand,
 ]);
 export type ClientOrchestrationCommand = typeof ClientOrchestrationCommand.Type;
+
+export const HttpOrchestrationCommand = Schema.Union([
+  ProjectCreateCommand,
+  ProjectMetaUpdateCommand,
+  ProjectDeleteCommand,
+  ThreadCreateCommand,
+  ThreadDeleteCommand,
+  ThreadArchiveCommand,
+  ThreadUnarchiveCommand,
+  ThreadSettleCommand,
+  ThreadUnsettleCommand,
+  ThreadSnoozeCommand,
+  ThreadUnsnoozeCommand,
+  ThreadPinCommand,
+  ThreadUnpinCommand,
+  ThreadPinReorderCommand,
+  ThreadMetaUpdateCommand,
+  ThreadRuntimeModeSetCommand,
+  ThreadInteractionModeSetCommand,
+  HttpThreadTurnStartCommand,
+  ThreadTurnInterruptCommand,
+  ThreadApprovalRespondCommand,
+  ThreadUserInputRespondCommand,
+  ThreadCheckpointRevertCommand,
+  ThreadSessionStopCommand,
+]);
+export type HttpOrchestrationCommand = typeof HttpOrchestrationCommand.Type;
 
 const ThreadSessionSetCommand = Schema.Struct({
   type: Schema.Literal("thread.session.set"),


### PR DESCRIPTION
## What Changed

- add a dedicated HTTP orchestration command schema
- exclude WebSocket-only turn bootstrap metadata from the HTTP contract
- reject bootstrap requests during payload validation instead of in the handler
- cover the HTTP schema boundary with an authenticated integration test

## Why

The HTTP endpoint advertised the full WebSocket command contract even though bootstrap execution only exists on the WebSocket route. A transport-specific command schema keeps support decisions in the contract and avoids a growing list of handler conditionals.

Closes #8319.

## Testing

- `vp test run apps/server/src/server.test.ts --testNamePattern="rejects WebSocket-only turn bootstrap at the HTTP schema"`
- `vp test run packages/contracts/src/environmentHttp.test.ts`
- `vp lint packages/contracts/src/orchestration.ts packages/contracts/src/environmentHttp.ts apps/server/src/orchestration/http.ts apps/server/src/server.test.ts`
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter t3 typecheck`

## Checklist

- [x] HTTP transport support is represented in contracts
- [x] WebSocket bootstrap behavior is unchanged
- [x] targeted tests, lint, and typechecks pass
- [x] rebased onto latest upstream `main`

Model: GPT-5.6 Sol
Harness: Codex in T3 Code