### PR TITLE
fix(server): preserve resource monitor executable modes

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,14 @@
     "dist"
   ],
   "type": "module",
+  "publishConfig": {
+    "executableFiles": [
+      "dist/resource-monitor/darwin-arm64/t3-resource-monitor",
+      "dist/resource-monitor/darwin-x64/t3-resource-monitor",
+      "dist/resource-monitor/linux-x64/t3-resource-monitor",
+      "dist/resource-monitor/win32-x64/t3-resource-monitor.exe"
+    ]
+  },
   "scripts": {
     "dev": "node --watch src/bin.ts",
     "build:bundle": "vp pack && vp pack src/service-launcher.ts --out-dir dist --no-clean",

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -15,7 +15,6 @@ import {
   resolveWebAssetBrandForPackageVersion,
   resolveWebIconOverrides,
 } from "../../../scripts/lib/brand-assets.ts";
-import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
 import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
 import { fromYaml } from "@t3tools/shared/schemaYaml";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
@@ -28,22 +27,7 @@ import {
   ServerCliPublishIconSourceMissingError,
   ServerCliPublishIconTargetMissingError,
 } from "./cliErrors.ts";
-
-interface PackageJson {
-  name: string;
-  repository: {
-    type: string;
-    url: string;
-    directory: string;
-  };
-  bin: Record<string, string>;
-  type: string;
-  version: string;
-  engines: Record<string, string>;
-  files: string[];
-  dependencies: Record<string, string>;
-  overrides: Record<string, string>;
-}
+import { createServerCliPublishPackageJson } from "./cliManifest.ts";
 
 const PackageJsonPrettyJson = fromJsonStringPretty(Schema.Unknown);
 const encodePackageJson = Schema.encodeEffect(PackageJsonPrettyJson);
@@ -241,25 +225,12 @@ const publishCmd = Command.make(
           const workspaceConfig = yield* readWorkspaceConfig();
           const workspaceCatalog = workspaceConfig.catalog ?? {};
           const workspaceOverrides = workspaceConfig.overrides ?? {};
-          const pkg: PackageJson = {
-            name: serverPackageJson.name,
-            repository: serverPackageJson.repository,
-            bin: serverPackageJson.bin,
-            type: serverPackageJson.type,
+          const pkg = createServerCliPublishPackageJson({
+            source: serverPackageJson,
             version,
-            engines: serverPackageJson.engines,
-            files: serverPackageJson.files,
-            dependencies: resolveCatalogDependencies(
-              serverPackageJson.dependencies,
-              workspaceCatalog,
-              "apps/server",
-            ),
-            overrides: resolveCatalogDependencies(
-              workspaceOverrides,
-              workspaceCatalog,
-              "apps/server",
-            ),
-          };
+            workspaceCatalog,
+            workspaceOverrides,
+          });
 
           return {
             packageJsonString: yield* encodePackageJson(pkg),

--- a/apps/server/scripts/cliManifest.test.ts
+++ b/apps/server/scripts/cliManifest.test.ts
@@ -1,0 +1,126 @@
+import * as NodeProcess from "node:process";
+import * as NodeZlib from "node:zlib";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import serverPackageJson from "../package.json" with { type: "json" };
+import { createServerCliPublishPackageJson } from "./cliManifest.ts";
+
+const RESOURCE_MONITOR_EXECUTABLES = [
+  "dist/resource-monitor/darwin-arm64/t3-resource-monitor",
+  "dist/resource-monitor/darwin-x64/t3-resource-monitor",
+  "dist/resource-monitor/linux-x64/t3-resource-monitor",
+  "dist/resource-monitor/win32-x64/t3-resource-monitor.exe",
+];
+const encodeUnknownJson = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+
+function readTarField(header: Uint8Array, start: number, end: number): string {
+  const field = header.subarray(start, end);
+  const nullOffset = field.indexOf(0);
+  return field
+    .subarray(0, nullOffset === -1 ? field.length : nullOffset)
+    .toString()
+    .trim();
+}
+
+function readTarModes(tarball: Uint8Array): ReadonlyMap<string, number> {
+  const archive = NodeZlib.gunzipSync(tarball);
+  const modes = new Map<string, number>();
+
+  for (let offset = 0; offset + 512 <= archive.length; ) {
+    const header = archive.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = readTarField(header, 0, 100);
+    const modeText = readTarField(header, 100, 108);
+    const sizeText = readTarField(header, 124, 136);
+    const mode = Number.parseInt(modeText, 8);
+    const size = Number.parseInt(sizeText, 8);
+
+    modes.set(name, mode & 0o777);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+
+  return modes;
+}
+
+describe("CLI publish manifest", () => {
+  it("marks every packaged resource monitor as executable", () => {
+    assert.deepStrictEqual(
+      serverPackageJson.publishConfig.executableFiles,
+      RESOURCE_MONITOR_EXECUTABLES,
+    );
+  });
+
+  it("retains executable file metadata in the generated publish manifest", () => {
+    const manifest = createServerCliPublishPackageJson({
+      source: { ...serverPackageJson, dependencies: {} },
+      version: "1.2.3",
+      workspaceCatalog: {},
+      workspaceOverrides: {},
+    });
+
+    assert.deepStrictEqual(manifest.publishConfig.executableFiles, RESOURCE_MONITOR_EXECUTABLES);
+  });
+
+  it.effect("packs every resource monitor with executable mode", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fixtureDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-resource-monitor-pack-",
+      });
+      const outputDir = path.join(fixtureDir, "packed");
+
+      yield* fileSystem.makeDirectory(outputDir);
+      yield* fileSystem.writeFileString(
+        path.join(fixtureDir, "package.json"),
+        encodeUnknownJson({
+          name: "t3-resource-monitor-pack-fixture",
+          version: "1.0.0",
+          packageManager: "pnpm@11.10.0",
+          files: ["dist"],
+          publishConfig: serverPackageJson.publishConfig,
+        }),
+      );
+
+      for (const executable of RESOURCE_MONITOR_EXECUTABLES) {
+        const executablePath = path.join(fixtureDir, executable);
+        yield* fileSystem.makeDirectory(path.dirname(executablePath), { recursive: true });
+        yield* fileSystem.writeFileString(executablePath, "fixture\n");
+        yield* fileSystem.chmod(executablePath, 0o644);
+      }
+
+      const vpExecutable = path.resolve(
+        import.meta.dirname,
+        "../../../node_modules/vite-plus/bin/vp",
+      );
+      const child = yield* spawner.spawn(
+        ChildProcess.make(
+          NodeProcess.execPath,
+          [vpExecutable, "pm", "pack", "--pack-destination", outputDir],
+          {
+            cwd: fixtureDir,
+            stdout: "inherit",
+            stderr: "inherit",
+          },
+        ),
+      );
+      assert.equal(yield* child.exitCode, 0);
+
+      const [tarballName] = yield* fileSystem.readDirectory(outputDir);
+      assert.ok(tarballName);
+      const modes = readTarModes(yield* fileSystem.readFile(path.join(outputDir, tarballName)));
+      for (const executable of RESOURCE_MONITOR_EXECUTABLES) {
+        assert.equal(modes.get(`package/${executable}`), 0o755, executable);
+      }
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/scripts/cliManifest.ts
+++ b/apps/server/scripts/cliManifest.ts
@@ -1,0 +1,50 @@
+import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
+
+export interface ServerCliPublishPackageJson {
+  readonly name: string;
+  readonly repository: {
+    readonly type: string;
+    readonly url: string;
+    readonly directory: string;
+  };
+  readonly bin: Readonly<Record<string, string>>;
+  readonly type: string;
+  readonly version: string;
+  readonly engines: Readonly<Record<string, string>>;
+  readonly files: ReadonlyArray<string>;
+  readonly dependencies: Readonly<Record<string, string>>;
+  readonly overrides: Readonly<Record<string, string>>;
+  readonly publishConfig: {
+    readonly executableFiles: ReadonlyArray<string>;
+  };
+}
+
+type ServerCliPackageSource = Omit<ServerCliPublishPackageJson, "version" | "overrides">;
+
+export function createServerCliPublishPackageJson(input: {
+  readonly source: ServerCliPackageSource;
+  readonly version: string;
+  readonly workspaceCatalog: Record<string, string>;
+  readonly workspaceOverrides: Record<string, string>;
+}): ServerCliPublishPackageJson {
+  return {
+    name: input.source.name,
+    repository: input.source.repository,
+    bin: input.source.bin,
+    type: input.source.type,
+    version: input.version,
+    engines: input.source.engines,
+    files: input.source.files,
+    dependencies: resolveCatalogDependencies(
+      input.source.dependencies,
+      input.workspaceCatalog,
+      "apps/server",
+    ),
+    overrides: resolveCatalogDependencies(
+      input.workspaceOverrides,
+      input.workspaceCatalog,
+      "apps/server",
+    ),
+    publishConfig: input.source.publishConfig,
+  };
+}


### PR DESCRIPTION
# CI-only mirror of the canonical Buzz resource-monitor candidate

Buzz is the repository of record. This GitHub pull request exists only to run the upstream checks on the exact canonical candidate. Do not merge it on GitHub.

The Nightly npm package currently stores all four shipped resource-monitor sidecars as mode `0644`:

- `dist/resource-monitor/darwin-arm64/t3-resource-monitor`
- `dist/resource-monitor/darwin-x64/t3-resource-monitor`
- `dist/resource-monitor/linux-x64/t3-resource-monitor`
- `dist/resource-monitor/win32-x64/t3-resource-monitor.exe`

This candidate declares all four paths in pnpm `publishConfig.executableFiles` and preserves the metadata when the release CLI rewrites the publish manifest. Its focused pack test starts every fixture at `0644`, performs a local pnpm pack, reads the tar headers, and requires `0755` for every path.

Reviewed predecessor `cfd77f6411a530cdca3ed0afac310667acfe1c46` listed unshipped `linux-arm64` and omitted shipped `win32-x64`. This candidate matches the release matrix.

Exact candidate:

- Canonical Buzz base: `018d7f2775daabd2ef07898af29586915a0b7f67`
- Head: `66738b4f0323a3f867829e7ad1e351300d3acc90`
- Tree: `4e141b7d47064db2d3cece0c639adcc89fe2de39`
- Head parent: `018d7f2775daabd2ef07898af29586915a0b7f67`
- Live upstream `main` observed at publication: `053affbed2659f90cd1b1efaaa7a75865c4131c7`

Focused checks:

- `cliManifest.test.ts`: 3 tests passed
- Local pnpm pack tar-mode assertions passed at `0755` for all four shipped paths
- Targeted lint passed
- Targeted format check passed
- Server typecheck passed; non-failing suggestions were confined to untouched baseline files
- Commit diff check passed

Canonical Buzz records:

- Repository: `30617:4a34c131ec5cb5dd9a200bac619bbd103c0793e068fad278d1de59203d05b97d:t3code`
- Issue: `4b043ee04a2f13111e4ad4f6de072239f40319510ecc747cbda97c4df19d403e`
- Pull request: `ef731045100fb7a8cbcfb444491e3fe66eb812888f2e18c460ff29d9e9b72e45`
- Buzz feature ref: `refs/heads/sats/resource-monitor-modes-66738b4f0323-20260829`

Model/harness: GPT-5.6 Sol via Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect npm publish packaging for bundled binaries; behavior is covered by pack tests, but a regression could still break resource monitoring for installed CLI users.
> 
> **Overview**
> Published `t3` packages were packing all four **resource-monitor** sidecar binaries as non-executable (`0644`), which can break spawning them after install.
> 
> This PR adds **`publishConfig.executableFiles`** in `apps/server/package.json` for the shipped darwin (arm64/x64), linux x64, and win32 x64 monitor paths, and moves publish-time `package.json` rewriting into **`createServerCliPublishPackageJson`** (`cliManifest.ts`) so that metadata is **not dropped** when the release CLI resolves catalog dependencies and overrides.
> 
> **`cliManifest.test.ts`** asserts the executable list on the source manifest and generated publish manifest, and runs a local **`vp pm pack`** fixture (files start at `0644`) to verify tarball entries end up at **`0755`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66738b4f0323a3f867829e7ad1e351300d3acc90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve executable file modes for resource monitor binaries in server publish
> - Adds `publishConfig.executableFiles` to [package.json](https://github.com/pingdotgg/t3code/pull/8650/files#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2) listing four platform-specific resource monitor binaries so the npm tarball keeps mode `0755`.
> - Refactors `publishCmd` in [cli.ts](https://github.com/pingdotgg/t3code/pull/8650/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) to build the publish manifest via the new `createServerCliPublishPackageJson` factory in [cliManifest.ts](https://github.com/pingdotgg/t3code/pull/8650/files#diff-21022fdd0f2917e6165c71fe90d723af07f6dce91e891d4e0afe5dfaf10fab14), which passes `publishConfig` through from the source package.
> - Adds tests in [cliManifest.test.ts](https://github.com/pingdotgg/t3code/pull/8650/files#diff-33fbe6ffc8fdec443ce1a75756dcb74a9459b60e1c86e20878814a3c23115c45) verifying the executable files appear in the packed tarball with the correct mode.
> - Behavioral Change: the generated publish `package.json` now includes `publishConfig` from the source manifest; consumers relying on its absence may see new fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66738b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->