### PR TITLE
feat(desktop): add configurable Windows Acrylic backdrop

### DIFF
--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -20,6 +20,7 @@ export interface MakeDesktopEnvironmentInput {
   readonly dirname: string;
   readonly homeDirectory: string;
   readonly platform: NodeJS.Platform;
+  readonly systemVersion?: string | undefined;
   readonly processArch: string;
   readonly appVersion: string;
   readonly appPath: string;
@@ -34,6 +35,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly path: Path.Path;
     readonly dirname: string;
     readonly platform: NodeJS.Platform;
+    readonly systemVersion: string | undefined;
     readonly processArch: string;
     readonly isPackaged: boolean;
     readonly isDevelopment: boolean;
@@ -190,6 +192,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     path,
     dirname: input.dirname,
     platform: input.platform,
+    systemVersion: input.systemVersion,
     processArch: input.processArch,
     isPackaged: input.isPackaged,
     isDevelopment,

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -94,6 +94,7 @@ function makeDesktopWindowLayer(
     flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,
     zoomMain: () => Effect.void,
+    isBackdropEnabled: () => false,
     syncAppearance: Effect.void,
   });
 }

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -94,6 +94,7 @@ function makePoolLayer(
           flushMainWindowBounds: Effect.void,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
           zoomMain: () => Effect.die("unexpected zoom"),
+          isBackdropEnabled: () => false,
           syncAppearance: Effect.void,
         } satisfies DesktopWindow.DesktopWindow["Service"]),
       ),

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -35,6 +35,7 @@ import {
   getLocalEnvironmentBootstraps,
   getLocalEnvironmentBearerToken,
   getSystemLocale,
+  getWindowBackdropState,
   getWindowFullscreenState,
   openExternal,
   probeRemoteEditors,
@@ -53,6 +54,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
 
   yield* ipc.handleSync(getAppBranding);
   yield* ipc.handleSync(getSystemLocale);
+  yield* ipc.handleSync(getWindowBackdropState);
   yield* ipc.handleSync(getWindowFullscreenState);
   yield* ipc.handleSync(getLocalEnvironmentBootstraps);
   yield* ipc.handle(getLocalEnvironmentBearerToken);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -8,6 +8,7 @@ export const PROBE_REMOTE_EDITORS_CHANNEL = "desktop:probe-remote-editors";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const QUIT_SHORTCUT_CHANNEL = "desktop:quit-shortcut";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
+export const WINDOW_BACKDROP_STATE_CHANNEL = "desktop:window-backdrop-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -8,6 +8,7 @@ export const PROBE_REMOTE_EDITORS_CHANNEL = "desktop:probe-remote-editors";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const QUIT_SHORTCUT_CHANNEL = "desktop:quit-shortcut";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
+export const GET_WINDOW_BACKDROP_STATE_CHANNEL = "desktop:get-window-backdrop-state";
 export const WINDOW_BACKDROP_STATE_CHANNEL = "desktop:window-backdrop-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";

--- a/apps/desktop/src/ipc/methods/clientSettings.ts
+++ b/apps/desktop/src/ipc/methods/clientSettings.ts
@@ -4,6 +4,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as DesktopClientSettings from "../../settings/DesktopClientSettings.ts";
+import * as DesktopWindow from "../../window/DesktopWindow.ts";
 import * as IpcChannels from "../channels.ts";
 import * as DesktopIpc from "../DesktopIpc.ts";
 
@@ -24,5 +25,7 @@ export const setClientSettings = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.clientSettings.set")(function* (settings) {
     const clientSettings = yield* DesktopClientSettings.DesktopClientSettings;
     yield* clientSettings.set(settings);
+    const desktopWindow = yield* DesktopWindow.DesktopWindow;
+    yield* desktopWindow.syncAppearance;
   }),
 });

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -11,6 +11,7 @@ import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
 import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
+import * as DesktopWindow from "../../window/DesktopWindow.ts";
 import {
   getLocalEnvironmentBootstraps,
   getWindowBackdropState,
@@ -167,6 +168,9 @@ describe("getWindowBackdropState", () => {
           Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
             platform: "darwin",
           } as DesktopEnvironment.DesktopEnvironment["Service"]),
+          Layer.mock(DesktopWindow.DesktopWindow)({
+            isBackdropEnabled: () => false,
+          }),
           Layer.mock(ElectronWindow.ElectronWindow)({
             currentMainOrFirst: Effect.succeed(Option.some(window)),
           }),

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -8,10 +8,12 @@ import type * as Electron from "electron";
 
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import {
   getLocalEnvironmentBootstraps,
+  getWindowBackdropState,
   getWindowFullscreenState,
   pickProjectFavicon,
 } from "./window.ts";
@@ -148,6 +150,27 @@ describe("getWindowFullscreenState", () => {
         Layer.mock(ElectronWindow.ElectronWindow)({
           currentMainOrFirst: Effect.succeed(Option.some(window)),
         }),
+      ),
+    );
+  });
+});
+
+describe("getWindowBackdropState", () => {
+  it.effect("returns false when the current platform is not Windows", () => {
+    const window = {} as Electron.BrowserWindow;
+
+    return Effect.gen(function* () {
+      assert.isFalse(yield* getWindowBackdropState.handler());
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+            platform: "darwin",
+          } as DesktopEnvironment.DesktopEnvironment["Service"]),
+          Layer.mock(ElectronWindow.ElectronWindow)({
+            currentMainOrFirst: Effect.succeed(Option.some(window)),
+          }),
+        ),
       ),
     );
   });

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -93,9 +93,10 @@ export const getWindowBackdropState = DesktopIpc.makeSyncIpcMethod({
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
     if (environment.platform !== "win32") return false;
 
+    const desktopWindow = yield* DesktopWindow.DesktopWindow;
     const electronWindow = yield* ElectronWindow.ElectronWindow;
     const window = yield* electronWindow.currentMainOrFirst;
-    return Option.isSome(window) && DesktopWindow.isWindowBackdropEnabled(window.value);
+    return Option.isSome(window) && desktopWindow.isBackdropEnabled(window.value);
   }),
 });
 

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -33,6 +33,7 @@ import * as ElectronMenu from "../../electron/ElectronMenu.ts";
 import * as ElectronShell from "../../electron/ElectronShell.ts";
 import * as ElectronTheme from "../../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
+import * as DesktopWindow from "../../window/DesktopWindow.ts";
 import * as IpcChannels from "../channels.ts";
 import * as DesktopIpc from "../DesktopIpc.ts";
 import {
@@ -82,6 +83,19 @@ export const getWindowFullscreenState = DesktopIpc.makeSyncIpcMethod({
     const electronWindow = yield* ElectronWindow.ElectronWindow;
     const window = yield* electronWindow.currentMainOrFirst;
     return Option.isSome(window) && window.value.isFullScreen();
+  }),
+});
+
+export const getWindowBackdropState = DesktopIpc.makeSyncIpcMethod({
+  channel: IpcChannels.GET_WINDOW_BACKDROP_STATE_CHANNEL,
+  result: Schema.Boolean,
+  handler: Effect.fn("desktop.ipc.window.getWindowBackdropState")(function* () {
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    if (environment.platform !== "win32") return false;
+
+    const electronWindow = yield* ElectronWindow.ElectronWindow;
+    const window = yield* electronWindow.currentMainOrFirst;
+    return Option.isSome(window) && DesktopWindow.isWindowBackdropEnabled(window.value);
   }),
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -75,6 +75,7 @@ const desktopEnvironmentLayer = Layer.unwrap(
       dirname: __dirname,
       homeDirectory: NodeOS.homedir(),
       platform,
+      systemVersion: process.getSystemVersion(),
       processArch,
       ...metadata,
     });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -140,6 +140,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   },
   getWindowFullscreenState: () =>
     ipcRenderer.sendSync(IpcChannels.GET_WINDOW_FULLSCREEN_STATE_CHANNEL) === true,
+  getWindowBackdropState: () =>
+    ipcRenderer.sendSync(IpcChannels.GET_WINDOW_BACKDROP_STATE_CHANNEL) === true,
   onWindowFullscreenStateChange: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, fullscreen: unknown) => {
       if (typeof fullscreen !== "boolean") return;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -151,6 +151,17 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.removeListener(IpcChannels.WINDOW_FULLSCREEN_STATE_CHANNEL, wrappedListener);
     };
   },
+  onWindowBackdropStateChange: (listener) => {
+    const wrappedListener = (_event: Electron.IpcRendererEvent, enabled: unknown) => {
+      if (typeof enabled !== "boolean") return;
+      listener(enabled);
+    };
+
+    ipcRenderer.on(IpcChannels.WINDOW_BACKDROP_STATE_CHANNEL, wrappedListener);
+    return () => {
+      ipcRenderer.removeListener(IpcChannels.WINDOW_BACKDROP_STATE_CHANNEL, wrappedListener);
+    };
+  },
   getUpdateState: () => ipcRenderer.invoke(IpcChannels.UPDATE_GET_STATE_CHANNEL),
   setUpdateChannel: (channel) =>
     ipcRenderer.invoke(IpcChannels.UPDATE_SET_CHANNEL_CHANNEL, channel),

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -25,6 +25,7 @@ const clientSettings: ClientSettings = {
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
   environmentIdentificationMode: "artwork",
+  desktopBackdropEnabled: true,
   favorites: [],
   fontFamilyCode: "",
   fontFamilyComposer: "",

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -83,6 +83,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     zoomMain: (direction) =>
       Deferred.succeed(selectedAction, `zoom-${direction}`).pipe(Effect.asVoid),
+    isBackdropEnabled: () => false,
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindow["Service"]);
 

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -104,6 +104,7 @@ function makeFakeBrowserWindow() {
     }),
     restore: vi.fn(),
     setBackgroundColor: vi.fn(),
+    setBackgroundMaterial: vi.fn(),
     setAutoHideCursor: vi.fn(),
     setTitle: vi.fn(),
     setTitleBarOverlay: vi.fn(),
