### PR TITLE
fix(web): keep environment pill inside narrow sidebar

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -94,8 +94,10 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
       <T3Wordmark />
       <span
         className={cn(
-          "-translate-y-px hidden truncate text-sm font-medium tracking-tight @[15rem]/sidebar-header:inline",
-          onBackdrop ? "text-white/70" : "text-muted-foreground",
+          "-translate-y-px truncate text-sm font-medium tracking-tight",
+          onBackdrop
+            ? "text-white/70"
+            : "hidden text-muted-foreground @[15rem]/sidebar-header:inline",
         )}
       >
         Code

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -64,7 +64,7 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
           backdropVariant && resolveSidebarStageFocusRingOffsetClass(backdropVariant),
         )}
       />
-      <div className="relative z-10 flex min-w-0 items-center gap-0.5 md:ml-[var(--workspace-titlebar-content-left)]">
+      <div className="relative z-10 flex min-w-0 items-center gap-1 md:ml-[var(--workspace-titlebar-content-left)]">
         <SidebarBrand onBackdrop={backdropVariant !== null} />
         {pillLabel ? (
           <Badge

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -51,7 +51,7 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
   return (
     <SidebarHeader
       className={cn(
-        "@container/sidebar-header relative h-[var(--workspace-topbar-height)] shrink-0 flex-row items-center px-3 py-0 md:px-0",
+        "@container/sidebar-header relative h-[var(--workspace-topbar-height)] shrink-0 flex-row items-center overflow-hidden px-3 py-0 md:px-0",
         isElectron && "drag-region",
       )}
     >
@@ -64,17 +64,19 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
           backdropVariant && resolveSidebarStageFocusRingOffsetClass(backdropVariant),
         )}
       />
-      <SidebarBrand onBackdrop={backdropVariant !== null} />
-      {pillLabel ? (
-        <Badge
-          className="relative z-10 ml-1 rounded-full px-1.5 text-muted-foreground"
-          data-environment-identification="pill"
-          size="sm"
-          variant="secondary"
-        >
-          {pillLabel}
-        </Badge>
-      ) : null}
+      <div className="relative z-10 flex min-w-0 items-center gap-0.5 md:ml-[var(--workspace-titlebar-content-left)]">
+        <SidebarBrand onBackdrop={backdropVariant !== null} />
+        {pillLabel ? (
+          <Badge
+            className="rounded-full px-1 text-muted-foreground"
+            data-environment-identification="pill"
+            size="sm"
+            variant="secondary"
+          >
+            {pillLabel}
+          </Badge>
+        ) : null}
+      </div>
     </SidebarHeader>
   );
 });
@@ -84,7 +86,7 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
     <Link
       aria-label="Go to threads"
       className={cn(
-        "relative z-10 ml-[var(--workspace-titlebar-content-left)] hidden h-7 w-fit min-w-0 shrink-0 items-center gap-1 overflow-hidden rounded-md outline-hidden ring-ring focus-visible:ring-2 md:flex",
+        "relative hidden h-7 w-fit min-w-0 shrink-0 items-center gap-1 overflow-hidden rounded-md outline-hidden ring-ring focus-visible:ring-2 md:flex",
         onBackdrop ? "text-white" : "text-foreground",
       )}
       to="/"
@@ -92,7 +94,7 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
       <T3Wordmark />
       <span
         className={cn(
-          "-translate-y-px truncate text-sm font-medium tracking-tight",
+          "-translate-y-px hidden truncate text-sm font-medium tracking-tight @[15rem]/sidebar-header:inline",
           onBackdrop ? "text-white/70" : "text-muted-foreground",
         )}
       >

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -64,11 +64,11 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
           backdropVariant && resolveSidebarStageFocusRingOffsetClass(backdropVariant),
         )}
       />
