### PR TITLE
fix(server): explain outdated Codex service tiers

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -29,7 +29,10 @@ import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
   AUTH_PROBE_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
   buildServerProvider,
+  parseGenericCliVersion,
+  spawnAndCollect,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
@@ -37,6 +40,9 @@ import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
 const CODEX_APP_SERVER_PROBE_FORCE_KILL_AFTER = "2 seconds" as const;
+const MINIMUM_CODEX_STRING_SERVICE_TIER_VERSION = "0.130.0";
+const LEGACY_CODEX_SERVICE_TIER_ERROR =
+  /unknown variant [`'"](?:default|priority)[`'"], expected [`'"]fast[`'"] or [`'"]flex[`'"]/i;
 
 const CODEX_PRESENTATION = {
   displayName: "Codex",
@@ -48,6 +54,50 @@ export interface CodexAppServerProviderSnapshot {
   readonly version: string | undefined;
   readonly models: ReadonlyArray<ServerProviderModel>;
   readonly skills: ReadonlyArray<ServerProviderSkill>;
+}
+
+interface CodexCliVersionProbeInput {
+  readonly binaryPath: string;
+  readonly homePath?: string;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+type CodexCliVersionProbe = (
+  input: CodexCliVersionProbeInput,
+) => Effect.Effect<string | null, never, ChildProcessSpawner.ChildProcessSpawner>;
+
+const probeCodexCliVersion = Effect.fn("probeCodexCliVersion")(
+  function* (input: CodexCliVersionProbeInput) {
+    const resolvedHomePath = input.homePath ? expandHomePath(input.homePath) : undefined;
+    const environment = {
+      ...input.environment,
+      ...(resolvedHomePath ? { CODEX_HOME: resolvedHomePath } : {}),
+    };
+    const spawnCommand = yield* resolveSpawnCommand(input.binaryPath, ["--version"], {
+      env: environment,
+      extendEnv: true,
+    });
+    const result = yield* spawnAndCollect(
+      input.binaryPath,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        cwd: input.cwd,
+        env: environment,
+        extendEnv: true,
+        forceKillAfter: CODEX_APP_SERVER_PROBE_FORCE_KILL_AFTER,
+        shell: spawnCommand.shell,
+      }),
+    );
+    return parseGenericCliVersion(`${result.stdout}\n${result.stderr}`);
+  },
+  Effect.orElseSucceed(() => null),
+);
+
+function isLegacyCodexServiceTierError(error: CodexErrors.CodexAppServerError): boolean {
+  return (
+    error._tag === "CodexAppServerRequestError" &&
+    LEGACY_CODEX_SERVICE_TIER_ERROR.test(error.errorMessage)
+  );
 }
 
 const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
@@ -514,6 +564,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
   > = probeCodexAppServerProvider,
   environment?: NodeJS.ProcessEnv,
+  versionProbe: CodexCliVersionProbe = probeCodexCliVersion,
 ): Effect.fn.Return<
   ServerProviderDraft,
   ServerSettingsError,
