### PR TITLE
fix(web): Fix file inline comment focus and persistence

### DIFF
--- a/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
+++ b/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
@@ -1,5 +1,5 @@
 import { MessageCircle, Trash2 } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
@@ -25,6 +25,7 @@ interface DiffCommentAnnotationProps {
   submitLabel?: string;
   pending?: boolean;
   secondaryAction?: DiffCommentSecondaryAction;
+  focusOnMount?: boolean;
 }
 
 /** The shared inline comment treatment for file previews, thread diffs, and pull-request diffs. */
@@ -40,10 +41,20 @@ export function DiffCommentAnnotation({
   submitLabel = "Comment",
   pending = false,
   secondaryAction,
+  focusOnMount = true,
 }: DiffCommentAnnotationProps) {
   const [localDraftText, setLocalDraftText] = useState("");
   const displayedText = kind === "draft" && !onTextChange ? localDraftText : text;
   const trimmedText = displayedText.trim();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (kind !== "draft" || !focusOnMount) return;
+    const frame = window.requestAnimationFrame(() => {
+      textareaRef.current?.focus({ preventScroll: true });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [focusOnMount, kind]);
 
   if (kind === "comment") {
     return (
@@ -78,9 +89,10 @@ export function DiffCommentAnnotation({
       onPointerDown={(event) => event.stopPropagation()}
     >
       <Textarea
-        autoFocus
+        ref={textareaRef}
+        autoFocus={focusOnMount}
         unstyled
-        className="relative inline-flex w-full rounded-md border border-border/50 bg-background/20 font-sans text-foreground transition-colors focus-within:border-border/70 [&_[data-slot=textarea]]:min-h-12 [&_[data-slot=textarea]]:cursor-text [&_[data-slot=textarea]]:px-2.5 [&_[data-slot=textarea]]:py-1.5 [&_[data-slot=textarea]]:font-sans [&_[data-slot=textarea]]:text-xs [&_[data-slot=textarea]]:leading-5 max-sm:[&_[data-slot=textarea]]:min-h-12"
+        className="relative inline-flex w-full rounded-md border border-border/50 bg-background/20 font-sans text-foreground transition-colors focus-within:border-border/70 [&_[data-slot=textarea]]:min-h-12 [&_[data-slot=textarea]]:cursor-text [&_[data-slot=textarea]]:caret-foreground [&_[data-slot=textarea]]:px-2.5 [&_[data-slot=textarea]]:py-1.5 [&_[data-slot=textarea]]:font-sans [&_[data-slot=textarea]]:text-xs [&_[data-slot=textarea]]:leading-5 max-sm:[&_[data-slot=textarea]]:min-h-12"
         size="sm"
         value={displayedText}
         placeholder={placeholder}

--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -5,6 +5,7 @@ import {
   formatFileCommentRange,
   normalizeFileCommentRange,
   remapFileCommentAnnotations,
+  resolveFileCommentAnnotationChanges,
 } from "./fileCommentAnnotations";
 import { isMarkdownPreviewFile, setMarkdownTaskChecked } from "./filePreviewMode";
 
@@ -101,6 +102,35 @@ describe("file comment annotations", () => {
         },
       },
     ]);
+  });
+
+  it("distinguishes removed and restored Pierre comments", () => {
+    const annotation = {
+      lineNumber: 5,
+      metadata: {
+        entries: [
+          {
+            id: "comment-1",
+            kind: "comment" as const,
+            startLine: 5,
+            endLine: 5,
+            text: "Keep this guarded.",
+          },
+        ],
+      },
+    };
+
+    const removed = resolveFileCommentAnnotationChanges([annotation], []);
+    expect([...removed.removedIds]).toEqual(["comment-1"]);
+    expect([...removed.addedIds]).toEqual([]);
+
+    const restored = resolveFileCommentAnnotationChanges([], [annotation]);
+    expect([...restored.addedIds]).toEqual(["comment-1"]);
+    expect([...restored.removedIds]).toEqual([]);
+
+    const neverRendered = resolveFileCommentAnnotationChanges([], []);
+    expect([...neverRendered.addedIds]).toEqual([]);
+    expect([...neverRendered.removedIds]).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  buildFileCommentAnnotations,
   formatFileCommentRange,
   normalizeFileCommentRange,
   remapFileCommentAnnotations,
@@ -46,6 +47,55 @@ describe("file comment annotations", () => {
               startLine: 11,
               endLine: 20,
               text: "Keep this guarded.",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("rebuilds persisted file annotations from composer review comments", () => {
+    expect(
+      buildFileCommentAnnotations(
+        [
+          {
+            id: "comment-1",
+            sectionId: "file:apps/web/src/example.ts",
+            sectionTitle: "File comment",
+            filePath: "apps/web/src/example.ts",
+            startIndex: 4,
+            endIndex: 6,
+            rangeLabel: "L5 to L7",
+            text: "Keep this visible after remount.",
+            diff: "a\nb\nc",
+            fenceLanguage: "ts",
+          },
+          {
+            id: "comment-2",
+            sectionId: "file:apps/web/src/other.ts",
+            sectionTitle: "File comment",
+            filePath: "apps/web/src/other.ts",
+            startIndex: 1,
+            endIndex: 1,
+            rangeLabel: "L2",
+            text: "Ignore this one.",
+            diff: "x",
+            fenceLanguage: "ts",
+          },
+        ],
+        "apps/web/src/example.ts",
+      ),
+    ).toEqual([
+      {
+        lineNumber: 7,
+        metadata: {
+          entries: [
+            {
+              id: "comment-1",
+              kind: "comment",
+              startLine: 5,
+              endLine: 7,
+              text: "Keep this visible after remount.",
             },
           ],
         },

--- a/apps/web/src/components/files/FilePreviewPanel.test.ts
+++ b/apps/web/src/components/files/FilePreviewPanel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  appendFileCommentEntry,
   buildFileCommentAnnotations,
   formatFileCommentRange,
   normalizeFileCommentRange,
@@ -97,6 +98,48 @@ describe("file comment annotations", () => {
               startLine: 5,
               endLine: 7,
               text: "Keep this visible after remount.",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("groups a draft with an existing comment on the same line", () => {
+    const persisted = appendFileCommentEntry([], {
+      id: "comment-1",
+      kind: "comment",
+      startLine: 5,
+      endLine: 5,
+      text: "Keep this guarded.",
+    });
+
+    expect(
+      appendFileCommentEntry(persisted, {
+        id: "draft-1",
+        kind: "draft",
+        startLine: 5,
+        endLine: 5,
+        text: "",
+      }),
+    ).toEqual([
+      {
+        lineNumber: 5,
+        metadata: {
+          entries: [
+            {
+              id: "comment-1",
+              kind: "comment",
+              startLine: 5,
+              endLine: 5,
+              text: "Keep this guarded.",
+            },
+            {
+              id: "draft-1",
+              kind: "draft",
+              startLine: 5,
+              endLine: 5,
+              text: "",
             },
           ],
         },

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -51,6 +51,7 @@ import {
   nextFileCommentId,
   normalizeFileCommentRange,
   remapFileCommentAnnotations,
+  resolveFileCommentAnnotationChanges,
 } from "./fileCommentAnnotations";
 import { installFileEditorDismissal } from "./fileEditorDismissal";
 import { resolveCenteredFileLineScrollTop } from "./fileLineReveal";
@@ -467,6 +468,8 @@ function EditableFileSurface({
   const lineAnnotations = draft ? [...persistedAnnotations, draft] : persistedAnnotations;
 
   const surfaceRef = useRef<HTMLDivElement>(null);
+  const editorAnnotationsRef = useRef<ReadonlyArray<FileCommentLineAnnotation>>([]);
+  const restorableCommentIdsRef = useRef(new Set<string>());
   const selectionFrameRef = useRef<number | null>(null);
   const saveCoordinator = useFileSaveCoordinator({
     environmentId,
@@ -498,11 +501,15 @@ function EditableFileSurface({
             const currentComments =
               useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)
                 ?.reviewComments ?? EMPTY_REVIEW_COMMENTS;
+            const annotationChanges = resolveFileCommentAnnotationChanges(
+              editorAnnotationsRef.current,
+              remapped,
+            );
+            editorAnnotationsRef.current = remapped;
             for (const annotation of remapped) {
               for (const entry of annotation.metadata.entries) {
                 if (entry.kind !== "comment") continue;
                 const currentComment = currentComments.find((comment) => comment.id === entry.id);
-                if (!currentComment) continue;
                 const nextComment = buildFileReviewComment({
                   id: entry.id,
                   filePath: relativePath,
@@ -511,6 +518,15 @@ function EditableFileSurface({
                   text: entry.text,
                   contents: file.contents,
                 });
+                if (!currentComment) {
+                  if (
+                    annotationChanges.addedIds.has(entry.id) &&
+                    restorableCommentIdsRef.current.delete(entry.id)
+                  ) {
+                    addReviewComment(composerDraftTarget, nextComment);
+                  }
+                  continue;
+                }
                 if (
                   currentComment.startIndex === nextComment.startIndex &&
                   currentComment.endIndex === nextComment.endIndex &&
@@ -521,10 +537,29 @@ function EditableFileSurface({
                 addReviewComment(composerDraftTarget, nextComment);
               }
             }
+            const sectionId = `file:${relativePath}`;
+            for (const comment of currentComments) {
+              if (
+                comment.sectionId === sectionId &&
+                comment.filePath === relativePath &&
+                annotationChanges.removedIds.has(comment.id)
+              ) {
+                restorableCommentIdsRef.current.add(comment.id);
+                removeReviewComment(composerDraftTarget, comment.id);
+              }
+            }
           }
         },
       }),
-    [addReviewComment, composerDraftTarget, cwd, environmentId, relativePath, saveCoordinator],
+    [
+      addReviewComment,
+      composerDraftTarget,
+      cwd,
+      environmentId,
+      relativePath,
+      removeReviewComment,
+      saveCoordinator,
+    ],
   );
 
   useEffect(
@@ -537,6 +572,7 @@ function EditableFileSurface({
   const removeAnnotationEntry = useCallback(
     (entryId: string) => {
       setSelectedRange(null);
+      restorableCommentIdsRef.current.delete(entryId);
       if (draft?.metadata.entries.some((entry) => entry.id === entryId)) {
         setDraft(null);
         return;
@@ -610,6 +646,9 @@ function EditableFileSurface({
   const handlePostRender = useCallback<FilePostRender>(
     (fileContainer, instance, phase) => {
       onPostRender(fileContainer, instance, phase);
+      if (phase !== "unmount") {
+        editorAnnotationsRef.current = lineAnnotations;
+      }
 
       if (selectionFrameRef.current !== null) {
         cancelAnimationFrame(selectionFrameRef.current);
@@ -623,7 +662,7 @@ function EditableFileSurface({
         instance.setSelectedLines(selectedRange, { notify: false });
       });
     },
-    [onPostRender, selectedRange],
+    [lineAnnotations, onPostRender, selectedRange],
   );
 
   return (

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -502,24 +502,23 @@ function EditableFileSurface({
               for (const entry of annotation.metadata.entries) {
                 if (entry.kind !== "comment") continue;
                 const currentComment = currentComments.find((comment) => comment.id === entry.id);
+                if (!currentComment) continue;
+                const nextComment = buildFileReviewComment({
+                  id: entry.id,
+                  filePath: relativePath,
+                  startLine: entry.startLine,
+                  endLine: entry.endLine,
+                  text: entry.text,
+                  contents: file.contents,
+                });
                 if (
-                  !currentComment ||
-                  (currentComment.startIndex === entry.startLine - 1 &&
-                    currentComment.endIndex === entry.endLine - 1)
+                  currentComment.startIndex === nextComment.startIndex &&
+                  currentComment.endIndex === nextComment.endIndex &&
+                  currentComment.diff === nextComment.diff
                 ) {
                   continue;
                 }
-                addReviewComment(
-                  composerDraftTarget,
-                  buildFileReviewComment({
-                    id: entry.id,
-                    filePath: relativePath,
-                    startLine: entry.startLine,
-                    endLine: entry.endLine,
-                    text: entry.text,
-                    contents: file.contents,
-                  }),
-                );
+                addReviewComment(composerDraftTarget, nextComment);
               }
             }
           }

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -561,42 +561,47 @@ function EditableFileSurface({
     ],
   );
 
-  const beginComment = useCallback((range: SelectedLineRange) => {
-    const { startLine, endLine } = normalizeFileCommentRange(range);
-    const draftEntry: FileCommentAnnotationEntry = {
-      id: nextFileCommentId(),
-      kind: "draft",
-      startLine,
-      endLine,
-      text: "",
-    };
-    setLineAnnotations((current) => {
-      const withoutDraft = current.flatMap((annotation) => {
-        const entries = annotation.metadata.entries.filter((entry) => entry.kind !== "draft");
-        return entries.length > 0 ? [{ ...annotation, metadata: { entries } }] : [];
+  const beginComment = useCallback(
+    (range: SelectedLineRange) => {
+      editor.setSelections([]);
+      editor.blur();
+      const { startLine, endLine } = normalizeFileCommentRange(range);
+      const draftEntry: FileCommentAnnotationEntry = {
+        id: nextFileCommentId(),
+        kind: "draft",
+        startLine,
+        endLine,
+        text: "",
+      };
+      setLineAnnotations((current) => {
+        const withoutDraft = current.flatMap((annotation) => {
+          const entries = annotation.metadata.entries.filter((entry) => entry.kind !== "draft");
+          return entries.length > 0 ? [{ ...annotation, metadata: { entries } }] : [];
+        });
+        const existingIndex = withoutDraft.findIndex(
+          (annotation) => annotation.lineNumber === endLine,
+        );
+        if (existingIndex < 0) {
+          return [
+            ...withoutDraft,
+            {
+              lineNumber: endLine,
+              metadata: { entries: [draftEntry] },
+            },
+          ];
+        }
+        return withoutDraft.map((annotation, index) =>
+          index === existingIndex
+            ? {
+                ...annotation,
+                metadata: { entries: [...annotation.metadata.entries, draftEntry] },
+              }
+            : annotation,
+        );
       });
-      const existingIndex = withoutDraft.findIndex(
-        (annotation) => annotation.lineNumber === endLine,
-      );
-      if (existingIndex < 0) {
-        return [
-          ...withoutDraft,
-          {
-            lineNumber: endLine,
-            metadata: { entries: [draftEntry] },
-          },
-        ];
-      }
-      return withoutDraft.map((annotation, index) =>
-        index === existingIndex
-          ? {
-              ...annotation,
-              metadata: { entries: [...annotation.metadata.entries, draftEntry] },
-            }
-          : annotation,
-      );
-    });
-  }, []);
+    },
+    [editor],
+  );
   const hasOpenCommentForm = lineAnnotations.some((annotation) =>
     annotation.metadata.entries.some((entry) => entry.kind === "draft"),
   );

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -43,6 +43,7 @@ import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
 import FileBrowserPanel from "./FileBrowserPanel";
 import {
+  appendFileCommentEntry,
   buildFileCommentAnnotations,
   type FileCommentAnnotationEntry,
   type FileCommentAnnotationGroup,
@@ -451,7 +452,7 @@ function EditableFileSurface({
   const reviewComments = useComposerDraftStore(
     (store) => store.getComposerDraft(composerDraftTarget)?.reviewComments ?? EMPTY_REVIEW_COMMENTS,
   );
-  const [draft, setDraft] = useState<FileCommentLineAnnotation | null>(null);
+  const [draft, setDraft] = useState<FileCommentAnnotationEntry | null>(null);
   const [selectionOverride, setSelectionOverride] = useState<FileSelectionOverride | null>(null);
   const selectedRange =
     selectionOverride?.revealRequestId === revealRequestId ? selectionOverride.range : null;
@@ -465,7 +466,10 @@ function EditableFileSurface({
     () => buildFileCommentAnnotations(reviewComments, relativePath),
     [relativePath, reviewComments],
   );
-  const lineAnnotations = draft ? [...persistedAnnotations, draft] : persistedAnnotations;
+  const lineAnnotations = useMemo(
+    () => (draft ? appendFileCommentEntry(persistedAnnotations, draft) : persistedAnnotations),
+    [draft, persistedAnnotations],
+  );
 
   const surfaceRef = useRef<HTMLDivElement>(null);
   const editorAnnotationsRef = useRef<ReadonlyArray<FileCommentLineAnnotation>>([]);
@@ -492,11 +496,9 @@ function EditableFileSurface({
             setDraft((current) =>
               current === null
                 ? null
-                : (remapped.find((annotation) =>
-                    annotation.metadata.entries.some((entry) =>
-                      current.metadata.entries.some((draftEntry) => draftEntry.id === entry.id),
-                    ),
-                  ) ?? null),
+                : (remapped
+                    .flatMap((annotation) => annotation.metadata.entries)
+                    .find((entry) => entry.id === current.id && entry.kind === "draft") ?? null),
             );
             const currentComments =
               useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)
@@ -573,7 +575,7 @@ function EditableFileSurface({
     (entryId: string) => {
       setSelectedRange(null);
       restorableCommentIdsRef.current.delete(entryId);
-      if (draft?.metadata.entries.some((entry) => entry.id === entryId)) {
+      if (draft?.id === entryId) {
         setDraft(null);
         return;
       }
@@ -584,7 +586,7 @@ function EditableFileSurface({
 
   const submitAnnotationEntry = useCallback(
     (entryId: string, text: string) => {
-      const entry = draft?.metadata.entries.find((candidate) => candidate.id === entryId);
+      const entry = draft?.id === entryId ? draft : null;
       if (!entry) return;
       setSelectedRange(null);
       addReviewComment(
@@ -615,10 +617,7 @@ function EditableFileSurface({
         endLine,
         text: "",
       };
-      setDraft({
-        lineNumber: endLine,
-        metadata: { entries: [draftEntry] },
-      });
+      setDraft(draftEntry);
     },
     [editor],
   );

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -33,7 +33,7 @@ import { Toggle } from "~/components/ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
-import { buildFileReviewComment } from "~/reviewCommentContext";
+import { buildFileReviewComment, type ReviewCommentContext } from "~/reviewCommentContext";
 import { assetEnvironment } from "~/state/assets";
 import { useEnvironmentHttpBaseUrl, usePrimaryEnvironmentId } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
@@ -43,6 +43,7 @@ import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
 import FileBrowserPanel from "./FileBrowserPanel";
 import {
+  buildFileCommentAnnotations,
   type FileCommentAnnotationEntry,
   type FileCommentAnnotationGroup,
   type FileCommentLineAnnotation,
@@ -84,6 +85,7 @@ const FILE_EXPLORER_STORAGE_KEY = "t3code.fileExplorerOpen";
 const RENDER_MARKDOWN_STORAGE_KEY = "t3code.renderMarkdown";
 const FILE_SAVE_DEBOUNCE_MS = 500;
 const FILE_LINK_REVEAL_ATTRIBUTE = "data-file-link-reveal";
+const EMPTY_REVIEW_COMMENTS: ReadonlyArray<ReviewCommentContext> = [];
 const FILE_LINK_REVEAL_UNSAFE_CSS = `
   ${DIFF_SURFACE_THEME_UNSAFE_CSS}
 
@@ -445,7 +447,10 @@ function EditableFileSurface({
 }: EditableFileSurfaceProps) {
   const addReviewComment = useComposerDraftStore((store) => store.addReviewComment);
   const removeReviewComment = useComposerDraftStore((store) => store.removeReviewComment);
-  const [lineAnnotations, setLineAnnotations] = useState<FileCommentLineAnnotation[]>([]);
+  const reviewComments = useComposerDraftStore(
+    (store) => store.getComposerDraft(composerDraftTarget)?.reviewComments ?? EMPTY_REVIEW_COMMENTS,
+  );
+  const [draft, setDraft] = useState<FileCommentLineAnnotation | null>(null);
   const [selectionOverride, setSelectionOverride] = useState<FileSelectionOverride | null>(null);
   const selectedRange =
     selectionOverride?.revealRequestId === revealRequestId ? selectionOverride.range : null;
@@ -455,6 +460,12 @@ function EditableFileSurface({
     },
     [revealRequestId],
   );
+  const persistedAnnotations = useMemo(
+    () => buildFileCommentAnnotations(reviewComments, relativePath),
+    [relativePath, reviewComments],
+  );
+  const lineAnnotations = draft ? [...persistedAnnotations, draft] : persistedAnnotations;
+
   const surfaceRef = useRef<HTMLDivElement>(null);
   const selectionFrameRef = useRef<number | null>(null);
   const saveCoordinator = useFileSaveCoordinator({
@@ -475,10 +486,29 @@ function EditableFileSurface({
             const remapped = remapFileCommentAnnotations(
               nextLineAnnotations as FileCommentLineAnnotation[],
             );
-            setLineAnnotations(remapped);
+            setDraft((current) =>
+              current === null
+                ? null
+                : (remapped.find((annotation) =>
+                    annotation.metadata.entries.some((entry) =>
+                      current.metadata.entries.some((draftEntry) => draftEntry.id === entry.id),
+                    ),
+                  ) ?? null),
+            );
+            const currentComments =
+              useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)
+                ?.reviewComments ?? EMPTY_REVIEW_COMMENTS;
             for (const annotation of remapped) {
               for (const entry of annotation.metadata.entries) {
                 if (entry.kind !== "comment") continue;
+                const currentComment = currentComments.find((comment) => comment.id === entry.id);
+                if (
+                  !currentComment ||
+                  (currentComment.startIndex === entry.startLine - 1 &&
+                    currentComment.endIndex === entry.endLine - 1)
+                ) {
+                  continue;
+                }
                 addReviewComment(
                   composerDraftTarget,
                   buildFileReviewComment({
@@ -508,57 +538,34 @@ function EditableFileSurface({
   const removeAnnotationEntry = useCallback(
     (entryId: string) => {
       setSelectedRange(null);
+      if (draft?.metadata.entries.some((entry) => entry.id === entryId)) {
+        setDraft(null);
+        return;
+      }
       removeReviewComment(composerDraftTarget, entryId);
-      setLineAnnotations((current) => {
-        return current.flatMap((annotation) => {
-          const entries = annotation.metadata.entries.filter((entry) => entry.id !== entryId);
-          return entries.length > 0 ? [{ ...annotation, metadata: { entries } }] : [];
-        });
-      });
     },
-    [composerDraftTarget, removeReviewComment, setSelectedRange],
+    [composerDraftTarget, draft, removeReviewComment, setSelectedRange],
   );
 
   const submitAnnotationEntry = useCallback(
     (entryId: string, text: string) => {
+      const entry = draft?.metadata.entries.find((candidate) => candidate.id === entryId);
+      if (!entry) return;
       setSelectedRange(null);
-      const entry = lineAnnotations
-        .flatMap((annotation) => annotation.metadata.entries)
-        .find((candidate) => candidate.id === entryId);
-      if (entry) {
-        addReviewComment(
-          composerDraftTarget,
-          buildFileReviewComment({
-            id: entry.id,
-            filePath: relativePath,
-            startLine: entry.startLine,
-            endLine: entry.endLine,
-            text,
-            contents,
-          }),
-        );
-      }
-      setLineAnnotations((current) =>
-        current.map((annotation) => ({
-          ...annotation,
-          metadata: {
-            entries: annotation.metadata.entries.map((annotationEntry) =>
-              annotationEntry.id === entryId
-                ? { ...annotationEntry, kind: "comment", text }
-                : annotationEntry,
-            ),
-          },
-        })),
+      addReviewComment(
+        composerDraftTarget,
+        buildFileReviewComment({
+          id: entry.id,
+          filePath: relativePath,
+          startLine: entry.startLine,
+          endLine: entry.endLine,
+          text,
+          contents,
+        }),
       );
+      setDraft(null);
     },
-    [
-      addReviewComment,
-      composerDraftTarget,
-      contents,
-      lineAnnotations,
-      relativePath,
-      setSelectedRange,
-    ],
+    [addReviewComment, composerDraftTarget, contents, draft, relativePath, setSelectedRange],
   );
 
   const beginComment = useCallback(
@@ -573,38 +580,14 @@ function EditableFileSurface({
         endLine,
         text: "",
       };
-      setLineAnnotations((current) => {
-        const withoutDraft = current.flatMap((annotation) => {
-          const entries = annotation.metadata.entries.filter((entry) => entry.kind !== "draft");
-          return entries.length > 0 ? [{ ...annotation, metadata: { entries } }] : [];
-        });
-        const existingIndex = withoutDraft.findIndex(
-          (annotation) => annotation.lineNumber === endLine,
-        );
-        if (existingIndex < 0) {
-          return [
-            ...withoutDraft,
-            {
-              lineNumber: endLine,
-              metadata: { entries: [draftEntry] },
-            },
-          ];
-        }
-        return withoutDraft.map((annotation, index) =>
-          index === existingIndex
-            ? {
-                ...annotation,
-                metadata: { entries: [...annotation.metadata.entries, draftEntry] },
-              }
-            : annotation,
-        );
+      setDraft({
+        lineNumber: endLine,
+        metadata: { entries: [draftEntry] },
       });
     },
     [editor],
   );
-  const hasOpenCommentForm = lineAnnotations.some((annotation) =>
-    annotation.metadata.entries.some((entry) => entry.kind === "draft"),
-  );
+  const hasOpenCommentForm = draft !== null;
   useEffect(() => {
     const root = surfaceRef.current;
     if (!root) return;

--- a/apps/web/src/components/files/fileCommentAnnotations.ts
+++ b/apps/web/src/components/files/fileCommentAnnotations.ts
@@ -84,6 +84,33 @@ export function buildFileCommentAnnotations(
   }, []);
 }
 
+export function resolveFileCommentAnnotationChanges(
+  previousAnnotations: ReadonlyArray<FileCommentLineAnnotation>,
+  nextAnnotations: ReadonlyArray<FileCommentLineAnnotation>,
+): {
+  addedIds: ReadonlySet<string>;
+  removedIds: ReadonlySet<string>;
+} {
+  const previousIds = new Set(
+    previousAnnotations.flatMap((annotation) =>
+      annotation.metadata.entries
+        .filter((entry) => entry.kind === "comment")
+        .map((entry) => entry.id),
+    ),
+  );
+  const nextIds = new Set(
+    nextAnnotations.flatMap((annotation) =>
+      annotation.metadata.entries
+        .filter((entry) => entry.kind === "comment")
+        .map((entry) => entry.id),
+    ),
+  );
+  return {
+    addedIds: new Set([...nextIds].filter((id) => !previousIds.has(id))),
+    removedIds: new Set([...previousIds].filter((id) => !nextIds.has(id))),
+  };
+}
+
 export function remapFileCommentAnnotations(
   annotations: ReadonlyArray<FileCommentLineAnnotation>,
 ): FileCommentLineAnnotation[] {

--- a/apps/web/src/components/files/fileCommentAnnotations.ts
+++ b/apps/web/src/components/files/fileCommentAnnotations.ts
@@ -1,5 +1,7 @@
 import type { LineAnnotation, SelectedLineRange } from "@pierre/diffs";
 
+import type { ReviewCommentContext } from "~/reviewCommentContext";
+
 export interface FileCommentAnnotationEntry {
   id: string;
   kind: "draft" | "comment";
@@ -33,6 +35,53 @@ export function normalizeFileCommentRange(range: SelectedLineRange): {
 
 export function formatFileCommentRange(startLine: number, endLine: number): string {
   return startLine === endLine ? `L${startLine}` : `L${startLine} to L${endLine}`;
+}
+
+function appendFileCommentEntry(
+  annotations: ReadonlyArray<FileCommentLineAnnotation>,
+  entry: FileCommentAnnotationEntry,
+): FileCommentLineAnnotation[] {
+  const existingIndex = annotations.findIndex(
+    (annotation) => annotation.lineNumber === entry.endLine,
+  );
+  if (existingIndex < 0) {
+    return [
+      ...annotations,
+      {
+        lineNumber: entry.endLine,
+        metadata: { entries: [entry] },
+      },
+    ];
+  }
+  return annotations.map((annotation, index) =>
+    index === existingIndex
+      ? {
+          ...annotation,
+          metadata: { entries: [...annotation.metadata.entries, entry] },
+        }
+      : annotation,
+  );
+}
+
+export function buildFileCommentAnnotations(
+  reviewComments: ReadonlyArray<ReviewCommentContext>,
+  filePath: string,
+): FileCommentLineAnnotation[] {
+  const sectionId = `file:${filePath}`;
+  return reviewComments.reduce<FileCommentLineAnnotation[]>((annotations, comment) => {
+    if (comment.sectionId !== sectionId || comment.filePath !== filePath) {
+      return annotations;
+    }
+    const startLine = comment.startIndex + 1;
+    const endLine = comment.endIndex + 1;
+    return appendFileCommentEntry(annotations, {
+      id: comment.id,
+      kind: "comment",
+      startLine,
+      endLine,
+      text: comment.text,
+    });
+  }, []);
 }
 
 export function remapFileCommentAnnotations(

--- a/apps/web/src/components/files/fileCommentAnnotations.ts
+++ b/apps/web/src/components/files/fileCommentAnnotations.ts
@@ -37,7 +37,7 @@ export function formatFileCommentRange(startLine: number, endLine: number): stri
   return startLine === endLine ? `L${startLine}` : `L${startLine} to L${endLine}`;
 }
 
-function appendFileCommentEntry(
+export function appendFileCommentEntry(
   annotations: ReadonlyArray<FileCommentLineAnnotation>,
   entry: FileCommentAnnotationEntry,
 ): FileCommentLineAnnotation[] {


### PR DESCRIPTION
## What Changed

- Added focus on mount logic to DiffCommentAnnotation component.
- Fixed caret losing color on file comments 
- Make file comments persist on tab navigation same as diffs comments. 

## Why

- On files when making a comment because of the pierre editor component. The DiffCommentAnnotation component wasn't autofocusing with the TextArea prop only. The autofocus was working only on diffs and not on general files. 
- Caret on the annotation component was blending with background in the files comment aswell and was not visible.
- When commenting on a file and you switched tabs the comment would get lost when going back to that same file, it should behave the same as diffs comments should be stored in zustand state not locally only.

## UI Changes

Old Caret/Focus:


https://github.com/user-attachments/assets/0d38423c-bdf0-4f68-be4c-f26d71ac8ccc


Fixed Caret/Focus:


https://github.com/user-attachments/assets/c986004e-d710-413b-9d15-cc38380e4c6e

Old Comment file state:

https://github.com/user-attachments/assets/ad31405a-b0f0-482d-9c50-6b41b809716b

Fixed comment file state:


https://github.com/user-attachments/assets/e4862d18-9885-4512-8868-bf34f1c8aa0a





## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> File comment state now flows through the composer draft store and Pierre remap sync, so incorrect add/remove/restore logic could lose or duplicate review comments.
> 
> **Overview**
> Fixes inline file comments so the draft field focuses reliably in the Pierre editor, the caret stays visible, and submitted comments survive leaving and returning to a file tab—matching diff review behavior.
> 
> **`DiffCommentAnnotation`** adds optional `focusOnMount` (default on) and focuses the draft textarea in a layout effect via `requestAnimationFrame` with `preventScroll`, instead of relying on `autoFocus` alone. Draft styling now sets `caret-foreground` so the cursor is visible on file surfaces.
> 
> **`EditableFileSurface`** no longer keeps all annotations in local state. Persisted comments come from the composer draft store’s `reviewComments` (rebuilt with `buildFileCommentAnnotations`); only the in-progress draft stays local. Pierre remap events sync the store through `resolveFileCommentAnnotationChanges`, with a restorable-ID set so transient Pierre removals don’t drop comments incorrectly. Starting a comment blurs the editor and clears selections; submit/cancel flows write through the store.
> 
> New helpers and tests live in `fileCommentAnnotations.ts` and `FilePreviewPanel.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea19cf864a0920cfcab1f31d5f44c3d3f099d14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file inline comment focus and sync annotations to composer draft store
> - Refactors `EditableFileSurface` to source line comment annotations from persisted `reviewComments` in the composer draft store instead of local state; opening a comment creates a local draft, submitting persists a `ReviewComment`, and removing an annotation removes it from the store
> - Adds `buildFileCommentAnnotations`, `appendFileCommentEntry`, and `resolveFileCommentAnnotationChanges` utilities in [fileCommentAnnotations.ts](https://github.com/pingdotgg/t3code/pull/8662/files#diff-b732239b7c1e50afab522e53318889c3a7cb93907e404b0268b31bdda9fae0cf) to derive renderable annotations from store state and detect added/removed comment IDs across renders
> - Comments pruned from editor annotations are removed from the store and temporarily held in `restorableCommentIdsRef` for same-session restoration
> - `DiffCommentAnnotation` now only programmatically focuses the textarea for draft comments on the next animation frame with `preventScroll`, and focus can be disabled via the new `focusOnMount` prop
> - Risk: annotation persistence now depends on the composer draft store; any code reading the old local `lineAnnotations` state or expecting `autoFocus` on all comment kinds will need to use the new store-backed flow
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea19cf8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->