-      <div className="relative z-10 flex min-w-0 flex-1 items-center gap-1 overflow-hidden md:mr-3 md:ml-[var(--workspace-titlebar-content-left)]">
+      <div className="relative z-10 flex min-w-0 flex-1 items-center gap-1 md:mr-3 md:ml-[var(--workspace-titlebar-content-left)]">
         <SidebarBrand onBackdrop={backdropVariant !== null} />
         {pillLabel ? (
           <Badge
-            className="ml-auto shrink-0 rounded-full px-1 text-muted-foreground"
+            className="ml-1 shrink-0 rounded-full px-1 text-muted-foreground md:ml-auto"
             data-environment-identification="pill"
             size="sm"
             variant="secondary"
@@ -86,7 +86,7 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
     <Link
       aria-label="Go to threads"
       className={cn(
-        "relative hidden h-7 w-fit min-w-0 shrink-0 items-center gap-1 overflow-hidden rounded-md outline-hidden ring-ring focus-visible:ring-2 md:flex",
+        "relative hidden h-7 w-fit min-w-0 items-center gap-1 overflow-hidden rounded-md outline-hidden ring-ring focus-visible:ring-2 md:flex",
         onBackdrop ? "text-white" : "text-foreground",
       )}
       to="/"

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -51,7 +51,7 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
   return (
     <SidebarHeader
       className={cn(
-        "@container/sidebar-header relative h-[var(--workspace-topbar-height)] shrink-0 flex-row items-center overflow-hidden px-3 py-0 md:px-0",
+        "@container/sidebar-header relative h-[var(--workspace-topbar-height)] shrink-0 flex-row items-center px-3 py-0 md:px-0",
         isElectron && "drag-region",
       )}
     >
@@ -64,11 +64,11 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
           backdropVariant && resolveSidebarStageFocusRingOffsetClass(backdropVariant),
         )}
       />
-      <div className="relative z-10 flex min-w-0 items-center gap-1 md:ml-[var(--workspace-titlebar-content-left)]">
+      <div className="relative z-10 flex min-w-0 flex-1 items-center gap-1 overflow-hidden md:mr-3 md:ml-[var(--workspace-titlebar-content-left)]">
         <SidebarBrand onBackdrop={backdropVariant !== null} />
         {pillLabel ? (
           <Badge
-            className="rounded-full px-1 text-muted-foreground"
+            className="ml-auto shrink-0 rounded-full px-1 text-muted-foreground"
             data-environment-identification="pill"
             size="sm"
             variant="secondary"


### PR DESCRIPTION
## What Changed

- Keep the T3 wordmark and environment pill inside a shared titlebar-safe container.
- Hide only the “Code” label when the sidebar is too narrow.
- Tighten the spacing around the pill and prevent header content from crossing the sidebar boundary.

## Why

When Environment identification is set to Version pill, resizing the sidebar to its minimum width can push the Dev or Nightly pill into the main page header.

The Nightly label makes the problem especially visible because it is wider. The header should preserve the T3 wordmark and environment pill at every supported sidebar width.

Fixes #8660

## UI Changes

### Before

https://github.com/user-attachments/assets/edebf1cd-43e5-418e-9454-4317220d9782

### After



https://github.com/user-attachments/assets/0f0f8ddc-4efe-45a4-aeeb-7e9090e8a2b3






## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Built with GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only sidebar header layout and responsive label visibility; no auth, data, or API changes.
> 
> **Overview**
> Fixes environment identification pills (e.g. Dev/Nightly) overflowing into the main header when the sidebar is at minimum width.
> 
> **Sidebar header layout** wraps the T3 brand link and environment pill in a single flex row with `min-w-0 flex-1`, moves the desktop titlebar left inset to that wrapper, and keeps the pill `shrink-0` with slightly tighter padding and `md:ml-auto` so both stay within the sidebar.
> 
> **Brand label behavior** drops the per-link titlebar margin and hides the “Code” text by default on non-backdrop headers, showing it only when the header container is at least **15rem** wide (`@[15rem]/sidebar-header`), while the wordmark and pill remain visible at all supported widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b2d397341acd3709a9b67032c8ef2e02907c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix environment pill overflow in narrow sidebar header
> - Wraps `SidebarBrand` and the environment pill `Badge` in a new flex container with `min-w-0` so the pill stays inside the sidebar on narrow widths instead of overflowing
> - Right-aligns the pill at md+ breakpoints (`md:ml-auto`) and trims its horizontal padding (`px-1.5` → `px-1`)
> - Hides the brand label text below a 15rem container-query breakpoint (`@[15rem]/sidebar-header:inline`), except on backdrop where it stays visible
> - Moves `z-10`, `shrink-0`, and left-margin spacing off the individual children onto the wrapper div
> - Behavioral Change: brand label is now invisible on sidebars narrower than 15rem (was always visible); reviewers should confirm the collapsed/collapsed-icon sidebar still reads correctly at that width
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24b2d39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->