### PR TITLE
fix(codex): scope provider models and suppress false capabilities

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -271,6 +271,35 @@ validationLayer("CodexAdapterLive validation", (it) => {
       NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
     }),
   );
+  it.effect("rejects an undeclared provider-namespaced model before starting Codex", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+      const result = yield* adapter
+        .startSession({
+          provider: ProviderDriverKind.make("codex"),
+          threadId: asThreadId("thread-namespaced-model"),
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("codex"),
+            "z-ai/glm-5.3-flash",
+          ),
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.deepStrictEqual(
+        result.failure,
+        new ProviderAdapterValidationError({
+          provider: ProviderDriverKind.make("codex"),
+          operation: "startSession",
+          issue:
+            "Provider-namespaced model 'z-ai/glm-5.3-flash' is not configured on instance 'codex'.",
+        }),
+      );
+      NodeAssert.equal(validationRuntimeFactory.factory.mock.calls.length, 0);
+    }),
+  );
   it.effect("maps codex model options before starting a session", () =>
     Effect.gen(function* () {
       validationRuntimeFactory.factory.mockClear();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -11,6 +11,7 @@ import {
   type CanonicalItemType,
   type CanonicalRequestType,
   type CodexSettings,
+  type ModelSelection,
   ProviderDriverKind,
   type ProviderEvent,
   ProviderInstanceId,
@@ -54,6 +55,7 @@ import {
 import { type CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import { isProviderNamespacedModelSlug } from "../providerSnapshot.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
@@ -1662,6 +1664,24 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
+  const customModelSlugs = new Set(codexConfig.customModels.map((model) => model.trim()));
+  const validateModelSelection = (
+    operation: "startSession" | "sendTurn",
+    selection: ModelSelection | undefined,
+  ): ProviderAdapterValidationError | undefined => {
+    if (
+      selection?.instanceId !== boundInstanceId ||
+      !isProviderNamespacedModelSlug(selection.model) ||
+      customModelSlugs.has(selection.model)
+    ) {
+      return undefined;
+    }
+    return new ProviderAdapterValidationError({
+      provider: PROVIDER,
+      operation,
+      issue: `Provider-namespaced model '${selection.model}' is not configured on instance '${boundInstanceId}'.`,
+    });
+  };
 
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
@@ -1672,6 +1692,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             operation: "startSession",
             issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
           });
+        }
+
+        const modelSelectionError = validateModelSelection("startSession", input.modelSelection);
+        if (modelSelectionError) {
+          return yield* modelSelectionError;
         }
 
         const existing = sessions.get(input.threadId);
@@ -1822,6 +1847,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   });
 
   const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
+    const modelSelectionError = validateModelSelection("sendTurn", input.modelSelection);
+    if (modelSelectionError) {
+      return yield* modelSelectionError;
+    }
+
     // Codex ingests images only. Anything else would be base64-encoded as an
     // image and rejected or misread; generic files reach the agent through the
     // path line ProviderService puts in the prompt.

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -178,6 +178,34 @@ it("requires provider-namespaced catalog models to be declared on the instance",
   ]);
 });
 
