### PR TITLE
fix(server): show dot entries in non-git projects

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.nonGitHidden.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.nonGitHidden.test.ts
@@ -1,0 +1,85 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as ServerConfig from "../config.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as WorkspaceEntries from "./WorkspaceEntries.ts";
+import * as WorkspacePaths from "./WorkspacePaths.ts";
+
+const TestLayer = Layer.empty.pipe(
+  Layer.provideMerge(WorkspaceEntries.layer.pipe(Layer.provide(WorkspacePaths.layer))),
+  Layer.provideMerge(WorkspacePaths.layer),
+  Layer.provideMerge(VcsProcess.layer),
+  Layer.provide(
+    ServerConfig.ServerConfig.layerTest(process.cwd(), {
+      prefix: "t3-workspace-non-git-hidden-test-",
+    }),
+  ),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const makeTempDir = Effect.fn(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  return yield* fileSystem.makeTempDirectoryScoped({
+    prefix: "t3code-workspace-non-git-hidden-",
+  });
+});
+
+function writeTextFile(cwd: string, relativePath: string, contents = "") {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const absolutePath = path.join(cwd, relativePath);
+    yield* fileSystem.makeDirectory(path.dirname(absolutePath), { recursive: true });
+    yield* fileSystem.writeFileString(absolutePath, contents);
+  });
+}
+
+it.layer(TestLayer, { excludeTestServices: true })("non-Git workspace dot entries", (it) => {
+  describe("list", () => {
+    it.effect("includes unignored dot entries", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, ".hidden-dir/inside.txt");
+        yield* writeTextFile(cwd, ".hidden-file.txt");
+        yield* writeTextFile(cwd, "visible-dir/inside.txt");
+        yield* writeTextFile(cwd, "visible.txt");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd });
+
+        expect(result.entries).toEqual(
+          expect.arrayContaining([
+            { path: ".hidden-dir", kind: "directory" },
+            { path: ".hidden-dir/inside.txt", kind: "file" },
+            { path: ".hidden-file.txt", kind: "file" },
+            { path: "visible-dir", kind: "directory" },
+            { path: "visible-dir/inside.txt", kind: "file" },
+            { path: "visible.txt", kind: "file" },
+          ]),
+        );
+      }),
+    );
+
+    it.effect("does not bypass ignore rules", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, ".gitignore", ".secret\n");
+        yield* writeTextFile(cwd, ".secret");
+        yield* writeTextFile(cwd, "visible.txt");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd });
+        const paths = result.entries.map((entry) => entry.path);
+
+        expect(paths).toContain("visible.txt");
+        expect(paths).not.toContain(".secret");
+      }),
+    );
+  });
+});

--- a/apps/server/src/workspace/WorkspaceEntries.nonGitHidden.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.nonGitHidden.test.ts
@@ -1,10 +1,12 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { describe, expect, it } from "@effect/vitest";
+import { FileFinder } from "@ff-labs/fff-node";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import { vi } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
@@ -41,6 +43,10 @@ function writeTextFile(cwd: string, relativePath: string, contents = "") {
 }
 
 it.layer(TestLayer, { excludeTestServices: true })("non-Git workspace dot entries", (it) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("list", () => {
     it.effect("includes unignored dot entries", () =>
       Effect.gen(function* () {
@@ -79,6 +85,40 @@ it.layer(TestLayer, { excludeTestServices: true })("non-Git workspace dot entrie
 
         expect(paths).toContain("visible.txt");
         expect(paths).not.toContain(".secret");
+      }),
+    );
+
+    it.effect("does not let dot entries displace indexed entries at the listing cap", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, ".hidden-a");
+        yield* writeTextFile(cwd, ".hidden-b");
+
+        const indexedEntryCount = 24_999;
+        vi.spyOn(FileFinder.prototype, "mixedSearch").mockReturnValue({
+          ok: true,
+          value: {
+            items: Array.from({ length: indexedEntryCount }, (_, index) => ({
+              type: "file",
+              item: {
+                relativePath: `zz-visible-${String(index).padStart(5, "0")}.txt`,
+              },
+            })),
+            totalMatched: indexedEntryCount,
+          },
+        } as never);
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.list({ cwd });
+        const visibleEntries = result.entries.filter((entry) =>
+          entry.path.startsWith("zz-visible-"),
+        );
+        const hiddenEntries = result.entries.filter((entry) => entry.path.startsWith(".hidden-"));
+
+        expect(visibleEntries).toHaveLength(indexedEntryCount);
+        expect(hiddenEntries).toHaveLength(1);
+        expect(result.entries).toHaveLength(25_000);
+        expect(result.truncated).toBe(true);
       }),
     );
   });

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -398,18 +398,26 @@ export const make = Effect.gen(function* () {
         return indexedResult;
       }
 
-      const entryByPath = new Map(indexedResult.entries.map((entry) => [entry.path, entry]));
-      for (const entry of dotEntries) {
-        entryByPath.set(entry.path, entry);
+      const indexedPaths = new Set(indexedResult.entries.map((entry) => entry.path));
+      const supplementalEntries = dotEntries
+        .filter((entry) => !indexedPaths.has(entry.path))
+        .toSorted((left, right) => left.path.localeCompare(right.path));
+      if (supplementalEntries.length === 0) {
+        return indexedResult;
       }
-      const sortedEntries = [...entryByPath.values()].toSorted((left, right) =>
-        left.path.localeCompare(right.path),
+
+      const remainingCapacity = Math.max(
+        0,
+        NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES - indexedResult.entries.length,
       );
-      const entries = sortedEntries.slice(0, NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES);
+      const acceptedSupplementalEntries = supplementalEntries.slice(0, remainingCapacity);
+      const entries = [...indexedResult.entries, ...acceptedSupplementalEntries].toSorted(
+        (left, right) => left.path.localeCompare(right.path),
+      );
 
       return {
         entries,
-        truncated: entries.length < sortedEntries.length,
+        truncated: acceptedSupplementalEntries.length < supplementalEntries.length,
       };
     },
   );

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -138,6 +138,102 @@ const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(fu
   return path.resolve(expandHomePath(input.cwd, path), input.partialPath);
 });
 
