### PR TITLE
fix(desktop): support Linux distro protocol launchers

### DIFF
--- a/apps/desktop/src/app/DesktopConfig.ts
+++ b/apps/desktop/src/app/DesktopConfig.ts
@@ -48,6 +48,7 @@ export const DesktopConfig = Config.all({
   otlpExportIntervalMs: Config.int("T3CODE_OTLP_EXPORT_INTERVAL_MS").pipe(
     Config.withDefault(10_000),
   ),
+  desktopExecutable: trimmedString("T3CODE_DESKTOP_EXECUTABLE"),
   appImagePath: trimmedString("APPIMAGE"),
   disableAutoUpdate: optionalBoolean("T3CODE_DISABLE_AUTO_UPDATE"),
   mockUpdates: optionalBoolean("T3CODE_DESKTOP_MOCK_UPDATES"),

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -47,6 +47,7 @@ describe("DesktopEnvironment", () => {
           T3CODE_DEV_REMOTE_T3_SERVER_ENTRY_PATH: " /remote/server.mjs ",
           T3CODE_OTLP_TRACES_URL: " http://127.0.0.1:4318/v1/traces ",
           T3CODE_OTLP_EXPORT_INTERVAL_MS: "2500",
+          T3CODE_DESKTOP_EXECUTABLE: " /nix/store/t3code/bin/t3code-desktop ",
         },
       );
 
@@ -79,6 +80,10 @@ describe("DesktopEnvironment", () => {
       assert.deepEqual(environment.commitHashOverride, Option.some("0123456789abcdef"));
       assert.deepEqual(environment.otlpTracesUrl, Option.some("http://127.0.0.1:4318/v1/traces"));
       assert.equal(environment.otlpExportIntervalMs, 2500);
+      assert.deepEqual(
+        environment.desktopExecutable,
+        Option.some("/nix/store/t3code/bin/t3code-desktop"),
+      );
     }),
   );
 

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -75,6 +75,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly linuxDesktopEntryName: string;
     readonly linuxWmClass: string;
     readonly linuxApplicationsDir: string;
+    readonly desktopExecutable: Option.Option<string>;
     readonly appImagePath: Option.Option<string>;
     readonly userDataDirName: string;
     readonly legacyUserDataDirName: string;
@@ -229,6 +230,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     linuxDesktopEntryName: isDevelopment ? "t3code-dev.desktop" : "t3code.desktop",
     linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",
     linuxApplicationsDir,
+    desktopExecutable: config.desktopExecutable,
     appImagePath: config.appImagePath,
     userDataDirName,
     legacyUserDataDirName,

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -25,6 +25,7 @@ const makeEnvironment = (overrides: Record<string, unknown> = {}) =>
     displayName: "T3 Code (Alpha)",
     linuxWmClass: "t3code",
     linuxApplicationsDir: "/home/alice/.local/share/applications",
+    desktopExecutable: Option.none(),
     appImagePath: Option.some("/home/alice/Applications/T3-Code.AppImage"),
     path: { join: (...parts: ReadonlyArray<string>) => parts.join("/") },
     ...overrides,
@@ -190,15 +191,40 @@ describe("DesktopLinuxUrlHandler", () => {
     });
   });
 