+it("does not infer capabilities for custom models absent from the catalog", () => {
+  const catalogModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    capabilities: {
+      optionDescriptors: [
+        {
+          id: "reasoningEffort",
+          label: "Reasoning",
+          type: "select",
+          options: [{ id: "xhigh", label: "xhigh" }],
+        },
+      ],
+    },
+  };
+
+  assert.deepStrictEqual(scopeCodexModelsToInstance([catalogModel], ["z-ai/glm-5.3-flash"]), [
+    catalogModel,
+    {
+      slug: "z-ai/glm-5.3-flash",
+      name: "z-ai/glm-5.3-flash",
+      isCustom: true,
+      capabilities: null,
+    },
+  ]);
+});
+
 it("preserves first-party catalog metadata when a custom slug shadows it", () => {
   const firstPartyModel: ServerProviderModel = {
     slug: "gpt-5.6-sol",

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,11 @@
 import { assert, it } from "@effect/vitest";
+import type { ServerProviderModel } from "@t3tools/contracts";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  scopeCodexModelsToInstance,
+} from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -143,4 +148,46 @@ it("ignores custom models that shadow a preferred slug", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("requires provider-namespaced catalog models to be declared on the instance", () => {
+  const openAiModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    capabilities: null,
+  };
+  const openRouterModel: ServerProviderModel = {
+    slug: "z-ai/glm-5.3-flash",
+    name: "GLM-5.3-Flash",
+    isCustom: false,
+    capabilities: { optionDescriptors: [] },
+  };
+  const catalog = [openAiModel, openRouterModel];
+
+  assert.deepStrictEqual(
+    scopeCodexModelsToInstance(catalog, []).map((model) => model.slug),
+    ["gpt-5.6-sol"],
+  );
+  assert.deepStrictEqual(scopeCodexModelsToInstance(catalog, ["z-ai/glm-5.3-flash"]), [
+    openAiModel,
+    {
+      ...openRouterModel,
+      isCustom: true,
+    },
+  ]);
+});
+
+it("preserves first-party catalog metadata when a custom slug shadows it", () => {
+  const firstPartyModel: ServerProviderModel = {
+    slug: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    isCustom: false,
+    isLegacy: true,
+    capabilities: null,
+  };
+
+  assert.deepStrictEqual(scopeCodexModelsToInstance([firstPartyModel], [firstPartyModel.slug]), [
+    firstPartyModel,
+  ]);
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -30,6 +30,7 @@ import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts
 import {
   AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
+  isProviderNamespacedModelSlug,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
@@ -224,31 +225,48 @@ export function applyPreferredCodexDefaultModel(
   });
 }
 
-function appendCustomCodexModels(
+/**
+ * Codex stores one model catalog cache per home, even when that home is used
+ * with multiple model providers. A provider-namespaced slug from that cache is
+ * therefore not evidence that the current instance can run it. Require an
+ * explicit custom-model declaration on this instance before exposing it.
+ */
+export function scopeCodexModelsToInstance(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
 ): ReadonlyArray<ServerProviderModel> {
-  if (customModels.length === 0) {
-    return models;
+  const customSlugs = new Set(customModels.map((model) => model.trim()).filter(Boolean));
+  const scopedModels: ServerProviderModel[] = [];
+  const seen = new Set<string>();
+
+  for (const model of models) {
+    if (isProviderNamespacedModelSlug(model.slug)) {
+      if (customSlugs.has(model.slug)) {
+        const { isLegacy: _isLegacy, ...rest } = model;
+        scopedModels.push({ ...rest, isCustom: true });
+        seen.add(model.slug);
+      }
+      continue;
+    }
+
+    scopedModels.push(model);
+    seen.add(model.slug);
   }
 
-  const seen = new Set(models.map((model) => model.slug));
   const fallbackCapabilities = models.find((model) => model.capabilities)?.capabilities ?? null;
-  const customEntries: ServerProviderModel[] = [];
-  for (const rawModel of customModels) {
-    const slug = rawModel.trim();
-    if (!slug || seen.has(slug)) {
+  for (const slug of customSlugs) {
+    if (seen.has(slug)) {
       continue;
     }
     seen.add(slug);
-    customEntries.push({
+    scopedModels.push({
       slug,
       name: slug,
       isCustom: true,
       capabilities: fallbackCapabilities,
     });
   }
-  return customEntries.length === 0 ? models : [...models, ...customEntries];
+  return scopedModels;
 }
 
 function parseCodexSkillsListResponse(
@@ -389,7 +407,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     return {
       account: accountResponse,
       version,
-      models: appendCustomCodexModels([], input.customModels ?? []),
+      models: scopeCodexModelsToInstance([], input.customModels ?? []),
       skills: [],
     } satisfies CodexAppServerProviderSnapshot;
   }
@@ -408,7 +426,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     account: accountResponse,
     version,
     models: applyPreferredCodexDefaultModel(
-      appendCustomCodexModels(models, input.customModels ?? []),
+      scopeCodexModelsToInstance(models, input.customModels ?? []),
     ),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
   } satisfies CodexAppServerProviderSnapshot;

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -253,7 +253,6 @@ export function scopeCodexModelsToInstance(
     seen.add(model.slug);
   }
 
-  const fallbackCapabilities = models.find((model) => model.capabilities)?.capabilities ?? null;
   for (const slug of customSlugs) {
     if (seen.has(slug)) {
       continue;
@@ -263,7 +262,7 @@ export function scopeCodexModelsToInstance(
       slug,
       name: slug,
       isCustom: true,
-      capabilities: fallbackCapabilities,
+      capabilities: null,
     });
   }
   return scopedModels;

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -603,6 +603,43 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ]);
       });
 
+      it("drops a removed provider-namespaced Codex custom model", () => {
+        const firstPartyModel = {
+          slug: "gpt-5.6-sol",
+          name: "GPT-5.6-Sol",
+          isCustom: false,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const removedCustomModel = {
+          slug: "z-ai/glm-5.3-flash",
+          name: "GLM-5.3-Flash",
+          isCustom: true,
+          capabilities: codexModelCapabilities,
+        } as const;
+        const previousProvider = {
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-08-28T00:00:00.000Z",
+          version: "1.0.0",
+          models: [firstPartyModel, removedCustomModel],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-08-28T00:01:00.000Z",
+          models: [],
+        } satisfies ServerProvider;
+
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
+          firstPartyModel,
+        ]);
+      });
+
       it("drops stale OpenCode models missing from a successful refresh", () => {
         const previousProvider = {
           instanceId: ProviderInstanceId.make("opencode"),

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -53,6 +53,7 @@ import {
 } from "../providerStatusCache.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import { isProviderNamespacedModelSlug } from "../providerSnapshot.ts";
 import type { ProviderSnapshotSource } from "../builtInProviderCatalog.ts";
 
 const loadProviders = (
@@ -101,9 +102,14 @@ const mergeProviderModels = (
   nextModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const shouldRetainMissingModels = shouldRetainMissingProviderModels(provider);
+  const retainablePreviousModels = previousModels.filter(
+    (model) =>
+      provider.driver !== ProviderDriverKind.make("codex") ||
+      !isProviderNamespacedModelSlug(model.slug),
+  );
 
   if (shouldRetainMissingModels && nextModels.length === 0 && previousModels.length > 0) {
-    return previousModels;
+    return retainablePreviousModels;
   }
 
   const previousBySlug = new Map(previousModels.map((model) => [model.slug, model] as const));
@@ -119,7 +125,7 @@ const mergeProviderModels = (
   });
   const nextSlugs = new Set(nextModels.map((model) => model.slug));
   return shouldRetainMissingModels
-    ? [...mergedModels, ...previousModels.filter((model) => !nextSlugs.has(model.slug))]
+    ? [...mergedModels, ...retainablePreviousModels.filter((model) => !nextSlugs.has(model.slug))]
     : mergedModels;
 };
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -67,6 +67,10 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+export function isProviderNamespacedModelSlug(slug: string): boolean {
+  return slug.includes("/");
+}
+
 export function isCommandMissingCause(error: unknown): boolean {
   if (isProviderCommandNotFoundError(error)) return true;
   return error instanceof PlatformError.PlatformError && error.reason._tag === "NotFound";

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -205,6 +205,33 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
     );
   });
 
+  it("does not hydrate undeclared provider-namespaced Codex models", () => {
+    const namespacedModel = {
+      slug: "z-ai/glm-5.3-flash",
+      name: "GLM-5.3-Flash",
+      isCustom: false,
+      capabilities: emptyCapabilities,
+    } as const;
+    const cachedCodex = makeProvider(CODEX_DRIVER, { models: [namespacedModel] });
+    const fallbackCodex = makeProvider(CODEX_DRIVER);
+
+    assert.deepStrictEqual(
+      hydrateCachedProvider({ cachedProvider: cachedCodex, fallbackProvider: fallbackCodex })
+        .models,
+      [],
+    );
+
+    const declaredModel = { ...namespacedModel, isCustom: true } as const;
+    const declaredFallback = makeProvider(CODEX_DRIVER, { models: [declaredModel] });
+    assert.deepStrictEqual(
+      hydrateCachedProvider({
+        cachedProvider: cachedCodex,
+        fallbackProvider: declaredFallback,
+      }).models,
+      [declaredModel],
+    );
+  });
+
   it("rejects cached snapshots that are not correlated to the fallback instance", () => {
     const fallbackCodex = makeProvider(CODEX_DRIVER, {
       models: [

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -11,17 +11,26 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import { writeFileStringAtomically } from "../atomicWrite.ts";
+import { isProviderNamespacedModelSlug } from "./providerSnapshot.ts";
 
 const decodeProviderStatusCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(ServerProviderSchema),
 );
 
 const mergeProviderModels = (
+  driver: ProviderDriverKind,
   fallbackModels: ReadonlyArray<ServerProvider["models"][number]>,
   cachedModels: ReadonlyArray<ServerProvider["models"][number]>,
 ): ReadonlyArray<ServerProvider["models"][number]> => {
   const fallbackSlugs = new Set(fallbackModels.map((model) => model.slug));
-  return [...fallbackModels, ...cachedModels.filter((model) => !fallbackSlugs.has(model.slug))];
+  return [
+    ...fallbackModels,
+    ...cachedModels.filter(
+      (model) =>
+        !fallbackSlugs.has(model.slug) &&
+        (driver !== "codex" || !isProviderNamespacedModelSlug(model.slug)),
+    ),
+  ];
 };
 
 export const orderProviderSnapshots = (
@@ -59,7 +68,11 @@ export const hydrateCachedProvider = (input: {
   const { message: _fallbackMessage, ...fallbackWithoutMessage } = input.fallbackProvider;
   const hydratedProvider: ServerProvider = {
     ...fallbackWithoutMessage,
-    models: mergeProviderModels(input.fallbackProvider.models, input.cachedProvider.models),
+    models: mergeProviderModels(
+      input.fallbackProvider.driver,
+      input.fallbackProvider.models,
+      input.cachedProvider.models,
+    ),
     installed: input.cachedProvider.installed,
     version: input.cachedProvider.version,
     status: input.cachedProvider.status,


### PR DESCRIPTION
# CI-only mirror of the canonical Buzz provider candidate

Buzz is the repository of record. This GitHub pull request exists only to run the upstream protected checks on the exact canonical candidate. Do not merge it on GitHub.

The original correction scopes provider-namespaced Codex model catalogs to the active T3 provider instance. The follow-up commit removes a false capability inference: when a configured custom model is absent from the live catalog, T3 now reports `capabilities: null` instead of copying reasoning and service-tier controls from an unrelated model such as Sol. That prevents unsupported Sol controls from appearing on `z-ai/glm-5.3-flash`.

Exact candidate:

- Canonical base: `018d7f2775daabd2ef07898af29586915a0b7f67`
- Head: `b2d8208a2bd340bcb3de8df3509a9bcba2b8c935`
- Tree: `a9b86eaf555f99e6b9c32e551980751c9379cb26`
- Head parent: `c27f09695aa8b17487973baf650dbbc33c1d5a95`
- Live upstream `main` observed at publication: `053affbed2659f90cd1b1efaaa7a75865c4131c7`

Focused checks:

- `CodexProvider.test.ts`: 9 tests passed
- Targeted lint passed on the two follow-up paths
- Targeted format check passed on the two follow-up paths
- Server typecheck passed; non-failing suggestions were confined to untouched baseline files
- Commit diff check passed
- The parent candidate previously passed 4 focused files / 92 tests, targeted lint, nine-file format check, server typecheck, and commit diff check

Canonical Buzz records:

- Repository: `30617:4a34c131ec5cb5dd9a200bac619bbd103c0793e068fad278d1de59203d05b97d:t3code`
- Issue: `0fe7a67b68001356dfe2bc49a5a6bee12eef704c6f25e79acfc67c02cd6f1bba`
- Pull request: `37293d0ac0d54ce13fadb87070e98f0d2653858fb7ea17e0b27851e00aa43767`
- Buzz feature ref: `refs/heads/buzz/provider-scoped-custom-models-rebase-018d7f2`

Model/harness: GPT-5.6 Sol via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex model catalog exposure, cache merge, and session validation; misconfiguration could hide models users expect, but the behavior is intentional and covered by new tests.
> 
> **Overview**
> **Codex model lists and sessions are now tied to each instance’s declared custom models**, so slugs like `z-ai/glm-5.3-flash` from a shared Codex home catalog are not treated as runnable on that instance unless they appear in settings.
> 
> `scopeCodexModelsToInstance` replaces the old “append all custom slugs” behavior: **provider-namespaced catalog entries** (detected via `isProviderNamespacedModelSlug`, i.e. a `/` in the slug) are **dropped** unless listed in `customModels`; when allowed, they are exposed as **custom** models. Slugs declared in settings but missing from the live catalog are still added with **`capabilities: null`**, so reasoning/service-tier UI is not copied from an unrelated first-party model.
> 
> **Runtime and snapshot hygiene** block stale or undeclared namespaced models: `CodexAdapter` rejects `startSession` / `sendTurn` when a namespaced model is not configured on the bound instance; `ProviderRegistry` merge and `providerStatusCache` hydration no longer retain or rehydrate undeclared namespaced Codex models from older snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d8208a2bd340bcb3de8df3509a9bcba2b8c935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope Codex provider models to instance and suppress inferred capabilities
> - Adds `scopeCodexModelsToInstance` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/8649/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) to filter the Codex model catalog per instance: provider-namespaced slugs (those containing `/`) are included only if declared in `customModels`, marked `isCustom`, and given `null` capabilities when absent from the catalog.
> - Adds `validateModelSelection` in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/8649/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) so `startSession` and `sendTurn` reject provider-namespaced slugs that are not declared as custom models on the bound instance.
> - Updates `mergeProviderModels` in [ProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/8649/files#diff-5c33694fd7889294ecb21a88beafee2debe92f779baab4629651d4c8be8a9a97) and [providerStatusCache.ts](https://github.com/pingdotgg/t3code/pull/8649/files#diff-6de08e2cd95df6ffd1cc93a059448e8a80f0392091e10e0d7aabd9b6b01dbb07) to exclude provider-namespaced slugs for the Codex driver when retaining previous models on empty refresh or cache hydration.
> - Risk: undeclared provider-namespaced Codex models are now dropped from the probed catalog, cache hydration, and snapshot retention; requests referencing them via `startSession` or `sendTurn` fail with `ProviderAdapterValidationError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b2d8208. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->