### PR TITLE
fix(server): skip IDE detection in Claude probes

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -22,6 +22,7 @@ it("isolates Claude capability probes without dropping workspace setting sources
     environment: {
       HOME: "/home/user",
       ENABLE_CLAUDEAI_MCP_SERVERS: "true",
+      FORCE_CODE_TERMINAL: "1",
     },
     cwd: "/workspace/project",
   });
@@ -37,7 +38,7 @@ it("isolates Claude capability probes without dropping workspace setting sources
   assert.equal(options.abortController, abortController);
   assert.equal(options.env?.HOME, "/home/user");
   assert.equal(options.env?.ENABLE_CLAUDEAI_MCP_SERVERS, "false");
-  assert.equal(options.env?.FORCE_CODE_TERMINAL, "1");
+  assert.equal(options.env?.FORCE_CODE_TERMINAL, undefined);
   assert.equal(options.env?.CLAUDE_CODE_AUTO_CONNECT_IDE, "0");
   assert.equal(options.env?.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL, "1");
 });

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -37,6 +37,9 @@ it("isolates Claude capability probes without dropping workspace setting sources
   assert.equal(options.abortController, abortController);
   assert.equal(options.env?.HOME, "/home/user");
   assert.equal(options.env?.ENABLE_CLAUDEAI_MCP_SERVERS, "false");
+  assert.equal(options.env?.FORCE_CODE_TERMINAL, "1");
+  assert.equal(options.env?.CLAUDE_CODE_AUTO_CONNECT_IDE, "0");
+  assert.equal(options.env?.CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL, "1");
 });
 
 it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -617,7 +617,7 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
       // This is a noninteractive health check, so IDE discovery cannot add any
       // useful capability data. Skipping it also avoids Claude spawning a
       // Windows `tasklist | findstr` process tree on every periodic refresh.
-      FORCE_CODE_TERMINAL: "1",
+      FORCE_CODE_TERMINAL: undefined,
       CLAUDE_CODE_AUTO_CONNECT_IDE: "0",
       CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL: "1",
     },

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -614,6 +614,12 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
       // Connected claude.ai MCP servers are discovered outside filesystem
       // config; disable them independently for this health check.
       ENABLE_CLAUDEAI_MCP_SERVERS: "false",
+      // This is a noninteractive health check, so IDE discovery cannot add any
+      // useful capability data. Skipping it also avoids Claude spawning a
+      // Windows `tasklist | findstr` process tree on every periodic refresh.
+      FORCE_CODE_TERMINAL: "1",
+      CLAUDE_CODE_AUTO_CONNECT_IDE: "0",
+      CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL: "1",
     },
     ...(input.cwd ? { cwd: input.cwd } : {}),
     stderr: () => {},


### PR DESCRIPTION
## What Changed

- disable Claude IDE auto-connect and auto-install during periodic capability probes
- clear any inherited terminal-forcing override from the probe environment
- keep normal Claude sessions and their configured environment unchanged
- assert the probe-only environment at the SDK options boundary

## Why

Claude capability refreshes do not need IDE integration, but on Windows the auto-detection path starts `tasklist.exe | findstr.exe`. Periodic refreshes can accumulate those descendants. The probe now opts out of IDE connection and installation without forcing Claude into a supported-terminal path.

Closes #8575.

## Testing

- `vp test run apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts`
- `vp lint apps/server/src/provider/Layers/ClaudeProvider.ts apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts`
- `vp run --filter t3 typecheck`

## Checklist

- [x] probe SDK options regression updated
- [x] normal Claude sessions are unchanged
- [x] targeted tests, lint, and server typecheck pass
- [x] rebased onto latest upstream `main`

Model: GPT-5.6 Sol
Harness: Codex in T3 Code