### PR TITLE
fix: clear implicit project model defaults

### DIFF
--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -30,7 +30,6 @@ import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSn
 import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
-import * as ServerRuntimeStartup from "../serverRuntimeStartup.ts";
 import {
   clearPersistedServerRuntimeState,
   readPersistedServerRuntimeState,
@@ -481,7 +480,7 @@ const projectAddCommand = Command.make("add", {
           projectId,
           title,
           workspaceRoot,
-          defaultModelSelection: ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(),
+          defaultModelSelection: null,
           createdAt: DateTime.formatIso(yield* DateTime.now),
         });
         return `Added project ${projectId} (${title}) at ${workspaceRoot}.`;

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -56,6 +56,7 @@ import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
 import Migration0041 from "./Migrations/041_AuthSessionClientConnection.ts";
 import Migration0042 from "./Migrations/042_ProjectionThreadLinkedPullRequest.ts";
 import Migration0043 from "./Migrations/043_ProjectionThreadsUnsettledAt.ts";
+import Migration0044 from "./Migrations/044_ClearImplicitProjectModelDefaults.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -111,6 +112,7 @@ export const migrationEntries = [
   [41, "AuthSessionClientConnection", Migration0041],
   [42, "ProjectionThreadLinkedPullRequest", Migration0042],
   [43, "ProjectionThreadsUnsettledAt", Migration0043],
+  [44, "ClearImplicitProjectModelDefaults", Migration0044],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/044_ClearImplicitProjectModelDefaults.test.ts
+++ b/apps/server/src/persistence/Migrations/044_ClearImplicitProjectModelDefaults.test.ts
@@ -1,0 +1,113 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+const createdAt = "2026-01-01T00:00:00.000Z";
+
+layer("044_ClearImplicitProjectModelDefaults", (it) => {
+  it.effect("clears only the known implicit creation default", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 43 });
+
+      const insertProject = (projectId: string, defaultModelSelection: string) => sql`
+        INSERT INTO projection_projects (
+          project_id, title, workspace_root, default_model_selection_json,
+          scripts_json, created_at, updated_at
+        ) VALUES (
+          ${projectId}, ${projectId}, ${`/tmp/${projectId}`}, ${defaultModelSelection},
+          '[]', ${createdAt}, ${createdAt}
+        )
+      `;
+      const insertEvent = (
+        eventId: string,
+        streamId: string,
+        streamVersion: number,
+        eventType: string,
+        payload: string,
+      ) => sql`
+        INSERT INTO orchestration_events (
+          event_id, aggregate_kind, stream_id, stream_version, event_type,
+          occurred_at, actor_kind, payload_json, metadata_json
+        ) VALUES (
+          ${eventId}, 'project', ${streamId}, ${streamVersion}, ${eventType},
+          ${createdAt}, 'user', ${payload}, '{}'
+        )
+      `;
+
+      const generated = '{"instanceId":"codex","model":"gpt-5.4"}';
+      const explicit = '{"instanceId":"claudeAgent","model":"claude-sonnet-5"}';
+      const callerSupplied = '{"instanceId":"codex","model":"gpt-5-codex"}';
+      yield* insertProject("implicit", generated);
+      yield* insertEvent(
+        "created-implicit",
+        "implicit",
+        1,
+        "project.created",
+        `{"defaultModelSelection":${generated}}`,
+      );
+      yield* insertEvent(
+        "renamed-implicit",
+        "implicit",
+        2,
+        "project.meta-updated",
+        '{"title":"Renamed"}',
+      );
+
+      yield* insertProject("explicit", explicit);
+      yield* insertEvent(
+        "created-explicit",
+        "explicit",
+        1,
+        "project.created",
+        `{"defaultModelSelection":${generated}}`,
+      );
+      yield* insertEvent(
+        "updated-explicit",
+        "explicit",
+        2,
+        "project.meta-updated",
+        `{"defaultModelSelection":${explicit}}`,
+      );
+
+      yield* insertProject("caller-supplied", callerSupplied);
+      yield* insertEvent(
+        "created-caller-supplied",
+        "caller-supplied",
+        1,
+        "project.created",
+        `{"defaultModelSelection":${callerSupplied}}`,
+      );
+
+      yield* runMigrations({ toMigrationInclusive: 44 });
+
+      const projects = yield* sql<{
+        readonly projectId: string;
+        readonly defaultModelSelection: string | null;
+      }>`
+        SELECT project_id AS "projectId",
+          default_model_selection_json AS "defaultModelSelection"
+        FROM projection_projects
+        ORDER BY project_id
+      `;
+      assert.deepStrictEqual(projects, [
+        { projectId: "caller-supplied", defaultModelSelection: callerSupplied },
+        { projectId: "explicit", defaultModelSelection: explicit },
+        { projectId: "implicit", defaultModelSelection: null },
+      ]);
+
+      const rewritten = yield* sql<{ readonly rewrittenCount: number }>`
+        SELECT COUNT(*) AS "rewrittenCount"
+        FROM orchestration_events
+        WHERE event_type = 'project.created'
+          AND json_type(payload_json, '$.defaultModelSelection') = 'null'
+      `;
+      assert.equal(rewritten[0]?.rewrittenCount, 2);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/044_ClearImplicitProjectModelDefaults.ts
+++ b/apps/server/src/persistence/Migrations/044_ClearImplicitProjectModelDefaults.ts
@@ -1,0 +1,50 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // The old client creation path always wrote this exact bare Codex default.
+  // Keep every other creation-time selection because the command contract
+  // also permits callers to supply a legitimate project default.
+  yield* sql`
+    UPDATE projection_projects
+    SET default_model_selection_json = NULL
+    WHERE default_model_selection_json IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM orchestration_events AS created
+        WHERE created.aggregate_kind = 'project'
+          AND created.stream_id = projection_projects.project_id
+          AND created.event_type = 'project.created'
+          AND COALESCE(
+            json_extract(created.payload_json, '$.defaultModelSelection.instanceId'),
+            json_extract(created.payload_json, '$.defaultModelSelection.provider')
+          ) = 'codex'
+          AND json_extract(created.payload_json, '$.defaultModelSelection.model') = 'gpt-5.4'
+          AND json_type(created.payload_json, '$.defaultModelSelection.options') IS NULL
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM orchestration_events AS updated
+        WHERE updated.aggregate_kind = 'project'
+          AND updated.stream_id = projection_projects.project_id
+          AND updated.event_type = 'project.meta-updated'
+          AND json_type(updated.payload_json, '$.defaultModelSelection') IS NOT NULL
+      )
+  `;
+
+  // Keep replay consistent with the repaired projection.
+  yield* sql`
+    UPDATE orchestration_events
+    SET payload_json = json_set(payload_json, '$.defaultModelSelection', json('null'))
+    WHERE aggregate_kind = 'project'
+      AND event_type = 'project.created'
+      AND COALESCE(
+        json_extract(payload_json, '$.defaultModelSelection.instanceId'),
+        json_extract(payload_json, '$.defaultModelSelection.provider')
+      ) = 'codex'
+      AND json_extract(payload_json, '$.defaultModelSelection.model') = 'gpt-5.4'
+      AND json_type(payload_json, '$.defaultModelSelection.options') IS NULL
+  `;
+});