+const NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES = 25_000;
+const NON_GIT_DOT_ENTRY_SKIP_DIRS = new Set([".git", "node_modules"]);
+const NON_GIT_IGNORE_FILE_NAMES = new Set([".gitignore", ".ignore"]);
+
+async function pathExistsForRepositoryDetection(input: string): Promise<boolean> {
+  try {
+    await NodeFSP.lstat(input);
+    return true;
+  } catch (cause) {
+    const code = (cause as NodeJS.ErrnoException | undefined)?.code;
+    return code !== "ENOENT" && code !== "ENOTDIR";
+  }
+}
+
+async function hasGitMetadataInAncestors(root: string, path: Path.Path): Promise<boolean> {
+  let current = root;
+  while (true) {
+    if (await pathExistsForRepositoryDetection(path.join(current, ".git"))) {
+      return true;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return false;
+    }
+    current = parent;
+  }
+}
+
+/**
+ * FFF intentionally skips root dot-entries for non-Git workspaces as a
+ * safeguard for home/root scans. For an ordinary project with no ignore
+ * rules, collect those omitted roots and their descendants. If ignore
+ * semantics or an incomplete scan make that unsafe to infer, keep FFF's
+ * result unchanged.
+ */
+async function collectNonGitRootDotEntries(
+  root: string,
+  path: Path.Path,
+): Promise<ReadonlyArray<ProjectListEntriesResult["entries"][number]> | null> {
+  const rootDirents = await NodeFSP.readdir(root, { withFileTypes: true }).catch(() => null);
+  if (!rootDirents || rootDirents.some((dirent) => NON_GIT_IGNORE_FILE_NAMES.has(dirent.name))) {
+    return null;
+  }
+
+  const entries: Array<ProjectListEntriesResult["entries"][number]> = [];
+  const pendingDirectories: string[] = [];
+  let scannedEntries = rootDirents.length;
+  if (scannedEntries > NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES) {
+    return null;
+  }
+
+  for (const dirent of rootDirents) {
+    if (!dirent.name.startsWith(".") || NON_GIT_DOT_ENTRY_SKIP_DIRS.has(dirent.name)) {
+      continue;
+    }
+    entries.push({
+      path: dirent.name,
+      kind: dirent.isDirectory() ? "directory" : "file",
+    });
+    if (dirent.isDirectory()) {
+      pendingDirectories.push(dirent.name);
+    }
+  }
+
+  for (let index = 0; index < pendingDirectories.length; index += 1) {
+    const relativeDirectory = pendingDirectories[index]!;
+    const dirents = await NodeFSP.readdir(path.join(root, relativeDirectory), {
+      withFileTypes: true,
+    }).catch(() => null);
+    if (!dirents || dirents.some((dirent) => NON_GIT_IGNORE_FILE_NAMES.has(dirent.name))) {
+      return null;
+    }
+
+    scannedEntries += dirents.length;
+    if (scannedEntries > NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES) {
+      return null;
+    }
+
+    for (const dirent of dirents) {
+      const relativePath = `${relativeDirectory}/${dirent.name}`;
+      if (NON_GIT_DOT_ENTRY_SKIP_DIRS.has(dirent.name)) {
+        continue;
+      }
+      entries.push({
+        path: relativePath,
+        kind: dirent.isDirectory() ? "directory" : "file",
+      });
+      if (dirent.isDirectory()) {
+        pendingDirectories.push(relativePath);
+      }
+    }
+  }
+
+  return entries;
+}
+
 export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
