### PR TITLE
feat(web): reorder active sidebar threads

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -19,6 +19,7 @@ import {
   isSidebarNestedLinkClick,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  resolveActiveThreadOrder,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -574,6 +575,42 @@ describe("orderItemsByPreferredIds", () => {
       "physical-a",
       "physical-b",
     ]);
+  });
+});
+
+describe("resolveActiveThreadOrder", () => {
+  it("keeps saved order while thread anchors match", () => {
+    expect(
+      resolveActiveThreadOrder({
+        threads: [
+          { id: "thread-newer", orderAnchor: "2026-08-29T12:00:00.000Z" },
+          { id: "thread-older", orderAnchor: "2026-08-29T10:00:00.000Z" },
+        ],
+        savedOrder: ["thread-older", "thread-newer"],
+        savedOrderAnchorById: {
+          "thread-newer": "2026-08-29T12:00:00.000Z",
+          "thread-older": "2026-08-29T10:00:00.000Z",
+        },
+      }),
+    ).toEqual(["thread-older", "thread-newer"]);
+  });
+
+  it("puts reactivated and new threads above the saved order", () => {
+    expect(
+      resolveActiveThreadOrder({
+        threads: [
+          { id: "thread-reactivated", orderAnchor: "2026-08-29T13:00:00.000Z" },
+          { id: "thread-new", orderAnchor: "2026-08-29T12:00:00.000Z" },
+          { id: "thread-saved", orderAnchor: "2026-08-29T10:00:00.000Z" },
+        ],
+        savedOrder: ["thread-saved", "thread-reactivated", "thread-hidden"],
+        savedOrderAnchorById: {
+          "thread-reactivated": "2026-08-29T09:00:00.000Z",
+          "thread-saved": "2026-08-29T10:00:00.000Z",
+          "thread-hidden": "2026-08-29T11:00:00.000Z",
+        },
+      }),
+    ).toEqual(["thread-reactivated", "thread-new", "thread-saved"]);
   });
 });
 
@@ -1507,6 +1544,36 @@ describe("getFallbackThreadIdAfterDelete", () => {
     });
 
     expect(fallbackThreadId).toBe(ThreadId.make("thread-next"));
