### PR TITLE
fix(web): keep turn status visible while scrolling

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -136,6 +136,7 @@ function matchMedia() {
 
 let MessagesTimeline: typeof import("./MessagesTimeline").MessagesTimeline;
 let resolveTimelineStatusRowPinned: typeof import("./MessagesTimeline").resolveTimelineStatusRowPinned;
+let resolveTimelineStatusRowTopOffset: typeof import("./MessagesTimeline").resolveTimelineStatusRowTopOffset;
 
 beforeAll(async () => {
   const classList = {
@@ -169,7 +170,8 @@ beforeAll(async () => {
     },
   });
 
-  ({ MessagesTimeline, resolveTimelineStatusRowPinned } = await import("./MessagesTimeline"));
+  ({ MessagesTimeline, resolveTimelineStatusRowPinned, resolveTimelineStatusRowTopOffset } =
+    await import("./MessagesTimeline"));
 }, 30_000);
 
 const ACTIVE_THREAD_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
@@ -334,14 +336,23 @@ describe("MessagesTimeline", () => {
   it("pins a keyed status row when later rows follow it", () => {
     const state = {
       scroll: 100,
-      positionByKey: (key: string) => (key === "working-indicator-row" ? 100 : undefined),
+      positionByKey: (key: string) => (key === "working-indicator-row" ? 112 : undefined),
     };
 
-    expect(resolveTimelineStatusRowPinned(state, "working-indicator-row")).toBe(true);
-    expect(resolveTimelineStatusRowPinned({ ...state, scroll: 99 }, "working-indicator-row")).toBe(
+    expect(resolveTimelineStatusRowPinned(state, "working-indicator-row", 12)).toBe(true);
+    expect(
+      resolveTimelineStatusRowPinned({ ...state, scroll: 99 }, "working-indicator-row", 12),
+    ).toBe(false);
+    expect(resolveTimelineStatusRowPinned({ scroll: 100 }, "working-indicator-row", 12)).toBe(
       false,
     );
-    expect(resolveTimelineStatusRowPinned({ scroll: 100 }, "working-indicator-row")).toBe(false);
+  });
+
+  it("matches the timeline header height at each breakpoint", () => {
+    expect(resolveTimelineStatusRowTopOffset(false, false)).toBe(12);
+    expect(resolveTimelineStatusRowTopOffset(false, true)).toBe(16);
+    expect(resolveTimelineStatusRowTopOffset(true, false)).toBe(40);
+    expect(resolveTimelineStatusRowTopOffset(true, true)).toBe(48);
   });
 
   it("uses the larger leading inset only when the top fade is enabled", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -135,6 +135,7 @@ function matchMedia() {
 }
 
 let MessagesTimeline: typeof import("./MessagesTimeline").MessagesTimeline;
+let resolveTimelineStatusRowPinned: typeof import("./MessagesTimeline").resolveTimelineStatusRowPinned;
 
 beforeAll(async () => {
   const classList = {
@@ -168,7 +169,7 @@ beforeAll(async () => {
     },
   });
 
-  ({ MessagesTimeline } = await import("./MessagesTimeline"));
+  ({ MessagesTimeline, resolveTimelineStatusRowPinned } = await import("./MessagesTimeline"));
 }, 30_000);
 
 const ACTIVE_THREAD_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
@@ -328,6 +329,19 @@ describe("MessagesTimeline", () => {
 
     expect(markup).toContain("Worked for 8.0s");
     expect(markup).toContain("px-1 text-sm leading-relaxed text-muted-foreground");
+  });
+
+  it("pins a keyed status row when later rows follow it", () => {
+    const state = {
+      scroll: 100,
+      positionByKey: (key: string) => (key === "working-indicator-row" ? 100 : undefined),
+    };
+
+    expect(resolveTimelineStatusRowPinned(state, "working-indicator-row")).toBe(true);
+    expect(resolveTimelineStatusRowPinned({ ...state, scroll: 99 }, "working-indicator-row")).toBe(
+      false,
+    );
+    expect(resolveTimelineStatusRowPinned({ scroll: 100 }, "working-indicator-row")).toBe(false);
   });
 
   it("uses the larger leading inset only when the top fade is enabled", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -103,6 +103,7 @@ import {
 } from "./MessagesTimeline.logic";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { useMediaQuery } from "~/hooks/useMediaQuery";
 import {
   deriveDisplayedUserMessageState,
   type ParsedTerminalContextEntry,
@@ -451,6 +452,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     null,
   );
   const [statusRowPinned, setStatusRowPinned] = useState(false);
+  const isWideViewport = useMediaQuery("sm");
+  const statusRowTop = resolveTimelineStatusRowTopOffset(topFadeEnabled, isWideViewport);
   const [minimapHasPersistentGutter, setMinimapHasPersistentGutter] = useState(false);
   const [minimapHitStripWidth, setMinimapHitStripWidth] = useState(0);
   const handleAnchorReady = useCallback(
@@ -480,7 +483,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
     const scrollTop = state.scroll ?? 0;
     setStatusRowPinned(
-      stickyStatusRow !== undefined && resolveTimelineStatusRowPinned(state, stickyStatusRow.id),
+      stickyStatusRow !== undefined &&
+        resolveTimelineStatusRowPinned(state, stickyStatusRow.id, statusRowTop),
     );
     if (minimapItems.length === 0) {
       return;
@@ -510,6 +514,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     minimapStripMap,
     onIsAtEndChange,
     stickyStatusRow,
+    statusRowTop,
   ]);
 
   useEffect(() => {
@@ -653,12 +658,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           />
           {statusRowPinned && stickyStatusRow ? (
             <div
-              className="pointer-events-none absolute inset-x-0 top-0 z-30 px-3 sm:px-5"
+              className="pointer-events-none absolute inset-x-0 z-10 px-3 sm:px-5"
               data-turn-status-row-pinned="true"
+              style={{ top: statusRowTop }}
             >
               <div
-                aria-hidden
-                className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip bg-background"
+                aria-hidden={stickyStatusRow.kind === "working" || undefined}
+                className={cn(
+                  "mx-auto w-full min-w-0 max-w-3xl overflow-x-clip bg-background",
+                  stickyStatusRow.kind === "turn-fold" && "pointer-events-auto",
+                )}
               >
                 <TimelineRowContent row={stickyStatusRow} />
               </div>
@@ -758,9 +767,21 @@ function resolveTimelineRowTop(state: TimelinePositionState, rowIndex: number) {
   return typeof top === "number" && Number.isFinite(top) ? top : null;
 }
 
-export function resolveTimelineStatusRowPinned(state: TimelinePositionState, rowKey: string) {
+export function resolveTimelineStatusRowPinned(
+  state: TimelinePositionState,
+  rowKey: string,
+  statusRowTop: number,
+) {
   const rowTop = state.positionByKey?.(rowKey);
-  return typeof rowTop === "number" && Number.isFinite(rowTop) && rowTop <= (state.scroll ?? 0);
+  return (
+    typeof rowTop === "number" &&
+    Number.isFinite(rowTop) &&
+    rowTop <= (state.scroll ?? 0) + statusRowTop
+  );
+}
+
+export function resolveTimelineStatusRowTopOffset(topFadeEnabled: boolean, isWide: boolean) {
+  return topFadeEnabled ? (isWide ? 48 : 40) : isWide ? 16 : 12;
 }
 
 function resolveTimelineRowHeight(state: TimelinePositionState, rowIndex: number) {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -444,9 +444,13 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   );
   const rows = useStableRows(rawRows);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
+  const stickyStatusRow = isWorking
+    ? rows.find((row) => row.kind === "working")
+    : rows.find((row) => row.kind === "turn-fold" && row.turnId === latestTurn?.turnId);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
   );
+  const [statusRowPinned, setStatusRowPinned] = useState(false);
   const [minimapHasPersistentGutter, setMinimapHasPersistentGutter] = useState(false);
   const [minimapHitStripWidth, setMinimapHitStripWidth] = useState(0);
   const handleAnchorReady = useCallback(
@@ -470,11 +474,18 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     if (isAtEnd !== undefined) {
       onIsAtEndChange(isAtEnd);
     }
-    if (!state || minimapItems.length === 0) {
+    if (!state) {
       return;
     }
 
     const scrollTop = state.scroll ?? 0;
+    setStatusRowPinned(
+      stickyStatusRow !== undefined && resolveTimelineStatusRowPinned(state, stickyStatusRow.id),
+    );
+    if (minimapItems.length === 0) {
+      return;
+    }
+
     const scrollBottom = scrollTop + (state.scrollLength ?? 0);
 
     for (const item of minimapItems) {
@@ -492,7 +503,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
       strip.dataset.inView = inView ? "true" : "false";
     }
-  }, [contentInsetEndAdjustment, listRef, minimapItems, minimapStripMap, onIsAtEndChange]);
+  }, [
+    contentInsetEndAdjustment,
+    listRef,
+    minimapItems,
+    minimapStripMap,
+    onIsAtEndChange,
+    stickyStatusRow,
+  ]);
 
   useEffect(() => {
     const frame = requestAnimationFrame(handleScroll);
@@ -633,6 +651,19 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             }
             ListFooterComponent={TIMELINE_LIST_FOOTER}
           />
+          {statusRowPinned && stickyStatusRow ? (
+            <div
+              className="pointer-events-none absolute inset-x-0 top-0 z-30 px-3 sm:px-5"
+              data-turn-status-row-pinned="true"
+            >
+              <div
+                aria-hidden
+                className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip bg-background"
+              >
+                <TimelineRowContent row={stickyStatusRow} />
+              </div>
+            </div>
+          ) : null}
           <TimelineMinimap
             items={minimapItems}
             hasPersistentGutter={minimapHasPersistentGutter}
@@ -670,6 +701,7 @@ interface TimelineMinimapItem {
 
 interface TimelinePositionState {
   readonly contentLength?: number;
+  readonly positionByKey?: (key: string) => number | undefined;
   readonly scroll?: number;
   readonly scrollLength?: number;
   readonly positionAtIndex?: (index: number) => number | undefined;
@@ -724,6 +756,11 @@ function compactMinimapPreview(text: string | null | undefined) {
 function resolveTimelineRowTop(state: TimelinePositionState, rowIndex: number) {
   const top = state.positionAtIndex?.(rowIndex);
   return typeof top === "number" && Number.isFinite(top) ? top : null;
+}
+
+export function resolveTimelineStatusRowPinned(state: TimelinePositionState, rowKey: string) {
+  const rowTop = state.positionByKey?.(rowKey);
+  return typeof rowTop === "number" && Number.isFinite(rowTop) && rowTop <= (state.scroll ?? 0);
 }
 
 function resolveTimelineRowHeight(state: TimelinePositionState, rowIndex: number) {
@@ -971,6 +1008,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
                   row.kind === "turn-plan"
                 ? "pb-2"
                 : "pb-4",
+        row.kind === "turn-fold" || row.kind === "working" ? "bg-background" : null,
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
       )}
       data-timeline-row-id={row.id}


### PR DESCRIPTION
The active turn status could scroll out of view because the old code assumed it was always the last timeline row. Once agent output followed it, that assumption was wrong.

This finds the status row by its stable list key and pins it only after it crosses the timeline header. It supports both the live `Working for… · current task` row and the completed `Worked for…` row. Scrolling back returns it to its normal place.

The live pinned copy is decorative and hidden from accessibility tools. The completed pinned row stays an accessible, clickable button. The overlay also follows the timeline fade offset and stays below banners and the composer.

## Evidence

### In place

![Turn status in its normal row](https://github.com/user-attachments/assets/813d6245-f3be-4626-9170-7e060f7bae97)

### Pinned

![Turn status pinned at the timeline top](https://github.com/user-attachments/assets/ce183489-0683-423c-8411-34e9fa880f9a)

### Scroll motion

https://github.com/user-attachments/assets/2ea4c899-5ac7-4b89-9547-35edcb1ba59f

## Verification

- `pnpm exec vitest run apps/web/src/components/chat/MessagesTimeline.test.tsx` — 40 tests passed
- targeted formatter and lint checks passed
- `pnpm --filter @t3tools/web typecheck` passed
- isolated real-browser pass: live row pins and unpins at the 48 px fade edge with z-index 10; completed row remains accessible and clickable; no browser errors

Risk is low. The change is limited to the web timeline status row and its focused regression check.

Generated with GPT-5.6 in the Codex harness.