@@ -275,7 +371,7 @@ export const make = Effect.gen(function* () {
   const list: WorkspaceEntries["Service"]["list"] = Effect.fn("WorkspaceEntries.list")(
     function* (input) {
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
-      return yield* Effect.gen(function* () {
+      const indexedResult = yield* Effect.gen(function* () {
         const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
         return yield* searchIndex.list();
       }).pipe(
@@ -285,6 +381,36 @@ export const make = Effect.gen(function* () {
           ),
         ),
       );
+
+      if (
+        indexedResult.truncated ||
+        normalizedCwd === path.resolve(NodeOS.homedir()) ||
+        path.dirname(normalizedCwd) === normalizedCwd ||
+        (yield* Effect.promise(() => hasGitMetadataInAncestors(normalizedCwd, path)))
+      ) {
+        return indexedResult;
+      }
+
+      const dotEntries = yield* Effect.promise(() =>
+        collectNonGitRootDotEntries(normalizedCwd, path),
+      );
+      if (!dotEntries || dotEntries.length === 0) {
+        return indexedResult;
+      }
+
+      const entryByPath = new Map(indexedResult.entries.map((entry) => [entry.path, entry]));
+      for (const entry of dotEntries) {
+        entryByPath.set(entry.path, entry);
+      }
+      const sortedEntries = [...entryByPath.values()].toSorted((left, right) =>
+        left.path.localeCompare(right.path),
+      );
+      const entries = sortedEntries.slice(0, NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES);
+
+      return {
+        entries,
+        truncated: entries.length < sortedEntries.length,
+      };
     },
   );
 


### PR DESCRIPTION
## What Changed

- Keep the existing FFF-backed workspace index for normal project listings.
- For non-Git project roots where the index intentionally omits root dot-entries, supplement the file tree with those dot-prefixed entries and their descendants.
- Preserve the existing safeguards for home/root scans, Git repositories, ignore files, `.git`, `node_modules`, and the 25,000-entry cap.
- Add regression coverage for the reported non-Git project case and for not bypassing ignore rules.

## Why

In a project that is not a Git repository, the Files panel can omit entries such as `.hidden-file.txt` and `.hidden-dir/` even though visible entries in the same directory appear normally.

`projects.listEntries` is backed by the FFF workspace index. FFF intentionally skips hidden entries for non-Git roots as a safety measure for large home/root scans. For an ordinary project directory, that behavior makes legitimate dot-entries invisible in the Files panel.

This change keeps the indexed listing as the source of truth and only supplements the missing dot-entry subtree when it is safe to do so, rather than changing the RPC contract or weakening Git/ignore behavior.

Fixes #8665

## Validation

- `pnpm exec vp test run apps/server/src/workspace/WorkspaceEntries.nonGitHidden.test.ts` — 3 passed
- `pnpm exec vp test run apps/server/src/workspace/WorkspaceEntries.test.ts` — 30 passed
- `pnpm exec vp run --filter t3 typecheck` — completed with unrelated Effect suggestions only
- `git diff --check main...HEAD` — passed

## Scope

- Server-side workspace listing only
- No contract changes
- No client changes
- No Git behavior changes
- No dependency changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem traversal and git/ignore gating on `projects.listEntries`; wrong fallbacks could hide dot entries or over-list, but scope is server listing only with explicit caps and abort conditions.
> 
> **Overview**
> **`WorkspaceEntries.list`** still uses the FFF path index as the primary source, but for ordinary **non-Git** project roots it can now **merge in** root-level dot files/directories (and descendants under those dot dirs) that FFF omits on purpose.
> 
> Augmentation is skipped when the index is already **truncated**, the cwd is **home or filesystem root**, **`.git` exists on the cwd or an ancestor**, the scan hits **`.gitignore`/`.ignore`**, unreadable dirs, or would exceed the shared **25,000** entry budget; **`.git`** and **`node_modules`** are not walked. Extra paths are deduped, sorted, and only fill **remaining capacity** so indexed entries are not displaced at the cap.
> 
> Adds **`WorkspaceEntries.nonGitHidden.test.ts`** for visible dot entries, respect for ignore files, and cap behavior with a mocked full index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c74aa91c032789b4e262a77282f235f6ee794ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show dot entries in non-Git workspaces in `WorkspaceEntries.list`
> - Augments indexed search results with unindexed root dot-entries and their descendants for non-Git workspaces, skipping `.git` and `node_modules`
> - Aborts supplemental collection when `.gitignore` or `.ignore` is present in any scanned directory, or when any ancestor contains Git metadata (`.git`), to avoid duplicating ignore logic
> - Merges supplemental entries up to a total cap of 25,000 entries (`NON_GIT_DOT_ENTRY_SCAN_MAX_ENTRIES`); the `truncated` flag reflects whether supplemental entries were dropped
> - Skips augmentation entirely for home directory scans, filesystem root, or already-truncated index results
> - Risk: `collectNonGitRootDotEntries` treats non-ENOENT/ENOTDIR `lstat` errors as existing paths in `pathExistsForRepositoryDetection`; check that this conservative default does not cause false Git detection in environments with permission or I/O errors
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c74aa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->