+  });
+
+  it("uses the active sidebar order when one is provided", () => {
+    const fallbackThreadId = getFallbackThreadIdAfterDelete({
+      threads: [
+        makeThread({
+          id: ThreadId.make("thread-active"),
+          projectId: ProjectId.make("project-1"),
+          createdAt: "2026-03-09T10:05:00.000Z",
+          messages: [],
+        }),
+        makeThread({
+          id: ThreadId.make("thread-newest"),
+          projectId: ProjectId.make("project-1"),
+          createdAt: "2026-03-09T10:10:00.000Z",
+          messages: [],
+        }),
+        makeThread({
+          id: ThreadId.make("thread-preferred"),
+          projectId: ProjectId.make("project-1"),
+          createdAt: "2026-03-09T10:00:00.000Z",
+          messages: [],
+        }),
+      ],
+      deletedThreadId: ThreadId.make("thread-active"),
+      preferredThreadIds: [ThreadId.make("thread-preferred"), ThreadId.make("thread-newest")],
+      sortOrder: "created_at",
+    });
+
+    expect(fallbackThreadId).toBe(ThreadId.make("thread-preferred"));
   });
 });
 describe("sortProjectsForSidebar", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -350,6 +350,24 @@ export function orderItemsByPreferredIds<TItem, TId>(input: {
   return [...ordered, ...remaining];
 }
 
+export function resolveActiveThreadOrder(input: {
+  threads: readonly { id: string; orderAnchor: string }[];
+  savedOrder: readonly string[];
+  savedOrderAnchorById: Readonly<Record<string, string>>;
+}): string[] {
+  const currentAnchorById = new Map(
+    input.threads.map((thread) => [thread.id, thread.orderAnchor] as const),
+  );
+  const savedOrder = input.savedOrder.filter(
+    (threadId) => currentAnchorById.get(threadId) === input.savedOrderAnchorById[threadId],
+  );
+  const savedIds = new Set(savedOrder);
+  const newOrReactivatedIds = input.threads
+    .map((thread) => thread.id)
+    .filter((threadId) => !savedIds.has(threadId));
+  return [...newOrReactivatedIds, ...savedOrder];
+}
+
 export function getVisibleSidebarThreadIds<TThreadId>(
   renderedProjects: readonly {
     shouldShowThreadPanel?: boolean;
@@ -852,23 +870,29 @@ export function getFallbackThreadIdAfterDelete<
   deletedThreadId: T["id"];
   sortOrder: SidebarThreadSortOrder;
   deletedThreadIds?: ReadonlySet<T["id"]>;
+  preferredThreadIds?: readonly T["id"][];
 }): T["id"] | null {
-  const { deletedThreadId, deletedThreadIds, sortOrder, threads } = input;
+  const { deletedThreadId, deletedThreadIds, preferredThreadIds, sortOrder, threads } = input;
   const deletedThread = threads.find((thread) => thread.id === deletedThreadId);
   if (!deletedThread) {
     return null;
   }
 
+  const sortedThreads = sortThreads(
+    threads.filter(
+      (thread) =>
+        thread.projectId === deletedThread.projectId &&
+        thread.id !== deletedThreadId &&
+        !deletedThreadIds?.has(thread.id),
+    ),
+    sortOrder,
+  );
   return (
-    sortThreads(
-      threads.filter(
-        (thread) =>
-          thread.projectId === deletedThread.projectId &&
-          thread.id !== deletedThreadId &&
-          !deletedThreadIds?.has(thread.id),
-      ),
-      sortOrder,
-    )[0]?.id ?? null
+    orderItemsByPreferredIds({
+      items: sortedThreads,
+      preferredIds: preferredThreadIds ?? [],
+      getId: (thread) => thread.id,
+    })[0]?.id ?? null
   );
 }
 export function getProjectSortTimestamp(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -124,7 +124,7 @@ import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
-  animatePinnedLayoutChanges,
+  animatePinnedLayoutChanges as animateThreadLayoutChanges,
   buildBulkTitleRegenerationContextMenuItem,
   filterSidebarProjectScopeItems,
   formatWorkingDurationLabel,
@@ -450,23 +450,23 @@ function SnoozePopoverButton(props: {
   );
 }
 
-// Subset of useSortable applied to a pinned card's root <li>. Listeners go
-// on the whole card (no dedicated handle): the pointer sensor's distance
+// Subset of useSortable applied to a thread row's root <li>. Listeners go
+// on the whole row (no dedicated handle): the pointer sensor's distance
 // constraint keeps plain clicks working, and we skip dnd-kit's aria
 // attributes since there is no keyboard sensor and the card body already
 // carries its own button semantics.
-type SortablePinnedRowBag = Pick<
+type SortableThreadRowBag = Pick<
   ReturnType<typeof useSortable>,
   "listeners" | "setNodeRef" | "transform" | "transition" | "isDragging"
 >;
 
-function SortablePinnedThreadRow(props: {
+function SortableThreadRow(props: {
   id: string;
-  children: (bag: SortablePinnedRowBag) => ReactNode;
+  children: (bag: SortableThreadRowBag) => ReactNode;
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: props.id,
-    animateLayoutChanges: animatePinnedLayoutChanges,
+    animateLayoutChanges: animateThreadLayoutChanges,
   });
   return props.children({ listeners, setNodeRef, transform, transition, isDragging });
 }
@@ -722,10 +722,10 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // rows. The marker can unpin the thread when the server supports pinning.
   pinningSupported: boolean;
   isPinned: boolean;
-  // Present only on pinned cards whose server supports reordering: dnd-kit
-  // sortable bag applied to the card root so the whole card drags (the
-  // pointer sensor's distance constraint keeps plain clicks working).
-  sortable?: SortablePinnedRowBag | undefined;
+  // Present only on rows that can be reordered: dnd-kit applies the sortable
+  // bag to the card root so the whole card drags (the pointer sensor's
+  // distance constraint keeps plain clicks working).
+  sortable?: SortableThreadRowBag | undefined;
   // Compact wake countdown ("2h") for rows in the snoozed shelf.
   snoozeWakeLabelText: string | null;
   // When a snooze ended (timer or early wake); drives the Woke pill until
@@ -1736,6 +1736,8 @@ const SidebarSearchResultRow = memo(function SidebarSearchResultRow(props: {
 export default function Sidebar() {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const threadOrder = useUiStateStore((store) => store.threadOrder);
+  const reorderThreads = useUiStateStore((store) => store.reorderThreads);
   const threads = useThreadShells();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -2076,7 +2078,7 @@ export default function Sidebar() {
   const {
     pinnedThreads,
     reorderablePinnedKeys,
-    activeThreads,
+    activeThreads: defaultActiveThreads,
     snoozedThreads,
     settledThreads,
     snoozeNow,
@@ -2173,6 +2175,30 @@ export default function Sidebar() {
     snoozeWakeTick,
     threads,
   ]);
+
+  const activeThreadKeys = useMemo(
+    () =>
+      defaultActiveThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+    [defaultActiveThreads],
+  );
+  const currentActiveThreadOrder = useMemo(() => {
+    const activeKeys = new Set(activeThreadKeys);
+    const savedOrder = threadOrder.filter((threadKey) => activeKeys.has(threadKey));
+    const savedKeys = new Set(savedOrder);
+    const newThreadKeys = activeThreadKeys.filter((threadKey) => !savedKeys.has(threadKey));
+    return [...newThreadKeys, ...savedOrder];
+  }, [activeThreadKeys, threadOrder]);
+  const activeThreads = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: defaultActiveThreads,
+        preferredIds: currentActiveThreadOrder,
+        getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      }),
+    [currentActiveThreadOrder, defaultActiveThreads],
+  );
 
   const threadSearchInputRef = useRef<HTMLInputElement>(null);
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
@@ -2630,7 +2656,7 @@ export default function Sidebar() {
   // win) and ANY membership change (new pin, unpin, snooze/wake) also
   // release it: the override can't say where members it never saw belong,
   // and holding it would launder a stale order into later drags.
-  const pinnedDndSensors = useSensors(
+  const threadDndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
   const [optimisticPinnedOrder, setOptimisticPinnedOrder] = useState<{
@@ -2794,6 +2820,15 @@ export default function Sidebar() {
       })();
     },
     [orderedPinnedThreads, reorderPinnedThread, reorderablePinnedKeys],
+  );
+  const handleActiveThreadDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const activeKey = String(event.active.id);
+      const overKey = event.over === null ? null : String(event.over.id);
+      if (overKey === null || activeKey === overKey) return;
+      reorderThreads(currentActiveThreadOrder, activeKey, overKey);
+    },
+    [currentActiveThreadOrder, reorderThreads],
   );
   // One snooze per thread at a time — same double-dispatch guard as settle.
   const snoozingThreadKeysRef = useRef(new Set<string>());
@@ -3755,7 +3790,7 @@ export default function Sidebar() {
                   const renderThreadRow = (
                     thread: EnvironmentThreadShell,
                     section: "pinned" | "active" | "snoozed" | "settled",
-                    sortable?: SortablePinnedRowBag,
+                    sortable?: SortableThreadRowBag,
                   ) => {
                     const threadKey = scopedThreadKey(
                       scopeThreadRef(thread.environmentId, thread.id),
@@ -3879,7 +3914,7 @@ export default function Sidebar() {
                     pinnedThreads.length > 0 ? (
                       <li key="pinned-dnd" className="list-none">
                         <DndContext
-                          sensors={pinnedDndSensors}
+                          sensors={threadDndSensors}
                           collisionDetection={closestCenter}
                           modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
                           onDragEnd={handlePinnedDragEnd}
@@ -3905,9 +3940,9 @@ export default function Sidebar() {
                                   return renderThreadRow(thread, "pinned");
                                 }
                                 return (
-                                  <SortablePinnedThreadRow key={threadKey} id={threadKey}>
+                                  <SortableThreadRow key={threadKey} id={threadKey}>
                                     {(bag) => renderThreadRow(thread, "pinned", bag)}
-                                  </SortablePinnedThreadRow>
+                                  </SortableThreadRow>
                                 );
                               })}
                             </ul>
@@ -3926,8 +3961,39 @@ export default function Sidebar() {
                       />,
                     );
                   }
-                  for (const thread of activeThreads) {
-                    items.push(renderThreadRow(thread, "active"));
+                  if (activeThreads.length > 0) {
+                    items.push(
+                      <li key="active-dnd" className="list-none">
+                        <DndContext
+                          sensors={threadDndSensors}
+                          collisionDetection={closestCenter}
+                          modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                          onDragEnd={handleActiveThreadDragEnd}
+                        >
+                          <SortableContext
+                            items={currentActiveThreadOrder}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            <ul
+                              role="list"
+                              aria-label="Active threads"
+                              className="flex flex-col gap-px"
+                            >
+                              {activeThreads.map((thread) => {
+                                const threadKey = scopedThreadKey(
+                                  scopeThreadRef(thread.environmentId, thread.id),
+                                );
+                                return (
+                                  <SortableThreadRow key={threadKey} id={threadKey}>
+                                    {(bag) => renderThreadRow(thread, "active", bag)}
+                                  </SortableThreadRow>
+                                );
+                              })}
+                            </ul>
+                          </SortableContext>
+                        </DndContext>
+                      </li>,
+                    );
                   }
                   // Snoozed shelf: between the inbox and Settled — out of the
                   // way, never gone. The header always renders while anything

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { autoAnimate } from "@formkit/auto-animate";
+import { autoAnimate, type AnimationController } from "@formkit/auto-animate";
 import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
@@ -2683,6 +2683,31 @@ export default function Sidebar() {
   const threadDndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
+  const activeThreadListAnimationControllerRef = useRef<AnimationController | null>(null);
+  const activeThreadListAnimationFrameRef = useRef<number | null>(null);
+  const pauseActiveThreadListAnimation = useCallback(() => {
+    const frameId = activeThreadListAnimationFrameRef.current;
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      activeThreadListAnimationFrameRef.current = null;
+    }
+    activeThreadListAnimationControllerRef.current?.disable();
+  }, []);
+  const resumeActiveThreadListAnimationAfterDrop = useCallback(() => {
+    const frameId = activeThreadListAnimationFrameRef.current;
+    if (frameId !== null) cancelAnimationFrame(frameId);
+    activeThreadListAnimationFrameRef.current = requestAnimationFrame(() => {
+      activeThreadListAnimationControllerRef.current?.enable();
+      activeThreadListAnimationFrameRef.current = null;
+    });
+  }, []);
+  useEffect(
+    () => () => {
+      const frameId = activeThreadListAnimationFrameRef.current;
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    },
+    [],
+  );
   const [optimisticPinnedOrder, setOptimisticPinnedOrder] = useState<{
     readonly order: readonly string[];
     /** pinOrderKey per thread as of the drop — the baseline that tells a
@@ -2847,12 +2872,23 @@ export default function Sidebar() {
   );
   const handleActiveThreadDragEnd = useCallback(
     (event: DragEndEvent) => {
-      const activeKey = String(event.active.id);
-      const overKey = event.over === null ? null : String(event.over.id);
-      if (overKey === null || activeKey === overKey) return;
-      reorderThreads(currentActiveThreadOrder, activeThreadOrderAnchorById, activeKey, overKey);
+      try {
+        const activeKey = String(event.active.id);
+        const overKey = event.over === null ? null : String(event.over.id);
+        if (overKey === null || activeKey === overKey) return;
+        reorderThreads(currentActiveThreadOrder, activeThreadOrderAnchorById, activeKey, overKey);
+      } finally {
+        // Keep auto-animate disabled through the committed reorder. dnd-kit
+        // already animates the drag; replaying the move would make it jump.
+        resumeActiveThreadListAnimationAfterDrop();
+      }
     },
-    [activeThreadOrderAnchorById, currentActiveThreadOrder, reorderThreads],
+    [
+      activeThreadOrderAnchorById,
+      currentActiveThreadOrder,
+      reorderThreads,
+      resumeActiveThreadListAnimationAfterDrop,
+    ],
   );
   // One snooze per thread at a time — same double-dispatch guard as settle.
   const snoozingThreadKeysRef = useRef(new Set<string>());
@@ -3469,6 +3505,17 @@ export default function Sidebar() {
     if (!node) return;
     autoAnimate(node, { duration: 150, easing: "ease-out" });
   }, []);
+  const attachActiveThreadListAutoAnimateRef = useCallback((node: HTMLUListElement | null) => {
+    if (node === null) {
+      activeThreadListAnimationControllerRef.current = null;
+      return;
+    }
+    if (activeThreadListAnimationControllerRef.current?.parent === node) return;
+    activeThreadListAnimationControllerRef.current = autoAnimate(node, {
+      duration: 150,
+      easing: "ease-out",
+    });
+  }, []);
 
   // New thread defaults to the project you're in (active thread's project,
   // falling back to the top project) — same resolution the command palette
@@ -3995,6 +4042,8 @@ export default function Sidebar() {
                           sensors={threadDndSensors}
                           collisionDetection={closestCenter}
                           modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+                          onDragStart={pauseActiveThreadListAnimation}
+                          onDragCancel={resumeActiveThreadListAnimationAfterDrop}
                           onDragEnd={handleActiveThreadDragEnd}
                         >
                           <SortableContext
@@ -4002,6 +4051,7 @@ export default function Sidebar() {
                             strategy={verticalListSortingStrategy}
                           >
                             <ul
+                              ref={attachActiveThreadListAutoAnimateRef}
                               role="list"
                               aria-label="Active threads"
                               className="flex flex-col gap-px"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -135,6 +135,7 @@ import {
   orderItemsByPreferredIds,
   planPinnedReorder,
   reduceSidebarProjectScopeMenuState,
+  resolveActiveThreadOrder,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
@@ -468,7 +469,11 @@ function SortableThreadRow(props: {
     id: props.id,
     animateLayoutChanges: animateThreadLayoutChanges,
   });
-  return props.children({ listeners, setNodeRef, transform, transition, isDragging });
+  const bag = useMemo(
+    () => ({ listeners, setNodeRef, transform, transition, isDragging }),
+    [isDragging, listeners, setNodeRef, transform, transition],
+  );
+  return props.children(bag);
 }
 
 // One unsent draft session the user has invested content in. Two lines,
@@ -1146,6 +1151,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       onFocus={(event) => event.currentTarget.select()}
       onKeyDown={handleRenameKeyDown}
       onBlur={handleRenameBlur}
+      onPointerDown={(event) => event.stopPropagation()}
       onClick={(event) => event.stopPropagation()}
       onDoubleClick={(event) => event.stopPropagation()}
       className="min-w-0 flex-1 rounded-sm border border-input bg-card px-1 text-sm font-medium text-card-foreground outline-none focus:border-foreground"
@@ -1737,6 +1743,7 @@ export default function Sidebar() {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threadOrder = useUiStateStore((store) => store.threadOrder);
+  const threadOrderAnchorById = useUiStateStore((store) => store.threadOrderAnchorById);
   const reorderThreads = useUiStateStore((store) => store.reorderThreads);
   const threads = useThreadShells();
   const router = useRouter();
@@ -2183,13 +2190,30 @@ export default function Sidebar() {
       ),
     [defaultActiveThreads],
   );
-  const currentActiveThreadOrder = useMemo(() => {
-    const activeKeys = new Set(activeThreadKeys);
-    const savedOrder = threadOrder.filter((threadKey) => activeKeys.has(threadKey));
-    const savedKeys = new Set(savedOrder);
-    const newThreadKeys = activeThreadKeys.filter((threadKey) => !savedKeys.has(threadKey));
-    return [...newThreadKeys, ...savedOrder];
-  }, [activeThreadKeys, threadOrder]);
+  const activeThreadOrderAnchorById = useMemo(
+    () =>
+      Object.fromEntries(
+        defaultActiveThreads.map((thread) => [
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          thread.unsettledAt ?? thread.createdAt,
+        ]),
+      ),
+    [defaultActiveThreads],
+  );
+  const currentActiveThreadOrder = useMemo(
+    () =>
+      resolveActiveThreadOrder({
+        threads: activeThreadKeys.map((threadId) => ({
+          id: threadId,
+          orderAnchor: activeThreadOrderAnchorById[threadId]!,
+        })),
+        savedOrder: threadOrder,
+        savedOrderAnchorById: threadOrderAnchorById,
+      }),
+    [activeThreadKeys, activeThreadOrderAnchorById, threadOrder, threadOrderAnchorById],
+  );
+  const currentActiveThreadOrderRef = useRef(currentActiveThreadOrder);
+  currentActiveThreadOrderRef.current = currentActiveThreadOrder;
   const activeThreads = useMemo(
     () =>
       orderItemsByPreferredIds({
@@ -2826,9 +2850,9 @@ export default function Sidebar() {
       const activeKey = String(event.active.id);
       const overKey = event.over === null ? null : String(event.over.id);
       if (overKey === null || activeKey === overKey) return;
-      reorderThreads(currentActiveThreadOrder, activeKey, overKey);
+      reorderThreads(currentActiveThreadOrder, activeThreadOrderAnchorById, activeKey, overKey);
     },
-    [currentActiveThreadOrder, reorderThreads],
+    [activeThreadOrderAnchorById, currentActiveThreadOrder, reorderThreads],
   );
   // One snooze per thread at a time — same double-dispatch guard as settle.
   const snoozingThreadKeysRef = useRef(new Set<string>());
@@ -3095,6 +3119,7 @@ export default function Sidebar() {
         if (!thread) continue;
         const result = await deleteThread(scopeThreadRef(thread.environmentId, thread.id), {
           deletedThreadKeys,
+          preferredThreadKeys: currentActiveThreadOrderRef.current,
         });
         if (result._tag === "Failure") {
           if (!isAtomCommandInterrupted(result)) {
@@ -3321,7 +3346,9 @@ export default function Sidebar() {
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
-            const result = await deleteThread(threadRef);
+            const result = await deleteThread(threadRef, {
+              preferredThreadKeys: currentActiveThreadOrderRef.current,
+            });
             if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
               const error = squashAtomCommandFailure(result);
               toastManager.add(

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -292,7 +292,13 @@ export function useThreadActions() {
   );
 
   const deleteThread = useCallback(
-    async (target: ScopedThreadRef, opts: { deletedThreadKeys?: ReadonlySet<string> } = {}) => {
+    async (
+      target: ScopedThreadRef,
+      opts: {
+        deletedThreadKeys?: ReadonlySet<string>;
+        preferredThreadKeys?: readonly string[];
+      } = {},
+    ) => {
       const resolved = resolveThreadTarget(target);
       if (!resolved) {
         // Thread not in main store (e.g. archived thread) — dispatch delete directly.
@@ -323,6 +329,10 @@ export function useThreadActions() {
               }),
             )
           : undefined;
+      const preferredThreadIds = opts.preferredThreadKeys?.flatMap((threadKey) => {
+        const ref = parseScopedThreadKey(threadKey);
+        return ref && ref.environmentId === threadRef.environmentId ? [ref.threadId] : [];
+      });
       const survivingThreads =
         deletedIds && deletedIds.size > 0
           ? threads.filter((entry) => entry.id === threadRef.threadId || !deletedIds.has(entry.id))
@@ -376,6 +386,7 @@ export function useThreadActions() {
         threads,
         deletedThreadId: threadRef.threadId,
         deletedThreadIds,
+        ...(preferredThreadIds ? { preferredThreadIds } : {}),
         sortOrder: sidebarThreadSortOrder,
       });
       const deleteResult = await deleteThreadMutation({

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -23,6 +23,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectExpandedById: {},
     projectOrder: [],
     threadOrder: [],
+    threadOrderAnchorById: {},
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
@@ -124,12 +125,24 @@ describe("uiStateStore pure functions", () => {
     const next = reorderThreads(
       state,
       ["thread-1", "thread-2", "thread-3"],
+      {
+        "thread-1": "2026-08-29T10:00:00.000Z",
+        "thread-2": "2026-08-29T11:00:00.000Z",
+        "thread-3": "2026-08-29T12:00:00.000Z",
+      },
       "thread-3",
       "thread-1",
     );
 
     expect(next.threadOrder).toEqual(["thread-3", "thread-1", "thread-2"]);
-    expect(reorderThreads(next, next.threadOrder, "thread-1", "thread-1")).toBe(next);
+    expect(next.threadOrderAnchorById).toEqual({
+      "thread-1": "2026-08-29T10:00:00.000Z",
+      "thread-2": "2026-08-29T11:00:00.000Z",
+      "thread-3": "2026-08-29T12:00:00.000Z",
+    });
+    expect(
+      reorderThreads(next, next.threadOrder, next.threadOrderAnchorById, "thread-1", "thread-1"),
+    ).toBe(next);
   });
 
   it("preserves hidden thread positions when reordering a filtered list", () => {
@@ -138,8 +151,17 @@ describe("uiStateStore pure functions", () => {
     });
 
     expect(
-      reorderThreads(state, ["visible-a", "visible-b", "visible-new"], "visible-new", "visible-a")
-        .threadOrder,
+      reorderThreads(
+        state,
+        ["visible-a", "visible-b", "visible-new"],
+        {
+          "visible-a": "2026-08-29T10:00:00.000Z",
+          "visible-b": "2026-08-29T11:00:00.000Z",
+          "visible-new": "2026-08-29T12:00:00.000Z",
+        },
+        "visible-new",
+        "visible-a",
+      ).threadOrder,
     ).toEqual(["hidden-a", "visible-new", "hidden-b", "visible-a", "inactive-a", "visible-b"]);
   });
 
@@ -182,6 +204,10 @@ describe("parsePersistedState", () => {
       },
       projectOrder: ["physical-b", "", "physical-a", "physical-b"],
       threadOrder: ["environment:thread-2", "", "environment:thread-1"],
+      threadOrderAnchorById: {
+        "environment:thread-1": "2026-08-29T10:00:00.000Z",
+        invalid: "not-a-date",
+      },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
@@ -202,6 +228,9 @@ describe("parsePersistedState", () => {
       },
       projectOrder: ["physical-b", "physical-a"],
       threadOrder: ["environment:thread-2", "environment:thread-1"],
+      threadOrderAnchorById: {
+        "environment:thread-1": "2026-08-29T10:00:00.000Z",
+      },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -300,6 +329,9 @@ describe("uiStateStore persistence", () => {
       },
       projectOrder: ["physical-b", "physical-a"],
       threadOrder: ["environment:thread-2", "environment:thread-1"],
+      threadOrderAnchorById: {
+        "environment:thread-1": "2026-08-29T10:00:00.000Z",
+      },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -323,6 +355,9 @@ describe("uiStateStore persistence", () => {
       },
       projectOrder: ["physical-b", "physical-a"],
       threadOrder: ["environment:thread-2", "environment:thread-1"],
+      threadOrderAnchorById: {
+        "environment:thread-1": "2026-08-29T10:00:00.000Z",
+      },
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -10,6 +10,7 @@ import {
   type PersistedUiState,
   persistState,
   reorderProjects,
+  reorderThreads,
   resolveProjectExpanded,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
@@ -21,6 +22,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
   return {
     projectExpandedById: {},
     projectOrder: [],
+    threadOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
@@ -116,6 +118,31 @@ describe("uiStateStore pure functions", () => {
     );
   });
 
+  it("reorders active threads from the current sidebar order", () => {
+    const state = makeUiState({ threadOrder: ["thread-1", "thread-2"] });
+
+    const next = reorderThreads(
+      state,
+      ["thread-1", "thread-2", "thread-3"],
+      "thread-3",
+      "thread-1",
+    );
+
+    expect(next.threadOrder).toEqual(["thread-3", "thread-1", "thread-2"]);
+    expect(reorderThreads(next, next.threadOrder, "thread-1", "thread-1")).toBe(next);
+  });
+
+  it("preserves hidden thread positions when reordering a filtered list", () => {
+    const state = makeUiState({
+      threadOrder: ["hidden-a", "visible-a", "hidden-b", "visible-b", "inactive-a"],
+    });
+
+    expect(
+      reorderThreads(state, ["visible-a", "visible-b", "visible-new"], "visible-new", "visible-a")
+        .threadOrder,
+    ).toEqual(["hidden-a", "visible-new", "hidden-b", "visible-a", "inactive-a", "visible-b"]);
+  });
+
   it("stores explicit changed-file expansion choices", () => {
     const threadId = ThreadId.make("thread-1");
     const collapsed = setThreadChangedFilesExpanded(makeUiState(), threadId, "turn-1", false);
@@ -154,6 +181,7 @@ describe("parsePersistedState", () => {
         invalid: "no" as unknown as boolean,
       },
       projectOrder: ["physical-b", "", "physical-a", "physical-b"],
+      threadOrder: ["environment:thread-2", "", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
@@ -173,6 +201,7 @@ describe("parsePersistedState", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrder: ["environment:thread-2", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -270,6 +299,7 @@ describe("uiStateStore persistence", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrder: ["environment:thread-2", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
@@ -292,6 +322,7 @@ describe("uiStateStore persistence", () => {
         logical: false,
       },
       projectOrder: ["physical-b", "physical-a"],
+      threadOrder: ["environment:thread-2", "environment:thread-1"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -20,6 +20,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
+  threadOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
@@ -35,6 +36,7 @@ export interface UiProjectState {
 }
 
 export interface UiThreadState {
+  threadOrder: string[];
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
@@ -48,6 +50,7 @@ export interface UiState extends UiProjectState, UiThreadState, UiEndpointState 
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
+  threadOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
@@ -125,6 +128,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
   return {
     projectExpandedById,
     projectOrder,
+    threadOrder: sanitizeStringArray(parsed.threadOrder),
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
@@ -203,6 +207,7 @@ export function persistState(state: UiState): void {
       JSON.stringify({
         projectExpandedById,
         projectOrder: state.projectOrder,
+        threadOrder: state.threadOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
@@ -337,6 +342,39 @@ export function setProjectExpanded(
   };
 }
 
+export function reorderThreads(
+  state: UiState,
+  currentThreadOrder: readonly string[],
+  draggedThreadId: string,
+  targetThreadId: string,
+): UiState {
+  const draggedIndex = currentThreadOrder.indexOf(draggedThreadId);
+  const targetIndex = currentThreadOrder.indexOf(targetThreadId);
+  if (draggedIndex < 0 || targetIndex < 0 || draggedIndex === targetIndex) {
+    return state;
+  }
+
+  const reorderedVisibleThreads = [...currentThreadOrder];
+  const [dragged] = reorderedVisibleThreads.splice(draggedIndex, 1);
+  reorderedVisibleThreads.splice(targetIndex, 0, dragged!);
+
+  // A project filter and lifecycle sections can hide unpinned threads. Keep
+  // those ids in their saved slots while replacing only the visible active
+  // ids, then append visible threads that do not have a persisted slot yet.
+  const visibleThreadIds = new Set(currentThreadOrder);
+  let nextVisibleIndex = 0;
+  const threadOrder = state.threadOrder.map((threadId) => {
+    if (!visibleThreadIds.has(threadId)) return threadId;
+    return reorderedVisibleThreads[nextVisibleIndex++]!;
+  });
+  threadOrder.push(...reorderedVisibleThreads.slice(nextVisibleIndex));
+
+  return {
+    ...state,
+    threadOrder,
+  };
+}
+
 export function reorderProjects(
   state: UiState,
   currentProjectOrder: readonly string[],
@@ -387,6 +425,11 @@ interface UiStateStore extends UiState {
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
+  reorderThreads: (
+    currentThreadOrder: readonly string[],
+    draggedThreadId: string,
+    targetThreadId: string,
+  ) => void;
   reorderProjects: (
     currentProjectOrder: readonly string[],
     draggedProjectIds: readonly string[],
@@ -406,6 +449,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
+  reorderThreads: (currentThreadOrder, draggedThreadId, targetThreadId) =>
+    set((state) => reorderThreads(state, currentThreadOrder, draggedThreadId, targetThreadId)),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>
     set((state) =>
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -21,6 +21,7 @@ export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
   threadOrder?: string[];
+  threadOrderAnchorById?: Record<string, string>;
   threadLastVisitedAtById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
@@ -37,6 +38,7 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadOrder: string[];
+  threadOrderAnchorById: Record<string, string>;
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
@@ -51,6 +53,7 @@ const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadOrder: [],
+  threadOrderAnchorById: {},
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
@@ -129,6 +132,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     projectExpandedById,
     projectOrder,
     threadOrder: sanitizeStringArray(parsed.threadOrder),
+    threadOrderAnchorById: sanitizeTimestampRecord(parsed.threadOrderAnchorById),
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
@@ -208,6 +212,7 @@ export function persistState(state: UiState): void {
         projectExpandedById,
         projectOrder: state.projectOrder,
         threadOrder: state.threadOrder,
+        threadOrderAnchorById: state.threadOrderAnchorById,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
@@ -345,6 +350,7 @@ export function setProjectExpanded(
 export function reorderThreads(
   state: UiState,
   currentThreadOrder: readonly string[],
+  currentThreadOrderAnchorById: Readonly<Record<string, string>>,
   draggedThreadId: string,
   targetThreadId: string,
 ): UiState {
@@ -368,10 +374,16 @@ export function reorderThreads(
     return reorderedVisibleThreads[nextVisibleIndex++]!;
   });
   threadOrder.push(...reorderedVisibleThreads.slice(nextVisibleIndex));
+  const threadOrderAnchorById = { ...state.threadOrderAnchorById };
+  for (const threadId of currentThreadOrder) {
+    const anchor = currentThreadOrderAnchorById[threadId];
+    if (anchor !== undefined) threadOrderAnchorById[threadId] = anchor;
+  }
 
   return {
     ...state,
     threadOrder,
+    threadOrderAnchorById,
   };
 }
 
@@ -427,6 +439,7 @@ interface UiStateStore extends UiState {
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
   reorderThreads: (
     currentThreadOrder: readonly string[],
+    currentThreadOrderAnchorById: Readonly<Record<string, string>>,
     draggedThreadId: string,
     targetThreadId: string,
   ) => void;
@@ -449,8 +462,21 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
-  reorderThreads: (currentThreadOrder, draggedThreadId, targetThreadId) =>
-    set((state) => reorderThreads(state, currentThreadOrder, draggedThreadId, targetThreadId)),
+  reorderThreads: (
+    currentThreadOrder,
+    currentThreadOrderAnchorById,
+    draggedThreadId,
+    targetThreadId,
+  ) =>
+    set((state) =>
+      reorderThreads(
+        state,
+        currentThreadOrder,
+        currentThreadOrderAnchorById,
+        draggedThreadId,
+        targetThreadId,
+      ),
+    ),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>
     set((state) =>
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -21,6 +21,10 @@ On web and desktop, drag a pinned thread to change its position. On mobile, open
 and choose **Move up** or **Move down**. The order is stored by the server and appears on your
 other connected devices.
 
+On web and desktop, you can also drag active, unpinned threads into your preferred order. That
+order is stored in the browser, survives reloads, and stays intact when you filter the sidebar by
+project. It does not sync to other browsers or devices.
+
 If reordering is unavailable for one environment, update the T3 Code server running in that
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.


### PR DESCRIPTION
## Problem

Pinned threads can be dragged into a custom order, but active unpinned threads are locked to creation order. That makes it hard to keep the current work queue arranged intentionally.

## Fix

- Make active unpinned sidebar rows sortable with the same whole-row drag interaction used by pinned threads.
- Persist the active order in browser-owned UI state so it survives reloads without changing server contracts.
- Keep new threads at the top until the user places them.
- Preserve saved positions for threads hidden by a project filter, while new and reactivated threads return to the top.
- Feed the custom order into search, jump shortcuts, selection, and fallback navigation so every sidebar path agrees.
- Document that active ordering is local to the browser, while pinned ordering remains server-synced.

This also addresses the filtered-project data-loss issue identified on the earlier closed implementation in #8039.

## Evidence

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/fbc3848e-03a1-41c6-81db-c2e7f8f36c2d" controls></video></td>
    <td><video src="https://github.com/user-attachments/assets/e2f23d8b-e5bd-4b1f-b1b1-85b2f28ec1d1" controls></video></td>
  </tr>
</table>

## Verification

- `vp test run src/uiStateStore.test.ts src/components/Sidebar.logic.test.ts --passWithNoTests --project unit` (134 tests passed)
- `vp run --filter @t3tools/web typecheck`
- Targeted lint passed for the changed TypeScript files
- Formatting check passed for all changed files

Built by GPT-5.6 Sol via the Codex harness in T3 Code.


Closes #9617

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only ordering in local persistence with unit tests; no server contract changes, aside from delete fallback navigation using the visible order.
> 
> **Overview**
> **Active unpinned threads** can now be drag-reordered in the sidebar (same whole-row interaction as pinned threads). Order is saved in **browser `localStorage`** via new `threadOrder` / `threadOrderAnchorById` state and **`reorderThreads`**, not synced across devices?docs call this out vs server-synced pinned order.
> 
> **`resolveActiveThreadOrder`** keeps a saved layout only when each thread?s **order anchor** still matches; **new or reactivated** threads appear above the saved list. Reordering while a **project filter** hides threads preserves slots for hidden IDs so positions aren?t lost when the filter clears.
> 
> The active list is wrapped in **dnd-kit** with **auto-animate paused during drag** to avoid double motion. **Search, jump shortcuts, and traversal** use the custom active order because **`orderedThreads`** includes reordered actives. **After delete**, **`getFallbackThreadIdAfterDelete`** / **`deleteThread`** take **`preferredThreadKeys`** so navigation follows sidebar order, not creation sort. **Rename** inputs **`stopPropagation` on pointer down** so drags don?t start while editing titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98da5ea9bd4068ec3bf74c8ae27d9aa0a80e67a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-to-reorder for active sidebar threads with browser persistence
> - Users can drag active, unpinned threads in the sidebar to set a preferred order; the order persists per-browser via `threadOrder` and `threadOrderAnchorById` in [uiStateStore.ts](apps/web/src/uiStateStore.ts)
> - `resolveActiveThreadOrder` merges new or reactivated threads ahead of the saved order when anchors mismatch, so stale persisted orders are corrected on load
> - `reorderThreads` computes deterministic state updates that preserve positions of hidden threads and append newly visible ones without slots
> - `getFallbackThreadIdAfterDelete` and `useThreadActions.deleteThread` now accept a preferred active order so post-delete navigation respects the current UI order
> - `SortableThreadRow` generalizes the previous pinned-only row wrapper for both pinned and active sections; auto-animate is paused during drag to avoid double animations
> - Risk: deleting threads while a project filter is active now navigates to the first thread in the active UI order rather than the first sorted thread — callers in [Sidebar.tsx](apps/web/src/components/Sidebar.tsx) and [useThreadActions.ts](apps/web/src/hooks/useThreadActions.ts) are updated; out-of-tree consumers of `deleteThread` must pass `preferredThreadKeys` to get the new behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98da5ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