@@ -556,6 +607,18 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   if (Result.isFailure(probeResult)) {
     const error = probeResult.failure;
     const installed = !isCodexAppServerSpawnError(error);
+    const hasLegacyServiceTierConfig = isLegacyCodexServiceTierError(error);
+    const version = hasLegacyServiceTierConfig
+      ? yield* versionProbe({
+          binaryPath: codexSettings.binaryPath,
+          homePath: codexSettings.homePath,
+          cwd: process.cwd(),
+          environment: resolvedEnvironment,
+        }).pipe(Effect.timeoutOption(DEFAULT_TIMEOUT_MS), Effect.map(Option.getOrNull))
+      : null;
+    const legacyServiceTierMessage = version
+      ? `Codex CLI ${version} cannot read this service tier. Update Codex CLI to ${MINIMUM_CODEX_STRING_SERVICE_TIER_VERSION} or newer, then refresh provider status.`
+      : `This Codex CLI cannot read this service tier. Update Codex CLI to ${MINIMUM_CODEX_STRING_SERVICE_TIER_VERSION} or newer, then refresh provider status.`;
     return buildServerProvider({
       presentation: CODEX_PRESENTATION,
       enabled: codexSettings.enabled,
@@ -564,11 +627,11 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
       skills: [],
       probe: {
         installed,
-        version: null,
+        version,
         status: "error",
         auth: { status: "unknown" },
         message: installed
-          ? `Codex app-server provider probe failed: ${error.message}.`
+          ? `Codex app-server provider probe failed: ${error.message}.${hasLegacyServiceTierConfig ? ` ${legacyServiceTierMessage}` : ""}`
           : "Codex CLI (`codex`) was not found on PATH.",
       },
     });

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -506,6 +506,33 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
+      it.effect("requires a current Codex CLI for current service tier settings", () =>
+        Effect.gen(function* () {
+          const status = yield* checkCodexProviderStatus(
+            defaultCodexSettings,
+            () =>
+              Effect.fail(
+                new CodexErrors.CodexAppServerRequestError({
+                  code: -32603,
+                  errorMessage:
+                    "failed to reload config: C:\\Users\\markb\\.codex\\config.toml:6:16: unknown variant `default`, expected `fast` or `flex`",
+                }),
+              ),
+            undefined,
+            () => Effect.succeed("0.129.0"),
+          );
+
+          assert.strictEqual(status.status, "error");
+          assert.strictEqual(status.installed, true);
+          assert.strictEqual(status.version, "0.129.0");
+          assert.strictEqual(status.auth.status, "unknown");
+          assert.strictEqual(
+            status.message,
+            "Codex app-server provider probe failed: failed to reload config: C:\\Users\\markb\\.codex\\config.toml:6:16: unknown variant `default`, expected `fast` or `flex`. Codex CLI 0.129.0 cannot read this service tier. Update Codex CLI to 0.130.0 or newer, then refresh provider status.",
+          );
+        }),
+      );
+
       it.effect("closes the app-server probe scope when provider status times out", () =>
         Effect.gen(function* () {
           const killCalls = yield* Ref.make(0);


### PR DESCRIPTION
Codex CLI 0.129 and older cannot read the `default` and `priority` service tier names written by newer Codex clients. T3 Code currently reports the resulting config reload failure without identifying the installed version or the required update.

Recognize that exact parser failure, probe `codex --version`, and publish the version with a clear requirement for Codex CLI 0.130.0 or newer. Publishing the version also lets the existing provider update flow offer its normal update action.

Fixes #8602

Tested with the focused provider registry suite, server lint, and server typecheck.

Built with GPT-5.6 Sol in the Codex harness inside T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Codex provider status probing and user-facing error text on an existing failure path, with no auth or session behavior changes.
> 
> **Overview**
> When the Codex app-server probe fails because the installed CLI cannot parse newer **service tier** values (`default` / `priority` in config), the server now recognizes that error pattern, runs **`codex --version`**, and surfaces the detected version on the provider status.
> 
> The probe error message is extended with guidance to upgrade to **Codex CLI 0.130.0+** and refresh provider status, so users get a clear fix instead of a raw config reload failure. Publishing **version** on the error snapshot also keeps the normal provider update flow available.
> 
> `checkCodexProviderStatus` accepts an injectable **versionProbe** (defaulting to the new CLI probe) for tests; a registry test covers the legacy tier failure path with a mocked **0.129.0** version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c7d2cdf7b02e848861cf751d2d9cecff0df11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add legacy Codex service tier detection and version probe to `checkCodexProviderStatus`
> - Adds `probeCodexCliVersion` which runs `codex --version` and parses the output, returning null on failure.
> - Adds `isLegacyCodexServiceTierError` to match known legacy service tier error patterns in `CodexAppServerRequestError`.
> - On legacy service tier errors, `checkCodexProviderStatus` now probes the CLI version, populates the snapshot `version` field, and appends guidance recommending upgrade to `0.130.0` or newer.
> - Adds a test in [ProviderRegistry.test.ts](https://github.com/pingdotgg/t3code/pull/8639/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f) covering the legacy error path with a simulated version of `0.129.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20c7d2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->