### PR TITLE
fix(desktop): refresh Linux MIME handler cache

### DIFF
--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -49,6 +49,7 @@ const makeHandlerLayer = (
   recorded: RecordedRegistration,
   input: {
     readonly environment?: Record<string, unknown>;
+    readonly updateDesktopDatabaseExitCode?: number;
     readonly xdgMimeExitCode?: number;
     readonly writeError?: PlatformError.PlatformError;
   } = {},
@@ -80,7 +81,11 @@ const makeHandlerLayer = (
               command: childProcess.command,
               args: childProcess.args,
             });
-            return Effect.succeed(mockProcess(input.xdgMimeExitCode ?? 0));
+            const exitCode =
+              childProcess.command === "update-desktop-database"
+                ? (input.updateDesktopDatabaseExitCode ?? 0)
+                : (input.xdgMimeExitCode ?? 0);
+            return Effect.succeed(mockProcess(exitCode));
           }),
         ),
       ),
@@ -170,6 +175,10 @@ describe("DesktopLinuxUrlHandler", () => {
       assert.include(recorded.files[0]?.content, "MimeType=x-scheme-handler/t3code;");
       assert.deepEqual(recorded.commands, [
         {
+          command: "update-desktop-database",
+          args: ["/home/alice/.local/share/applications"],
+        },
+        {
           command: "xdg-mime",
           args: ["default", "t3code-url-handler.desktop", "x-scheme-handler/t3code"],
         },
@@ -207,10 +216,12 @@ describe("DesktopLinuxUrlHandler", () => {
   });
 
   it.effect("never fails startup when registration cannot complete", () => {
+    const desktopDatabaseFailed = emptyRecording();
     const xdgMimeFailed = emptyRecording();
     const writeFailed = emptyRecording();
 
     return Effect.gen(function* () {
+      yield* runRegister(desktopDatabaseFailed, { updateDesktopDatabaseExitCode: 1 });
       yield* runRegister(xdgMimeFailed, { xdgMimeExitCode: 1 });
       yield* runRegister(writeFailed, {
         writeError: PlatformError.systemError({
@@ -222,6 +233,10 @@ describe("DesktopLinuxUrlHandler", () => {
         }),
       });
 
+      assert.deepEqual(
+        desktopDatabaseFailed.commands.map(({ command }) => command),
+        ["update-desktop-database", "xdg-mime"],
+      );
       assert.equal(xdgMimeFailed.files.length, 1);
       assert.deepEqual(writeFailed.commands, []);
     });

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -17,9 +17,9 @@ import { makeComponentLogger } from "./DesktopObservability.ts";
 // Electron's app.setAsDefaultProtocolClient resolves the desktop id from
 // setDesktopName, which cannot match those files — so the browser keeps
 // prompting "Choose an application" for every OAuth callback. Instead, write
-// our own handler entry pointing at the current AppImage and claim the
-// scheme default via xdg-mime, exactly what the file manager's "set as
-// default" checkbox would record in mimeapps.list.
+// our own handler entry pointing at the current AppImage, refresh the desktop
+// MIME cache so desktop environments recognize that entry as a handler, and
+// use xdg-mime to record it as the scheme default in mimeapps.list.
 export const URL_HANDLER_DESKTOP_ENTRY_NAME = "t3code-url-handler.desktop";
 
 const { logInfo, logWarning } = makeComponentLogger("desktop-linux-url-handler");
@@ -41,6 +41,23 @@ export class DesktopLinuxUrlHandlerRegistrationError extends Schema.TaggedErrorC
 }
 
 const isRegistrationError = Schema.is(DesktopLinuxUrlHandlerRegistrationError);
+
+export class DesktopLinuxUrlHandlerCacheRefreshError extends Schema.TaggedErrorClass<DesktopLinuxUrlHandlerCacheRefreshError>()(
+  "DesktopLinuxUrlHandlerCacheRefreshError",
+  {
+    applicationsDir: Schema.String,
+    exitCode: Schema.optionalKey(Schema.Number),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    const exitCode =
+      this.exitCode === undefined ? "" : `, update-desktop-database exit code ${this.exitCode}`;
+    return `Failed to refresh the desktop MIME cache at ${this.applicationsDir}${exitCode}.`;
+  }
+}
+
+const isCacheRefreshError = Schema.is(DesktopLinuxUrlHandlerCacheRefreshError);
 
 const escapeDesktopEntryString = (value: string): string =>
   value
@@ -128,6 +145,37 @@ export const make = Effect.gen(function* () {
     ),
   );
 
+  const updateDesktopDatabase = Effect.scoped(
+    Effect.gen(function* () {
+      const command = ChildProcess.make(
+        "update-desktop-database",
+        [environment.linuxApplicationsDir],
+        {
+          stdin: "ignore",
+          stdout: "ignore",
+          stderr: "ignore",
+        },
+      );
+      const handle = yield* spawner.spawn(command);
+      const exitCode = yield* handle.exitCode;
+      if (exitCode !== 0) {
+        return yield* new DesktopLinuxUrlHandlerCacheRefreshError({
+          applicationsDir: environment.linuxApplicationsDir,
+          exitCode,
+        });
+      }
+    }),
+  ).pipe(
+    Effect.mapError((error) =>
+      isCacheRefreshError(error)
+        ? error
+        : new DesktopLinuxUrlHandlerCacheRefreshError({
+            applicationsDir: environment.linuxApplicationsDir,
+            cause: error,
+          }),
+    ),
+  );
+
   const setDefaultHandler = Effect.scoped(
     Effect.gen(function* () {
       const command = ChildProcess.make(
@@ -166,6 +214,21 @@ export const make = Effect.gen(function* () {
       return;
     }
     yield* writeDesktopEntry;
+
+    yield* updateDesktopDatabase.pipe(
+      // Some MIME implementations, including GIO, use mimeinfo.cache to verify
+      // that a desktop entry is associated with a scheme. Cache refresh is
+      // independently best-effort so a missing update-desktop-database executable
+      // does not prevent xdg-mime from recording the requested default.
+      Effect.catch((error) =>
+        logWarning("desktop MIME cache refresh failed", {
+          applicationsDir: environment.linuxApplicationsDir,
+          message: error.message,
+          ...(error.exitCode === undefined ? {} : { exitCode: error.exitCode }),
+        }),
+      ),
+    );
+
     yield* setDefaultHandler;
     yield* logInfo("registered URL scheme handler", { scheme });
   }).pipe(


### PR DESCRIPTION
## What Changed

- Run `update-desktop-database` on the user applications directory after writing the Linux URL-handler entry.
- Keep the MIME-cache refresh best-effort so failure does not prevent `xdg-mime` from recording the scheme default or block application startup.
- Cover command ordering and cache-refresh failure behavior in the existing URL-handler tests.

## Why

`xdg-mime default` records the selected handler in `mimeapps.list`, but desktop environments such as GNOME can also consult `mimeinfo.cache` when discovering applications capable of opening a URL scheme. Without refreshing that cache after generating the `.desktop` entry, OAuth callbacks can show an empty application chooser even though T3 Code is configured as the default.

Linux packages should expose `update-desktop-database` from `desktop-file-utils` on the desktop process PATH. The command remains optional at runtime because its failure is handled independently.

This was split from #8668 so distro launcher selection and MIME-cache registration can be reviewed independently.

## Related

Closes #10354

## Verification

- 6 focused Linux URL-handler tests pass.
- Targeted lint passes without warnings.
- Desktop typechecking passes.
- Formatting and `git diff --check` pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there are no UI changes
- [x] Video is not applicable because there are no animation or interaction changes

Implemented and verified with GPT-5.6 in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linux-only, best-effort desktop integration with existing startup-safe registration; no changes to auth logic or data handling.
> 
> **Overview**
> After writing the custom `t3code-url-handler.desktop` entry on packaged Linux builds, registration now runs **`update-desktop-database`** on the user applications directory **before** **`xdg-mime default`**, so environments that read **`mimeinfo.cache`** (e.g. GNOME/GIO) can see the new handler and OAuth scheme choosers are less likely to appear empty.
> 
> Cache refresh is **best-effort**: failures map to a new **`DesktopLinuxUrlHandlerCacheRefreshError`**, are logged as warnings, and do **not** skip **`xdg-mime`** or fail startup. Tests assert command order and that a non-zero **`update-desktop-database`** exit still allows **`xdg-mime`** to run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd38fa331d57e50ca3edfbab25651e83dcf8ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh desktop MIME cache via `update-desktop-database` in `DesktopLinuxUrlHandler`
> - During registration, `DesktopLinuxUrlHandler.make` now spawns `update-desktop-database <applicationsDir>` after writing the desktop entry and before calling `xdg-mime`.
> - Cache refresh failures are caught and logged as warnings (with `applicationsDir` and optional `exitCode`); registration continues regardless.
> - Adds a new tagged error type `DesktopLinuxUrlHandlerCacheRefreshError` and a `Schema.is` type guard `isCacheRefreshError`.
> - Behavioral Change: `update-desktopDatabase` is now invoked as part of every Linux URL handler registration; if the binary is missing or exits non-zero, registration still proceeds but a warning is logged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cd38fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