--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -1,5 +1,11 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { DEFAULT_MODEL, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import {
+  DEFAULT_MODEL,
+  type OrchestrationCommand,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
@@ -185,7 +191,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
 
 it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when missing", () =>
   Effect.gen(function* () {
-    const dispatchCalls = yield* Ref.make<ReadonlyArray<string>>([]);
+    const dispatchCalls = yield* Ref.make<ReadonlyArray<OrchestrationCommand>>([]);
     const targets = yield* ServerRuntimeStartup.resolveAutoBootstrapWelcomeTargets.pipe(
       Effect.provideService(ServerConfig.ServerConfig, {
         cwd: "/tmp/startup-project",
@@ -211,7 +217,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
       Effect.provideService(OrchestrationEngine.OrchestrationEngineService, {
         readEvents: () => Stream.empty,
         dispatch: (command) =>
-          Ref.update(dispatchCalls, (calls) => [...calls, command.type]).pipe(
+          Ref.update(dispatchCalls, (calls) => [...calls, command]).pipe(
             Effect.as({ sequence: 1 }),
           ),
         streamDomainEvents: Stream.empty,
@@ -222,7 +228,18 @@ it.effect("resolveAutoBootstrapWelcomeTargets creates a project and thread when 
 
     assert.equal(typeof targets.bootstrapProjectId, "string");
     assert.equal(typeof targets.bootstrapThreadId, "string");
-    assert.deepStrictEqual(yield* Ref.get(dispatchCalls), ["project.create", "thread.create"]);
+    const calls = yield* Ref.get(dispatchCalls);
+    assert.equal(calls[0]?.type, "project.create");
+    assert.equal(calls[1]?.type, "thread.create");
+    if (calls[0]?.type === "project.create") {
+      assert.equal(calls[0].defaultModelSelection, null);
+    }
+    if (calls[1]?.type === "thread.create") {
+      assert.deepStrictEqual(
+        calls[1].modelSelection,
+        ServerRuntimeStartup.getAutoBootstrapDefaultModelSelection(),
+      );
+    }
   }),
 );
 

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -199,25 +199,25 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
         serverConfig.cwd,
       );
       let nextProjectId: ProjectId;
-      let nextProjectDefaultModelSelection: ModelSelection;
+      let nextThreadModelSelection: ModelSelection;
 
       if (Option.isNone(existingProject)) {
         const createdAt = DateTime.formatIso(yield* DateTime.now);
         nextProjectId = ProjectId.make(yield* randomUUID);
         const bootstrapProjectTitle = path.basename(serverConfig.cwd) || "project";
-        nextProjectDefaultModelSelection = getAutoBootstrapDefaultModelSelection();
+        nextThreadModelSelection = getAutoBootstrapDefaultModelSelection();
         yield* orchestrationEngine.dispatch({
           type: "project.create",
           commandId: CommandId.make(yield* randomUUID),
           projectId: nextProjectId,
           title: bootstrapProjectTitle,
           workspaceRoot: serverConfig.cwd,
-          defaultModelSelection: nextProjectDefaultModelSelection,
+          defaultModelSelection: null,
           createdAt,
         });
       } else {
         nextProjectId = existingProject.value.id;
-        nextProjectDefaultModelSelection =
+        nextThreadModelSelection =
           existingProject.value.defaultModelSelection ?? getAutoBootstrapDefaultModelSelection();
       }
 
@@ -232,7 +232,7 @@ export const resolveAutoBootstrapWelcomeTargets = Effect.gen(function* () {
           threadId: createdThreadId,
           projectId: nextProjectId,
           title: "New thread",
-          modelSelection: nextProjectDefaultModelSelection,
+          modelSelection: nextThreadModelSelection,
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "full-access",
           branch: null,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -147,11 +147,7 @@ import {
 } from "./ThreadCommandSubtitle";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
-import {
-  deriveProviderInstanceEntries,
-  resolveDefaultProviderModelSelection,
-  type ProviderInstanceEntry,
-} from "../providerInstances";
+import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import { CommandDialog, CommandDialogPopup, CommandFooterAction } from "./ui/command";
 import { Button } from "./ui/button";
@@ -1756,10 +1752,6 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const projectId = newProjectId();
-      const targetEnvironmentProviders =
-        environments.find((environment) => environment.environmentId === input.environmentId)
-          ?.serverConfig?.providers ??
-        (input.environmentId === primaryEnvironmentId ? providers : []);
       const createResult = await createProject({
         environmentId: input.environmentId,
         input: {
@@ -1767,10 +1759,7 @@ function OpenCommandPaletteDialog(props: {
           title: inferProjectTitleFromPath(cwd),
           workspaceRoot: cwd,
           createWorkspaceRootIfMissing: true,
-          defaultModelSelection: resolveDefaultProviderModelSelection(
-            targetEnvironmentProviders,
-            null,
-          ),
+          defaultModelSelection: null,
         },
       });
       if (createResult._tag === "Failure") {
@@ -1810,7 +1799,6 @@ function OpenCommandPaletteDialog(props: {
       navigate,
       primaryEnvironmentId,
       projects,
-      providers,
       setOpen,
       clientSettings.sidebarThreadSortOrder,
       threads,


### PR DESCRIPTION
## What Changed

- Added migration 044 to clear only the exact bare Codex `gpt-5.4` project default written by the legacy implicit-creation path. Other caller-supplied creation values and later explicit project updates are preserved.
- Rewrites the matching creation event alongside the projection so replay cannot restore that legacy implicit value.
- Auto-bootstrap, CLI project creation, and command-palette project creation no longer pin the current model to the project. Auto-bootstrap still uses the current default for its initial thread.

## Why

Older project creation paths silently stored `gpt-5.4` as a project default even though the user never configured it.

After #6011 made configured project defaults authoritative for new threads, those dormant values began overriding the last-picked model. Restricting cleanup to the exact legacy-generated shape repairs that cohort without weakening real project defaults or erasing other values supplied through the project creation contract.

## Verification

- `vp test run apps/server/src/persistence/Migrations/044_ClearImplicitProjectModelDefaults.test.ts apps/server/src/serverRuntimeStartup.test.ts packages/client-runtime/src/operations/projects.test.ts` (26 tests)
- Targeted lint and formatting checks for all changed files
- `vp run typecheck` in `apps/server`
- `vp run typecheck` in `apps/web`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no UI change)
- [ ] I included a video for animation/interaction changes (not applicable)

Built with GPT-5.6-Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Migration 044 mutates historical `project.created` events and project projections; incorrect matching could clear real defaults, though predicates are narrow and explicit meta-updates are excluded.
> 
> **Overview**
> Stops treating the app-wide model as a **project default** when projects are created. **CLI add**, **server auto-bootstrap**, and **command palette add project** now dispatch `project.create` with `defaultModelSelection: null`. Auto-bootstrap still applies `getAutoBootstrapDefaultModelSelection()` on the **initial** `thread.create` only.
> 
> Adds **migration 044** to repair legacy data: it nulls `projection_projects.default_model_selection_json` and rewrites matching `project.created` event payloads when the stored value was only the old implicit Codex `gpt-5.4` default (no options) and the user never set a default via `project.meta-updated`. Explicit project defaults and caller-supplied creation values are left intact. Tests cover the migration and bootstrap dispatch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89486e9f3f4c3a7b53cd50dcc020daa4e1586cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear implicit `defaultModelSelection` across project creation paths and add migration 44
> - New project creation in the CLI (`projectAddCommand`), auto-bootstrap (`resolveAutoBootstrapWelcomeTargets`), and web command palette (`OpenCommandPaletteDialog`) now sets `defaultModelSelection` to `null` instead of an auto-resolved model
> - Migration 44 (`ClearImplicitProjectModelDefaults`) sets `projection_projects.default_model_selection_json` to NULL for projects whose creation event used the bare Codex `gpt-5.4` default with no later explicit update, and normalizes the corresponding `project.created` event payloads to stay replay-consistent
> - Auto-bootstrap still assigns a model selection to the initial thread via `getAutoBootstrapDefaultModelSelection` when the project has no default
> - Risk: migration 44 mutates existing `projection_projects` rows and `project.created` event payloads for projects matching the implicit-default criteria; reviewers should verify the matching condition in [044_ClearImplicitProjectModelDefaults.ts](https://github.com/pingdotgg/t3code/pull/8672/files#diff-a96f6f2ae50c6bcbca661122b6d6daa9ad3fddae69ec449fb7319c48caca5919) does not catch projects with explicit caller-supplied defaults
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89486e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->