@@ -394,6 +395,28 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
   });
 
 describe("DesktopWindow", () => {
+  it("uses transparent Acrylic-ready window options only on Windows", () => {
+    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true), {
+      backgroundColor: "#00000000",
+      backgroundMaterial: "acrylic",
+      frame: false,
+      roundedCorners: true,
+      thickFrame: true,
+      transparent: true,
+    });
+    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true, false), {
+      backgroundColor: "#0a0a0a",
+      backgroundMaterial: "none",
+      frame: false,
+      roundedCorners: true,
+      thickFrame: true,
+      transparent: true,
+    });
+    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("darwin", true), {
+      backgroundColor: "#0a0a0a",
+    });
+  });
+
   it("restores bounds only when the window fits within a connected display", () => {
     const persistedBounds = { x: 2040, y: 80, width: 1320, height: 880 };
     const displays = [

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -127,6 +127,8 @@ function makeFakeBrowserWindow() {
     send: webContents.send,
     setZoomLevel: webContents.setZoomLevel,
     setBackgroundThrottling: webContents.setBackgroundThrottling,
+    setBackgroundColor: window.setBackgroundColor,
+    setBackgroundMaterial: window.setBackgroundMaterial,
     setAutoHideCursor: window.setAutoHideCursor,
     webContentsListeners,
     windowListeners,
@@ -177,17 +179,20 @@ const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
   onUpdated: () => Effect.void,
 } satisfies ElectronTheme.ElectronTheme["Service"]);
 
-const desktopEnvironmentLayer = DesktopEnvironment.layer(environmentInput).pipe(
-  Layer.provide(
-    Layer.mergeAll(
-      NodeServices.layer,
-      DesktopConfig.layerTest({
-        T3CODE_PORT: "3773",
-        VITE_DEV_SERVER_URL: "http://127.0.0.1:5733",
-      }),
+const makeDesktopEnvironmentLayer = (platform: NodeJS.Platform = environmentInput.platform) =>
+  DesktopEnvironment.layer({ ...environmentInput, platform }).pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        DesktopConfig.layerTest({
+          T3CODE_PORT: "3773",
+          VITE_DEV_SERVER_URL: "http://127.0.0.1:5733",
+        }),
+      ),
     ),
-  ),
-);
+  );
+
+const desktopEnvironmentLayer = makeDesktopEnvironmentLayer();
 
 const desktopWindowBoundsEquivalence = Schema.toEquivalence(
   DesktopAppSettings.DesktopWindowBoundsSchema,
@@ -206,6 +211,7 @@ function makeTestLayer(input: {
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly previewZoomReapplies?: number[];
+  readonly platform?: NodeJS.Platform;
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -264,7 +270,7 @@ function makeTestLayer(input: {
     Layer.provide(
       Layer.mergeAll(
         desktopAssetsLayer,
-        desktopEnvironmentLayer,
+        makeDesktopEnvironmentLayer(input.platform),
         desktopAppSettingsLayer,
         desktopClientSettingsLayer,
         desktopServerExposureLayer,
@@ -416,6 +422,28 @@ describe("DesktopWindow", () => {
       backgroundColor: "#0a0a0a",
     });
   });
+
+  it.effect("does not apply the Windows backdrop to unowned auxiliary windows", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        platform: "win32",
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.syncAppearance;
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(fakeWindow.setBackgroundMaterial.mock.calls.length, 0);
+      assert.equal(fakeWindow.setBackgroundColor.mock.calls.length, 0);
+    }),
+  );
 
   it("restores bounds only when the window fits within a connected display", () => {
     const persistedBounds = { x: 2040, y: 80, width: 1320, height: 880 };

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -43,7 +43,11 @@ import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
-import { MENU_ACTION_CHANNEL, WINDOW_FULLSCREEN_STATE_CHANNEL } from "../ipc/channels.ts";
+import {
+  MENU_ACTION_CHANNEL,
+  WINDOW_BACKDROP_STATE_CHANNEL,
+  WINDOW_FULLSCREEN_STATE_CHANNEL,
+} from "../ipc/channels.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 import * as PreviewManager from "../preview/Manager.ts";
@@ -52,6 +56,7 @@ const environmentInput = {
   dirname: "/repo/apps/desktop/dist-electron",
   homeDirectory: "/Users/alice",
   platform: "darwin",
+  systemVersion: undefined,
   processArch: "arm64",
   appVersion: "1.2.3",
   appPath: "/repo",
@@ -179,8 +184,11 @@ const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
   onUpdated: () => Effect.void,
 } satisfies ElectronTheme.ElectronTheme["Service"]);
 
-const makeDesktopEnvironmentLayer = (platform: NodeJS.Platform = environmentInput.platform) =>
-  DesktopEnvironment.layer({ ...environmentInput, platform }).pipe(
+const makeDesktopEnvironmentLayer = (
+  platform: NodeJS.Platform = environmentInput.platform,
+  systemVersion: string | undefined = environmentInput.systemVersion,
+) =>
+  DesktopEnvironment.layer({ ...environmentInput, platform, systemVersion }).pipe(
     Layer.provide(
       Layer.mergeAll(
         NodeServices.layer,
@@ -212,6 +220,7 @@ function makeTestLayer(input: {
   readonly openedExternalUrls?: unknown[];
   readonly previewZoomReapplies?: number[];
   readonly platform?: NodeJS.Platform;
+  readonly systemVersion?: string;
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -270,7 +279,7 @@ function makeTestLayer(input: {
     Layer.provide(
       Layer.mergeAll(
         desktopAssetsLayer,
-        makeDesktopEnvironmentLayer(input.platform),
+        makeDesktopEnvironmentLayer(input.platform, input.systemVersion),
         desktopAppSettingsLayer,
         desktopClientSettingsLayer,
         desktopServerExposureLayer,
@@ -402,7 +411,13 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
 
 describe("DesktopWindow", () => {
   it("uses transparent Acrylic-ready window options only on Windows", () => {
-    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true), {
+    assert.isTrue(DesktopWindow.isWindowsAcrylicSupported("win32", "10.0.22621"));
+    assert.isTrue(DesktopWindow.isWindowsAcrylicSupported("win32", "10.0.26100"));
+    assert.isFalse(DesktopWindow.isWindowsAcrylicSupported("win32", "10.0.22000"));
+    assert.isFalse(DesktopWindow.isWindowsAcrylicSupported("win32", undefined));
+    assert.isFalse(DesktopWindow.isWindowsAcrylicSupported("darwin", "10.0.22621"));
+
+    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true, true, true), {
       backgroundColor: "#00000000",
       backgroundMaterial: "acrylic",
       frame: false,
@@ -410,7 +425,15 @@ describe("DesktopWindow", () => {
       thickFrame: true,
       transparent: true,
     });
-    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true, false), {
+    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true, false, true), {
+      backgroundColor: "#0a0a0a",
+      backgroundMaterial: "none",
+      frame: false,
+      roundedCorners: true,
+      thickFrame: true,
+      transparent: true,
+    });
+    assert.deepEqual(DesktopWindow.getWindowBackdropOptions("win32", true, true, false), {
       backgroundColor: "#0a0a0a",
       backgroundMaterial: "none",
       frame: false,
@@ -442,6 +465,35 @@ describe("DesktopWindow", () => {
 
       assert.equal(fakeWindow.setBackgroundMaterial.mock.calls.length, 0);
       assert.equal(fakeWindow.setBackgroundColor.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("keeps the Windows window opaque when Acrylic is unsupported", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const createdWindowOptions: Electron.BrowserWindowConstructorOptions[] = [];
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        createdWindowOptions,
+        platform: "win32",
+        systemVersion: "10.0.22000",
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        assert.equal(createdWindowOptions[0]?.backgroundMaterial, "none");
+        assert.equal(createdWindowOptions[0]?.backgroundColor, "#ffffff");
+        assert.deepEqual(fakeWindow.setBackgroundMaterial.mock.calls, [["none"]]);
+        assert.deepEqual(fakeWindow.setBackgroundColor.mock.calls, [["#ffffff"]]);
+        assert.isFalse(desktopWindow.isBackdropEnabled(fakeWindow.window));
+        assert.deepEqual(fakeWindow.send.mock.calls, [[WINDOW_BACKDROP_STATE_CHANNEL, false]]);
+      }).pipe(Effect.provide(layer));
     }),
   );
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -109,6 +109,7 @@ export class DesktopWindow extends Context.Service<
     // guest page instead of the app UI. The menu routes here to always target
     // the main window.
     readonly zoomMain: (direction: MainWindowZoomDirection) => Effect.Effect<void>;
+    readonly isBackdropEnabled: (window: Electron.BrowserWindow) => boolean;
     readonly syncAppearance: Effect.Effect<void>;
   }
 >()("@t3tools/desktop/window/DesktopWindow") {}
@@ -132,37 +133,46 @@ function getInitialWindowBackgroundColor(shouldUseDarkColors: boolean): string {
   return shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
 }
 
-const windowsWithAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
-const windowsWithoutAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
-const windowsManagedForBackdrop = new WeakSet<Electron.BrowserWindow>();
-const windowsWithBackdropStateListener = new WeakSet<Electron.BrowserWindow>();
+type WindowBackdropState = {
+  readonly windowsWithAcrylicBackdrop: WeakSet<Electron.BrowserWindow>;
+  readonly windowsWithoutAcrylicBackdrop: WeakSet<Electron.BrowserWindow>;
+  readonly windowsManagedForBackdrop: WeakSet<Electron.BrowserWindow>;
+  readonly windowsWithBackdropStateListener: WeakSet<Electron.BrowserWindow>;
+};
 
-export function isWindowBackdropEnabled(window: Electron.BrowserWindow): boolean {
-  return windowsWithAcrylicBackdrop.has(window);
-}
-
-function sendWindowBackdropState(window: Electron.BrowserWindow): void {
+function sendWindowBackdropState(
+  window: Electron.BrowserWindow,
+  backdropState: WindowBackdropState,
+): void {
   if (window.isDestroyed()) return;
 
   try {
-    window.webContents.send(WINDOW_BACKDROP_STATE_CHANNEL, isWindowBackdropEnabled(window));
+    window.webContents.send(
+      WINDOW_BACKDROP_STATE_CHANNEL,
+      backdropState.windowsWithAcrylicBackdrop.has(window),
+    );
   } catch {
     // The renderer may not be ready yet. The did-finish-load listener retries it.
   }
 }
 
-function registerWindowBackdropStateSync(window: Electron.BrowserWindow): void {
-  if (!windowsWithBackdropStateListener.has(window)) {
+function registerWindowBackdropStateSync(
+  window: Electron.BrowserWindow,
+  backdropState: WindowBackdropState,
+): void {
+  if (!backdropState.windowsWithBackdropStateListener.has(window)) {
     try {
-      window.webContents.on("did-finish-load", () => sendWindowBackdropState(window));
-      windowsWithBackdropStateListener.add(window);
+      window.webContents.on("did-finish-load", () =>
+        sendWindowBackdropState(window, backdropState),
+      );
+      backdropState.windowsWithBackdropStateListener.add(window);
     } catch {
       // Native appearance must remain best effort if a test double or old shell
       // does not expose the renderer event surface.
     }
   }
 
-  sendWindowBackdropState(window);
+  sendWindowBackdropState(window, backdropState);
 }
 
 export function getWindowBackdropOptions(
@@ -199,39 +209,39 @@ function applyWindowsBackdrop(
   platform: NodeJS.Platform,
   shouldUseDarkColors: boolean,
   desktopBackdropEnabled: boolean,
+  backdropState: WindowBackdropState,
 ): Effect.Effect<void> {
   if (platform !== "win32") {
     return Effect.void;
   }
 
-  windowsManagedForBackdrop.add(window);
-
   return Effect.try({
     try: () => {
+      backdropState.windowsManagedForBackdrop.add(window);
       window.setBackgroundMaterial(desktopBackdropEnabled ? WINDOWS_ACRYLIC_MATERIAL : "none");
       if (desktopBackdropEnabled) {
-        windowsWithAcrylicBackdrop.add(window);
-        windowsWithoutAcrylicBackdrop.delete(window);
+        backdropState.windowsWithAcrylicBackdrop.add(window);
+        backdropState.windowsWithoutAcrylicBackdrop.delete(window);
         window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
       } else {
-        windowsWithAcrylicBackdrop.delete(window);
-        windowsWithoutAcrylicBackdrop.add(window);
+        backdropState.windowsWithAcrylicBackdrop.delete(window);
+        backdropState.windowsWithoutAcrylicBackdrop.add(window);
         window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
       }
     },
     catch: (cause) => cause,
   }).pipe(
-    Effect.andThen(Effect.sync(() => registerWindowBackdropStateSync(window))),
+    Effect.andThen(Effect.sync(() => registerWindowBackdropStateSync(window, backdropState))),
     Effect.catchCause((cause) =>
       Effect.gen(function* () {
-        windowsWithAcrylicBackdrop.delete(window);
-        windowsWithoutAcrylicBackdrop.add(window);
+        backdropState.windowsWithAcrylicBackdrop.delete(window);
+        backdropState.windowsWithoutAcrylicBackdrop.add(window);
         try {
           window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
         } catch {
           // Preserve the original backdrop failure; window creation must stay best effort.
         }
-        registerWindowBackdropStateSync(window);
+        registerWindowBackdropStateSync(window, backdropState);
         yield* logWindowWarning("Windows backdrop material unavailable; using solid background", {
           cause,
         });
@@ -348,6 +358,7 @@ function syncWindowAppearance(
   shouldUseDarkColors: boolean,
   platform: NodeJS.Platform,
   desktopBackdropEnabled: boolean,
+  backdropState: WindowBackdropState,
 ): Effect.Effect<void> {
   return Effect.gen(function* () {
     if (window.isDestroyed()) {
@@ -355,10 +366,13 @@ function syncWindowAppearance(
     }
 
     if (platform === "win32") {
-      if (windowsManagedForBackdrop.has(window)) {
-        if (desktopBackdropEnabled && windowsWithAcrylicBackdrop.has(window)) {
+      if (backdropState.windowsManagedForBackdrop.has(window)) {
+        if (desktopBackdropEnabled && backdropState.windowsWithAcrylicBackdrop.has(window)) {
           window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
-        } else if (!desktopBackdropEnabled && windowsWithoutAcrylicBackdrop.has(window)) {
+        } else if (
+          !desktopBackdropEnabled &&
+          backdropState.windowsWithoutAcrylicBackdrop.has(window)
+        ) {
           window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
         } else {
           yield* applyWindowsBackdrop(
@@ -366,6 +380,7 @@ function syncWindowAppearance(
             platform,
             shouldUseDarkColors,
             desktopBackdropEnabled,
+            backdropState,
           );
         }
       }
@@ -417,6 +432,14 @@ export const make = Effect.gen(function* () {
   // The transient "Connecting to WSL" splash window, tracked separately so it
   // is never mistaken for the real main window.
   const splashWindowRef = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+  const backdropState: WindowBackdropState = {
+    windowsWithAcrylicBackdrop: new WeakSet(),
+    windowsWithoutAcrylicBackdrop: new WeakSet(),
+    windowsManagedForBackdrop: new WeakSet(),
+    windowsWithBackdropStateListener: new WeakSet(),
+  };
+  const isBackdropEnabled = (window: Electron.BrowserWindow): boolean =>
+    backdropState.windowsWithAcrylicBackdrop.has(window);
   const context = yield* Effect.context<DesktopWindowRuntimeServices>();
   const runFork = Effect.runForkWith(context);
   const runPromise = Effect.runPromiseWith(context);
@@ -523,6 +546,7 @@ export const make = Effect.gen(function* () {
       environment.platform,
       shouldUseDarkColors,
       desktopBackdropEnabled,
+      backdropState,
     );
 
     if (environment.platform === "darwin") {
@@ -986,6 +1010,7 @@ export const make = Effect.gen(function* () {
       environment.platform,
       shouldUseDarkColors,
       desktopBackdropEnabled,
+      backdropState,
     );
     void splash.loadURL(buildConnectingSplashDataUrl(shouldUseDarkColors, environment.platform));
     yield* logWindowInfo("connecting splash shown");
@@ -1072,6 +1097,7 @@ export const make = Effect.gen(function* () {
       // own zoom, so put each guest back where the preview left it.
       yield* previewManager.reapplyZoom();
     }),
+    isBackdropEnabled,
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
       const desktopBackdropEnabled = yield* getDesktopBackdropEnabled;
@@ -1081,6 +1107,7 @@ export const make = Effect.gen(function* () {
           shouldUseDarkColors,
           environment.platform,
           desktopBackdropEnabled,
+          backdropState,
         ),
       );
     }).pipe(Effect.withSpan("desktop.window.syncAppearance")),

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -34,6 +34,8 @@ const TITLEBAR_COLOR = "#01000000"; // #00000000 does not work correctly on Linu
 const TITLEBAR_LIGHT_SYMBOL_COLOR = "#1f2937";
 const TITLEBAR_DARK_SYMBOL_COLOR = "#f8fafc";
 const MAIN_WINDOW_BOUNDS_PERSIST_DEBOUNCE_MS = 500;
+const WINDOWS_TRANSPARENT_BACKGROUND_COLOR = "#00000000";
+const WINDOWS_ACRYLIC_MATERIAL = "acrylic" as const;
 const DEVELOPMENT_LOAD_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000] as const;
 // Renderer crash (usually V8 OOM on long sessions) recovery: reload after a
 // short delay, at most MAX_ATTEMPTS times per rolling WINDOW so a renderer
@@ -129,6 +131,80 @@ function getInitialWindowBackgroundColor(shouldUseDarkColors: boolean): string {
   return shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
 }
 
+const windowsWithAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
+const windowsWithoutAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
+
+export function getWindowBackdropOptions(
+  platform: NodeJS.Platform,
+  shouldUseDarkColors: boolean,
+  desktopBackdropEnabled = true,
+): Pick<
+  Electron.BrowserWindowConstructorOptions,
+  | "backgroundColor"
+  | "backgroundMaterial"
+  | "frame"
+  | "roundedCorners"
+  | "thickFrame"
+  | "transparent"
+> {
+  if (platform !== "win32") {
+    return { backgroundColor: getInitialWindowBackgroundColor(shouldUseDarkColors) };
+  }
+
+  return {
+    backgroundColor: desktopBackdropEnabled
+      ? WINDOWS_TRANSPARENT_BACKGROUND_COLOR
+      : getInitialWindowBackgroundColor(shouldUseDarkColors),
+    backgroundMaterial: desktopBackdropEnabled ? WINDOWS_ACRYLIC_MATERIAL : "none",
+    frame: false,
+    roundedCorners: true,
+    thickFrame: true,
+    transparent: true,
+  };
+}
+
+function applyWindowsBackdrop(
+  window: Electron.BrowserWindow,
+  platform: NodeJS.Platform,
+  shouldUseDarkColors: boolean,
+  desktopBackdropEnabled: boolean,
+): Effect.Effect<void> {
+  if (platform !== "win32") {
+    return Effect.void;
+  }
+
+  return Effect.try({
+    try: () => {
+      window.setBackgroundMaterial(desktopBackdropEnabled ? WINDOWS_ACRYLIC_MATERIAL : "none");
+      if (desktopBackdropEnabled) {
+        windowsWithAcrylicBackdrop.add(window);
+        windowsWithoutAcrylicBackdrop.delete(window);
+        window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
+      } else {
+        windowsWithAcrylicBackdrop.delete(window);
+        windowsWithoutAcrylicBackdrop.add(window);
+        window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+      }
+    },
+    catch: (cause) => cause,
+  }).pipe(
+    Effect.catchCause((cause) =>
+      Effect.gen(function* () {
+        windowsWithAcrylicBackdrop.delete(window);
+        windowsWithoutAcrylicBackdrop.add(window);
+        try {
+          window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+        } catch {
+          // Preserve the original backdrop failure; window creation must stay best effort.
+        }
+        yield* logWindowWarning("Windows backdrop material unavailable; using solid background", {
+          cause,
+        });
+      }),
+    ),
+  );
+}
+
 type DisplayBounds = Pick<Electron.Rectangle, "x" | "y" | "width" | "height">;
 
 function windowFitsWithinDisplay(
@@ -171,8 +247,12 @@ export function resolveInitialMainWindowBounds(
 // A self-contained "Connecting to WSL" splash, shown immediately in wsl-only
 // mode while the WSL backend (which serves the renderer) cold-boots. Inlined as
 // a data URL so it needs no bundled asset and no backend — pure CSS, no JS.
-function buildConnectingSplashDataUrl(shouldUseDarkColors: boolean): string {
-  const background = getInitialWindowBackgroundColor(shouldUseDarkColors);
+function buildConnectingSplashDataUrl(
+  shouldUseDarkColors: boolean,
+  platform: NodeJS.Platform,
+): string {
+  const background =
+    platform === "win32" ? "transparent" : getInitialWindowBackgroundColor(shouldUseDarkColors);
   const label = shouldUseDarkColors ? "#9ca3af" : "#6b7280";
   const accent = shouldUseDarkColors ? "#f8fafc" : "#1f2937";
   const track = shouldUseDarkColors ? "rgba(248,250,252,0.18)" : "rgba(31,41,55,0.18)";
@@ -232,13 +312,25 @@ function syncWindowAppearance(
   window: Electron.BrowserWindow,
   shouldUseDarkColors: boolean,
   platform: NodeJS.Platform,
+  desktopBackdropEnabled: boolean,
 ): Effect.Effect<void> {
-  return Effect.sync(() => {
+  return Effect.gen(function* () {
     if (window.isDestroyed()) {
       return;
     }
 
-    window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+    if (platform === "win32") {
+      if (desktopBackdropEnabled && windowsWithAcrylicBackdrop.has(window)) {
+        window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
+      } else if (!desktopBackdropEnabled && windowsWithoutAcrylicBackdrop.has(window)) {
+        window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+      } else {
+        yield* applyWindowsBackdrop(window, platform, shouldUseDarkColors, desktopBackdropEnabled);
+      }
+    } else {
+      window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+    }
+
     const { titleBarOverlay } = getWindowTitleBarOptions(shouldUseDarkColors, platform);
     if (typeof titleBarOverlay === "object") {
       window.setTitleBarOverlay(titleBarOverlay);
@@ -286,6 +378,14 @@ export const make = Effect.gen(function* () {
   const context = yield* Effect.context<DesktopWindowRuntimeServices>();
   const runFork = Effect.runForkWith(context);
   const runPromise = Effect.runPromiseWith(context);
+  const getDesktopBackdropEnabled = clientSettings.get.pipe(
+    Effect.map((settings) =>
+      Option.match(settings, {
+        onNone: () => DEFAULT_CLIENT_SETTINGS.desktopBackdropEnabled,
+        onSome: (value) => value.desktopBackdropEnabled,
+      }),
+    ),
+  );
   let flushMainWindowBounds: Effect.Effect<void> = Effect.void;
 
   const dismissConnectingSplash = Effect.gen(function* () {
@@ -323,6 +423,7 @@ export const make = Effect.gen(function* () {
     const iconPaths = yield* assets.iconPaths;
     const iconOption = getIconOption(iconPaths, environment.platform);
     const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
+    const desktopBackdropEnabled = yield* getDesktopBackdropEnabled;
     const persistedSettings = yield* desktopSettings.get;
     const persistedBounds = persistedSettings.mainWindowBounds;
     const displayBoundsResult = yield* Effect.sync(() => {
@@ -353,7 +454,11 @@ export const make = Effect.gen(function* () {
       show: false,
       autoHideMenuBar: true,
       ...(environment.platform === "darwin" ? { disableAutoHideCursor: true } : {}),
-      backgroundColor: getInitialWindowBackgroundColor(shouldUseDarkColors),
+      ...getWindowBackdropOptions(
+        environment.platform,
+        shouldUseDarkColors,
+        desktopBackdropEnabled,
+      ),
       ...iconOption,
       title: environment.displayName,
       ...getWindowTitleBarOptions(shouldUseDarkColors, environment.platform),
@@ -371,6 +476,12 @@ export const make = Effect.gen(function* () {
         webviewTag: true,
       },
     });
+    yield* applyWindowsBackdrop(
+      window,
+      environment.platform,
+      shouldUseDarkColors,
+      desktopBackdropEnabled,
+    );
 
     if (environment.platform === "darwin") {
       window.setAutoHideCursor(false);
@@ -795,6 +906,7 @@ export const make = Effect.gen(function* () {
     if (Option.isSome(existingWindow)) return;
 
     const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
+    const desktopBackdropEnabled = yield* getDesktopBackdropEnabled;
     const splash = yield* electronWindow.create({
       width: 360,
       height: 220,
@@ -806,7 +918,11 @@ export const make = Effect.gen(function* () {
       center: true,
       show: false,
       skipTaskbar: false,
-      backgroundColor: getInitialWindowBackgroundColor(shouldUseDarkColors),
+      ...getWindowBackdropOptions(
+        environment.platform,
+        shouldUseDarkColors,
+        desktopBackdropEnabled,
+      ),
       title: environment.displayName,
       webPreferences: {
         contextIsolation: true,
@@ -823,7 +939,13 @@ export const make = Effect.gen(function* () {
         splash.show();
       }
     });
-    void splash.loadURL(buildConnectingSplashDataUrl(shouldUseDarkColors));
+    yield* applyWindowsBackdrop(
+      splash,
+      environment.platform,
+      shouldUseDarkColors,
+      desktopBackdropEnabled,
+    );
+    void splash.loadURL(buildConnectingSplashDataUrl(shouldUseDarkColors, environment.platform));
     yield* logWindowInfo("connecting splash shown");
   }).pipe(
     // The splash is best-effort UX — never let it fail startup.
@@ -910,8 +1032,14 @@ export const make = Effect.gen(function* () {
     }),
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
+      const desktopBackdropEnabled = yield* getDesktopBackdropEnabled;
       yield* electronWindow.syncAllAppearance((window) =>
-        syncWindowAppearance(window, shouldUseDarkColors, environment.platform),
+        syncWindowAppearance(
+          window,
+          shouldUseDarkColors,
+          environment.platform,
+          desktopBackdropEnabled,
+        ),
       );
     }).pipe(Effect.withSpan("desktop.window.syncAppearance")),
   });

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -137,11 +137,15 @@ const windowsWithoutAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
 const windowsManagedForBackdrop = new WeakSet<Electron.BrowserWindow>();
 const windowsWithBackdropStateListener = new WeakSet<Electron.BrowserWindow>();
 
+export function isWindowBackdropEnabled(window: Electron.BrowserWindow): boolean {
+  return windowsWithAcrylicBackdrop.has(window);
+}
+
 function sendWindowBackdropState(window: Electron.BrowserWindow): void {
   if (window.isDestroyed()) return;
 
   try {
-    window.webContents.send(WINDOW_BACKDROP_STATE_CHANNEL, windowsWithAcrylicBackdrop.has(window));
+    window.webContents.send(WINDOW_BACKDROP_STATE_CHANNEL, isWindowBackdropEnabled(window));
   } catch {
     // The renderer may not be ready yet. The did-finish-load listener retries it.
   }

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -37,6 +37,7 @@ const TITLEBAR_DARK_SYMBOL_COLOR = "#f8fafc";
 const MAIN_WINDOW_BOUNDS_PERSIST_DEBOUNCE_MS = 500;
 const WINDOWS_TRANSPARENT_BACKGROUND_COLOR = "#00000000";
 const WINDOWS_ACRYLIC_MATERIAL = "acrylic" as const;
+const WINDOWS_ACRYLIC_MIN_BUILD = 22621; // Windows 11 22H2
 const DEVELOPMENT_LOAD_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000] as const;
 // Renderer crash (usually V8 OOM on long sessions) recovery: reload after a
 // short delay, at most MAX_ATTEMPTS times per rolling WINDOW so a renderer
@@ -133,6 +134,18 @@ function getInitialWindowBackgroundColor(shouldUseDarkColors: boolean): string {
   return shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
 }
 
+export function isWindowsAcrylicSupported(
+  platform: NodeJS.Platform,
+  systemVersion: string | undefined,
+): boolean {
+  if (platform !== "win32" || systemVersion === undefined) {
+    return false;
+  }
+
+  const build = Number.parseInt(systemVersion.split(".")[2] ?? "", 10);
+  return Number.isInteger(build) && build >= WINDOWS_ACRYLIC_MIN_BUILD;
+}
+
 type WindowBackdropState = {
   readonly windowsWithAcrylicBackdrop: WeakSet<Electron.BrowserWindow>;
   readonly windowsWithoutAcrylicBackdrop: WeakSet<Electron.BrowserWindow>;
@@ -179,6 +192,7 @@ export function getWindowBackdropOptions(
   platform: NodeJS.Platform,
   shouldUseDarkColors: boolean,
   desktopBackdropEnabled = true,
+  windowsAcrylicSupported = false,
 ): Pick<
   Electron.BrowserWindowConstructorOptions,
   | "backgroundColor"
@@ -192,11 +206,13 @@ export function getWindowBackdropOptions(
     return { backgroundColor: getInitialWindowBackgroundColor(shouldUseDarkColors) };
   }
 
+  const useAcrylic = desktopBackdropEnabled && windowsAcrylicSupported;
+
   return {
-    backgroundColor: desktopBackdropEnabled
+    backgroundColor: useAcrylic
       ? WINDOWS_TRANSPARENT_BACKGROUND_COLOR
       : getInitialWindowBackgroundColor(shouldUseDarkColors),
-    backgroundMaterial: desktopBackdropEnabled ? WINDOWS_ACRYLIC_MATERIAL : "none",
+    backgroundMaterial: useAcrylic ? WINDOWS_ACRYLIC_MATERIAL : "none",
     frame: false,
     roundedCorners: true,
     thickFrame: true,
@@ -209,6 +225,7 @@ function applyWindowsBackdrop(
   platform: NodeJS.Platform,
   shouldUseDarkColors: boolean,
   desktopBackdropEnabled: boolean,
+  windowsAcrylicSupported: boolean,
   backdropState: WindowBackdropState,
 ): Effect.Effect<void> {
   if (platform !== "win32") {
@@ -218,8 +235,9 @@ function applyWindowsBackdrop(
   return Effect.try({
     try: () => {
       backdropState.windowsManagedForBackdrop.add(window);
-      window.setBackgroundMaterial(desktopBackdropEnabled ? WINDOWS_ACRYLIC_MATERIAL : "none");
-      if (desktopBackdropEnabled) {
+      const useAcrylic = desktopBackdropEnabled && windowsAcrylicSupported;
+      window.setBackgroundMaterial(useAcrylic ? WINDOWS_ACRYLIC_MATERIAL : "none");
+      if (useAcrylic) {
         backdropState.windowsWithAcrylicBackdrop.add(window);
         backdropState.windowsWithoutAcrylicBackdrop.delete(window);
         window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
@@ -358,6 +376,7 @@ function syncWindowAppearance(
   shouldUseDarkColors: boolean,
   platform: NodeJS.Platform,
   desktopBackdropEnabled: boolean,
+  windowsAcrylicSupported: boolean,
   backdropState: WindowBackdropState,
 ): Effect.Effect<void> {
   return Effect.gen(function* () {
@@ -367,12 +386,10 @@ function syncWindowAppearance(
 
     if (platform === "win32") {
       if (backdropState.windowsManagedForBackdrop.has(window)) {
-        if (desktopBackdropEnabled && backdropState.windowsWithAcrylicBackdrop.has(window)) {
+        const useAcrylic = desktopBackdropEnabled && windowsAcrylicSupported;
+        if (useAcrylic && backdropState.windowsWithAcrylicBackdrop.has(window)) {
           window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
-        } else if (
-          !desktopBackdropEnabled &&
-          backdropState.windowsWithoutAcrylicBackdrop.has(window)
-        ) {
+        } else if (!useAcrylic && backdropState.windowsWithoutAcrylicBackdrop.has(window)) {
           window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
         } else {
           yield* applyWindowsBackdrop(
@@ -380,6 +397,7 @@ function syncWindowAppearance(
             platform,
             shouldUseDarkColors,
             desktopBackdropEnabled,
+            windowsAcrylicSupported,
             backdropState,
           );
         }
@@ -423,6 +441,10 @@ export const make = Effect.gen(function* () {
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const clientSettings = yield* DesktopClientSettings.DesktopClientSettings;
   const electronApp = yield* ElectronApp.ElectronApp;
+  const windowsAcrylicSupported = isWindowsAcrylicSupported(
+    environment.platform,
+    environment.systemVersion,
+  );
   // Window-side latch for the primary backend's readiness. Set by
   // handleBackendReady (driven by the pool's onReady callback), cleared
   // by handleBackendNotReady (driven by onShutdown). Only consumed by
@@ -523,6 +545,7 @@ export const make = Effect.gen(function* () {
         environment.platform,
         shouldUseDarkColors,
         desktopBackdropEnabled,
+        windowsAcrylicSupported,
       ),
       ...iconOption,
       title: environment.displayName,
@@ -546,6 +569,7 @@ export const make = Effect.gen(function* () {
       environment.platform,
       shouldUseDarkColors,
       desktopBackdropEnabled,
+      windowsAcrylicSupported,
       backdropState,
     );
 
@@ -988,6 +1012,7 @@ export const make = Effect.gen(function* () {
         environment.platform,
         shouldUseDarkColors,
         desktopBackdropEnabled,
+        windowsAcrylicSupported,
       ),
       title: environment.displayName,
       webPreferences: {
@@ -1010,6 +1035,7 @@ export const make = Effect.gen(function* () {
       environment.platform,
       shouldUseDarkColors,
       desktopBackdropEnabled,
+      windowsAcrylicSupported,
       backdropState,
     );
     void splash.loadURL(buildConnectingSplashDataUrl(shouldUseDarkColors, environment.platform));
@@ -1107,6 +1133,7 @@ export const make = Effect.gen(function* () {
           shouldUseDarkColors,
           environment.platform,
           desktopBackdropEnabled,
+          windowsAcrylicSupported,
           backdropState,
         ),
       );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -5,6 +5,7 @@ import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
 
@@ -153,6 +154,20 @@ type WindowBackdropState = {
   readonly windowsWithBackdropStateListener: WeakSet<Electron.BrowserWindow>;
 };
 
+const WindowsBackdropMaterial = Schema.Literals(["acrylic", "none"]);
+
+class DesktopWindowBackdropError extends Schema.TaggedErrorClass<DesktopWindowBackdropError>()(
+  "DesktopWindowBackdropError",
+  {
+    material: WindowsBackdropMaterial,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to apply Windows backdrop material "${this.material}".`;
+  }
+}
+
 function sendWindowBackdropState(
   window: Electron.BrowserWindow,
   backdropState: WindowBackdropState,
@@ -232,11 +247,13 @@ function applyWindowsBackdrop(
     return Effect.void;
   }
 
+  const useAcrylic = desktopBackdropEnabled && windowsAcrylicSupported;
+  const material = useAcrylic ? WINDOWS_ACRYLIC_MATERIAL : "none";
+
   return Effect.try({
     try: () => {
       backdropState.windowsManagedForBackdrop.add(window);
-      const useAcrylic = desktopBackdropEnabled && windowsAcrylicSupported;
-      window.setBackgroundMaterial(useAcrylic ? WINDOWS_ACRYLIC_MATERIAL : "none");
+      window.setBackgroundMaterial(material);
       if (useAcrylic) {
         backdropState.windowsWithAcrylicBackdrop.add(window);
         backdropState.windowsWithoutAcrylicBackdrop.delete(window);
@@ -247,24 +264,25 @@ function applyWindowsBackdrop(
         window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
       }
     },
-    catch: (cause) => cause,
+    catch: (cause) => new DesktopWindowBackdropError({ material, cause }),
   }).pipe(
     Effect.andThen(Effect.sync(() => registerWindowBackdropStateSync(window, backdropState))),
-    Effect.catchCause((cause) =>
-      Effect.gen(function* () {
-        backdropState.windowsWithAcrylicBackdrop.delete(window);
-        backdropState.windowsWithoutAcrylicBackdrop.add(window);
-        try {
-          window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
-        } catch {
-          // Preserve the original backdrop failure; window creation must stay best effort.
-        }
-        registerWindowBackdropStateSync(window, backdropState);
-        yield* logWindowWarning("Windows backdrop material unavailable; using solid background", {
-          cause,
-        });
-      }),
-    ),
+    Effect.catchTags({
+      DesktopWindowBackdropError: (error) =>
+        Effect.gen(function* () {
+          backdropState.windowsWithAcrylicBackdrop.delete(window);
+          backdropState.windowsWithoutAcrylicBackdrop.add(window);
+          try {
+            window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+          } catch {
+            // Preserve the original backdrop failure; window creation must stay best effort.
+          }
+          registerWindowBackdropStateSync(window, backdropState);
+          yield* logWindowWarning("Windows backdrop material unavailable; using solid background", {
+            cause: error.cause,
+          });
+        }),
+    }),
   );
 }
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -21,6 +21,7 @@ import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import {
   MENU_ACTION_CHANNEL,
   QUIT_SHORTCUT_CHANNEL,
+  WINDOW_BACKDROP_STATE_CHANNEL,
   WINDOW_FULLSCREEN_STATE_CHANNEL,
 } from "../ipc/channels.ts";
 import * as PreviewManager from "../preview/Manager.ts";
@@ -133,6 +134,32 @@ function getInitialWindowBackgroundColor(shouldUseDarkColors: boolean): string {
 
 const windowsWithAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
 const windowsWithoutAcrylicBackdrop = new WeakSet<Electron.BrowserWindow>();
+const windowsManagedForBackdrop = new WeakSet<Electron.BrowserWindow>();
+const windowsWithBackdropStateListener = new WeakSet<Electron.BrowserWindow>();
+
+function sendWindowBackdropState(window: Electron.BrowserWindow): void {
+  if (window.isDestroyed()) return;
+
+  try {
+    window.webContents.send(WINDOW_BACKDROP_STATE_CHANNEL, windowsWithAcrylicBackdrop.has(window));
+  } catch {
+    // The renderer may not be ready yet. The did-finish-load listener retries it.
+  }
+}
+
+function registerWindowBackdropStateSync(window: Electron.BrowserWindow): void {
+  if (!windowsWithBackdropStateListener.has(window)) {
+    try {
+      window.webContents.on("did-finish-load", () => sendWindowBackdropState(window));
+      windowsWithBackdropStateListener.add(window);
+    } catch {
+      // Native appearance must remain best effort if a test double or old shell
+      // does not expose the renderer event surface.
+    }
+  }
+
+  sendWindowBackdropState(window);
+}
 
 export function getWindowBackdropOptions(
   platform: NodeJS.Platform,
@@ -173,6 +200,8 @@ function applyWindowsBackdrop(
     return Effect.void;
   }
 
+  windowsManagedForBackdrop.add(window);
+
   return Effect.try({
     try: () => {
       window.setBackgroundMaterial(desktopBackdropEnabled ? WINDOWS_ACRYLIC_MATERIAL : "none");
@@ -188,6 +217,7 @@ function applyWindowsBackdrop(
     },
     catch: (cause) => cause,
   }).pipe(
+    Effect.andThen(Effect.sync(() => registerWindowBackdropStateSync(window))),
     Effect.catchCause((cause) =>
       Effect.gen(function* () {
         windowsWithAcrylicBackdrop.delete(window);
@@ -197,6 +227,7 @@ function applyWindowsBackdrop(
         } catch {
           // Preserve the original backdrop failure; window creation must stay best effort.
         }
+        registerWindowBackdropStateSync(window);
         yield* logWindowWarning("Windows backdrop material unavailable; using solid background", {
           cause,
         });
@@ -320,12 +351,19 @@ function syncWindowAppearance(
     }
 
     if (platform === "win32") {
-      if (desktopBackdropEnabled && windowsWithAcrylicBackdrop.has(window)) {
-        window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
-      } else if (!desktopBackdropEnabled && windowsWithoutAcrylicBackdrop.has(window)) {
-        window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
-      } else {
-        yield* applyWindowsBackdrop(window, platform, shouldUseDarkColors, desktopBackdropEnabled);
+      if (windowsManagedForBackdrop.has(window)) {
+        if (desktopBackdropEnabled && windowsWithAcrylicBackdrop.has(window)) {
+          window.setBackgroundColor(WINDOWS_TRANSPARENT_BACKGROUND_COLOR);
+        } else if (!desktopBackdropEnabled && windowsWithoutAcrylicBackdrop.has(window)) {
+          window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));
+        } else {
+          yield* applyWindowsBackdrop(
+            window,
+            platform,
+            shouldUseDarkColors,
+            desktopBackdropEnabled,
+          );
+        }
       }
     } else {
       window.setBackgroundColor(getInitialWindowBackgroundColor(shouldUseDarkColors));

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6849,7 +6849,7 @@ function ChatViewContent(props: ChatViewProps) {
     composerBannerItems.length > 0 || Boolean(threadSyncPhase && !activeEnvironmentUnavailable);
 
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+    <div className="desktop-window-canvas relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
       {rightPanelOpen && !shouldUseRightPanelSheet ? panelLayoutControls : null}
       <div
         className={cn(
@@ -6863,7 +6863,7 @@ function ChatViewContent(props: ChatViewProps) {
           data-chat-header
           electron={isElectron}
           reserveNativeControls={reserveTitleBarControlInset && !inlineRightPanelOwnsTitleBar}
-          className="relative bg-background"
+          className="desktop-window-canvas relative bg-background"
         >
           {!rightPanelOpen ? panelLayoutControls : null}
           <ChatHeader

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -845,7 +845,7 @@ export default function DiffPanel({
         </div>
       ) : (
         <>
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
+          <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
             {isSelectedPatchTruncated && (
               <p className="shrink-0 border-b border-border/70 bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
                 This diff was truncated because it exceeded the preview limit. The changes shown are

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -28,7 +28,7 @@ export function DiffPanelShell(props: {
   return (
     <div
       className={cn(
-        "flex h-full min-w-0 flex-col bg-background",
+        "desktop-window-canvas flex h-full min-w-0 flex-col bg-background",
         props.mode === "inline"
           ? "w-[42vw] min-w-[360px] max-w-[560px] shrink-0 border-l border-border"
           : "w-full",
@@ -88,7 +88,7 @@ function DiffCodeLineSkeleton({ contentClassName }: { contentClassName: string }
 export function DiffPanelLoadingState(props: { label: string }) {
   return (
     <div
-      className="min-h-0 flex-1 overflow-hidden bg-background"
+      className="desktop-window-canvas min-h-0 flex-1 overflow-hidden bg-background"
       role="status"
       aria-live="polite"
       aria-label={props.label}

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -6,7 +6,7 @@ import { WorkspacePageHeader } from "./WorkspacePageHeader";
 export function NoActiveThreadState() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+      <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
         <WorkspacePageHeader electron={isElectron} className="border-b border-border">
           {isElectron ? (
             <span className="text-xs text-muted-foreground/50">No active thread</span>

--- a/apps/web/src/components/SplashScreen.tsx
+++ b/apps/web/src/components/SplashScreen.tsx
@@ -1,6 +1,6 @@
 export function SplashScreen() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
+    <div className="desktop-window-canvas flex min-h-screen items-center justify-center bg-background">
       <div className="flex size-24 items-center justify-center" aria-label="T3 Code splash screen">
         <img alt="T3 Code" className="size-16 object-contain" src="/apple-touch-icon.png" />
       </div>

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1392,7 +1392,7 @@ export default function ThreadTerminalDrawer({
       <aside
         data-terminal-owner={isPanel ? "right-panel" : "drawer"}
         className={cn(
-          "thread-terminal-drawer relative flex min-w-0 flex-col overflow-hidden bg-background",
+          "desktop-window-canvas thread-terminal-drawer relative flex min-w-0 flex-col overflow-hidden bg-background",
           isPanel ? "h-full flex-1" : "shrink-0 border-t border-border/80",
         )}
         style={isPanel ? undefined : { height: `${drawerHeight}px` }}
@@ -1422,7 +1422,7 @@ export default function ThreadTerminalDrawer({
     <aside
       data-terminal-owner={isPanel ? "right-panel" : "drawer"}
       className={cn(
-        "thread-terminal-drawer relative flex min-w-0 flex-col overflow-hidden bg-background",
+        "desktop-window-canvas thread-terminal-drawer relative flex min-w-0 flex-col overflow-hidden bg-background",
         isPanel ? "h-full flex-1" : "shrink-0 border-t border-border/80",
       )}
       style={isPanel ? undefined : { height: `${drawerHeight}px` }}

--- a/apps/web/src/components/auth/AuthSurfaceShell.tsx
+++ b/apps/web/src/components/auth/AuthSurfaceShell.tsx
@@ -11,7 +11,7 @@ export function AuthSurfaceShell({ children }: { readonly children: ReactNode })
   const stageVariant = resolveSidebarStageBackdropVariant(APP_STAGE_LABEL);
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+    <div className="desktop-window-canvas relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
       <div className="pointer-events-none absolute inset-0 opacity-80">
         <div className="absolute inset-x-0 top-0 h-72 bg-[radial-gradient(48rem_20rem_at_top,color-mix(in_srgb,var(--color-blue-500)_12%,transparent),transparent)]" />
         <div className="absolute inset-0 bg-[linear-gradient(145deg,color-mix(in_srgb,var(--background)_94%,var(--color-black))_0%,var(--background)_62%)]" />

--- a/apps/web/src/components/auth/PairingRouteSurface.tsx
+++ b/apps/web/src/components/auth/PairingRouteSurface.tsx
@@ -16,7 +16,7 @@ import { useAtomCommand } from "../../state/use-atom-command";
 
 export function PairingPendingSurface() {
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+    <div className="desktop-window-canvas relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
       <div className="pointer-events-none absolute inset-0 opacity-80">
         <div className="absolute inset-x-0 top-0 h-44 bg-[radial-gradient(44rem_16rem_at_top,color-mix(in_srgb,var(--color-emerald-500)_14%,transparent),transparent)]" />
         <div className="absolute inset-y-0 left-0 w-72 bg-[radial-gradient(28rem_18rem_at_left,color-mix(in_srgb,var(--color-sky-500)_10%,transparent),transparent)]" />
@@ -97,7 +97,7 @@ export function PairingRouteSurface({
   }, [submitCredential]);
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+    <div className="desktop-window-canvas relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
       <div className="pointer-events-none absolute inset-0 opacity-80">
         <div className="absolute inset-x-0 top-0 h-44 bg-[radial-gradient(44rem_16rem_at_top,color-mix(in_srgb,var(--color-emerald-500)_14%,transparent),transparent)]" />
         <div className="absolute inset-y-0 left-0 w-72 bg-[radial-gradient(28rem_18rem_at_left,color-mix(in_srgb,var(--color-sky-500)_10%,transparent),transparent)]" />
@@ -233,7 +233,7 @@ export function HostedPairingRouteSurface() {
   const request = hostedPairingRequestRef.current;
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+    <div className="desktop-window-canvas relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
       <div className="pointer-events-none absolute inset-0 opacity-80">
         <div className="absolute inset-x-0 top-0 h-44 bg-[radial-gradient(44rem_16rem_at_top,color-mix(in_srgb,var(--color-emerald-500)_14%,transparent),transparent)]" />
         <div className="absolute inset-y-0 left-0 w-72 bg-[radial-gradient(28rem_18rem_at_left,color-mix(in_srgb,var(--color-sky-500)_10%,transparent),transparent)]" />

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -353,7 +353,7 @@ export default function FileBrowserPanel({
   return (
     <div
       ref={panelRef}
-      className="flex min-h-0 flex-1 flex-col bg-background"
+      className="desktop-window-canvas flex min-h-0 flex-1 flex-col bg-background"
       data-file-browser-panel={`${environmentId}:${cwd}`}
     >
       <div

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -857,7 +857,7 @@ export default function FilePreviewPanel({
   }, [absolutePath, createAssetUrl, environmentHttpBaseUrl, openPreview, threadRef]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+    <div className="desktop-window-canvas flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       {relativePath ? (
         <div
           className="flex h-10 min-h-10 shrink-0 items-center gap-2 border-b border-border/60 bg-background px-3 in-data-[preview-panel-mode=inline]:mb-3 in-data-[preview-panel-mode=inline]:h-7 in-data-[preview-panel-mode=inline]:min-h-7 in-data-[preview-panel-mode=inline]:border-b-transparent"
@@ -1066,7 +1066,7 @@ export default function FilePreviewPanel({
         {explorerOpen || relativePath === null ? (
           <aside
             className={cn(
-              "flex min-h-0 shrink-0 bg-background",
+              "desktop-window-canvas flex min-h-0 shrink-0 bg-background",
               relativePath
                 ? "w-[min(22rem,46%)] min-w-64 border-l border-border/60"
                 : "min-w-0 flex-1",

--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -81,7 +81,7 @@ export function PreviewPanelShell(props: {
     <div
       ref={hostRef}
       className={cn(
-        "relative flex h-full min-h-0 min-w-0 max-w-full flex-col self-stretch bg-background",
+        "desktop-window-canvas relative flex h-full min-h-0 min-w-0 max-w-full flex-col self-stretch bg-background",
         isInline
           ? props.maximized
             ? "flex-1 border-l border-border"

--- a/apps/web/src/components/preview/PreviewUnreachable.tsx
+++ b/apps/web/src/components/preview/PreviewUnreachable.tsx
@@ -21,7 +21,7 @@ export function PreviewUnreachable({ url, code, description, onReload }: Props) 
   const errorLabel = description.length > 0 ? description : `ERR_${Math.abs(code) || "FAILED"}`;
 
   return (
-    <div className="relative flex h-full min-h-0 w-full overflow-y-auto bg-background">
+    <div className="desktop-window-canvas relative flex h-full min-h-0 w-full overflow-y-auto bg-background">
       <div className="mx-auto flex w-full max-w-xl flex-1 flex-col px-8 py-12 sm:py-16">
         <ErrorIcon className="mb-6 size-12 text-muted-foreground/70" />
         <h1 className="mb-3 text-2xl font-semibold leading-tight text-foreground">

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -653,7 +653,7 @@ export function PreviewView({
 
   return (
     <div
-      className="flex min-h-0 flex-1 flex-col bg-background"
+      className="desktop-window-canvas flex min-h-0 flex-1 flex-col bg-background"
       data-thread-key={scopedThreadKey(threadRef)}
     >
       <PreviewChromeRow

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1116,7 +1116,7 @@ export function PullRequestDetailPanel({
   }
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+    <div className="desktop-window-canvas flex h-full min-h-0 w-full flex-col bg-background">
       <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 border-b border-border/60">
         <div className="ml-4 grid h-7 min-w-0 items-center">
           <div

--- a/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
@@ -67,7 +67,7 @@ export function PullRequestDetailGhost() {
     <div
       role="status"
       aria-label="Loading pull request"
-      className="animate-ghost-pulse flex h-full min-h-0 flex-col overflow-hidden bg-background"
+      className="desktop-window-canvas animate-ghost-pulse flex h-full min-h-0 flex-col overflow-hidden bg-background"
     >
       <div className="shrink-0 border-b border-border/60">
         <div className="flex h-7 items-center justify-between gap-3 px-4">

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -178,7 +178,7 @@ export function ProjectSettingsPage({ projectKey }: { projectKey: string }) {
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
+      <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         <WorkspacePageHeader electron={isElectron}>
           <ProjectSettingsBreadcrumb projectKey={projectKey} />
         </WorkspacePageHeader>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -78,7 +78,7 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
-import { isMacPlatform } from "../../lib/utils";
+import { isMacPlatform, isWindowsPlatform } from "../../lib/utils";
 import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
@@ -481,6 +481,9 @@ export function useSettingsRestore(onRestored?: () => void) {
         ? ["Contrast"]
         : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
+      ...(settings.desktopBackdropEnabled !== DEFAULT_UNIFIED_SETTINGS.desktopBackdropEnabled
+        ? ["Desktop background blur"]
+        : []),
       ...(settings.environmentIdentificationMode !==
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
         ? ["Environment identification"]
@@ -574,6 +577,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.fontSizePrompt,
       settings.fontSizeTerminal,
       settings.glassOpacity,
+      settings.desktopBackdropEnabled,
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
       settings.sidebarAutoSettleAfterDays,
@@ -659,6 +663,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       showSkillsInSlashMenu: DEFAULT_UNIFIED_SETTINGS.showSkillsInSlashMenu,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+      desktopBackdropEnabled: DEFAULT_UNIFIED_SETTINGS.desktopBackdropEnabled,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
@@ -997,6 +1002,8 @@ export function AppearanceSettingsPanel() {
   const environmentStageLabel = useEnvironmentStageLabel();
   const showEnvironmentIdentification =
     resolveEnvironmentIdentificationPillLabel(environmentStageLabel) !== null;
+  const showDesktopBackdropSetting =
+    isElectron && typeof navigator !== "undefined" && isWindowsPlatform(navigator.platform);
   const glassOpacityRatio =
     (settings.glassOpacity - MIN_GLASS_OPACITY) / (MAX_GLASS_OPACITY - MIN_GLASS_OPACITY);
   const glassOpacitySliderStyle = {
@@ -1080,7 +1087,7 @@ export function AppearanceSettingsPanel() {
 
         <SettingsRow
           {...searchableSetting("setting-glass-opacity")}
-          description="Control how transparent glass surfaces are. Higher values make menus, dialogs, and the composer more solid."
+          description="Control how transparent glass surfaces are. On Windows, lower values reveal more of the desktop Acrylic backdrop; higher values make surfaces more solid."
           resetAction={
             settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? (
               <SettingResetButton
@@ -1123,6 +1130,35 @@ export function AppearanceSettingsPanel() {
             </div>
           }
         />
+
+        {showDesktopBackdropSetting ? (
+          <SettingsRow
+            {...searchableSetting("setting-desktop-backdrop")}
+            description="Blur the desktop behind T3 Code using Windows Acrylic. Changes apply immediately; unsupported systems use a solid surface."
+            resetAction={
+              settings.desktopBackdropEnabled !==
+              DEFAULT_UNIFIED_SETTINGS.desktopBackdropEnabled ? (
+                <SettingResetButton
+                  label="desktop background blur"
+                  onClick={() =>
+                    updateSettings({
+                      desktopBackdropEnabled: DEFAULT_UNIFIED_SETTINGS.desktopBackdropEnabled,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Switch
+                checked={settings.desktopBackdropEnabled}
+                onCheckedChange={(checked) =>
+                  updateSettings({ desktopBackdropEnabled: Boolean(checked) })
+                }
+                aria-label="Desktop background blur"
+              />
+            }
+          />
+        ) : null}
 
         {showEnvironmentIdentification ? (
           <SettingsRow

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -1,4 +1,5 @@
 import { isElectron } from "~/env";
+import { isWindowsPlatform } from "~/lib/utils";
 
 export type SettingsPath =
   | "/settings/general"
@@ -18,6 +19,8 @@ export interface SettingsSearchItem {
   // Its row only renders in the desktop app, so a browser result would land on
   // an anchor that isn't there.
   readonly desktopOnly?: boolean;
+  // Its row only renders on Windows desktop, where the native backdrop exists.
+  readonly windowsOnly?: boolean;
 }
 
 /**
@@ -68,6 +71,13 @@ export const SETTINGS_SEARCH_ITEMS = [
     id: "setting-glass-opacity",
     title: "Glass opacity",
     to: "/settings/appearance",
+  },
+  {
+    id: "setting-desktop-backdrop",
+    title: "Desktop background blur",
+    to: "/settings/appearance",
+    desktopOnly: true,
+    windowsOnly: true,
   },
   {
     id: "environment-identification",
@@ -295,9 +305,12 @@ export function searchSettings(
   const normalizedQuery = normalizeSearchText(query);
   if (normalizedQuery.length === 0) return [];
 
+  const isWindows = typeof navigator !== "undefined" && isWindowsPlatform(navigator.platform);
+
   return items.filter(
     (item) =>
       (isElectron || item.desktopOnly !== true) &&
+      (item.windowsOnly !== true || (isElectron && isWindows)) &&
       normalizeSearchText(item.title).includes(normalizedQuery),
   );
 }

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -632,7 +632,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   return (
     <main
       className={cn(
-        "relative flex min-w-0 w-full flex-1 flex-col bg-background surface-grain",
+        "relative flex min-w-0 w-full flex-1 flex-col bg-background surface-grain desktop-window-canvas",
         "md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm/5",
         className,
       )}

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -203,7 +203,7 @@ export function UsagePage() {
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
+      <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         <WorkspacePageHeader electron={isElectron}>{topbarContent}</WorkspacePageHeader>
 
         <ScrollArea className="min-h-0 flex-1">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2063,6 +2063,15 @@ html.electron-windows [data-slot="sidebar-inner"] {
   background-color: var(--desktop-window-sidebar) !important;
 }
 
+/* A route can contain several named canvas owners (for example SidebarInset,
+   ChatView, and a terminal drawer). Only the outermost owner should paint the
+   alpha layer; nested owners must let that layer and the native material show
+   through instead of compounding opacity. */
+html.electron-windows .desktop-window-canvas .desktop-window-canvas,
+html.electron-windows [data-app-sidebar] [data-slot="sidebar-inner"] {
+  background-color: transparent !important;
+}
+
 /* App-chrome grain. Baked into each surface's own background (behind
    content) rather than a fixed overlay on top: a full-viewport overlay
    forces the compositor to re-blend every frame any animation produces,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2018,33 +2018,46 @@ body {
 
 .electron-windows {
   --desktop-window-right-resize-inset: 6px;
-  --desktop-window-canvas: color-mix(in srgb, var(--background) var(--glass-opacity), transparent);
-  --desktop-window-sidebar: color-mix(in srgb, var(--sidebar) var(--glass-opacity), transparent);
+  --desktop-window-canvas: var(--background);
 }
 
-html.electron-windows[data-desktop-backdrop="off"] {
-  --desktop-window-canvas: var(--background);
-  --desktop-window-sidebar: var(--sidebar);
+html.electron-windows[data-desktop-backdrop="on"] {
+  --desktop-window-canvas: color-mix(in srgb, var(--background) var(--glass-opacity), transparent);
 }
 
 /* Electron's Windows Acrylic backdrop is native to the BrowserWindow. The
    renderer must leave the window and its primary app surfaces translucent so
    that the native material can reach the entire client area. Reuse the
    existing glass opacity preference; web, macOS, Linux, and mobile keep their
-   current surface behavior. */
-html.electron-windows,
-html.electron-windows body,
-html.electron-windows #root,
-html.electron-windows [data-slot="sidebar-wrapper"] {
+   current surface behavior. The explicit canvas marker keeps controls and
+   nested cards on their normal theme surfaces. */
+html.electron-windows[data-desktop-backdrop="on"],
+html.electron-windows[data-desktop-backdrop="on"] body,
+html.electron-windows[data-desktop-backdrop="on"] #root,
+html.electron-windows[data-desktop-backdrop="on"] [data-slot="sidebar-wrapper"] {
   background-color: transparent !important;
 }
 
-html.electron-windows .bg-background,
-html.electron-windows [data-slot="sidebar-inset"] {
+html.electron-windows[data-desktop-backdrop="off"],
+html.electron-windows[data-desktop-backdrop="off"] body,
+html.electron-windows[data-desktop-backdrop="off"] #root,
+html.electron-windows[data-desktop-backdrop="off"] [data-slot="sidebar-wrapper"] {
+  background-color: var(--background) !important;
+}
+
+html.electron-windows [data-slot="sidebar-inset"],
+html.electron-windows .desktop-window-canvas {
   background-color: var(--desktop-window-canvas) !important;
 }
 
-html.electron-windows .bg-sidebar,
+html.electron-windows [data-app-sidebar] {
+  --desktop-window-sidebar: var(--sidebar);
+}
+
+html.electron-windows[data-desktop-backdrop="on"] [data-app-sidebar] {
+  --desktop-window-sidebar: color-mix(in srgb, var(--sidebar) var(--glass-opacity), transparent);
+}
+
 html.electron-windows [data-app-sidebar],
 html.electron-windows [data-slot="sidebar-inner"] {
   background-color: var(--desktop-window-sidebar) !important;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2058,8 +2058,7 @@ html.electron-windows[data-desktop-backdrop="on"] [data-app-sidebar] {
   --desktop-window-sidebar: color-mix(in srgb, var(--sidebar) var(--glass-opacity), transparent);
 }
 
-html.electron-windows [data-app-sidebar],
-html.electron-windows [data-slot="sidebar-inner"] {
+html.electron-windows [data-app-sidebar] {
   background-color: var(--desktop-window-sidebar) !important;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2071,6 +2071,14 @@ html.electron-windows [data-app-sidebar] [data-slot="sidebar-inner"] {
   background-color: transparent !important;
 }
 
+/* Sheets and dialogs are portalled outside the window canvas and paint their
+   own opaque popup surface, so canvas owners inside them must stay solid
+   instead of blending toward the native material. */
+html.electron-windows [data-slot="sheet-popup"],
+html.electron-windows [data-slot="dialog-popup"] {
+  --desktop-window-canvas: var(--background);
+}
+
 /* App-chrome grain. Baked into each surface's own background (behind
    content) rather than a fixed overlay on top: a full-viewport overlay
    forces the compositor to re-blend every frame any animation produces,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2018,6 +2018,36 @@ body {
 
 .electron-windows {
   --desktop-window-right-resize-inset: 6px;
+  --desktop-window-canvas: color-mix(in srgb, var(--background) var(--glass-opacity), transparent);
+  --desktop-window-sidebar: color-mix(in srgb, var(--sidebar) var(--glass-opacity), transparent);
+}
+
+html.electron-windows[data-desktop-backdrop="off"] {
+  --desktop-window-canvas: var(--background);
+  --desktop-window-sidebar: var(--sidebar);
+}
+
+/* Electron's Windows Acrylic backdrop is native to the BrowserWindow. The
+   renderer must leave the window and its primary app surfaces translucent so
+   that the native material can reach the entire client area. Reuse the
+   existing glass opacity preference; web, macOS, Linux, and mobile keep their
+   current surface behavior. */
+html.electron-windows,
+html.electron-windows body,
+html.electron-windows #root,
+html.electron-windows [data-slot="sidebar-wrapper"] {
+  background-color: transparent !important;
+}
+
+html.electron-windows .bg-background,
+html.electron-windows [data-slot="sidebar-inset"] {
+  background-color: var(--desktop-window-canvas) !important;
+}
+
+html.electron-windows .bg-sidebar,
+html.electron-windows [data-app-sidebar],
+html.electron-windows [data-slot="sidebar-inner"] {
+  background-color: var(--desktop-window-sidebar) !important;
 }
 
 /* App-chrome grain. Baked into each surface's own background (behind

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2054,7 +2054,8 @@ html.electron-windows [data-app-sidebar] {
   --desktop-window-sidebar: var(--sidebar);
 }
 
-html.electron-windows[data-desktop-backdrop="on"] [data-app-sidebar] {
+html.electron-windows[data-desktop-backdrop="on"]
+  [data-app-sidebar]:not([data-slot="sheet-popup"]) {
   --desktop-window-sidebar: color-mix(in srgb, var(--sidebar) var(--glass-opacity), transparent);
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -106,6 +106,7 @@ function RootRouteView() {
     return (
       <>
         <DocumentTitleSync />
+        <GlassAppearanceSync />
         <Outlet />
       </>
     );
@@ -115,6 +116,7 @@ function RootRouteView() {
     return (
       <>
         <DocumentTitleSync />
+        <GlassAppearanceSync />
         <Outlet />
       </>
     );
@@ -167,12 +169,20 @@ function ContrastAppearanceSync() {
 function GlassAppearanceSync() {
   const glassOpacity = useClientSettings((settings) => settings.glassOpacity);
   const desktopBackdropEnabled = useClientSettings((settings) => settings.desktopBackdropEnabled);
+  const [nativeBackdropEnabled, setNativeBackdropEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const subscribe = window.desktopBridge?.onWindowBackdropStateChange;
+    if (!subscribe) return;
+    return subscribe(setNativeBackdropEnabled);
+  }, []);
 
   useEffect(() => {
     const root = document.documentElement;
     root.style.setProperty("--glass-opacity", `${glassOpacity}%`);
-    root.dataset.desktopBackdrop = desktopBackdropEnabled ? "on" : "off";
-  }, [desktopBackdropEnabled, glassOpacity]);
+    root.dataset.desktopBackdrop =
+      desktopBackdropEnabled && nativeBackdropEnabled !== false ? "on" : "off";
+  }, [desktopBackdropEnabled, glassOpacity, nativeBackdropEnabled]);
 
   return null;
 }
@@ -259,7 +269,7 @@ function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
   const details = errorDetails(error);
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+    <div className="desktop-window-canvas relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
       <div className="pointer-events-none absolute inset-0 opacity-80">
         <div className="absolute inset-x-0 top-0 h-44 bg-[radial-gradient(44rem_16rem_at_top,color-mix(in_srgb,var(--color-red-500)_16%,transparent),transparent)]" />
         <div className="absolute inset-0 bg-[linear-gradient(145deg,color-mix(in_srgb,var(--background)_90%,var(--color-black))_0%,var(--background)_55%)]" />

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -169,12 +169,31 @@ function ContrastAppearanceSync() {
 function GlassAppearanceSync() {
   const glassOpacity = useClientSettings((settings) => settings.glassOpacity);
   const desktopBackdropEnabled = useClientSettings((settings) => settings.desktopBackdropEnabled);
-  const [nativeBackdropEnabled, setNativeBackdropEnabled] = useState<boolean | null>(null);
+  const [nativeBackdropEnabled, setNativeBackdropEnabled] = useState<boolean | null>(() => {
+    if (typeof window === "undefined") return null;
+    const getState = window.desktopBridge?.getWindowBackdropState;
+    if (typeof getState !== "function") return null;
+    try {
+      return getState();
+    } catch {
+      return null;
+    }
+  });
 
   useEffect(() => {
-    const subscribe = window.desktopBridge?.onWindowBackdropStateChange;
-    if (!subscribe) return;
-    return subscribe(setNativeBackdropEnabled);
+    const bridge = window.desktopBridge;
+    if (!bridge) return;
+
+    if (typeof bridge.getWindowBackdropState === "function") {
+      try {
+        setNativeBackdropEnabled(bridge.getWindowBackdropState());
+      } catch {
+        // Older shells or a very early renderer can reject the synchronous query.
+      }
+    }
+
+    if (typeof bridge.onWindowBackdropStateChange !== "function") return;
+    return bridge.onWindowBackdropStateChange(setNativeBackdropEnabled);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -166,10 +166,13 @@ function ContrastAppearanceSync() {
 
 function GlassAppearanceSync() {
   const glassOpacity = useClientSettings((settings) => settings.glassOpacity);
+  const desktopBackdropEnabled = useClientSettings((settings) => settings.desktopBackdropEnabled);
 
   useEffect(() => {
-    document.documentElement.style.setProperty("--glass-opacity", `${glassOpacity}%`);
-  }, [glassOpacity]);
+    const root = document.documentElement;
+    root.style.setProperty("--glass-opacity", `${glassOpacity}%`);
+    root.dataset.desktopBackdrop = desktopBackdropEnabled ? "on" : "off";
+  }, [desktopBackdropEnabled, glassOpacity]);
 
   return null;
 }

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -108,7 +108,7 @@ function NoProjectsHero() {
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+      <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
         <Empty className="flex-1">
           <div className="w-full max-w-lg px-8 py-12">
             <EmptyHeader className="max-w-none">
@@ -141,7 +141,7 @@ function HostedStaticOnboardingState() {
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+      <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
         <WorkspacePageHeader className="border-b border-border">
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-foreground md:text-muted-foreground/60">

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1845,7 +1845,7 @@ function PullRequestsColumn({
   return (
     // Painted flat like the chat column: the inset underneath carries the chrome grain, and a
     // content surface that lets it show reads as a different background than every thread.
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
+    <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col bg-background">
       {/* A closed right panel leaves this column full-width, so the shared header
           reserves native window controls and hosts the controls strip itself: on
           desktop the header is a drag-region, and only a no-drag descendant wins
@@ -1856,7 +1856,7 @@ function PullRequestsColumn({
       <WorkspacePageHeader
         electron={isElectron}
         reserveNativeControls={!rightPanelOpen}
-        className="relative bg-background"
+        className="desktop-window-canvas relative bg-background"
       >
         {titlebarControls}
         {condensed ? (

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -70,7 +70,7 @@ function SettingsContentLayout() {
 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
+      <div className="desktop-window-canvas flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         <WorkspacePageHeader electron={isElectron}>
           <div className="flex w-full items-center gap-3">
             <SettingsBreadcrumb pathname={location.pathname} />

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)
+- [Desktop appearance](./user/desktop-appearance.md)
 - [Mobile appearance](./user/mobile-appearance.md)
 - [Remote access](./user/remote-access.md)
 - [Keeping app and server in sync](./user/updating.md)

--- a/docs/user/desktop-appearance.md
+++ b/docs/user/desktop-appearance.md
@@ -1,0 +1,17 @@
+# Desktop appearance
+
+On Windows, T3 Code can blur the desktop behind the app using the native Windows Acrylic
+material.
+
+To enable or disable it:
+
+1. Open **Settings**.
+2. Select **Appearance**.
+3. Turn **Desktop background blur** on or off.
+
+The change applies immediately. **Glass opacity** controls how much of the Acrylic backdrop is
+visible through the app surfaces. On Windows versions that do not support Acrylic, T3 Code uses a
+solid surface instead.
+
+The setting is available only in the Windows desktop app. Web, macOS, Linux, and mobile clients
+keep their existing appearance behavior.

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1147,6 +1147,8 @@ export interface DesktopBridge {
   onQuitShortcut?: (listener: (state: "down" | "up") => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
+  /** Effective native Windows backdrop state. Optional for older desktop shells. */
+  onWindowBackdropStateChange?: (listener: (enabled: boolean) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1148,6 +1148,7 @@ export interface DesktopBridge {
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
   /** Effective native Windows backdrop state. Optional for older desktop shells. */
+  getWindowBackdropState?: () => boolean;
   onWindowBackdropStateChange?: (listener: (enabled: boolean) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -82,6 +82,15 @@ describe("ClientSettings glass opacity", () => {
   });
 });
 
+describe("ClientSettings desktop backdrop", () => {
+  it("defaults the Windows desktop blur on and accepts the patch", () => {
+    expect(decodeClientSettings({}).desktopBackdropEnabled).toBe(true);
+    expect(
+      decodeClientSettingsPatch({ desktopBackdropEnabled: false }).desktopBackdropEnabled,
+    ).toBe(false);
+  });
+});
+
 describe("ClientSettings appearance contrast", () => {
   it("defaults to the theme's original contrast", () => {
     expect(decodeClientSettings({}).appearanceContrast).toBe(100);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -75,6 +75,7 @@ export const GlassOpacity = Schema.Int.check(
 );
 export type GlassOpacity = typeof GlassOpacity.Type;
 export const DEFAULT_GLASS_OPACITY: GlassOpacity = 80;
+export const DEFAULT_DESKTOP_BACKDROP_ENABLED = true;
 
 export const MIN_APPEARANCE_CONTRAST = 50;
 export const MAX_APPEARANCE_CONTRAST = 200;
@@ -177,6 +178,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
+  ),
+  desktopBackdropEnabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_DESKTOP_BACKDROP_ENABLED)),
   ),
   fontSizeInterface: InterfaceFontSize.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_INTERFACE_FONT_SIZE)),
@@ -910,6 +914,7 @@ export const ClientSettingsPatch = Schema.Struct({
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
   environmentIdentificationMode: Schema.optionalKey(EnvironmentIdentificationMode),
   glassOpacity: Schema.optionalKey(GlassOpacity),
+  desktopBackdropEnabled: Schema.optionalKey(Schema.Boolean),
   fontSizeInterface: Schema.optionalKey(InterfaceFontSize),
   fontSizePrompt: Schema.optionalKey(PromptFontSize),
   fontSizeCode: Schema.optionalKey(CodeFontSize),


### PR DESCRIPTION
## What changed

Windows desktop users currently have no setting for the native desktop blur shown by applications such as Windows Terminal. T3 Code's existing Glass opacity setting only controls renderer surfaces and cannot blur the desktop behind the Electron window.

This PR:

- adds a persisted Windows desktop-only **Desktop background blur** setting under **Settings → Appearance**
- initializes Windows Electron windows with the native Acrylic material and transparent renderer surfaces
- applies setting changes immediately through the existing client-settings IPC path
- keeps a solid readable fallback when Acrylic is unavailable
- leaves web, macOS, Linux, and mobile clients unchanged
- documents the setting in the user documentation

## Validation

- Manually verified on Windows 11 with the local desktop build: the backdrop is visible, the setting appears under Appearance, and toggling it applies immediately.
- 103 focused tests passed.
- `@t3tools/desktop` typecheck passed.
- `@t3tools/web` typecheck passed.
- Desktop build passed.
- Formatting and `git diff --check` passed.

## Scope

This is intentionally limited to the Windows desktop surface. The setting defaults on and uses the existing Glass opacity control to determine how much of the native backdrop is visible through app surfaces.

Generated with Codex (GPT-5.6) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on acrylic changes window creation and renderer painting for all supported Windows desktop users; failures are handled with solid fallbacks, but the native material path is new and platform-specific.
> 
> **Overview**
> Adds an optional **Windows Acrylic** desktop blur for the Electron app, controlled by a new persisted **`desktopBackdropEnabled`** setting (default on) and the existing **Glass opacity** slider.
> 
> On **win32** with OS build ≥ 22621, the main process configures transparent `BrowserWindow` options, applies `backgroundMaterial: acrylic` at runtime, and pushes effective backdrop state to the renderer via sync IPC and `WINDOW_BACKDROP_STATE_CHANNEL`. **`systemVersion`** is threaded through `DesktopEnvironment` from `process.getSystemVersion()` for that gate; unsupported Windows builds and non-Windows platforms keep solid themed backgrounds. Saving client settings now calls **`syncAppearance`** so toggles apply immediately.
> 
> The web UI marks primary surfaces with **`desktop-window-canvas`** and sets **`data-desktop-backdrop`** from the user preference plus native capability. Windows-only CSS makes root/sidebar areas translucent when backdrop is on while nested canvases and portalled dialogs stay opaque. Appearance settings, search, contracts, preload bridge APIs, tests, and user docs cover the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e811e3ff8919156d51bf40fbfa6d87b06608c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable Windows Acrylic backdrop to desktop windows
> - Adds `desktopBackdropEnabled` to `ClientSettings` (defaults `true`) and a Windows-only toggle in Settings > Appearance; non-Windows platforms hide the row and settings-search entry
> - On Windows (build >= 22621), `DesktopWindow` now creates managed windows with transparent Acrylic backgrounds, applies the material at runtime via `applyWindowsBackdrop`, and falls back to solid color on failure
> - New `DesktopEnvironment.systemVersion` feeds `isWindowsAcrylicSupported`; IPC channels `GET_WINDOW_BACKDROP_STATE_CHANNEL` and `WINDOW_BACKDROP_STATE_CHANNEL` expose state to the renderer
> - Web root sets `data-desktop-backdrop` and `--glass-opacity`; [index.css](https://github.com/pingdotgg/t3code/pull/8643/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) makes primary surfaces translucent when backdrop is on, and many components gain `desktop-window-canvas` for backdrop-aware backgrounds
> - `SET_CLIENT_SETTINGS` IPC now triggers `syncAppearance` so backdrop changes apply immediately
> - Risk: components relying on opaque root backgrounds may render incorrectly when `data-desktop-backdrop="on"` sets `html`/`body`/`#root` to transparent — verify nested surfaces in [index.css](https://github.com/pingdotgg/t3code/pull/8643/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) under the `[data-desktop-backdrop="on"]` selector
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7e811e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->