-  it.effect("does nothing on other platforms or unpackaged builds", () => {
+  it.effect("prefers a configured distro launcher over AppImage metadata", () => {
+    const recorded = emptyRecording();
+
+    return Effect.gen(function* () {
+      yield* runRegister(recorded, {
+        environment: {
+          desktopExecutable: Option.some("/nix/store/t3code/bin/t3code-desktop"),
+        },
+      });
+
+      assert.include(recorded.files[0]?.content, 'Exec="/nix/store/t3code/bin/t3code-desktop" %U');
+    });
+  });
+
+  it.effect("registers unpackaged production builds", () => {
+    const recorded = emptyRecording();
+
+    return Effect.gen(function* () {
+      yield* runRegister(recorded, { environment: { isPackaged: false } });
+
+      assert.equal(recorded.files.length, 1);
+      assert.equal(recorded.commands.length, 1);
+    });
+  });
+
+  it.effect("does nothing on other platforms or development builds", () => {
     const nonLinux = emptyRecording();
-    const unpackaged = emptyRecording();
+    const development = emptyRecording();
 
     return Effect.gen(function* () {
       yield* runRegister(nonLinux, { environment: { platform: "darwin" } });
-      yield* runRegister(unpackaged, { environment: { isPackaged: false } });
+      yield* runRegister(development, { environment: { isDevelopment: true } });
 
-      for (const recorded of [nonLinux, unpackaged]) {
+      for (const recorded of [nonLinux, development]) {
         assert.deepEqual(recorded.directories, []);
         assert.deepEqual(recorded.files, []);
         assert.deepEqual(recorded.commands, []);

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -197,6 +197,7 @@ describe("DesktopLinuxUrlHandler", () => {
     return Effect.gen(function* () {
       yield* runRegister(recorded, {
         environment: {
+          isPackaged: false,
           desktopExecutable: Option.some("/nix/store/t3code/bin/t3code-desktop"),
         },
       });
@@ -205,14 +206,15 @@ describe("DesktopLinuxUrlHandler", () => {
     });
   });
 
-  it.effect("registers unpackaged production builds", () => {
+  it.effect("does nothing for unpackaged production launches without an explicit launcher", () => {
     const recorded = emptyRecording();
 
     return Effect.gen(function* () {
       yield* runRegister(recorded, { environment: { isPackaged: false } });
 
-      assert.equal(recorded.files.length, 1);
-      assert.equal(recorded.commands.length, 1);
+      assert.deepEqual(recorded.directories, []);
+      assert.deepEqual(recorded.files, []);
+      assert.deepEqual(recorded.commands, []);
     });
   });
 

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -218,15 +218,25 @@ describe("DesktopLinuxUrlHandler", () => {
     });
   });
 
-  it.effect("does nothing on other platforms or development builds", () => {
+  it.effect("preserves packaged launches while skipping development distro launchers", () => {
     const nonLinux = emptyRecording();
-    const development = emptyRecording();
+    const packagedDevelopment = emptyRecording();
+    const distroDevelopment = emptyRecording();
 
     return Effect.gen(function* () {
       yield* runRegister(nonLinux, { environment: { platform: "darwin" } });
-      yield* runRegister(development, { environment: { isDevelopment: true } });
+      yield* runRegister(packagedDevelopment, { environment: { isDevelopment: true } });
+      yield* runRegister(distroDevelopment, {
+        environment: {
+          isPackaged: false,
+          isDevelopment: true,
+          desktopExecutable: Option.some("/nix/store/t3code/bin/t3code-desktop"),
+        },
+      });
 
-      for (const recorded of [nonLinux, development]) {
+      assert.equal(packagedDevelopment.files.length, 1);
+      assert.equal(packagedDevelopment.commands.length, 1);
+      for (const recorded of [nonLinux, distroDevelopment]) {
         assert.deepEqual(recorded.directories, []);
         assert.deepEqual(recorded.files, []);
         assert.deepEqual(recorded.commands, []);

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -169,12 +169,9 @@ export const make = Effect.gen(function* () {
 
   const register = Effect.gen(function* () {
     const isSupportedProductionLaunch =
-      environment.isPackaged || Option.isSome(environment.desktopExecutable);
-    if (
-      environment.platform !== "linux" ||
-      environment.isDevelopment ||
-      !isSupportedProductionLaunch
-    ) {
+      environment.isPackaged ||
+      (!environment.isDevelopment && Option.isSome(environment.desktopExecutable));
+    if (environment.platform !== "linux" || !isSupportedProductionLaunch) {
       return;
     }
     yield* writeDesktopEntry;

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -168,7 +168,13 @@ export const make = Effect.gen(function* () {
   );
 
   const register = Effect.gen(function* () {
-    if (environment.platform !== "linux" || environment.isDevelopment) {
+    const isSupportedProductionLaunch =
+      environment.isPackaged || Option.isSome(environment.desktopExecutable);
+    if (
+      environment.platform !== "linux" ||
+      environment.isDevelopment ||
+      !isSupportedProductionLaunch
+    ) {
       return;
     }
     yield* writeDesktopEntry;

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -11,9 +11,11 @@ import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import { makeComponentLogger } from "./DesktopObservability.ts";
 
-// Linux ships as an AppImage, so the .desktop entry users end up with is
-// created by whatever integration tool they use (AppImageLauncher names it
-// appimagekit_<hash>-….desktop) and its filename is not under our control.
+// Linux release builds ship as an AppImage, while distro packages may launch
+// the app through a shared Electron executable. In either case the .desktop
+// entry users end up with may not be a stable protocol-handler identity.
+// AppImage integration tools, for example, name it
+// appimagekit_<hash>-….desktop, so its filename is not under our control.
 // Electron's app.setAsDefaultProtocolClient resolves the desktop id from
 // setDesktopName, which cannot match those files — so the browser keeps
 // prompting "Choose an application" for every OAuth callback. Instead, write
@@ -104,9 +106,13 @@ export const make = Effect.gen(function* () {
   );
 
   const writeDesktopEntry = Effect.gen(function* () {
+    // Distro packages can provide their launcher explicitly because
+    // process.execPath points at the shared Electron executable.
     // Inside the mounted AppImage, process.execPath points at a transient
     // /tmp/.mount_* path — the handler must launch the AppImage itself.
-    const execTarget = Option.getOrElse(environment.appImagePath, () => process.execPath);
+    const execTarget = Option.getOrElse(environment.desktopExecutable, () =>
+      Option.getOrElse(environment.appImagePath, () => process.execPath),
+    );
     yield* fileSystem.makeDirectory(environment.linuxApplicationsDir, { recursive: true });
     yield* fileSystem.writeFileString(
       desktopEntryPath,
@@ -162,7 +168,7 @@ export const make = Effect.gen(function* () {
   );
 
   const register = Effect.gen(function* () {
-    if (environment.platform !== "linux" || !environment.isPackaged) {
+    if (environment.platform !== "linux" || environment.isDevelopment) {
       return;
     }
     yield* writeDesktopEntry;


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->
## What Changed

- Added a configurable `T3CODE_DESKTOP_EXECUTABLE` path for Linux distro packages.
- Prefer the configured launcher when writing the Linux `.desktop` protocol handler.
- Register unpackaged non-development builds when an explicit distro launcher is configured, while preserving every existing packaged Linux trigger case.
- Expanded environment and URL-handler test coverage.

## Why

Linux distro packages may launch through a shared Electron executable, while AppImage integrations use launcher identities that are not stable. A configured launcher gives the generated protocol-handler entry a durable `Exec` target so OAuth callbacks launch T3 Code correctly.

The desktop MIME-cache refresh has been split into a separate pull request to keep this change focused on distro launcher support.

## Verification

- 14 focused desktop URL-handler and environment tests pass.
- Targeted lint passes without warnings.
- Desktop typechecking passes.
- Formatting and `git diff --check` pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there are no UI changes
- [x] Video is not applicable because there are no animation or interaction changes

Implemented and verified with GPT-5.6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux OAuth/deep-link registration gating and which binary launches callbacks; unpackaged production no longer registers unless `T3CODE_DESKTOP_EXECUTABLE` is set.
> 
> **Overview**
> Adds **`T3CODE_DESKTOP_EXECUTABLE`** so Linux distro packages can point the custom protocol-handler `.desktop` entry at a stable launcher instead of a shared Electron binary or transient AppImage mount path.
> 
> **`DesktopLinuxUrlHandler`** now picks the handler `Exec` target in order: configured `desktopExecutable`, then `APPIMAGE`, then `process.execPath`. Registration still runs only on Linux non-dev builds, but **unpackaged production** can register when an explicit launcher is set; unpackaged production **without** that env var is skipped (previously gated mainly on `isPackaged`). Tests cover env parsing, launcher preference, and the new skip/register cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05563cc3fb1986282f9e8452ed7f9c95a8d9f8e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `desktopExecutable` config and prefer distro launcher in `DesktopLinuxUrlHandler`
> - Adds `desktopExecutable` to `DesktopConfig` via the `T3CODE_DESKTOP_EXECUTABLE` env var and surfaces it on the `DesktopEnvironment` service as an `Option.Option<string>`.
> - `DesktopLinuxUrlHandler.make` now writes the `.desktop` Exec target as `environment.desktopExecutable` when present, falling back to `appImagePath` then `process.execPath`.
> - Registration gating on Linux now allows unpackaged production launches when `desktopExecutable` is provided; development unpackaged launches are skipped even if a distro launcher is set.
> - Risk: reviewers should verify the exec target selection order in [DesktopLinuxUrlHandler.ts](https://github.com/pingdotgg/t3code/pull/8668/files#diff-504ebe51e9dfd4ae2551fe7de89cc99cac2fc37ae741fb4a2ccace15c8b81187) does not regress packaged AppImage launches, since `desktopExecutable` now takes precedence over `appImagePath`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99efd0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->