### PR TITLE
fix(web): make new agent replies unmistakable

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -34,6 +34,7 @@ import {
   scheduleEnvironmentReconnectWarning,
   startNewThreadForProject,
   shouldDockDraftHeroForSubmission,
+  shouldMarkThreadCompletionVisited,
   shouldReleaseTimelineAnchorForToolActivity,
   shouldShowBranchMismatchBanner,
   shouldShowPlanFollowUpPrompt,
@@ -44,6 +45,33 @@ const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
 const now = "2026-03-29T00:00:00.000Z";
+
+describe("completion visit visibility", () => {
+  const visibleCompletion = {
+    completedAt: now,
+    isAtTimelineEnd: true,
+    isPageForeground: true,
+  };
+
+  it("marks a completion visited only when the latest reply is visible", () => {
+    expect(shouldMarkThreadCompletionVisited(visibleCompletion)).toBe(true);
+    expect(
+      shouldMarkThreadCompletionVisited({ ...visibleCompletion, isAtTimelineEnd: false }),
+    ).toBe(false);
+    expect(
+      shouldMarkThreadCompletionVisited({ ...visibleCompletion, isPageForeground: false }),
+    ).toBe(false);
+  });
+
+  it("rejects absent and malformed completion timestamps", () => {
+    expect(shouldMarkThreadCompletionVisited({ ...visibleCompletion, completedAt: null })).toBe(
+      false,
+    );
+    expect(
+      shouldMarkThreadCompletionVisited({ ...visibleCompletion, completedAt: "not-a-date" }),
+    ).toBe(false);
+  });
+});
 
 describe("draft hero submission transition", () => {
   it("does not dock the composer before a background submission", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -39,6 +39,19 @@ export const ENVIRONMENT_RECONNECT_WARNING_GRACE_MS = 2_000;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
+export function shouldMarkThreadCompletionVisited(input: {
+  readonly completedAt: string | null | undefined;
+  readonly isAtTimelineEnd: boolean;
+  readonly isPageForeground: boolean;
+}): boolean {
+  return (
+    input.completedAt != null &&
+    Number.isFinite(Date.parse(input.completedAt)) &&
+    input.isAtTimelineEnd &&
+    input.isPageForeground
+  );
+}
+
 export function shouldDockDraftHeroForSubmission(input: {
   isDraftHeroState: boolean;
   activeThreadKey: string | null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -348,6 +348,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
   shouldDockDraftHeroForSubmission,
+  shouldMarkThreadCompletionVisited,
   shouldReleaseTimelineAnchorForToolActivity,
   shouldShowBranchMismatchBanner,
   shouldShowPlanFollowUpPrompt,
@@ -1508,6 +1509,13 @@ function ChatViewContent(props: ChatViewProps) {
   const [composerOverlayElement, setComposerOverlayElement] = useState<HTMLDivElement | null>(null);
   const [composerOverlayHeight, setComposerOverlayHeight] = useState(0);
   const isAtEndRef = useRef(true);
+  const [isAtTimelineEnd, setIsAtTimelineEnd] = useState(false);
+  const [isPageForeground, setIsPageForeground] = useState(
+    () =>
+      typeof document !== "undefined" &&
+      document.visibilityState === "visible" &&
+      document.hasFocus(),
+  );
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewPromotionInFlightByMessageIdRef = useRef<Record<string, true>>({});
   const sendInFlightRef = useRef(false);
@@ -1806,19 +1814,44 @@ function ChatViewContent(props: ChatViewProps) {
   const activeRunningTurnId =
     (activeThread?.session?.status === "running" ? activeThread.session.activeTurnId : null) ??
     (activeLatestTurn?.state === "running" ? activeLatestTurn.turnId : null);
-  // Reading a finished thread clears the sidebar's Done badge. The visit is
-  // stamped at the turn's completion time — not now/updatedAt — so it clears
-  // exactly the completion the user is looking at: a wake or completion that
-  // lands later still gets its signal (markThreadVisited never moves the
-  // timestamp backwards).
+  useEffect(() => {
+    const syncPageForeground = () => {
+      setIsPageForeground(document.visibilityState === "visible" && document.hasFocus());
+    };
+    window.addEventListener("focus", syncPageForeground);
+    window.addEventListener("blur", syncPageForeground);
+    document.addEventListener("visibilitychange", syncPageForeground);
+    return () => {
+      window.removeEventListener("focus", syncPageForeground);
+      window.removeEventListener("blur", syncPageForeground);
+      document.removeEventListener("visibilitychange", syncPageForeground);
+    };
+  }, []);
+
+  // A completion is read only when the latest reply is actually on screen.
+  // Keeping a thread routed in a background window, or viewing older history,
+  // must not silently consume its New reply signal. The visit is stamped at
+  // the completion time so a later completion can still raise attention.
   useEffect(() => {
     const completedAt = serverThread?.latestTurn?.completedAt;
-    if (!serverThread?.id || !completedAt) return;
+    if (
+      !serverThread?.id ||
+      completedAt == null ||
+      !shouldMarkThreadCompletionVisited({
+        completedAt,
+        isAtTimelineEnd,
+        isPageForeground,
+      })
+    ) {
+      return;
+    }
     markThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
       completedAt,
     );
   }, [
+    isAtTimelineEnd,
+    isPageForeground,
     markThreadVisited,
     serverThread?.environmentId,
     serverThread?.id,
@@ -4261,6 +4294,7 @@ function ChatViewContent(props: ChatViewProps) {
   }, []);
 
   const onIsAtEndChange = useCallback((isAtEnd: boolean) => {
+    setIsAtTimelineEnd(isAtEnd);
     if (
       !isAtEnd &&
       liveFollowUserScrollGenerationRef.current === anchorUserScrollGenerationRef.current
@@ -4344,6 +4378,9 @@ function ChatViewContent(props: ChatViewProps) {
   useEffect(() => {
     setPullRequestDialogState(null);
     isAtEndRef.current = true;
+    // Wait for the newly mounted timeline to report its real position before
+    // consuming a completion. The previous thread's end state is irrelevant.
+    setIsAtTimelineEnd(false);
     timelineScrollModeRef.current = "following-end";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
     setTimelineLiveFollowEnabled(true);
@@ -6075,6 +6112,13 @@ function ChatViewContent(props: ChatViewProps) {
         failure = startResult;
       } else {
         turnStartSucceeded = true;
+        // Seed the read marker from the user's own message. If they leave the
+        // thread before the agent finishes, the later completion now has a
+        // stable baseline and can surface as New reply even on a fresh thread.
+        markThreadVisited(
+          scopedThreadKey(scopeThreadRef(activeThread.environmentId, threadIdForSend)),
+          messageCreatedAt,
+        );
         if (turnUsesAttachmentUploads) {
           releaseDraftAttachments(composerAttachmentsSnapshot);
         }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -38,7 +38,6 @@ import {
   CheckIcon,
   ChevronDownIcon,
   CircleAlertIcon,
-  CircleCheckIcon,
   CircleDashedIcon,
   ClockIcon,
   FolderIcon,
@@ -192,6 +191,7 @@ import {
 } from "./ui/combobox";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
+import { SidebarNewReplyChip } from "./sidebar/SidebarNewReplyChip";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import {
@@ -846,7 +846,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     });
   // In-flight rows (working, or waiting on approval/input) fade as a whole:
   // there is nothing for the user to do yet, so prominence is reserved for
-  // rows that need a human — done (unread), read-but-unsettled, failed, and
+  // rows that need a human — new replies, read-but-unsettled, failed, and
   // freshly woken. The status label keeps its hue, so waiting rows stay
   // findable. In-flight rows recede the same as read-ready ones (inbox-zero:
   // working threads aren't your problem yet) — only the colored status label
@@ -902,13 +902,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     icon: "woke" as const,
                     className: "text-amber-700 dark:text-amber-300",
                   }
-                : isUnread
-                  ? {
-                      label: "Done",
-                      icon: "done" as const,
-                      className: "text-emerald-700 dark:text-emerald-300",
-                    }
-                  : null;
+                : null;
   const isWokeStatus = topStatus?.icon === "woke";
 
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
@@ -1128,9 +1122,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       ? "bg-sidebar-row-active text-sidebar-foreground"
       : isSelected
         ? "bg-sidebar-row-selected text-sidebar-foreground"
-        : shouldRecede
-          ? "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
-          : "bg-transparent text-sidebar-foreground hover:bg-sidebar-row-hover",
+        : isUnread
+          ? "bg-success/4 text-sidebar-foreground hover:bg-success/8 dark:bg-success/8 dark:hover:bg-success/12"
+          : shouldRecede
+            ? "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+            : "bg-transparent text-sidebar-foreground hover:bg-sidebar-row-hover",
     isInFlight &&
       !props.isActive &&
       !isSelected &&
@@ -1493,8 +1489,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                       >
                         {topStatus.icon === "working" ? (
                           <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
-                        ) : topStatus.icon === "done" ? (
-                          <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
                         ) : null}
                         {/* The label alone is the live region: a role="status"
                             wrapper around the ticking duration would make
@@ -1555,6 +1549,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             </div>
             <div className="mt-1 flex min-w-0">
               {title}
+              {isUnread ? <SidebarNewReplyChip /> : null}
               {isRegeneratingTitle ? (
                 <span role="status" className="sr-only">
                   Regenerating title

--- a/apps/web/src/components/sidebar/SidebarNewReplyChip.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarNewReplyChip.test.tsx
@@ -1,0 +1,15 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { SidebarNewReplyChip } from "./SidebarNewReplyChip";
+
+describe("SidebarNewReplyChip", () => {
+  it("renders a persistent labeled success chip", () => {
+    const markup = renderToStaticMarkup(<SidebarNewReplyChip />);
+
+    expect(markup).toContain('aria-label="New reply"');
+    expect(markup).toContain('data-testid="sidebar-new-reply-chip"');
+    expect(markup).toContain("bg-success/8");
+    expect(markup).toContain("New reply");
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarNewReplyChip.tsx
+++ b/apps/web/src/components/sidebar/SidebarNewReplyChip.tsx
@@ -1,0 +1,18 @@
+import { MessageSquareIcon } from "lucide-react";
+
+import { Badge } from "../ui/badge";
+
+export function SidebarNewReplyChip() {
+  return (
+    <Badge
+      aria-label="New reply"
+      className="ml-1.5 gap-1 self-center"
+      data-testid="sidebar-new-reply-chip"
+      size="sm"
+      variant="success"
+    >
+      <MessageSquareIcon aria-hidden className="size-2.5" />
+      New reply
+    </Badge>
+  );
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -13,6 +13,11 @@ request merges if **Auto-settle merged threads** is enabled.
 When you un-settle a thread, it returns to the top of the active list so you can find it right
 away. Its timestamps do not change. Other threads keep their positions.
 
+When an agent finishes after you leave a thread, the sidebar shows a **New reply** chip and a
+highlighted card. The chip appears alongside statuses such as **Needs input**, so a reply does not
+hide what the agent is waiting for. It clears when T3 Code is in the foreground and you view the
+newest message. Choose **Mark unread** from the thread menu to bring the indicator back.
+
 Right-click a pull request link in a thread and choose **Link to thread** to show that pull request
 in the sidebar. The thread settles when the linked pull request merges if **Auto-settle merged
 threads** is enabled. Right-click the same link and choose **Unlink from thread** to remove it.


### PR DESCRIPTION
Threads could finish without becoming visually distinct: the existing Done label competed with operational statuses and a routed thread was marked read even in a background tab or while older history was visible.

This adds a persistent New reply chip and subtle card highlight independent of working/input/approval state. Completion is now marked read only while T3 Code is foregrounded and the newest timeline content is visible, and a successful user send seeds the read baseline for fresh threads.

Tests:
- focused web tests (4 files, 183 tests)
- @t3tools/web typecheck
- targeted lint and formatting

UI evidence will be added before this leaves draft.

Implemented by GPT-5.6-sol through the Codex harness.